### PR TITLE
hamburger

### DIFF
--- a/src/lib/ez-icons/icon-map.ts
+++ b/src/lib/ez-icons/icon-map.ts
@@ -75,6 +75,7 @@ export const ICON_MAP: Record<string, string> = {
   MailOpen: "mail-open",
   MapPin: "map-pin",
   MapPinIcon: "map-pin",
+  Menu: "menu-01",
   MessageCircle: "message-01",
   MessageSquare: "message-02",
   Minus: "minus-sign",

--- a/src/lib/ez-icons/index.ts
+++ b/src/lib/ez-icons/index.ts
@@ -98,6 +98,7 @@ export const Mail = createIcon("Mail");
 export const MailOpen = createIcon("MailOpen");
 export const MapPin = createIcon("MapPin");
 export const MapPinIcon = createIcon("MapPinIcon");
+export const Menu = createIcon("Menu");
 export const MessageCircle = createIcon("MessageCircle");
 export const MessageSquare = createIcon("MessageSquare");
 export const Minus = createIcon("Minus");

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -24,7 +24,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { FileText, Send, Download, MoreHorizontal, Trash2, Calendar, User, Tag, FileSignature } from "@/lib/ez-icons";
+import { FileText, Send, Download, Menu, Trash2, Calendar, User, Tag, FileSignature } from "@/lib/ez-icons";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -373,7 +373,7 @@ function GabinetDocumentsPage() {
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
                 <span className="sr-only">Otwórz menu</span>
-                <MoreHorizontal className="h-4 w-4" />
+                <Menu className="h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #292.

Closes #292

---

## Claude summary

Committed. Summary of changes:

On the Gabinet documents page (`/dashboard/gabinet/documents`), the row-action button trigger in the actions column now uses a hamburger (three horizontal lines) icon instead of the three-dots icon. Done by:

- Adding `Menu: "menu-01"` to `src/lib/ez-icons/icon-map.ts` and exporting `Menu` from `src/lib/ez-icons/index.ts` (the project's ezicons wrapper around the `easier-icon` web component).
- Swapping `MoreHorizontal` for `Menu` in `_layout.gabinet.documents.index.tsx` (both the import and the JSX inside `DropdownMenuTrigger`).

Note: I couldn't run typecheck — this worktree has no `node_modules` installed. The change is a 1:1 icon swap with no API differences, so the risk is low, but a CI run will confirm.