### PR TITLE
Fix tests/convex import paths

### DIFF
--- a/convex/vitest.config.ts
+++ b/convex/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     },
   },
   test: {
+    include: ["**/*.test.ts", "../tests/convex/**/*.test.ts"],
     server: { deps: { inline: ["convex-test"] } },
   },
 });

--- a/tests/convex/activityEnvelope.test.ts
+++ b/tests/convex/activityEnvelope.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "vitest";
-import { api } from "../_generated/api";
-import type { Id } from "../_generated/dataModel";
-import { createTestCtx, seedTestUser } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import type { Id } from "../../convex/_generated/dataModel";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 import {
   publishActivityEnvelope,
   type ActivityEnvelopeTarget,
-} from "../_helpers/activityEnvelope";
-import { logActivity } from "../_helpers/activities";
+} from "../../convex/_helpers/activityEnvelope";
+import { logActivity } from "../../convex/_helpers/activities";
 
 async function listActivities(
   t: ReturnType<typeof createTestCtx>,

--- a/tests/convex/appointmentSms.test.ts
+++ b/tests/convex/appointmentSms.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { api, internal } from "../_generated/api";
+import { api, internal } from "../../convex/_generated/api";
 import {
   createTestCtx,
   seedGabinetPrereqs,
   seedSecondUser,
   seedTestUser,
-} from "../_test_helpers";
+} from "../../convex/_test_helpers";
 
 const activeContexts = new Set<ReturnType<typeof createTestCtx>>();
 

--- a/tests/convex/appointmentStateMachine.test.ts
+++ b/tests/convex/appointmentStateMachine.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { api } from "../_generated/api";
-import { createTestCtx, seedTestUser, seedGabinetPrereqs } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser, seedGabinetPrereqs } from "../../convex/_test_helpers";
 
 const activeContexts = new Set<ReturnType<typeof createTestCtx>>();
 

--- a/tests/convex/automation.test.ts
+++ b/tests/convex/automation.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { api, internal } from "../_generated/api";
-import { DEFAULT_PERMISSIONS } from "../_helpers/permissions";
+import { api, internal } from "../../convex/_generated/api";
+import { DEFAULT_PERMISSIONS } from "../../convex/_helpers/permissions";
 import {
   createTestCtx,
   seedGabinetPrereqs,
   seedSecondUser,
   seedTestUser,
-} from "../_test_helpers";
+} from "../../convex/_test_helpers";
 
 const activeContexts = new Set<ReturnType<typeof createTestCtx>>();
 

--- a/tests/convex/avatarConsistency.test.ts
+++ b/tests/convex/avatarConsistency.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "vitest";
-import { api } from "../_generated/api";
-import { createTestCtx, seedTestUser } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 
 describe("updateUserImage", () => {
   test("caches storage URL in image field when imageId is set", async () => {

--- a/tests/convex/conflictChecking.test.ts
+++ b/tests/convex/conflictChecking.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "vitest";
-import { api } from "../_generated/api";
-import { createTestCtx, seedTestUser, seedGabinetPrereqs } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser, seedGabinetPrereqs } from "../../convex/_test_helpers";
 
 describe("conflict checking", () => {
   test("cannot double-book same employee at same time", async () => {

--- a/tests/convex/emailActivities.test.ts
+++ b/tests/convex/emailActivities.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
-import { api, internal } from "../_generated/api";
-import { createTestCtx, seedTestUser } from "../_test_helpers";
+import { api, internal } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 import { sendEmail } from "@cvx/email";
 
 vi.mock("@cvx/email", () => ({

--- a/tests/convex/emailEventTrigger.test.ts
+++ b/tests/convex/emailEventTrigger.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "vitest";
-import { internal } from "../_generated/api";
-import { createTestCtx, seedTestUser } from "../_test_helpers";
+import { internal } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 
 describe("emailEventTrigger", () => {
   // ─── No-op: no bindings configured ────────────────────────────

--- a/tests/convex/packageActivities.test.ts
+++ b/tests/convex/packageActivities.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { api } from "../_generated/api";
-import { createTestCtx, seedGabinetPrereqs, seedTestUser } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedGabinetPrereqs, seedTestUser } from "../../convex/_test_helpers";
 
 describe("package activities", () => {
   test("purchasePackage publishes semantic package_assigned envelope", async () => {

--- a/tests/convex/patientAuth.test.ts
+++ b/tests/convex/patientAuth.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, describe } from "vitest";
 import { createHash } from "crypto";
-import { api } from "../_generated/api";
-import { createTestCtx, seedTestUser, seedGabinetPrereqs } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser, seedGabinetPrereqs } from "../../convex/_test_helpers";
 
 /** SHA-256 helper matching what the production code uses. */
 function sha256Sync(input: string): string {

--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "vitest";
-import { api } from "../_generated/api";
-import { createTestCtx, seedTestUser } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 
 describe("payments", () => {
   test("create a pending payment", async () => {

--- a/tests/convex/productAccess.test.ts
+++ b/tests/convex/productAccess.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "vitest";
-import { api } from "../_generated/api";
-import { createTestCtx, seedTestUser } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 
 describe("verifyProductAccess", () => {
   test("grace period: allows access when no subscriptions exist globally", async () => {

--- a/tests/convex/recentlyViewed.test.ts
+++ b/tests/convex/recentlyViewed.test.ts
@@ -1,8 +1,8 @@
 import { expect, test, describe } from "vitest";
 import { convexTest } from "convex-test";
-import { api } from "../_generated/api";
-import schema from "../schema";
-import { seedTestUser } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import schema from "../../convex/schema";
+import { seedTestUser } from "../../convex/_test_helpers";
 
 const modules = (
   import.meta as ImportMeta & {

--- a/tests/convex/seatLimits.test.ts
+++ b/tests/convex/seatLimits.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "vitest";
-import { api } from "../_generated/api";
-import { createTestCtx, seedTestUser, seedSecondUser } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser, seedSecondUser } from "../../convex/_test_helpers";
 
 describe("checkSeatLimit via getSeatUsage", () => {
   test("returns 1 seat used for org with only owner (free tier default)", async () => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #97.

Closes #97

---

## Claude summary

Committed. Summary:

Fixed the import paths across all 14 affected test files in `tests/convex/`. Each `../X` import (which resolved to a nonexistent `tests/X` path) was changed to `../../convex/X` so it reaches the real Convex codegen, helper, and schema modules. Additionally added `include: ["**/*.test.ts", "../tests/convex/**/*.test.ts"]` to `convex/vitest.config.ts` so `npm run test:unit` (which `cd`s into `convex/`) actually discovers the sibling test files.

Verified: vitest discovers all 15 test files (was 0), `emailShell.test.ts` passes (7/7). Remaining 14 test failures are unrelated to imports — they hit `convex/_test_helpers.ts`, which is a stub that throws "Not available in Convex runtime"; the real implementation was moved to `_test_helpers.ts.bak` at the repo root. That's a separate pre-existing issue.

## Follow-ups
- Restore working `convex/_test_helpers.ts` so tests/convex tests can actually run: file is currently a stub that throws "Not available in Convex runtime"; real impl was relocated to `_test_helpers.ts.bak` because it uses Vite-only `import.meta.glob` that breaks Convex deploy. Need to gate the helper so it ships a real impl in vitest while staying inert in the Convex runtime build (e.g. via vitest config alias to the `.bak` file, or split into a vitest-only module).