### PR TITLE
Fix typecheck errors in `src/components/forms/package-form.tsx`

### DIFF
--- a/src/components/forms/package-form.tsx
+++ b/src/components/forms/package-form.tsx
@@ -1,8 +1,9 @@
 import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
-import { convexQuery } from "@convex-dev/react-query";
+import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
+import { Id } from "@cvx/_generated/dataModel";
 
 import { useOrganization } from "@/components/org-context";
 import { Button } from "@/components/ui/button";
@@ -28,6 +29,13 @@ export interface PackageFormData {
   treatments: Array<{ treatmentId: string; quantity: number }>;
 }
 
+interface TreatmentDoc {
+  _id: Id<"gabinetTreatments">;
+  name: string;
+  duration: number;
+  price: number;
+}
+
 interface PackageFormProps {
   initialData?: Partial<PackageFormData>;
   onSubmit: (data: PackageFormData) => void;
@@ -44,9 +52,13 @@ export function PackageForm({
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
 
-  const { data: treatments } = useQuery(
-    convexQuery(api.gabinet.treatments.listActive, { organizationId })
-  );
+  const listActiveTreatments = useAction(api.gabinet.treatments.listActive);
+  const { data: treatmentsRaw } = useQuery({
+    queryKey: ["gabinet.treatments.listActive", organizationId],
+    queryFn: () => listActiveTreatments({ organizationId }),
+    enabled: !!organizationId,
+  });
+  const treatments = treatmentsRaw as unknown as TreatmentDoc[] | undefined;
 
   const [name, setName] = useState(initialData?.name ?? "");
   const [description, setDescription] = useState(initialData?.description ?? "");


### PR DESCRIPTION
Auto-generated by Claude in response to issue #168.

Closes #168

---

## Claude summary

Committed.

Summary: `api.gabinet.treatments.listActive` is an action, but `package-form.tsx` was passing it to `convexQuery` (which expects a query reference). Switched to the established `useAction` + `useQuery` + cast-through-unknown pattern used elsewhere in the gabinet module (package-purchase-drawer, patient-packages-card, appointment-form, fixed in #151), and defined a narrow `TreatmentDoc` interface for the four fields the form reads (`_id`, `name`, `duration`, `price`). That clears the action-passed-to-query error plus the two implicit-any callback errors. Verified: typecheck reports zero errors in `package-form.tsx`.