### PR TITLE
Strengthen Convex action return types instead of `Record<string, unknown>`

### DIFF
--- a/convex/_helpers/supabaseRows.ts
+++ b/convex/_helpers/supabaseRows.ts
@@ -12,6 +12,14 @@ export type GabinetTreatmentRow = SupabaseRow<"gabinetTreatments">;
 export type GabinetPatientRow = SupabaseRow<"gabinetPatients">;
 export type GabinetAppointmentRow = SupabaseRow<"gabinetAppointments">;
 export type GabinetEmployeeRow = SupabaseRow<"gabinetEmployees">;
+export type GabinetEmployeeScheduleRow = SupabaseRow<"gabinetEmployeeSchedules">;
+export type GabinetLeaveRow = SupabaseRow<"gabinetLeaves">;
+export type GabinetLeaveTypeRow = SupabaseRow<"gabinetLeaveTypes">;
+export type GabinetLocationRow = SupabaseRow<"gabinetLocations">;
+export type GabinetRoomRow = SupabaseRow<"gabinetRooms">;
+export type GabinetEquipmentRow = SupabaseRow<"gabinetEquipment">;
+export type GabinetTreatmentPackageRow = SupabaseRow<"gabinetTreatmentPackages">;
+export type GabinetPackageUsageRow = SupabaseRow<"gabinetPackageUsage">;
 export type EmailRow = SupabaseRow<"emails">;
 
 // Envelope returned by Supabase-backed list actions that imitate the Convex

