### PR TITLE
Apply the same `_creationTime` fix to non-gabinet Mapped* types (contacts, compa

### DIFF
--- a/src/lib/supabase/mappers/activities.ts
+++ b/src/lib/supabase/mappers/activities.ts
@@ -18,6 +18,7 @@ type ActivityRowWithUser = ActivityRow & {
 
 export interface MappedActivity {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   entityType: string;
   entityId: string;
@@ -38,6 +39,7 @@ export function mapActivityFromSupabase(row: ActivityRowWithUser): MappedActivit
   const mapped = activityMapper.mapFromSupabase(row);
   return {
     ...mapped,
+    _creationTime: mapped.createdAt,
     performedByName: row.users?.name ?? row.users?.email ?? undefined,
   };
 }

--- a/src/lib/supabase/mappers/activity-types.ts
+++ b/src/lib/supabase/mappers/activity-types.ts
@@ -10,6 +10,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedActivityType {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   key: string;
   name: string;
@@ -24,5 +25,10 @@ export interface MappedActivityType {
 
 const activityTypeMapper = createEntityMapper<ActivityTypeDefinitionRow, MappedActivityType>({});
 
-export const mapActivityTypeFromSupabase = activityTypeMapper.mapFromSupabase;
+export const mapActivityTypeFromSupabase = (
+  row: ActivityTypeDefinitionRow,
+): MappedActivityType => {
+  const mapped = activityTypeMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapActivityTypeToSupabase = activityTypeMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/audit-log.ts
+++ b/src/lib/supabase/mappers/audit-log.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedAuditLogEntry {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   userId: string;
   action: string;
@@ -20,5 +21,10 @@ export interface MappedAuditLogEntry {
 
 const auditLogMapper = createEntityMapper<AuditLogRow, MappedAuditLogEntry>({});
 
-export const mapAuditLogFromSupabase = auditLogMapper.mapFromSupabase;
+export const mapAuditLogFromSupabase = (
+  row: AuditLogRow,
+): MappedAuditLogEntry => {
+  const mapped = auditLogMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapAuditLogToSupabase = auditLogMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/automation-rules.ts
+++ b/src/lib/supabase/mappers/automation-rules.ts
@@ -18,6 +18,7 @@ type AutomationRuleRow = Database["public"]["Tables"]["automation_rules"]["Row"]
 /** Shape that mirrors `Doc<'automationRules'>` from Convex (camelCase). */
 export interface MappedAutomationRule {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   name: string;
   description?: string;
@@ -43,7 +44,8 @@ const automationRuleMapper = createEntityMapper<AutomationRuleRow, MappedAutomat
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapAutomationRuleFromSupabase(row: AutomationRuleRow): MappedAutomationRule {
-  return automationRuleMapper.mapFromSupabase(row);
+  const mapped = automationRuleMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapAutomationRuleToSupabase(

--- a/src/lib/supabase/mappers/automation-run-steps.ts
+++ b/src/lib/supabase/mappers/automation-run-steps.ts
@@ -15,6 +15,7 @@ type AutomationRunStepRow = Database["public"]["Tables"]["automation_run_steps"]
 /** Shape that mirrors `Doc<'automationRunSteps'>` from Convex (camelCase). */
 export interface MappedAutomationRunStep {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   runId: string;
   ruleId?: string;
@@ -45,7 +46,8 @@ const automationRunStepMapper = createEntityMapper<AutomationRunStepRow, MappedA
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapAutomationRunStepFromSupabase(row: AutomationRunStepRow): MappedAutomationRunStep {
-  return automationRunStepMapper.mapFromSupabase(row);
+  const mapped = automationRunStepMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapAutomationRunStepToSupabase(

--- a/src/lib/supabase/mappers/automation-runs.ts
+++ b/src/lib/supabase/mappers/automation-runs.ts
@@ -15,6 +15,7 @@ type AutomationRunRow = Database["public"]["Tables"]["automation_runs"]["Row"];
 /** Shape that mirrors `Doc<'automationRuns'>` from Convex (camelCase). */
 export interface MappedAutomationRun {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   ruleId?: string;
   module: string;
@@ -41,7 +42,8 @@ const automationRunMapper = createEntityMapper<AutomationRunRow, MappedAutomatio
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapAutomationRunFromSupabase(row: AutomationRunRow): MappedAutomationRun {
-  return automationRunMapper.mapFromSupabase(row);
+  const mapped = automationRunMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapAutomationRunToSupabase(

--- a/src/lib/supabase/mappers/calls.ts
+++ b/src/lib/supabase/mappers/calls.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedCall {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   outcome: string;
   callDate: number;
@@ -22,5 +23,8 @@ export interface MappedCall {
 
 const callMapper = createEntityMapper<CallRow, MappedCall>();
 
-export const mapCallFromSupabase = callMapper.mapFromSupabase;
+export const mapCallFromSupabase = (row: CallRow): MappedCall => {
+  const mapped = callMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapCallToSupabase = callMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/companies.ts
+++ b/src/lib/supabase/mappers/companies.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedCompany {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   name: string;
   domain?: string;
@@ -29,5 +30,8 @@ const companyMapper = createEntityMapper<CompanyRow, MappedCompany>({
   exclude: ["search_vector"],
 });
 
-export const mapCompanyFromSupabase = companyMapper.mapFromSupabase;
+export const mapCompanyFromSupabase = (row: CompanyRow): MappedCompany => {
+  const mapped = companyMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapCompanyToSupabase = companyMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/contacts.ts
+++ b/src/lib/supabase/mappers/contacts.ts
@@ -15,6 +15,7 @@ import { createEntityMapper } from "./generic";
 export interface MappedContact {
   /** Supabase UUID → used as _id surrogate for list rendering */
   _id: string;
+  _creationTime: number;
   organizationId: string;
   firstName: string;
   lastName?: string;
@@ -61,7 +62,8 @@ const contactMapper = createEntityMapper<SupabaseContactRow, MappedContact>({
 // ─── Exported Functions (backward-compatible signatures) ──────────────────────
 
 export function mapContactFromSupabase(row: SupabaseContactRow): MappedContact {
-  return contactMapper.mapFromSupabase(row);
+  const mapped = contactMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapContactToSupabase(

--- a/src/lib/supabase/mappers/documents.ts
+++ b/src/lib/supabase/mappers/documents.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedDocument {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   name: string;
   description?: string;
@@ -32,5 +33,8 @@ const documentMapper = createEntityMapper<DocumentRow, MappedDocument>({
   exclude: ["search_vector"],
 });
 
-export const mapDocumentFromSupabase = documentMapper.mapFromSupabase;
+export const mapDocumentFromSupabase = (row: DocumentRow): MappedDocument => {
+  const mapped = documentMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapDocumentToSupabase = documentMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/email-accounts.ts
+++ b/src/lib/supabase/mappers/email-accounts.ts
@@ -15,6 +15,7 @@ type EmailAccountRow = Database["public"]["Tables"]["email_accounts"]["Row"];
 /** Shape that mirrors `Doc<'emailAccounts'>` from Convex (camelCase). */
 export interface MappedEmailAccount {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   fromName: string;
   fromEmail: string;
@@ -31,7 +32,8 @@ const emailAccountMapper = createEntityMapper<EmailAccountRow, MappedEmailAccoun
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapEmailAccountFromSupabase(row: EmailAccountRow): MappedEmailAccount {
-  return emailAccountMapper.mapFromSupabase(row);
+  const mapped = emailAccountMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapEmailAccountToSupabase(

--- a/src/lib/supabase/mappers/email-brand-config.ts
+++ b/src/lib/supabase/mappers/email-brand-config.ts
@@ -18,6 +18,7 @@ type EmailBrandConfigRow = Database["public"]["Tables"]["email_brand_config"]["R
 /** Shape that mirrors `Doc<'emailBrandConfig'>` from Convex (camelCase). */
 export interface MappedEmailBrandConfig {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   logoStorageId?: string;
   logoUrl?: string;
@@ -44,7 +45,8 @@ const emailBrandConfigMapper = createEntityMapper<EmailBrandConfigRow, MappedEma
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapEmailBrandConfigFromSupabase(row: EmailBrandConfigRow): MappedEmailBrandConfig {
-  return emailBrandConfigMapper.mapFromSupabase(row);
+  const mapped = emailBrandConfigMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapEmailBrandConfigToSupabase(

--- a/src/lib/supabase/mappers/email-event-bindings.ts
+++ b/src/lib/supabase/mappers/email-event-bindings.ts
@@ -15,6 +15,7 @@ type EmailEventBindingRow = Database["public"]["Tables"]["email_event_bindings"]
 /** Shape that mirrors `Doc<'emailEventBindings'>` from Convex (camelCase). */
 export interface MappedEmailEventBinding {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   eventType: string;
   templateId: string;
@@ -34,7 +35,8 @@ const emailEventBindingMapper = createEntityMapper<EmailEventBindingRow, MappedE
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapEmailEventBindingFromSupabase(row: EmailEventBindingRow): MappedEmailEventBinding {
-  return emailEventBindingMapper.mapFromSupabase(row);
+  const mapped = emailEventBindingMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapEmailEventBindingToSupabase(

--- a/src/lib/supabase/mappers/email-event-log.ts
+++ b/src/lib/supabase/mappers/email-event-log.ts
@@ -15,6 +15,7 @@ type EmailEventLogRow = Database["public"]["Tables"]["email_event_log"]["Row"];
 /** Shape that mirrors `Doc<'emailEventLog'>` from Convex (camelCase). */
 export interface MappedEmailEventLog {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   eventType: string;
   bindingId?: string;
@@ -43,7 +44,8 @@ const emailEventLogMapper = createEntityMapper<EmailEventLogRow, MappedEmailEven
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapEmailEventLogFromSupabase(row: EmailEventLogRow): MappedEmailEventLog {
-  return emailEventLogMapper.mapFromSupabase(row);
+  const mapped = emailEventLogMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapEmailEventLogToSupabase(

--- a/src/lib/supabase/mappers/email-event-types.ts
+++ b/src/lib/supabase/mappers/email-event-types.ts
@@ -15,6 +15,7 @@ type EmailEventTypeRow = Database["public"]["Tables"]["email_event_types"]["Row"
 /** Shape that mirrors `Doc<'emailEventTypes'>` from Convex (camelCase). */
 export interface MappedEmailEventType {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   eventType: string;
   module: string;
@@ -34,7 +35,8 @@ const emailEventTypeMapper = createEntityMapper<EmailEventTypeRow, MappedEmailEv
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapEmailEventTypeFromSupabase(row: EmailEventTypeRow): MappedEmailEventType {
-  return emailEventTypeMapper.mapFromSupabase(row);
+  const mapped = emailEventTypeMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapEmailEventTypeToSupabase(

--- a/src/lib/supabase/mappers/email-layouts.ts
+++ b/src/lib/supabase/mappers/email-layouts.ts
@@ -15,6 +15,7 @@ type EmailLayoutRow = Database["public"]["Tables"]["email_layouts"]["Row"];
 /** Shape that mirrors `Doc<'emailLayouts'>` from Convex (camelCase). */
 export interface MappedEmailLayout {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   headerBlocks: string;
   footerBlocks: string;
@@ -36,7 +37,8 @@ const emailLayoutMapper = createEntityMapper<EmailLayoutRow, MappedEmailLayout>(
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapEmailLayoutFromSupabase(row: EmailLayoutRow): MappedEmailLayout {
-  return emailLayoutMapper.mapFromSupabase(row);
+  const mapped = emailLayoutMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.updatedAt };
 }
 
 export function mapEmailLayoutToSupabase(

--- a/src/lib/supabase/mappers/email-sequence-enrollments.ts
+++ b/src/lib/supabase/mappers/email-sequence-enrollments.ts
@@ -15,6 +15,7 @@ type EmailSequenceEnrollmentRow = Database["public"]["Tables"]["email_sequence_e
 /** Shape that mirrors `Doc<'emailSequenceEnrollments'>` from Convex (camelCase). */
 export interface MappedEmailSequenceEnrollment {
   _id: string;
+  _creationTime: number;
   sequenceId: string;
   organizationId: string;
   recipientEmail: string;
@@ -35,7 +36,8 @@ const emailSequenceEnrollmentMapper = createEntityMapper<EmailSequenceEnrollment
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapEmailSequenceEnrollmentFromSupabase(row: EmailSequenceEnrollmentRow): MappedEmailSequenceEnrollment {
-  return emailSequenceEnrollmentMapper.mapFromSupabase(row);
+  const mapped = emailSequenceEnrollmentMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.enrolledAt };
 }
 
 export function mapEmailSequenceEnrollmentToSupabase(

--- a/src/lib/supabase/mappers/email-sequence-steps.ts
+++ b/src/lib/supabase/mappers/email-sequence-steps.ts
@@ -15,6 +15,7 @@ type EmailSequenceStepRow = Database["public"]["Tables"]["email_sequence_steps"]
 /** Shape that mirrors `Doc<'emailSequenceSteps'>` from Convex (camelCase). */
 export interface MappedEmailSequenceStep {
   _id: string;
+  _creationTime: number;
   sequenceId: string;
   organizationId: string;
   order: number;
@@ -32,7 +33,8 @@ const emailSequenceStepMapper = createEntityMapper<EmailSequenceStepRow, MappedE
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapEmailSequenceStepFromSupabase(row: EmailSequenceStepRow): MappedEmailSequenceStep {
-  return emailSequenceStepMapper.mapFromSupabase(row);
+  const mapped = emailSequenceStepMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapEmailSequenceStepToSupabase(

--- a/src/lib/supabase/mappers/email-sequences.ts
+++ b/src/lib/supabase/mappers/email-sequences.ts
@@ -15,6 +15,7 @@ type EmailSequenceRow = Database["public"]["Tables"]["email_sequences"]["Row"];
 /** Shape that mirrors `Doc<'emailSequences'>` from Convex (camelCase). */
 export interface MappedEmailSequence {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   name: string;
   triggerEventType: string;
@@ -31,7 +32,8 @@ const emailSequenceMapper = createEntityMapper<EmailSequenceRow, MappedEmailSequ
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapEmailSequenceFromSupabase(row: EmailSequenceRow): MappedEmailSequence {
-  return emailSequenceMapper.mapFromSupabase(row);
+  const mapped = emailSequenceMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapEmailSequenceToSupabase(

--- a/src/lib/supabase/mappers/email-templates.ts
+++ b/src/lib/supabase/mappers/email-templates.ts
@@ -18,6 +18,7 @@ type EmailTemplateRow = Database["public"]["Tables"]["email_templates"]["Row"];
 /** Shape that mirrors `Doc<'emailTemplates'>` from Convex (camelCase). */
 export interface MappedEmailTemplate {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   name: string;
   subject: string;
@@ -46,7 +47,8 @@ const emailTemplateMapper = createEntityMapper<EmailTemplateRow, MappedEmailTemp
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapEmailTemplateFromSupabase(row: EmailTemplateRow): MappedEmailTemplate {
-  return emailTemplateMapper.mapFromSupabase(row);
+  const mapped = emailTemplateMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapEmailTemplateToSupabase(

--- a/src/lib/supabase/mappers/emails.ts
+++ b/src/lib/supabase/mappers/emails.ts
@@ -15,6 +15,7 @@ type EmailRow = Database["public"]["Tables"]["emails"]["Row"];
 /** Shape that mirrors `Doc<'emails'>` from Convex (camelCase). */
 export interface MappedEmail {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   threadId: string;
   messageId: string;
@@ -55,7 +56,8 @@ const emailMapper = createEntityMapper<EmailRow, MappedEmail>({});
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapEmailFromSupabase(row: EmailRow): MappedEmail {
-  return emailMapper.mapFromSupabase(row);
+  const mapped = emailMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapEmailToSupabase(

--- a/src/lib/supabase/mappers/form-documents.ts
+++ b/src/lib/supabase/mappers/form-documents.ts
@@ -9,6 +9,7 @@ export type FormDocumentRow = Database["public"]["Tables"]["form_documents"]["Ro
 
 export interface MappedFormDocument {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   templateId: string;
   title: string;
@@ -41,5 +42,10 @@ const formDocumentMapper = createEntityMapper<FormDocumentRow, MappedFormDocumen
   exclude: [],
 });
 
-export const mapFormDocumentFromSupabase = formDocumentMapper.mapFromSupabase;
+export const mapFormDocumentFromSupabase = (
+  row: FormDocumentRow,
+): MappedFormDocument => {
+  const mapped = formDocumentMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapFormDocumentToSupabase = formDocumentMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/invitations.ts
+++ b/src/lib/supabase/mappers/invitations.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedInvitation {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   email: string;
   role: string;
@@ -22,5 +23,10 @@ export interface MappedInvitation {
 
 const invitationMapper = createEntityMapper<InvitationRow, MappedInvitation>({});
 
-export const mapInvitationFromSupabase = invitationMapper.mapFromSupabase;
+export const mapInvitationFromSupabase = (
+  row: InvitationRow,
+): MappedInvitation => {
+  const mapped = invitationMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapInvitationToSupabase = invitationMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/leads.ts
+++ b/src/lib/supabase/mappers/leads.ts
@@ -15,6 +15,7 @@ type LeadRow = Database["public"]["Tables"]["leads"]["Row"];
 /** Shape that mirrors `Doc<'leads'>` from Convex (camelCase). */
 export interface MappedLead {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   title: string;
   value?: number;
@@ -49,7 +50,8 @@ const leadMapper = createEntityMapper<LeadRow, MappedLead>({
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapLeadFromSupabase(row: LeadRow): MappedLead {
-  return leadMapper.mapFromSupabase(row);
+  const mapped = leadMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapLeadToSupabase(

--- a/src/lib/supabase/mappers/lost-reasons.ts
+++ b/src/lib/supabase/mappers/lost-reasons.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedLostReason {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   label: string;
   order: number;
@@ -19,5 +20,10 @@ export interface MappedLostReason {
 
 const lostReasonMapper = createEntityMapper<LostReasonRow, MappedLostReason>();
 
-export const mapLostReasonFromSupabase = lostReasonMapper.mapFromSupabase;
+export const mapLostReasonFromSupabase = (
+  row: LostReasonRow,
+): MappedLostReason => {
+  const mapped = lostReasonMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapLostReasonToSupabase = lostReasonMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/mail-providers.ts
+++ b/src/lib/supabase/mappers/mail-providers.ts
@@ -18,6 +18,7 @@ type MailProviderRow = Database["public"]["Tables"]["mail_providers"]["Row"];
 /** Shape that mirrors `Doc<'mailProviders'>` from Convex (camelCase). */
 export interface MappedMailProvider {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   name: string;
   providerType: string;
@@ -47,7 +48,8 @@ const mailProviderMapper = createEntityMapper<MailProviderRow, MappedMailProvide
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapMailProviderFromSupabase(row: MailProviderRow): MappedMailProvider {
-  return mailProviderMapper.mapFromSupabase(row);
+  const mapped = mailProviderMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapMailProviderToSupabase(

--- a/src/lib/supabase/mappers/notes.ts
+++ b/src/lib/supabase/mappers/notes.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedNote {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   entityType: string;
   entityId: string;
@@ -21,5 +22,8 @@ export interface MappedNote {
 
 const noteMapper = createEntityMapper<NoteRow, MappedNote>();
 
-export const mapNoteFromSupabase = noteMapper.mapFromSupabase;
+export const mapNoteFromSupabase = (row: NoteRow): MappedNote => {
+  const mapped = noteMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapNoteToSupabase = noteMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/notifications.ts
+++ b/src/lib/supabase/mappers/notifications.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedNotification {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   userId: string;
   type: string;
@@ -20,5 +21,10 @@ export interface MappedNotification {
 
 const notificationMapper = createEntityMapper<NotificationRow, MappedNotification>({});
 
-export const mapNotificationFromSupabase = notificationMapper.mapFromSupabase;
+export const mapNotificationFromSupabase = (
+  row: NotificationRow,
+): MappedNotification => {
+  const mapped = notificationMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapNotificationToSupabase = notificationMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/org-settings.ts
+++ b/src/lib/supabase/mappers/org-settings.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedOrgSettings {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   allowCustomLostReason: boolean;
   lostReasonRequired: boolean;
@@ -23,5 +24,10 @@ export interface MappedOrgSettings {
 
 const orgSettingsMapper = createEntityMapper<OrgSettingsRow, MappedOrgSettings>({});
 
-export const mapOrgSettingsFromSupabase = orgSettingsMapper.mapFromSupabase;
+export const mapOrgSettingsFromSupabase = (
+  row: OrgSettingsRow,
+): MappedOrgSettings => {
+  const mapped = orgSettingsMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapOrgSettingsToSupabase = orgSettingsMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/organizations.ts
+++ b/src/lib/supabase/mappers/organizations.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedOrganization {
   _id: string;
+  _creationTime: number;
   name: string;
   slug: string;
   ownerId: string;
@@ -20,5 +21,10 @@ export interface MappedOrganization {
 
 const organizationMapper = createEntityMapper<OrganizationRow, MappedOrganization>({});
 
-export const mapOrganizationFromSupabase = organizationMapper.mapFromSupabase;
+export const mapOrganizationFromSupabase = (
+  row: OrganizationRow,
+): MappedOrganization => {
+  const mapped = organizationMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapOrganizationToSupabase = organizationMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/pipeline-stage-actions.ts
+++ b/src/lib/supabase/mappers/pipeline-stage-actions.ts
@@ -16,6 +16,7 @@ type PipelineStageActionRow = Database["public"]["Tables"]["pipeline_stage_actio
 /** Shape that mirrors `Doc<'pipelineStageActions'>` from Convex (camelCase). */
 export interface MappedPipelineStageAction {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   stageId: string;
   actionType: string;
@@ -37,7 +38,8 @@ const pipelineStageActionMapper = createEntityMapper<
 export function mapPipelineStageActionFromSupabase(
   row: PipelineStageActionRow,
 ): MappedPipelineStageAction {
-  return pipelineStageActionMapper.mapFromSupabase(row);
+  const mapped = pipelineStageActionMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapPipelineStageActionToSupabase(

--- a/src/lib/supabase/mappers/pipelines.ts
+++ b/src/lib/supabase/mappers/pipelines.ts
@@ -16,6 +16,7 @@ type PipelineStageRow = Database["public"]["Tables"]["pipeline_stages"]["Row"];
 /** Shape that mirrors `Doc<'pipelines'>` from Convex (camelCase). */
 export interface MappedPipeline {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   name: string;
   description?: string;
@@ -30,6 +31,7 @@ export interface MappedPipeline {
 /** Shape that mirrors `Doc<'pipelineStages'>` from Convex (camelCase). */
 export interface MappedPipelineStage {
   _id: string;
+  _creationTime: number;
   pipelineId: string;
   organizationId: string;
   name: string;
@@ -51,7 +53,8 @@ const pipelineStageMapper = createEntityMapper<PipelineStageRow, MappedPipelineS
 // ─── Exported Functions ───────────────────────────────────────────────────────
 
 export function mapPipelineFromSupabase(row: PipelineRow): MappedPipeline {
-  return pipelineMapper.mapFromSupabase(row);
+  const mapped = pipelineMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapPipelineToSupabase(
@@ -61,7 +64,8 @@ export function mapPipelineToSupabase(
 }
 
 export function mapPipelineStageFromSupabase(row: PipelineStageRow): MappedPipelineStage {
-  return pipelineStageMapper.mapFromSupabase(row);
+  const mapped = pipelineStageMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
 }
 
 export function mapPipelineStageToSupabase(

--- a/src/lib/supabase/mappers/products.ts
+++ b/src/lib/supabase/mappers/products.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedProduct {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   name: string;
   sku: string;
@@ -26,5 +27,8 @@ const productMapper = createEntityMapper<ProductRow, MappedProduct>({
   exclude: ["search_vector"],
 });
 
-export const mapProductFromSupabase = productMapper.mapFromSupabase;
+export const mapProductFromSupabase = (row: ProductRow): MappedProduct => {
+  const mapped = productMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapProductToSupabase = productMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/recently-viewed.ts
+++ b/src/lib/supabase/mappers/recently-viewed.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedRecentlyViewed {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   userId: string;
   entityType: string;
@@ -18,5 +19,10 @@ export interface MappedRecentlyViewed {
 
 const recentlyViewedMapper = createEntityMapper<RecentlyViewedRow, MappedRecentlyViewed>({});
 
-export const mapRecentlyViewedFromSupabase = recentlyViewedMapper.mapFromSupabase;
+export const mapRecentlyViewedFromSupabase = (
+  row: RecentlyViewedRow,
+): MappedRecentlyViewed => {
+  const mapped = recentlyViewedMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.viewedAt };
+};
 export const mapRecentlyViewedToSupabase = recentlyViewedMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/saved-views.ts
+++ b/src/lib/supabase/mappers/saved-views.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedSavedView {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   entityType: string;
   name: string;
@@ -25,5 +26,10 @@ export interface MappedSavedView {
 
 const savedViewMapper = createEntityMapper<SavedViewRow, MappedSavedView>();
 
-export const mapSavedViewFromSupabase = savedViewMapper.mapFromSupabase;
+export const mapSavedViewFromSupabase = (
+  row: SavedViewRow,
+): MappedSavedView => {
+  const mapped = savedViewMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapSavedViewToSupabase = savedViewMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/scheduled-activities.ts
+++ b/src/lib/supabase/mappers/scheduled-activities.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedScheduledActivity {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   title: string;
   activityType: string;
@@ -39,5 +40,10 @@ export interface MappedScheduledActivity {
 
 const scheduledActivityMapper = createEntityMapper<ScheduledActivityRow, MappedScheduledActivity>({});
 
-export const mapScheduledActivityFromSupabase = scheduledActivityMapper.mapFromSupabase;
+export const mapScheduledActivityFromSupabase = (
+  row: ScheduledActivityRow,
+): MappedScheduledActivity => {
+  const mapped = scheduledActivityMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapScheduledActivityToSupabase = scheduledActivityMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/sources.ts
+++ b/src/lib/supabase/mappers/sources.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedSource {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   name: string;
   order: number;
@@ -19,5 +20,8 @@ export interface MappedSource {
 
 const sourceMapper = createEntityMapper<SourceRow, MappedSource>();
 
-export const mapSourceFromSupabase = sourceMapper.mapFromSupabase;
+export const mapSourceFromSupabase = (row: SourceRow): MappedSource => {
+  const mapped = sourceMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
 export const mapSourceToSupabase = sourceMapper.mapToSupabase;

--- a/src/lib/supabase/mappers/team-memberships.ts
+++ b/src/lib/supabase/mappers/team-memberships.ts
@@ -7,6 +7,7 @@ import { createEntityMapper } from "./generic";
 
 export interface MappedTeamMembership {
   _id: string;
+  _creationTime: number;
   userId: string;
   organizationId: string;
   role: string;
@@ -17,5 +18,10 @@ export interface MappedTeamMembership {
 
 const teamMembershipMapper = createEntityMapper<TeamMembershipRow, MappedTeamMembership>({});
 
-export const mapTeamMembershipFromSupabase = teamMembershipMapper.mapFromSupabase;
+export const mapTeamMembershipFromSupabase = (
+  row: TeamMembershipRow,
+): MappedTeamMembership => {
+  const mapped = teamMembershipMapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.joinedAt };
+};
 export const mapTeamMembershipToSupabase = teamMembershipMapper.mapToSupabase;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #255.

Closes #255

---

## Claude summary

Committed. The fix mirrors the gabinet pattern (#228/#254) across all 38 non-gabinet `Mapped*` types: each interface now declares `_creationTime: number` and the `mapFromSupabase` function populates it from `createdAt` (or the closest creation-timestamp field for the four tables without `createdAt`: `team_memberships.joinedAt`, `recently_viewed.viewedAt`, `email_sequence_enrollments.enrolledAt`, `email_layouts.updatedAt`).

Typecheck error count is unchanged from baseline (15 pre-existing errors, none mapper-related).

## Follow-ups
- Drop `as unknown as Doc<T>[]` / domain-type casts in non-gabinet route files: now that mappers expose `_creationTime`, casts in `_layout.contacts.index.tsx`, `_layout.companies.index.tsx`, `_layout.leads.index.tsx`, `_layout.products.index.tsx`, `_layout.calls.index.tsx`, `_layout.documents.index.tsx`, `_layout.activities.index.tsx`, `_layout.calendar.tsx`, `_layout.settings.email-sequences.tsx`, `_layout.settings.automations.*.tsx`, and `_layout.settings.form-templates.index.tsx` may be removable — analogous to #229/#232/#233/#235 for gabinet.