### PR TITLE
Land the invitations.ts dual-write fix from PR #19 onto main

### DIFF
--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -1,5 +1,6 @@
 import { query, action, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
+import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
 import { verifyOrgAccess, requireOrgAdmin, requireUser } from "./_helpers/auth";
 import { checkSeatLimit } from "./_helpers/seatLimits";
@@ -68,16 +69,44 @@ export const create = action({
     role: orgRoleValidator,
   },
   handler: async (ctx, args): Promise<string> => {
-    const invitationId: string = await ctx.runMutation(
-      internal.invitations._createInternal,
-      {
-        organizationId: args.organizationId,
-        email: args.email,
-        role: args.role,
-      },
-    );
+    const created: {
+      invitationId: string;
+      email: string;
+      role: "admin" | "member" | "viewer" | "owner";
+      token: string;
+      status: "pending";
+      invitedBy: string;
+      expiresAt: number;
+      createdAt: number;
+      updatedAt: number;
+    } = await ctx.runMutation(internal.invitations._createInternal, {
+      organizationId: args.organizationId,
+      email: args.email,
+      role: args.role,
+    });
 
-    return invitationId;
+    // Mirror to Supabase so the team-settings page (which reads from
+    // Supabase via useSupabasePendingInvitations) sees the new pending
+    // invitation immediately. Matches the pattern used by organizations.create.
+    try {
+      const db = createSupabaseDb();
+      await db.insert("invitations", {
+        _id: created.invitationId,
+        organizationId: args.organizationId,
+        email: created.email,
+        role: created.role,
+        token: created.token,
+        status: created.status,
+        invitedBy: created.invitedBy,
+        expiresAt: created.expiresAt,
+        createdAt: created.createdAt,
+        updatedAt: created.updatedAt,
+      });
+    } catch (e) {
+      console.error("[invitations.create] Supabase mirror failed:", e);
+    }
+
+    return created.invitationId;
   },
 });
 
@@ -163,7 +192,17 @@ export const _createInternal = internalMutation({
       details: JSON.stringify({ email: args.email, role: args.role }),
     });
 
-    return String(invitationId);
+    return {
+      invitationId: String(invitationId),
+      email: args.email,
+      role: args.role,
+      token,
+      status: "pending" as const,
+      invitedBy: String(user._id),
+      expiresAt,
+      createdAt: now,
+      updatedAt: now,
+    };
   },
 });
 
@@ -291,6 +330,18 @@ export const cancel = action({
       organizationId: args.organizationId,
       invitationId: args.invitationId as any,
     });
+
+    // Mirror status change to Supabase so the team page (which reads
+    // pending invitations from Supabase) updates.
+    try {
+      const db = createSupabaseDb();
+      await db.patch("invitations", args.invitationId, {
+        status: "expired",
+        updatedAt: Date.now(),
+      });
+    } catch (e) {
+      console.error("[invitations.cancel] Supabase mirror failed:", e);
+    }
   },
 });
 
@@ -323,10 +374,26 @@ export const resend = action({
     invitationId: v.string(),
   },
   handler: async (ctx, args) => {
-    await ctx.runMutation(internal.invitations._resendInternal, {
-      organizationId: args.organizationId,
-      invitationId: args.invitationId as any,
-    });
+    const updated: { expiresAt: number; updatedAt: number } = await ctx.runMutation(
+      internal.invitations._resendInternal,
+      {
+        organizationId: args.organizationId,
+        invitationId: args.invitationId as any,
+      },
+    );
+
+    // Mirror new expiry to Supabase so any consumer reading from there
+    // sees the refreshed expiresAt.
+    try {
+      const db = createSupabaseDb();
+      await db.patch("invitations", args.invitationId, {
+        expiresAt: updated.expiresAt,
+        updatedAt: updated.updatedAt,
+      });
+    } catch (e) {
+      console.error("[invitations.resend] Supabase mirror failed:", e);
+    }
+
     return args.invitationId;
   },
 });
@@ -347,9 +414,10 @@ export const _resendInternal = internalMutation({
       throw new Error("Invitation is no longer pending");
     }
 
-    await ctx.db.patch(args.invitationId, {
-      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
-      updatedAt: Date.now(),
-    });
+    const expiresAt = Date.now() + 7 * 24 * 60 * 60 * 1000;
+    const updatedAt = Date.now();
+    await ctx.db.patch(args.invitationId, { expiresAt, updatedAt });
+
+    return { expiresAt, updatedAt };
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #83.

Closes #83

---

## Claude summary

Restored the dual-write pattern in `convex/invitations.ts`. The `create` action now mirrors new invitations to Supabase via `db.insert("invitations", ...)` (matching `organizations.create`), and `cancel`/`resend` mirror their status/expiry patches. `_createInternal` now returns the full row payload and `_resendInternal` returns the new `expiresAt`/`updatedAt` so the action wrappers stay in sync. Supabase writes are best-effort (errors logged, not thrown) so the auth-critical Convex write isn't affected by Supabase outages.

Verified: `npx tsc -p convex/tsconfig.json --noEmit` produces zero errors for `invitations.ts`. The pre-existing convex unit tests in `tests/convex/seatLimits.test.ts` cannot run in this environment (broken import path `../_generated/api` — a pre-existing infrastructure issue), but the action's external contract (returns `invitationId` string) is preserved, so behavior is unchanged for callers.

## Follow-ups
- Fix tests/convex import paths: tests reference `../_generated/api` but the Convex codegen is at `convex/_generated/api`, so `npm run test:unit` finds zero tests and any direct vitest run fails with a module-not-found error
- Update seatLimits.test.ts to use `.action()` instead of `.mutation()` for `api.invitations.create`: the create export has been an action since Phase 4 (commit 9c8eb1d), but tests still call it via `t.mutation(...)`
- Consider mirroring `accept` and `decline` invitation status changes to Supabase: currently only create/cancel/resend mirror, so accepted/declined invitations remain `status=pending` in Supabase until something else syncs them