### PR TITLE
Wire CRM `products/openFilter` dispatch

### DIFF
--- a/src/modules/manifest-dispatches.test.ts
+++ b/src/modules/manifest-dispatches.test.ts
@@ -35,7 +35,6 @@ type Orphan = `${string}::${string}::${string}`;
 // passes today and starts failing the moment a NEW orphan is introduced — or
 // an existing orphan is wired up (in which case remove the entry).
 const KNOWN_ORPHANS: ReadonlySet<Orphan> = new Set<Orphan>([
-  "src/modules/crm/manifest.ts::products::openFilter",
   "src/modules/crm/manifest.ts::email-templates::openSearch",
   "src/modules/crm/manifest.ts::email-templates::composeEmail",
   "src/modules/gabinet/manifest.ts::packages::viewExpiring",

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -66,6 +66,7 @@ function ProductsPage() {
   const [panelOpen, setPanelOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
   const [savedViewsDialogOpen, setSavedViewsDialogOpen] = useState(false);
+  const [filterSlideoutOpen, setFilterSlideoutOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
   const [activeFilters, setActiveFilters] = useState<FilterCondition[]>([]);
   const { handleExport } = useCsvExport(organizationId, "products");
@@ -95,6 +96,7 @@ function ProductsPage() {
   useSidebarDispatch("importCsv", () => setImportOpen(true));
   useSidebarDispatch("exportCsv", () => handleExport());
   useSidebarDispatch("savedViews", () => setSavedViewsDialogOpen(true));
+  useSidebarDispatch("openFilter", () => setFilterSlideoutOpen(true));
   useSidebarDispatch("manageTags", () => setTagsSlideoutOpen(true));
   useSidebarDispatch("manageCategories", () => setCategoriesSlideoutOpen(true));
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
@@ -277,6 +279,8 @@ function ProductsPage() {
         filterableFields={filterableFields}
         createDialogOpen={savedViewsDialogOpen}
         onCreateDialogOpenChange={setSavedViewsDialogOpen}
+        filterSlideoutOpen={filterSlideoutOpen}
+        onFilterSlideoutOpenChange={setFilterSlideoutOpen}
         searchValue={searchValue}
         onSearchChange={setSearchValue}
         searchPlaceholder={t('products.searchPlaceholder')}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #112.

Closes #112

---

## Claude summary

Fix committed. Summary:

The products page sidebar action "Filtruj wg kategorii" (`dispatch: "openFilter"`) was declared in the CRM manifest but had no handler on `/dashboard/products`, so clicking it was a no-op. I wired it up the same way other list pages do (activities, documents, calendar): added `filterSlideoutOpen` state, an `useSidebarDispatch("openFilter", ...)` handler that opens the slideout, and passed the controlled-state props to `DataListFilterBar`. The corresponding entry was removed from `KNOWN_ORPHANS` in `src/modules/manifest-dispatches.test.ts`. Test passes and typecheck is clean.