### PR TITLE
Pre-existing type errors in `convex/documentInstances.ts` lines 149/183/185/199/

### DIFF
--- a/convex/documentInstances.ts
+++ b/convex/documentInstances.ts
@@ -1,6 +1,7 @@
 import { query, action, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
+import type { Id } from "./_generated/dataModel";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { verifyOrgAccess } from "./_helpers/auth";
 import { resolveSource } from "./documentDataSources";
@@ -143,7 +144,7 @@ export const _createResolveAndInsert = internalMutation({
   },
   handler: async (ctx, args) => {
     const now = Date.now();
-    const templateId = args.templateId as any;
+    const templateId = args.templateId as Id<"documentTemplates">;
     const template = await ctx.db.get(templateId);
     if (!template) throw new Error("Template not found");
     if (template.status !== "active") throw new Error("Template is not active");
@@ -337,7 +338,7 @@ export const updateStatus = action({
 export const _resolveReviewerName = internalMutation({
   args: { reviewerId: v.string() },
   handler: async (ctx, args) => {
-    const reviewer = await ctx.db.get(args.reviewerId as any);
+    const reviewer = await ctx.db.get(args.reviewerId as Id<"users">);
     return reviewer?.name ?? "";
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #65.

Closes #65

---

## Claude summary

Fixed and committed.

The root cause was that the internal mutations `_createResolveAndInsert` and `_resolveReviewerName` cast their string id args via `as any` before calling `ctx.db.get()`. With `any`, Convex's type system can't narrow the result, so `ctx.db.get()` returns a union of every table's document — and accessing `status`, `content`, `signatureSlots`, `version`, `module`, or `name` fails because no single field exists on every variant.

Casting to `Id<"documentTemplates">` and `Id<"users">` instead narrows the union to the correct document shape, eliminating all six type errors at lines 149/183/185/199/205/341.

Verified via `tsc -p convex/tsconfig.json --noEmit`: those six errors are gone. Remaining errors in the file are pre-existing recursive-action `TS7022/TS7023` issues (same family as already-fixed #60/#61/#62) and an unused-variable warning, all out of scope for this issue.

## Follow-ups
- Add return-type annotations to recursive actions in convex/documentInstances.ts: same TS7022/TS7023 recursive-action pattern as #60/#61/#62, on `create` and `generateUploadUrl` actions
- Remove unused `userId` local in convex/documentInstances.ts:194: `const userId = args.userId as any;` is declared but never read