### PR TITLE
Replace `h-dvh` on AppSidebar middle column with `h-full`

### DIFF
--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -136,7 +136,7 @@ export function AppSidebar() {
       {shellSidebarMode !== "icon-only" && (
         <div
           className={cn(
-            "bg-sidebar sticky top-0 flex h-dvh w-65 shrink-0 flex-col border-r",
+            "bg-sidebar sticky top-0 flex h-full w-65 shrink-0 flex-col border-r",
             wideContent ? "max-2xl:hidden lg:flex" : "max-lg:hidden",
           )}
         >


### PR DESCRIPTION
Auto-generated by Claude in response to issue #185.

Closes #185

---

## Claude summary

Replaced `h-dvh` with `h-full` on the AppSidebar middle column at `src/components/layout/app-sidebar.tsx:139` and committed as `c0143b2`. Single-line CSS class change; no follow-ups.