### PR TITLE
Add return-type annotations to recursive actions in convex/supabase/backfill.ts

### DIFF
--- a/convex/supabase/backfill.ts
+++ b/convex/supabase/backfill.ts
@@ -75,7 +75,7 @@ export const _getTreatment = internalQuery({
 
 export const backfillSinglePatient = internalAction({
   args: { patientId: v.string() },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<{ synced: number; errors: string[] }> => {
     const p = await ctx.runQuery(internal.supabase.backfill._getPatient, {
       patientId: args.patientId,
     });
@@ -158,7 +158,7 @@ export const backfillSinglePatient = internalAction({
 
 export const backfillSingleTreatment = internalAction({
   args: { treatmentId: v.string() },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<{ synced: number; errors: string[] }> => {
     const t = await ctx.runQuery(internal.supabase.backfill._getTreatment, {
       treatmentId: args.treatmentId,
     });
@@ -468,7 +468,17 @@ export const backfillEmployees = internalAction({
 
 export const backfillAll = internalAction({
   args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    users: number;
+    patients: number;
+    treatments: number;
+    employees: number;
+    appointments: number;
+    totalErrors: number;
+  }> => {
     const orgId = args.organizationId;
 
     console.info("=== BACKFILL START ===");


### PR DESCRIPTION
Auto-generated by Claude in response to issue #62.

Closes #62

---

## Claude summary

Fix committed on `claude/issue-62` as `4efe6a4`. Added return-type annotations to the three recursive `internalAction` handlers (`backfillSinglePatient`, `backfillSingleTreatment`, `backfillAll`) in `convex/supabase/backfill.ts` to break the TS7022/7023 type-inference cycle, following the same pattern used in PRs #59, #73, and #79.