### PR TITLE
Replace dynamic imports with static in convex/resourceInvites.ts

### DIFF
--- a/convex/resourceInvites.ts
+++ b/convex/resourceInvites.ts
@@ -3,6 +3,8 @@ import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
 import { verifyOrgAccess } from "./_helpers/auth";
+import { createNotificationDirect } from "./notifications";
+import { logAudit } from "./auditLog";
 
 export const listByResource = query({
   args: {
@@ -165,9 +167,6 @@ export const _createSideEffects = internalMutation({
     accessLevel: v.string(),
   },
   handler: async (ctx, args) => {
-    const { createNotificationDirect } = await import("./notifications");
-    const { logAudit } = await import("./auditLog");
-
     const org = await ctx.db.get(args.organizationId);
     if (org) {
       await createNotificationDirect(ctx, {
@@ -200,7 +199,6 @@ export const _revokeSideEffects = internalMutation({
     resourceId: v.string(),
   },
   handler: async (ctx, args) => {
-    const { logAudit } = await import("./auditLog");
     await logAudit(ctx, {
       organizationId: args.organizationId,
       userId: args.userId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #26.

Closes #26

---

## Claude summary

Done. Hoisted the two dynamic imports (`createNotificationDirect`, `logAudit`) from inside `_createSideEffects` and `_revokeSideEffects` (both `internalMutation` — V8 runtime) to top-level static imports, matching the fixes from #23/#30/#33.

## Follow-ups
- Replace dynamic imports with static in convex/scheduledActivities.ts: `_createSideEffects`, `_updateSideEffects`, and `_deleteSideEffects` (all internalMutation, V8) dynamically import `logActivity` and `createNotificationDirect` — same anti-pattern, will fail in production.
- Replace dynamic imports with static in convex/payments.ts: `_createPaymentSideEffects`, `_markPaidSideEffects`, and `_refundSideEffects` (all internalMutation, V8) dynamically import `logActivity`/`logAudit` — same anti-pattern.
- Replace dynamic imports with static in convex/gabinet/packages.ts: `_createSideEffects`, `_purchaseSideEffects`, and `_batchUsageSideEffects` (all internalMutation, V8) dynamically import `logActivity` and `publishActivityEnvelope`.
- Replace dynamic imports with static in convex/gabinet/appointmentReminders.ts: `_scheduleReminderSideEffects`, `sendReminder`, `scheduleReminderInternal` (internalMutation, V8) and `listByAppointment` (query, V8) all dynamically import `createSupabaseDb` / `verifyOrgAccess`.
- Replace dynamic imports with static in convex/gabinet/patientAuth.ts: `_sendOtpEmail` (internalMutation, V8) dynamically imports `sendEmail` and `AUTH_RESEND_KEY` from `@cvx/email` and `@cvx/env`.
- Replace dynamic imports with static in convex/documents/templates.ts: `listByCategory` and `listDocumentTemplates` (both query, V8) dynamically import `verifyOrgAccess`.
- Replace dynamic import with static in convex/documentDataSources.ts: `resolveSourceValues` (query, V8) dynamically imports `@cvx/auth` to resolve userId.