### PR TITLE
Type `getTreatmentDetailedStats` return shape in convex/gabinet/treatments.ts

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -442,12 +442,45 @@ export const getTreatmentStats = query({
   },
 });
 
+export interface TreatmentDetailedStats {
+  total: number;
+  thisMonth: number;
+  completed: number;
+  cancelled: number;
+  noShow: number;
+  revenue: number;
+  completionRate: number;
+  cancellationRate: number;
+  noShowRate: number;
+  statusCounts: Record<string, number>;
+  monthlyTrend: { month: string; appointments: number; revenue: number }[];
+  employeeRanking: {
+    userId: string;
+    name: string;
+    image?: string | null;
+    totalAppointments: number;
+    completedAppointments: number;
+    revenue: number;
+  }[];
+  lastAppointment: { date: string; startTime: string; patientName: string } | null;
+  nextAppointment: { date: string; startTime: string; patientName: string } | null;
+  packageStats: {
+    totalPackages: number;
+    activePackages: number;
+    totalSlots: number;
+    usedSlots: number;
+    remainingSlots: number;
+  };
+  uniquePatients: number;
+  price: number;
+}
+
 export const getTreatmentDetailedStats = action({
   args: {
     organizationId: v.id("organizations"),
     treatmentId: v.string(),
   },
-  handler: async (ctx, args): Promise<Record<string, unknown>> => {
+  handler: async (ctx, args): Promise<TreatmentDetailedStats> => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });

--- a/src/components/gabinet/treatment-overview-stats.tsx
+++ b/src/components/gabinet/treatment-overview-stats.tsx
@@ -28,43 +28,11 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import { useTranslation } from "react-i18next";
+import type { TreatmentDetailedStats } from "@cvx/gabinet/treatments";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-interface DetailedStats {
-  total: number;
-  thisMonth: number;
-  completed: number;
-  cancelled: number;
-  noShow: number;
-  revenue: number;
-  completionRate: number;
-  cancellationRate: number;
-  noShowRate: number;
-  statusCounts: Record<string, number>;
-  monthlyTrend: { month: string; appointments: number; revenue: number }[];
-  employeeRanking: {
-    userId: string;
-    name: string;
-    image?: string | null;
-    totalAppointments: number;
-    completedAppointments: number;
-    revenue: number;
-  }[];
-  lastAppointment: { date: string; startTime: string; patientName: string } | null;
-  nextAppointment: { date: string; startTime: string; patientName: string } | null;
-  packageStats: {
-    totalPackages: number;
-    activePackages: number;
-    totalSlots: number;
-    usedSlots: number;
-    remainingSlots: number;
-  };
-  uniquePatients: number;
-  price: number;
-}
 
 interface RecentAppointment {
   _id: string;
@@ -77,7 +45,7 @@ interface RecentAppointment {
 }
 
 interface TreatmentOverviewStatsProps {
-  stats: DetailedStats;
+  stats: TreatmentDetailedStats;
   recentAppointments: RecentAppointment[];
   currency?: string;
   treatmentName: string;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #196.

Closes #196

---

## Claude summary

Replaced the `Record<string, unknown>` return type on `getTreatmentDetailedStats` in `convex/gabinet/treatments.ts:445` with an exported `TreatmentDetailedStats` interface, then updated `src/components/gabinet/treatment-overview-stats.tsx` to import that shared type and removed the duplicated local `DetailedStats` interface. Convex typecheck is clean; the pre-existing line 526 type mismatch in the route consumer is now resolved.

## Follow-ups
- Type `getTreatmentEmployees` return shape in convex/gabinet/treatments.ts: still returns `Array<Record<string, unknown>>`, causing TS errors at `_layout.gabinet.treatments.$treatmentId.tsx:811-838` (unknown `_id`, `firstName`, `lastName`, `userName`, `specialization`, `role`, `isActive`).
- Type `listTreatmentAppointments` Supabase enriched rows in convex/gabinet/treatments.ts: causes `{}` type errors at `_layout.gabinet.treatments.$treatmentId.tsx:1126-1141` for status/employee/patient cells.