### PR TITLE
Wire sortByPrice/manageCategories-like dispatches for gabinet treatments

### DIFF
--- a/src/modules/manifest-dispatches.test.ts
+++ b/src/modules/manifest-dispatches.test.ts
@@ -42,7 +42,6 @@ const KNOWN_ORPHANS: ReadonlySet<Orphan> = new Set<Orphan>([
   "src/modules/crm/manifest.ts::products::openFilter",
   "src/modules/crm/manifest.ts::email-templates::openSearch",
   "src/modules/crm/manifest.ts::email-templates::composeEmail",
-  "src/modules/gabinet/manifest.ts::treatments::sortByPrice",
   "src/modules/gabinet/manifest.ts::packages::viewExpiring",
   "src/modules/gabinet/manifest.ts::packages::assignPackage",
   "src/modules/gabinet/manifest.ts::documents::createFromTemplate",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -20,6 +20,7 @@ import { Plus, Pencil, Trash2, Power } from "@/lib/ez-icons";
 import type { SavedView, FieldDef, FilterCondition } from "@/components/crm/types";
 import { Doc, Id } from "@cvx/_generated/dataModel";
 import { useState, useMemo, useCallback } from "react";
+import type { SortDescriptor } from "react-aria-components";
 import { useTranslation } from "react-i18next";
 import { useSavedViews, applyFilterConditions } from "@/hooks/use-saved-views";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
@@ -63,10 +64,18 @@ function TreatmentsIndex() {
   const [tagsSlideoutOpen, setTagsSlideoutOpen] = useState(false);
   const [categoriesSlideoutOpen, setCategoriesSlideoutOpen] = useState(false);
   const [filterSlideoutOpen, setFilterSlideoutOpen] = useState(false);
+  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor | undefined>(undefined);
 
   useSidebarDispatch("manageTags", () => setTagsSlideoutOpen(true));
   useSidebarDispatch("manageCategories", () => setCategoriesSlideoutOpen(true));
   useSidebarDispatch("openFilter", () => setFilterSlideoutOpen(true));
+  useSidebarDispatch("sortByPrice", () => {
+    setSortDescriptor((prev) =>
+      prev?.column === "price" && prev.direction === "descending"
+        ? { column: "price", direction: "ascending" }
+        : { column: "price", direction: "descending" },
+    );
+  });
 
   const getTreatmentsKpis = useAction(api.gabinet.sidebarWidgets.getTreatmentsKpis);
   const getTopTreatments = useAction(api.gabinet.sidebarWidgets.getTopTreatments);
@@ -424,6 +433,8 @@ function TreatmentsIndex() {
         data={filteredTreatments}
         isLoading={isLoading}
         hiddenColumnIds={hiddenColumnIds}
+        sortDescriptor={sortDescriptor}
+        onSortChange={setSortDescriptor}
         enableBulkSelect
         bulkActions={[
           {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #105.

Closes #105

---

## Claude summary

Committed `2f0e0bd` on `claude/issue-105`. Untracked changes left in working tree are just `npm install` and route-generator artifacts — not part of the fix.

The treatments page now subscribes to `sortByPrice` and pipes a controlled `SortDescriptor` into `CrmDataTable`. Each click of the sidebar's "Sortuj po cenie" action toggles the price column between descending and ascending; the column-header sort still works through the same controlled state. Removed the corresponding entry from `KNOWN_ORPHANS` in `src/modules/manifest-dispatches.test.ts`; audit test passes (`vitest run src/modules/manifest-dispatches.test.ts` → 4/4) and `tsc --noEmit` is clean.