### PR TITLE
Apply the same `_creationTime` fix to other gabinet Mapped* types

### DIFF
--- a/src/lib/supabase/mappers/gabinet/appointments.ts
+++ b/src/lib/supabase/mappers/gabinet/appointments.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetAppointment {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   patientId: string;
   treatmentId?: string;
@@ -53,5 +54,10 @@ export interface MappedGabinetAppointment {
 
 const mapper = createEntityMapper<GabinetAppointmentRow, MappedGabinetAppointment>({});
 
-export const mapGabinetAppointmentFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetAppointmentFromSupabase = (
+  row: GabinetAppointmentRow,
+): MappedGabinetAppointment => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapGabinetAppointmentToSupabase = mapper.mapToSupabase;

--- a/src/lib/supabase/mappers/gabinet/employee-schedules.ts
+++ b/src/lib/supabase/mappers/gabinet/employee-schedules.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetEmployeeSchedule {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   userId: string;
   dayOfWeek: number;
@@ -29,5 +30,10 @@ const mapper = createEntityMapper<
   MappedGabinetEmployeeSchedule
 >({});
 
-export const mapGabinetEmployeeScheduleFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetEmployeeScheduleFromSupabase = (
+  row: GabinetEmployeeScheduleRow,
+): MappedGabinetEmployeeSchedule => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapGabinetEmployeeScheduleToSupabase = mapper.mapToSupabase;

--- a/src/lib/supabase/mappers/gabinet/equipment-transfers.ts
+++ b/src/lib/supabase/mappers/gabinet/equipment-transfers.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetEquipmentTransfer {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   equipmentId: string;
   fromLocationId?: string;
@@ -23,5 +24,10 @@ const mapper = createEntityMapper<
   MappedGabinetEquipmentTransfer
 >({});
 
-export const mapGabinetEquipmentTransferFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetEquipmentTransferFromSupabase = (
+  row: GabinetEquipmentTransferRow,
+): MappedGabinetEquipmentTransfer => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.transferredAt };
+};
 export const mapGabinetEquipmentTransferToSupabase = mapper.mapToSupabase;

--- a/src/lib/supabase/mappers/gabinet/equipment.ts
+++ b/src/lib/supabase/mappers/gabinet/equipment.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetEquipment {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   name: string;
   description?: string;
@@ -24,5 +25,10 @@ const mapper = createEntityMapper<GabinetEquipmentRow, MappedGabinetEquipment>(
   {},
 );
 
-export const mapGabinetEquipmentFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetEquipmentFromSupabase = (
+  row: GabinetEquipmentRow,
+): MappedGabinetEquipment => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapGabinetEquipmentToSupabase = mapper.mapToSupabase;

--- a/src/lib/supabase/mappers/gabinet/leave-balances.ts
+++ b/src/lib/supabase/mappers/gabinet/leave-balances.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetLeaveBalance {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   employeeId: string;
   leaveTypeId: string;
@@ -23,5 +24,10 @@ const mapper = createEntityMapper<
   MappedGabinetLeaveBalance
 >({});
 
-export const mapGabinetLeaveBalanceFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetLeaveBalanceFromSupabase = (
+  row: GabinetLeaveBalanceRow,
+): MappedGabinetLeaveBalance => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapGabinetLeaveBalanceToSupabase = mapper.mapToSupabase;

--- a/src/lib/supabase/mappers/gabinet/leave-types.ts
+++ b/src/lib/supabase/mappers/gabinet/leave-types.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetLeaveType {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   name: string;
   color?: string;
@@ -24,5 +25,10 @@ const mapper = createEntityMapper<GabinetLeaveTypeRow, MappedGabinetLeaveType>(
   {},
 );
 
-export const mapGabinetLeaveTypeFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetLeaveTypeFromSupabase = (
+  row: GabinetLeaveTypeRow,
+): MappedGabinetLeaveType => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapGabinetLeaveTypeToSupabase = mapper.mapToSupabase;

--- a/src/lib/supabase/mappers/gabinet/leaves.ts
+++ b/src/lib/supabase/mappers/gabinet/leaves.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetLeave {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   userId: string;
   type: string;
@@ -27,5 +28,10 @@ export interface MappedGabinetLeave {
 
 const mapper = createEntityMapper<GabinetLeaveRow, MappedGabinetLeave>({});
 
-export const mapGabinetLeaveFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetLeaveFromSupabase = (
+  row: GabinetLeaveRow,
+): MappedGabinetLeave => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapGabinetLeaveToSupabase = mapper.mapToSupabase;

--- a/src/lib/supabase/mappers/gabinet/locations.ts
+++ b/src/lib/supabase/mappers/gabinet/locations.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetLocation {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   name: string;
   address?: unknown;
@@ -24,5 +25,10 @@ const mapper = createEntityMapper<GabinetLocationRow, MappedGabinetLocation>(
   {},
 );
 
-export const mapGabinetLocationFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetLocationFromSupabase = (
+  row: GabinetLocationRow,
+): MappedGabinetLocation => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapGabinetLocationToSupabase = mapper.mapToSupabase;

--- a/src/lib/supabase/mappers/gabinet/loyalty-points.ts
+++ b/src/lib/supabase/mappers/gabinet/loyalty-points.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetLoyaltyPoints {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   patientId: string;
   balance: number;
@@ -23,5 +24,10 @@ const mapper = createEntityMapper<
   MappedGabinetLoyaltyPoints
 >({});
 
-export const mapGabinetLoyaltyPointsFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetLoyaltyPointsFromSupabase = (
+  row: GabinetLoyaltyPointsRow,
+): MappedGabinetLoyaltyPoints => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapGabinetLoyaltyPointsToSupabase = mapper.mapToSupabase;

--- a/src/lib/supabase/mappers/gabinet/loyalty-transactions.ts
+++ b/src/lib/supabase/mappers/gabinet/loyalty-transactions.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetLoyaltyTransaction {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   patientId: string;
   type: string;
@@ -25,5 +26,10 @@ const mapper = createEntityMapper<
   MappedGabinetLoyaltyTransaction
 >({});
 
-export const mapGabinetLoyaltyTransactionFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetLoyaltyTransactionFromSupabase = (
+  row: GabinetLoyaltyTransactionRow,
+): MappedGabinetLoyaltyTransaction => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapGabinetLoyaltyTransactionToSupabase = mapper.mapToSupabase;

--- a/src/lib/supabase/mappers/gabinet/overtime.ts
+++ b/src/lib/supabase/mappers/gabinet/overtime.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetOvertime {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   userId: string;
   date: string;
@@ -23,5 +24,10 @@ export interface MappedGabinetOvertime {
 
 const mapper = createEntityMapper<GabinetOvertimeRow, MappedGabinetOvertime>({});
 
-export const mapGabinetOvertimeFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetOvertimeFromSupabase = (
+  row: GabinetOvertimeRow,
+): MappedGabinetOvertime => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapGabinetOvertimeToSupabase = mapper.mapToSupabase;

--- a/src/lib/supabase/mappers/gabinet/package-usage.ts
+++ b/src/lib/supabase/mappers/gabinet/package-usage.ts
@@ -18,6 +18,7 @@ export interface PackageTreatmentUsageEntry {
 
 export interface MappedGabinetPackageUsage {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   patientId: string;
   packageId: string;
@@ -45,6 +46,7 @@ export function mapGabinetPackageUsageFromSupabase(
   const base = mapper.mapFromSupabase(row);
   return {
     ...base,
+    _creationTime: base.createdAt,
     treatmentsUsed: (row.treatments_used ?? []) as PackageTreatmentUsageEntry[],
   };
 }

--- a/src/lib/supabase/mappers/gabinet/rooms.ts
+++ b/src/lib/supabase/mappers/gabinet/rooms.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetRoom {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   locationId: string;
   name: string;
@@ -19,5 +20,10 @@ export interface MappedGabinetRoom {
 
 const mapper = createEntityMapper<GabinetRoomRow, MappedGabinetRoom>({});
 
-export const mapGabinetRoomFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetRoomFromSupabase = (
+  row: GabinetRoomRow,
+): MappedGabinetRoom => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapGabinetRoomToSupabase = mapper.mapToSupabase;

--- a/src/lib/supabase/mappers/gabinet/treatment-packages.ts
+++ b/src/lib/supabase/mappers/gabinet/treatment-packages.ts
@@ -18,6 +18,7 @@ export interface PackageTreatmentEntry {
 
 export interface MappedGabinetTreatmentPackage {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   name: string;
   description?: string;
@@ -47,6 +48,7 @@ export function mapGabinetTreatmentPackageFromSupabase(
   const base = mapper.mapFromSupabase(row);
   return {
     ...base,
+    _creationTime: base.createdAt,
     treatments: (row.treatments ?? []) as PackageTreatmentEntry[],
   };
 }

--- a/src/lib/supabase/mappers/gabinet/treatment-variants.ts
+++ b/src/lib/supabase/mappers/gabinet/treatment-variants.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetTreatmentVariant {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   treatmentId: string;
   name: string;
@@ -25,5 +26,10 @@ const mapper = createEntityMapper<
   MappedGabinetTreatmentVariant
 >({});
 
-export const mapGabinetTreatmentVariantFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetTreatmentVariantFromSupabase = (
+  row: GabinetTreatmentVariantRow,
+): MappedGabinetTreatmentVariant => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: 0 };
+};
 export const mapGabinetTreatmentVariantToSupabase = mapper.mapToSupabase;

--- a/src/lib/supabase/mappers/gabinet/working-hours.ts
+++ b/src/lib/supabase/mappers/gabinet/working-hours.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "../generic";
 
 export interface MappedGabinetWorkingHours {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   dayOfWeek: number;
   startTime: string;
@@ -26,5 +27,10 @@ const mapper = createEntityMapper<
   MappedGabinetWorkingHours
 >({});
 
-export const mapGabinetWorkingHoursFromSupabase = mapper.mapFromSupabase;
+export const mapGabinetWorkingHoursFromSupabase = (
+  row: GabinetWorkingHoursRow,
+): MappedGabinetWorkingHours => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapGabinetWorkingHoursToSupabase = mapper.mapToSupabase;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #254.

Closes #254

---

## Claude summary

Applied the same `_creationTime` fix from #228 to all 16 remaining gabinet mappers as requested in #254. Each `MappedGabinet*` type now carries `_creationTime: number` and the corresponding `mapGabinet*FromSupabase` function populates it from the row's `createdAt` (with two exceptions: `equipment-transfers` uses `transferredAt` since that's the only timestamp on the table, and `treatment-variants` uses `0` since the table has no timestamp column at all).

Frontend typecheck shows the same 15 pre-existing errors before and after — no regressions introduced. Convex typecheck shows no mapper-related errors. Committed as `5524172` on branch `claude/issue-254`.