### PR TITLE
Wire openFilter on gabinet treatments page

### DIFF
--- a/src/modules/manifest-dispatches.test.ts
+++ b/src/modules/manifest-dispatches.test.ts
@@ -42,7 +42,6 @@ const KNOWN_ORPHANS: ReadonlySet<Orphan> = new Set<Orphan>([
   "src/modules/crm/manifest.ts::products::openFilter",
   "src/modules/crm/manifest.ts::email-templates::openSearch",
   "src/modules/crm/manifest.ts::email-templates::composeEmail",
-  "src/modules/gabinet/manifest.ts::treatments::openFilter",
   "src/modules/gabinet/manifest.ts::treatments::sortByPrice",
   "src/modules/gabinet/manifest.ts::packages::openFilter",
   "src/modules/gabinet/manifest.ts::packages::viewExpiring",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -62,9 +62,11 @@ function TreatmentsIndex() {
   const { categories } = useCategoryDefinitions(organizationId, "gabinetTreatment");
   const [tagsSlideoutOpen, setTagsSlideoutOpen] = useState(false);
   const [categoriesSlideoutOpen, setCategoriesSlideoutOpen] = useState(false);
+  const [filterSlideoutOpen, setFilterSlideoutOpen] = useState(false);
 
   useSidebarDispatch("manageTags", () => setTagsSlideoutOpen(true));
   useSidebarDispatch("manageCategories", () => setCategoriesSlideoutOpen(true));
+  useSidebarDispatch("openFilter", () => setFilterSlideoutOpen(true));
 
   const getTreatmentsKpis = useAction(api.gabinet.sidebarWidgets.getTreatmentsKpis);
   const getTopTreatments = useAction(api.gabinet.sidebarWidgets.getTopTreatments);
@@ -371,6 +373,8 @@ function TreatmentsIndex() {
         onCreateView={onCreateView}
         onDeleteView={onDeleteView}
         filterableFields={filterableFields}
+        filterSlideoutOpen={filterSlideoutOpen}
+        onFilterSlideoutOpenChange={setFilterSlideoutOpen}
         searchValue={searchValue}
         onSearchChange={setSearchValue}
         searchPlaceholder={t("gabinet.treatments.searchPlaceholder")}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #102.

Closes #102

---

## Claude summary

Committed.

Summary: Wired `openFilter` dispatch on the gabinet treatments page using the same controlled-prop pattern from #88. Added `useSidebarDispatch("openFilter", ...)` with local state, passed `filterSlideoutOpen` / `onFilterSlideoutOpenChange` to `DataListFilterBar`, and removed the now-resolved orphan entry from `manifest-dispatches.test.ts`. Test passes; tsc clean.