### PR TITLE
Audit other `db.get("users", ...)` callers now that the table is mapped

### DIFF
--- a/convex/gabinet/sidebarWidgets.ts
+++ b/convex/gabinet/sidebarWidgets.ts
@@ -376,7 +376,14 @@ export const getDayAgenda = action({
         const [patient, treatment, employee] = await Promise.all([
           appt.patientId ? db.get("gabinetPatients", String(appt.patientId)).catch(() => null) : null,
           appt.treatmentId ? db.get("gabinetTreatments", String(appt.treatmentId)).catch(() => null) : null,
-          appt.employeeId ? db.get("users", String(appt.employeeId)).catch(() => null) : null,
+          appt.employeeId
+            ? db
+                .get<{ name?: string | null; email?: string | null }>(
+                  "users",
+                  String(appt.employeeId),
+                )
+                .catch(() => null)
+            : null,
         ]);
 
         const row: DayAgendaAppointment = {
@@ -389,7 +396,10 @@ export const getDayAgenda = action({
             : "—",
           treatmentName: ((treatment as any)?.name as string | undefined) ?? "—",
           treatmentDuration: Number((treatment as any)?.duration ?? 0),
-          employeeName: employee ? (employee as any).name || "Employee" : "—",
+          employeeName:
+            (employee?.name as string | null | undefined) ||
+            (employee?.email as string | null | undefined) ||
+            "—",
           confirmed: appt.status === "confirmed" || appt.status === "completed",
         };
         return row;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #263.

Closes #263

---

## Claude summary

Audit complete. Walked all six `db.get("users", ...)` sites listed in the issue (the issue cited line 2465 in `appointments.ts` but the actual user lookups there are at lines 2329 and 2486). Five of the six already use the standard `users.name ?? users.email ?? "—"` fallback pattern established in #235/#262. The sixth — `getDayAgenda` in `convex/gabinet/sidebarWidgets.ts:379` — was the only one that fell back to a hardcoded string ("Employee") when `users.name` was empty, instead of `users.email`. Aligned it with the rest, tightened the return type to drop an `as any` cast, and committed. `tsc -p convex/tsconfig.json --noEmit` passes cleanly.