### PR TITLE
Remove dead try/catch in convex/invitations.ts create action

### DIFF
--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -1,6 +1,5 @@
 import { query, action, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
-import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
 import { verifyOrgAccess, requireOrgAdmin, requireUser } from "./_helpers/auth";
 import { checkSeatLimit } from "./_helpers/seatLimits";
@@ -77,15 +76,6 @@ export const create = action({
         role: args.role,
       },
     );
-
-    // Also write to Supabase
-    try {
-      const db = createSupabaseDb();
-      const inv = await db.get("invitations", invitationId);
-      // invitation already written by internal mutation + scheduler
-    } catch {
-      // best-effort
-    }
 
     return invitationId;
   },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #77.

Closes #77

---

## Claude summary

Removed the dead try/catch block (lines 81-88) in `convex/invitations.ts` `create` action and dropped the now-unused `createSupabaseDb` import. Committed on `claude/issue-77`.