### PR TITLE
fix: close cross-tenant data leakage in sidebar widget queries

### DIFF
--- a/convex/nudges.ts
+++ b/convex/nudges.ts
@@ -333,11 +333,16 @@ export const getProductsNudges = query({
       .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
       .collect();
 
-    const dealProducts = await ctx.db
-      .query("dealProducts")
-      .collect();
-
-    const usedProductIds = new Set(dealProducts.map((dp) => String(dp.productId)));
+    const usedProductIds = new Set<string>();
+    for (const p of products) {
+      const hasDeals = await ctx.db
+        .query("dealProducts")
+        .withIndex("by_product", (q) => q.eq("productId", p._id))
+        .first();
+      if (hasDeals) {
+        usedProductIds.add(String(p._id));
+      }
+    }
     const unused = products.filter((p) => !usedProductIds.has(String(p._id)));
 
     if (unused.length > 0) {

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -329,7 +329,8 @@ export function createCrmTables({
     createdAt: v.number(),
   })
     .index("by_deal", ["dealId"])
-    .index("by_product", ["productId"]),
+    .index("by_product", ["productId"])
+    .index("by_org", ["organizationId"]),
 
   // --- Calls ---
 

--- a/convex/sidebarWidgets.ts
+++ b/convex/sidebarWidgets.ts
@@ -1,6 +1,7 @@
 // convex/sidebarWidgets.ts
 import { query } from "./_generated/server";
 import { v } from "convex/values";
+import { Id } from "./_generated/dataModel";
 import { verifyOrgAccess } from "./_helpers/auth";
 
 // --- Insights (Dashboard) ---
@@ -451,19 +452,18 @@ export const getTopProducts = query({
       .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
       .collect();
 
-    const dealProducts = await ctx.db
-      .query("dealProducts")
-      .collect();
-
-    const countMap = new Map<string, number>();
-    for (const dp of dealProducts) {
-      const key = String(dp.productId);
-      countMap.set(key, (countMap.get(key) ?? 0) + 1);
+    const results: { label: string; value: number }[] = [];
+    for (const p of products) {
+      const dpCount = (await ctx.db
+        .query("dealProducts")
+        .withIndex("by_product", (q) => q.eq("productId", p._id))
+        .collect()).length;
+      if (dpCount > 0) {
+        results.push({ label: p.name, value: dpCount });
+      }
     }
 
-    return products
-      .map((p) => ({ label: p.name, value: countMap.get(String(p._id)) ?? 0 }))
-      .filter((p) => p.value > 0)
+    return results
       .sort((a, b) => b.value - a.value)
       .slice(0, 5);
   },
@@ -576,8 +576,8 @@ export const getTopTemplates = query({
     // Look up template names
     const results: { label: string; value: number }[] = [];
     for (const [templateId, count] of templateCounts) {
-      const template = await ctx.db.get(templateId as any);
-      if (template && "name" in template) {
+      const template = await ctx.db.get(templateId as Id<"emailTemplates">);
+      if (template && "name" in template && (template as any).organizationId === args.organizationId) {
         results.push({ label: template.name as string, value: count });
       }
     }

--- a/convex/sidebarWidgets.ts
+++ b/convex/sidebarWidgets.ts
@@ -231,13 +231,15 @@ export const getProductsKpis = query({
       .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
       .collect();
 
-    const dealProducts = await ctx.db
-      .query("dealProducts")
-      .collect();
-
     const productUsage = new Map<string, number>();
-    for (const dp of dealProducts) {
-      productUsage.set(String(dp.productId), (productUsage.get(String(dp.productId)) ?? 0) + 1);
+    for (const p of products) {
+      const dpCount = (await ctx.db
+        .query("dealProducts")
+        .withIndex("by_product", (q) => q.eq("productId", p._id))
+        .collect()).length;
+      if (dpCount > 0) {
+        productUsage.set(String(p._id), dpCount);
+      }
     }
 
     let topSeller = "";


### PR DESCRIPTION
## Summary
- Fixed `getTopProducts` in `sidebarWidgets.ts` which was loading ALL dealProducts across all organizations. Now queries per-product using the `by_product` index, implicitly scoped to the org since products are already org-filtered.
- Fixed `getTopTemplates` in `sidebarWidgets.ts` where `ctx.db.get()` on template IDs did not verify org ownership. Added `organizationId` check against the querying organization.
- Added `by_org` index to `dealProducts` table in `convex/schema/crm.ts` for future org-scoped queries.

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] No existing unit tests to regress (test:unit finds no test files)
- [x] No UI changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)