### PR TITLE
Remove unused `userId` local in convex/documentInstances.ts

### DIFF
--- a/convex/documentInstances.ts
+++ b/convex/documentInstances.ts
@@ -191,7 +191,6 @@ export const _createResolveAndInsert = internalMutation({
     }));
 
     const db = createSupabaseDb();
-    const userId = args.userId as any;
 
     const instanceId = await db.insert("documentInstances", {
       organizationId: String(args.organizationId),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #86.

Closes #86

---

## Claude summary

Removed the unused `const userId = args.userId as any;` declaration at convex/documentInstances.ts:194 and committed as `797b453`. The `args.userId` reference is still used directly at lines 158 and 208 where it's actually needed.