### PR TITLE
feat: revoke Google OAuth tokens on disconnect

### DIFF
--- a/convex/oauthConnections.ts
+++ b/convex/oauthConnections.ts
@@ -59,6 +59,11 @@ export const revokeAndDeactivate = action({
     connectionId: v.id("oauthConnections"),
   },
   handler: async (ctx, args) => {
+    // Verify the calling user is an admin of this org (auth context propagates to internal queries)
+    await ctx.runQuery(internal.oauthConnections.verifyAdminAccess, {
+      organizationId: args.organizationId,
+    });
+
     const connection = await ctx.runQuery(internal.oauthConnections.getForRevocation, {
       connectionId: args.connectionId,
       organizationId: args.organizationId,
@@ -150,6 +155,13 @@ export const createOrUpdate = internalMutation({
       createdAt: now,
       updatedAt: now,
     });
+  },
+});
+
+export const verifyAdminAccess = internalQuery({
+  args: { organizationId: v.id("organizations") },
+  handler: async (ctx, args) => {
+    await requireOrgAdmin(ctx, args.organizationId);
   },
 });
 

--- a/convex/oauthConnections.ts
+++ b/convex/oauthConnections.ts
@@ -1,4 +1,5 @@
-import { query, mutation, internalQuery, internalMutation } from "./_generated/server";
+import { query, mutation, internalQuery, internalMutation, action } from "./_generated/server";
+import { internal } from "./_generated/api";
 import { v } from "convex/values";
 import { verifyOrgAccess, requireOrgAdmin } from "./_helpers/auth";
 
@@ -48,6 +49,43 @@ export const deactivate = mutation({
     await ctx.db.patch(args.connectionId, {
       isActive: false,
       updatedAt: Date.now(),
+    });
+  },
+});
+
+export const revokeAndDeactivate = action({
+  args: {
+    organizationId: v.id("organizations"),
+    connectionId: v.id("oauthConnections"),
+  },
+  handler: async (ctx, args) => {
+    const connection = await ctx.runQuery(internal.oauthConnections.getForRevocation, {
+      connectionId: args.connectionId,
+      organizationId: args.organizationId,
+    });
+
+    if (!connection) {
+      throw new Error("Connection not found");
+    }
+
+    try {
+      const response = await fetch("https://oauth2.googleapis.com/revoke", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          token: connection.refreshToken,
+        }),
+      });
+
+      if (!response.ok) {
+        console.warn("Google token revocation failed:", await response.text());
+      }
+    } catch (error) {
+      console.warn("Google token revocation error:", error);
+    }
+
+    await ctx.runMutation(internal.oauthConnections.internalDeactivate, {
+      connectionId: args.connectionId,
     });
   },
 });
@@ -111,6 +149,32 @@ export const createOrUpdate = internalMutation({
       connectedBy: args.connectedBy,
       createdAt: now,
       updatedAt: now,
+    });
+  },
+});
+
+export const getForRevocation = internalQuery({
+  args: {
+    connectionId: v.id("oauthConnections"),
+    organizationId: v.id("organizations"),
+  },
+  handler: async (ctx, args) => {
+    const connection = await ctx.db.get(args.connectionId);
+    if (!connection || connection.organizationId !== args.organizationId) {
+      return null;
+    }
+    return connection;
+  },
+});
+
+export const internalDeactivate = internalMutation({
+  args: {
+    connectionId: v.id("oauthConnections"),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.connectionId, {
+      isActive: false,
+      updatedAt: Date.now(),
     });
   },
 });

--- a/src/components/settings/google-integration-card.tsx
+++ b/src/components/settings/google-integration-card.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useMutation } from "convex/react";
+import { useAction } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { Id } from "@cvx/_generated/dataModel";
@@ -30,7 +30,7 @@ export function GoogleIntegrationCard({
     })
   );
 
-  const deactivate = useMutation(api.oauthConnections.deactivate);
+  const revokeAndDeactivate = useAction(api.oauthConnections.revokeAndDeactivate);
 
   const handleConnect = () => {
     const url = `${convexSiteUrl}/google/oauth/initiate?organizationId=${organizationId}&userId=${userId}`;
@@ -41,7 +41,7 @@ export function GoogleIntegrationCard({
     if (!connection || !window.confirm(t("integrations.confirmDisconnect"))) return;
     setDisconnecting(true);
     try {
-      await deactivate({ organizationId, connectionId: connection._id });
+      await revokeAndDeactivate({ organizationId, connectionId: connection._id });
     } finally {
       setDisconnecting(false);
     }


### PR DESCRIPTION
## Summary
- Added `revokeAndDeactivate` action in `convex/oauthConnections.ts` that calls Google's token revocation endpoint before deactivating the connection locally
- Added supporting `getForRevocation` internal query and `internalDeactivate` internal mutation for the action to use
- Updated `google-integration-card.tsx` to call the new action via `useAction` instead of the old `useMutation` deactivate

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [x] No unit test regressions (no test files exist for this module)
- [ ] Manual: connect Google integration, then disconnect — verify token is revoked and connection deactivated

🤖 Generated with [Claude Code](https://claude.com/claude-code)