### PR TITLE
Drop stale `convexQuery`/`useMutation`/`Id` imports across many route files

### DIFF
--- a/src/components/gabinet/change-employee-modal.tsx
+++ b/src/components/gabinet/change-employee-modal.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";

--- a/src/hooks/use-supabase-form-documents.ts
+++ b/src/hooks/use-supabase-form-documents.ts
@@ -9,7 +9,6 @@ import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
 import { useSupabase } from "@/components/supabase-provider";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { mapFormDocumentFromSupabase, type MappedFormDocument } from "@/lib/supabase/mappers/form-documents";
-import type { Id } from "@cvx/_generated/dataModel";
 
 // ---------------------------------------------------------------------------
 // Form Documents List

--- a/src/routes/_app/_auth/dashboard/_layout.calendar-preview.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calendar-preview.tsx
@@ -1,8 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
-import { convexQuery } from "@convex-dev/react-query";
-import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import {
   Calendar,

--- a/src/routes/_app/_auth/dashboard/_layout.document-editor.$id.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.document-editor.$id.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useAction, useQuery as useConvexQuery } from "convex/react";
+import { useAction } from "convex/react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
@@ -33,7 +33,6 @@ import {
 } from "@/components/documents/document-template-editor";
 import { TemplatePreviewSheet } from "@/components/documents/template-preview-sheet";
 import type { VariableField } from "@/lib/document-variables";
-import type { Id } from "@cvx/_generated/dataModel";
 import { Menu } from "lucide-react";
 
 export const Route = createFileRoute(

--- a/src/routes/_app/_auth/dashboard/_layout.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.documents.index.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useSupabaseFormDocumentsList } from "@/hooks/use-supabase-form-documents";
 import { useSupabaseOrganizationMembers } from "@/hooks/use-supabase-organizations";

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -1,6 +1,5 @@
 import { createLazyFileRoute, useNavigate } from "@tanstack/react-router";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { convexQuery } from "@convex-dev/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useSupabaseOrganizationMembers } from "@/hooks/use-supabase-organizations";

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useSupabaseOrganizationMembers } from "@/hooks/use-supabase-organizations";
 import { useOrganization } from "@/components/org-context";

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -2,7 +2,6 @@ import { useState, useMemo, useEffect } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseGabinetEmployee } from "@/hooks/use-supabase-gabinet-employees";

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, useNavigate, Link } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
 import { useSupabaseOrganizationMembers } from "@/hooks/use-supabase-organizations";

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useAction, useQuery as useConvexQuery } from "convex/react";
+import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -2,7 +2,6 @@ import { useState, useMemo, useCallback, useEffect } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseGabinetTreatment, useSupabaseGabinetTreatmentVariants } from "@/hooks/use-supabase-gabinet-treatments";

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -2,7 +2,6 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Link } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
 import { useOrganization } from "@/components/org-context";


### PR DESCRIPTION
Auto-generated by Claude in response to issue #157.

Closes #157

---

## Claude summary

Committed. Removed 16 unused-import lines across 12 files (`convexQuery`, `useConvexQuery`, `Id`, plus the adjacent `useQuery`/`api` imports that became stale on the same line). Typecheck error count went from 229 to 213 with no new errors. Other unrelated TS errors elsewhere in the codebase are out of scope.