### PR TITLE
Type the unknown action results in `_layout.leads.$leadId.lazy.tsx`

### DIFF
--- a/convex/products.ts
+++ b/convex/products.ts
@@ -7,6 +7,14 @@ import { verifyOrgAccess } from "./_helpers/auth";
 import { logActivity } from "./_helpers/activities";
 import { checkPermission } from "./_helpers/permissions";
 import { Id } from "./_generated/dataModel";
+import type { SupabaseRow } from "./_helpers/supabaseRows";
+
+type DealProductRow = SupabaseRow<"dealProducts">;
+type ProductRow = SupabaseRow<"products">;
+
+export interface DealProductWithProduct extends DealProductRow {
+  product: ProductRow | null;
+}
 
 // Dual-write refs removed — Supabase is now primary for product writes
 
@@ -367,7 +375,7 @@ export const listByDeal = action({
     organizationId: v.id("organizations"),
     dealId: v.string(),
   },
-  handler: async (ctx, args): Promise<Array<Record<string, unknown>>> => {
+  handler: async (ctx, args): Promise<DealProductWithProduct[]> => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
@@ -379,14 +387,16 @@ export const listByDeal = action({
     if (!perm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
-    const dealProducts = (await db
-      .query("dealProducts")
+    const dealProducts = await db
+      .query<DealProductRow>("dealProducts")
       .eq("dealId", args.dealId)
-      .collect()) as Array<Record<string, any>>;
+      .collect();
 
     const products = await Promise.all(
       dealProducts.map(async (dp) => {
-        const product = await db.get("products", String(dp.productId)).catch(() => null);
+        const product = await db
+          .get<ProductRow>("products", String(dp.productId))
+          .catch(() => null);
         return { ...dp, product };
       }),
     );

--- a/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
@@ -379,8 +379,12 @@ function LeadDetail() {
   const relationships = relationshipsQuery.data;
 
   const listProductsByDeal = useAction(api.products.listByDeal);
+  const dealProductsQueryKey = useMemo(
+    () => ["products.listByDeal", organizationId, leadId] as const,
+    [organizationId, leadId],
+  );
   const { data: dealProducts } = useQuery({
-    queryKey: ["products.listByDeal", organizationId, leadId],
+    queryKey: dealProductsQueryKey,
     queryFn: () =>
       listProductsByDeal({
         organizationId,
@@ -781,7 +785,7 @@ function LeadDetail() {
       discount,
     });
 
-    await queryClient.invalidateQueries({ queryKey: dealProductsQuery.queryKey });
+    await queryClient.invalidateQueries({ queryKey: dealProductsQueryKey });
     handleCloseProductDialog(false);
   };
 
@@ -791,7 +795,7 @@ function LeadDetail() {
       dealProductId,
     });
 
-    await queryClient.invalidateQueries({ queryKey: dealProductsQuery.queryKey });
+    await queryClient.invalidateQueries({ queryKey: dealProductsQueryKey });
   };
 
   const handleCreateActivity = async (data: {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #232.

Closes #232

---

## Claude summary

Fixed and committed. Two changes:

`convex/products.ts` — typed `listByDeal` to return `DealProductWithProduct[]` (a `SupabaseRow<"dealProducts">` joined with `SupabaseRow<"products"> | null`), replacing `Array<Record<string, unknown>>`. The old `as any` casts on the supabaseDb calls are gone — we use the existing generic parameters on `db.query<T>()` and `db.get<T>()` instead.

`src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx` — extracted the deal-products query key into a memoized `dealProductsQueryKey` constant, so `invalidateQueries` and `useQuery` share it (the prior code referenced a never-defined `dealProductsQuery` symbol — a partial refactor). With the action now returning `DealProductWithProduct[]`, the inline `dealProducts.reduce(...)` and the `LeadProductsSidebarCard products={...}` prop both typecheck without casts.

Verified: error count for the file dropped from 5 → 0; the convex tsconfig project also typechecks clean. The remaining errors in the workspace are in unrelated files.