### PR TITLE
Replace dynamic imports with static in `convex/gabinet/patientPortal.ts`

### DIFF
--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -5,6 +5,11 @@ import { v } from "convex/values";
 import { Id } from "../_generated/dataModel";
 import { validatePortalSession } from "../_helpers/portalSession";
 import { createNotificationDirect } from "../notifications";
+import {
+  getAvailableSlotsSupabase,
+  checkEmployeeQualificationSupabase,
+  checkConflictSupabase,
+} from "./_availability_supabase";
 
 // ---------------------------------------------------------------------------
 // Internal query: validate portal session via Supabase
@@ -262,7 +267,6 @@ export const getPublicAvailableSlots = action({
     }
     const organizationId = String(session.organizationId);
 
-    const { getAvailableSlotsSupabase } = await import("./_availability_supabase");
     return await getAvailableSlotsSupabase(db, {
       organizationId,
       userId: args.employeeId,
@@ -331,13 +335,9 @@ export const bookFromPortal = action({
         },
       );
 
-      const {
-        getAvailableSlotsSupabase: _slotsFn,
-      } = await import("./_availability_supabase");
-
       let foundEmployee: string | null = null;
       for (const emp of qualifiedEmployees) {
-        const slots = await _slotsFn(db, {
+        const slots = await getAvailableSlotsSupabase(db, {
           organizationId: String(organizationId),
           userId: String(emp.userId),
           date: args.preferredDate,
@@ -356,10 +356,6 @@ export const bookFromPortal = action({
     }
 
     // Verify qualification via Supabase
-    const {
-      checkEmployeeQualificationSupabase,
-      checkConflictSupabase,
-    } = await import("./_availability_supabase");
     const qualification = await checkEmployeeQualificationSupabase(db, {
       organizationId: String(organizationId),
       userId: employeeId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #57.

Closes #57

---

## Claude summary

Replaced the three dynamic `await import("./_availability_supabase")` calls in `convex/gabinet/patientPortal.ts` with a single static import at the top of the file, matching the pattern from #54/#55/#56. The `getPublicAvailableSlots` and `bookFromPortal` actions now use the hoisted imports directly, eliminating the V8 dynamic-import hazard. Committed as `6a15845`.