### PR TITLE
Wire Gabinet `packages/*` dispatches (openFilter, viewExpiring, assignPackage) o

### DIFF
--- a/src/modules/manifest-dispatches.test.ts
+++ b/src/modules/manifest-dispatches.test.ts
@@ -35,8 +35,6 @@ type Orphan = `${string}::${string}::${string}`;
 // passes today and starts failing the moment a NEW orphan is introduced — or
 // an existing orphan is wired up (in which case remove the entry).
 const KNOWN_ORPHANS: ReadonlySet<Orphan> = new Set<Orphan>([
-  "src/modules/gabinet/manifest.ts::packages::viewExpiring",
-  "src/modules/gabinet/manifest.ts::packages::assignPackage",
   "src/modules/gabinet/manifest.ts::reports::exportReport",
   "src/modules/gabinet/manifest.ts::reports::filterByDate",
   "src/modules/gabinet/manifest.ts::reports::viewTreatmentStats",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -5,6 +5,7 @@ import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseGabinetTreatmentPackagesList, useSupabaseGabinetPackageUsageActive } from "@/hooks/use-supabase-gabinet-packages";
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
+import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { PageHeader } from "@/components/layout/page-header";
 import { SidePanel } from "@/components/crm/side-panel";
@@ -38,7 +39,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Plus, Trash2, Package, Pencil } from "@/lib/ez-icons";
+import { Plus, Trash2, Package, Pencil, Loader2 } from "@/lib/ez-icons";
 import { useState, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -131,11 +132,16 @@ function PackagesIndex() {
   const updatePkg = useAction(api.gabinet.packages.update);
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
   const removePkg = useAction(api.gabinet.packages.remove);
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
+  const purchasePackage = useAction(api.gabinet.packages.purchasePackage);
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
+  const createPayment = useAction(api.payments.create);
 
   // Supabase-backed queries (replacing convexQuery)
   const { data: packagesData } = useSupabaseGabinetTreatmentPackagesList(organizationId);
   const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId);
   const { data: activeUsagesData } = useSupabaseGabinetPackageUsageActive(organizationId);
+  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId);
 
   // Filter treatments to active-only (original Convex query was listActive)
   const treatments = useMemo(
@@ -161,8 +167,16 @@ function PackagesIndex() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [filterPanelOpen, setFilterPanelOpen] = useState(false);
   const [statusFilter, setStatusFilter] = useState<"all" | "active" | "inactive">("all");
+  const [expiringOnly, setExpiringOnly] = useState(false);
+  const [assignPanelOpen, setAssignPanelOpen] = useState(false);
+  const [assignPatientId, setAssignPatientId] = useState<string>("");
+  const [assignPackageId, setAssignPackageId] = useState<string>("");
+  const [assignPaymentMethod, setAssignPaymentMethod] = useState<string>("cash");
+  const [assignSubmitting, setAssignSubmitting] = useState(false);
 
   useSidebarDispatch("openFilter", () => setFilterPanelOpen(true));
+  useSidebarDispatch("viewExpiring", () => setExpiringOnly(true));
+  useSidebarDispatch("assignPackage", () => setAssignPanelOpen(true));
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -291,12 +305,64 @@ function PackagesIndex() {
     }
   };
 
