### PR TITLE
Fix typecheck error in src/hooks/use-supabase-form-documents.ts

### DIFF
--- a/src/hooks/use-supabase-form-documents.ts
+++ b/src/hooks/use-supabase-form-documents.ts
@@ -87,7 +87,7 @@ export function useSupabaseFormDocumentsList(
       // (In production, this should be done via a database join or view)
       if (category?.trim()) {
         const templateIds = mapped
-          .filter((doc) => {
+          .filter((_doc) => {
             // This is a placeholder - we'd need template data
             // For now, return all docs if category filter is set
             return true;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #240.

Closes #240

---

## Claude summary

Fixed by renaming `doc` to `_doc` on line 90 of `src/hooks/use-supabase-form-documents.ts` — the parameter is genuinely unused (the callback returns `true` for all items, per the placeholder comment), and the underscore prefix is the standard convention for intentionally-unused parameters. Verified `tsc -p tsconfig.app.json` no longer reports the TS6133 error for this file. Committed as `6149642`.

## Follow-ups
- Fix TS2339 in calendar-preview.tsx: `Property 'moduleId' does not exist on type '{}'` at src/routes/_app/_auth/dashboard/_layout.calendar-preview.tsx:61