### PR TITLE
fix(ui): mount Toaster so toast notifications actually render

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import {
 import React, { Suspense } from "react";
 import { Helmet } from "react-helmet-async";
 import { RouteErrorBoundary } from "@/components/layout/route-error-boundary";
+import { Toaster } from "@/components/ui/sonner";
 
 const TanStackRouterDevtools =
   process.env.NODE_ENV === "production"
@@ -41,6 +42,7 @@ export const Route = createRootRouteWithContext<{
         <Helmet>
           <title>{title}</title>
         </Helmet>
+        <Toaster richColors position="top-right" />
         <Suspense>
           <TanStackRouterDevtools />
         </Suspense>


### PR DESCRIPTION
Mounts `<Toaster />` once at the root so every `toast.success / .error / .info` call across the app actually renders.

Without this, all toast calls were silent no-ops. Most visible on the invitation flow reported in #19 — users saw no feedback after clicking *Send invite*, even when the underlying action succeeded.

Supersedes the UI portion of PR #287 (the Convex-side V8 fix from that PR is already on `main` via PRs #23 and #290).

Closes #19