### PR TITLE
Narrow ctx.db.get type via Id casts in convex/supabase/backfill.ts

### DIFF
--- a/convex/supabase/backfill.ts
+++ b/convex/supabase/backfill.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { internalAction, internalQuery } from "../_generated/server";
 import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
 import { createServiceRoleClient } from "./client";
 
 const BATCH_SIZE = 50;
@@ -37,7 +38,7 @@ export const _getUser = internalQuery({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
     try {
-      return await ctx.db.get(args.userId as any);
+      return await ctx.db.get(args.userId as Id<"users">);
     } catch {
       const all = await ctx.db.query("users").collect();
       return all.find((u) => u._id === args.userId) ?? null;
@@ -49,7 +50,7 @@ export const _getPatient = internalQuery({
   args: { patientId: v.string() },
   handler: async (ctx, args) => {
     try {
-      return await ctx.db.get(args.patientId as any);
+      return await ctx.db.get(args.patientId as Id<"gabinetPatients">);
     } catch {
       const all = await ctx.db.query("gabinetPatients").collect();
       return all.find((p) => p._id === args.patientId) ?? null;
@@ -61,7 +62,7 @@ export const _getTreatment = internalQuery({
   args: { treatmentId: v.string() },
   handler: async (ctx, args) => {
     try {
-      return await ctx.db.get(args.treatmentId as any);
+      return await ctx.db.get(args.treatmentId as Id<"gabinetTreatments">);
     } catch {
       const all = await ctx.db.query("gabinetTreatments").collect();
       return all.find((t) => t._id === args.treatmentId) ?? null;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #92.

Closes #92

---

## Claude summary

Committed. The fix narrows the three `ctx.db.get(... as any)` casts in `convex/supabase/backfill.ts:41,53,65` to typed `Id<"users">`, `Id<"gabinetPatients">`, `Id<"gabinetTreatments">`, matching the pattern from #65. This eliminates 53 of 56 TS2339 errors in the file.

The remaining 3 errors are real schema mismatches that were previously hidden by the `as any` cast — flagged below as follow-ups.

## Follow-ups
- Fix schema mismatch in supabase backfillSingleTreatment: lines 218,220 reference `t.treatmentParameters` and `t.requiresCompletion` which don't exist on `gabinetTreatments` schema (these fields exist in the bulk `backfillTreatments` row mapper but not in the schema)
- Fix qualifiedTreatments→qualifiedTreatmentIds in supabase/backfill.ts:447: `e.qualifiedTreatments` doesn't exist on `gabinetEmployees`; the correct field is `qualifiedTreatmentIds`