### PR TITLE
Type moduleRef properly on MappedScheduledActivity

### DIFF
--- a/src/hooks/use-supabase-scheduled-activities.ts
+++ b/src/hooks/use-supabase-scheduled-activities.ts
@@ -218,7 +218,7 @@ export function useSupabaseScheduledActivitiesByDateRange(
       if (error) throw error;
       let activities = (data ?? []).map(mapScheduledActivityFromSupabase);
       if (moduleFilter) {
-        activities = activities.filter((a) => (a.moduleRef as { moduleId?: string } | undefined)?.moduleId === moduleFilter);
+        activities = activities.filter((a) => a.moduleRef?.moduleId === moduleFilter);
       }
 
       // Enrich gabinet-linked activities with appointment metadata so the
@@ -228,8 +228,8 @@ export function useSupabaseScheduledActivitiesByDateRange(
       const gabinetEntityIds = Array.from(
         new Set(
           activities
-            .filter((a) => (a.moduleRef as { moduleId?: string } | undefined)?.moduleId === "gabinet")
-            .map((a) => (a.moduleRef as { entityId?: string } | undefined)?.entityId)
+            .filter((a) => a.moduleRef?.moduleId === "gabinet")
+            .map((a) => a.moduleRef?.entityId)
             .filter((id): id is string => !!id),
         ),
       );
@@ -303,7 +303,7 @@ export function useSupabaseScheduledActivitiesByDateRange(
       }
 
       return activities.map<CalendarScheduledActivity>((a) => {
-        const moduleRef = a.moduleRef as { moduleId?: string; entityId?: string } | undefined;
+        const moduleRef = a.moduleRef;
         const metadata: Record<string, unknown> = {};
         if (moduleRef?.moduleId === "gabinet" && moduleRef.entityId) {
           const appt = apptMap.get(moduleRef.entityId);
@@ -398,9 +398,7 @@ export function useSupabaseUpcomingEvents(
 
       return activities.slice(0, limit).map<UpcomingEvent>((a) => {
         const owner = ownerMap.get(String(a.ownerId));
-        const moduleRef = a.moduleRef as
-          | { moduleId?: string; entityType?: string; entityId?: string }
-          | undefined;
+        const moduleRef = a.moduleRef;
         const isAppointment =
           moduleRef?.moduleId === "gabinet" &&
           moduleRef?.entityType === "gabinetAppointment";

--- a/src/lib/supabase/mappers/scheduled-activities.ts
+++ b/src/lib/supabase/mappers/scheduled-activities.ts
@@ -28,7 +28,7 @@ export interface MappedScheduledActivity {
   sourceType?: string;
   syncConfigId?: string;
   visibilityOverride?: string;
-  moduleRef?: unknown;
+  moduleRef?: { moduleId?: string; entityType?: string; entityId?: string };
   resourceId?: string;
   tagIds?: string[];
   categoryId?: string;

--- a/src/routes/_app/_auth/dashboard/_layout.calendar-preview.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calendar-preview.tsx
@@ -53,17 +53,14 @@ function CalendarPreview() {
 
   const events: CalendarEvent[] = useMemo(() => {
     if (!rawEvents) return [];
-    return rawEvents.map((a) => {
-      const moduleRef = a.moduleRef as { moduleId?: string } | undefined;
-      return {
-        id: a._id,
-        title: a.title,
-        start: new Date(a.dueDate),
-        end: new Date(a.endDate ?? a.dueDate + 60 * 60 * 1000),
-        color: getEventColor(a.activityType, a.isCompleted, moduleRef?.moduleId),
-        dot: a.isCompleted,
-      };
-    });
+    return rawEvents.map((a) => ({
+      id: a._id,
+      title: a.title,
+      start: new Date(a.dueDate),
+      end: new Date(a.endDate ?? a.dueDate + 60 * 60 * 1000),
+      color: getEventColor(a.activityType, a.isCompleted, a.moduleRef?.moduleId),
+      dot: a.isCompleted,
+    }));
   }, [rawEvents]);
 
   // Hide mini calendar when leaving this page


### PR DESCRIPTION
Auto-generated by Claude in response to issue #273.

Closes #273

---

## Claude summary

Committed. Summary of what changed:

- `src/lib/supabase/mappers/scheduled-activities.ts`: Changed `moduleRef?: unknown` to `moduleRef?: { moduleId?: string; entityType?: string; entityId?: string }` on `MappedScheduledActivity`.
- `src/hooks/use-supabase-scheduled-activities.ts`: Removed 5 redundant `as` casts in `useSupabaseScheduledActivitiesByDateRange` and `useSupabaseUpcomingEvents`.
- `src/routes/_app/_auth/dashboard/_layout.calendar-preview.tsx`: Removed 1 redundant cast and inlined the `moduleRef` access in the `useMemo`.

Verified `tsc -p tsconfig.app.json` shows no `moduleRef`-related errors (the 15 pre-existing errors are unrelated — Convex registration types and shared illustration types).