### PR TITLE
Update seatLimits.test.ts to use `.action()` instead of `.mutation()` for `api.i

### DIFF
--- a/tests/convex/seatLimits.test.ts
+++ b/tests/convex/seatLimits.test.ts
@@ -219,7 +219,7 @@ describe("invitations.create with seat limit", () => {
     const t = createTestCtx();
     const { organizationId, identity } = await seedTestUser(t);
 
-    const invitationId = await t.withIdentity(identity).mutation(
+    const invitationId = await t.withIdentity(identity).action(
       api.invitations.create,
       {
         organizationId,
@@ -273,7 +273,7 @@ describe("invitations.create with seat limit", () => {
 
     // Owner already counts as 1 seat, limit is 1
     await expect(
-      t.withIdentity(identity).mutation(api.invitations.create, {
+      t.withIdentity(identity).action(api.invitations.create, {
         organizationId,
         email: "new@example.com",
         role: "member",
@@ -321,7 +321,7 @@ describe("invitations.create with seat limit", () => {
     });
 
     await expect(
-      t.withIdentity(identity).mutation(api.invitations.create, {
+      t.withIdentity(identity).action(api.invitations.create, {
         organizationId,
         email: "new@example.com",
         role: "member",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #98.

Closes #98

---

## Claude summary

Updated the three `t.withIdentity(identity).mutation(api.invitations.create, ...)` calls in `tests/convex/seatLimits.test.ts` (lines 222, 276, 324) to `.action(...)` to match `invitations.create`'s actual export type (`action`, confirmed at `convex/invitations.ts:65`). Committed as `a68fb13`.