### PR TITLE
Replace dynamic imports with static in convex/pipelines.ts

### DIFF
--- a/convex/pipelines.ts
+++ b/convex/pipelines.ts
@@ -2,14 +2,15 @@ import { query, action, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
+import { verifyOrgAccess } from "./_helpers/auth";
+import { checkPermission } from "./_helpers/permissions";
+import { logActivity } from "./_helpers/activities";
 
 // ── Queries (unchanged — still read from Convex) ────────────────────────────
 
 export const list = query({
   args: { organizationId: v.id("organizations") },
   handler: async (ctx, args) => {
-    const { verifyOrgAccess } = await import("./_helpers/auth");
-    const { checkPermission } = await import("./_helpers/permissions");
     const { user } = await verifyOrgAccess(ctx, args.organizationId);
     const perm = await checkPermission(ctx, args.organizationId, "pipelines", "view");
     if (!perm.allowed) throw new Error("Permission denied");
@@ -30,8 +31,6 @@ export const getById = query({
     pipelineId: v.id("pipelines"),
   },
   handler: async (ctx, args) => {
-    const { verifyOrgAccess } = await import("./_helpers/auth");
-    const { checkPermission } = await import("./_helpers/permissions");
     const { user } = await verifyOrgAccess(ctx, args.organizationId);
     const perm = await checkPermission(ctx, args.organizationId, "pipelines", "view");
     if (!perm.allowed) throw new Error("Permission denied");
@@ -52,8 +51,6 @@ export const getStages = query({
     pipelineId: v.id("pipelines"),
   },
   handler: async (ctx, args) => {
-    const { verifyOrgAccess } = await import("./_helpers/auth");
-    const { checkPermission } = await import("./_helpers/permissions");
     await verifyOrgAccess(ctx, args.organizationId);
     const perm = await checkPermission(ctx, args.organizationId, "pipelines", "view");
     if (!perm.allowed) throw new Error("Permission denied");
@@ -67,8 +64,6 @@ export const getStages = query({
 export const getAllStages = query({
   args: { organizationId: v.id("organizations") },
   handler: async (ctx, args) => {
-    const { verifyOrgAccess } = await import("./_helpers/auth");
-    const { checkPermission } = await import("./_helpers/permissions");
     await verifyOrgAccess(ctx, args.organizationId);
     const perm = await checkPermission(ctx, args.organizationId, "pipelines", "view");
     if (!perm.allowed) throw new Error("Permission denied");
@@ -102,7 +97,6 @@ export const _sideEffects = internalMutation({
     leadIds: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
-    const { logActivity } = await import("./_helpers/activities");
     const userId = args.userId as any;
 
     if (args.type === "pipeline_created" && args.pipelineId) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #25.

Closes #25

---

## Claude summary

Committed as `cc303d9`. Hoisted `verifyOrgAccess`, `checkPermission`, and `logActivity` to top-level static imports in `convex/pipelines.ts`, removing 5 dynamic `await import(...)` calls inside 4 queries and 1 internal mutation. Same pattern as PR #23 and #30. Could not run typecheck — no `node_modules` in this worktree — but the change is mechanical (3-line static import + deletion of dynamic ones).

## Follow-ups
- Replace dynamic imports with static in convex/payments.ts: `_createPaymentSideEffects`, `_markPaidSideEffects`, and `_refundSideEffects` internal mutations dynamically import `./auditLog` and `./_helpers/activities` — same V8 bug as #25
- Replace dynamic imports with static in convex/resourceInvites.ts: `_createSideEffects` and `_revokeSideEffects` internal mutations dynamically import helpers — same V8 bug as #25
- Replace dynamic imports with static in convex/scheduledActivities.ts: internal mutations at lines 26-27, 70-71, 113 use dynamic imports — same V8 bug as #25
- Replace dynamic imports with static in convex/documents/templates.ts: `listByCategory` and `listDocumentTemplates` queries dynamically import `../_helpers/auth` — same V8 bug as #25
- Replace dynamic imports with static in convex/documentDataSources.ts: `resolveSourceValues` query at line 185 dynamically imports `@cvx/auth` — same V8 bug as #25
- Replace dynamic imports with static in convex/gabinet/appointmentReminders.ts: internal mutations at lines 107, 125 use dynamic imports — same V8 bug as #25
- Replace dynamic imports with static in convex/gabinet/packages.ts: internal mutations use dynamic imports at lines 166, 383, 547 — same V8 bug as #25
- Replace dynamic imports with static in convex/gabinet/patientAuth.ts: `_sendOtpEmail` internal mutation dynamically imports helpers at lines 136-137 — same V8 bug as #25