### PR TITLE
Wire CRM `calendar/openFilter` dispatch

### DIFF
--- a/src/modules/manifest-dispatches.test.ts
+++ b/src/modules/manifest-dispatches.test.ts
@@ -35,7 +35,6 @@ type Orphan = `${string}::${string}::${string}`;
 // passes today and starts failing the moment a NEW orphan is introduced — or
 // an existing orphan is wired up (in which case remove the entry).
 const KNOWN_ORPHANS: ReadonlySet<Orphan> = new Set<Orphan>([
-  "src/modules/crm/manifest.ts::calendar::openFilter",
   "src/modules/crm/manifest.ts::documents::openFilter",
   "src/modules/crm/manifest.ts::products::openFilter",
   "src/modules/crm/manifest.ts::email-templates::openSearch",

--- a/src/routes/_app/_auth/dashboard/_layout.calendar.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calendar.tsx
@@ -299,6 +299,11 @@ function UnifiedCalendarPage() {
 
   // Sidebar dispatch handlers
   useSidebarDispatch("goToToday", goToday);
+  useSidebarDispatch("openFilter", () => {
+    setModuleFilter((prev) =>
+      prev === "all" ? "gabinet" : prev === "gabinet" ? "crm" : "all"
+    );
+  });
 
   const title = useMemo(() => {
     const locale = i18n.language;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #110.

Closes #110

---

## Claude summary

Committed. Wired the CRM `calendar/openFilter` dispatch on `/dashboard/calendar` to cycle the existing `moduleFilter` state through `all → gabinet → crm → all`, and removed `src/modules/crm/manifest.ts::calendar::openFilter` from `KNOWN_ORPHANS`. The `npm run test:manifests` audit passes.