### PR TITLE
Fix typecheck errors in src/hooks/use-saved-views.ts

### DIFF
--- a/convex/savedViews.ts
+++ b/convex/savedViews.ts
@@ -50,6 +50,7 @@ export const create = action({
     columns: v.optional(v.array(v.string())),
     sortField: v.optional(v.string()),
     sortDirection: v.optional(v.string()),
+    selectedId: v.optional(v.string()),
     isDefault: v.optional(v.boolean()),
     isSystem: v.boolean(),
   },
@@ -92,6 +93,7 @@ export const create = action({
       columns: args.columns ?? null,
       sortField: args.sortField ?? null,
       sortDirection: args.sortDirection ?? null,
+      selectedId: args.selectedId ?? null,
       isDefault: args.isDefault ?? null,
       isSystem: args.isSystem,
       createdBy: String(authResult.userId),
@@ -113,6 +115,7 @@ export const update = action({
     columns: v.optional(v.array(v.string())),
     sortField: v.optional(v.string()),
     sortDirection: v.optional(v.string()),
+    selectedId: v.optional(v.string()),
     isDefault: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
@@ -139,6 +142,7 @@ export const update = action({
     if (args.columns !== undefined) updates.columns = args.columns;
     if (args.sortField !== undefined) updates.sortField = args.sortField;
     if (args.sortDirection !== undefined) updates.sortDirection = args.sortDirection;
+    if (args.selectedId !== undefined) updates.selectedId = args.selectedId;
     if (args.isDefault !== undefined) updates.isDefault = args.isDefault;
 
     await db.patch("savedViews", args.viewId, updates);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #239.

Closes #239

---

## Claude summary

Fixed and committed. Both TS2353 errors at `src/hooks/use-saved-views.ts:173` and `:193` are gone. Root cause: commit 738282c added `selectedId` to the frontend `SavedView` type and the Supabase migration but didn't update the Convex action validators in `convex/savedViews.ts`. Added `selectedId: v.optional(v.string())` to both `create` and `update` action args and propagated the value to the Supabase insert/patch (camelCase→snake_case mapping in `supabaseDb.ts` lands it in the `selected_id` column).

## Follow-ups
- Fix unused `doc` variable in src/hooks/use-supabase-form-documents.ts:90: pre-existing TS6133 error blocks `npm run typecheck`
- Type calendar-preview route loaderData: src/routes/_app/_auth/dashboard/_layout.calendar-preview.tsx:61 hits TS2339 on `moduleId`, pre-existing
- Add `selectedId` to convex/supabase/savedViews.ts write actions: writeSavedViewToSupabase / updateSavedViewInSupabase still don't accept selectedId (currently unreferenced, but inconsistent with primary actions)