### PR TITLE
Fix `routeContext` access in `src/routes/__root.tsx`

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -30,8 +30,10 @@ export const Route = createRootRouteWithContext<{
     const router = useRouter();
     const matchWithTitle = [...router.state.matches]
       .reverse()
-      .find((d) => d.routeContext?.title);
-    const title = matchWithTitle?.routeContext.title || "Convex SaaS";
+      .find((d) => (d.context as { title?: string } | undefined)?.title);
+    const title =
+      (matchWithTitle?.context as { title?: string } | undefined)?.title ||
+      "Convex SaaS";
 
     return (
       <>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #205.

Closes #205

---

## Claude summary

Fixed and committed. In TanStack Router 1.161, `RouteMatch` exposes its accumulated context as `context`, not `routeContext`. `src/routes/__root.tsx` was reading `d.routeContext?.title`, which is always `undefined` on current versions, so the `<title>` always fell back to "Convex SaaS". The fix reads `d.context.title` with a narrow inline cast for the title shape.