### PR TITLE
Zle pokazuje godzine

### DIFF
--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -44,7 +44,7 @@ export function DraggableAppointment({
       {...listeners}
       {...attributes}
       data-appointment-card="true"
-      className={isDragging ? "opacity-50 cursor-grabbing" : "cursor-grab"}
+      className={`h-full ${isDragging ? "opacity-50 cursor-grabbing" : "cursor-grab"}`}
     >
       <AppointmentCard
         startTime={startTime}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #18.

Closes #18

---

## Claude summary

Fixed and committed.

The bug was in `src/components/gabinet/calendar/draggable-appointment.tsx`: the absolute-positioned wrapper around each appointment in the gabinet calendar correctly sized itself to the booking duration (30px for 30 min), but the intermediate `DraggableAppointment` div had no height, so the inner `AppointmentCard`'s `h-full overflow-hidden` had nothing to clip against. The card expanded to its 3-line content (~60px), visually occupying a full hour. Adding `h-full` to the draggable wrapper lets the card honor the parent's explicit height — so a 09:00–09:30 appointment now ends at 09:30 instead of looking like it runs to 10:00.

I couldn't run `typecheck` because `node_modules` isn't installed in this fresh worktree, but the change is purely a Tailwind class addition with no API surface impact.