### PR TITLE
Extend gen-db-types.mjs to parse incremental migrations

### DIFF
--- a/scripts/gen-db-types.mjs
+++ b/scripts/gen-db-types.mjs
@@ -2,8 +2,19 @@
 /**
  * gen-db-types.mjs
  *
- * Parses supabase/migrations/00001_initial_schema.sql and generates
- * src/lib/supabase/database.types.ts with Row/Insert/Update for every table.
+ * Parses every SQL file in supabase/migrations/ (in lexicographic order)
+ * and generates src/lib/supabase/database.types.ts with Row/Insert/Update
+ * for every table, plus src/lib/supabase/database.columns.ts with a
+ * runtime column registry.
+ *
+ * Migrations are applied incrementally: 00001 typically defines the initial
+ * schema with CREATE TABLE; subsequent files may CREATE TABLE [IF NOT EXISTS]
+ * for new tables, ALTER TABLE ... ADD COLUMN for new columns, and so on.
+ *
+ * Supported DDL:
+ *   • CREATE TYPE ... AS ENUM (...)
+ *   • CREATE TABLE [IF NOT EXISTS] <name> ( ... )
+ *   • ALTER TABLE [IF EXISTS] <name> ADD COLUMN [IF NOT EXISTS] <col> <type> ...
  *
  * SQL column → TypeScript mapping rules:
  *   TEXT                → string
@@ -24,117 +35,159 @@
  * PRIMARY KEY (id)       → optional in Insert (may be auto-generated)
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 
-const sql = readFileSync(
-  resolve(ROOT, "supabase/migrations/00001_initial_schema.sql"),
-  "utf-8",
-);
+const MIGRATIONS_DIR = resolve(ROOT, "supabase/migrations");
+const migrationFiles = readdirSync(MIGRATIONS_DIR)
+  .filter((f) => f.endsWith(".sql"))
+  .sort();
 
-// ─── Collect ENUM types ───────────────────────────────────────────────────────
+// ─── ENUM types & tables accumulate across all migrations ────────────────────
 /** @type {Map<string, string[]>} */
 const enums = new Map();
-const enumRe =
-  /CREATE\s+TYPE\s+(\w+)\s+AS\s+ENUM\s*\(\s*([\s\S]*?)\);/gi;
-for (const m of sql.matchAll(enumRe)) {
-  const name = m[1];
-  const values = [...m[2].matchAll(/'([^']+)'/g)].map((v) => v[1]);
-  enums.set(name, values);
-}
 
-// ─── Parse CREATE TABLE blocks ────────────────────────────────────────────────
 /**
  * @typedef {{ name: string, tsType: string, nullable: boolean, hasDefault: boolean, isPk: boolean, isGenerated: boolean }} Col
  * @typedef {{ tableName: string, columns: Col[] }} Table
  */
 
-/** @type {Table[]} */
-const tables = [];
+/** Tables keyed by name to allow incremental updates from ALTER TABLE. */
+/** @type {Map<string, Table>} */
+const tables = new Map();
 
-const tableRe =
-  /CREATE\s+TABLE\s+(\w+)\s*\(\s*([\s\S]*?)\n\);/gi;
+/**
+ * Map a raw SQL type token (already upper-cased) to a TS type, or `null`
+ * if the column should be skipped (e.g. tsvector generated column).
+ *
+ * @param {string} rawType
+ * @returns {string | null}
+ */
+function mapSqlType(rawType) {
+  if (rawType.startsWith("TEXT[]")) return "string[]";
+  if (rawType === "TEXT" || rawType === "TEXT NOT NULL") return "string";
+  if (rawType === "INTEGER" || rawType === "INT") return "number";
+  if (rawType === "BIGINT") return "number";
+  if (rawType === "NUMERIC" || rawType.startsWith("NUMERIC(")) return "number";
+  if (rawType === "BOOLEAN") return "boolean";
+  if (rawType === "JSONB") return "unknown";
+  if (rawType === "TSVECTOR") return null;
+  // Known enum (lowercase) → string is safe
+  if (enums.has(rawType.toLowerCase())) return "string";
+  return "string"; // fallback
+}
 
