### PR TITLE
Fix typecheck error in src/routes/_app/_auth/dashboard/_layout.calendar-preview.

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.calendar-preview.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calendar-preview.tsx
@@ -53,14 +53,17 @@ function CalendarPreview() {
 
   const events: CalendarEvent[] = useMemo(() => {
     if (!rawEvents) return [];
-    return rawEvents.map((a) => ({
-      id: a._id,
-      title: a.title,
-      start: new Date(a.dueDate),
-      end: new Date(a.endDate ?? a.dueDate + 60 * 60 * 1000),
-      color: getEventColor(a.activityType, a.isCompleted, a.moduleRef?.moduleId),
-      dot: a.isCompleted,
-    }));
+    return rawEvents.map((a) => {
+      const moduleRef = a.moduleRef as { moduleId?: string } | undefined;
+      return {
+        id: a._id,
+        title: a.title,
+        start: new Date(a.dueDate),
+        end: new Date(a.endDate ?? a.dueDate + 60 * 60 * 1000),
+        color: getEventColor(a.activityType, a.isCompleted, moduleRef?.moduleId),
+        dot: a.isCompleted,
+      };
+    });
   }, [rawEvents]);
 
   // Hide mini calendar when leaving this page


### PR DESCRIPTION
Auto-generated by Claude in response to issue #242.

Closes #242

---

## Claude summary

Fixed and committed. The error was that `MappedScheduledActivity.moduleRef` is typed as `unknown` (mappers/scheduled-activities.ts:30), so `a.moduleRef?.moduleId` failed TS2339. The hook itself uses a `as { moduleId?: string } | undefined` cast in several places — I applied the same pattern in the `events` mapper at line 57.

## Follow-ups
- Type moduleRef properly on MappedScheduledActivity: replace `unknown` with `{ moduleId?: string; entityType?: string; entityId?: string }` so callers don't need ad-hoc casts (used in 4+ spots in use-supabase-scheduled-activities.ts alone)