### PR TITLE
Type `_layout.gabinet.employees.index.tsx` (`MappedGabinetEmployee[]` / `MappedG

### DIFF
--- a/src/lib/supabase/mappers/gabinet/employees.ts
+++ b/src/lib/supabase/mappers/gabinet/employees.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetEmployee {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   userId: string;
   firstName?: string;
@@ -46,5 +47,10 @@ const mapper = createEntityMapper<GabinetEmployeeRow, MappedGabinetEmployee>(
   {},
 );
 
-export const mapGabinetEmployeeFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetEmployeeFromSupabase = (
+  row: GabinetEmployeeRow,
+): MappedGabinetEmployee => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapGabinetEmployeeToSupabase = mapper.mapToSupabase;

--- a/src/lib/supabase/mappers/gabinet/patients.ts
+++ b/src/lib/supabase/mappers/gabinet/patients.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetPatient {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   contactId?: string;
   firstName: string;
@@ -37,5 +38,10 @@ export interface MappedGabinetPatient {
 
 const mapper = createEntityMapper<GabinetPatientRow, MappedGabinetPatient>({});
 
-export const mapGabinetPatientFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetPatientFromSupabase = (
+  row: GabinetPatientRow,
+): MappedGabinetPatient => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapGabinetPatientToSupabase = mapper.mapToSupabase;

--- a/src/lib/supabase/mappers/gabinet/treatments.ts
+++ b/src/lib/supabase/mappers/gabinet/treatments.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetTreatment {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   name: string;
   description?: string;
@@ -42,5 +43,10 @@ const mapper = createEntityMapper<GabinetTreatmentRow, MappedGabinetTreatment>(
   {},
 );
 
-export const mapGabinetTreatmentFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetTreatmentFromSupabase = (
+  row: GabinetTreatmentRow,
+): MappedGabinetTreatment => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapGabinetTreatmentToSupabase = mapper.mapToSupabase;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #228.

Closes #228

---

## Claude summary

Done. Added `_creationTime: number` to `MappedGabinetEmployee`, `MappedGabinetPatient`, and `MappedGabinetTreatment` and wrapped each `mapFromSupabase` to populate it from the row's `createdAt` (same unix-ms semantics as Convex's `_creationTime`). Typecheck shows no new errors — pre-existing failures are unrelated to gabinet mappers.

## Follow-ups
- Apply the same `_creationTime` fix to other gabinet Mapped* types: appointments, employee-schedules, treatment-packages, package-usage, leaves, overtime, working-hours, leave-types, leave-balances, loyalty-points, loyalty-transactions, locations, rooms, equipment, equipment-transfers, treatment-variants — they share the same shape mismatch with their Doc<T> counterparts.
- Apply the same `_creationTime` fix to non-gabinet Mapped* types (contacts, companies, leads, deals, products, activities, calls, emails, notes, etc.): same gap, same `as unknown as Doc<T>[]` casts likely exist throughout the route files.
- Replace `as unknown as Doc<T>[]` casts in gabinet route files with proper typing once Mapped* types are fully Doc-shaped: removes a class of unsafe casts and improves IDE autocomplete reliability.