### PR TITLE
Drop `as unknown as Doc<T>[]` / domain-type casts in non-gabinet route files

### DIFF
--- a/src/components/forms/lead-form.tsx
+++ b/src/components/forms/lead-form.tsx
@@ -28,13 +28,13 @@ interface FieldDefinition {
 }
 
 interface PipelineStage {
-  _id: Id<"pipelineStages">;
+  _id: string;
   name: string;
-  pipelineId: Id<"pipelines">;
+  pipelineId: string;
 }
 
 interface Pipeline {
-  _id: Id<"pipelines">;
+  _id: string;
   name: string;
 }
 

--- a/src/components/settings/automation-builder/automation-simple-presets.ts
+++ b/src/components/settings/automation-builder/automation-simple-presets.ts
@@ -116,7 +116,7 @@ export type AutomationRuleRecord = {
 };
 
 export type AutomationEmailTemplateRecord = {
-  _id: Id<"emailTemplates">;
+  _id: string;
   name: string;
   subject: string;
   module?: string;

--- a/src/lib/supabase/mappers/companies.ts
+++ b/src/lib/supabase/mappers/companies.ts
@@ -15,7 +15,13 @@ export interface MappedCompany {
   size?: string;
   website?: string;
   phone?: string;
-  address?: unknown;
+  address?: {
+    street?: string;
+    city?: string;
+    state?: string;
+    zip?: string;
+    country?: string;
+  };
   notes?: string;
   tags?: string[];
   tagIds?: string[];

--- a/src/routes/_app/_auth/dashboard/_layout.activities.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.activities.index.tsx
@@ -43,7 +43,8 @@ import {
 import { getActivityIcon } from "@/lib/activity-icon-registry";
 import type { SavedView, FieldDef, FilterCondition } from "@/components/crm/types";
 import { applyFilterConditions } from "@/hooks/use-saved-views";
-import { Doc, Id } from "@cvx/_generated/dataModel";
+import { Id } from "@cvx/_generated/dataModel";
+import type { MappedScheduledActivity } from "@/lib/supabase/mappers/scheduled-activities";
 import { useSavedViews } from "@/hooks/use-saved-views";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
@@ -58,7 +59,7 @@ export const Route = createFileRoute(
   component: ActivitiesPage,
 });
 
-type ScheduledActivity = Doc<"scheduledActivities">;
+type ScheduledActivity = MappedScheduledActivity;
 type ActivityRow = ScheduledActivity & { __cfValues: Record<string, unknown> };
 
 function ActivitiesPage() {
@@ -161,19 +162,19 @@ function ActivitiesPage() {
     let data: ScheduledActivity[];
     switch (activeViewId) {
       case "open":
-        data = (openActivities ?? []) as unknown as ScheduledActivity[];
+        data = openActivities ?? [];
         break;
       case "due-today":
-        data = (dueTodayData ?? []) as unknown as ScheduledActivity[];
+        data = dueTodayData ?? [];
         break;
       case "due-this-week":
-        data = (dueThisWeekData ?? []) as unknown as ScheduledActivity[];
+        data = dueThisWeekData ?? [];
         break;
       case "overdue":
-        data = (overdueData ?? []) as unknown as ScheduledActivity[];
+        data = overdueData ?? [];
         break;
       default:
-        data = (allActivities ?? []) as unknown as ScheduledActivity[];
+        data = allActivities ?? [];
     }
     let filtered = applyFilters(data);
     filtered = applyFilterConditions(filtered, activeFilters);
@@ -185,7 +186,7 @@ function ActivitiesPage() {
   }, [activeViewId, allActivities, openActivities, dueTodayData, dueThisWeekData, overdueData, applyFilters, activeFilters, searchValue]);
 
   const activityIds = useMemo(
-    () => activities.map((a) => a._id as string),
+    () => activities.map((a) => a._id),
     [activities]
   );
 

--- a/src/routes/_app/_auth/dashboard/_layout.calendar.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calendar.tsx
@@ -6,7 +6,10 @@ import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { usePermission } from "@/hooks/use-permission";
-import { useSupabaseScheduledActivitiesByDateRange } from "@/hooks/use-supabase-scheduled-activities";
+import {
+  useSupabaseScheduledActivitiesByDateRange,
+  type CalendarScheduledActivity,
+} from "@/hooks/use-supabase-scheduled-activities";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -40,23 +43,7 @@ export const Route = createFileRoute(
 type ViewMode = "day" | "week" | "month";
 type ModuleFilter = "all" | "gabinet" | "crm";
 
-interface CalendarEvent {
-  _id: string;
-  title: string;
-  activityType: string;
-  dueDate: number;
-  endDate?: number;
-  isCompleted: boolean;
-  location?: string;
-  meetingUrl?: string;
-  description?: string;
-  googleEventId?: string;
-  googleCalendarId?: string;
-  moduleRef?: { moduleId: string; entityType: string; entityId: string };
-  metadata: Record<string, unknown>;
-  requiresCompletion?: boolean;
-  _isBusyOnly?: boolean;
-}
+type CalendarEvent = CalendarScheduledActivity & { _isBusyOnly?: boolean };
 
 // --- Helpers ---
 
@@ -276,7 +263,7 @@ function UnifiedCalendarPage() {
     endTs,
     { moduleFilter: moduleFilter === "all" ? undefined : moduleFilter },
   );
-  const events = rawEvents as unknown as CalendarEvent[] | undefined;
+  const events: CalendarEvent[] | undefined = rawEvents;
 
   const updateActivity = useAction(api.scheduledActivities.update);
   const updateAppointment = useAction(

--- a/src/routes/_app/_auth/dashboard/_layout.calls.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calls.index.tsx
@@ -28,7 +28,8 @@ import { callOutcomeOptions } from "@/lib/options";
 import { Plus, Pencil, Trash2 } from "@/lib/ez-icons";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import type { SavedView, FieldDef, FilterCondition } from "@/components/crm/types";
-import { Doc, Id } from "@cvx/_generated/dataModel";
+import { Id } from "@cvx/_generated/dataModel";
+import type { MappedCall } from "@/lib/supabase/mappers/calls";
 import { useSavedViews, applyFilterConditions } from "@/hooks/use-saved-views";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
@@ -44,7 +45,7 @@ export const Route = createFileRoute(
   component: CallsPage,
 });
 
-type Call = Doc<"calls">;
+type Call = MappedCall;
 type CallOutcome = "busy" | "leftVoiceMessage" | "movedConversationForward" | "wrongNumber" | "noAnswer";
 
 const OUTCOME_CONFIG: Record<CallOutcome, { color: string; labelKey: string }> = {
@@ -117,7 +118,7 @@ function CallsPage() {
     return map;
   }, [members]);
 
-  const callIds = useMemo(() => allCalls.map((c) => c._id as string), [allCalls]);
+  const callIds = useMemo(() => allCalls.map((c) => c._id), [allCalls]);
 
   const getRelationshipsForSources = useAction(api.relationships.getForSources);
   const { data: relMap } = useQuery({
@@ -273,9 +274,9 @@ function CallsPage() {
       id: "createdBy",
       label: t('calls.performedBy', "Wykonał"),
       sortable: true,
-      render: (item) => renderUserAvatar(item.createdBy),
+      render: (item) => renderUserAvatar(item.createdBy as Id<"users">),
       getSortValue: (item) => {
-        const u = userMap.get(item.createdBy);
+        const u = userMap.get(item.createdBy as Id<"users">);
         return u?.name ?? u?.email ?? "";
       },
     },
@@ -360,7 +361,7 @@ function CallsPage() {
       <CrmDataTable
         columns={allColumns}
         hiddenColumnIds={hiddenColumnIds}
-        data={calls as unknown as Call[]}
+        data={calls}
         rowActions={rowActions}
         isLoading={isLoading}
       />

--- a/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
@@ -15,7 +15,8 @@ import { companySizeOptions } from "@/lib/options";
 import { Plus, Trash2, Upload, Download } from "@/lib/ez-icons";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { CsvImportDialog } from "@/components/csv/csv-import-dialog";
-import { Doc, Id } from "@cvx/_generated/dataModel";
+import { Id } from "@cvx/_generated/dataModel";
+import type { MappedCompany } from "@/lib/supabase/mappers/companies";
 import { useState, useMemo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import type { SavedView, TimeRange, FieldDef, FilterCondition } from "@/components/crm/types";
@@ -37,7 +38,7 @@ export const Route = createFileRoute(
   component: CompaniesIndex,
 });
 
-type Company = Doc<"companies">;
+type Company = MappedCompany;
 type CompanyRow = Company & { __cfValues: Record<string, unknown> };
 
 function CompaniesIndex() {
@@ -94,10 +95,9 @@ function CompaniesIndex() {
     { id: "categoryId", label: t('common.category', { defaultValue: "Kategoria" }), type: "select" as const, options: categories.map(cat => ({ label: cat.name, value: cat._id })) },
   ], [t, tags, categories]);
 
-  const { data: companiesRaw = [], isLoading } = useSupabaseCompaniesList(organizationId);
-  const companies = companiesRaw as unknown as Company[];
+  const { data: companies = [], isLoading } = useSupabaseCompaniesList(organizationId);
 
-  const companyIds = useMemo(() => companies.map((c) => c._id as string), [companies]);
+  const companyIds = useMemo(() => companies.map((c) => c._id), [companies]);
 
   const { definitions: cfDefs, columns: cfColumns, mergeCustomFieldValues } =
     useCustomFieldColumns<Company>({ organizationId, entityType: "company", entityIds: companyIds });

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
@@ -14,7 +14,7 @@ import { AvatarLabelGroup } from "@untitled/base/avatar/avatar-label-group";
 import { Plus, Trash2, Upload, Download } from "@/lib/ez-icons";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { CsvImportDialog } from "@/components/csv/csv-import-dialog";
-import type { Doc } from "@cvx/_generated/dataModel";
+import type { MappedContact } from "@/lib/supabase/mappers/contacts";
 import { useState, useMemo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import type { SavedView, TimeRange, FieldDef } from "@/components/crm/types";
@@ -33,7 +33,7 @@ export const Route = createFileRoute(
   component: ContactsIndex,
 });
 
-type Contact = Doc<"contacts">;
+type Contact = MappedContact;
 
 function ContactsIndex() {
   const { t } = useTranslation();
@@ -82,10 +82,9 @@ function ContactsIndex() {
     { id: "categoryId", label: t('common.category', { defaultValue: "Kategoria" }), type: "select" as const, options: categories.map(cat => ({ label: cat.name, value: cat._id })) },
   ], [t, tags, categories]);
 
-  const { data: contactsRaw = [], isLoading } = useSupabaseContactsList(organizationId);
-  const contacts = contactsRaw as unknown as Contact[];
+  const { data: contacts = [], isLoading } = useSupabaseContactsList(organizationId);
 
-  const contactIds = useMemo(() => contacts.map((c) => c._id as string), [contacts]);
+  const contactIds = useMemo(() => contacts.map((c) => c._id), [contacts]);
 
   const { definitions: cfDefs, columns: cfColumns, mergeCustomFieldValues } =
     useCustomFieldColumns<Contact>({ organizationId, entityType: "contact", entityIds: contactIds });

--- a/src/routes/_app/_auth/dashboard/_layout.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.documents.index.tsx
@@ -23,7 +23,8 @@ import { FileText, Eye, Trash2 } from "@/lib/ez-icons";
 import { AvatarLabelGroup } from "@untitled/base/avatar/avatar-label-group";
 import { useState, useMemo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import type { Doc, Id } from "@cvx/_generated/dataModel";
+import type { Id } from "@cvx/_generated/dataModel";
+import type { MappedFormDocument } from "@/lib/supabase/mappers/form-documents";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
@@ -84,7 +85,7 @@ const STATUS_OPTIONS: FormDocumentStatus[] = [
   "voided",
 ];
 
-type FormDocument = Doc<"formDocuments">;
+type FormDocument = MappedFormDocument;
 
 // ---------------------------------------------------------------------------
 // Component
@@ -128,8 +129,7 @@ function DocumentsPage() {
   const [activeFilters, setActiveFilters] = useState<FilterCondition[]>([]);
   const [savedViewsDialogOpen, setSavedViewsDialogOpen] = useState(false);
   const [filterSlideoutOpen, setFilterSlideoutOpen] = useState(false);
-  const [selectedDocId, setSelectedDocId] =
-    useState<Id<"formDocuments"> | null>(null);
+  const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
 
   // --- Data ---
   const { data: documents, isLoading: docsLoading } = useSupabaseFormDocumentsList(
@@ -289,8 +289,8 @@ function DocumentsPage() {
   const filteredDocuments = useMemo(() => {
     if (!documents) return [];
 
-    let data = (documents as unknown as FormDocument[]).map(
-      (doc) => ({ ...doc, category: getCategoryKey(doc.templateId as string) }),
+    let data = documents.map(
+      (doc) => ({ ...doc, category: getCategoryKey(doc.templateId) }),
     );
 
     // System view filter (status-based)

--- a/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
@@ -39,7 +39,8 @@ import {
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { Download } from "@/lib/ez-icons";
 import { CsvImportDialog } from "@/components/csv/csv-import-dialog";
-import { Doc, Id } from "@cvx/_generated/dataModel";
+import { Id } from "@cvx/_generated/dataModel";
+import type { MappedLead } from "@/lib/supabase/mappers/leads";
 import { useState, useMemo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import type { SavedView, TimeRange, FieldDef, FilterCondition } from "@/components/crm/types";
@@ -59,7 +60,7 @@ export const Route = createFileRoute("/_app/_auth/dashboard/_layout/leads/")({
   component: LeadsIndex,
 });
 
-type Lead = Doc<"leads">;
+type Lead = MappedLead;
 type LeadRow = Lead & { __cfValues: Record<string, unknown> };
 
 const stageColors: Record<string, string> = {
@@ -232,7 +233,7 @@ function LeadsIndex() {
     return map;
   }, [companiesRaw]);
 
-  const leads = (leadsData?.page ?? []) as unknown as Lead[];
+  const leads = leadsData?.page ?? [];
 
   const filteredLeads = useMemo(() => {
     let data = applyFilterConditions(leads, activeFilters);
@@ -252,7 +253,7 @@ function LeadsIndex() {
   }, [leads, activeViewId, applyFilters, activeFilters]);
 
   const leadIds = useMemo(
-    () => filteredLeads.map((l) => l._id as string),
+    () => filteredLeads.map((l) => l._id),
     [filteredLeads],
   );
   const {
@@ -659,8 +660,8 @@ function LeadsIndex() {
         description={t("deals.createDescription")}
       >
         <LeadForm
-          pipelines={pipelines as unknown as { _id: Id<"pipelines">; name: string }[]}
-          stages={stages as unknown as { _id: Id<"pipelineStages">; name: string; pipelineId: Id<"pipelines"> }[]}
+          pipelines={pipelines}
+          stages={stages}
           customFieldDefinitions={cfDefs}
           isSubmitting={isSubmitting}
           onCancel={() => setCreateOpen(false)}

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -18,7 +18,8 @@ import { Plus, Pencil, Trash2, Power, Upload, Download } from "@/lib/ez-icons";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { CsvImportDialog } from "@/components/csv/csv-import-dialog";
 import type { SavedView, FieldDef, FilterCondition } from "@/components/crm/types";
-import { Doc, Id } from "@cvx/_generated/dataModel";
+import { Id } from "@cvx/_generated/dataModel";
+import type { MappedProduct } from "@/lib/supabase/mappers/products";
 import { useSavedViews, applyFilterConditions } from "@/hooks/use-saved-views";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
@@ -34,7 +35,7 @@ export const Route = createFileRoute(
   component: ProductsPage,
 });
 
-type Product = Doc<"products">;
+type Product = MappedProduct;
 
 function generateSku(): string {
   const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -300,7 +301,7 @@ function ProductsPage() {
       <CrmDataTable
         columns={allColumns}
         hiddenColumnIds={hiddenColumnIds}
-        data={products as unknown as Product[]}
+        data={products}
         rowActions={rowActions}
         isLoading={isLoading}
       />

--- a/src/routes/_app/_auth/dashboard/_layout.settings.automations.$ruleId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.automations.$ruleId.tsx
@@ -22,7 +22,6 @@ import {
   classifyAutomationPlaygroundRule,
   type AutomationActionCapability,
   type AutomationCustomFieldDefinition,
-  type AutomationEmailTemplateRecord,
   type AutomationRuleRecord,
   type AutomationUpdateFieldTargetEntityType,
   type AutomationRuleAction,
@@ -332,7 +331,7 @@ function EditAutomationRulePage() {
         <AutomationSimpleMode
           eventCatalog={(eventCatalog ?? []) as AutomationBuilderEventCatalogEntry[]}
           actionCapabilities={actionCapabilities as AutomationActionCapability[]}
-          emailTemplates={emailTemplates as unknown as AutomationEmailTemplateRecord[]}
+          emailTemplates={emailTemplates ?? []}
           customFieldsByEntityType={customFieldsByEntityType}
           initialValue={playgroundValue}
           isSubmitting={isSubmitting}

--- a/src/routes/_app/_auth/dashboard/_layout.settings.automations.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.automations.new.tsx
@@ -18,7 +18,6 @@ import { AutomationSimpleMode } from "@/components/settings/automation-builder/a
 import {
   type AutomationActionCapability,
   type AutomationCustomFieldDefinition,
-  type AutomationEmailTemplateRecord,
   type AutomationUpdateFieldTargetEntityType,
 } from "@/components/settings/automation-builder/automation-simple-presets";
 import { Button } from "@/components/ui/button";
@@ -184,7 +183,7 @@ function NewAutomationRulePage() {
         <AutomationSimpleMode
           eventCatalog={(eventCatalog ?? []) as AutomationBuilderEventCatalogEntry[]}
           actionCapabilities={actionCapabilities as AutomationActionCapability[]}
-          emailTemplates={emailTemplates as unknown as AutomationEmailTemplateRecord[]}
+          emailTemplates={emailTemplates ?? []}
           customFieldsByEntityType={customFieldsByEntityType}
           isSubmitting={isSubmitting}
           onCancel={handleCancel}

--- a/src/routes/_app/_auth/dashboard/_layout.settings.email-sequences.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.email-sequences.tsx
@@ -6,6 +6,7 @@ import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseEmailSequencesList, useSupabaseEmailSequence, useSupabaseEmailSequenceSteps } from "@/hooks/use-supabase-email-sequences";
+import type { MappedEmailSequenceStep } from "@/lib/supabase/mappers/email-sequence-steps";
 import { useSupabaseEmailEventTypes } from "@/hooks/use-supabase-email-events";
 import { useSupabaseEmailTemplatesList } from "@/hooks/use-supabase-email-templates";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
@@ -71,13 +72,7 @@ interface Sequence {
   updatedAt: number;
 }
 
-interface SequenceStep {
-  _id: string;
-  sequenceId: string;
-  order: number;
-  delayMs: number;
-  templateId: string;
-}
+type SequenceStep = MappedEmailSequenceStep;
 
 
 
@@ -421,7 +416,7 @@ function SequenceEditorDialog({
     organizationId as string, sequenceId,
   );
 
-  const steps = (stepsRaw ?? []) as unknown as SequenceStep[];
+  const steps = stepsRaw ?? [];
   const sequence = sequenceBase ? { ...sequenceBase, steps } : null;
   const isLoading = seqLoading || stepsLoading;
 

--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -95,7 +95,7 @@ interface FormTemplateRecord {
   description?: string;
   category: string;
   folderPath?: string;
-  templateType?: "document";
+  templateType?: "document" | "pdfme";
   modules: string[];
   entityTypes: string[];
   version: number;
@@ -521,8 +521,8 @@ function FormTemplatesListPage() {
   const seedTemplates = useMutation(api.documents.seed.seedFormTemplates);
   const migrateFolders = useMutation(api.documents.seed.migrateFolderPaths);
 
-  const allTemplates = useMemo(
-    () => (templates ?? []) as unknown as FormTemplateRecord[],
+  const allTemplates = useMemo<FormTemplateRecord[]>(
+    () => templates ?? [],
     [templates],
   );
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #277.

Closes #277

---

## Claude summary

Commit e295cea on `claude/issue-277` drops the `as unknown as Doc<T>[]` and related domain-type casts across the 12 non-gabinet route files called out in #277. Each file now types its rows via the corresponding `Mapped*` from `src/lib/supabase/mappers` (e.g. `MappedCall`, `MappedLead`, `MappedFormDocument`, `MappedScheduledActivity`, `CalendarScheduledActivity`, `MappedEmailSequenceStep`).

Supporting tweaks needed to remove casts cleanly:
- `lead-form.tsx`: widen `Pipeline._id` / `PipelineStage._id` / `pipelineId` to `string` (the form already cast back to `Id<"pipelineStages">` at submit). Removes the awkward cast at the `LeadForm` callsite.
- `automation-simple-presets.ts`: `AutomationEmailTemplateRecord._id` widened to `string` so the supabase-mapped templates flow through without `as unknown as`.
- `mappers/companies.ts`: replaced `address?: unknown` with the structured shape used by the form.
- `_layout.settings.form-templates.index.tsx`: widened the local `FormTemplateRecord.templateType` to `"document" | "pdfme"` to match the schema (`pdfme` is kept for legacy schema compat).

Typecheck status (`tsc -p tsconfig.app.json`): only the pre-existing TS2589 in `_layout.calendar.tsx` (the `convexQuery(api.oauthConnections.getByProvider, ...)` instantiation depth) remains; verified it was already on `main` before any change in this branch. `tsconfig.node.json` and `convex/tsconfig.json` are clean.