### PR TITLE
Fix appointmentReminders.ts employee lookup

### DIFF
--- a/convex/gabinet/appointmentReminders.ts
+++ b/convex/gabinet/appointmentReminders.ts
@@ -179,8 +179,24 @@ export const sendReminder = internalMutation({
 
     // Send appointment.reminder email if patient has email
     if (patient?.email) {
-      const employee = await db.get("gabinetEmployees", String(appointment.employeeId));
-      const employeeName = (employee?.name as string) ?? "Specjalista";
+      // appointment.employeeId references users(id), not gabinetEmployees(id),
+      // so query the gabinet profile by userId and fall back to the linked user.
+      const employeeUserId = String(appointment.employeeId);
+      const [employee, employeeUser] = await Promise.all([
+        db.query("gabinetEmployees")
+          .eq("organizationId", String(reminder.organizationId))
+          .eq("userId", employeeUserId)
+          .first(),
+        db.get("users", employeeUserId).catch(() => null),
+      ]);
+      const employeeFullName = employee
+        ? [employee.firstName, employee.lastName].filter(Boolean).join(" ").trim()
+        : "";
+      const employeeName =
+        (employeeUser?.name as string | undefined) ??
+        (employeeFullName.length > 0 ? employeeFullName : undefined) ??
+        (employeeUser?.email as string | undefined) ??
+        "Specjalista";
       await ctx.runMutation(internal.emailEventTrigger.triggerEmailEvent, {
         organizationId: reminder.organizationId as Id<"organizations">,
         eventType: "appointment.reminder",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #262.

Closes #262

---

## Claude summary

Fix committed. Summary:

The bug at `convex/gabinet/appointmentReminders.ts:182` was identical to the one fixed in #235: `gabinetAppointments.employeeId` is `v.id("users")` (schema line 347), not a `gabinetEmployees` primary key, so the `db.get("gabinetEmployees", ...)` call always returned null and reminder emails always read "Specjalista" as the employee name.

The fix mirrors #235's `getFullDetail` pattern: query `gabinetEmployees` by `(organizationId, userId)` and fetch the linked `users` row in parallel, then build `employeeName` from `users.name` → `firstName + lastName` → `users.email` → fallback "Specjalista". Typecheck on the touched file is clean (other repo-wide TS errors are pre-existing).