### PR TITLE
Fix typecheck errors in src/components/crm/enhanced-data-table.tsx

### DIFF
--- a/src/components/crm/enhanced-data-table.tsx
+++ b/src/components/crm/enhanced-data-table.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { Selection, SortDescriptor } from "react-aria-components";
 import { SearchLg, Menu01 } from "@untitledui/icons";
@@ -290,10 +290,10 @@ export function CrmDataTable<TData>({
                             size="sm"
                             color="tertiary"
                             iconLeading={<Menu01 className="size-5" />}
-                            onClick={(e) => {
+                            onClick={(e: ReactMouseEvent<HTMLButtonElement>) => {
                               e.stopPropagation();
                             }}
-                            onPointerDown={(e) => {
+                            onPointerDown={(e: ReactPointerEvent<HTMLButtonElement>) => {
                               // Prevent React Aria from starting selection on pointer down
                               e.stopPropagation();
                             }}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #237.

Closes #237

---

## Claude summary

Fixed both TS7006 implicit-any errors at `src/components/crm/enhanced-data-table.tsx:293` and `:296` by explicitly typing the `e` parameters as `ReactMouseEvent<HTMLButtonElement>` and `ReactPointerEvent<HTMLButtonElement>` (imported as type aliases from React). The Button component's `Props = ButtonProps | LinkProps` union prevented TS from inferring the handler param types, so explicit annotations were the cleanest fix. Verified the two errors are gone via `tsc -p tsconfig.app.json`; remaining typecheck errors in other files are pre-existing and out of scope. Committed as `2761522`.