### PR TITLE
Cut off and overlapping date display on dashboard.

### DIFF
--- a/src/components/layout/app-footer.tsx
+++ b/src/components/layout/app-footer.tsx
@@ -126,7 +126,7 @@ export function AppFooter() {
     <footer className="bg-card sticky bottom-0 z-40 border-t">
       <div className="flex items-center justify-between gap-3 px-4 py-2 sm:px-6">
         <div className="flex items-center gap-2 max-sm:hidden">
-          <p className="text-muted-foreground text-xs text-balance">
+          <p className="text-muted-foreground text-xs whitespace-nowrap">
             {`© ${new Date().getFullYear()}`}
           </p>
           <LanguageSwitcher />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #29.

Closes #29

---

## Claude summary

Fixed and committed.

The dashboard footer was rendering `© 2026` as two stacked lines (`©` on top, `2026` below). The cause was `text-balance` (CSS `text-wrap: balance`) on the very short copyright string in `src/components/layout/app-footer.tsx:129` — the balance algorithm split it into two "balanced" lines. Swapped for `whitespace-nowrap` so the copyright stays on a single line.

## Follow-ups
- Investigate large empty space below dashboard content on /dashboard/gabinet: screenshot 2 shows a tall blank gap between footer and viewport bottom; likely a min-height on the page wrapper or sticky-footer layout interaction worth checking.