### PR TITLE
Fix typecheck errors in `src/components/email/email-entity-tab.tsx`

### DIFF
--- a/convex/_helpers/supabaseRows.ts
+++ b/convex/_helpers/supabaseRows.ts
@@ -12,6 +12,7 @@ export type GabinetTreatmentRow = SupabaseRow<"gabinetTreatments">;
 export type GabinetPatientRow = SupabaseRow<"gabinetPatients">;
 export type GabinetAppointmentRow = SupabaseRow<"gabinetAppointments">;
 export type GabinetEmployeeRow = SupabaseRow<"gabinetEmployees">;
+export type EmailRow = SupabaseRow<"emails">;
 
 // Envelope returned by Supabase-backed list actions that imitate the Convex
 // pagination contract. The cursor is unused (Supabase-backed lists return

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -8,6 +8,7 @@ import { publishActivityEnvelope } from "./_helpers/activityEnvelope";
 import { emailDirectionValidator } from "@cvx/schema";
 import { sendEmail } from "@cvx/email";
 import { Id } from "./_generated/dataModel";
+import type { EmailRow } from "./_helpers/supabaseRows";
 
 // Dual-write refs removed — Supabase is now primary for email writes
 
@@ -123,30 +124,30 @@ export const listByEntity = action({
     entityType: v.string(),
     entityId: v.string(),
   },
-  handler: async (ctx, args): Promise<Array<Record<string, unknown>>> => {
+  handler: async (ctx, args): Promise<EmailRow[]> => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
 
     const db = createSupabaseDb();
     const orgIdStr = String(args.organizationId);
-    let emails: Array<Record<string, any>>;
+    let emails: EmailRow[];
 
     if (args.entityType === "contact") {
       emails = (await db.query("emails")
         .eq("organizationId", orgIdStr)
         .eq("contactId", args.entityId)
-        .collect()) as Array<Record<string, any>>;
+        .collect()) as EmailRow[];
     } else if (args.entityType === "company") {
       emails = (await db.query("emails")
         .eq("organizationId", orgIdStr)
         .eq("companyId", args.entityId)
-        .collect()) as Array<Record<string, any>>;
+        .collect()) as EmailRow[];
     } else if (args.entityType === "lead") {
       emails = (await db.query("emails")
         .eq("organizationId", orgIdStr)
         .eq("leadId", args.entityId)
-        .collect()) as Array<Record<string, any>>;
+        .collect()) as EmailRow[];
     } else {
       throw new Error(`Invalid entity type: ${args.entityType}`);
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #167.

Closes #167

---

## Claude summary

Fixed the 6 typecheck errors in `src/components/email/email-entity-tab.tsx`. The action `api.emails.listByEntity` was returning `Array<Record<string, unknown>>`, so every field access in JSX (`email.subject`, `email.sentAt`, `email.from`, etc.) was typed as `unknown`. Following the pattern established in #166, I added `EmailRow = SupabaseRow<"emails">` to `convex/_helpers/supabaseRows.ts` and updated `convex/emails.ts:120` to return `EmailRow[]`. App typecheck on the file is now clean and convex typecheck passes (exit 0).