### PR TITLE
Add type annotations to recursive Convex actions in convex/organizations.ts

### DIFF
--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -6,6 +6,7 @@ import { requireUser, verifyOrgAccess, requireOrgAdmin } from "./_helpers/auth";
 import { checkSeatLimit } from "./_helpers/seatLimits";
 import { logActivity } from "./_helpers/activities";
 import { orgRoleValidator } from "@cvx/schema";
+import type { Id } from "./_generated/dataModel";
 
 // organizations and teamMemberships are AUTH tables — STAY in Convex DB.
 // Supabase gets a copy for analytics/reporting.
@@ -17,9 +18,9 @@ export const create = action({
     logo: v.optional(v.string()),
     website: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<string> => {
     // Create org and membership in Convex DB (auth tables)
-    const orgId = await ctx.runMutation(internal.organizations._createOrgInternal, {
+    const orgId: string = await ctx.runMutation(internal.organizations._createOrgInternal, {
       name: args.name,
       slug: args.slug,
       logo: args.logo,
@@ -138,7 +139,7 @@ export const update = action({
     logo: v.optional(v.string()),
     website: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<Id<"organizations">> => {
     // Update in Convex DB (auth table)
     await ctx.runMutation(internal.organizations._updateOrgInternal, {
       organizationId: args.organizationId,
@@ -233,8 +234,8 @@ export const inviteMember = action({
     userId: v.string(),
     role: orgRoleValidator,
   },
-  handler: async (ctx, args) => {
-    const membershipId = await ctx.runMutation(
+  handler: async (ctx, args): Promise<string> => {
+    const membershipId: string = await ctx.runMutation(
       internal.organizations._inviteMemberInternal,
       {
         organizationId: args.organizationId,
@@ -299,7 +300,7 @@ export const updateMemberRole = action({
     membershipId: v.string(),
     role: orgRoleValidator,
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<string> => {
     await ctx.runMutation(internal.organizations._updateMemberRoleInternal, {
       organizationId: args.organizationId,
       membershipId: args.membershipId as any,
@@ -344,7 +345,7 @@ export const removeMember = action({
     organizationId: v.id("organizations"),
     membershipId: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<string> => {
     await ctx.runMutation(internal.organizations._removeMemberInternal, {
       organizationId: args.organizationId,
       membershipId: args.membershipId as any,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #32.

Closes #32

---

## Claude summary

Committed. Summary:

Added explicit return-type annotations (`Promise<string>` / `Promise<Id<"organizations">>`) to the 5 actions in `convex/organizations.ts` that call `ctx.runMutation(internal.organizations._xxx, ...)`. This breaks the action ↔ internal-mutation circular type inference that was triggering TS7022/7023. Verified with `tsc -p convex/tsconfig.json`: errors in `organizations.ts` are gone, and the cascading errors elsewhere drop from 651 → 223 across the convex project.

## Follow-ups
- Add return-type annotations to recursive actions in convex/invitations.ts: same TS7022/7023 cycle on `create` and `accept` (lines 65, 181)
- Add return-type annotations to recursive actions in convex/notifications.ts: same TS7022/7023 cycle on `markAllRead` (line 69)
- Add return-type annotations to recursive actions in convex/documentInstances.ts: same TS7022/7023 cycle on `create` and `generateUploadUrl` (lines 106, 447)
- Add return-type annotations to recursive actions in convex/supabase/backfill.ts: same TS7022/7023 cycle on `backfillSinglePatient`, `backfillSingleTreatment`, `backfillAll` (lines 76, 159, 469)