### PR TITLE
Fix typecheck errors in src/components/notifications/nudges-badge.tsx

### DIFF
--- a/src/components/notifications/nudges-badge.tsx
+++ b/src/components/notifications/nudges-badge.tsx
@@ -4,20 +4,17 @@ import {
   AlertTriangle,
   AlertCircle,
   CheckCircle,
-  X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Badge } from "@/components/ui/badge";
 import { ScrollShadow } from "@/components/ui/scroll-shadow";
 import { useNudges } from "@/contexts/nudges-context";
-import { NudgeData } from "@/contexts/nudges-context";
 
 const severityConfig = {
   red: {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #238.

Closes #238

---

## Claude summary

Removed the three unused imports (`X` from lucide-react, `DropdownMenuItem` from dropdown-menu, and `NudgeData` from nudges-context) in `src/components/notifications/nudges-badge.tsx`. Verified each was imported but never referenced in the file body. Committed as `d6918c5`.

Note: I couldn't run `npm run typecheck` locally since `node_modules` isn't installed in this worktree, but the fix matches the exact errors enumerated in the issue and the imports are demonstrably unused.