### PR TITLE
Type `MappedGabinetEmployee`/`MappedGabinetPatient`/`MappedGabinetTreatment` to 

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -23,7 +23,9 @@ import { useTranslation } from "react-i18next";
 import { DataListFilterBar } from "@/components/crm/data-list-filter-bar";
 import type { FieldDef, FilterCondition } from "@/components/crm/types";
 import { toast } from "sonner";
-import { Id, Doc } from "@cvx/_generated/dataModel";
+import { Id } from "@cvx/_generated/dataModel";
+import type { MappedGabinetEmployee } from "@/lib/supabase/mappers/gabinet/employees";
+import type { MappedGabinetTreatment } from "@/lib/supabase/mappers/gabinet/treatments";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
@@ -45,7 +47,7 @@ export const Route = createFileRoute(
 });
 
 
-type Employee = Doc<"gabinetEmployees">;
+type Employee = MappedGabinetEmployee;
 
 function EmployeesIndex() {
   const { t } = useTranslation();
@@ -91,14 +93,13 @@ function EmployeesIndex() {
   const createEmployee = useAction(api.gabinet.employees.create);
   const removeEmployee = useAction(api.gabinet.employees.remove);
 
-  const { data: employeesRaw } = useSupabaseGabinetEmployeesList(organizationId);
-  const employees = employeesRaw as unknown as Employee[] | undefined;
+  const { data: employees } = useSupabaseGabinetEmployeesList(organizationId);
 
   const { data: members } = useSupabaseOrganizationMembers(organizationId);
 
   const { data: allTreatmentsRaw } = useSupabaseGabinetTreatmentsList(organizationId);
-  const treatments = useMemo(
-    () => (allTreatmentsRaw ?? []).filter((t) => t.isActive) as unknown as Doc<"gabinetTreatments">[],
+  const treatments: MappedGabinetTreatment[] = useMemo(
+    () => (allTreatmentsRaw ?? []).filter((t) => t.isActive),
     [allTreatmentsRaw],
   );
 
@@ -269,7 +270,7 @@ function EmployeesIndex() {
         icon: <Trash2 className="h-4 w-4" variant="stroke" />,
         onClick: async () => {
           if (window.confirm(t("gabinet.employees.confirmDelete"))) {
-            await removeEmployee({ organizationId, employeeId: row._id });
+            await removeEmployee({ organizationId, employeeId: row._id as Id<"gabinetEmployees"> });
           }
         },
       },
@@ -281,7 +282,7 @@ function EmployeesIndex() {
     async (action: string, selectedRows: Employee[]) => {
       if (action === "delete") {
         for (const row of selectedRows) {
-          await removeEmployee({ organizationId, employeeId: row._id });
+          await removeEmployee({ organizationId, employeeId: row._id as Id<"gabinetEmployees"> });
         }
       }
     },
@@ -412,7 +413,7 @@ function CreateEmployeeSheet({
   open: boolean;
   onClose: () => void;
   availableUsers: Array<{ _id: Id<"users">; name?: string | null; email?: string | null }>;
-  treatments: Array<{ _id: Id<"gabinetTreatments">; name: string }>;
+  treatments: Array<{ _id: string; name: string }>;
   organizationId: Id<"organizations">;
   onCreate: any;
   tags: Array<{ _id: Id<"tagDefinitions">; name: string; color: string }>;

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -15,7 +15,8 @@ import { Badge } from "@/components/ui/badge";
 import { Plus, Trash2, Download } from "@/lib/ez-icons";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
-import { Doc, Id } from "@cvx/_generated/dataModel";
+import { Id } from "@cvx/_generated/dataModel";
+import type { MappedGabinetPatient } from "@/lib/supabase/mappers/gabinet/patients";
 import { useState, useMemo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import type { SavedView, TimeRange, FieldDef, FilterCondition } from "@/components/crm/types";
@@ -35,7 +36,7 @@ export const Route = createFileRoute(
   component: PatientsIndex,
 });
 
-type Patient = Doc<"gabinetPatients">;
+type Patient = MappedGabinetPatient;
 
 function PatientsIndex() {
   const { t } = useTranslation();
@@ -144,8 +145,7 @@ function PatientsIndex() {
     [t, tags, categories],
   );
 
-  const { data: patientsRaw = [], isLoading } = useSupabaseGabinetPatientsList(organizationId);
-  const patients = patientsRaw as unknown as Patient[];
+  const { data: patients = [], isLoading } = useSupabaseGabinetPatientsList(organizationId);
 
   const {
     views,
@@ -345,7 +345,7 @@ function PatientsIndex() {
     async (action: string, selectedRows: Patient[]) => {
       if (action === "delete") {
         for (const row of selectedRows) {
-          await removePatient({ organizationId, patientId: row._id });
+          await removePatient({ organizationId, patientId: row._id as Id<"gabinetPatients"> });
         }
       }
     },
@@ -364,7 +364,7 @@ function PatientsIndex() {
         icon: <Trash2 className="h-4 w-4" variant="stroke" />,
         onClick: async () => {
           if (window.confirm(t("gabinet.patients.confirmDelete"))) {
-            await removePatient({ organizationId, patientId: row._id });
+            await removePatient({ organizationId, patientId: row._id as Id<"gabinetPatients"> });
           }
         },
       },

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -17,7 +17,8 @@ import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 import { Plus, Pencil, Trash2, Power } from "@/lib/ez-icons";
 import type { SavedView, FieldDef, FilterCondition } from "@/components/crm/types";
-import { Doc, Id } from "@cvx/_generated/dataModel";
+import { Id } from "@cvx/_generated/dataModel";
+import type { MappedGabinetTreatment } from "@/lib/supabase/mappers/gabinet/treatments";
 import { useState, useMemo, useCallback } from "react";
 import type { SortDescriptor } from "react-aria-components";
 import { useTranslation } from "react-i18next";
@@ -41,7 +42,7 @@ export const Route = createFileRoute(
   component: TreatmentsIndex,
 });
 
-type Treatment = Doc<"gabinetTreatments">;
+type Treatment = MappedGabinetTreatment;
 
 function formatCurrency(amount: number, currency?: string): string {
   return new Intl.NumberFormat("pl-PL", {
@@ -154,8 +155,7 @@ function TreatmentsIndex() {
     [t, tags, categories],
   );
 
-  const { data: allTreatmentsRaw = [], isLoading } = useSupabaseGabinetTreatmentsList(organizationId);
-  const allTreatments = allTreatmentsRaw as unknown as Treatment[];
+  const { data: allTreatments = [], isLoading } = useSupabaseGabinetTreatmentsList(organizationId);
 
   const {
     views,
@@ -291,7 +291,7 @@ function TreatmentsIndex() {
         if (editingTreatment) {
           await updateTreatment({
             organizationId,
-            treatmentId: editingTreatment._id,
+            treatmentId: editingTreatment._id as Id<"gabinetTreatments">,
             ...formData,
             tagIds,
             categoryId,
@@ -319,7 +319,7 @@ function TreatmentsIndex() {
     async (action: string, selectedRows: Treatment[]) => {
       if (action === "delete") {
         for (const row of selectedRows) {
-          await removeTreatment({ organizationId, treatmentId: row._id });
+          await removeTreatment({ organizationId, treatmentId: row._id as Id<"gabinetTreatments"> });
         }
       }
     },
@@ -339,11 +339,11 @@ function TreatmentsIndex() {
         onClick: async () => {
           // Soft toggle by removing (deactivate) or updating
           if (row.isActive) {
-            await removeTreatment({ organizationId, treatmentId: row._id });
+            await removeTreatment({ organizationId, treatmentId: row._id as Id<"gabinetTreatments"> });
           } else {
             await updateTreatment({
               organizationId,
-              treatmentId: row._id,
+              treatmentId: row._id as Id<"gabinetTreatments">,
               name: row.name,
             });
           }
@@ -354,7 +354,7 @@ function TreatmentsIndex() {
         icon: <Trash2 className="h-4 w-4" variant="stroke" />,
         onClick: async () => {
           if (window.confirm(t("gabinet.treatments.confirmDelete"))) {
-            await removeTreatment({ organizationId, treatmentId: row._id });
+            await removeTreatment({ organizationId, treatmentId: row._id as Id<"gabinetTreatments"> });
           }
         },
       },
@@ -487,7 +487,7 @@ function TreatmentsIndex() {
                   requiredEquipment:
                     editingTreatment.requiredEquipment ?? undefined,
                   requiredEquipmentIds:
-                    editingTreatment.requiredEquipmentIds ?? undefined,
+                    (editingTreatment.requiredEquipmentIds as Id<"gabinetEquipment">[] | undefined) ?? undefined,
                   contraindications:
                     editingTreatment.contraindications ?? undefined,
                   preparationInstructions:


### PR DESCRIPTION
Auto-generated by Claude in response to issue #233.

Closes #233

---

## Claude summary

Committed as `45cf38d`. Summary:

Replaced `Doc<gabinetEmployees|Patients|Treatments>` row types and the `as unknown as Doc<>[]` casts in the three gabinet index routes with the mapper DTOs (`MappedGabinetEmployee` / `MappedGabinetPatient` / `MappedGabinetTreatment`), which now carry `_creationTime` after #228. Action calls that take `Id<>` arguments get narrow `as Id<>` casts at each call site (row `_id` for remove/update mutations, `requiredEquipmentIds` for TreatmentForm initial data).

`treatments.$treatmentId.tsx` is mentioned in the issue text but already uses the typed result from `useSupabaseGabinetTreatment` directly with appropriate inline `as Id<>` casts at action boundaries — no change needed there.

Typecheck confirms no new errors in any of the four files; the remaining 9 unrelated errors in the project (enhanced-data-table, nudges-badge, use-saved-views, etc.) were present before these changes and are out of scope.

## Follow-ups
- Tighten `MappedGabinetPatient.email` to `string | undefined`: schema marks `email` as `v.optional(v.string())` and consumers already null-check it (e.g. `p.email && p.email.toLowerCase()`), but the mapper types it as required `string`, hiding the real shape.