### PR TITLE
Fix typecheck errors in `src/components/gabinet/{appointment-form,appointment-di

### DIFF
--- a/src/components/gabinet/appointment-form.tsx
+++ b/src/components/gabinet/appointment-form.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
-import { useMutation, useAction, useConvex } from "convex/react";
+import { useAction } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
@@ -97,6 +97,18 @@ interface AppointmentFormProps {
   isSubmitting?: boolean;
   tagDefinitions?: TagDef[];
   categoryDefinitions?: CategoryDef[];
+}
+
+interface RoomDoc {
+  _id: Id<"gabinetRooms">;
+  name: string;
+  isActive: boolean;
+}
+
+interface LocationWithRoomsDoc {
+  _id: Id<"gabinetLocations">;
+  name: string;
+  rooms?: RoomDoc[];
 }
 
 export function AppointmentForm({
@@ -200,11 +212,10 @@ export function AppointmentForm({
   const [roomId, setRoomId] = useState("");
   const [tagIds, setTagIds] = useState<Id<"tagDefinitions">[]>([]);
   const [categoryId, setCategoryId] = useState<Id<"categoryDefinitions"> | undefined>();
-  const convex = useConvex();
 
   // Rooms query — enabled only when a location is selected
   const getLocationAction = useAction(api.gabinet.locations.getLocation);
-  const { data: locationWithRooms } = useQuery({
+  const { data: locationWithRoomsRaw } = useQuery({
     queryKey: ["gabinet.locations.getLocation", organizationId, locationId],
     queryFn: () =>
       getLocationAction({
@@ -213,6 +224,7 @@ export function AppointmentForm({
       }),
     enabled: !!organizationId && !!locationId,
   });
+  const locationWithRooms = locationWithRoomsRaw as unknown as LocationWithRoomsDoc | null | undefined;
   const activeRooms = locationWithRooms?.rooms?.filter((r) => r.isActive) ?? [];
 
   // Equipment at selected location — for advisory warnings
@@ -241,7 +253,9 @@ export function AppointmentForm({
   const missingEquipmentIds = useMemo(() => {
     if (!locationId || !selectedTreatment?.requiredEquipmentIds?.length) return [];
     const atLocationIds = new Set(equipmentAtLocation?.map((e) => e._id) ?? []);
-    return selectedTreatment.requiredEquipmentIds.filter((id) => !atLocationIds.has(id));
+    return (selectedTreatment.requiredEquipmentIds as Id<"gabinetEquipment">[]).filter(
+      (id) => !atLocationIds.has(id),
+    );
   }, [locationId, selectedTreatment, equipmentAtLocation]);
 
   // Filter employees by treatment qualification

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { useMutation, useAction, useConvex } from "convex/react";
+import { useAction, useConvex } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
@@ -296,7 +296,7 @@ export function AppointmentDialog({
 
   // Rooms query — enabled only when a location is selected
   const getLocationAction = useAction(api.gabinet.locations.getLocation);
-  const { data: locationWithRooms } = useQuery({
+  const { data: locationWithRoomsRaw } = useQuery({
     queryKey: ["gabinet.locations.getLocation", organizationId, locationId],
     queryFn: () =>
       getLocationAction({
@@ -305,7 +305,11 @@ export function AppointmentDialog({
       }),
     enabled: !!locationId,
   });
-  const activeRooms = locationWithRooms?.rooms?.filter((r: { isActive: boolean }) => r.isActive) ?? [];
+  const locationWithRooms = locationWithRoomsRaw as unknown as
+    | { rooms?: Array<{ _id: Id<"gabinetRooms">; name: string; isActive: boolean }> }
+    | null
+    | undefined;
+  const activeRooms = locationWithRooms?.rooms?.filter((r) => r.isActive) ?? [];
 
   // Equipment at selected location — for advisory warnings
   const listEquipmentAction = useAction(api.gabinet.equipment.listEquipment);

--- a/src/components/gabinet/package-purchase-drawer.tsx
+++ b/src/components/gabinet/package-purchase-drawer.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
@@ -30,6 +29,26 @@ interface PackagePurchaseDrawerProps {
   onOpenChange: (open: boolean) => void;
 }
 
+interface PackageTreatmentEntry {
+  treatmentId: Id<"gabinetTreatments">;
+  quantity: number;
+}
+
+interface PackageDoc {
+  _id: Id<"gabinetTreatmentPackages">;
+  name: string;
+  description?: string;
+  treatments: PackageTreatmentEntry[];
+  totalPrice: number;
+  currency?: string;
+  validityDays?: number;
+}
+
+interface TreatmentDoc {
+  _id: Id<"gabinetTreatments">;
+  name: string;
+}
+
 export function PackagePurchaseDrawer({
   patientId,
   organizationId,
@@ -45,18 +64,20 @@ export function PackagePurchaseDrawer({
   const [submitting, setSubmitting] = useState(false);
 
   const listActivePackages = useAction(api.gabinet.packages.listActive);
-  const { data: activePackages } = useQuery({
+  const { data: activePackagesRaw } = useQuery({
     queryKey: ["gabinet.packages.listActive", organizationId],
     queryFn: () => listActivePackages({ organizationId }),
     enabled: !!organizationId,
-  }) as { data: any[] | undefined };
+  });
+  const activePackages = activePackagesRaw as unknown as PackageDoc[] | undefined;
 
   const listActiveTreatments = useAction(api.gabinet.treatments.listActive);
-  const { data: treatments } = useQuery({
+  const { data: treatmentsRaw } = useQuery({
     queryKey: ["gabinet.treatments.listActive", organizationId],
     queryFn: () => listActiveTreatments({ organizationId }),
     enabled: !!organizationId,
-  }) as { data: any[] | undefined };
+  });
+  const treatments = treatmentsRaw as unknown as TreatmentDoc[] | undefined;
 
   const treatmentMap = new Map(
     (treatments ?? []).map((tr) => [tr._id, tr.name])

--- a/src/components/gabinet/package-usage-selector.tsx
+++ b/src/components/gabinet/package-usage-selector.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { convexQuery } from "@convex-dev/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { Id } from "@cvx/_generated/dataModel";
@@ -15,6 +14,25 @@ interface PackageUsageSelectorProps {
   selectedUsageId?: string | null;
 }
 
+interface PackageUsageTreatmentEntry {
+  treatmentId: Id<"gabinetTreatments">;
+  usedCount: number;
+  totalCount: number;
+}
+
+interface PackageUsageDoc {
+  _id: Id<"gabinetPackageUsage">;
+  packageId: Id<"gabinetTreatmentPackages">;
+  status: string;
+  expiresAt?: number;
+  treatmentsUsed: PackageUsageTreatmentEntry[];
+}
+
+interface PackageDoc {
+  _id: Id<"gabinetTreatmentPackages">;
+  name: string;
+}
+
 export function PackageUsageSelector({
   patientId,
   treatmentId,
@@ -25,7 +43,7 @@ export function PackageUsageSelector({
   const { t } = useTranslation();
 
   const getPatientPackagesAction = useAction(api.gabinet.packages.getPatientPackages);
-  const { data: usages } = useQuery({
+  const { data: usagesRaw } = useQuery({
     queryKey: ["gabinet.packages.getPatientPackages", organizationId, patientId],
     queryFn: () =>
       getPatientPackagesAction({
@@ -34,13 +52,15 @@ export function PackageUsageSelector({
       }),
     enabled: !!organizationId && !!patientId,
   });
+  const usages = usagesRaw as unknown as PackageUsageDoc[] | undefined;
 
   const listActivePackages = useAction(api.gabinet.packages.listActive);
-  const { data: allPackages } = useQuery({
+  const { data: allPackagesRaw } = useQuery({
     queryKey: ["gabinet.packages.listActive", organizationId],
     queryFn: () => listActivePackages({ organizationId }),
     enabled: !!organizationId,
-  }) as { data: any[] | undefined };
+  });
+  const allPackages = allPackagesRaw as unknown as PackageDoc[] | undefined;
 
   const packageMap = new Map(
     (allPackages ?? []).map((p) => [p._id, p.name])

--- a/src/components/gabinet/patient-packages-card.tsx
+++ b/src/components/gabinet/patient-packages-card.tsx
@@ -16,6 +16,30 @@ interface PatientPackagesCardProps {
   organizationId: Id<"organizations">;
 }
 
+interface PackageUsageTreatmentEntry {
+  treatmentId: Id<"gabinetTreatments">;
+  usedCount: number;
+  totalCount: number;
+}
+
+interface PackageUsageDoc {
+  _id: Id<"gabinetPackageUsage">;
+  packageId: Id<"gabinetTreatmentPackages">;
+  status: string;
+  expiresAt?: number;
+  treatmentsUsed: PackageUsageTreatmentEntry[];
+}
+
+interface PackageDoc {
+  _id: Id<"gabinetTreatmentPackages">;
+  name: string;
+}
+
+interface TreatmentDoc {
+  _id: Id<"gabinetTreatments">;
+  name: string;
+}
+
 const statusColors: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
   active: "default",
   completed: "secondary",
@@ -28,7 +52,7 @@ export function PatientPackagesCard({ patientId, organizationId }: PatientPackag
   const [purchaseOpen, setPurchaseOpen] = useState(false);
 
   const getPatientPackagesAction = useAction(api.gabinet.packages.getPatientPackages);
-  const { data: usages } = useQuery({
+  const { data: usagesRaw } = useQuery({
     queryKey: ["gabinet.packages.getPatientPackages", organizationId, patientId],
     queryFn: () =>
       getPatientPackagesAction({
@@ -37,20 +61,23 @@ export function PatientPackagesCard({ patientId, organizationId }: PatientPackag
       }),
     enabled: !!organizationId && !!patientId,
   });
+  const usages = usagesRaw as unknown as PackageUsageDoc[] | undefined;
 
   const listActivePackages = useAction(api.gabinet.packages.listActive);
-  const { data: allPackages } = useQuery({
+  const { data: allPackagesRaw } = useQuery({
     queryKey: ["gabinet.packages.listActive", organizationId],
     queryFn: () => listActivePackages({ organizationId }),
     enabled: !!organizationId,
-  }) as { data: any[] | undefined };
+  });
+  const allPackages = allPackagesRaw as unknown as PackageDoc[] | undefined;
 
   const listActiveTreatments = useAction(api.gabinet.treatments.listActive);
-  const { data: treatments } = useQuery({
+  const { data: treatmentsRaw } = useQuery({
     queryKey: ["gabinet.treatments.listActive", organizationId],
     queryFn: () => listActiveTreatments({ organizationId }),
     enabled: !!organizationId,
-  }) as { data: any[] | undefined };
+  });
+  const treatments = treatmentsRaw as unknown as TreatmentDoc[] | undefined;
 
   const treatmentMap = new Map(
     (treatments ?? []).map((tr) => [tr._id, tr.name])

--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
-import { convexQuery } from "@convex-dev/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { Button } from "@/components/ui/button";


### PR DESCRIPTION
Auto-generated by Claude in response to issue #151.

Closes #151

---

## Claude summary

Fixed all typecheck errors in the files specified by issue #151. Defined narrow `RoomDoc` / `LocationWithRoomsDoc` / `PackageDoc` / `PackageUsageDoc` / `TreatmentDoc` interfaces and cast the loosely-typed `Record<string, unknown>` results from the action endpoints through `unknown` at the query boundary, matching the pattern from PR #150. Also removed unused imports flagged by TS6133. Verified no remaining errors in the targeted files (`grep -E "components/gabinet/(appointment-form|appointment-dialog|package-|patient-packages-card|treatment-form)"` returns empty).

## Follow-ups
- Fix typecheck errors in `src/components/gabinet/change-employee-modal.tsx`: unused `convexQuery` import (TS6133)
- Fix typecheck errors in `src/components/forms/package-form.tsx`: action wrongly passed to `useQuery` instead of `useAction`, plus implicit-any callbacks
- Fix typecheck errors in `src/components/email/email-entity-tab.tsx`: unknown row fields from action returning `Record<string, unknown>`
- Fix typecheck errors in `src/components/sidebar-widgets/day-timeline.tsx`: unknown fields on `appt` (treatmentDuration etc.) from loose action return type
- Strengthen Convex action return types instead of `Record<string, unknown>`: removes the need for per-consumer type-cast shims across the gabinet module