### PR TITLE
Wire openFilter on gabinet packages page

### DIFF
--- a/src/modules/manifest-dispatches.test.ts
+++ b/src/modules/manifest-dispatches.test.ts
@@ -43,7 +43,6 @@ const KNOWN_ORPHANS: ReadonlySet<Orphan> = new Set<Orphan>([
   "src/modules/crm/manifest.ts::email-templates::openSearch",
   "src/modules/crm/manifest.ts::email-templates::composeEmail",
   "src/modules/gabinet/manifest.ts::treatments::sortByPrice",
-  "src/modules/gabinet/manifest.ts::packages::openFilter",
   "src/modules/gabinet/manifest.ts::packages::viewExpiring",
   "src/modules/gabinet/manifest.ts::packages::assignPackage",
   "src/modules/gabinet/manifest.ts::documents::createFromTemplate",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -31,6 +31,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Progress } from "@/components/ui/progress";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Tooltip,
   TooltipContent,
@@ -44,6 +45,7 @@ import { toast } from "sonner";
 
 import { EmptyState } from "@/components/layout/empty-state";
 import { QuickActionBar } from "@/components/crm/quick-action-bar";
+import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import type { MappedGabinetTreatmentPackage } from "@/lib/supabase/mappers/gabinet/treatment-packages";
 import type { MappedGabinetPackageUsage } from "@/lib/supabase/mappers/gabinet/package-usage";
 
@@ -157,6 +159,11 @@ function PackagesIndex() {
 
   const [panelOpen, setPanelOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [filterPanelOpen, setFilterPanelOpen] = useState(false);
+  const [statusFilter, setStatusFilter] = useState<"all" | "active" | "inactive">("all");
+
+  useSidebarDispatch("openFilter", () => setFilterPanelOpen(true));
+
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [totalPrice, setTotalPrice] = useState("");
@@ -284,7 +291,12 @@ function PackagesIndex() {
     }
   };
 
-  const items = packagesData ?? [];
+  const items = useMemo(() => {
+    const all = packagesData ?? [];
+    if (statusFilter === "active") return all.filter((p) => p.isActive);
+    if (statusFilter === "inactive") return all.filter((p) => !p.isActive);
+    return all;
+  }, [packagesData, statusFilter]);
 
   // Build a treatment name lookup from loaded treatments
   const treatmentNameMap = useMemo(() => {
@@ -538,6 +550,50 @@ function PackagesIndex() {
               </div>
             ))}
           </div>
+        </div>
+      </SidePanel>
+
+      <SidePanel
+        open={filterPanelOpen}
+        onOpenChange={setFilterPanelOpen}
+        title={t("nav.actions.filterByStatus")}
+      >
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>{t("common.status")}</Label>
+            <RadioGroup
+              value={statusFilter}
+              onValueChange={(val) => setStatusFilter(val as "all" | "active" | "inactive")}
+            >
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="all" id="package-filter-all" />
+                <Label htmlFor="package-filter-all" className="font-normal">
+                  {t("common.all")}
+                </Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="active" id="package-filter-active" />
+                <Label htmlFor="package-filter-active" className="font-normal">
+                  {t("gabinet.packages.active")}
+                </Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="inactive" id="package-filter-inactive" />
+                <Label htmlFor="package-filter-inactive" className="font-normal">
+                  {t("gabinet.packages.inactive")}
+                </Label>
+              </div>
+            </RadioGroup>
+          </div>
+          {statusFilter !== "all" && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setStatusFilter("all")}
+            >
+              {t("common.clearFilters")}
+            </Button>
+          )}
         </div>
       </SidePanel>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #103.

Closes #103

---

## Claude summary

Fix committed. Wired `openFilter` dispatch on the gabinet packages page by subscribing to `useSidebarDispatch("openFilter", ...)` and adding a small SidePanel filter with an active/inactive/all status RadioGroup that filters the rendered card grid. Also removed the resolved orphan from `KNOWN_ORPHANS` in the manifest dispatches audit test, which now passes.

Unlike the treatments (#102) and employees (#88) fixes, the packages page doesn't use `DataListFilterBar` (it's a plain card grid), so the existing controlled-prop pattern from #88 didn't apply — a dedicated SidePanel + RadioGroup keeps the change scoped to this page without refactoring the grid into a list.