### PR TITLE
Replace dynamic imports with static in `convex/gabinet/scheduling.ts`

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -6,6 +6,7 @@ import { verifyOrgAccess } from "../_helpers/auth";
 import { verifyProductAccess } from "../_helpers/products";
 import { GABINET_PRODUCT_ID } from "./_registry";
 import { gabinetLeaveTypeValidator, gabinetLeaveStatusValidator } from "../schema";
+import { getAvailableSlotsSupabase } from "./_availability_supabase";
 
 // Dual-write refs removed — Supabase is now primary for scheduling writes
 
@@ -620,7 +621,6 @@ export const findNextAvailableSlot = action({
     });
 
     const db = createSupabaseDb();
-    const { getAvailableSlotsSupabase } = await import("./_availability_supabase");
 
     const maxDays = args.maxDaysToSearch ?? 30;
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #56.

Closes #56

---

## Claude summary

Replaced the dynamic `await import("./_availability_supabase")` in `findNextAvailableSlot` with a top-level static import — same pattern as the prior fixes in #31/#54/#55. Committed as `5d19d79`.