### PR TITLE
błąd przy zapraszaniu

### DIFF
--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -5,6 +5,9 @@ import { v } from "convex/values";
 import { verifyOrgAccess, requireOrgAdmin, requireUser } from "./_helpers/auth";
 import { checkSeatLimit } from "./_helpers/seatLimits";
 import { orgRoleValidator } from "@cvx/schema";
+import { logActivity } from "./_helpers/activities";
+import { logAudit } from "./auditLog";
+import { createNotificationDirect } from "./notifications";
 
 export const listPending = query({
   args: { organizationId: v.id("organizations") },
@@ -152,7 +155,6 @@ export const _createInternal = internalMutation({
       updatedAt: now,
     });
 
-    const { logActivity } = await import("./_helpers/activities");
     await logActivity(ctx, {
       organizationId: args.organizationId,
       entityType: "organization",
@@ -162,7 +164,6 @@ export const _createInternal = internalMutation({
       performedBy: user._id,
     });
 
-    const { logAudit } = await import("./auditLog");
     await logAudit(ctx, {
       organizationId: args.organizationId,
       userId: user._id,
@@ -229,7 +230,6 @@ export const _acceptInternal = internalMutation({
       updatedAt: Date.now(),
     });
 
-    const { logActivity } = await import("./_helpers/activities");
     await logActivity(ctx, {
       organizationId: invitation.organizationId,
       entityType: "organization",
@@ -239,7 +239,6 @@ export const _acceptInternal = internalMutation({
       performedBy: user._id,
     });
 
-    const { logAudit } = await import("./auditLog");
     await logAudit(ctx, {
       organizationId: invitation.organizationId,
       userId: user._id,
@@ -250,7 +249,6 @@ export const _acceptInternal = internalMutation({
     });
 
     // Notify org owner
-    const { createNotificationDirect } = await import("./notifications");
     const org = await ctx.db.get(invitation.organizationId);
     if (org && org.ownerId !== user._id) {
       await createNotificationDirect(ctx, {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #19.

Closes #19

---

## Claude summary

Committed.

Root cause: `convex/invitations.ts` used `await import(...)` inside the `_createInternal` and `_acceptInternal` internalMutations. Convex's V8 mutation/query runtime doesn't support dynamic `import()`, which produced the production error `Uncaught TypeError: dynamic module import unsupported` at `invitations.ts:155` when a user clicked invite on the team settings page.

Fix: hoisted `logActivity`, `logAudit`, and `createNotificationDirect` to static top-level imports. The exported symbols already exist in their respective modules, and the modules don't have circular dependencies on `invitations.ts`.

Note: the same anti-pattern exists in several other Convex files (`organizations.ts`, `pipelines.ts`, `resourceInvites.ts`, `payments.ts`, `scheduledActivities.ts`, etc.). Whether they fail likely depends on whether the call site is an action (Node runtime, dynamic imports allowed) or a mutation/query (V8, not allowed). This commit only addresses the invitations flow reported in #19; a sweep across the rest is out of scope.