### PR TITLE
Wire openFilter on gabinet documents page

### DIFF
--- a/src/modules/manifest-dispatches.test.ts
+++ b/src/modules/manifest-dispatches.test.ts
@@ -46,7 +46,6 @@ const KNOWN_ORPHANS: ReadonlySet<Orphan> = new Set<Orphan>([
   "src/modules/gabinet/manifest.ts::packages::viewExpiring",
   "src/modules/gabinet/manifest.ts::packages::assignPackage",
   "src/modules/gabinet/manifest.ts::documents::createFromTemplate",
-  "src/modules/gabinet/manifest.ts::documents::openFilter",
   "src/modules/gabinet/manifest.ts::documents::pendingSignatures",
   "src/modules/gabinet/manifest.ts::reports::exportReport",
   "src/modules/gabinet/manifest.ts::reports::filterByDate",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -44,6 +44,7 @@ import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-s
 import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
 import { useSupabaseFormDocumentsList } from "@/hooks/use-supabase-form-documents";
 import { useSavedViews } from "@/hooks/use-saved-views";
+import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 
 // ---------------------------------------------------------------------------
 // Route
@@ -95,6 +96,9 @@ function GabinetDocumentsPage() {
   const { categories } = useCategoryDefinitions(organizationId, "gabinetDocument");
   const [tagsSlideoutOpen, setTagsSlideoutOpen] = useState(false);
   const [categoriesSlideoutOpen, setCategoriesSlideoutOpen] = useState(false);
+  const [filterSlideoutOpen, setFilterSlideoutOpen] = useState(false);
+
+  useSidebarDispatch("openFilter", () => setFilterSlideoutOpen(true));
 
   // --- State ---
   const [searchValue, setSearchValue] = useState("");
@@ -475,6 +479,8 @@ function GabinetDocumentsPage() {
         onCreateView={onCreateView}
         onDeleteView={async (id) => { onDeleteView(id); }}
         filterableFields={filterableFields}
+        filterSlideoutOpen={filterSlideoutOpen}
+        onFilterSlideoutOpenChange={setFilterSlideoutOpen}
         createDialogOpen={savedViewsDialogOpen}
         onCreateDialogOpenChange={setSavedViewsDialogOpen}
         searchValue={searchValue}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #104.

Closes #104

---

## Claude summary

Committed as 6a27903.

Summary: The gabinet documents page sidebar action "Filtruj wg statusu" dispatched `openFilter`, but `GabinetDocumentsPage` had no handler — same regression class as #88/#102/#103. Fixed by adding `useSidebarDispatch("openFilter", ...)` to set local `filterSlideoutOpen` state and passing the controlled `filterSlideoutOpen` / `onFilterSlideoutOpenChange` props to the existing `DataListFilterBar` (controlled mode added in #88). Removed the matching entry from `KNOWN_ORPHANS` in `src/modules/manifest-dispatches.test.ts`; the audit test passes (4/4).