### PR TITLE
Replace dynamic imports with static in convex/organizations.ts

### DIFF
--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -4,6 +4,7 @@ import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
 import { requireUser, verifyOrgAccess, requireOrgAdmin } from "./_helpers/auth";
 import { checkSeatLimit } from "./_helpers/seatLimits";
+import { logActivity } from "./_helpers/activities";
 import { orgRoleValidator } from "@cvx/schema";
 
 // organizations and teamMemberships are AUTH tables — STAY in Convex DB.
@@ -80,7 +81,6 @@ export const _createOrgInternal = internalMutation({
       joinedAt: now,
     });
 
-    const { logActivity } = await import("./_helpers/activities");
     await logActivity(ctx, {
       organizationId: orgId,
       entityType: "organization",
@@ -189,7 +189,6 @@ export const _updateOrgInternal = internalMutation({
 
     await ctx.db.patch(organizationId, { ...updates, updatedAt: Date.now() });
 
-    const { logActivity } = await import("./_helpers/activities");
     await logActivity(ctx, {
       organizationId,
       entityType: "organization",
@@ -281,7 +280,6 @@ export const _inviteMemberInternal = internalMutation({
       joinedAt: Date.now(),
     });
 
-    const { logActivity } = await import("./_helpers/activities");
     await logActivity(ctx, {
       organizationId: args.organizationId,
       entityType: "organization",
@@ -330,7 +328,6 @@ export const _updateMemberRoleInternal = internalMutation({
 
     await ctx.db.patch(args.membershipId, { role: args.role });
 
-    const { logActivity } = await import("./_helpers/activities");
     await logActivity(ctx, {
       organizationId: args.organizationId,
       entityType: "organization",
@@ -374,7 +371,6 @@ export const _removeMemberInternal = internalMutation({
 
     await ctx.db.delete(args.membershipId);
 
-    const { logActivity } = await import("./_helpers/activities");
     await logActivity(ctx, {
       organizationId: args.organizationId,
       entityType: "organization",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #24.

Closes #24

---

## Claude summary

Hoisted the 5 dynamic `await import("./_helpers/activities")` calls inside `_createOrgInternal`, `_updateOrgInternal`, `_inviteMemberInternal`, `_updateMemberRoleInternal`, and `_removeMemberInternal` to a single static top-level import — same fix pattern as PR #23. All 5 sites are `internalMutation`s, so they ran in the V8 runtime and would have thrown "dynamic module import unsupported" when their respective activity-log branch fired in production. Committed as `73c2149`.

Verified the typecheck output for `convex/organizations.ts` is identical before and after (pre-existing self-referential `any` warnings on `create`/`inviteMember` actions, unrelated to this change).

## Follow-ups
- Audit remaining convex/ files for dynamic imports inside mutations/queries: grep `await import(` across `convex/` to confirm no other V8 runtime hazards remain after #19, #23, #24.
- Add type annotations to recursive Convex actions in convex/organizations.ts: `create`, `update`, `inviteMember`, `updateMemberRole`, `removeMember` produce TS7022/7023 errors due to action→internalMutation self-reference; explicit return types would fix.