### PR TITLE
Fix typecheck errors in `src/components/shadcn-studio/blocks/dashboard-dialog-16

### DIFF
--- a/src/components/shadcn-studio/blocks/dashboard-dialog-16/dialog-create-app.tsx
+++ b/src/components/shadcn-studio/blocks/dashboard-dialog-16/dialog-create-app.tsx
@@ -370,7 +370,12 @@ const CreateAppDialog = ({ defaultOpen = false, trigger, className }: Props) => 
               billing: () => <BillingStep />
             })}
             <DialogFooter className='flex !justify-between'>
-              <Button variant='secondary' size='lg' onClick={stepper.navigation.prev} disabled={stepper.state.isFirst}>
+              <Button
+                variant='secondary'
+                size='lg'
+                onClick={() => stepper.navigation.prev()}
+                disabled={stepper.state.isFirst}
+              >
                 <ArrowLeftIcon />
                 Previous
               </Button>
@@ -385,7 +390,7 @@ const CreateAppDialog = ({ defaultOpen = false, trigger, className }: Props) => 
                   </Button>
                 </DialogClose>
               ) : (
-                <Button size='lg' onClick={stepper.navigation.next}>
+                <Button size='lg' onClick={() => stepper.navigation.next()}>
                   Next
                   <ArrowRightIcon />
                 </Button>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #155.

Closes #155

---

## Claude summary

Fixed and committed. The two `TS2322` errors at lines 373 and 388 were caused by passing `stepper.navigation.prev` / `stepper.navigation.next` (which take a `TransitionPayload`) directly as the Button's `onClick` (which expects a `MouseEventHandler`). Wrapped both in arrow functions to match the existing pattern on line 335. Re-ran `tsc -p tsconfig.app.json` and confirmed both errors are gone.