### PR TITLE
Wire createFromTemplate/pendingSignatures on gabinet documents page

### DIFF
--- a/src/modules/manifest-dispatches.test.ts
+++ b/src/modules/manifest-dispatches.test.ts
@@ -44,8 +44,6 @@ const KNOWN_ORPHANS: ReadonlySet<Orphan> = new Set<Orphan>([
   "src/modules/crm/manifest.ts::email-templates::composeEmail",
   "src/modules/gabinet/manifest.ts::packages::viewExpiring",
   "src/modules/gabinet/manifest.ts::packages::assignPackage",
-  "src/modules/gabinet/manifest.ts::documents::createFromTemplate",
-  "src/modules/gabinet/manifest.ts::documents::pendingSignatures",
   "src/modules/gabinet/manifest.ts::reports::exportReport",
   "src/modules/gabinet/manifest.ts::reports::filterByDate",
   "src/modules/gabinet/manifest.ts::reports::viewTreatmentStats",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -99,6 +99,9 @@ function GabinetDocumentsPage() {
   const [filterSlideoutOpen, setFilterSlideoutOpen] = useState(false);
 
   useSidebarDispatch("openFilter", () => setFilterSlideoutOpen(true));
+  useSidebarDispatch("createFromTemplate", () =>
+    navigate({ to: "/dashboard/settings/form-templates" }),
+  );
 
   // --- State ---
   const [searchValue, setSearchValue] = useState("");
@@ -131,6 +134,10 @@ function GabinetDocumentsPage() {
     systemViews: systemViews,
     defaultColumnVisibility: {},
   });
+
+  useSidebarDispatch("pendingSignatures", () =>
+    onViewChange("pending_signature"),
+  );
 
   // --- Mutations ---
   const resendSigningEmail = useAction(api.documents.documents.resendSigningEmail);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #106.

Closes #106

---

## Claude summary

Wired both sidebar dispatches on the gabinet documents page. `createFromTemplate` navigates to the form-templates settings page (matching the existing "Szablony" header button), and `pendingSignatures` switches the active view to the built-in `pending_signature` system view via `onViewChange`. Removed both entries from `KNOWN_ORPHANS` and confirmed the manifest-dispatches audit test passes (4/4). TypeScript error count for the file is unchanged from `main` (11 pre-existing errors, none in the new lines).