### PR TITLE
Fix typecheck errors in `src/routes/_app/_auth/dashboard/_layout.{contacts,compa

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
@@ -94,7 +94,8 @@ function CompaniesIndex() {
     { id: "categoryId", label: t('common.category', { defaultValue: "Kategoria" }), type: "select" as const, options: categories.map(cat => ({ label: cat.name, value: cat._id })) },
   ], [t, tags, categories]);
 
-  const { data: companies = [], isLoading } = useSupabaseCompaniesList(organizationId);
+  const { data: companiesRaw = [], isLoading } = useSupabaseCompaniesList(organizationId);
+  const companies = companiesRaw as unknown as Company[];
 
   const companyIds = useMemo(() => companies.map((c) => c._id as string), [companies]);
 

--- a/src/routes/_app/_auth/dashboard/_layout.companies.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.new.tsx
@@ -8,7 +8,7 @@ import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { PageHeader } from "@/components/layout/page-header";
 import { CompanyForm } from "@/components/forms/company-form";
 import { Card, CardContent } from "@/components/ui/card";
-import { useState } from "react";
+import { useState, type ComponentProps } from "react";
 import { Id } from "@cvx/_generated/dataModel";
 
 export const Route = createFileRoute(
@@ -35,7 +35,9 @@ function NewCompany() {
       <Card>
         <CardContent className="pt-6">
           <CompanyForm
-            customFieldDefinitions={customFieldDefs}
+            customFieldDefinitions={
+              customFieldDefs as unknown as ComponentProps<typeof CompanyForm>["customFieldDefinitions"]
+            }
             isSubmitting={isSubmitting}
             onCancel={() => navigate({ to: "/dashboard/companies" })}
             onSubmit={async (data, customFieldRecord) => {

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
@@ -82,7 +82,8 @@ function ContactsIndex() {
     { id: "categoryId", label: t('common.category', { defaultValue: "Kategoria" }), type: "select" as const, options: categories.map(cat => ({ label: cat.name, value: cat._id })) },
   ], [t, tags, categories]);
 
-  const { data: contacts = [], isLoading } = useSupabaseContactsList(organizationId);
+  const { data: contactsRaw = [], isLoading } = useSupabaseContactsList(organizationId);
+  const contacts = contactsRaw as unknown as Contact[];
 
   const contactIds = useMemo(() => contacts.map((c) => c._id as string), [contacts]);
 

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.new.tsx
@@ -7,7 +7,7 @@ import { useSupabaseCustomFieldDefinitions } from "@/hooks/use-supabase-custom-f
 import { PageHeader } from "@/components/layout/page-header";
 import { ContactForm } from "@/components/forms/contact-form";
 import { Card, CardContent } from "@/components/ui/card";
-import { useState } from "react";
+import { useState, type ComponentProps } from "react";
 import { Id } from "@cvx/_generated/dataModel";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 
@@ -35,7 +35,9 @@ function NewContact() {
       <Card>
         <CardContent className="pt-6">
           <ContactForm
-            customFieldDefinitions={customFieldDefs}
+            customFieldDefinitions={
+              customFieldDefs as unknown as ComponentProps<typeof ContactForm>["customFieldDefinitions"]
+            }
             isSubmitting={isSubmitting}
             onCancel={() => navigate({ to: "/dashboard/contacts" })}
             onSubmit={async (data, customFieldRecord) => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #154.

Closes #154

---

## Claude summary

Cleared the 9 typecheck errors called out in #154 across the four contacts/companies routes. Cast `MappedCompany[]`/`MappedContact[]` once at the supabase destructure to `Doc<...>[]` (mirroring the leads.index.tsx pattern from #141), and cast the `customFieldDefs` prop in both `*.new.tsx` files via `ComponentProps<typeof Form>["customFieldDefinitions"]` to bridge `MappedCustomFieldDefinition.fieldType: string` → `CustomFieldType` literal union without duplicating the form's local `FieldDefinition` interface. Net: 196 → 187 src/ typecheck errors, no regressions, committed as `6ca68d1`.