### PR TITLE
security: enforce admin-only access on sources and lostReasons mutations

### DIFF
--- a/convex/lostReasons.ts
+++ b/convex/lostReasons.ts
@@ -1,6 +1,6 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
-import { verifyOrgAccess } from "./_helpers/auth";
+import { verifyOrgAccess, requireOrgAdmin } from "./_helpers/auth";
 
 export const list = query({
   args: {
@@ -25,7 +25,7 @@ export const create = mutation({
     label: v.string(),
   },
   handler: async (ctx, args) => {
-    const { user } = await verifyOrgAccess(ctx, args.organizationId);
+    const { user } = await requireOrgAdmin(ctx, args.organizationId);
     const now = Date.now();
 
     const existing = await ctx.db
@@ -56,7 +56,7 @@ export const update = mutation({
     isActive: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await requireOrgAdmin(ctx, args.organizationId);
 
     const reason = await ctx.db.get(args.reasonId);
     if (!reason || reason.organizationId !== args.organizationId) {
@@ -76,7 +76,7 @@ export const remove = mutation({
     reasonId: v.id("lostReasons"),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await requireOrgAdmin(ctx, args.organizationId);
 
     const reason = await ctx.db.get(args.reasonId);
     if (!reason || reason.organizationId !== args.organizationId) {
@@ -137,7 +137,7 @@ export const reorder = mutation({
     reasonIds: v.array(v.id("lostReasons")),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await requireOrgAdmin(ctx, args.organizationId);
 
     for (let i = 0; i < args.reasonIds.length; i++) {
       const reason = await ctx.db.get(args.reasonIds[i]);

--- a/convex/sources.ts
+++ b/convex/sources.ts
@@ -1,6 +1,6 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
-import { verifyOrgAccess } from "./_helpers/auth";
+import { verifyOrgAccess, requireOrgAdmin } from "./_helpers/auth";
 
 export const list = query({
   args: {
@@ -25,7 +25,7 @@ export const create = mutation({
     name: v.string(),
   },
   handler: async (ctx, args) => {
-    const { user } = await verifyOrgAccess(ctx, args.organizationId);
+    const { user } = await requireOrgAdmin(ctx, args.organizationId);
     const now = Date.now();
 
     const existing = await ctx.db
@@ -56,7 +56,7 @@ export const update = mutation({
     isActive: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await requireOrgAdmin(ctx, args.organizationId);
 
     const source = await ctx.db.get(args.sourceId);
     if (!source || source.organizationId !== args.organizationId) {
@@ -76,7 +76,7 @@ export const remove = mutation({
     sourceId: v.id("sources"),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await requireOrgAdmin(ctx, args.organizationId);
 
     const source = await ctx.db.get(args.sourceId);
     if (!source || source.organizationId !== args.organizationId) {
@@ -94,7 +94,7 @@ export const reorder = mutation({
     sourceIds: v.array(v.id("sources")),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await requireOrgAdmin(ctx, args.organizationId);
 
     for (let i = 0; i < args.sourceIds.length; i++) {
       const source = await ctx.db.get(args.sourceIds[i]);


### PR DESCRIPTION
## Summary
- Replace `verifyOrgAccess` with `requireOrgAdmin` in write mutations (create, update, remove, reorder) in `convex/sources.ts` and `convex/lostReasons.ts`
- This ensures only org owners and admins can modify these admin-level configuration settings, closing a privilege escalation gap where any org member could modify them
- Matches the existing pattern in `convex/activityTypes.ts`

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] Read-only `list` query and `seed` mutation remain using `verifyOrgAccess` (no regression for normal members reading data or org setup)
- [x] No UI changes needed — frontend already guards these settings pages behind admin navigation, but the backend was missing enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)