### PR TITLE
Fix src/ typecheck errors

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useMutation, useAction } from "convex/react";
+import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useSupabasePipelinesList, useSupabaseAllPipelineStages } from "@/hooks/use-supabase-pipelines";
 import { useSupabaseLeadsList } from "@/hooks/use-supabase-leads";
@@ -232,7 +232,7 @@ function LeadsIndex() {
     return map;
   }, [companiesRaw]);
 
-  const leads = (leadsData?.page ?? []) as Lead[];
+  const leads = (leadsData?.page ?? []) as unknown as Lead[];
 
   const filteredLeads = useMemo(() => {
     let data = applyFilterConditions(leads, activeFilters);
@@ -659,8 +659,8 @@ function LeadsIndex() {
         description={t("deals.createDescription")}
       >
         <LeadForm
-          pipelines={pipelines}
-          stages={stages}
+          pipelines={pipelines as unknown as { _id: Id<"pipelines">; name: string }[]}
+          stages={stages as unknown as { _id: Id<"pipelineStages">; name: string; pipelineId: Id<"pipelines"> }[]}
           customFieldDefinitions={cfDefs}
           isSubmitting={isSubmitting}
           onCancel={() => setCreateOpen(false)}

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -300,7 +300,7 @@ function ProductsPage() {
       <CrmDataTable
         columns={allColumns}
         hiddenColumnIds={hiddenColumnIds}
-        data={products}
+        data={products as unknown as Product[]}
         rowActions={rowActions}
         isLoading={isLoading}
       />

--- a/src/routes/_app/_auth/dashboard/_layout.settings.document-components.$id.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.document-components.$id.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useAction } from "convex/react";
 import { useQuery } from "@tanstack/react-query";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { Button } from "@/components/ui/button";
@@ -68,10 +67,10 @@ function EditDocumentComponentPage() {
   // Load component data when fetched
   useEffect(() => {
     if (component && !loaded) {
-      setName(component.name);
-      setDescription(component.description ?? "");
+      setName(component.name as string);
+      setDescription((component.description as string | undefined) ?? "");
       setCategory(component.category as ComponentCategory);
-      setContentJson(component.contentJson);
+      setContentJson(component.contentJson as string);
       setLoaded(true);
     }
   }, [component, loaded]);

--- a/src/routes/_app/_auth/dashboard/_layout.settings.document-components.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.document-components.index.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useTranslation } from "react-i18next";

--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.$id.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.$id.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useAction, useQuery as useConvexQuery } from "convex/react";
+import { useAction } from "convex/react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
@@ -22,7 +22,6 @@ import {
 } from "@/components/ui/select";
 import { ArrowLeft, ChevronDown, ChevronUp } from "@/lib/ez-icons";
 import { toast } from "sonner";
-import type { Id } from "@cvx/_generated/dataModel";
 import { DocumentTemplateEditor } from "@/components/documents/document-template-editor";
 
 export const Route = createFileRoute(
@@ -131,19 +130,21 @@ function EditFormTemplatePage() {
   // Initialize form from loaded template
   useEffect(() => {
     if (template && !initialized) {
-      setName(template.name);
-      setDescription(template.description ?? "");
+      setName(template.name as string);
+      setDescription((template.description as string | undefined) ?? "");
       setCategory(template.category as FormCategory);
       setModules((template.modules ?? []) as Module[]);
       setEntityTypes((template.entityTypes ?? []) as EntityType[]);
-      setRequiresSignature(template.requiresSignature);
+      setRequiresSignature(template.requiresSignature as boolean);
       if (template.signatureConfig) {
-        setSignatureMethod(
-          template.signatureConfig.method as SignatureMethod,
-        );
-        setSignerRole(template.signatureConfig.signerRole as SignerRole);
+        const signatureConfig = template.signatureConfig as {
+          method: SignatureMethod;
+          signerRole: SignerRole;
+        };
+        setSignatureMethod(signatureConfig.method);
+        setSignerRole(signatureConfig.signerRole);
       }
-      setContentJson(template.contentJson ?? "{}");
+      setContentJson((template.contentJson as string | undefined) ?? "{}");
       setInitialized(true);
     }
   }, [template, initialized]);
@@ -237,10 +238,10 @@ function EditFormTemplatePage() {
             {t("settings.formTemplates.title")}
           </Link>
           <span>/</span>
-          <span className="text-foreground">{template.name}</span>
+          <span className="text-foreground">{template.name as string}</span>
         </div>
         <div className="ml-auto flex items-center gap-2">
-          <Badge variant="outline">v{template.version}</Badge>
+          <Badge variant="outline">v{template.version as number}</Badge>
           <Badge variant={template.isActive ? "default" : "secondary"}>
             {template.isActive
               ? t("settings.formTemplates.statusActive")

--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -2,7 +2,6 @@ import { useState, useMemo, useEffect, useCallback } from "react";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useMutation, useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useTranslation } from "react-i18next";
@@ -523,7 +522,7 @@ function FormTemplatesListPage() {
   const migrateFolders = useMutation(api.documents.seed.migrateFolderPaths);
 
   const allTemplates = useMemo(
-    () => (templates ?? []) as FormTemplateRecord[],
+    () => (templates ?? []) as unknown as FormTemplateRecord[],
     [templates],
   );
 

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -67,7 +67,7 @@ import { SidebarActionsContext } from "@/components/layout/sidebar-context";
 import { MiniCalendarProvider } from "@/components/layout/mini-calendar-context";
 import { SidebarSlotProvider, useSidebarSlot } from "@/components/layout/sidebar-slot-context";
 import { HeaderSlotProvider, HeaderBackButton } from "@/components/layout/header-slot-context";
-import { moduleRegistry, getVisibleModules } from "@/modules/registry";
+import { moduleRegistry } from "@/modules/registry";
 import { useMatchRoute } from "@tanstack/react-router";
 import { ContactForm } from "@/components/forms/contact-form";
 import { CompanyForm } from "@/components/forms/company-form";

--- a/src/routes/_app/_auth/onboarding/_layout.username.tsx
+++ b/src/routes/_app/_auth/onboarding/_layout.username.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/ui/button";
 import { useForm } from "@tanstack/react-form";
 import { zodValidator } from "@tanstack/zod-form-adapter";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { convexQuery, useConvexAction } from "@convex-dev/react-query";
 import { api } from "~/convex/_generated/api";
 import { Route as DashboardRoute } from "@/routes/_app/_auth/dashboard/_layout.index";
 import * as validators from "@/utils/validators";
@@ -25,7 +25,7 @@ export default function OnboardingUsername() {
   const { data: user } = useQuery(convexQuery(api.app.getCurrentUser, {}));
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { mutateAsync: completeOnboarding } = useMutation({
-    mutationFn: useConvexMutation(api.app.completeOnboarding),
+    mutationFn: useConvexAction(api.app.completeOnboarding),
   });
   const navigate = useNavigate();
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #141.

Closes #141

---

## Claude summary

Cleared the typecheck errors specifically called out in #141 across all eight named route files. The fixes fall into three patterns: drop unused imports (TS6133), cast `MappedX[]` → `Doc<X>[]` via `unknown` where the runtime shapes overlap but `_creationTime` is missing on the Mapped variants, and coerce `unknown`-typed fields from `useAction(...)` results in `setState` calls with explicit narrowing casts.

One non-mechanical fix: `onboarding/_layout.username.tsx` was using `useConvexMutation` against `api.app.completeOnboarding`, which is an action — switched to `useConvexAction` to match the function kind.

After the change, `npx tsc -p tsconfig.app.json` reports 0 errors in the eight targeted files; the rest of `src/` still has ~366 errors in unrelated files (documents/, gabinet/, hooks/use-supabase-*, other routes). Those were never in #141's scope.

## Follow-ups
- Fix typecheck errors in `src/components/documents/*`: ~50 errors around `FormDoc[]` casts and unknown-typed fields in checklist/dialog/tab components
- Fix typecheck errors in `src/components/gabinet/calendar/appointment-detail-dialog.tsx`: ~25 errors from unknown-typed treatment fields and t() options
- Fix typecheck errors in `src/components/gabinet/{appointment-form,appointment-dialog,package-*,patient-packages-card,treatment-form}.tsx`: action-vs-query mismatches and unknown row fields
- Fix typecheck errors in `src/hooks/use-supabase-scheduled-activities.ts`: ~30 errors from `never`-typed Supabase query rows and `{}` moduleRef
- Fix typecheck errors in `src/routes/_app/_auth/dashboard/_layout.calendar.tsx` and `_layout.calls.index.tsx`: action-as-mutation typing and `MappedCall[]` cast (mirrors the pattern fixed in #141)
- Fix typecheck errors in `src/routes/_app/_auth/dashboard/_layout.{contacts,companies}.{index,new}.tsx`: same `MappedX` vs `Doc<X>` pattern + `MappedCustomFieldDefinition.fieldType` is `string` instead of literal union
- Fix typecheck errors in `src/components/shadcn-studio/blocks/dashboard-dialog-16/dialog-create-app.tsx`: `TransitionPayload` vs `MouseEventHandler` mismatch on stepper button onClick
- Replace bare `useMutation` of action `api.calendar.updateAppointment` in `_layout.calendar.tsx`: kind mismatch (`"action"` vs `"mutation"`)
- Drop stale `convexQuery`/`useMutation`/`Id` imports across many route files: TS6133 noise that masks real errors
- Audit and tighten `MappedX` types vs `Doc<X>`: either include `_creationTime` in the mappers or expose a shared `Doc<X>` superset to remove the per-call-site `as unknown as` ladder