### PR TITLE
Fix typecheck errors in `_layout.gabinet.appointments.$appointmentId.lazy.tsx`

### DIFF
--- a/convex/_helpers/supabaseRows.ts
+++ b/convex/_helpers/supabaseRows.ts
@@ -20,6 +20,10 @@ export type GabinetRoomRow = SupabaseRow<"gabinetRooms">;
 export type GabinetEquipmentRow = SupabaseRow<"gabinetEquipment">;
 export type GabinetTreatmentPackageRow = SupabaseRow<"gabinetTreatmentPackages">;
 export type GabinetPackageUsageRow = SupabaseRow<"gabinetPackageUsage">;
+export type GabinetLoyaltyTransactionRow = SupabaseRow<"gabinetLoyaltyTransactions">;
+export type AppointmentWorkflowHistoryRow = SupabaseRow<"appointmentWorkflowHistory">;
+export type PaymentRow = SupabaseRow<"payments">;
+export type NoteRow = SupabaseRow<"notes">;
 export type EmailRow = SupabaseRow<"emails">;
 
 // Envelope returned by Supabase-backed list actions that imitate the Convex

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -24,8 +24,15 @@ import {
 import { Id, Doc } from "../_generated/dataModel";
 import type {
   GabinetAppointmentRow,
+  GabinetEmployeeRow,
   GabinetPatientRow,
   GabinetTreatmentRow,
+  GabinetPackageUsageRow,
+  GabinetLoyaltyTransactionRow,
+  AppointmentWorkflowHistoryRow,
+  FormDocumentRow,
+  PaymentRow,
+  NoteRow,
   SupabasePaginationResult,
 } from "../_helpers/supabaseRows";
 import { logAudit } from "../auditLog";
@@ -2195,12 +2202,76 @@ export const cancelRecurringSeries = action({
   },
 });
 