-for (const m of sql.matchAll(tableRe)) {
-  const tableName = m[1];
-  const body = m[2];
+/**
+ * Parse a single column-definition line into a Col, or null if it should be
+ * skipped (constraint line, generated column, unparseable, etc.).
+ *
+ * @param {string} rawLine
+ * @returns {Col | null}
+ */
+function parseColumnLine(rawLine) {
+  const line = rawLine.replace(/--.*$/, "").trim();
+  if (!line) return null;
+  // Skip table-level constraints
+  if (/^(CONSTRAINT|CHECK|UNIQUE|PRIMARY\s+KEY|FOREIGN\s+KEY|EXCLUDE)\b/i.test(line)) return null;
 
-  /** @type {Col[]} */
-  const columns = [];
-  // Split lines, filter out constraints / indexes
-  for (const rawLine of body.split("\n")) {
-    const line = rawLine.replace(/--.*$/, "").trim();
-    if (!line || line.startsWith("--")) continue;
+  const colMatch = line.match(
+    /^"?(\w+)"?\s+([\w\s\[\]()]+?)(\s+(?:NOT\s+NULL|NULL|DEFAULT|PRIMARY\s+KEY|REFERENCES|CHECK|UNIQUE|GENERATED).*)?,?\s*$/i,
+  );
+  if (!colMatch) return null;
 
-    // Skip table-level constraints
-    if (/^(CONSTRAINT|CHECK|UNIQUE|PRIMARY\s+KEY|FOREIGN\s+KEY|EXCLUDE)\b/i.test(line)) continue;
+  const colName = colMatch[1];
+  const rawType = colMatch[2].trim().toUpperCase();
+  const rest = (colMatch[3] || "").toUpperCase();
 
-    // Column definition pattern: name type ...
-    const colMatch = line.match(
-      /^"?(\w+)"?\s+([\w\s\[\]()]+?)(\s+(?:NOT\s+NULL|NULL|DEFAULT|PRIMARY\s+KEY|REFERENCES|CHECK|UNIQUE|GENERATED).*)?,?\s*$/i,
-    );
-    if (!colMatch) continue;
+  if (rest.includes("GENERATED ALWAYS")) return null;
 
-    const colName = colMatch[1];
-    let rawType = colMatch[2].trim().toUpperCase();
-    const rest = (colMatch[3] || "").toUpperCase();
+  const tsType = mapSqlType(rawType);
+  if (tsType === null) return null;
 
-    // Skip GENERATED ALWAYS (tsvector search vectors)
-    if (rest.includes("GENERATED ALWAYS")) continue;
+  const isPk = rest.includes("PRIMARY KEY");
+  const nullable = isPk ? false : !rest.includes("NOT NULL");
+  const hasDefault = rest.includes("DEFAULT") || rest.includes("GENERATED");
 
-    const isPk = rest.includes("PRIMARY KEY");
-    const nullable = isPk ? false : !rest.includes("NOT NULL");
-    const hasDefault = rest.includes("DEFAULT") || rest.includes("GENERATED");
+  return { name: colName, tsType, nullable, hasDefault, isPk, isGenerated: false };
+}
 
-    // Map SQL type → TS type
-    let tsType = "string";
-    if (rawType.startsWith("TEXT[]")) {
-      tsType = "string[]";
-    } else if (rawType === "TEXT" || rawType === "TEXT NOT NULL") {
-      tsType = "string";
-    } else if (rawType === "INTEGER" || rawType === "INT") {
-      tsType = "number";
-    } else if (rawType === "BIGINT") {
-      tsType = "number";
-    } else if (rawType === "NUMERIC" || rawType.startsWith("NUMERIC(")) {
-      tsType = "number";
-    } else if (rawType === "BOOLEAN") {
-      tsType = "boolean";
-    } else if (rawType === "JSONB") {
-      tsType = "unknown";
-    } else if (rawType === "TSVECTOR") {
-      // skip entirely
-      continue;
-    } else {
-      // Check for known enum types (lowercase)
-      const lowerType = rawType.toLowerCase();
-      if (enums.has(lowerType)) {
-        tsType = "string"; // Could be union; string is safe
-      } else {
-        tsType = "string"; // fallback
-      }
-    }
-
-    columns.push({ name: colName, tsType, nullable, hasDefault, isPk, isGenerated: false });
+/**
+ * Apply a single migration's SQL to the running enum / table state.
+ * @param {string} sql
+ */
+function applyMigration(sql) {
+  // ─── ENUMs ──
+  const enumRe = /CREATE\s+TYPE\s+(\w+)\s+AS\s+ENUM\s*\(\s*([\s\S]*?)\);/gi;
+  for (const m of sql.matchAll(enumRe)) {
+    const name = m[1];
+    const values = [...m[2].matchAll(/'([^']+)'/g)].map((v) => v[1]);
+    enums.set(name, values);
   }
 
-  if (columns.length > 0) {
-    tables.push({ tableName, columns });
+  // ─── CREATE TABLE [IF NOT EXISTS] <name> ( ... ); ──
+  const tableRe = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"?(\w+)"?\s*\(\s*([\s\S]*?)\n\s*\)\s*;/gi;
+  for (const m of sql.matchAll(tableRe)) {
+    const tableName = m[1];
+    const body = m[2];
+
+    /** @type {Col[]} */
+    const columns = [];
+    for (const rawLine of body.split("\n")) {
+      const col = parseColumnLine(rawLine);
+      if (col) columns.push(col);
+    }
+    if (columns.length === 0) continue;
+
+    // IF NOT EXISTS semantics: keep the existing definition if already known.
+    if (!tables.has(tableName)) {
+      tables.set(tableName, { tableName, columns });
+    }
+  }
+
+  // ─── ALTER TABLE [IF EXISTS] <name> ADD COLUMN [IF NOT EXISTS] <col> ... ; ──
+  // Each ALTER TABLE statement may carry multiple comma-separated actions; we
+  // handle the ADD COLUMN ones and ignore others (constraints, RLS, etc.).
+  const alterRe = /ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?"?(\w+)"?\s+([\s\S]*?);/gi;
+  for (const m of sql.matchAll(alterRe)) {
+    const tableName = m[1];
+    const actions = m[2];
+    const table = tables.get(tableName);
+    if (!table) continue;
+
+    const addRe = /ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?([\s\S]*?)(?=,\s*(?:ADD|ALTER|DROP|RENAME|ENABLE|DISABLE)\b|$)/gi;
+    for (const a of actions.matchAll(addRe)) {
+      const col = parseColumnLine(a[1].trim());
+      if (col && !table.columns.some((c) => c.name === col.name)) {
+        table.columns.push(col);
+      }
+    }
   }
 }
 
+for (const file of migrationFiles) {
+  const sql = readFileSync(resolve(MIGRATIONS_DIR, file), "utf-8");
+  applyMigration(sql);
+}
+
+const tablesList = [...tables.values()];
+
 // ─── Emit TypeScript ──────────────────────────────────────────────────────────
+
+const headerSource = migrationFiles.map((f) => ` *   • ${f}`).join("\n");
 
 const lines = [];
 lines.push(`/**`);
 lines.push(` * Supabase Database Types`);
 lines.push(` *`);
-lines.push(` * AUTO-GENERATED from supabase/migrations/00001_initial_schema.sql`);
-lines.push(` * by scripts/gen-db-types.mjs — DO NOT EDIT MANUALLY.`);
+lines.push(` * AUTO-GENERATED from supabase/migrations/ by scripts/gen-db-types.mjs`);
+lines.push(` * — DO NOT EDIT MANUALLY.`);
+lines.push(` *`);
+lines.push(` * Source migrations (applied in order):`);
+lines.push(headerSource);
 lines.push(` *`);
 lines.push(` * Re-generate: npx tsx scripts/gen-db-types.mjs`);
 lines.push(` *   (or: node scripts/gen-db-types.mjs)`);
@@ -147,7 +200,7 @@ lines.push(`export interface Database {`);
 lines.push(`  public: {`);
 lines.push(`    Tables: {`);
 
-for (const table of tables) {
+for (const table of tablesList) {
   lines.push(`      ${table.tableName}: {`);
 
   // ── Row ──
@@ -194,8 +247,11 @@ lines.push(`export type ContactInsert = Database["public"]["Tables"]["contacts"]
 lines.push(`export type ContactUpdate = Database["public"]["Tables"]["contacts"]["Update"];`);
 lines.push(``);
 
-// ── Additional S01 entity aliases ──
+// ── Entity aliases ──
+// Hand-curated singular names — generic singularization can't reliably handle
+// "lost_reasons" → "LostReason", "saved_views" → "SavedView", etc.
 const entityAliases = [
+  // CRM
   { table: "companies", singular: "Company" },
   { table: "products", singular: "Product" },
   { table: "notes", singular: "Note" },
@@ -208,9 +264,49 @@ const entityAliases = [
   { table: "custom_field_definitions", singular: "CustomFieldDefinition" },
   { table: "custom_field_values", singular: "CustomFieldValue" },
   { table: "object_relationships", singular: "ObjectRelationship" },
+  { table: "leads", singular: "Lead" },
+  { table: "pipelines", singular: "Pipeline" },
+  { table: "pipeline_stages", singular: "PipelineStage" },
+  { table: "pipeline_stage_actions", singular: "PipelineStageAction" },
+
+  // Platform
+  { table: "organizations", singular: "Organization" },
+  { table: "team_memberships", singular: "TeamMembership" },
+  { table: "invitations", singular: "Invitation" },
+  { table: "notifications", singular: "Notification" },
+  { table: "recently_viewed", singular: "RecentlyViewed" },
+  { table: "org_settings", singular: "OrgSettings" },
+  { table: "audit_log", singular: "AuditLog" },
+  { table: "activity_type_definitions", singular: "ActivityTypeDefinition" },
+  { table: "scheduled_activities", singular: "ScheduledActivity" },
+  { table: "email_sequences", singular: "EmailSequence" },
+
+  // Gabinet
+  { table: "gabinet_patients", singular: "GabinetPatient" },
+  { table: "gabinet_treatments", singular: "GabinetTreatment" },
+  { table: "gabinet_treatment_variants", singular: "GabinetTreatmentVariant" },
+  { table: "gabinet_employees", singular: "GabinetEmployee" },
+  { table: "gabinet_locations", singular: "GabinetLocation" },
+  { table: "gabinet_rooms", singular: "GabinetRoom" },
+  { table: "gabinet_equipment", singular: "GabinetEquipment" },
+  { table: "gabinet_equipment_transfers", singular: "GabinetEquipmentTransfer" },
+  { table: "gabinet_leave_types", singular: "GabinetLeaveType" },
+  { table: "gabinet_leave_balances", singular: "GabinetLeaveBalance" },
+  { table: "gabinet_working_hours", singular: "GabinetWorkingHours" },
+  { table: "gabinet_employee_schedules", singular: "GabinetEmployeeSchedule" },
+  { table: "gabinet_appointments", singular: "GabinetAppointment" },
+  { table: "gabinet_leaves", singular: "GabinetLeave" },
+  { table: "gabinet_overtime", singular: "GabinetOvertime" },
+  { table: "gabinet_document_templates", singular: "GabinetDocumentTemplate" },
+  { table: "gabinet_documents", singular: "GabinetDocument" },
+  { table: "gabinet_treatment_packages", singular: "GabinetTreatmentPackage" },
+  { table: "gabinet_package_usage", singular: "GabinetPackageUsage" },
+  { table: "gabinet_loyalty_points", singular: "GabinetLoyaltyPoints" },
+  { table: "gabinet_loyalty_transactions", singular: "GabinetLoyaltyTransaction" },
 ];
 
 for (const { table, singular } of entityAliases) {
+  if (!tables.has(table)) continue; // Alias references a not-yet-migrated table.
   lines.push(`export type ${singular}Row = Database["public"]["Tables"]["${table}"]["Row"];`);
   lines.push(`export type ${singular}Insert = Database["public"]["Tables"]["${table}"]["Insert"];`);
   lines.push(`export type ${singular}Update = Database["public"]["Tables"]["${table}"]["Update"];`);
@@ -221,8 +317,9 @@ const outPath = resolve(ROOT, "src/lib/supabase/database.types.ts");
 writeFileSync(outPath, out, "utf-8");
 
 console.log(`✅ Generated ${outPath}`);
-console.log(`   Tables: ${tables.length}`);
-console.log(`   Row types: ${tables.length} (one per table)`);
+console.log(`   Migrations: ${migrationFiles.length}`);
+console.log(`   Tables: ${tablesList.length}`);
+console.log(`   Row types: ${tablesList.length} (one per table)`);
 
 // ─── Generate runtime column registry ───────────────────────────────────────
 //
@@ -235,15 +332,18 @@ const colsLines = [];
 colsLines.push(`/**`);
 colsLines.push(` * Supabase Runtime Column Registry`);
 colsLines.push(` *`);
-colsLines.push(` * AUTO-GENERATED from supabase/migrations/00001_initial_schema.sql`);
-colsLines.push(` * by scripts/gen-db-types.mjs — DO NOT EDIT MANUALLY.`);
+colsLines.push(` * AUTO-GENERATED from supabase/migrations/ by scripts/gen-db-types.mjs`);
+colsLines.push(` * — DO NOT EDIT MANUALLY.`);
+colsLines.push(` *`);
+colsLines.push(` * Source migrations (applied in order):`);
+colsLines.push(headerSource);
 colsLines.push(` *`);
 colsLines.push(` * Re-generate: npx tsx scripts/gen-db-types.mjs`);
 colsLines.push(` */`);
 colsLines.push(``);
 colsLines.push(`/** Set of table names known to the generated schema. */`);
 colsLines.push(`export type TableName =`);
-const tableNames = tables.map((t) => `  | "${t.tableName}"`);
+const tableNames = tablesList.map((t) => `  | "${t.tableName}"`);
 colsLines.push(tableNames.join("\n") + ";");
 colsLines.push(``);
 colsLines.push(`/**`);
@@ -251,7 +351,7 @@ colsLines.push(` * Column names per table, as a runtime-checkable Set.`);
 colsLines.push(` * Generated columns (e.g. tsvector search_vector) are excluded.`);
 colsLines.push(` */`);
 colsLines.push(`export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {`);
-for (const table of tables) {
+for (const table of tablesList) {
   const cols = table.columns.map((c) => `"${c.name}"`).join(", ");
   colsLines.push(`  ${table.tableName}: new Set([${cols}]),`);
 }
@@ -262,4 +362,4 @@ const colsPath = resolve(ROOT, "src/lib/supabase/database.columns.ts");
 writeFileSync(colsPath, colsOut, "utf-8");
 
 console.log(`✅ Generated ${colsPath}`);
-console.log(`   Tables: ${tables.length}`);
+console.log(`   Tables: ${tablesList.length}`);

--- a/src/lib/supabase/database.columns.ts
+++ b/src/lib/supabase/database.columns.ts
@@ -1,8 +1,14 @@
 /**
  * Supabase Runtime Column Registry
  *
- * AUTO-GENERATED from supabase/migrations/00001_initial_schema.sql
- * by scripts/gen-db-types.mjs — DO NOT EDIT MANUALLY.
+ * AUTO-GENERATED from supabase/migrations/ by scripts/gen-db-types.mjs
+ * — DO NOT EDIT MANUALLY.
+ *
+ * Source migrations (applied in order):
+ *   • 00001_initial_schema.sql
+ *   • 00002_rls_policies.sql
+ *   • 00003_add_selected_id_to_saved_views.sql
+ *   • 00004_document_components.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  */
@@ -98,7 +104,8 @@ export type TableName =
   | "form_documents"
   | "automation_rules"
   | "automation_runs"
-  | "automation_run_steps";
+  | "automation_run_steps"
+  | "document_components";
 
 /**
  * Column names per table, as a runtime-checkable Set.
@@ -143,7 +150,7 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   calls: new Set(["id", "organization_id", "outcome", "call_date", "note", "duration", "tag_ids", "category_id", "created_by", "created_at", "updated_at"]),
   lost_reasons: new Set(["id", "organization_id", "label", "order", "is_active", "created_by", "created_at", "updated_at"]),
   sources: new Set(["id", "organization_id", "name", "order", "is_active", "created_by", "created_at", "updated_at"]),
-  saved_views: new Set(["id", "organization_id", "entity_type", "name", "filters", "columns", "sort_field", "sort_direction", "is_default", "is_system", "created_by", "order", "created_at", "updated_at"]),
+  saved_views: new Set(["id", "organization_id", "entity_type", "name", "filters", "columns", "sort_field", "sort_direction", "is_default", "is_system", "created_by", "order", "created_at", "updated_at", "selected_id"]),
   email_templates: new Set(["id", "organization_id", "name", "subject", "body", "content_json", "rendered_html", "slug", "category", "module", "event_type", "is_system", "locale", "required_sources", "variables", "created_by", "is_active", "created_at", "updated_at"]),
   email_layouts: new Set(["id", "organization_id", "header_blocks", "footer_blocks", "background_color", "content_background_color", "primary_color", "logo_url", "company_name", "footer_text", "updated_by", "updated_at"]),
   email_accounts: new Set(["id", "organization_id", "from_name", "from_email", "is_default", "created_at", "updated_at"]),
@@ -195,4 +202,5 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   automation_rules: new Set(["id", "organization_id", "name", "description", "module", "event_type", "entity_type", "trigger", "graph", "definition_version", "conditions", "actions", "enabled", "created_by", "created_at", "updated_at"]),
   automation_runs: new Set(["id", "organization_id", "rule_id", "module", "event_type", "entity_type", "entity_id", "event_idempotency_key", "correlation_key", "payload_snapshot", "actor_user_id", "status", "error_message", "occurred_at", "processed_at", "created_at", "updated_at"]),
   automation_run_steps: new Set(["id", "organization_id", "run_id", "rule_id", "action_index", "action_type", "idempotency_key", "status", "recipient", "recipient_name", "linked_entity_type", "linked_entity_id", "rendered_subject", "rendered_body", "metadata_snapshot", "error_message", "email_event_log_id", "appointment_sms_event_id", "processed_at", "created_at", "updated_at"]),
+  document_components: new Set(["id", "organization_id", "scope", "created_by", "name", "description", "category", "content_json", "protected", "position_constraint", "version", "is_active", "created_at", "updated_at"]),
 };

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -1,8 +1,14 @@
 /**
  * Supabase Database Types
  *
- * AUTO-GENERATED from supabase/migrations/00001_initial_schema.sql
- * by scripts/gen-db-types.mjs — DO NOT EDIT MANUALLY.
+ * AUTO-GENERATED from supabase/migrations/ by scripts/gen-db-types.mjs
+ * — DO NOT EDIT MANUALLY.
+ *
+ * Source migrations (applied in order):
+ *   • 00001_initial_schema.sql
+ *   • 00002_rls_policies.sql
+ *   • 00003_add_selected_id_to_saved_views.sql
+ *   • 00004_document_components.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -1516,6 +1522,7 @@ export interface Database {
           order: number;
           created_at: number;
           updated_at: number;
+          selected_id: string | null;
         };
         Insert: {
           id?: string;
@@ -1532,6 +1539,7 @@ export interface Database {
           order: number;
           created_at: number;
           updated_at: number;
+          selected_id?: string | null;
         };
         Update: {
           id?: string;
@@ -1548,6 +1556,7 @@ export interface Database {
           order?: number;
           created_at?: number;
           updated_at?: number;
+          selected_id?: string | null;
         };
       };
       email_templates: {
@@ -4442,6 +4451,56 @@ export interface Database {
           updated_at?: number;
         };
       };
+      document_components: {
+        Row: {
+          id: string;
+          organization_id: string | null;
+          scope: string;
+          created_by: string | null;
+          name: string;
+          description: string | null;
+          category: string;
+          content_json: string;
+          protected: boolean;
+          position_constraint: string | null;
+          version: number;
+          is_active: boolean;
+          created_at: number;
+          updated_at: number;
+        };
+        Insert: {
+          id?: string;
+          organization_id?: string | null;
+          scope: string;
+          created_by?: string | null;
+          name: string;
+          description?: string | null;
+          category: string;
+          content_json: string;
+          protected?: boolean;
+          position_constraint?: string | null;
+          version?: number;
+          is_active?: boolean;
+          created_at: number;
+          updated_at: number;
+        };
+        Update: {
+          id?: string;
+          organization_id?: string | null;
+          scope?: string;
+          created_by?: string | null;
+          name?: string;
+          description?: string | null;
+          category?: string;
+          content_json?: string;
+          protected?: boolean;
+          position_constraint?: string | null;
+          version?: number;
+          is_active?: boolean;
+          created_at?: number;
+          updated_at?: number;
+        };
+      };
     };
     Views: Record<string, never>;
     Functions: Record<string, never>;
@@ -4491,145 +4550,108 @@ export type CustomFieldValueUpdate = Database["public"]["Tables"]["custom_field_
 export type ObjectRelationshipRow = Database["public"]["Tables"]["object_relationships"]["Row"];
 export type ObjectRelationshipInsert = Database["public"]["Tables"]["object_relationships"]["Insert"];
 export type ObjectRelationshipUpdate = Database["public"]["Tables"]["object_relationships"]["Update"];
-
 export type LeadRow = Database["public"]["Tables"]["leads"]["Row"];
 export type LeadInsert = Database["public"]["Tables"]["leads"]["Insert"];
 export type LeadUpdate = Database["public"]["Tables"]["leads"]["Update"];
-
 export type PipelineRow = Database["public"]["Tables"]["pipelines"]["Row"];
 export type PipelineInsert = Database["public"]["Tables"]["pipelines"]["Insert"];
 export type PipelineUpdate = Database["public"]["Tables"]["pipelines"]["Update"];
-
 export type PipelineStageRow = Database["public"]["Tables"]["pipeline_stages"]["Row"];
 export type PipelineStageInsert = Database["public"]["Tables"]["pipeline_stages"]["Insert"];
 export type PipelineStageUpdate = Database["public"]["Tables"]["pipeline_stages"]["Update"];
-
 export type PipelineStageActionRow = Database["public"]["Tables"]["pipeline_stage_actions"]["Row"];
 export type PipelineStageActionInsert = Database["public"]["Tables"]["pipeline_stage_actions"]["Insert"];
 export type PipelineStageActionUpdate = Database["public"]["Tables"]["pipeline_stage_actions"]["Update"];
-
-// ── Platform Entities ─────────────────────────────────────────────────────
 export type OrganizationRow = Database["public"]["Tables"]["organizations"]["Row"];
 export type OrganizationInsert = Database["public"]["Tables"]["organizations"]["Insert"];
 export type OrganizationUpdate = Database["public"]["Tables"]["organizations"]["Update"];
-
 export type TeamMembershipRow = Database["public"]["Tables"]["team_memberships"]["Row"];
 export type TeamMembershipInsert = Database["public"]["Tables"]["team_memberships"]["Insert"];
 export type TeamMembershipUpdate = Database["public"]["Tables"]["team_memberships"]["Update"];
-
 export type InvitationRow = Database["public"]["Tables"]["invitations"]["Row"];
 export type InvitationInsert = Database["public"]["Tables"]["invitations"]["Insert"];
 export type InvitationUpdate = Database["public"]["Tables"]["invitations"]["Update"];
-
 export type NotificationRow = Database["public"]["Tables"]["notifications"]["Row"];
 export type NotificationInsert = Database["public"]["Tables"]["notifications"]["Insert"];
 export type NotificationUpdate = Database["public"]["Tables"]["notifications"]["Update"];
-
 export type RecentlyViewedRow = Database["public"]["Tables"]["recently_viewed"]["Row"];
 export type RecentlyViewedInsert = Database["public"]["Tables"]["recently_viewed"]["Insert"];
 export type RecentlyViewedUpdate = Database["public"]["Tables"]["recently_viewed"]["Update"];
-
 export type OrgSettingsRow = Database["public"]["Tables"]["org_settings"]["Row"];
 export type OrgSettingsInsert = Database["public"]["Tables"]["org_settings"]["Insert"];
 export type OrgSettingsUpdate = Database["public"]["Tables"]["org_settings"]["Update"];
-
 export type AuditLogRow = Database["public"]["Tables"]["audit_log"]["Row"];
 export type AuditLogInsert = Database["public"]["Tables"]["audit_log"]["Insert"];
 export type AuditLogUpdate = Database["public"]["Tables"]["audit_log"]["Update"];
-
 export type ActivityTypeDefinitionRow = Database["public"]["Tables"]["activity_type_definitions"]["Row"];
 export type ActivityTypeDefinitionInsert = Database["public"]["Tables"]["activity_type_definitions"]["Insert"];
 export type ActivityTypeDefinitionUpdate = Database["public"]["Tables"]["activity_type_definitions"]["Update"];
-
 export type ScheduledActivityRow = Database["public"]["Tables"]["scheduled_activities"]["Row"];
 export type ScheduledActivityInsert = Database["public"]["Tables"]["scheduled_activities"]["Insert"];
 export type ScheduledActivityUpdate = Database["public"]["Tables"]["scheduled_activities"]["Update"];
-
 export type EmailSequenceRow = Database["public"]["Tables"]["email_sequences"]["Row"];
 export type EmailSequenceInsert = Database["public"]["Tables"]["email_sequences"]["Insert"];
 export type EmailSequenceUpdate = Database["public"]["Tables"]["email_sequences"]["Update"];
-
-// ── Gabinet Entities ──────────────────────────────────────────────────────
 export type GabinetPatientRow = Database["public"]["Tables"]["gabinet_patients"]["Row"];
 export type GabinetPatientInsert = Database["public"]["Tables"]["gabinet_patients"]["Insert"];
 export type GabinetPatientUpdate = Database["public"]["Tables"]["gabinet_patients"]["Update"];
-
 export type GabinetTreatmentRow = Database["public"]["Tables"]["gabinet_treatments"]["Row"];
 export type GabinetTreatmentInsert = Database["public"]["Tables"]["gabinet_treatments"]["Insert"];
 export type GabinetTreatmentUpdate = Database["public"]["Tables"]["gabinet_treatments"]["Update"];
-
 export type GabinetTreatmentVariantRow = Database["public"]["Tables"]["gabinet_treatment_variants"]["Row"];
 export type GabinetTreatmentVariantInsert = Database["public"]["Tables"]["gabinet_treatment_variants"]["Insert"];
 export type GabinetTreatmentVariantUpdate = Database["public"]["Tables"]["gabinet_treatment_variants"]["Update"];
-
 export type GabinetEmployeeRow = Database["public"]["Tables"]["gabinet_employees"]["Row"];
 export type GabinetEmployeeInsert = Database["public"]["Tables"]["gabinet_employees"]["Insert"];
 export type GabinetEmployeeUpdate = Database["public"]["Tables"]["gabinet_employees"]["Update"];
-
 export type GabinetLocationRow = Database["public"]["Tables"]["gabinet_locations"]["Row"];
 export type GabinetLocationInsert = Database["public"]["Tables"]["gabinet_locations"]["Insert"];
 export type GabinetLocationUpdate = Database["public"]["Tables"]["gabinet_locations"]["Update"];
-
 export type GabinetRoomRow = Database["public"]["Tables"]["gabinet_rooms"]["Row"];
 export type GabinetRoomInsert = Database["public"]["Tables"]["gabinet_rooms"]["Insert"];
 export type GabinetRoomUpdate = Database["public"]["Tables"]["gabinet_rooms"]["Update"];
-
 export type GabinetEquipmentRow = Database["public"]["Tables"]["gabinet_equipment"]["Row"];
 export type GabinetEquipmentInsert = Database["public"]["Tables"]["gabinet_equipment"]["Insert"];
 export type GabinetEquipmentUpdate = Database["public"]["Tables"]["gabinet_equipment"]["Update"];
-
 export type GabinetEquipmentTransferRow = Database["public"]["Tables"]["gabinet_equipment_transfers"]["Row"];
 export type GabinetEquipmentTransferInsert = Database["public"]["Tables"]["gabinet_equipment_transfers"]["Insert"];
 export type GabinetEquipmentTransferUpdate = Database["public"]["Tables"]["gabinet_equipment_transfers"]["Update"];
-
 export type GabinetLeaveTypeRow = Database["public"]["Tables"]["gabinet_leave_types"]["Row"];
 export type GabinetLeaveTypeInsert = Database["public"]["Tables"]["gabinet_leave_types"]["Insert"];
 export type GabinetLeaveTypeUpdate = Database["public"]["Tables"]["gabinet_leave_types"]["Update"];
-
 export type GabinetLeaveBalanceRow = Database["public"]["Tables"]["gabinet_leave_balances"]["Row"];
 export type GabinetLeaveBalanceInsert = Database["public"]["Tables"]["gabinet_leave_balances"]["Insert"];
 export type GabinetLeaveBalanceUpdate = Database["public"]["Tables"]["gabinet_leave_balances"]["Update"];
-
 export type GabinetWorkingHoursRow = Database["public"]["Tables"]["gabinet_working_hours"]["Row"];
 export type GabinetWorkingHoursInsert = Database["public"]["Tables"]["gabinet_working_hours"]["Insert"];
 export type GabinetWorkingHoursUpdate = Database["public"]["Tables"]["gabinet_working_hours"]["Update"];
-
 export type GabinetEmployeeScheduleRow = Database["public"]["Tables"]["gabinet_employee_schedules"]["Row"];
 export type GabinetEmployeeScheduleInsert = Database["public"]["Tables"]["gabinet_employee_schedules"]["Insert"];
 export type GabinetEmployeeScheduleUpdate = Database["public"]["Tables"]["gabinet_employee_schedules"]["Update"];
-
 export type GabinetAppointmentRow = Database["public"]["Tables"]["gabinet_appointments"]["Row"];
 export type GabinetAppointmentInsert = Database["public"]["Tables"]["gabinet_appointments"]["Insert"];
 export type GabinetAppointmentUpdate = Database["public"]["Tables"]["gabinet_appointments"]["Update"];
-
 export type GabinetLeaveRow = Database["public"]["Tables"]["gabinet_leaves"]["Row"];
 export type GabinetLeaveInsert = Database["public"]["Tables"]["gabinet_leaves"]["Insert"];
 export type GabinetLeaveUpdate = Database["public"]["Tables"]["gabinet_leaves"]["Update"];
-
 export type GabinetOvertimeRow = Database["public"]["Tables"]["gabinet_overtime"]["Row"];
 export type GabinetOvertimeInsert = Database["public"]["Tables"]["gabinet_overtime"]["Insert"];
 export type GabinetOvertimeUpdate = Database["public"]["Tables"]["gabinet_overtime"]["Update"];
-
 export type GabinetDocumentTemplateRow = Database["public"]["Tables"]["gabinet_document_templates"]["Row"];
 export type GabinetDocumentTemplateInsert = Database["public"]["Tables"]["gabinet_document_templates"]["Insert"];
 export type GabinetDocumentTemplateUpdate = Database["public"]["Tables"]["gabinet_document_templates"]["Update"];
-
 export type GabinetDocumentRow = Database["public"]["Tables"]["gabinet_documents"]["Row"];
 export type GabinetDocumentInsert = Database["public"]["Tables"]["gabinet_documents"]["Insert"];
 export type GabinetDocumentUpdate = Database["public"]["Tables"]["gabinet_documents"]["Update"];
-
 export type GabinetTreatmentPackageRow = Database["public"]["Tables"]["gabinet_treatment_packages"]["Row"];
 export type GabinetTreatmentPackageInsert = Database["public"]["Tables"]["gabinet_treatment_packages"]["Insert"];
 export type GabinetTreatmentPackageUpdate = Database["public"]["Tables"]["gabinet_treatment_packages"]["Update"];
-
 export type GabinetPackageUsageRow = Database["public"]["Tables"]["gabinet_package_usage"]["Row"];
 export type GabinetPackageUsageInsert = Database["public"]["Tables"]["gabinet_package_usage"]["Insert"];
 export type GabinetPackageUsageUpdate = Database["public"]["Tables"]["gabinet_package_usage"]["Update"];
-
 export type GabinetLoyaltyPointsRow = Database["public"]["Tables"]["gabinet_loyalty_points"]["Row"];
 export type GabinetLoyaltyPointsInsert = Database["public"]["Tables"]["gabinet_loyalty_points"]["Insert"];
 export type GabinetLoyaltyPointsUpdate = Database["public"]["Tables"]["gabinet_loyalty_points"]["Update"];
-
 export type GabinetLoyaltyTransactionRow = Database["public"]["Tables"]["gabinet_loyalty_transactions"]["Row"];
 export type GabinetLoyaltyTransactionInsert = Database["public"]["Tables"]["gabinet_loyalty_transactions"]["Insert"];
 export type GabinetLoyaltyTransactionUpdate = Database["public"]["Tables"]["gabinet_loyalty_transactions"]["Update"];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #221.

Closes #221

---

## Claude summary

Committed. Summary of changes:

`scripts/gen-db-types.mjs` now reads every `.sql` file in `supabase/migrations/` in order and supports `CREATE TABLE [IF NOT EXISTS]` plus `ALTER TABLE ... ADD COLUMN [IF NOT EXISTS]` (including comma-separated multi-action ALTERs). The previously hand-maintained alias block at the bottom of `database.types.ts` (Lead*, Pipeline*, Organization*, Gabinet*, …) is folded into the script's `entityAliases` list so the file is fully regenerable; the emitted alias set is byte-identical to what was there before.

Regenerated outputs now include `saved_views.selected_id` (from 00003) and the `document_components` table (from 00004) in both `database.types.ts` and `database.columns.ts`. Verified with a synthetic 00099 migration that multi-column ALTERs and `CREATE TABLE IF NOT EXISTS` both parse correctly. I couldn't run `npm run typecheck` because `node_modules` isn't installed in this worktree.