### PR TITLE
W oknie dodawania klienta, pole telefon jest obowiązkowe i brakuje gwiazdki

### DIFF
--- a/src/components/forms/patient-form.tsx
+++ b/src/components/forms/patient-form.tsx
@@ -150,11 +150,14 @@ export function PatientForm({
           />
         </div>
         <div className="space-y-1.5">
-          <Label>{t("common.phone")}</Label>
+          <Label>
+            {t("common.phone")} <span className="text-destructive">*</span>
+          </Label>
           <Input
             type="tel"
             value={phone}
             onChange={(e) => setPhone(e.target.value)}
+            required
           />
         </div>
         <div className="space-y-1.5">
@@ -284,7 +287,7 @@ export function PatientForm({
         <Button type="button" variant="outline" onClick={onCancel}>
           {t("common.cancel")}
         </Button>
-        <Button type="submit" disabled={!firstName.trim() || !lastName.trim() || !email.trim() || isSubmitting}>
+        <Button type="submit" disabled={!firstName.trim() || !lastName.trim() || !email.trim() || !phone.trim() || isSubmitting}>
           {isSubmitting
             ? t("common.saving")
             : initialData


### PR DESCRIPTION
Auto-generated by Claude in response to issue #15.

Closes #15

---

## Claude summary

Fix committed on `claude/issue-15`.

The issue reported that in the "Nowy klient" (new patient) dialog opened from the calendar, the phone field was effectively required but the label was missing the asterisk that other required fields (first name, last name, email) had.

The fix in `src/components/forms/patient-form.tsx`: added the red asterisk to the phone label, the `required` attribute on the input, and included phone in the submit-disabled check — so the field is now visually and behaviorally consistent with the other required fields. The Supabase schema (`phone TEXT` nullable) and Convex action (`v.optional(v.string())`) still accept null, so this is a frontend-only constraint enforcing that the user fills it in via the UI.