### PR TITLE
Fix typecheck errors in `src/components/sidebar-widgets/day-timeline.tsx`

### DIFF
--- a/convex/gabinet/sidebarWidgets.ts
+++ b/convex/gabinet/sidebarWidgets.ts
@@ -337,11 +337,23 @@ export const getReportsKpis = action({
 });
 
 // --- Day Agenda ---
+export interface DayAgendaAppointment {
+  id: string;
+  startTime: string;
+  endTime: string;
+  status: string;
+  patientName: string;
+  treatmentName: string;
+  treatmentDuration: number;
+  employeeName: string;
+  confirmed: boolean;
+}
+
 export const getDayAgenda = action({
   args: { organizationId: v.id("organizations"), date: v.string() },
   handler: async (ctx, args): Promise<{
     date: string;
-    appointments: Array<Record<string, unknown>>;
+    appointments: DayAgendaAppointment[];
     totalAppointments: number;
     confirmedCount: number;
   }> => {
@@ -367,17 +379,20 @@ export const getDayAgenda = action({
           appt.employeeId ? db.get("users", String(appt.employeeId)).catch(() => null) : null,
         ]);
 
-        return {
-          id: appt._id ?? appt.id,
-          startTime: appt.startTime,
-          endTime: appt.endTime,
-          status: appt.status,
-          patientName: patient ? `${(patient as any).firstName} ${(patient as any).lastName}` : "—",
-          treatmentName: (treatment as any)?.name ?? "—",
-          treatmentDuration: (treatment as any)?.duration ?? 0,
+        const row: DayAgendaAppointment = {
+          id: String(appt._id ?? appt.id ?? ""),
+          startTime: String(appt.startTime ?? ""),
+          endTime: String(appt.endTime ?? ""),
+          status: String(appt.status ?? ""),
+          patientName: patient
+            ? `${(patient as any).firstName ?? ""} ${(patient as any).lastName ?? ""}`.trim() || "—"
+            : "—",
+          treatmentName: ((treatment as any)?.name as string | undefined) ?? "—",
+          treatmentDuration: Number((treatment as any)?.duration ?? 0),
           employeeName: employee ? (employee as any).name || "Employee" : "—",
           confirmed: appt.status === "confirmed" || appt.status === "completed",
         };
+        return row;
       }),
     );
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #176.

Closes #176

---

## Claude summary

Committed. Summary of the fix:

The root cause was `getDayAgenda` in `convex/gabinet/sidebarWidgets.ts:340` declaring its return as `appointments: Array<Record<string, unknown>>`. Inside `Record<string, unknown>`, every field access yields `unknown`, so `appt.treatmentDuration > 0` and other reads in `src/components/sidebar-widgets/day-timeline.tsx` failed typecheck.

I introduced a `DayAgendaAppointment` interface co-located with the action (matching the named-row-type pattern established by #166 for Supabase-backed actions) and replaced the loose return shape with it. Inside the handler the row build is now annotated as `DayAgendaAppointment` and primitives are coerced with `String(...)` / `Number(...)` at the Supabase boundary, since the underlying row is still `any`. No consumer-side change is needed — the type now flows through `getDayAgenda` to `useQuery`.

I couldn't run typecheck locally (no `node_modules` in the worktree), but the diff is small and isolated to a single function; CI will validate.