### PR TITLE
Fix typecheck errors in remaining gabinet route files

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -106,15 +106,15 @@ function GabinetDocumentsPage() {
   const [searchValue, setSearchValue] = useState("");
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [docToDelete, setDocToDelete] = useState<string | null>(null);
-  const [activeFilters, setActiveFilters] = useState<FilterCondition[]>([]);
+  const [, setActiveFilters] = useState<FilterCondition[]>([]);
   const [savedViewsDialogOpen, setSavedViewsDialogOpen] = useState(false);
 
   // --- System views ---
   const systemViews = useMemo((): SavedView[] => [
     { id: "all", name: t("gabinet.formDocuments.views.all", "Wszystkie"), isSystem: true, isDefault: true },
-    { id: "draft", name: t("gabinet.formDocuments.views.draft", "Wersje robocze"), isSystem: true },
-    { id: "pending_signature", name: t("gabinet.formDocuments.views.pendingSignature", "Oczekujące podpisu"), isSystem: true },
-    { id: "signed", name: t("gabinet.formDocuments.views.signed", "Podpisane"), isSystem: true },
+    { id: "draft", name: t("gabinet.formDocuments.views.draft", "Wersje robocze"), isSystem: true, isDefault: false },
+    { id: "pending_signature", name: t("gabinet.formDocuments.views.pendingSignature", "Oczekujące podpisu"), isSystem: true, isDefault: false },
+    { id: "signed", name: t("gabinet.formDocuments.views.signed", "Podpisane"), isSystem: true, isDefault: false },
   ], [t]);
 
   // --- Saved views ---
@@ -166,11 +166,15 @@ function GabinetDocumentsPage() {
 
   // Build user lookup from org members
   const userMap = useMemo(() => {
-    if (!members)
-      return new Map<string, { name?: string; email?: string }>();
     const map = new Map<string, { name?: string; email?: string }>();
+    if (!members) return map;
     for (const m of members) {
-      if (m.user) map.set(m.user._id as string, m.user);
+      if (m.user) {
+        map.set(m.user._id as string, {
+          name: m.user.name ?? undefined,
+          email: m.user.email ?? undefined,
+        });
+      }
     }
     return map;
   }, [members]);
@@ -586,21 +590,15 @@ function GabinetDocumentsPage() {
           if (!open) setSelectedId(undefined);
         }}
         title={selectedDoc?.title ?? "—"}
-        description={
-          selectedDoc && (
-            <span className="flex items-center gap-2">
-              <DocumentStatusBadge
-                status={selectedDoc.status as any}
-              />
-              <span className="text-xs">
-                {formatDate(selectedDoc.createdAt)}
-              </span>
-            </span>
-          )
-        }
       >
         {selectedDoc && (
           <>
+            <div className="flex items-center gap-2 -mt-2 mb-2">
+              <DocumentStatusBadge status={selectedDoc.status as any} />
+              <span className="text-xs text-muted-foreground">
+                {formatDate(selectedDoc.createdAt)}
+              </span>
+            </div>
             {/* Statistics section */}
             <div className="space-y-2">
               <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -91,13 +91,14 @@ function EmployeesIndex() {
   const createEmployee = useAction(api.gabinet.employees.create);
   const removeEmployee = useAction(api.gabinet.employees.remove);
 
-  const { data: employees } = useSupabaseGabinetEmployeesList(organizationId);
+  const { data: employeesRaw } = useSupabaseGabinetEmployeesList(organizationId);
+  const employees = employeesRaw as unknown as Employee[] | undefined;
 
   const { data: members } = useSupabaseOrganizationMembers(organizationId);
 
   const { data: allTreatmentsRaw } = useSupabaseGabinetTreatmentsList(organizationId);
   const treatments = useMemo(
-    () => (allTreatmentsRaw ?? []).filter((t) => t.isActive),
+    () => (allTreatmentsRaw ?? []).filter((t) => t.isActive) as unknown as Doc<"gabinetTreatments">[],
     [allTreatmentsRaw],
   );
 
@@ -126,7 +127,7 @@ function EmployeesIndex() {
   // Users not yet registered as employees
   const availableUsers = useMemo(() => {
     if (!members || !employees) return [] as Array<{ _id: Id<"users">; name?: string | null; email?: string | null }>;
-    const empUserIds = new Set(employees.map((e) => e.userId));
+    const empUserIds = new Set<string>(employees.map((e) => e.userId as string));
     return members
       .filter((m) => m.user && !empUserIds.has(m.userId))
       .map((m) => ({ _id: m.user!._id as Id<"users">, name: m.user!.name, email: m.user!.email }));

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -144,7 +144,8 @@ function PatientsIndex() {
     [t, tags, categories],
   );
 
-  const { data: patients = [], isLoading } = useSupabaseGabinetPatientsList(organizationId);
+  const { data: patientsRaw = [], isLoading } = useSupabaseGabinetPatientsList(organizationId);
+  const patients = patientsRaw as unknown as Patient[];
 
   const {
     views,

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -280,7 +280,7 @@ function TreatmentDetail() {
 
   // Derived: unassigned employees (those that don't have this treatment in qualifiedTreatmentIds)
   const assignedEmployeeIds = useMemo(() => {
-    return new Set((treatmentEmployees ?? []).map((e) => e._id));
+    return new Set<string>((treatmentEmployees ?? []).map((e) => e._id as string));
   }, [treatmentEmployees]);
 
   const unassignedEmployees = useMemo(() => {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -154,7 +154,8 @@ function TreatmentsIndex() {
     [t, tags, categories],
   );
 
-  const { data: allTreatments = [], isLoading } = useSupabaseGabinetTreatmentsList(organizationId);
+  const { data: allTreatmentsRaw = [], isLoading } = useSupabaseGabinetTreatmentsList(organizationId);
+  const allTreatments = allTreatmentsRaw as unknown as Treatment[];
 
   const {
     views,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #202.

Closes #202

---

## Claude summary

Cleared all typecheck errors in the five gabinet route files listed in the issue. Net: src/ typecheck errors went from 48 → 17 (the remaining 17 are in unrelated files: notifications, leads, root, etc.).

Summary of fixes mirroring the established `as unknown as` cast pattern from #154:
- `patients.index.tsx`, `treatments.index.tsx`: cast supabase-mapped data to `Patient[]` / `Treatment[]` at the destructure so `CrmDataTable` columns and view-filter assignments typecheck.
- `employees.index.tsx`: same cast for `employeesRaw` → `Employee[]` and the active-filter `treatments` derivation; widen `empUserIds` set to `Set<string>` so it still accepts string-shaped `m.userId` from supabase members.
- `treatments.$treatmentId.tsx`: type `assignedEmployeeIds` as `Set<string>` so it accepts mapped `emp._id: string` while being built from typed action results (`Id<"gabinetEmployees">`).
- `documents.index.tsx`: this one had unrelated typecheck errors — dropped unused `activeFilters` destructure (only the setter is wired); added missing `isDefault: false` to three system views; coerced nullable user `name` / `email` from supabase to undefined when populating `userMap`; removed the JSX `description` prop on `SidePanel` (typed for `string`) and inlined the status badge + date at the top of the panel body.

Note: `_layout.gabinet.settings.equipment.tsx` (also listed in the issue) had no current typecheck errors — likely already fixed in the equipment supabase migration (commit b679b5c).

Commit: `281d248`.