### PR TITLE
Add return-type annotations to recursive actions in convex/invitations.ts

### DIFF
--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -68,8 +68,8 @@ export const create = action({
     email: v.string(),
     role: orgRoleValidator,
   },
-  handler: async (ctx, args) => {
-    const invitationId = await ctx.runMutation(
+  handler: async (ctx, args): Promise<string> => {
+    const invitationId: string = await ctx.runMutation(
       internal.invitations._createInternal,
       {
         organizationId: args.organizationId,
@@ -180,8 +180,8 @@ export const _createInternal = internalMutation({
 // Accept needs seat limit check + creates teamMembership (auth table) — stays in Convex DB
 export const accept = action({
   args: { token: v.string() },
-  handler: async (ctx, args) => {
-    const orgId = await ctx.runMutation(
+  handler: async (ctx, args): Promise<string> => {
+    const orgId: string = await ctx.runMutation(
       internal.invitations._acceptInternal,
       { token: args.token },
     );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #60.

Closes #60

---

## Claude summary

Annotated `create` (line 65) and `accept` (line 181) handlers with `Promise<string>` and gave the local `runMutation` results explicit `string` types — same pattern as the #32 fix in `convex/organizations.ts`. Verified by re-running `tsc -p convex/tsconfig.json --noEmit`: the four TS7022/TS7023 errors on `invitations.ts` are gone (only a pre-existing unused-variable warning remains, out of scope). Committed as `40d345c`.

## Follow-ups
- Add return-type annotations to recursive actions in convex/documentInstances.ts: tsc still reports TS7022/TS7023 cycles in this file
- Add return-type annotations to recursive actions in convex/notifications.ts: tsc still reports TS7022/TS7023 cycles in this file
- Add return-type annotations to recursive actions in convex/supabase/backfill.ts: tsc still reports TS7022/TS7023 cycles in this file
- Remove dead try/catch in convex/invitations.ts create action: lines 81-88 fetch `inv` but never use it (TS6133), and the comment says the work is already done by the internal mutation — block can be deleted