### PR TITLE
Gabinet dashboard renders 2 cards in a 3-column grid

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
@@ -362,8 +362,8 @@ function GabinetDashboard() {
         />
       </div>
 
-      {/* Today's schedule + Pending leaves + Nudges */}
-      <div ref={todayScheduleRef} className="grid gap-6 lg:grid-cols-2 xl:grid-cols-3 scroll-mt-6">
+      {/* Today's schedule + Pending leaves */}
+      <div ref={todayScheduleRef} className="grid gap-6 lg:grid-cols-2 scroll-mt-6">
         {/* Today's schedule */}
         <Card className="gap-0 py-0">
           <CardHeader className="flex flex-row items-center justify-between px-4 py-3">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #186.

Closes #186

---

## Claude summary

Changed `lg:grid-cols-2 xl:grid-cols-3` to just `lg:grid-cols-2` on the Today's schedule + Pending leaves grid at `_layout.gabinet.index.tsx:366`, and updated the stale comment that still referenced "Nudges". Now the two cards each take half the row at lg+ widths instead of leaving an empty third column at xl. Committed as `879cb58`.