### PR TITLE
Audit remaining convex/ files for dynamic imports inside mutations/queries

### DIFF
--- a/convex/documentDataSources.ts
+++ b/convex/documentDataSources.ts
@@ -16,6 +16,7 @@ import { query } from "./_generated/server";
 import { v } from "convex/values";
 import type { GenericQueryCtx } from "convex/server";
 import type { DataModel } from "./_generated/dataModel";
+import { auth } from "@cvx/auth";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -182,7 +183,7 @@ export const resolveSourceValues = query({
     sources: v.any(), // Record<string, string | null>
   },
   handler: async (ctx, args) => {
-    const userId = await (await import("@cvx/auth")).auth.getUserId(ctx);
+    const userId = await auth.getUserId(ctx);
     if (!userId) return {};
 
     const rctx: DataSourceResolverContext = {

--- a/convex/documents/templates.ts
+++ b/convex/documents/templates.ts
@@ -2,6 +2,7 @@ import { query, action, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { v } from "convex/values";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
+import { verifyOrgAccess } from "../_helpers/auth";
 import { formCategoryValidator } from "../schema/documents";
 
 // Dual-write refs removed — Supabase is now primary for template writes
@@ -43,7 +44,6 @@ export const listByCategory = query({
     category: formCategoryValidator,
   },
   handler: async (ctx, args) => {
-    const { verifyOrgAccess } = await import("../_helpers/auth");
     await verifyOrgAccess(ctx, args.organizationId);
     return await ctx.db
       .query("formTemplates")
@@ -81,7 +81,6 @@ export const listDocumentTemplates = query({
     organizationId: v.id("organizations"),
   },
   handler: async (ctx, args) => {
-    const { verifyOrgAccess } = await import("../_helpers/auth");
     await verifyOrgAccess(ctx, args.organizationId);
     const all = await ctx.db
       .query("formTemplates")

--- a/convex/gabinet/appointmentReminders.ts
+++ b/convex/gabinet/appointmentReminders.ts
@@ -2,6 +2,7 @@ import { query, action, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
+import { verifyOrgAccess } from "../_helpers/auth";
 import { checkPermission } from "../_helpers/permissions";
 import { createNotificationDirect } from "../notifications";
 import { Id } from "../_generated/dataModel";
@@ -104,8 +105,7 @@ export const _scheduleReminderSideEffects = internalMutation({
     );
 
     // Store scheduled function ID in Supabase so we can cancel if needed
-    const { createSupabaseDb: createDb } = await import("../_helpers/supabaseDb");
-    const db = createDb();
+    const db = createSupabaseDb();
     await db.patch("appointmentReminders", args.reminderId, {
       scheduledFunctionId: scheduledId as unknown as string,
     });
@@ -122,8 +122,7 @@ export const sendReminder = internalMutation({
     reminderId: v.string(),
   },
   handler: async (ctx, args) => {
-    const { createSupabaseDb: createDb } = await import("../_helpers/supabaseDb");
-    const db = createDb();
+    const db = createSupabaseDb();
 
     const reminder = await db.get("appointmentReminders", args.reminderId);
     if (!reminder) return;
@@ -317,8 +316,7 @@ export const scheduleReminderInternal = internalMutation({
     appointmentId: v.string(),
   },
   handler: async (ctx, args) => {
-    const { createSupabaseDb: createDb } = await import("../_helpers/supabaseDb");
-    const db = createDb();
+    const db = createSupabaseDb();
 
     const appointment = await db.get("gabinetAppointments", args.appointmentId);
     if (!appointment) return null;
@@ -406,7 +404,6 @@ export const listByAppointment = query({
     appointmentId: v.string(),
   },
   handler: async (ctx, args) => {
-    const { verifyOrgAccess } = await import("../_helpers/auth");
     await verifyOrgAccess(ctx, args.organizationId);
     const perm = await checkPermission(
       ctx,

--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -5,6 +5,8 @@ import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { verifyOrgAccess } from "../_helpers/auth";
 import { checkPermission } from "../_helpers/permissions";
+import { logActivity } from "../_helpers/activities";
+import { publishActivityEnvelope } from "../_helpers/activityEnvelope";
 import { Id } from "../_generated/dataModel";
 
 // Dual-write refs removed — Supabase is now primary for package writes
@@ -163,7 +165,6 @@ export const _createSideEffects = internalMutation({
     createdBy: v.string(),
   },
   handler: async (ctx, args) => {
-    const { logActivity } = await import("../_helpers/activities");
     await logActivity(ctx, {
       organizationId: args.organizationId,
       entityType: "gabinetPackage",
@@ -380,7 +381,6 @@ export const _purchaseSideEffects = internalMutation({
     createdAt: v.number(),
   },
   handler: async (ctx, args) => {
-    const { publishActivityEnvelope } = await import("../_helpers/activityEnvelope");
     await publishActivityEnvelope(ctx, {
       organizationId: args.organizationId,
       action: "package_assigned",
@@ -544,7 +544,6 @@ export const _batchUsageSideEffects = internalMutation({
     createdBy: v.string(),
   },
   handler: async (ctx, args) => {
-    const { logActivity } = await import("../_helpers/activities");
     const pkg = await ctx.db.get(args.packageId as Id<"gabinetTreatmentPackages">);
     await logActivity(ctx, {
       organizationId: args.organizationId,

--- a/convex/gabinet/patientAuth.ts
+++ b/convex/gabinet/patientAuth.ts
@@ -3,6 +3,8 @@ import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
 import { Id } from "../_generated/dataModel";
+import { sendEmail } from "@cvx/email";
+import { AUTH_RESEND_KEY } from "@cvx/env";
 
 // ---------------------------------------------------------------------------
 // Crypto helpers
@@ -133,9 +135,6 @@ export const _sendOtpEmail = internalMutation({
     otp: v.string(),
   },
   handler: async (ctx, args) => {
-    const { sendEmail } = await import("@cvx/email");
-    const { AUTH_RESEND_KEY } = await import("@cvx/env");
-
     if (AUTH_RESEND_KEY) {
       const org = await ctx.db.get(args.organizationId);
       const orgName = org?.name ?? "Portal Klienta";


### PR DESCRIPTION
Auto-generated by Claude in response to issue #31.

Closes #31

---

## Claude summary

Audited `convex/` for `await import(` and replaced 11 V8-runtime hazards across 5 files (1 query in `documentDataSources`, 2 queries in `documents/templates`, 4 mutations + 1 query in `gabinet/appointmentReminders`, 1 mutation in `gabinet/patientAuth`, 3 mutations in `gabinet/packages`). All hoisted to top-level static imports. Pre-existing typecheck errors are unchanged; my edits don't add new ones. Committed as `c712951`.

Remaining `await import(...)` call sites are inside `action` handlers (V8 by default, also unsafe), but they're outside this issue's scope. Captured below.

## Follow-ups
- Replace dynamic imports with static in `convex/documents/generate.ts`: `resolveScopeSupabase` is dynamically imported in `resolveEntityScope` and `previewDocumentData` actions; same V8 hazard.
- Replace dynamic imports with static in `convex/gabinet/scheduling.ts`: `getAvailableSlotsSupabase` dynamically imported in `findNextAvailableSlot` action; same V8 hazard.
- Replace dynamic imports with static in `convex/gabinet/patientPortal.ts`: `_availability_supabase` helpers dynamically imported in `getPublicAvailableSlots` and `bookFromPortal` actions; same V8 hazard.
- Make `convex/mailProviders.testConnection` a Node action: it dynamically imports `"use node"` mail adapters (mailgun/google/microsoft) which can't be statically imported from a V8 file. Move the action into a `"use node"` file (or have it `ctx.runAction` into one) so the adapters load at bundle time.