### PR TITLE
Make `convex/mailProviders.testConnection` a Node action

### DIFF
--- a/convex/mail/testConnectionNode.ts
+++ b/convex/mail/testConnectionNode.ts
@@ -1,0 +1,82 @@
+"use node";
+
+import { v } from "convex/values";
+import { internalAction } from "../_generated/server";
+import { createMailgunAdapter } from "./adapters/mailgun";
+import { createGoogleAdapter } from "./adapters/google";
+import { createMicrosoftAdapter } from "./adapters/microsoft";
+import type { ConnectionTestResult } from "./adapter";
+
+export const runProviderTest = internalAction({
+  args: {
+    providerType: v.union(
+      v.literal("google"),
+      v.literal("microsoft"),
+      v.literal("mailgun"),
+      v.literal("resend"),
+    ),
+    fromEmail: v.string(),
+    fromName: v.string(),
+    apiConfig: v.optional(
+      v.object({
+        apiKey: v.optional(v.string()),
+        domain: v.optional(v.string()),
+        region: v.optional(v.string()),
+      }),
+    ),
+    oauthTokens: v.optional(
+      v.object({
+        accessToken: v.string(),
+        refreshToken: v.optional(v.string()),
+        expiresAt: v.optional(v.number()),
+      }),
+    ),
+  },
+  handler: async (_ctx, args): Promise<ConnectionTestResult> => {
+    try {
+      if (args.providerType === "mailgun") {
+        const adapter = createMailgunAdapter(
+          args.apiConfig?.apiKey ?? "",
+          args.apiConfig?.domain ?? "",
+          args.fromEmail,
+          args.fromName,
+          args.apiConfig?.region ?? "us",
+        );
+        return adapter.testConnection
+          ? await adapter.testConnection()
+          : { success: true, accountEmail: args.fromEmail };
+      }
+      if (args.providerType === "google") {
+        const adapter = createGoogleAdapter(
+          args.oauthTokens?.accessToken ?? "",
+          args.oauthTokens?.refreshToken ?? "",
+          args.fromEmail,
+          args.fromName,
+          process.env.GOOGLE_CLIENT_ID ?? "",
+          process.env.GOOGLE_CLIENT_SECRET ?? "",
+          args.oauthTokens?.expiresAt ?? 0,
+        );
+        return adapter.testConnection
+          ? await adapter.testConnection()
+          : { success: true, accountEmail: args.fromEmail };
+      }
+      if (args.providerType === "microsoft") {
+        const adapter = createMicrosoftAdapter(
+          args.oauthTokens?.accessToken ?? "",
+          args.oauthTokens?.refreshToken ?? "",
+          args.fromEmail,
+          args.fromName,
+        );
+        return adapter.testConnection
+          ? await adapter.testConnection()
+          : { success: true, accountEmail: args.fromEmail };
+      }
+      // Resend has no testConnection — check that API key is present
+      return args.apiConfig?.apiKey
+        ? { success: true, accountEmail: args.fromEmail }
+        : { success: false, error: "Missing API key" };
+    } catch (err) {
+      return { success: false, error: String(err) };
+    }
+  },
+});

--- a/convex/mailProviders.ts
+++ b/convex/mailProviders.ts
@@ -292,55 +292,32 @@ export const testConnection = action({
       throw new Error("Mail provider not found");
     }
 
-    let result: { success: boolean; error?: string; accountEmail?: string };
+    const oauthTokens = provider.oauthTokens as
+      | { accessToken?: string; refreshToken?: string; expiresAt?: number }
+      | null
+      | undefined;
 
-    try {
-      if (provider.providerType === "mailgun") {
-        const { createMailgunAdapter } = await import("./mail/adapters/mailgun");
-        const adapter = createMailgunAdapter(
-          (provider.apiConfig as any)?.apiKey ?? "",
-          (provider.apiConfig as any)?.domain ?? "",
-          provider.fromEmail as string,
-          provider.fromName as string,
-          (provider.apiConfig as any)?.region ?? "us",
-        );
-        result = adapter.testConnection
-          ? await adapter.testConnection()
-          : { success: true, accountEmail: provider.fromEmail as string };
-      } else if (provider.providerType === "google") {
-        const { createGoogleAdapter } = await import("./mail/adapters/google");
-        const adapter = createGoogleAdapter(
-          (provider.oauthTokens as any)?.accessToken ?? "",
-          (provider.oauthTokens as any)?.refreshToken ?? "",
-          provider.fromEmail as string,
-          provider.fromName as string,
-          process.env.GOOGLE_CLIENT_ID ?? "",
-          process.env.GOOGLE_CLIENT_SECRET ?? "",
-          (provider.oauthTokens as any)?.expiresAt ?? 0,
-        );
-        result = adapter.testConnection
-          ? await adapter.testConnection()
-          : { success: true, accountEmail: provider.fromEmail as string };
-      } else if (provider.providerType === "microsoft") {
-        const { createMicrosoftAdapter } = await import("./mail/adapters/microsoft");
-        const adapter = createMicrosoftAdapter(
-          (provider.oauthTokens as any)?.accessToken ?? "",
-          (provider.oauthTokens as any)?.refreshToken ?? "",
-          provider.fromEmail as string,
-          provider.fromName as string,
-        );
-        result = adapter.testConnection
-          ? await adapter.testConnection()
-          : { success: true, accountEmail: provider.fromEmail as string };
-      } else {
-        // Resend has no testConnection — check that API key is present
-        result = (provider.apiConfig as any)?.apiKey
-          ? { success: true, accountEmail: provider.fromEmail as string }
-          : { success: false, error: "Missing API key" };
-      }
-    } catch (err) {
-      result = { success: false, error: String(err) };
-    }
+    const result: { success: boolean; error?: string; accountEmail?: string } =
+      await ctx.runAction(internal.mail.testConnectionNode.runProviderTest, {
+        providerType: provider.providerType as
+          | "google"
+          | "microsoft"
+          | "mailgun"
+          | "resend",
+        fromEmail: provider.fromEmail as string,
+        fromName: provider.fromName as string,
+        apiConfig: (provider.apiConfig as
+          | { apiKey?: string; domain?: string; region?: string }
+          | null
+          | undefined) ?? undefined,
+        oauthTokens: oauthTokens
+          ? {
+              accessToken: oauthTokens.accessToken ?? "",
+              refreshToken: oauthTokens.refreshToken,
+              expiresAt: oauthTokens.expiresAt,
+            }
+          : undefined,
+      });
 
     // Update provider status based on test result
     if (result.success && provider.status !== "active") {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #58.

Closes #58

---

## Claude summary

Committed as `826785b`. Summary:

The fix moves the dynamic imports of `"use node"` mail adapters out of the V8 runtime. I added `convex/mail/testConnectionNode.ts` (a `"use node"` file) containing an `internalAction` `runProviderTest` that statically imports `createMailgunAdapter`, `createGoogleAdapter`, and `createMicrosoftAdapter` and dispatches the connection test by `providerType`. The public action `mailProviders.testConnection` stays a V8 action (so the API path doesn't change and queries on the same module still work) — it does the org-access check, fetches the provider from Supabase, calls `ctx.runAction(internal.mail.testConnectionNode.runProviderTest, …)` with the relevant config, and updates the provider status based on the result. Lint and convex typecheck are clean for the changed files; the rest of the typecheck output was pre-existing unrelated errors. Couldn't run `convex codegen` here because the CLI requires Node ≥20, but the new module follows the same path-based registration as the existing `mail/*` files.