### PR TITLE
Consider mirroring `accept` and `decline` invitation status changes to Supabase

### DIFF
--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -210,11 +210,29 @@ export const _createInternal = internalMutation({
 export const accept = action({
   args: { token: v.string() },
   handler: async (ctx, args): Promise<string> => {
-    const orgId: string = await ctx.runMutation(
-      internal.invitations._acceptInternal,
-      { token: args.token },
-    );
-    return orgId;
+    const result: {
+      organizationId: string;
+      invitationId: string;
+      acceptedAt: number;
+      updatedAt: number;
+    } = await ctx.runMutation(internal.invitations._acceptInternal, {
+      token: args.token,
+    });
+
+    // Mirror status change to Supabase so the team page (which reads
+    // pending invitations from Supabase) stops showing this invitation.
+    try {
+      const db = createSupabaseDb();
+      await db.patch("invitations", result.invitationId, {
+        status: "accepted",
+        acceptedAt: result.acceptedAt,
+        updatedAt: result.updatedAt,
+      });
+    } catch (e) {
+      console.error("[invitations.accept] Supabase mirror failed:", e);
+    }
+
+    return result.organizationId;
   },
 });
 
@@ -253,10 +271,11 @@ export const _acceptInternal = internalMutation({
       joinedAt: Date.now(),
     });
 
+    const acceptedAt = Date.now();
     await ctx.db.patch(invitation._id, {
       status: "accepted",
-      acceptedAt: Date.now(),
-      updatedAt: Date.now(),
+      acceptedAt,
+      updatedAt: acceptedAt,
     });
 
     await logActivity(ctx, {
@@ -289,14 +308,34 @@ export const _acceptInternal = internalMutation({
       });
     }
 
-    return String(invitation.organizationId);
+    return {
+      organizationId: String(invitation.organizationId),
+      invitationId: String(invitation._id),
+      acceptedAt,
+      updatedAt: acceptedAt,
+    };
   },
 });
 
 export const decline = action({
   args: { token: v.string() },
   handler: async (ctx, args) => {
-    await ctx.runMutation(internal.invitations._declineInternal, { token: args.token });
+    const result: { invitationId: string; updatedAt: number } = await ctx.runMutation(
+      internal.invitations._declineInternal,
+      { token: args.token },
+    );
+
+    // Mirror status change to Supabase so the team page (which reads
+    // pending invitations from Supabase) stops showing this invitation.
+    try {
+      const db = createSupabaseDb();
+      await db.patch("invitations", result.invitationId, {
+        status: "declined",
+        updatedAt: result.updatedAt,
+      });
+    } catch (e) {
+      console.error("[invitations.decline] Supabase mirror failed:", e);
+    }
   },
 });
 
@@ -313,10 +352,16 @@ export const _declineInternal = internalMutation({
     if (!invitation) throw new Error("Invitation not found");
     if (invitation.status !== "pending") throw new Error("Invitation is no longer pending");
 
+    const updatedAt = Date.now();
     await ctx.db.patch(invitation._id, {
       status: "declined",
-      updatedAt: Date.now(),
+      updatedAt,
     });
+
+    return {
+      invitationId: String(invitation._id),
+      updatedAt,
+    };
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #99.

Closes #99

---

## Claude summary

Committed. Summary of changes in `convex/invitations.ts:209-366`:

- `_acceptInternal` now returns `{ organizationId, invitationId, acceptedAt, updatedAt }` (was just `organizationId`); the `acceptedAt` is computed once and reused for `updatedAt` so both fields match.
- `accept` action mirrors `status="accepted"`, `acceptedAt`, `updatedAt` to Supabase via `createSupabaseDb().patch("invitations", ...)`, wrapped in try/catch with the same `console.error` fail-open pattern used by `cancel`/`resend`.
- `_declineInternal` now returns `{ invitationId, updatedAt }` (was void).
- `decline` action mirrors `status="declined"` and `updatedAt` to Supabase the same way.

I couldn't run `tsc` (no `node_modules` in this worktree), but the change is a narrow extension of the existing dual-write pattern already used in the same file and uses the same `createSupabaseDb` helper signature.