### PR TITLE
W widoku kalendarza potrzebuje, zeby dalio sie przeciagnac i stworzyc wizyte

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -72,6 +72,7 @@ interface AppointmentDialogProps {
   onOpenChange: (open: boolean) => void;
   defaultDate?: string;
   defaultTime?: string;
+  defaultEndTime?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -108,6 +109,7 @@ export function AppointmentDialog({
   onOpenChange,
   defaultDate,
   defaultTime,
+  defaultEndTime,
 }: AppointmentDialogProps) {
   const { t, i18n } = useTranslation();
   const dateFnsLocale = i18n.resolvedLanguage === "pl" ? pl : undefined;
@@ -168,7 +170,9 @@ export function AppointmentDialog({
   const [selectedSlot, setSelectedSlot] = useState<{
     start: string;
     end: string;
-  } | null>(defaultTime ? { start: defaultTime, end: "" } : null);
+  } | null>(
+    defaultTime ? { start: defaultTime, end: defaultEndTime ?? "" } : null,
+  );
   const [notes, setNotes] = useState("");
   const [isRecurring, setIsRecurring] = useState(false);
   const [frequency, setFrequency] = useState("weekly");
@@ -491,7 +495,7 @@ export function AppointmentDialog({
         defaultDate ? new Date(defaultDate + "T00:00:00") : undefined,
       );
       setSelectedSlot(
-        defaultTime ? { start: defaultTime, end: "" } : null,
+        defaultTime ? { start: defaultTime, end: defaultEndTime ?? "" } : null,
       );
       setNotes("");
       setIsRecurring(false);
@@ -502,7 +506,7 @@ export function AppointmentDialog({
       setLocationId("");
       setRoomId("");
     }
-  }, [open, defaultDate, defaultTime]);
+  }, [open, defaultDate, defaultTime, defaultEndTime]);
 
   // -------------------------------------------------------------------------
   // Determine which panels are active

--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { DraggableAppointment } from "./draggable-appointment";
 import { DroppableSlot } from "./droppable-slot";
+import { useDragToCreate } from "./use-drag-to-create";
 
 interface Appointment {
   _id: string;
@@ -16,6 +17,7 @@ interface CalendarDayViewProps {
   date: string;
   appointments: Appointment[];
   onSlotClick?: (time: string) => void;
+  onSlotDragSelect?: (date: string, startTime: string, endTime: string) => void;
   onAppointmentClick?: (id: string) => void;
   workingHours?: { startTime: string; endTime: string; breakStart?: string; breakEnd?: string } | null;
 }
@@ -90,7 +92,7 @@ function layoutAppointments(appts: Appointment[]): LayoutedAppointment[] {
   return result;
 }
 
-export function CalendarDayView({ date, appointments, onSlotClick, onAppointmentClick, workingHours }: CalendarDayViewProps) {
+export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSelect, onAppointmentClick, workingHours }: CalendarDayViewProps) {
   const now = new Date();
   const isToday = date === `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
   const currentMinutes = now.getHours() * 60 + now.getMinutes();
@@ -103,6 +105,33 @@ export function CalendarDayView({ date, appointments, onSlotClick, onAppointment
   const workEndTop = workingHours ? timeToTop(workingHours.endTime) : null;
   const breakStartTop = workingHours?.breakStart ? timeToTop(workingHours.breakStart) : null;
   const breakEndTop = workingHours?.breakEnd ? timeToTop(workingHours.breakEnd) : null;
+
+  const handleClick = useCallback(
+    (time: string) => onSlotClick?.(time),
+    [onSlotClick],
+  );
+  const handleDragSelect = useCallback(
+    (startTime: string, endTime: string) =>
+      onSlotDragSelect?.(date, startTime, endTime),
+    [onSlotDragSelect, date],
+  );
+
+  const dragHandler = useDragToCreate({
+    hoursStart: 7,
+    hoursCount: HOURS.length,
+    hourHeight: 60,
+    snapMinutes: 15,
+    minDragDistance: 8,
+    onClick: handleClick,
+    onDragSelect: handleDragSelect,
+  });
+
+  const dragTop = dragHandler.dragRange
+    ? Math.min(dragHandler.dragRange.start, dragHandler.dragRange.end)
+    : 0;
+  const dragHeight = dragHandler.dragRange
+    ? Math.abs(dragHandler.dragRange.end - dragHandler.dragRange.start)
+    : 0;
 
   return (
     <div className="relative flex h-full overflow-y-auto">
@@ -118,7 +147,11 @@ export function CalendarDayView({ date, appointments, onSlotClick, onAppointment
       </div>
 
       {/* Grid + appointments */}
-      <div className="relative flex-1">
+      <div
+        ref={dragHandler.containerRef}
+        className="relative flex-1 select-none"
+        onMouseDown={dragHandler.handleMouseDown}
+      >
         {/* Working hours background */}
         {workStartTop !== null && workEndTop !== null && (
           <div
@@ -150,12 +183,20 @@ export function CalendarDayView({ date, appointments, onSlotClick, onAppointment
             time={`${String(h).padStart(2, "0")}:00`}
             className="h-[60px] border-b border-dashed border-muted"
           >
-            <div
-              className="h-full w-full cursor-pointer hover:bg-muted/30"
-              onClick={() => onSlotClick?.(`${String(h).padStart(2, "0")}:00`)}
-            />
+            <div className="h-full w-full cursor-pointer hover:bg-muted/30" />
           </DroppableSlot>
         ))}
+
+        {/* Drag-to-create ghost */}
+        {dragHandler.dragRange && dragHeight > 0 && (
+          <div
+            className="pointer-events-none absolute left-1 right-1 z-30 rounded-sm bg-primary/30 ring-2 ring-primary/60"
+            style={{
+              top: `${dragTop}px`,
+              height: `${Math.max(dragHeight, 4)}px`,
+            }}
+          />
+        )}
 
         {/* Current time line */}
         {isToday && currentLineTop > 0 && currentLineTop < HOURS.length * 60 && (

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -1,7 +1,8 @@
 // @ts-nocheck
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { DraggableAppointment } from "./draggable-appointment";
 import { DroppableSlot } from "./droppable-slot";
+import { useDragToCreate } from "./use-drag-to-create";
 
 interface Appointment {
   _id: string;
@@ -18,6 +19,7 @@ interface CalendarWeekViewProps {
   weekStart: string; // Monday YYYY-MM-DD
   appointments: Appointment[];
   onSlotClick?: (date: string, time: string) => void;
+  onSlotDragSelect?: (date: string, startTime: string, endTime: string) => void;
   onAppointmentClick?: (id: string) => void;
   onDayHeaderClick?: (date: string) => void;
   selectedDate?: string;
@@ -110,7 +112,159 @@ function layoutDayAppointments(appts: Appointment[]): LayoutedAppointment[] {
   return result;
 }
 
-export function CalendarWeekView({ weekStart, appointments, onSlotClick, onAppointmentClick, onDayHeaderClick, selectedDate, employeeSchedules }: CalendarWeekViewProps) {
+interface WeekDayColumnProps {
+  date: string;
+  dayIndex: number;
+  isToday: boolean;
+  isSelected: boolean;
+  layouts: LayoutedAppointment[];
+  schedule?: { startTime: string; endTime: string; breakStart?: string; breakEnd?: string };
+  onSlotClick?: (date: string, time: string) => void;
+  onSlotDragSelect?: (date: string, startTime: string, endTime: string) => void;
+  onAppointmentClick?: (id: string) => void;
+  onDayHeaderClick?: (date: string) => void;
+}
+
+function WeekDayColumn({
+  date,
+  dayIndex,
+  isToday,
+  isSelected,
+  layouts,
+  schedule,
+  onSlotClick,
+  onSlotDragSelect,
+  onAppointmentClick,
+  onDayHeaderClick,
+}: WeekDayColumnProps) {
+  const handleClick = useCallback(
+    (time: string) => onSlotClick?.(date, time),
+    [onSlotClick, date],
+  );
+  const handleDragSelect = useCallback(
+    (startTime: string, endTime: string) =>
+      onSlotDragSelect?.(date, startTime, endTime),
+    [onSlotDragSelect, date],
+  );
+
+  const dragHandler = useDragToCreate({
+    hoursStart: 7,
+    hoursCount: HOURS.length,
+    hourHeight: 60,
+    snapMinutes: 15,
+    minDragDistance: 8,
+    onClick: handleClick,
+    onDragSelect: handleDragSelect,
+  });
+
+  const dragTop = dragHandler.dragRange
+    ? Math.min(dragHandler.dragRange.start, dragHandler.dragRange.end)
+    : 0;
+  const dragHeight = dragHandler.dragRange
+    ? Math.abs(dragHandler.dragRange.end - dragHandler.dragRange.start)
+    : 0;
+
+  return (
+    <div className="flex-1 min-w-[120px] border-r last:border-r-0">
+      {/* Day header */}
+      <div
+        className={`sticky top-0 z-10 border-b px-2 py-1 text-center text-xs font-medium ${
+          isSelected ? "bg-primary/20 ring-1 ring-inset ring-primary/30" : isToday ? "bg-primary/10" : "bg-muted/50"
+        } ${onDayHeaderClick ? "cursor-pointer hover:bg-primary/15" : ""}`}
+        onClick={() => onDayHeaderClick?.(date)}
+      >
+        <div>{DAY_LABELS[dayIndex]}</div>
+        <div className={isToday ? "font-bold text-primary" : isSelected ? "font-semibold text-primary" : "text-muted-foreground"}>
+          {date.split("-")[2]}
+        </div>
+      </div>
+
+      {/* Hour slots */}
+      <div
+        ref={dragHandler.containerRef}
+        className="relative select-none"
+        onMouseDown={dragHandler.handleMouseDown}
+      >
+        {/* Working hours background for this day */}
+        {schedule && (
+          <>
+            <div
+              className="absolute left-0 right-0 bg-primary/5 border-y border-primary/10 z-0"
+              style={{
+                top: `${timeToTop(schedule.startTime)}px`,
+                height: `${timeToTop(schedule.endTime) - timeToTop(schedule.startTime)}px`,
+              }}
+            />
+            {schedule.breakStart && schedule.breakEnd && (
+              <div
+                className="absolute left-0 right-0 bg-orange-100/50 border-y border-orange-200/50 z-0"
+                style={{
+                  top: `${timeToTop(schedule.breakStart)}px`,
+                  height: `${timeToTop(schedule.breakEnd) - timeToTop(schedule.breakStart)}px`,
+                }}
+              />
+            )}
+          </>
+        )}
+
+        {HOURS.map((h) => (
+          <DroppableSlot
+            key={h}
+            id={`${date}-${h}`}
+            date={date}
+            time={`${String(h).padStart(2, "0")}:00`}
+            className="h-[60px] border-b border-dashed border-muted"
+          >
+            <div className="h-full w-full cursor-pointer hover:bg-muted/20" />
+          </DroppableSlot>
+        ))}
+
+        {/* Drag-to-create ghost */}
+        {dragHandler.dragRange && dragHeight > 0 && (
+          <div
+            className="pointer-events-none absolute left-0.5 right-0.5 z-30 rounded-sm bg-primary/30 ring-2 ring-primary/60"
+            style={{
+              top: `${dragTop}px`,
+              height: `${Math.max(dragHeight, 4)}px`,
+            }}
+          />
+        )}
+
+        {/* Appointments — cascading stack when overlapping */}
+        {layouts.map((laid) => {
+          const appt = laid.appointment;
+          const top = timeToTop(appt.startTime);
+          const height = timeToTop(appt.endTime) - top;
+          if (top < 0 || height <= 0) return null;
+
+          const step = Math.min(24, Math.floor(75 / laid.totalColumns));
+          const leftPct = laid.column * step;
+
+          return (
+            <div
+              key={appt._id}
+              className={`absolute ${laid.column > 0 ? "shadow-md" : ""}`}
+              style={{
+                top: `${top}px`,
+                height: `${Math.max(height, 18)}px`,
+                left: `${leftPct}%`,
+                right: '2px',
+                zIndex: 10 + laid.column,
+              }}
+            >
+              <DraggableAppointment
+                {...appt}
+                onAppointmentClick={onAppointmentClick}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotDragSelect, onAppointmentClick, onDayHeaderClick, selectedDate, employeeSchedules }: CalendarWeekViewProps) {
   const dates = useMemo(() => getWeekDates(weekStart), [weekStart]);
   const now = new Date();
   const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
@@ -140,96 +294,22 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onAppoi
         const layouts = layoutsByDate.get(date) ?? [];
         const isToday = date === today;
         const isSelected = date === selectedDate;
-
-        // Get working hours for this day
-        const dayOfWeek = di; // 0=Mon, 6=Sun
-        const schedule = employeeSchedules?.get(`${dayOfWeek}`);
+        const schedule = employeeSchedules?.get(`${di}`);
 
         return (
-          <div key={date} className="flex-1 min-w-[120px] border-r last:border-r-0">
-            {/* Day header */}
-            <div
-              className={`sticky top-0 z-10 border-b px-2 py-1 text-center text-xs font-medium ${
-                isSelected ? "bg-primary/20 ring-1 ring-inset ring-primary/30" : isToday ? "bg-primary/10" : "bg-muted/50"
-              } ${onDayHeaderClick ? "cursor-pointer hover:bg-primary/15" : ""}`}
-              onClick={() => onDayHeaderClick?.(date)}
-            >
-              <div>{DAY_LABELS[di]}</div>
-              <div className={isToday ? "font-bold text-primary" : isSelected ? "font-semibold text-primary" : "text-muted-foreground"}>
-                {date.split("-")[2]}
-              </div>
-            </div>
-
-            {/* Hour slots */}
-            <div className="relative">
-              {/* Working hours background for this day */}
-              {schedule && (
-                <>
-                  <div
-                    className="absolute left-0 right-0 bg-primary/5 border-y border-primary/10 z-0"
-                    style={{
-                      top: `${timeToTop(schedule.startTime)}px`,
-                      height: `${timeToTop(schedule.endTime) - timeToTop(schedule.startTime)}px`,
-                    }}
-                  />
-                  {schedule.breakStart && schedule.breakEnd && (
-                    <div
-                      className="absolute left-0 right-0 bg-orange-100/50 border-y border-orange-200/50 z-0"
-                      style={{
-                        top: `${timeToTop(schedule.breakStart)}px`,
-                        height: `${timeToTop(schedule.breakEnd) - timeToTop(schedule.breakStart)}px`,
-                      }}
-                    />
-                  )}
-                </>
-              )}
-
-              {HOURS.map((h) => (
-                <DroppableSlot
-                  key={h}
-                  id={`${date}-${h}`}
-                  date={date}
-                  time={`${String(h).padStart(2, "0")}:00`}
-                  className="h-[60px] border-b border-dashed border-muted"
-                >
-                  <div
-                    className="h-full w-full cursor-pointer hover:bg-muted/20"
-                    onClick={() => onSlotClick?.(date, `${String(h).padStart(2, "0")}:00`)}
-                  />
-                </DroppableSlot>
-              ))}
-
-              {/* Appointments — cascading stack when overlapping */}
-              {layouts.map((laid) => {
-                const appt = laid.appointment;
-                const top = timeToTop(appt.startTime);
-                const height = timeToTop(appt.endTime) - top;
-                if (top < 0 || height <= 0) return null;
-
-                const step = Math.min(24, Math.floor(75 / laid.totalColumns));
-                const leftPct = laid.column * step;
-
-                return (
-                  <div
-                    key={appt._id}
-                    className={`absolute ${laid.column > 0 ? "shadow-md" : ""}`}
-                    style={{
-                      top: `${top}px`,
-                      height: `${Math.max(height, 18)}px`,
-                      left: `${leftPct}%`,
-                      right: '2px',
-                      zIndex: 10 + laid.column,
-                    }}
-                  >
-                    <DraggableAppointment
-                      {...appt}
-                      onAppointmentClick={onAppointmentClick}
-                    />
-                  </div>
-                );
-              })}
-            </div>
-          </div>
+          <WeekDayColumn
+            key={date}
+            date={date}
+            dayIndex={di}
+            isToday={isToday}
+            isSelected={isSelected}
+            layouts={layouts}
+            schedule={schedule}
+            onSlotClick={onSlotClick}
+            onSlotDragSelect={onSlotDragSelect}
+            onAppointmentClick={onAppointmentClick}
+            onDayHeaderClick={onDayHeaderClick}
+          />
         );
       })}
     </div>

--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -43,6 +43,7 @@ export function DraggableAppointment({
       ref={setNodeRef}
       {...listeners}
       {...attributes}
+      data-appointment-card="true"
       className={isDragging ? "opacity-50 cursor-grabbing" : "cursor-grab"}
     >
       <AppointmentCard

--- a/src/components/gabinet/calendar/use-drag-to-create.ts
+++ b/src/components/gabinet/calendar/use-drag-to-create.ts
@@ -1,0 +1,102 @@
+import { useCallback, useRef, useState } from "react";
+
+interface UseDragToCreateOptions {
+  hoursStart: number;
+  hoursCount: number;
+  hourHeight: number;
+  snapMinutes: number;
+  minDragDistance: number;
+  onClick: (time: string) => void;
+  onDragSelect: (startTime: string, endTime: string) => void;
+}
+
+export interface DragRange {
+  start: number;
+  end: number;
+}
+
+export function useDragToCreate({
+  hoursStart,
+  hoursCount,
+  hourHeight,
+  snapMinutes,
+  minDragDistance,
+  onClick,
+  onDragSelect,
+}: UseDragToCreateOptions) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [dragRange, setDragRange] = useState<DragRange | null>(null);
+
+  const yToSnappedTime = useCallback(
+    (y: number) => {
+      const totalHeight = hoursCount * hourHeight;
+      const clamped = Math.max(0, Math.min(totalHeight, y));
+      const totalMinutes =
+        Math.round(((clamped / hourHeight) * 60) / snapMinutes) * snapMinutes;
+      const h = Math.floor(totalMinutes / 60) + hoursStart;
+      const m = totalMinutes % 60;
+      return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+    },
+    [hoursStart, hoursCount, hourHeight, snapMinutes],
+  );
+
+  const yToHourTime = useCallback(
+    (y: number) => {
+      const totalHeight = hoursCount * hourHeight;
+      const clamped = Math.max(0, Math.min(totalHeight - 1, y));
+      const hour = Math.floor(clamped / hourHeight) + hoursStart;
+      return `${String(hour).padStart(2, "0")}:00`;
+    },
+    [hoursStart, hoursCount, hourHeight],
+  );
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.button !== 0) return;
+      const target = e.target as HTMLElement;
+      if (target.closest("[data-appointment-card]")) return;
+      if (!containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const startY = e.clientY - rect.top;
+      setDragRange({ start: startY, end: startY });
+
+      const handleMove = (ev: MouseEvent) => {
+        if (!containerRef.current) return;
+        const r = containerRef.current.getBoundingClientRect();
+        const y = ev.clientY - r.top;
+        setDragRange({ start: startY, end: y });
+      };
+
+      const handleUp = (ev: MouseEvent) => {
+        window.removeEventListener("mousemove", handleMove);
+        window.removeEventListener("mouseup", handleUp);
+        setDragRange(null);
+        if (!containerRef.current) return;
+        const r = containerRef.current.getBoundingClientRect();
+        const endY = ev.clientY - r.top;
+        const distance = Math.abs(endY - startY);
+        if (distance >= minDragDistance) {
+          const minY = Math.min(startY, endY);
+          const maxY = Math.max(startY, endY);
+          const startTime = yToSnappedTime(minY);
+          const endTime = yToSnappedTime(maxY);
+          if (startTime !== endTime) {
+            onDragSelect(startTime, endTime);
+            return;
+          }
+        }
+        onClick(yToHourTime(startY));
+      };
+
+      window.addEventListener("mousemove", handleMove);
+      window.addEventListener("mouseup", handleUp);
+    },
+    [minDragDistance, yToSnappedTime, yToHourTime, onClick, onDragSelect],
+  );
+
+  return {
+    containerRef,
+    dragRange,
+    handleMouseDown,
+  };
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -104,6 +104,9 @@ function GabinetCalendarPage() {
   const [createDefaultTime, setCreateDefaultTime] = useState<
     string | undefined
   >();
+  const [createDefaultEndTime, setCreateDefaultEndTime] = useState<
+    string | undefined
+  >();
 
   // Drag state
   const [activeAppointment, setActiveAppointment] = useState<{
@@ -426,9 +429,21 @@ function GabinetCalendarPage() {
         setCreateDefaultDate(formatDateStr(currentDate));
         setCreateDefaultTime(dateOrTime);
       }
+      setCreateDefaultEndTime(undefined);
       setCreateDialogOpen(true);
     },
     [currentDate],
+  );
+
+  // Drag-to-create handler (sets both start and end time)
+  const handleSlotDragSelect = useCallback(
+    (date: string, startTime: string, endTime: string) => {
+      setCreateDefaultDate(date);
+      setCreateDefaultTime(startTime);
+      setCreateDefaultEndTime(endTime);
+      setCreateDialogOpen(true);
+    },
+    [],
   );
 
   const handleDayClick = useCallback((date: string) => {
@@ -643,6 +658,7 @@ function GabinetCalendarPage() {
                 onClick={() => {
                   setCreateDefaultDate(formatDateStr(currentDate));
                   setCreateDefaultTime(undefined);
+                  setCreateDefaultEndTime(undefined);
                   setCreateDialogOpen(true);
                 }}
               >
@@ -805,6 +821,7 @@ function GabinetCalendarPage() {
               onSlotClick={(time) =>
                 handleSlotClick(formatDateStr(currentDate), time)
               }
+              onSlotDragSelect={handleSlotDragSelect}
               onAppointmentClick={handleAppointmentClick}
               workingHours={dayWorkingHours}
             />
@@ -814,6 +831,7 @@ function GabinetCalendarPage() {
               weekStart={formatDateStr(getMonday(currentDate))}
               appointments={viewAppointments}
               onSlotClick={handleSlotClick}
+              onSlotDragSelect={handleSlotDragSelect}
               onAppointmentClick={handleAppointmentClick}
               onDayHeaderClick={handleDayClick}
               selectedDate={formatDateStr(currentDate)}
@@ -838,6 +856,7 @@ function GabinetCalendarPage() {
           onOpenChange={setCreateDialogOpen}
           defaultDate={createDefaultDate}
           defaultTime={createDefaultTime}
+          defaultEndTime={createDefaultEndTime}
         />
       </div>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #14.

Closes #14

---

## Claude summary

Implemented drag-to-create on the gabinet calendar. Click-and-drag across time slots in day/week views now opens the appointment dialog with both `defaultDate`/`defaultTime` and a new `defaultEndTime` pre-filled. Single clicks still open the dialog at the clicked hour. Mousedowns on existing appointment cards are skipped (via a `data-appointment-card` marker) so dnd-kit's move and the click-to-navigate behavior remain intact.

Files changed:
- `src/components/gabinet/calendar/use-drag-to-create.ts` — new hook handling mousedown/move/up, snapping to 15-min increments, click vs drag dispatch
- `src/components/gabinet/calendar/calendar-day-view.tsx` — wired hook + ghost overlay
- `src/components/gabinet/calendar/calendar-week-view.tsx` — extracted `WeekDayColumn` so the hook can run per day
- `src/components/gabinet/calendar/draggable-appointment.tsx` — added `data-appointment-card` marker
- `src/components/gabinet/calendar/appointment-dialog.tsx` — new `defaultEndTime` prop wired into `selectedSlot.end`
- `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx` — added `handleSlotDragSelect` and threaded `createDefaultEndTime` through

Verified: typecheck shows no new errors in changed files (only pre-existing issues), eslint clean on new files. Committed as `c12ac13` on `claude/issue-14`.