### PR TITLE
Add return-type annotations to recursive actions in convex/supabase/backfill.ts

### DIFF
--- a/convex/supabase/backfill.ts
+++ b/convex/supabase/backfill.ts
@@ -286,7 +286,7 @@ export const _listEmployees = internalQuery({
 
 export const backfillPatients = internalAction({
   args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<{ synced: number; errors: string[] }> => {
     const patients = await ctx.runQuery(
       internal.supabase.backfill._listPatients,
       { organizationId: args.organizationId },
@@ -332,7 +332,7 @@ export const backfillPatients = internalAction({
 
 export const backfillAppointments = internalAction({
   args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<{ synced: number; errors: string[] }> => {
     const appointments = await ctx.runQuery(
       internal.supabase.backfill._listAppointments,
       { organizationId: args.organizationId },
@@ -396,7 +396,7 @@ export const backfillAppointments = internalAction({
 
 export const backfillTreatments = internalAction({
   args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<{ synced: number; errors: string[] }> => {
     const treatments = await ctx.runQuery(
       internal.supabase.backfill._listTreatments,
       { organizationId: args.organizationId },
@@ -432,7 +432,7 @@ export const backfillTreatments = internalAction({
 
 export const backfillEmployees = internalAction({
   args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<{ synced: number; errors: string[] }> => {
     const employees = await ctx.runQuery(
       internal.supabase.backfill._listEmployees,
       { organizationId: args.organizationId },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #76.

Closes #76

---

## Claude summary

Committed as `07532db` on `claude/issue-76`.

Summary: Issue #62's prior fix already broke the TS7022/TS7023 cycle by annotating `backfillSinglePatient`, `backfillSingleTreatment`, and `backfillAll`. But the four sub-actions `backfillAll` calls via `ctx.runAction` (`backfillPatients`, `backfillAppointments`, `backfillTreatments`, `backfillEmployees`) still had inferred return types — fragile, since they're called through the self-referential `internal.supabase.backfill.*` API. I annotated each handler's return type as `Promise<{ synced: number; errors: string[] }>` (the shape returned by `upsertBatch`). Verified via `tsc -p convex/tsconfig.json --noEmit`: zero TS7022/TS7023 errors before and after, and the change introduced no new errors. Pre-existing TS2339 errors in this file (from `ctx.db.get(... as any)` returning a union of all tables) are unrelated to this issue's scope.

## Follow-ups
- Narrow ctx.db.get type via Id casts in convex/supabase/backfill.ts: 56 TS2339 errors caused by `ctx.db.get(args.userId as any)` returning a union of all 90+ tables in `_getUser`/`_getPatient`/`_getTreatment`; same pattern was fixed for documentInstances.ts in #65 — apply the Id cast approach here.