+/**
+ * Treatment usage entry within an enriched package usage row — the raw
+ * `treatmentsUsed` array is augmented with a resolved `treatmentName`.
+ */
+export interface AppointmentFullDetailPackageTreatment {
+  treatmentId: string;
+  usedCount: number;
+  totalCount: number;
+  treatmentName: string | null;
+}
+
+/**
+ * Package usage row enriched with the package name, totals across all
+ * treatments, and a progress percentage. Returned by `getFullDetail`.
+ */
+export interface AppointmentFullDetailPackageUsage
+  extends Omit<GabinetPackageUsageRow, "treatmentsUsed"> {
+  packageName: string | null;
+  treatmentsUsed: AppointmentFullDetailPackageTreatment[];
+  totalUsed: number;
+  totalCount: number;
+  progressPercent: number;
+}
+
+/** Past appointment in the patient's history, enriched with the treatment row. */
+export interface AppointmentFullDetailHistoryEntry extends GabinetAppointmentRow {
+  treatment?: GabinetTreatmentRow;
+}
+
+/** Note row enriched with the resolved author display name. */
+export interface AppointmentFullDetailNote extends NoteRow {
+  authorName: string | null;
+}
+
+/**
+ * Employee row returned by the action. The Convex schema for
+ * `gabinetEmployees` doesn't define `name` or `image`, but the consumer
+ * code reads them as optional fallbacks (always `undefined` at runtime
+ * for this action — the underlying enrichment lives elsewhere). Kept on
+ * the type so call sites typecheck without `as` casts.
+ */
+export type AppointmentFullDetailEmployee = GabinetEmployeeRow & {
+  name?: string;
+  image?: string;
+};
+
+/** Full DTO returned by `getFullDetail`. */
+export interface AppointmentFullDetail {
+  appointment: GabinetAppointmentRow;
+  patient: GabinetPatientRow | null;
+  treatment: GabinetTreatmentRow | null;
+  employee: AppointmentFullDetailEmployee | null;
+  documents: FormDocumentRow[];
+  payments: PaymentRow[];
+  notes: AppointmentFullDetailNote[];
+  patientPackageUsage: AppointmentFullDetailPackageUsage[];
+  patientHistory: AppointmentFullDetailHistoryEntry[];
+  loyaltyBalance: number;
+  loyaltyTier: string | null;
+  loyaltyTransactions: GabinetLoyaltyTransactionRow[];
+  allPatientPayments: PaymentRow[];
+  workflowHistory: AppointmentWorkflowHistoryRow[];
+}
+
 export const getFullDetail = action({
   args: {
     organizationId: v.id("organizations"),
     appointmentId: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<AppointmentFullDetail> => {
     const authResult = await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
@@ -2215,16 +2286,17 @@ export const getFullDetail = action({
     const db = createSupabaseDb();
     const orgIdStr = String(args.organizationId);
 
-    const appointment = await db.get("gabinetAppointments", args.appointmentId);
-    if (!appointment || String(appointment.organizationId) !== orgIdStr) {
+    const appointmentRaw = await db.get("gabinetAppointments", args.appointmentId);
+    if (!appointmentRaw || String(appointmentRaw.organizationId) !== orgIdStr) {
       throw new Error("Appointment not found");
     }
     if (
       perm.scope === "own" &&
-      String(appointment.createdBy) !== String(authResult.userId)
+      String(appointmentRaw.createdBy) !== String(authResult.userId)
     ) {
       throw new Error("Permission denied: you can only view your own records");
     }
+    const appointment = appointmentRaw as unknown as GabinetAppointmentRow;
 
     const patientId = String(appointment.patientId);
     const treatmentId = appointment.treatmentId
@@ -2233,18 +2305,18 @@ export const getFullDetail = action({
     const employeeId = String(appointment.employeeId);
 
     const [
-      patient,
-      treatment,
-      employee,
-      documents,
-      payments,
-      notes,
-      patientPackageUsage,
-      patientHistoryRaw,
+      patientRaw,
+      treatmentRaw,
+      employeeRaw,
+      documentsRaw,
+      paymentsRaw,
+      notesRaw,
+      patientPackageUsageRaw,
+      patientHistoryRawAll,
       loyaltyBalanceRow,
-      loyaltyTransactions,
-      allPatientPayments,
-      workflowHistory,
+      loyaltyTransactionsRaw,
+      allPatientPaymentsRaw,
+      workflowHistoryRaw,
     ] = await Promise.all([
       db.get("gabinetPatients", patientId),
       treatmentId ? db.get("gabinetTreatments", treatmentId) : Promise.resolve(null),
@@ -2294,6 +2366,18 @@ export const getFullDetail = action({
         .collect(),
     ]);
 
+    const patient = patientRaw as unknown as GabinetPatientRow | null;
+    const treatment = treatmentRaw as unknown as GabinetTreatmentRow | null;
+    const employee = employeeRaw as unknown as AppointmentFullDetailEmployee | null;
+    const documents = documentsRaw as unknown as FormDocumentRow[];
+    const payments = paymentsRaw as unknown as PaymentRow[];
+    const notes = notesRaw as unknown as NoteRow[];
+    const patientPackageUsage = patientPackageUsageRaw as unknown as GabinetPackageUsageRow[];
+    const patientHistoryRaw = patientHistoryRawAll as unknown as GabinetAppointmentRow[];
+    const loyaltyTransactions = loyaltyTransactionsRaw as unknown as GabinetLoyaltyTransactionRow[];
+    const allPatientPayments = allPatientPaymentsRaw as unknown as PaymentRow[];
+    const workflowHistory = workflowHistoryRaw as unknown as AppointmentWorkflowHistoryRow[];
+
     const patientHistory = patientHistoryRaw
       .filter((a) => String(a._id) !== args.appointmentId)
       .slice(0, 20);
@@ -2309,10 +2393,10 @@ export const getFullDetail = action({
     const historyTreatments = await Promise.all(
       historyTreatmentIds.map((id) => db.get("gabinetTreatments", id)),
     );
-    const treatmentMap = new Map(
+    const treatmentMap = new Map<string, GabinetTreatmentRow>(
       historyTreatments
         .filter((t): t is Record<string, unknown> => t !== null)
-        .map((t) => [String(t._id), t]),
+        .map((t) => [String(t._id), t as unknown as GabinetTreatmentRow]),
     );
 
     // Enrich package usage
@@ -2326,9 +2410,7 @@ export const getFullDetail = action({
     const pkgUsageTreatmentIds = Array.from(
       new Set(
         patientPackageUsage.flatMap((u) =>
-          ((u.treatmentsUsed as Array<{ treatmentId: string }>) ?? []).map((t) =>
-            String(t.treatmentId),
-          ),
+          (u.treatmentsUsed ?? []).map((t) => String(t.treatmentId)),
         ),
       ),
     );
@@ -2336,41 +2418,40 @@ export const getFullDetail = action({
       Promise.all(pkgUsagePkgIds.map((id) => db.get("gabinetTreatmentPackages", id))),
       Promise.all(pkgUsageTreatmentIds.map((id) => db.get("gabinetTreatments", id))),
     ]);
-    const pkgDefMap = new Map(
+    const pkgDefMap = new Map<string, Record<string, unknown>>(
       pkgDefs
         .filter((p): p is Record<string, unknown> => p !== null)
         .map((p) => [String(p._id), p]),
     );
-    const pkgTreatmentMap = new Map(
+    const pkgTreatmentMap = new Map<string, Record<string, unknown>>(
       pkgTreatmentDefs
         .filter((t): t is Record<string, unknown> => t !== null)
         .map((t) => [String(t._id), t]),
     );
 
-    const enrichedPatientPackageUsage = patientPackageUsage.map((u) => {
-      const pkgDef = pkgDefMap.get(String(u.packageId));
-      const treatmentsUsedArr =
-        (u.treatmentsUsed as Array<{
-          treatmentId: string;
-          usedCount: number;
-          totalCount: number;
-        }>) ?? [];
-      const enrichedTreatments = treatmentsUsedArr.map((t) => ({
-        ...t,
-        treatmentName:
-          (pkgTreatmentMap.get(String(t.treatmentId))?.name as string | null) ?? null,
-      }));
-      const totalUsed = enrichedTreatments.reduce((s, t) => s + (t.usedCount ?? 0), 0);
-      const totalCount = enrichedTreatments.reduce((s, t) => s + (t.totalCount ?? 0), 0);
-      return {
-        ...u,
-        packageName: (pkgDef?.name as string | null) ?? null,
-        treatmentsUsed: enrichedTreatments,
-        totalUsed,
-        totalCount,
-        progressPercent: totalCount > 0 ? Math.round((totalUsed / totalCount) * 100) : 0,
-      };
-    });
+    const enrichedPatientPackageUsage: AppointmentFullDetailPackageUsage[] =
+      patientPackageUsage.map((u) => {
+        const pkgDef = pkgDefMap.get(String(u.packageId));
+        const treatmentsUsedArr = u.treatmentsUsed ?? [];
+        const enrichedTreatments: AppointmentFullDetailPackageTreatment[] =
+          treatmentsUsedArr.map((t) => ({
+            treatmentId: String(t.treatmentId),
+            usedCount: Number(t.usedCount ?? 0),
+            totalCount: Number(t.totalCount ?? 0),
+            treatmentName:
+              (pkgTreatmentMap.get(String(t.treatmentId))?.name as string | null) ?? null,
+          }));
+        const totalUsed = enrichedTreatments.reduce((s, t) => s + (t.usedCount ?? 0), 0);
+        const totalCount = enrichedTreatments.reduce((s, t) => s + (t.totalCount ?? 0), 0);
+        return {
+          ...u,
+          packageName: (pkgDef?.name as string | null) ?? null,
+          treatmentsUsed: enrichedTreatments,
+          totalUsed,
+          totalCount,
+          progressPercent: totalCount > 0 ? Math.round((totalUsed / totalCount) * 100) : 0,
+        };
+      });
 
     // Enrich notes with author names
     const noteAuthorIds = Array.from(
@@ -2383,12 +2464,15 @@ export const getFullDetail = action({
     const noteAuthors = await Promise.all(
       noteAuthorIds.map((id) => db.get("users", id).catch(() => null)),
     );
-    const noteAuthorMap = new Map(
+    const noteAuthorMap = new Map<string, string | null>(
       noteAuthors
         .filter((u): u is Record<string, unknown> => u !== null)
-        .map((u) => [String(u._id), (u.name as string | null) ?? (u.email as string | null)]),
+        .map((u) => [
+          String(u._id),
+          (u.name as string | null) ?? (u.email as string | null),
+        ]),
     );
-    const enrichedNotes = notes.map((n) => ({
+    const enrichedNotes: AppointmentFullDetailNote[] = notes.map((n) => ({
       ...n,
       authorName: noteAuthorMap.get(String(n.createdBy)) ?? null,
     }));

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -93,6 +93,7 @@ import {
   Inbox,
 } from "@/lib/ez-icons";
 import { Id } from "@cvx/_generated/dataModel";
+import type { AppointmentFullDetailNote } from "@cvx/gabinet/appointments";
 import { useTranslation } from "react-i18next";
 import { Link } from "@tanstack/react-router";
 import { toast } from "sonner";
@@ -172,24 +173,6 @@ function getSmsSummary(events: Array<Record<string, unknown>>, appointmentStatus
   return { labelKey: "gabinet.appointmentDetail.sms.summaryNoHistory", tone: "secondary" as const };
 }
 
-function getPackageUsageTotals(pkg: Record<string, unknown>) {
-  const treatmentsUsed = Array.isArray(pkg?.treatmentsUsed)
-    ? pkg.treatmentsUsed
-    : [];
-
-  return treatmentsUsed.reduce(
-    (acc: { used: number; total: number }, treatment: Record<string, unknown>) => {
-      const usedCount = Number(treatment?.usedCount ?? 0);
-      const totalCount = Number(treatment?.totalCount ?? 0);
-      return {
-        used: acc.used + (Number.isFinite(usedCount) ? usedCount : 0),
-        total: acc.total + (Number.isFinite(totalCount) ? totalCount : 0),
-      };
-    },
-    { used: 0, total: 0 },
-  );
-}
-
 // Note Item Component
 function NoteItem({
   note,
@@ -206,7 +189,7 @@ function NoteItem({
   hasReplies = false,
   isReply = false,
 }: {
-  note: Record<string, unknown>;
+  note: AppointmentFullDetailNote;
   isEditing: boolean;
   editContent: string;
   onEditContentChange: (content: string) => void;
@@ -221,9 +204,9 @@ function NoteItem({
   isReply?: boolean;
 }) {
   const { t, i18n } = useTranslation();
-  const authorName = (note.authorName as string) ?? t("common.unknown");
+  const authorName = note.authorName ?? t("common.unknown");
   const initials = authorName.slice(0, 2).toUpperCase();
-  const dateStr = new Date(note.createdAt as number).toLocaleString(i18n.language);
+  const dateStr = new Date(note.createdAt).toLocaleString(i18n.language);
 
   return (
     <article className="relative flex gap-3">
@@ -283,7 +266,7 @@ function NoteItem({
           <div className="flex items-start gap-1">
             <section className="flex-1 rounded-lg rounded-tl-none border p-3">
               <p className="text-sm whitespace-pre-wrap">
-                {plateJsonToText(note.content as string)}
+                {plateJsonToText(note.content)}
               </p>
             </section>
             <DropdownMenu>
@@ -492,10 +475,9 @@ function AppointmentDetail() {
     if (!detail) return null;
     const { appointment: appt, patient: pat, treatment: treat, employee: emp, patientPackageUsage: pkgUsage, loyaltyBalance: loyBal } = detail;
     const empName = emp ? (emp.name ?? emp.email ?? "-") : "-";
-    const relevantPkgs = (pkgUsage ?? []).filter((pkg: Record<string, unknown>) => {
-      const treatments = Array.isArray(pkg?.treatmentsUsed) ? pkg.treatmentsUsed : [];
-      return treatments.some((tu: Record<string, unknown>) => tu.treatmentId === appt.treatmentId);
-    });
+    const relevantPkgs = (pkgUsage ?? []).filter((pkg) =>
+      pkg.treatmentsUsed.some((tu) => tu.treatmentId === appt.treatmentId),
+    );
 
     return (
       <div className="space-y-3">
@@ -597,20 +579,21 @@ function AppointmentDetail() {
             <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
               {t("gabinet.packages.activePackages", "Aktywne pakiety")}
             </p>
-            {relevantPkgs.map((pkg: Record<string, unknown>) => {
-              const treatmentsUsed = Array.isArray(pkg?.treatmentsUsed) ? pkg.treatmentsUsed : [];
-              const relevantTreatment = treatmentsUsed.find((tu: Record<string, unknown>) => tu.treatmentId === appt.treatmentId) as Record<string, unknown> | undefined;
-              const used = Number(relevantTreatment?.usedCount ?? 0);
-              const total = Number(relevantTreatment?.totalCount ?? 0);
+            {relevantPkgs.map((pkg) => {
+              const relevantTreatment = pkg.treatmentsUsed.find(
+                (tu) => tu.treatmentId === appt.treatmentId,
+              );
+              const used = relevantTreatment?.usedCount ?? 0;
+              const total = relevantTreatment?.totalCount ?? 0;
               const remaining = Math.max(total - used, 0);
               const pct = total > 0 ? Math.min((used / total) * 100, 100) : 0;
               let barColor = "bg-emerald-500";
               if (remaining <= 0) barColor = "bg-red-500";
               else if (remaining / total < 0.3) barColor = "bg-amber-500";
               return (
-                <div key={pkg._id as string} className="rounded-md border p-2.5 space-y-1.5">
+                <div key={pkg._id} className="rounded-md border p-2.5 space-y-1.5">
                   <div className="flex items-center justify-between gap-2">
-                    <p className="text-xs font-medium truncate">{pkg.packageName as string}</p>
+                    <p className="text-xs font-medium truncate">{pkg.packageName}</p>
                     <Badge variant="outline" className={`text-[10px] shrink-0 ${pkg.status === "active" ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-400" : ""}`}>
                       {t(`gabinet.packages.status.${pkg.status}`)}
                     </Badge>
@@ -935,9 +918,9 @@ function AppointmentDetail() {
     }
   };
 
-  const startEditNote = (note: Record<string, unknown>) => {
-    setEditingNoteId(note._id as string);
-    setEditNoteContent(note.content as string);
+  const startEditNote = (note: AppointmentFullDetailNote) => {
+    setEditingNoteId(note._id);
+    setEditNoteContent(note.content);
   };
 
   // Body chart handlers
@@ -965,9 +948,9 @@ function AppointmentDetail() {
   };
 
   // Group notes by parent for threading
-  const rootNotes = notes.filter((n: Record<string, unknown>) => !n.parentNoteId);
+  const rootNotes = notes.filter((n) => !n.parentNoteId);
   const getReplies = (noteId: string) =>
-    notes.filter((n: Record<string, unknown>) => n.parentNoteId === noteId);
+    notes.filter((n) => n.parentNoteId === noteId);
 
   // Calculate payment summary
   const treatmentPrice = treatment?.price ?? 0;
@@ -1624,8 +1607,8 @@ function AppointmentDetail() {
                 <div className="relative">
                   <div className="absolute left-3 top-0 bottom-0 w-px bg-border" />
                   <div className="space-y-4">
-                    {patientHistory.map((appt: Record<string, unknown>, index: number) => (
-                      <div key={appt._id as string} className="relative flex gap-4">
+                    {patientHistory.map((appt, index) => (
+                      <div key={appt._id} className="relative flex gap-4">
                         <div className="relative z-10 flex items-center justify-center w-6 h-6 rounded-full bg-background border-2">
                           {index === 0 && (
                             <div className="w-2 h-2 rounded-full bg-primary" />
@@ -1633,22 +1616,22 @@ function AppointmentDetail() {
                         </div>
                         <Link
                           to="/dashboard/gabinet/appointments/$appointmentId"
-                          params={{ appointmentId: appt._id as string }}
+                          params={{ appointmentId: appt._id }}
                           className="flex-1 flex items-center justify-between p-3 border rounded-lg hover:bg-muted/50 transition-colors"
                         >
                           <div>
                             <p className="font-medium">
-                              {((appt as Record<string, unknown>).treatment as Record<string, unknown>)?.name as string ?? "-"}
+                              {appt.treatment?.name ?? "-"}
                             </p>
                             <p className="text-sm text-muted-foreground">
-                              {formatDate(appt.date as string)} &bull;{" "}
-                              {formatTime(appt.startTime as string)} -{" "}
-                              {formatTime(appt.endTime as string)}
+                              {formatDate(appt.date)} &bull;{" "}
+                              {formatTime(appt.startTime)} -{" "}
+                              {formatTime(appt.endTime)}
                             </p>
                           </div>
                           <Badge
                             variant={
-                              statusColors[appt.status as string] ?? "secondary"
+                              statusColors[appt.status] ?? "secondary"
                             }
                           >
                             {t(
@@ -1681,8 +1664,8 @@ function AppointmentDetail() {
                 />
               ) : (
                 <div className="space-y-3">
-                  {patientPackageUsage.map((pkg: Record<string, unknown>) => {
-                    const totals = getPackageUsageTotals(pkg);
+                  {patientPackageUsage.map((pkg) => {
+                    const totals = { used: pkg.totalUsed, total: pkg.totalCount };
                     const progressPercent =
                       totals.total > 0
                         ? Math.min((totals.used / totals.total) * 100, 100)
@@ -1694,11 +1677,10 @@ function AppointmentDetail() {
                     else if (overallRemainingRatio < 0.3) overallBarColor = "bg-amber-500";
 
                     return (
-                      <div key={pkg._id as string} className="p-4 border rounded-lg space-y-3">
+                      <div key={pkg._id} className="p-4 border rounded-lg space-y-3">
                         <div className="flex items-center justify-between">
                           <p className="font-medium">
-                            {(pkg.packageName as string) ??
-                              t("gabinet.packages.package")}
+                            {pkg.packageName ?? t("gabinet.packages.package")}
                           </p>
                           <div className="flex items-center gap-2">
                             {pkg.status === "active" && (
@@ -1706,14 +1688,14 @@ function AppointmentDetail() {
                                 variant="outline"
                                 size="sm"
                                 onClick={() => {
-                                  setUsageDialogPkgId(pkg._id as string);
+                                  setUsageDialogPkgId(pkg._id);
                                   setUsageDialogItems(
-                                    ((pkg.treatmentsUsed as Array<Record<string, unknown>>) ?? [])
-                                      .filter((e: Record<string, unknown>) => ((e.usedCount as number) ?? 0) < ((e.totalCount as number) ?? 0))
-                                      .map((e: Record<string, unknown>) => ({
-                                        treatmentId: e.treatmentId as string,
-                                        treatmentName: (e.treatmentName as string) ?? t("gabinet.packages.treatment"),
-                                        remaining: ((e.totalCount as number) ?? 0) - ((e.usedCount as number) ?? 0),
+                                    pkg.treatmentsUsed
+                                      .filter((e) => (e.usedCount ?? 0) < (e.totalCount ?? 0))
+                                      .map((e) => ({
+                                        treatmentId: e.treatmentId,
+                                        treatmentName: e.treatmentName ?? t("gabinet.packages.treatment"),
+                                        remaining: (e.totalCount ?? 0) - (e.usedCount ?? 0),
                                         qty: 0,
                                       })),
                                   );
@@ -1754,15 +1736,14 @@ function AppointmentDetail() {
                         </div>
 
                         {/* Per-treatment progress bars */}
-                        {!!(Array.isArray(pkg.treatmentsUsed) &&
-                          (pkg.treatmentsUsed as Array<Record<string, unknown>>).length > 0) && (
+                        {pkg.treatmentsUsed.length > 0 && (
                             <div className="space-y-2">
                               <p className="text-xs font-medium text-muted-foreground">
                                 {t("gabinet.packages.perTreatmentProgress")}
                               </p>
-                              {(pkg.treatmentsUsed as Array<Record<string, unknown>>).map((entry: Record<string, unknown>, index: number) => {
-                                const usedCount = (entry.usedCount as number) ?? 0;
-                                const totalCount = (entry.totalCount as number) ?? 0;
+                              {pkg.treatmentsUsed.map((entry, index) => {
+                                const usedCount = entry.usedCount ?? 0;
+                                const totalCount = entry.totalCount ?? 0;
                                 const remaining = totalCount - usedCount;
                                 const pct = totalCount > 0 ? Math.round((usedCount / totalCount) * 100) : 0;
                                 const remainingRatio = totalCount > 0 ? remaining / totalCount : 1;
@@ -1773,10 +1754,10 @@ function AppointmentDetail() {
                                 else if (remainingRatio < 0.3) { barColor = "bg-amber-500"; statusLabel = t("gabinet.packages.runningLow"); }
 
                                 return (
-                                  <div key={`${pkg._id}-${(entry.treatmentId as string) ?? index}`} className="space-y-1">
+                                  <div key={`${pkg._id}-${entry.treatmentId ?? index}`} className="space-y-1">
                                     <div className="flex items-center justify-between text-xs">
                                       <span className="truncate max-w-[50%]">
-                                        {(entry.treatmentName as string) ?? t("gabinet.treatments.treatment")}
+                                        {entry.treatmentName ?? t("gabinet.treatments.treatment")}
                                       </span>
                                       <span className="text-muted-foreground tabular-nums">
                                         {usedCount} / {totalCount}
@@ -1798,7 +1779,7 @@ function AppointmentDetail() {
                         {!!pkg.expiresAt && (
                           <p className="text-xs text-muted-foreground">
                             {t("gabinet.packages.expires")}:{" "}
-                            {new Date(pkg.expiresAt as number).toLocaleDateString(
+                            {new Date(pkg.expiresAt).toLocaleDateString(
                               i18n.language,
                             )}
                           </p>
@@ -2047,10 +2028,10 @@ function AppointmentDetail() {
               />
             ) : (
               <ul className="flex flex-col gap-8">
-                {rootNotes.map((note: Record<string, unknown>) => {
-                  const replies = getReplies(note._id as string);
+                {rootNotes.map((note) => {
+                  const replies = getReplies(note._id);
                   return (
-                    <li key={note._id as string}>
+                    <li key={note._id}>
                       <NoteItem
                         note={note}
                         isEditing={editingNoteId === note._id}
@@ -2061,17 +2042,17 @@ function AppointmentDetail() {
                           setEditingNoteId(null);
                           setEditNoteContent("");
                         }}
-                        onSaveEdit={() => handleUpdateNote(note._id as Id<"notes">)}
-                        onDelete={() => handleDeleteNote(note._id as Id<"notes">)}
-                        onTogglePin={() => handleTogglePin(note._id as Id<"notes">)}
-                        onReply={() => setReplyToNoteId(note._id as string)}
+                        onSaveEdit={() => handleUpdateNote(note._id)}
+                        onDelete={() => handleDeleteNote(note._id)}
+                        onTogglePin={() => handleTogglePin(note._id)}
+                        onReply={() => setReplyToNoteId(note._id)}
                         isSubmitting={isNoteSubmitting}
                         hasReplies={replies.length > 0}
                       />
                       {replies.length > 0 && (
                         <ul className="ml-12 mt-4 flex flex-col gap-6">
-                          {replies.map((reply: Record<string, unknown>) => (
-                            <li key={reply._id as string}>
+                          {replies.map((reply) => (
+                            <li key={reply._id}>
                               <NoteItem
                                 note={reply}
                                 isEditing={editingNoteId === reply._id}
@@ -2082,14 +2063,10 @@ function AppointmentDetail() {
                                   setEditingNoteId(null);
                                   setEditNoteContent("");
                                 }}
-                                onSaveEdit={() =>
-                                  handleUpdateNote(reply._id as Id<"notes">)
-                                }
-                                onDelete={() => handleDeleteNote(reply._id as Id<"notes">)}
-                                onTogglePin={() =>
-                                  handleTogglePin(reply._id as Id<"notes">)
-                                }
-                                onReply={() => setReplyToNoteId(note._id as string)}
+                                onSaveEdit={() => handleUpdateNote(reply._id)}
+                                onDelete={() => handleDeleteNote(reply._id)}
+                                onTogglePin={() => handleTogglePin(reply._id)}
+                                onReply={() => setReplyToNoteId(note._id)}
                                 isSubmitting={isNoteSubmitting}
                                 isReply
                               />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #201.

Closes #201

---

## Claude summary

Committed. Summary:

The route file `_layout.gabinet.appointments.$appointmentId.lazy.tsx` had ~80 typecheck errors stemming from `getFullDetail` action returning an unknown shape, forcing every consumer to cast through `Record<string, unknown>`. Following the same DTO-export pattern as #196/#197/#198, I exported `AppointmentFullDetail` (with sub-DTOs for package usage, history entries, notes, and employee) from `convex/gabinet/appointments.ts`, annotated the action handler with `Promise<AppointmentFullDetail>`, and rewrote the route to consume the typed result. Also dropped the inline `getPackageUsageTotals` helper that recomputed totals already computed by the action. Result: 0 errors in the target file (verified via `tsc -p tsconfig.app.json` and `tsc -p convex/tsconfig.json`); 31 unrelated errors remain in other files.

## Follow-ups
- Type the unknown action results in `_layout.leads.$leadId.lazy.tsx`: 5 errors around `dealProductsQuery`/`LeadProductItem` from the same unknown-action-result pattern.
- Type `MappedGabinetEmployee`/`MappedGabinetPatient`/`MappedGabinetTreatment` to satisfy `_creationTime`: 7 errors across `_layout.gabinet.{employees,patients,treatments}.index.tsx` and `treatments.$treatmentId.tsx` — mappers strip `_creationTime` and downcast `Id<>` to `string`, breaking consumers that expect the full Convex doc shape.
- Fix `SavedView` shape in `_layout.gabinet.documents.index.tsx`: missing `isDefault` on three system view literals plus a `null`/`undefined` mismatch when passing user objects to a name-formatter helper.
- Investigate `gabinetEmployees` schema vs consumer `emp.name`/`emp.image` reads: schema has no such fields, so reads are always undefined; the new `AppointmentFullDetailEmployee` type preserves this for compat but the underlying enrichment is missing.