### PR TITLE
Investigate large empty space below dashboard content on /dashboard/gabinet

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -684,17 +684,18 @@ function DashboardLayout() {
         </div>
         <DevInfoDialog open={devInfoOpen} onOpenChange={handleDevInfoClose} />
 
-        <div className="flex min-w-0 flex-1">
+        <div className="flex min-h-0 min-w-0 flex-1">
         <SidebarActionsContext.Provider value={sidebarActionsValue}>
           <SidebarProvider
             defaultOpen={false}
+            className="!min-h-0 h-full"
             style={{ "--sidebar-width-icon": "3.5625rem" } as CSSProperties}
           >
             {/* Columns 1 & 2: Icon sidebar + Detail panel */}
             <AppSidebar />
 
             {/* Column 3: Main content */}
-            <div className="flex min-w-0 flex-1 flex-col h-[calc(100dvh-30px)] overflow-hidden">
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
               <header className="bg-card sticky top-0 z-50 flex min-h-20 items-center justify-between gap-6 border-b px-4 py-2 sm:px-6">
                 <div className="flex items-center gap-4">
                   <HeaderBackButton />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #53.

Closes #53

---

## Claude summary

Fix committed (2860ae4). Confirmed the screenshot from issue #29 shows the gabinet dashboard footer pinned mid-viewport with a tall white gap below — caused by mixing two height strategies in `src/routes/_app/_auth/dashboard/_layout.tsx`:

- The outer container is `flex h-dvh flex-col overflow-hidden` minus a 30px beta strip, so the inner row gets `dvh - 30px`.
- shadcn's `SidebarProvider` wraps its children with `flex min-h-svh w-full` (`min-h-svh` ≈ `100dvh`), forcing it 30px taller than its allotted parent space and overflowing the viewport.
- The right column hard-coded `h-[calc(100dvh-30px)]` to compensate, but the explicit calc-vs-flex math wasn't aligning with actual remaining space (likely interacting with browser/scrollbar quirks), leaving the footer rendered above the viewport bottom.

The fix overrides `min-h-svh` via `className="!min-h-0 h-full"` on `SidebarProvider`, adds `min-h-0` on the wrapping row so flex children can shrink, and replaces the right column's calc-based height with `flex-1`. Heights now cascade purely through flex (outer h-dvh → row flex-1 → SidebarProvider h-full → right column flex-1), so the footer sits at the viewport bottom on all dashboard routes, not just gabinet.

## Follow-ups
- Replace `h-dvh` on AppSidebar middle column with `h-full`: `src/components/layout/app-sidebar.tsx:139` still uses `sticky top-0 flex h-dvh`, which is 30px taller than its parent SidebarProvider and overflows when the workspace settings/detail rail is rendered (non-icon-only mode); should match the new flex-cascade pattern.
- Gabinet dashboard renders 2 cards in a 3-column grid: `src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx:366` uses `xl:grid-cols-3` but the third "Nudges" column was removed in commit 0b0ab0f, leaving an empty third column on wide screens.