### PR TITLE
Fix typecheck errors in `src/hooks/use-supabase-scheduled-activities.ts`

### DIFF
--- a/src/hooks/use-supabase-scheduled-activities.ts
+++ b/src/hooks/use-supabase-scheduled-activities.ts
@@ -244,13 +244,19 @@ export function useSupabaseScheduledActivitiesByDateRange(
           .select("id,status,patient_id,treatment_id")
           .in("id", gabinetEntityIds);
         if (apptErr) throw apptErr;
+        const apptRows = (appts ?? []) as Array<{
+          id: string;
+          status: string | null;
+          patient_id: string;
+          treatment_id: string | null;
+        }>;
         apptMap = new Map(
-          (appts ?? []).map((a) => [
-            a.id as string,
+          apptRows.map((a) => [
+            a.id,
             {
-              status: (a.status as string) ?? "scheduled",
-              patientId: a.patient_id as string,
-              treatmentId: (a.treatment_id as string | null) ?? null,
+              status: a.status ?? "scheduled",
+              patientId: a.patient_id,
+              treatmentId: a.treatment_id ?? null,
             },
           ]),
         );
@@ -261,10 +267,15 @@ export function useSupabaseScheduledActivitiesByDateRange(
             .from("gabinet_patients")
             .select("id,first_name,last_name")
             .in("id", patientIds);
+          const patientRows = (patients ?? []) as Array<{
+            id: string;
+            first_name: string | null;
+            last_name: string | null;
+          }>;
           patientMap = new Map(
-            (patients ?? []).map((p) => [
-              p.id as string,
-              `${(p.first_name as string) ?? ""} ${(p.last_name as string) ?? ""}`.trim(),
+            patientRows.map((p) => [
+              p.id,
+              `${p.first_name ?? ""} ${p.last_name ?? ""}`.trim(),
             ]),
           );
         }
@@ -281,8 +292,12 @@ export function useSupabaseScheduledActivitiesByDateRange(
             .from("gabinet_treatments")
             .select("id,name")
             .in("id", treatmentIds);
+          const treatmentRows = (treatments ?? []) as Array<{
+            id: string;
+            name: string | null;
+          }>;
           treatmentMap = new Map(
-            (treatments ?? []).map((t) => [t.id as string, (t.name as string) ?? ""]),
+            treatmentRows.map((t) => [t.id, t.name ?? ""]),
           );
         }
       }
@@ -372,22 +387,30 @@ export function useSupabaseUpcomingEvents(
           .select("id,name,email,image")
           .in("id", ownerIds);
         if (usersErr) throw usersErr;
-        owners = userRows ?? [];
+        owners = (userRows ?? []) as Array<{
+          id: string;
+          name: string | null;
+          email: string | null;
+          image: string | null;
+        }>;
       }
       const ownerMap = new Map(owners.map((u) => [u.id, u]));
 
       return activities.slice(0, limit).map<UpcomingEvent>((a) => {
         const owner = ownerMap.get(String(a.ownerId));
+        const moduleRef = a.moduleRef as
+          | { moduleId?: string; entityType?: string; entityId?: string }
+          | undefined;
         const isAppointment =
-          a.moduleRef?.moduleId === "gabinet" &&
-          a.moduleRef?.entityType === "gabinetAppointment";
+          moduleRef?.moduleId === "gabinet" &&
+          moduleRef?.entityType === "gabinetAppointment";
         return {
           id: a._id,
           title: a.title,
           startTime: a.dueDate,
           type: a.activityType,
-          appointmentLink: isAppointment && a.moduleRef?.entityId
-            ? `/dashboard/gabinet/appointments/${a.moduleRef.entityId}`
+          appointmentLink: isAppointment && moduleRef?.entityId
+            ? `/dashboard/gabinet/appointments/${moduleRef.entityId}`
             : null,
           ownerId: String(a.ownerId),
           ownerName: owner?.name ?? owner?.email ?? "?",
@@ -431,7 +454,11 @@ export function useSupabaseActivitiesKpis(
       todayStart.setHours(0, 0, 0, 0);
       const todayEnd = todayStart.getTime() + 86400000;
 
-      const rows = data ?? [];
+      const rows = (data ?? []) as Array<{
+        due_date: number | null;
+        is_completed: boolean | null;
+        owner_id: string | null;
+      }>;
       const overdue = rows.filter(
         (a) => a.due_date && a.due_date < now && !a.is_completed,
       ).length;
@@ -481,7 +508,12 @@ export function useSupabaseCalendarKpis(
       const todayEnd = todayStart.getTime() + 86400000;
       const weekEnd = todayStart.getTime() + 7 * 86400000;
 
-      const rows = data ?? [];
+      const rows = (data ?? []) as Array<{
+        due_date: number | null;
+        is_completed: boolean | null;
+        owner_id: string | null;
+        requires_completion: boolean | null;
+      }>;
       return {
         today: rows.filter((a) => a.due_date && a.due_date >= todayStart.getTime() && a.due_date < todayEnd).length,
         overdue: rows.filter((a) => a.due_date && a.due_date < now && !a.is_completed).length,
@@ -532,7 +564,12 @@ export function useSupabaseWeeklyActivitiesTrend(
         .eq("owner_id", userId)
         .gte("created_at", days[0]._start);
       if (error) throw error;
-      const rows = data ?? [];
+      const rows = (data ?? []) as Array<{
+        created_at: number;
+        is_completed: boolean | null;
+        completed_at: number | null;
+        owner_id: string | null;
+      }>;
 
       for (const day of days) {
         day.created = rows.filter((a) => a.created_at >= day._start && a.created_at < day._end).length;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #152.

Closes #152

---

## Claude summary

Resolved all 36 typecheck errors in `src/hooks/use-supabase-scheduled-activities.ts` (#152). The Supabase client returns `never`-typed rows for partial selects under the project's generated `Database` types, and `MappedScheduledActivity.moduleRef` is typed `unknown` — both required explicit shape casts.

Changes (commit `1b272f6`):
- Cast `(data ?? []) as Array<{...}>` for the gabinet appointment / patient / treatment enrichment joins inside `useSupabaseScheduledActivitiesByDateRange`, removing per-field `as string` casts that no longer compile because the row itself was `never`.
- Cast the `users` join result in `useSupabaseUpcomingEvents` and hoisted a `moduleRef` cast (`{ moduleId?; entityType?; entityId? } | undefined`) so the optional-chain accesses compile.
- Cast `(data ?? [])` to the partial-select shape in `useSupabaseActivitiesKpis`, `useSupabaseCalendarKpis`, and `useSupabaseWeeklyActivitiesTrend` so `due_date`, `is_completed`, `requires_completion`, `created_at`, `completed_at` access typecheck.

Repo total errors went 240 → 204 (-36, exactly the count attributed to this file). Followed the existing pattern from `src/hooks/use-supabase-dashboard.ts` (`(rows ?? []) as RowType[]`).