### PR TITLE
zmien kolejnosc - pierwszy ma byc gabinet

### DIFF
--- a/src/modules/registry.ts
+++ b/src/modules/registry.ts
@@ -2,7 +2,7 @@ import { crmManifest } from "@/modules/crm/manifest";
 import { gabinetManifest } from "@/modules/gabinet/manifest";
 import type { ModuleManifest, ModuleId, ProductKey } from "@/modules/types";
 
-export const moduleRegistry: ModuleManifest[] = [crmManifest, gabinetManifest];
+export const moduleRegistry: ModuleManifest[] = [gabinetManifest, crmManifest];
 
 export function getModuleById(id: ModuleId) {
   return moduleRegistry.find((module) => module.id === id);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #63.

Closes #63

---

## Claude summary

Committed. Reordered `moduleRegistry` in `src/modules/registry.ts:5` so `gabinetManifest` comes before `crmManifest`. This makes Gabinet appear first in both the workspace switcher dropdown (left sidebar) and the header module switcher used in icon-only mode. Route matching uses `routeAwareModules` which sorts by `workspaceRoot` length independently, so navigation behavior is unchanged.