### PR TITLE
Add return-type annotations to recursive actions in convex/documentInstances.ts

### DIFF
--- a/convex/documentInstances.ts
+++ b/convex/documentInstances.ts
@@ -112,7 +112,7 @@ export const create = action({
     sources: v.any(),
     fieldOverrides: v.optional(v.any()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<string> => {
     const authResult = await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
@@ -228,7 +228,7 @@ export const updateDraft = action({
     mimeType: v.optional(v.string()),
     fileSize: v.optional(v.number()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<void> => {
     const db = createSupabaseDb();
     const instance = await db.get("documentInstances", args.id);
     if (!instance) throw new Error("Document not found");
@@ -281,7 +281,7 @@ export const updateStatus = action({
     status: statusValidator,
     assignedReviewerId: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<void> => {
     const db = createSupabaseDb();
     const instance = await db.get("documentInstances", args.id);
     if (!instance) throw new Error("Document not found");
@@ -404,7 +404,7 @@ export const createFromFile = action({
     category: v.optional(v.string()),
     module: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<string> => {
     const authResult = await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
@@ -447,7 +447,7 @@ export const createFromFile = action({
 
 export const generateUploadUrl = action({
   args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<string> => {
     await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #74.

Closes #74

---

## Claude summary

Committed as `beeade5`. Annotated the five actions in `convex/documentInstances.ts` that call `internal.documentInstances.*` recursively (`create` → `Promise<string>`, `updateDraft` → `Promise<void>`, `updateStatus` → `Promise<void>`, `createFromFile` → `Promise<string>`, `generateUploadUrl` → `Promise<string>`). Confirmed via `tsc -p convex/tsconfig.json`: the two baseline TS7022/TS7023 errors on `create` and `generateUploadUrl` are gone, no new errors introduced. Remaining tsc diagnostics in the file (TS6133 unused `userId`, TS2322 string-vs-`Id<"organizations">`) are pre-existing and out of scope for #74.