### PR TITLE
Replace dynamic imports with static in `convex/documents/generate.ts`

### DIFF
--- a/convex/documents/generate.ts
+++ b/convex/documents/generate.ts
@@ -4,6 +4,7 @@ import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { verifyOrgAccess } from "../_helpers/auth";
 import { resolveScope, EntityType } from "./scopeResolver";
+import { resolveScopeSupabase } from "./scopeResolver_supabase";
 import { resolveComponentsInContent } from "./resolveComponents";
 import { Id } from "../_generated/dataModel";
 
@@ -25,7 +26,6 @@ export const resolveEntityScope = action({
       organizationId: args.organizationId,
     });
     const db = createSupabaseDb();
-    const { resolveScopeSupabase } = await import("./scopeResolver_supabase");
     return await resolveScopeSupabase(
       db,
       String(args.organizationId),
@@ -60,7 +60,6 @@ export const previewDocumentData = action({
     if (!template || String(template.organizationId) !== String(args.organizationId))
       throw new Error("Template not found");
 
-    const { resolveScopeSupabase } = await import("./scopeResolver_supabase");
     const scopeData = await resolveScopeSupabase(
       db,
       String(args.organizationId),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #55.

Closes #55

---

## Claude summary

Done. Replaced the two dynamic `await import("./scopeResolver_supabase")` calls in `convex/documents/generate.ts` (lines 28 and 63) with a single top-level static import, matching the pattern from #27/#28/#31. Committed as `3206a6b` on `claude/issue-55`.

Note: Couldn't run typecheck — `node_modules` is not installed in this fresh worktree. The change is a mechanical 1:1 hoist of an existing import with no functional difference, so risk is low.