### PR TITLE
Type `listPatientsWithStatsForEmployee` consumer cleanup

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -531,6 +531,19 @@ export const listPatientsForEmployee = query({
 });
 
 /**
+ * Row shape returned by `listPatientsWithStatsForEmployee` — a patient
+ * augmented with per-employee visit summary fields. Exported so consumers
+ * can type props directly instead of duck-typing the result.
+ */
+export type EmployeePatientStats = GabinetPatientRow & {
+  visitCount: number;
+  lastVisitDate: string | null;
+  firstVisitDate: string | null;
+  treatmentIds: string[];
+  statuses: string[];
+};
+
+/**
  * Returns patients for an employee enriched with visit summary data
  * (visit count, last visit date, treatments used, statuses).
  * Used by the employee detail "Klienci" tab for search & filtering.
@@ -540,13 +553,7 @@ export const listPatientsWithStatsForEmployee = action({
     organizationId: v.id("organizations"),
     employeeId: v.string(),
   },
-  handler: async (ctx, args): Promise<Array<GabinetPatientRow & {
-    visitCount: number;
-    lastVisitDate: string | null;
-    firstVisitDate: string | null;
-    treatmentIds: string[];
-    statuses: string[];
-  }>> => {
+  handler: async (ctx, args): Promise<EmployeePatientStats[]> => {
     const authResult = await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -69,6 +69,7 @@ import {
   FileText,
 } from "@/lib/ez-icons";
 import { Id } from "@cvx/_generated/dataModel";
+import type { EmployeePatientStats } from "@cvx/gabinet/appointments";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { useSidebarSlot } from "@/components/layout/sidebar-slot-context";
@@ -272,11 +273,11 @@ function EmployeeDetail() {
     }
     // Status filter
     if (clientStatusFilter !== "all") {
-      result = result.filter((p) => (p.statuses as string[]).includes(clientStatusFilter));
+      result = result.filter((p) => p.statuses.includes(clientStatusFilter));
     }
     // Treatment filter
     if (clientTreatmentFilter !== "all") {
-      result = result.filter((p) => (p.treatmentIds as string[]).includes(clientTreatmentFilter));
+      result = result.filter((p) => p.treatmentIds.includes(clientTreatmentFilter));
     }
     return result;
   }, [employeePatients, clientSearch, clientStatusFilter, clientTreatmentFilter]);
@@ -617,8 +618,8 @@ function EmployeeDetail() {
       count: employeePatients?.length,
       content: (
         <PatientsTabContent
-          employeePatients={employeePatients as any}
-          filteredClients={filteredClients as any}
+          employeePatients={employeePatients}
+          filteredClients={filteredClients}
           clientSearch={clientSearch}
           setClientSearch={setClientSearch}
           clientStatusFilter={clientStatusFilter}
@@ -1003,28 +1004,8 @@ function PatientsTabContent({
   t,
   i18nLanguage,
 }: {
-  employeePatients: Array<{
-    _id: string;
-    firstName: string;
-    lastName: string;
-    email?: string;
-    phone?: string;
-    visitCount: number;
-    lastVisitDate?: string;
-    isActive: boolean;
-    statuses: string[];
-    treatmentIds: string[];
-  }> | undefined;
-  filteredClients: Array<{
-    _id: string;
-    firstName: string;
-    lastName: string;
-    email?: string;
-    phone?: string;
-    visitCount: number;
-    lastVisitDate?: string;
-    isActive: boolean;
-  }>;
+  employeePatients: EmployeePatientStats[] | undefined;
+  filteredClients: EmployeePatientStats[];
   clientSearch: string;
   setClientSearch: (v: string) => void;
   clientStatusFilter: string;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #197.

Closes #197

---

## Claude summary

Done. Exported `EmployeePatientStats` from `convex/gabinet/appointments.ts` (a `GabinetPatientRow & {visitCount, lastVisitDate, firstVisitDate, treatmentIds, statuses}` alias) and used it as the prop type in `PatientsTabContent`. This removed the two ad-hoc inline shapes, the `as any` casts on lines 620–621, and the redundant `as string[]` casts on `p.statuses` / `p.treatmentIds`. App typecheck for the file now passes without casts; convex typecheck stays clean.

## Follow-ups
- Type `_layout.gabinet.appointments.$appointmentId.lazy.tsx` consumers: ~80 TS errors from duck-typed appointment/treatment access (`{}.toFixed`, `{}.split`, `unknown` arithmetic) — same root cause as #197 but on a different action surface.
- Type `_layout.gabinet.employees.index.tsx` (`MappedGabinetEmployee[]` / `MappedGabinetTreatment[]`) and `_layout.gabinet.patients.index.tsx` / `_layout.gabinet.treatments.index.tsx`: Mapped* types miss `_creationTime`, breaking assignability against full `Doc<T>` shapes consumers expect.
- Audit remaining `as any` casts in `_layout.gabinet.employees.$employeeId.tsx`: still present on `employeeAppointments`, `calendarAppointments`, `employee`, and several mutation handler args — same duck-typing pattern the issue calls out, just on different actions.