### PR TITLE
Add return-type annotations to recursive actions in convex/notifications.ts

### DIFF
--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -46,7 +46,7 @@ export const markAsRead = action({
   args: {
     notificationId: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<string> => {
     const authResult = await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       // notifications are user-scoped, we pass a dummy org to verify auth
@@ -70,7 +70,7 @@ export const markAllRead = action({
   args: {
     organizationId: v.id("organizations"),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<number> => {
     const authResult = await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #61.

Closes #61

---

## Claude summary

Annotated `markAsRead` with `Promise<string>` and `markAllRead` with `Promise<number>` in `convex/notifications.ts`. Both actions reference `internal._helpers.authAction.verifyOrgAccess` and were caught in the same TS7022/7023 inference cycle as the prior fixes (#59, #73). Runtime behavior unchanged. Committed on `claude/issue-61`.