### PR TITLE
Wire CRM `documents/openFilter` dispatch

### DIFF
--- a/src/modules/manifest-dispatches.test.ts
+++ b/src/modules/manifest-dispatches.test.ts
@@ -35,7 +35,6 @@ type Orphan = `${string}::${string}::${string}`;
 // passes today and starts failing the moment a NEW orphan is introduced — or
 // an existing orphan is wired up (in which case remove the entry).
 const KNOWN_ORPHANS: ReadonlySet<Orphan> = new Set<Orphan>([
-  "src/modules/crm/manifest.ts::documents::openFilter",
   "src/modules/crm/manifest.ts::products::openFilter",
   "src/modules/crm/manifest.ts::email-templates::openSearch",
   "src/modules/crm/manifest.ts::email-templates::composeEmail",

--- a/src/routes/_app/_auth/dashboard/_layout.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.documents.index.tsx
@@ -128,6 +128,7 @@ function DocumentsPage() {
   const [searchValue, setSearchValue] = useState("");
   const [activeFilters, setActiveFilters] = useState<FilterCondition[]>([]);
   const [savedViewsDialogOpen, setSavedViewsDialogOpen] = useState(false);
+  const [filterSlideoutOpen, setFilterSlideoutOpen] = useState(false);
   const [selectedDocId, setSelectedDocId] =
     useState<Id<"formDocuments"> | null>(null);
 
@@ -150,6 +151,7 @@ function DocumentsPage() {
 
   // --- Sidebar dispatches ---
   useSidebarDispatch("savedViews", () => setSavedViewsDialogOpen(true));
+  useSidebarDispatch("openFilter", () => setFilterSlideoutOpen(true));
   useSidebarDispatch("manageTags", () => setTagsSlideoutOpen(true));
   useSidebarDispatch("manageCategories", () => setCategoriesSlideoutOpen(true));
 
@@ -468,6 +470,8 @@ function DocumentsPage() {
         filterableFields={filterableFields}
         createDialogOpen={savedViewsDialogOpen}
         onCreateDialogOpenChange={setSavedViewsDialogOpen}
+        filterSlideoutOpen={filterSlideoutOpen}
+        onFilterSlideoutOpenChange={setFilterSlideoutOpen}
         searchValue={searchValue}
         onSearchChange={setSearchValue}
         searchPlaceholder={t("documents.searchPlaceholder", "Szukaj po tytule...")}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #111.

Closes #111

---

## Claude summary

Wired the `documents/openFilter` dispatch on `_layout.documents.index.tsx` by adding a `filterSlideoutOpen` state, the `useSidebarDispatch("openFilter", ...)` handler, and the matching `filterSlideoutOpen` / `onFilterSlideoutOpenChange` props on `DataListFilterBar` (mirrors the activities page pattern). Removed the corresponding `KNOWN_ORPHANS` entry from `src/modules/manifest-dispatches.test.ts`. Could not run vitest — node_modules is not installed in this worktree — but the change is structurally identical to the already-wired activities/calendar pages.