+  const resetAssignForm = useCallback(() => {
+    setAssignPatientId("");
+    setAssignPackageId("");
+    setAssignPaymentMethod("cash");
+  }, []);
+
+  const handleAssignPackage = async () => {
+    if (!assignPatientId || !assignPackageId) return;
+    const pkg = (packagesData ?? []).find((p) => p._id === assignPackageId);
+    if (!pkg) return;
+    setAssignSubmitting(true);
+    try {
+      const usageId = await purchasePackage({
+        organizationId,
+        patientId: assignPatientId,
+        packageId: assignPackageId,
+        paidAmount: pkg.totalPrice,
+        paymentMethod: assignPaymentMethod,
+      });
+      await createPayment({
+        organizationId,
+        patientId: assignPatientId,
+        packageUsageId: usageId,
+        amount: pkg.totalPrice,
+        currency: pkg.currency ?? "PLN",
+        paymentMethod: assignPaymentMethod as "cash" | "card" | "transfer",
+        notes: `Package: ${pkg.name}`,
+      });
+      toast.success(t("gabinet.packages.purchased"));
+      invalidatePackages();
+      setAssignPanelOpen(false);
+      resetAssignForm();
+    } catch (e: any) {
+      toast.error(e.message);
+    } finally {
+      setAssignSubmitting(false);
+    }
+  };
+
+  const expiringPackageIds = useMemo(() => {
+    const now = Date.now();
+    const thirtyDays = 30 * 24 * 60 * 60 * 1000;
+    const ids = new Set<string>();
+    for (const u of activeUsagesData ?? []) {
+      if (u.expiresAt != null && u.expiresAt > now && u.expiresAt <= now + thirtyDays) {
+        ids.add(u.packageId);
+      }
+    }
+    return ids;
+  }, [activeUsagesData]);
+
   const items = useMemo(() => {
-    const all = packagesData ?? [];
-    if (statusFilter === "active") return all.filter((p) => p.isActive);
-    if (statusFilter === "inactive") return all.filter((p) => !p.isActive);
+    let all = packagesData ?? [];
+    if (statusFilter === "active") all = all.filter((p) => p.isActive);
+    else if (statusFilter === "inactive") all = all.filter((p) => !p.isActive);
+    if (expiringOnly) all = all.filter((p) => expiringPackageIds.has(p._id));
     return all;
-  }, [packagesData, statusFilter]);
+  }, [packagesData, statusFilter, expiringOnly, expiringPackageIds]);
 
   // Build a treatment name lookup from loaded treatments
   const treatmentNameMap = useMemo(() => {
@@ -342,6 +408,20 @@ function PackagesIndex() {
           }
         />
       </div>
+
+      {expiringOnly && (
+        <div className="flex items-center justify-between rounded-md border bg-amber-50 dark:bg-amber-950/20 px-3 py-2 text-sm">
+          <span>
+            {t("gabinet.packages.expiringFilterActive", {
+              count: expiringPackageIds.size,
+              defaultValue: "Showing packages with usages expiring within 30 days ({{count}})",
+            })}
+          </span>
+          <Button variant="ghost" size="sm" onClick={() => setExpiringOnly(false)}>
+            {t("common.clearFilters")}
+          </Button>
+        </div>
+      )}
 
       <QuickActionBar
         actions={[
@@ -594,6 +674,74 @@ function PackagesIndex() {
               {t("common.clearFilters")}
             </Button>
           )}
+        </div>
+      </SidePanel>
+
+      <SidePanel
+        open={assignPanelOpen}
+        onOpenChange={(open) => {
+          setAssignPanelOpen(open);
+          if (!open) resetAssignForm();
+        }}
+        title={t("nav.actions.assignPackage")}
+      >
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>{t("gabinet.packages.selectPatient", "Patient")}</Label>
+            <Select value={assignPatientId} onValueChange={setAssignPatientId}>
+              <SelectTrigger>
+                <SelectValue placeholder={t("gabinet.packages.selectPatientPlaceholder", "Select a patient...")} />
+              </SelectTrigger>
+              <SelectContent>
+                {(patientsData ?? []).map((p) => (
+                  <SelectItem key={p._id} value={p._id}>
+                    {p.firstName} {p.lastName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>{t("gabinet.packages.selectPackage")}</Label>
+            <Select value={assignPackageId} onValueChange={setAssignPackageId}>
+              <SelectTrigger>
+                <SelectValue placeholder={t("gabinet.packages.selectPackagePlaceholder")} />
+              </SelectTrigger>
+              <SelectContent>
+                {(packagesData ?? [])
+                  .filter((p) => p.isActive)
+                  .map((pkg) => (
+                    <SelectItem key={pkg._id} value={pkg._id}>
+                      {pkg.name} — {pkg.totalPrice} {pkg.currency ?? "PLN"}
+                    </SelectItem>
+                  ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>{t("gabinet.packages.paymentMethod")}</Label>
+            <Select value={assignPaymentMethod} onValueChange={setAssignPaymentMethod}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="cash">{t("gabinet.packages.paymentMethods.cash")}</SelectItem>
+                <SelectItem value="card">{t("gabinet.packages.paymentMethods.card")}</SelectItem>
+                <SelectItem value="transfer">{t("gabinet.packages.paymentMethods.transfer")}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <Button
+            className="w-full"
+            disabled={!assignPatientId || !assignPackageId || assignSubmitting}
+            onClick={handleAssignPackage}
+          >
+            {assignSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" variant="stroke" />}
+            {t("gabinet.packages.purchaseButton")}
+          </Button>
         </div>
       </SidePanel>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #115.

Closes #115

---

## Claude summary

Committed as `af8f9a8` on branch `claude/issue-115`.

Wired both orphaned dispatches on the gabinet packages page: `viewExpiring` toggles a client-side filter that narrows the card grid to packages with active usages expiring within 30 days (with a dismissible banner), and `assignPackage` opens a SidePanel with patient/package/payment-method selectors that calls the existing `api.gabinet.packages.purchasePackage` action plus `api.payments.create`. Removed both entries from `KNOWN_ORPHANS` so the audit test (`src/modules/manifest-dispatches.test.ts`) stays clean — all 4 tests pass.