### PR TITLE
Audit module manifests for orphaned dispatches

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "status:dashboard": "npm --prefix status-dashboard run dev",
     "test:e2e": "playwright test",
     "test:unit": "cd convex && vitest run",
+    "test:manifests": "vitest run src/modules/manifest-dispatches.test.ts",
     "test": "npm run test:unit && npm run test:e2e",
     "verify:jwt": "npx tsx scripts/verify-jwt-bridge.ts",
     "verify:s03": "npx tsx scripts/verify-s03-integration.ts",

--- a/src/modules/manifest-dispatches.test.ts
+++ b/src/modules/manifest-dispatches.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+/*
+ * Audit test for module manifest dispatches.
+ *
+ * Every `dispatch: "<id>"` in `src/modules/<module>/manifest.ts` must be
+ * handled by a `useSidebarDispatch("<id>", ...)` call on at least one of the
+ * route files that match the page context's `to` paths. Otherwise the sidebar
+ * action menu will render the entry, fire the dispatch on click, and silently
+ * do nothing (regression behind #88).
+ *
+ * The audit reads manifests and route files as text (no module imports), so it
+ * has no runtime dependencies on icons/widgets/Convex.
+ *
+ * KNOWN_ORPHANS holds dispatches that are declared in a manifest but not yet
+ * wired up on the target page. Adding a new manifest dispatch without a
+ * matching `useSidebarDispatch` will fail this test. Wiring up an orphan
+ * without removing it from this list will also fail (so the list stays tidy).
+ */
+
+const REPO_ROOT = resolve(__dirname, "../..");
+const ROUTES_DIR = join(REPO_ROOT, "src/routes/_app/_auth/dashboard");
+
+const MANIFEST_FILES = [
+  "src/modules/crm/manifest.ts",
+  "src/modules/gabinet/manifest.ts",
+] as const;
+
+type Orphan = `${string}::${string}::${string}`;
+
+// Manifests in this repo currently declare these dispatches without a matching
+// `useSidebarDispatch` on the target route. They are tracked here so the test
+// passes today and starts failing the moment a NEW orphan is introduced — or
+// an existing orphan is wired up (in which case remove the entry).
+const KNOWN_ORPHANS: ReadonlySet<Orphan> = new Set<Orphan>([
+  "src/modules/crm/manifest.ts::companies::viewRelationships",
+  "src/modules/crm/manifest.ts::activities::openFilter",
+  "src/modules/crm/manifest.ts::calendar::openFilter",
+  "src/modules/crm/manifest.ts::documents::openFilter",
+  "src/modules/crm/manifest.ts::products::openFilter",
+  "src/modules/crm/manifest.ts::email-templates::openSearch",
+  "src/modules/crm/manifest.ts::email-templates::composeEmail",
+  "src/modules/gabinet/manifest.ts::treatments::openFilter",
+  "src/modules/gabinet/manifest.ts::treatments::sortByPrice",
+  "src/modules/gabinet/manifest.ts::packages::openFilter",
+  "src/modules/gabinet/manifest.ts::packages::viewExpiring",
+  "src/modules/gabinet/manifest.ts::packages::assignPackage",
+  "src/modules/gabinet/manifest.ts::documents::createFromTemplate",
+  "src/modules/gabinet/manifest.ts::documents::openFilter",
+  "src/modules/gabinet/manifest.ts::documents::pendingSignatures",
+  "src/modules/gabinet/manifest.ts::reports::exportReport",
+  "src/modules/gabinet/manifest.ts::reports::filterByDate",
+  "src/modules/gabinet/manifest.ts::reports::viewTreatmentStats",
+  "src/modules/gabinet/manifest.ts::reports::viewRevenueReport",
+]);
+
+interface PageContextEntry {
+  manifestFile: string;
+  key: string;
+  routes: string[];
+  dispatches: string[];
+}
+
+function extractTopLevelObjects(text: string, arrayStart: number): string[] {
+  const objects: string[] = [];
+  let i = arrayStart;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === "]") return objects;
+    if (ch !== "{") {
+      i++;
+      continue;
+    }
+    let depth = 0;
+    let inString = false;
+    let stringChar = "";
+    let escape = false;
+    const start = i;
+    while (i < text.length) {
+      const c = text[i];
+      if (escape) {
+        escape = false;
+        i++;
+        continue;
+      }
+      if (inString) {
+        if (c === "\\") {
+          escape = true;
+        } else if (c === stringChar) {
+          inString = false;
+        }
+        i++;
+        continue;
+      }
+      if (c === '"' || c === "'" || c === "`") {
+        inString = true;
+        stringChar = c;
+      } else if (c === "{") {
+        depth++;
+      } else if (c === "}") {
+        depth--;
+        if (depth === 0) {
+          i++;
+          objects.push(text.slice(start, i));
+          break;
+        }
+      }
+      i++;
+    }
+  }
+  return objects;
+}
+
+function parseManifest(filePathRel: string): PageContextEntry[] {
+  const filePath = join(REPO_ROOT, filePathRel);
+  const text = readFileSync(filePath, "utf8");
+  const marker = text.indexOf("pageContexts:");
+  if (marker < 0) return [];
+  const arrayStart = text.indexOf("[", marker);
+  if (arrayStart < 0) return [];
+  const blocks = extractTopLevelObjects(text, arrayStart + 1);
+
+  return blocks
+    .map((block): PageContextEntry | null => {
+      const keyMatch = /\bkey:\s*"([^"]+)"/.exec(block);
+      if (!keyMatch) return null;
+      const routes = Array.from(block.matchAll(/\bto:\s*"([^"]+)"/g)).map(
+        (m) => m[1]
+      );
+      const dispatches = Array.from(
+        block.matchAll(/\bdispatch:\s*"([^"]+)"/g)
+      ).map((m) => m[1]);
+      return {
+        manifestFile: filePathRel,
+        key: keyMatch[1],
+        routes,
+        dispatches,
+      };
+    })
+    .filter((c): c is PageContextEntry => c !== null);
+}
+
+function routePathToCandidateFiles(routePath: string): string[] {
+  const trimmed = routePath.replace(/^\/+|\/+$/g, "");
+  const segments = trimmed.split("/").filter(Boolean);
+  if (segments[0] !== "dashboard") return [];
+  const rest = segments.slice(1);
+  const prefix = rest.length === 0 ? "_layout" : `_layout.${rest.join(".")}`;
+  // TanStack Router conventions: index, lazy, and base files all map to the
+  // same route path. Either the page file itself or its lazy companion may
+  // host the dispatch handler.
+  return [
+    `${prefix}.tsx`,
+    `${prefix}.index.tsx`,
+    `${prefix}.lazy.tsx`,
+    `${prefix}.index.lazy.tsx`,
+    `${prefix}.index.lazy.ts`,
+  ];
+}
+
+function findExistingFiles(routePath: string): string[] {
+  const candidates = routePathToCandidateFiles(routePath);
+  return candidates
+    .map((name) => join(ROUTES_DIR, name))
+    .filter((p) => existsSync(p));
+}
+
+function fileMentionsDispatch(filePath: string, dispatchId: string): boolean {
+  const text = readFileSync(filePath, "utf8");
+  // Match `useSidebarDispatch("id", ...)` or `useSidebarDispatch('id', ...)`.
+  const re = new RegExp(
+    `useSidebarDispatch\\(\\s*["'\`]${escapeRegExp(dispatchId)}["'\`]`,
+    "m"
+  );
+  return re.test(text);
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+describe("module manifest dispatches", () => {
+  const allContexts = MANIFEST_FILES.flatMap((f) => parseManifest(f));
+
+  it("ROUTES_DIR exists", () => {
+    expect(existsSync(ROUTES_DIR)).toBe(true);
+  });
+
+  it("at least one manifest page context was discovered", () => {
+    expect(allContexts.length).toBeGreaterThan(0);
+  });
+
+  const flagged: { entry: Orphan; reason: string }[] = [];
+  const wired: Orphan[] = [];
+
+  for (const ctx of allContexts) {
+    for (const dispatchId of ctx.dispatches) {
+      const orphanKey: Orphan = `${ctx.manifestFile}::${ctx.key}::${dispatchId}`;
+      const candidateFiles = ctx.routes.flatMap(findExistingFiles);
+      let matched = false;
+      let candidatesMissing = candidateFiles.length === 0;
+      for (const file of candidateFiles) {
+        if (fileMentionsDispatch(file, dispatchId)) {
+          matched = true;
+          break;
+        }
+      }
+      if (matched) {
+        wired.push(orphanKey);
+      } else {
+        flagged.push({
+          entry: orphanKey,
+          reason: candidatesMissing
+            ? `no route file found for ${ctx.routes.join(", ")}`
+            : `useSidebarDispatch("${dispatchId}") missing from: ${candidateFiles
+                .map((p) => p.replace(`${REPO_ROOT}/`, ""))
+                .join(", ")}`,
+        });
+      }
+    }
+  }
+
+  it("no NEW orphan dispatches (every manifest dispatch is wired up or in KNOWN_ORPHANS)", () => {
+    const newOrphans = flagged.filter((f) => !KNOWN_ORPHANS.has(f.entry));
+    if (newOrphans.length > 0) {
+      const detail = newOrphans
+        .map((o) => `  - ${o.entry}: ${o.reason}`)
+        .join("\n");
+      expect.fail(
+        `Found ${newOrphans.length} new orphaned manifest dispatch(es):\n${detail}\n\n` +
+          `Either add a useSidebarDispatch handler on the target page, or add the entry to KNOWN_ORPHANS in this test file.`
+      );
+    }
+  });
+
+  it("KNOWN_ORPHANS contains no resolved entries (clean up the list as orphans get wired)", () => {
+    const flaggedSet = new Set(flagged.map((f) => f.entry));
+    const stale: string[] = [];
+    for (const orphan of KNOWN_ORPHANS) {
+      if (!flaggedSet.has(orphan)) {
+        stale.push(orphan);
+      }
+    }
+    if (stale.length > 0) {
+      expect.fail(
+        `KNOWN_ORPHANS contains entries that are no longer orphaned. Remove them:\n` +
+          stale.map((s) => `  - ${s}`).join("\n")
+      );
+    }
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #89.

Closes #89

---

## Claude summary

Audit complete. Added `src/modules/manifest-dispatches.test.ts` — a static-analysis vitest test that parses every `dispatch: "..."` from both module manifests, maps each page context's `to:` paths to the corresponding TanStack Router file(s), and verifies a `useSidebarDispatch("...")` call exists on at least one of them. The test surfaced 19 orphaned dispatches across 8 page contexts (all baselined in `KNOWN_ORPHANS`), and now fails on any newly-introduced orphan as well as on entries that get wired up without being removed from the list. Wired via `npm run test:manifests`.

## Follow-ups
- Wire CRM `companies/viewRelationships` dispatch: open the relationships side panel on `/dashboard/companies` and remove from KNOWN_ORPHANS in `src/modules/manifest-dispatches.test.ts`
- Wire CRM `activities/openFilter` dispatch: open type filter on `/dashboard/activities` and remove from KNOWN_ORPHANS
- Wire CRM `calendar/openFilter` dispatch: open type filter on `/dashboard/calendar` and remove from KNOWN_ORPHANS
- Wire CRM `documents/openFilter` dispatch: open type filter on `/dashboard/documents` and remove from KNOWN_ORPHANS
- Wire CRM `products/openFilter` dispatch: open category filter on `/dashboard/products` and remove from KNOWN_ORPHANS
- Wire CRM `email-templates/openSearch` and `email-templates/composeEmail` dispatches on `/dashboard/email-templates` and remove from KNOWN_ORPHANS
- Wire Gabinet `treatments/openFilter` and `treatments/sortByPrice` dispatches on `/dashboard/gabinet/treatments` and remove from KNOWN_ORPHANS
- Wire Gabinet `packages/*` dispatches (openFilter, viewExpiring, assignPackage) on `/dashboard/gabinet/packages` and remove from KNOWN_ORPHANS
- Wire Gabinet `documents/*` dispatches (createFromTemplate, openFilter, pendingSignatures) on `/dashboard/gabinet/documents` and remove from KNOWN_ORPHANS
- Wire Gabinet `reports/*` dispatches (exportReport, filterByDate, viewTreatmentStats, viewRevenueReport) on `/dashboard/gabinet/reports` and remove from KNOWN_ORPHANS
- Run `npm run test:manifests` in CI: the audit test currently has no automated trigger and only runs locally