--- a/convex/gabinet/equipment.ts
+++ b/convex/gabinet/equipment.ts
@@ -4,6 +4,7 @@ import { Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { verifyOrgAccess } from "../_helpers/auth";
+import type { GabinetEquipmentRow } from "../_helpers/supabaseRows";
 
 // Dual-write refs removed — Supabase is now primary for equipment writes
 
@@ -12,7 +13,7 @@ export const listEquipment = action({
     organizationId: v.id("organizations"),
     locationId: v.optional(v.string()),
   },
-  handler: async (ctx, args): Promise<Array<Record<string, unknown>>> => {
+  handler: async (ctx, args): Promise<GabinetEquipmentRow[]> => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
@@ -21,7 +22,7 @@ export const listEquipment = action({
     if (args.locationId) {
       q = q.eq("currentLocationId", String(args.locationId));
     }
-    return (await q.collect()) as Array<Record<string, unknown>>;
+    return (await q.collect()) as GabinetEquipmentRow[];
   },
 });
 

--- a/convex/gabinet/leaveTypes.ts
+++ b/convex/gabinet/leaveTypes.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { verifyOrgAccess } from "../_helpers/auth";
+import type { GabinetLeaveTypeRow } from "../_helpers/supabaseRows";
 
 // Dual-write refs removed — Supabase is now primary for leaveType writes
 
@@ -11,7 +12,7 @@ export const list = action({
     organizationId: v.id("organizations"),
     activeOnly: v.optional(v.boolean()),
   },
-  handler: async (ctx, args): Promise<Array<Record<string, unknown>>> => {
+  handler: async (ctx, args): Promise<GabinetLeaveTypeRow[]> => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
@@ -20,7 +21,7 @@ export const list = action({
     if (args.activeOnly) {
       q = q.eq("isActive", true);
     }
-    return (await q.collect()) as Array<Record<string, unknown>>;
+    return (await q.collect()) as GabinetLeaveTypeRow[];
   },
 });
 

--- a/convex/gabinet/locations.ts
+++ b/convex/gabinet/locations.ts
@@ -3,12 +3,18 @@ import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { verifyOrgAccess } from "../_helpers/auth";
+import type {
+  GabinetLocationRow,
+  GabinetRoomRow,
+} from "../_helpers/supabaseRows";
+
+type GabinetLocationWithRooms = GabinetLocationRow & { rooms: GabinetRoomRow[] };
 
 // Dual-write refs removed — Supabase is now primary for location/room writes
 
 export const listLocations = action({
   args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args): Promise<Array<Record<string, unknown>>> => {
+  handler: async (ctx, args): Promise<GabinetLocationRow[]> => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
@@ -16,7 +22,7 @@ export const listLocations = action({
     const results = (await db
       .query("gabinetLocations")
       .eq("organizationId", String(args.organizationId))
-      .collect()) as Array<Record<string, unknown>>;
+      .collect()) as GabinetLocationRow[];
     return results;
   },
 });
@@ -26,17 +32,19 @@ export const getLocation = action({
     organizationId: v.id("organizations"),
     locationId: v.string(),
   },
-  handler: async (ctx, args): Promise<Record<string, unknown> | null> => {
+  handler: async (ctx, args): Promise<GabinetLocationWithRooms | null> => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
     const db = createSupabaseDb();
-    const location = await db.get("gabinetLocations", args.locationId);
+    const location = (await db.get("gabinetLocations", args.locationId)) as
+      | GabinetLocationRow
+      | null;
     if (!location || String(location.organizationId) !== String(args.organizationId)) return null;
     const rooms = (await db
       .query("gabinetRooms")
       .eq("locationId", args.locationId)
-      .collect()) as Array<Record<string, unknown>>;
+      .collect()) as GabinetRoomRow[];
     return { ...location, rooms };
   },
 });

--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -8,6 +8,11 @@ import { checkPermission } from "../_helpers/permissions";
 import { logActivity } from "../_helpers/activities";
 import { publishActivityEnvelope } from "../_helpers/activityEnvelope";
 import { Id } from "../_generated/dataModel";
+import type {
+  GabinetPackageUsageRow,
+  GabinetTreatmentPackageRow,
+  SupabasePaginationResult,
+} from "../_helpers/supabaseRows";
 
 // Dual-write refs removed — Supabase is now primary for package writes
 
@@ -16,11 +21,10 @@ export const list = action({
     organizationId: v.id("organizations"),
     paginationOpts: paginationOptsValidator,
   },
-  handler: async (ctx, args): Promise<{
-    page: Array<Record<string, unknown>>;
-    isDone: boolean;
-    continueCursor: string;
-  }> => {
+  handler: async (
+    ctx,
+    args,
+  ): Promise<SupabasePaginationResult<GabinetTreatmentPackageRow>> => {
     const authResult = await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
@@ -40,7 +44,7 @@ export const list = action({
       .query("gabinetTreatmentPackages")
       .eq("organizationId", orgIdStr)
       .order("createdAt", false)
-      .collect()) as Array<Record<string, any>>;
+      .collect()) as GabinetTreatmentPackageRow[];
     if (perm.scope === "own") {
       page = page.filter((r) => String(r.createdBy) === userIdStr);
     }
@@ -50,7 +54,7 @@ export const list = action({
 
 export const listActive = action({
   args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args): Promise<Array<Record<string, unknown>>> => {
+  handler: async (ctx, args): Promise<GabinetTreatmentPackageRow[]> => {
     const authResult = await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
@@ -70,7 +74,7 @@ export const listActive = action({
       .query("gabinetTreatmentPackages")
       .eq("organizationId", orgIdStr)
       .eq("isActive", true)
-      .collect()) as Array<Record<string, any>>;
+      .collect()) as GabinetTreatmentPackageRow[];
     if (perm.scope === "own") {
       results = results.filter((r) => String(r.createdBy) === userIdStr);
     }
@@ -583,7 +587,7 @@ export const getPatientPackages = action({
     organizationId: v.id("organizations"),
     patientId: v.string(),
   },
-  handler: async (ctx, args): Promise<Array<Record<string, unknown>>> => {
+  handler: async (ctx, args): Promise<GabinetPackageUsageRow[]> => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
@@ -599,7 +603,7 @@ export const getPatientPackages = action({
       .query("gabinetPackageUsage")
       .eq("organizationId", String(args.organizationId))
       .eq("patientId", args.patientId)
-      .collect()) as Array<Record<string, unknown>>;
+      .collect()) as GabinetPackageUsageRow[];
   },
 });
 

--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -5,6 +5,10 @@ import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { verifyOrgAccess } from "../_helpers/auth";
 import { gabinetLeaveTypeValidator, gabinetLeaveStatusValidator } from "../schema";
 import { getAvailableSlotsSupabase } from "./_availability_supabase";
+import type {
+  GabinetEmployeeScheduleRow,
+  GabinetLeaveRow,
+} from "../_helpers/supabaseRows";
 
 // Dual-write refs removed — Supabase is now primary for scheduling writes
 
@@ -146,7 +150,7 @@ export const getEmployeeSchedule = action({
     organizationId: v.id("organizations"),
     userId: v.string(),
   },
-  handler: async (ctx, args): Promise<Array<Record<string, unknown>>> => {
+  handler: async (ctx, args): Promise<GabinetEmployeeScheduleRow[]> => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
@@ -155,7 +159,7 @@ export const getEmployeeSchedule = action({
       .query("gabinetEmployeeSchedules")
       .eq("organizationId", String(args.organizationId))
       .eq("userId", args.userId)
-      .collect()) as Array<Record<string, unknown>>;
+      .collect()) as GabinetEmployeeScheduleRow[];
   },
 });
 
@@ -412,7 +416,7 @@ export const listLeaves = action({
     organizationId: v.id("organizations"),
     status: v.optional(gabinetLeaveStatusValidator),
   },
-  handler: async (ctx, args): Promise<Array<Record<string, unknown>>> => {
+  handler: async (ctx, args): Promise<GabinetLeaveRow[]> => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
@@ -421,7 +425,7 @@ export const listLeaves = action({
     if (args.status) {
       q = q.eq("status", args.status);
     }
-    return (await q.collect()) as Array<Record<string, unknown>>;
+    return (await q.collect()) as GabinetLeaveRow[];
   },
 });
 

--- a/src/components/forms/leave-form.tsx
+++ b/src/components/forms/leave-form.tsx
@@ -62,7 +62,7 @@ export function LeaveForm({
     queryKey: ["gabinet.leaveTypes.list", organizationId],
     queryFn: () => listLeaveTypes({ organizationId }),
     enabled: !!organizationId,
-  }) as { data: any[] | undefined };
+  });
 
   const [userId, setUserId] = useState<string>("");
   const [type, setType] = useState<LeaveType>("vacation");

--- a/src/components/gabinet/appointment-form.tsx
+++ b/src/components/gabinet/appointment-form.tsx
@@ -99,18 +99,6 @@ interface AppointmentFormProps {
   categoryDefinitions?: CategoryDef[];
 }
 
-interface RoomDoc {
-  _id: Id<"gabinetRooms">;
-  name: string;
-  isActive: boolean;
-}
-
-interface LocationWithRoomsDoc {
-  _id: Id<"gabinetLocations">;
-  name: string;
-  rooms?: RoomDoc[];
-}
-
 export function AppointmentForm({
   onSubmit,
   onCancel,
@@ -192,7 +180,7 @@ export function AppointmentForm({
     queryKey: ["gabinet.locations.listLocations", organizationId],
     queryFn: () => listLocationsAction({ organizationId: organizationId! }),
     enabled: !!organizationId,
-  }) as { data: any[] | undefined };
+  });
 
   // Form state
   const [patientId, setPatientId] = useState("");
@@ -215,7 +203,7 @@ export function AppointmentForm({
 
   // Rooms query — enabled only when a location is selected
   const getLocationAction = useAction(api.gabinet.locations.getLocation);
-  const { data: locationWithRoomsRaw } = useQuery({
+  const { data: locationWithRooms } = useQuery({
     queryKey: ["gabinet.locations.getLocation", organizationId, locationId],
     queryFn: () =>
       getLocationAction({
@@ -224,7 +212,6 @@ export function AppointmentForm({
       }),
     enabled: !!organizationId && !!locationId,
   });
-  const locationWithRooms = locationWithRoomsRaw as unknown as LocationWithRoomsDoc | null | undefined;
   const activeRooms = locationWithRooms?.rooms?.filter((r) => r.isActive) ?? [];
 
   // Equipment at selected location — for advisory warnings
@@ -236,7 +223,7 @@ export function AppointmentForm({
       locationId: locationId,
     }),
     enabled: !!organizationId && !!locationId,
-  }) as { data: any[] | undefined };
+  });
 
   const activeLocations = locations?.filter((l) => l.isActive) ?? [];
 

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -155,7 +155,7 @@ export function AppointmentDialog({
     queryKey: ["gabinet.locations.listLocations", organizationId],
     queryFn: () => listLocationsAction({ organizationId }),
     enabled: !!organizationId,
-  }) as { data: any[] | undefined };
+  });
 
   // -------------------------------------------------------------------------
   // State
@@ -296,7 +296,7 @@ export function AppointmentDialog({
 
   // Rooms query — enabled only when a location is selected
   const getLocationAction = useAction(api.gabinet.locations.getLocation);
-  const { data: locationWithRoomsRaw } = useQuery({
+  const { data: locationWithRooms } = useQuery({
     queryKey: ["gabinet.locations.getLocation", organizationId, locationId],
     queryFn: () =>
       getLocationAction({
@@ -305,10 +305,6 @@ export function AppointmentDialog({
       }),
     enabled: !!locationId,
   });
-  const locationWithRooms = locationWithRoomsRaw as unknown as
-    | { rooms?: Array<{ _id: Id<"gabinetRooms">; name: string; isActive: boolean }> }
-    | null
-    | undefined;
   const activeRooms = locationWithRooms?.rooms?.filter((r) => r.isActive) ?? [];
 
   // Equipment at selected location — for advisory warnings
@@ -320,9 +316,9 @@ export function AppointmentDialog({
       locationId,
     }),
     enabled: !!organizationId && !!locationId,
-  }) as { data: any[] | undefined };
+  });
 
-  const activeLocations = locations?.filter((l: { isActive: boolean }) => l.isActive) ?? [];
+  const activeLocations = locations?.filter((l) => l.isActive) ?? [];
 
   // Equipment warning — advisory only
   const missingEquipmentIds = useMemo(() => {

--- a/src/components/gabinet/package-purchase-drawer.tsx
+++ b/src/components/gabinet/package-purchase-drawer.tsx
@@ -29,26 +29,6 @@ interface PackagePurchaseDrawerProps {
   onOpenChange: (open: boolean) => void;
 }
 
-interface PackageTreatmentEntry {
-  treatmentId: Id<"gabinetTreatments">;
-  quantity: number;
-}
-
-interface PackageDoc {
-  _id: Id<"gabinetTreatmentPackages">;
-  name: string;
-  description?: string;
-  treatments: PackageTreatmentEntry[];
-  totalPrice: number;
-  currency?: string;
-  validityDays?: number;
-}
-
-interface TreatmentDoc {
-  _id: Id<"gabinetTreatments">;
-  name: string;
-}
-
 export function PackagePurchaseDrawer({
   patientId,
   organizationId,
@@ -64,20 +44,18 @@ export function PackagePurchaseDrawer({
   const [submitting, setSubmitting] = useState(false);
 
   const listActivePackages = useAction(api.gabinet.packages.listActive);
-  const { data: activePackagesRaw } = useQuery({
+  const { data: activePackages } = useQuery({
     queryKey: ["gabinet.packages.listActive", organizationId],
     queryFn: () => listActivePackages({ organizationId }),
     enabled: !!organizationId,
   });
-  const activePackages = activePackagesRaw as unknown as PackageDoc[] | undefined;
 
   const listActiveTreatments = useAction(api.gabinet.treatments.listActive);
-  const { data: treatmentsRaw } = useQuery({
+  const { data: treatments } = useQuery({
     queryKey: ["gabinet.treatments.listActive", organizationId],
     queryFn: () => listActiveTreatments({ organizationId }),
     enabled: !!organizationId,
   });
-  const treatments = treatmentsRaw as unknown as TreatmentDoc[] | undefined;
 
   const treatmentMap = new Map(
     (treatments ?? []).map((tr) => [tr._id, tr.name])

--- a/src/components/gabinet/package-usage-selector.tsx
+++ b/src/components/gabinet/package-usage-selector.tsx
@@ -14,25 +14,6 @@ interface PackageUsageSelectorProps {
   selectedUsageId?: string | null;
 }
 
-interface PackageUsageTreatmentEntry {
-  treatmentId: Id<"gabinetTreatments">;
-  usedCount: number;
-  totalCount: number;
-}
-
-interface PackageUsageDoc {
-  _id: Id<"gabinetPackageUsage">;
-  packageId: Id<"gabinetTreatmentPackages">;
-  status: string;
-  expiresAt?: number;
-  treatmentsUsed: PackageUsageTreatmentEntry[];
-}
-
-interface PackageDoc {
-  _id: Id<"gabinetTreatmentPackages">;
-  name: string;
-}
-
 export function PackageUsageSelector({
   patientId,
   treatmentId,
@@ -43,7 +24,7 @@ export function PackageUsageSelector({
   const { t } = useTranslation();
 
   const getPatientPackagesAction = useAction(api.gabinet.packages.getPatientPackages);
-  const { data: usagesRaw } = useQuery({
+  const { data: usages } = useQuery({
     queryKey: ["gabinet.packages.getPatientPackages", organizationId, patientId],
     queryFn: () =>
       getPatientPackagesAction({
@@ -52,15 +33,13 @@ export function PackageUsageSelector({
       }),
     enabled: !!organizationId && !!patientId,
   });
-  const usages = usagesRaw as unknown as PackageUsageDoc[] | undefined;
 
   const listActivePackages = useAction(api.gabinet.packages.listActive);
-  const { data: allPackagesRaw } = useQuery({
+  const { data: allPackages } = useQuery({
     queryKey: ["gabinet.packages.listActive", organizationId],
     queryFn: () => listActivePackages({ organizationId }),
     enabled: !!organizationId,
   });
-  const allPackages = allPackagesRaw as unknown as PackageDoc[] | undefined;
 
   const packageMap = new Map(
     (allPackages ?? []).map((p) => [p._id, p.name])

--- a/src/components/gabinet/patient-packages-card.tsx
+++ b/src/components/gabinet/patient-packages-card.tsx
@@ -16,30 +16,6 @@ interface PatientPackagesCardProps {
   organizationId: Id<"organizations">;
 }
 
-interface PackageUsageTreatmentEntry {
-  treatmentId: Id<"gabinetTreatments">;
-  usedCount: number;
-  totalCount: number;
-}
-
-interface PackageUsageDoc {
-  _id: Id<"gabinetPackageUsage">;
-  packageId: Id<"gabinetTreatmentPackages">;
-  status: string;
-  expiresAt?: number;
-  treatmentsUsed: PackageUsageTreatmentEntry[];
-}
-
-interface PackageDoc {
-  _id: Id<"gabinetTreatmentPackages">;
-  name: string;
-}
-
-interface TreatmentDoc {
-  _id: Id<"gabinetTreatments">;
-  name: string;
-}
-
 const statusColors: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
   active: "default",
   completed: "secondary",
@@ -52,7 +28,7 @@ export function PatientPackagesCard({ patientId, organizationId }: PatientPackag
   const [purchaseOpen, setPurchaseOpen] = useState(false);
 
   const getPatientPackagesAction = useAction(api.gabinet.packages.getPatientPackages);
-  const { data: usagesRaw } = useQuery({
+  const { data: usages } = useQuery({
     queryKey: ["gabinet.packages.getPatientPackages", organizationId, patientId],
     queryFn: () =>
       getPatientPackagesAction({
@@ -61,23 +37,20 @@ export function PatientPackagesCard({ patientId, organizationId }: PatientPackag
       }),
     enabled: !!organizationId && !!patientId,
   });
-  const usages = usagesRaw as unknown as PackageUsageDoc[] | undefined;
 
   const listActivePackages = useAction(api.gabinet.packages.listActive);
-  const { data: allPackagesRaw } = useQuery({
+  const { data: allPackages } = useQuery({
     queryKey: ["gabinet.packages.listActive", organizationId],
     queryFn: () => listActivePackages({ organizationId }),
     enabled: !!organizationId,
   });
-  const allPackages = allPackagesRaw as unknown as PackageDoc[] | undefined;
 
   const listActiveTreatments = useAction(api.gabinet.treatments.listActive);
-  const { data: treatmentsRaw } = useQuery({
+  const { data: treatments } = useQuery({
     queryKey: ["gabinet.treatments.listActive", organizationId],
     queryFn: () => listActiveTreatments({ organizationId }),
     enabled: !!organizationId,
   });
-  const treatments = treatmentsRaw as unknown as TreatmentDoc[] | undefined;
 
   const treatmentMap = new Map(
     (treatments ?? []).map((tr) => [tr._id, tr.name])

--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -98,7 +98,7 @@ export function TreatmentForm({
     queryKey: ["gabinet.equipment.listEquipment", organizationId],
     queryFn: () => listEquipmentAction({ organizationId }),
     enabled: !!organizationId,
-  }) as { data: any[] | undefined };
+  });
 
   const legacyEquipment = initialData?.requiredEquipment ?? [];
   const hasLegacyEquipment =

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -52,7 +52,7 @@ export function AppSidebar() {
     queryKey: ["gabinet.scheduling.listLeaves", organizationId, "pending"],
     queryFn: () => listLeaves({ organizationId, status: "pending" as const }),
     enabled: hasGabinet && !!organizationId,
-  }) as { data: any[] | undefined };
+  });
   const pendingLeaveCount = pendingLeaves?.length ?? 0;
 
   const matchedModule = routeAwareModules.find((module) =>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #177.

Closes #177

---

## Claude summary

Strengthened return types on Supabase-backed gabinet actions (`equipment.listEquipment`, `leaveTypes.list`, `locations.{listLocations,getLocation}`, `packages.{list,listActive,getPatientPackages}`, `scheduling.{getEmployeeSchedule,listLeaves}`) by adding `SupabaseRow<T>` aliases for the relevant tables and using them instead of `Record<string, unknown>`. Removed seven local `*Doc` interfaces plus `as unknown as ...` and `as { data: any[] | undefined }` casts across five consumer components and three pages.

Verification: convex typecheck clean, frontend typecheck drops 3 errors (in `gabinet.settings.equipment.tsx`, where `getLocation().rooms` was previously `unknown`), eslint warnings drop from 16 to 9 across the touched files.

## Follow-ups
- Strengthen `convex/gabinet/treatments.ts` action returns: `getTreatmentDetailedStats` returns `Record<string, unknown>` and `getTreatmentEmployees` returns `Array<Record<string, unknown>>`; consumers in `_layout.gabinet.treatments.$treatmentId.tsx` cast the stats to `DetailedStats` and would benefit from a real type.
- Type `convex/gabinet/appointments.ts` `getFullDetail` action return: it currently has no explicit return type, so `db.get(...)` calls leak `Record<string, unknown> | null` for `appointment`/`patient`/`treatment`/`employee` into the inferred shape, causing 30+ `unknown`/`{}` errors in `_layout.gabinet.appointments.$appointmentId.lazy.tsx`.
- Fix `db.get`/`db.query.collect` typing in `convex/_helpers/supabaseDb.ts`: returning `Record<string, unknown>` forces every action to add a `SupabaseRow<T>` cast at every call site; making `get<T>` and `collect<T>` generic would eliminate the casts.