### PR TITLE
Wire 'Filtruj wg roli' (openFilter) on gabinet employees page

### DIFF
--- a/src/components/crm/data-list-filter-bar.tsx
+++ b/src/components/crm/data-list-filter-bar.tsx
@@ -83,6 +83,8 @@ export interface DataListFilterBarProps {
   filterableFields?: FieldDef[];
   createDialogOpen?: boolean;
   onCreateDialogOpenChange?: (open: boolean) => void;
+  filterSlideoutOpen?: boolean;
+  onFilterSlideoutOpenChange?: (open: boolean) => void;
 
   // Search (right side)
   searchValue: string;
@@ -142,6 +144,8 @@ export function DataListFilterBar({
   filterableFields = [],
   createDialogOpen: externalCreateDialogOpen,
   onCreateDialogOpenChange,
+  filterSlideoutOpen: externalFilterSlideoutOpen,
+  onFilterSlideoutOpenChange,
   searchValue,
   onSearchChange,
   searchPlaceholder,
@@ -156,10 +160,16 @@ export function DataListFilterBar({
 }: DataListFilterBarProps) {
   const { t } = useTranslation();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const [filterSlideoutOpen, setFilterSlideoutOpen] = useState(false);
+  const [internalFilterSlideoutOpen, setInternalFilterSlideoutOpen] =
+    useState(false);
   const [internalCreateDialogOpen, setInternalCreateDialogOpen] =
     useState(false);
   const [newViewName, setNewViewName] = useState("");
+
+  const filterSlideoutOpen =
+    externalFilterSlideoutOpen ?? internalFilterSlideoutOpen;
+  const setFilterSlideoutOpen =
+    onFilterSlideoutOpenChange ?? setInternalFilterSlideoutOpen;
 
   const createDialogOpen =
     externalCreateDialogOpen ?? internalCreateDialogOpen;

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -56,9 +56,11 @@ function EmployeesIndex() {
   const { categories } = useCategoryDefinitions(organizationId, "gabinetEmployee");
   const [tagsSlideoutOpen, setTagsSlideoutOpen] = useState(false);
   const [categoriesSlideoutOpen, setCategoriesSlideoutOpen] = useState(false);
+  const [filterSlideoutOpen, setFilterSlideoutOpen] = useState(false);
 
   useSidebarDispatch("manageTags", () => setTagsSlideoutOpen(true));
   useSidebarDispatch("manageCategories", () => setCategoriesSlideoutOpen(true));
+  useSidebarDispatch("openFilter", () => setFilterSlideoutOpen(true));
 
   const [showCreate, setShowCreate] = useState(false);
   const [searchValue, setSearchValue] = useState("");
@@ -332,6 +334,8 @@ function EmployeesIndex() {
 
       <DataListFilterBar
         filterableFields={filterableFields}
+        filterSlideoutOpen={filterSlideoutOpen}
+        onFilterSlideoutOpenChange={setFilterSlideoutOpen}
         searchValue={searchValue}
         onSearchChange={setSearchValue}
         searchPlaceholder={t("gabinet.employees.searchPlaceholder")}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #88.

Closes #88

---

## Claude summary

Committed. The fix has two parts: I added optional `filterSlideoutOpen` / `onFilterSlideoutOpenChange` props to `DataListFilterBar` (matching the existing `createDialogOpen` controlled-prop pattern), and wired `useSidebarDispatch("openFilter", () => setFilterSlideoutOpen(true))` in the employees page so the sidebar's "Filtruj wg roli" button now opens the filter slideout — where the user can pick the `role` field, which is already among the page's `filterableFields`.

I noted but did not address that the gabinet treatments page (`_layout.gabinet.treatments.index.tsx`) has the same issue — its sidebar manifest also dispatches `openFilter` (and `sortByPrice`) without any matching `useSidebarDispatch` handler. Same for the packages and documents pages per `src/modules/gabinet/manifest.ts`.

## Follow-ups
- Wire openFilter on gabinet treatments page: `_layout.gabinet.treatments.index.tsx` uses `DataListFilterBar` but doesn't subscribe to the `openFilter` dispatch from `nav.actions.categoryFilter`; same pattern as #88
- Wire openFilter on gabinet packages page: `nav.actions.filterByStatus` dispatches `openFilter` but the packages page lacks a handler
- Wire openFilter on gabinet documents page: `nav.actions.filterByStatus` dispatches `openFilter` but the documents page lacks a handler
- Wire sortByPrice/manageCategories-like dispatches for gabinet treatments: `nav.actions.sortByPrice` dispatches `sortByPrice` with no handler in the treatments page
- Wire viewExpiring/assignPackage on gabinet packages page: sidebar dispatches `viewExpiring` and `assignPackage` with no handlers on the packages page
- Wire createFromTemplate/pendingSignatures on gabinet documents page: sidebar dispatches both with no handlers on the documents page