### PR TITLE
Remove dead `ctx` parameters in convex actions

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -232,7 +232,7 @@ export const submitDocumentFormFields = action({
     formFieldValues: v.string(), // JSON map of field values
     scopeData: v.optional(v.string()), // JSON map of scope/variable data for re-rendering
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     const db = createSupabaseDb();
 
     const doc = await db.query("formDocuments")
@@ -409,7 +409,7 @@ export const recordSignature = action({
     signedByIp: v.optional(v.string()),
     resolvedHtml: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     const db = createSupabaseDb();
 
     const doc = await db.query("formDocuments")

--- a/convex/gabinet/patientAuth.ts
+++ b/convex/gabinet/patientAuth.ts
@@ -173,7 +173,7 @@ export const verifyPortalOtp = action({
     organizationId: v.id("organizations"),
     otp: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     const db = createSupabaseDb();
 
     const patient = await db.query("gabinetPatients")
@@ -292,7 +292,7 @@ export const logoutPortal = action({
   args: {
     tokenHash: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     const db = createSupabaseDb();
 
     const session = await db.query("gabinetPortalSessions")

--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -60,7 +60,7 @@ export const updateMyProfile = action({
     emergencyContactName: v.optional(v.string()),
     emergencyContactPhone: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     // Validate session via Supabase
     const db = createSupabaseDb();
     const session = await db.query("gabinetPortalSessions")
@@ -254,7 +254,7 @@ export const getPublicAvailableSlots = action({
     date: v.string(),
     duration: v.number(),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     const db = createSupabaseDb();
 
     // Validate portal session (read-only — via Supabase)

--- a/convex/signatureRequests.ts
+++ b/convex/signatureRequests.ts
@@ -380,7 +380,7 @@ export const _notifyAuthor = internalMutation({
 
 export const createOtp = action({
   args: { token: v.string() },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     const db = createSupabaseDb();
 
     const request = await db.query("signatureRequests")
@@ -419,7 +419,7 @@ export const verifyOtp = action({
     token: v.string(),
     code: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     const db = createSupabaseDb();
 
     const request = await db.query("signatureRequests")


### PR DESCRIPTION
Auto-generated by Claude in response to issue #170.

Closes #170

---

## Claude summary

Renamed the eight unused `ctx` → `_ctx` in `convex/documents/documents.ts` (lines 235, 412), `convex/gabinet/patientAuth.ts` (176, 295), `convex/gabinet/patientPortal.ts` (63, 257), and `convex/signatureRequests.ts` (383, 422). Each handler operates solely against `createSupabaseDb()` + `args`, so prefixing with underscore is the appropriate fix — same convention used across `convex/supabase/*`. Committed as `4155806`.