### PR TITLE
Consider replacing `Record<string, unknown>[]` typing in `upsertBatch` with tabl

### DIFF
--- a/convex/supabase/backfill.ts
+++ b/convex/supabase/backfill.ts
@@ -2,13 +2,18 @@ import { v } from "convex/values";
 import { internalAction, internalQuery } from "../_generated/server";
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
+import type { Database } from "~/src/lib/supabase/database.types";
 import { createServiceRoleClient } from "./client";
 
 const BATCH_SIZE = 50;
 
-async function upsertBatch(
-  table: string,
-  rows: Record<string, unknown>[],
+type SupabaseTable = keyof Database["public"]["Tables"];
+type SupabaseInsert<T extends SupabaseTable> =
+  Database["public"]["Tables"][T]["Insert"];
+
+async function upsertBatch<T extends SupabaseTable>(
+  table: T,
+  rows: SupabaseInsert<T>[],
 ): Promise<{ synced: number; errors: string[] }> {
   if (rows.length === 0) return { synced: 0, errors: [] };
   const client = createServiceRoleClient();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #162.

Closes #162

---

## Claude summary

Made `upsertBatch` generic over the Supabase table name in `convex/supabase/backfill.ts:14` so each call typechecks rows against `Database["public"]["Tables"][T]["Insert"]`. Verified by:

1. `tsc -p convex/tsconfig.json` passes cleanly with the new generic and existing call sites (`gabinet_patients`, `gabinet_appointments`, `gabinet_treatments`, `gabinet_employees`, `users`).
2. Sanity-test: temporarily renaming `first_name` → `first_name_RENAMED` in the patients row produced the expected TS2345 error pointing at the `upsertBatch` call site, then reverted.

Pre-existing typecheck errors in `src/routes/...` are unrelated and present on baseline.

## Follow-ups
- Apply same generic typing to upsertWithFkRetry in convex/supabase/client.ts: also takes `Record<string, unknown>` and has the same column-rename blind spot
- Type the local upsertBatch in scripts/seed-from-convex.mts: the seeding script uses `Record<string, any>[]` and dynamic camelCase→snake_case mapping, so column renames silently produce wrong rows