### PR TITLE
Audit non-gabinet table backfills for parity with their runtime writers

### DIFF
--- a/convex/supabase/backfill.ts
+++ b/convex/supabase/backfill.ts
@@ -330,7 +330,7 @@ export const backfillPatients = internalAction({
       tags: p.tags ?? null,
       tag_ids: p.tagIds?.map(String) ?? null,
       category_id: p.categoryId ? String(p.categoryId) : null,
-      custom_fields: null,
+      custom_fields: p.customFields ?? null,
       created_by: String(p.createdBy),
       created_at: p.createdAt,
       updated_at: p.updatedAt,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #161.

Closes #161

---

## Claude summary

Audit summary: across the 5 tables in `convex/supabase/backfill.ts` (users, gabinet_patients, gabinet_treatments, gabinet_employees, gabinet_appointments), I compared each backfill row against its runtime writer (`convex/supabase/gabinet/*.ts`).

The only in-scope regression was the bulk `backfillPatients` action still hardcoding `custom_fields: null` — a leftover from #143/#159, which only fixed the single-record path. I updated line 333 to `p.customFields ?? null` so the bulk path matches `backfillSinglePatient` and `writePatientToSupabase`. The users column set is consistent across all four upsert sites; the appointments backfill matches the runtime writer (both intentionally null out `scheduled_activity_id` on insert).

I also found two parity gaps that are runtime-writer side rather than backfill side, listed below as follow-ups. Both are dormant today because `writeTreatmentToSupabase`/`writeEmployeeToSupabase` aren't scheduled from any Convex mutation (verified via grep).

## Follow-ups
- Add missing columns to writeTreatmentToSupabase: runtime create writer at `convex/supabase/gabinet/treatments.ts:13-78` omits parameters, requiredDocumentTemplateIds, requiredFormTemplates, shortDescription, image — present in schema, in backfill, and in update writer; first create will leave them null until the next update.
- Add missing columns to writeEmployeeToSupabase: runtime create writer at `convex/supabase/gabinet/employees.ts:13-64` omits 16 HR columns (phone, email, dateOfBirth, pesel, address, employmentType, endDate, position, department, skills, yearsOfExperience, certifications, baseSalary, commissionPercent, bankAccount) — present in schema, in backfill, and in update writer.
- Wire up gabinet runtime writers from Convex mutations: writePatient/Treatment/Employee/AppointmentToSupabase have zero schedule callsites, so dual-write to Supabase is currently backfill-only for these four tables.