### PR TITLE
Wire CRM `activities/openFilter` dispatch

### DIFF
--- a/src/modules/manifest-dispatches.test.ts
+++ b/src/modules/manifest-dispatches.test.ts
@@ -35,7 +35,6 @@ type Orphan = `${string}::${string}::${string}`;
 // passes today and starts failing the moment a NEW orphan is introduced — or
 // an existing orphan is wired up (in which case remove the entry).
 const KNOWN_ORPHANS: ReadonlySet<Orphan> = new Set<Orphan>([
-  "src/modules/crm/manifest.ts::activities::openFilter",
   "src/modules/crm/manifest.ts::calendar::openFilter",
   "src/modules/crm/manifest.ts::documents::openFilter",
   "src/modules/crm/manifest.ts::products::openFilter",

--- a/src/routes/_app/_auth/dashboard/_layout.activities.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.activities.index.tsx
@@ -107,6 +107,7 @@ function ActivitiesPage() {
   const [activeFilters, setActiveFilters] = useState<FilterCondition[]>([]);
   const [tagsSlideoutOpen, setTagsSlideoutOpen] = useState(false);
   const [categoriesSlideoutOpen, setCategoriesSlideoutOpen] = useState(false);
+  const [filterSlideoutOpen, setFilterSlideoutOpen] = useState(false);
   const [panelOpen, setPanelOpen] = useState(false);
   const [editingActivity, setEditingActivity] = useState<ScheduledActivity | null>(null);
   const [searchValue, setSearchValue] = useState("");
@@ -116,6 +117,7 @@ function ActivitiesPage() {
     // Switch to "open" view which shows only incomplete activities
     onViewChange("open");
   });
+  useSidebarDispatch("openFilter", () => setFilterSlideoutOpen(true));
   useSidebarDispatch("manageTags", () => setTagsSlideoutOpen(true));
   useSidebarDispatch("manageCategories", () => setCategoriesSlideoutOpen(true));
 
@@ -373,6 +375,8 @@ function ActivitiesPage() {
         onViewChange={onViewChange}
         onCreateView={onCreateView}
         filterableFields={filterableFields}
+        filterSlideoutOpen={filterSlideoutOpen}
+        onFilterSlideoutOpenChange={setFilterSlideoutOpen}
         onFiltersChange={setActiveFilters}
         searchValue={searchValue}
         onSearchChange={setSearchValue}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #109.

Closes #109

---

## Claude summary

Commit landed (the bash exit-1 was a cwd hook issue, not the commit itself). The fix wires `useSidebarDispatch("openFilter", ...)` on the CRM activities page to open the existing DataListFilterBar slideout in controlled mode, and removes the now-resolved entry from `KNOWN_ORPHANS` in the audit test. Both the dispatch audit test (4/4 passing) and `tsc --noEmit` are clean.