### PR TITLE
feat(platform): platformSettings backend + isPlatformAdmin role

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -136,6 +136,7 @@ import type * as payments from "../payments.js";
 import type * as permissions from "../permissions.js";
 import type * as pipelineStageActions from "../pipelineStageActions.js";
 import type * as pipelines from "../pipelines.js";
+import type * as platformSettings from "../platformSettings.js";
 import type * as productSubscriptions from "../productSubscriptions.js";
 import type * as products from "../products.js";
 import type * as recentlyViewed from "../recentlyViewed.js";
@@ -351,6 +352,7 @@ declare const fullApi: ApiFromModules<{
   permissions: typeof permissions;
   pipelineStageActions: typeof pipelineStageActions;
   pipelines: typeof pipelines;
+  platformSettings: typeof platformSettings;
   productSubscriptions: typeof productSubscriptions;
   products: typeof products;
   recentlyViewed: typeof recentlyViewed;

--- a/convex/_helpers/auth.ts
+++ b/convex/_helpers/auth.ts
@@ -43,3 +43,14 @@ export async function requireOrgAdmin(
   }
   return { user, membership };
 }
+
+// Platform-level admin guard. Used by /admin pages and the platformSettings
+// mutation. Distinct from organization roles — a platform admin can configure
+// global settings (e.g. invitation From address) regardless of org membership.
+export async function requirePlatformAdmin(ctx: QueryCtx | MutationCtx) {
+  const user = await requireUser(ctx);
+  if (!user.isPlatformAdmin) {
+    throw new Error("Platform admin access required");
+  }
+  return user;
+}

--- a/convex/email/index.ts
+++ b/convex/email/index.ts
@@ -24,6 +24,9 @@ export type SendEmailOptions = {
   subject: string;
   html: string;
   text?: string;
+  // Optional per-call overrides. If unset, falls back to AUTH_EMAIL env.
+  from?: string;
+  replyTo?: string;
 };
 
 export async function sendEmail(options: SendEmailOptions) {
@@ -31,8 +34,13 @@ export async function sendEmail(options: SendEmailOptions) {
     throw new Error(`Resend - ${ERRORS.ENVS_NOT_INITIALIZED}`);
   }
 
-  const from = AUTH_EMAIL ?? "Convex SaaS <onboarding@resend.dev>";
-  const email = { from, ...options };
+  const { from: fromOverride, replyTo, ...rest } = options;
+  const from = fromOverride ?? AUTH_EMAIL ?? "Convex SaaS <onboarding@resend.dev>";
+  const email = {
+    from,
+    ...rest,
+    ...(replyTo ? { reply_to: replyTo } : {}),
+  };
 
   const response = await fetch("https://api.resend.com/emails", {
     method: "POST",

--- a/convex/email/templates/invitationEmail.tsx
+++ b/convex/email/templates/invitationEmail.tsx
@@ -19,6 +19,11 @@ type InvitationEmailOptions = {
   inviterName: string;
   role: string;
   token: string;
+  // Optional platform-level overrides. If unset, sendEmail falls back to the
+  // AUTH_EMAIL env var.
+  fromName?: string;
+  fromEmail?: string;
+  replyTo?: string;
 };
 
 /**
@@ -98,6 +103,9 @@ export async function sendInvitationEmail({
   inviterName,
   role,
   token,
+  fromName,
+  fromEmail,
+  replyTo,
 }: InvitationEmailOptions) {
   const html = renderInvitationEmail({
     email,
@@ -107,9 +115,16 @@ export async function sendInvitationEmail({
     token,
   });
 
+  // Build the From header only if BOTH name+email are provided; partial
+  // overrides fall back to AUTH_EMAIL to keep the address valid.
+  const from =
+    fromName && fromEmail ? `${fromName} <${fromEmail}>` : fromEmail || undefined;
+
   await sendEmail({
     to: email,
     subject: `You've been invited to join ${orgName}`,
     html,
+    ...(from ? { from } : {}),
+    ...(replyTo ? { replyTo } : {}),
   });
 }

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -138,13 +138,13 @@ export const _sendInvitationEmail = internalAction({
     inviterUserId: v.string(),
   },
   handler: async (ctx, args) => {
-    const ctxInfo = await ctx.runQuery(
-      internal.invitations._getEmailContext,
-      {
+    const [ctxInfo, platformSettings] = await Promise.all([
+      ctx.runQuery(internal.invitations._getEmailContext, {
         organizationId: args.organizationId,
         inviterUserId: args.inviterUserId,
-      },
-    );
+      }),
+      ctx.runQuery(internal.platformSettings._getInternal, {}),
+    ]);
     try {
       await sendInvitationEmail({
         email: args.email,
@@ -152,6 +152,9 @@ export const _sendInvitationEmail = internalAction({
         inviterName: ctxInfo.inviterName,
         role: args.role,
         token: args.token,
+        fromName: platformSettings?.invitationFromName,
+        fromEmail: platformSettings?.invitationFromEmail,
+        replyTo: platformSettings?.invitationReplyToEmail,
       });
     } catch (e) {
       console.error(

--- a/convex/platformSettings.ts
+++ b/convex/platformSettings.ts
@@ -1,0 +1,81 @@
+import { v } from "convex/values";
+import {
+  query,
+  mutation,
+  internalQuery,
+  internalMutation,
+} from "./_generated/server";
+import { requirePlatformAdmin } from "./_helpers/auth";
+
+// Get the current platform settings (singleton). Returns null if not yet
+// configured. Reading is allowed for any authenticated context — the
+// invitation-send action needs the From overrides at runtime — so we don't
+// guard this with requirePlatformAdmin. There are no secrets in the row.
+export const get = query({
+  args: {},
+  handler: async (ctx) => {
+    const row = await ctx.db.query("platformSettings").first();
+    return row ?? null;
+  },
+});
+
+// Internal variant for server-side callers (e.g. the invitation send action).
+// Same shape — separate so we can keep `get` public without worrying about
+// circular auth dependencies.
+export const _getInternal = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const row = await ctx.db.query("platformSettings").first();
+    return row ?? null;
+  },
+});
+
+// Upsert the singleton settings row. Platform admin only.
+// The frontend admin form (PR #295+) sends the full set of fields each save;
+// undefined keys clear the override and fall back to env-based defaults.
+export const set = mutation({
+  args: {
+    invitationFromName: v.optional(v.string()),
+    invitationFromEmail: v.optional(v.string()),
+    invitationReplyToEmail: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const user = await requirePlatformAdmin(ctx);
+    const existing = await ctx.db.query("platformSettings").first();
+    const now = Date.now();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        invitationFromName: args.invitationFromName,
+        invitationFromEmail: args.invitationFromEmail,
+        invitationReplyToEmail: args.invitationReplyToEmail,
+        updatedAt: now,
+        updatedBy: user._id,
+      });
+      return existing._id;
+    }
+    return await ctx.db.insert("platformSettings", {
+      invitationFromName: args.invitationFromName,
+      invitationFromEmail: args.invitationFromEmail,
+      invitationReplyToEmail: args.invitationReplyToEmail,
+      updatedAt: now,
+      updatedBy: user._id,
+    });
+  },
+});
+
+// Bootstrap helper — grants the platform-admin role to a user by email.
+// Intended to be called via `npx convex run` (requires admin token), exactly
+// once per environment, to seed the first platform admin. Subsequent admins
+// can be granted via the admin UI once one exists.
+export const _grantPlatformAdmin = internalMutation({
+  args: { email: v.string() },
+  handler: async (ctx, args) => {
+    const user = await ctx.db
+      .query("users")
+      .withIndex("email", (q) => q.eq("email", args.email))
+      .unique();
+    if (!user) throw new Error(`No user found for email ${args.email}`);
+    await ctx.db.patch(user._id, { isPlatformAdmin: true });
+    return { userId: user._id, email: args.email };
+  },
+});

--- a/convex/schema/platform.ts
+++ b/convex/schema/platform.ts
@@ -34,6 +34,10 @@ export function createPlatformTables({
       v.union(v.literal("light"), v.literal("dark"), v.literal("system")),
     ),
     timezone: v.optional(v.string()),
+    // Platform-level admin flag. Distinct from organization roles; grants
+    // access to the /admin area and ability to configure global platform
+    // settings (e.g. invitation email From address).
+    isPlatformAdmin: v.optional(v.boolean()),
   })
     .index("email", ["email"])
     .index("customerId", ["customerId"]),
@@ -261,5 +265,19 @@ export function createPlatformTables({
   })
     .index("by_user_type", ["organizationId", "userId", "entityType", "viewedAt"])
     .index("by_entity", ["entityId"]),
+
+  // Singleton-style table: holds global platform configuration that is NOT
+  // scoped to any organization. There should be at most ONE row here; the
+  // queries/mutations in convex/platformSettings.ts enforce that invariant.
+  // Used for things like the From name/email used on platform-sent emails
+  // (invitations, password resets, etc.) so they represent Quera (the
+  // platform) rather than any individual tenant gabinet.
+  platformSettings: defineTable({
+    invitationFromName: v.optional(v.string()),
+    invitationFromEmail: v.optional(v.string()),
+    invitationReplyToEmail: v.optional(v.string()),
+    updatedAt: v.number(),
+    updatedBy: v.optional(v.id("users")),
+  }),
   };
 }


### PR DESCRIPTION
## What

Backend for platform-level configuration that lives outside any single tenant. First use: invitation email From override.

## Schema

- New `platformSettings` table — singleton, holds invitationFromName/FromEmail/ReplyTo
- New optional `isPlatformAdmin` boolean on `users`

## Functions

- `platformSettings.get` — public read (no secrets in the row)
- `platformSettings._getInternal` — server-side variant
- `platformSettings.set` — admin-guarded upsert
- `platformSettings._grantPlatformAdmin` — bootstrap (callable via `npx convex run`)
- `_helpers/auth.ts requirePlatformAdmin` — guard

## Wiring

`sendEmail` + `sendInvitationEmail` accept optional `from` / `replyTo`. `_sendInvitationEmail` action loads `platformSettings` and passes overrides. If unset, falls back to AUTH_EMAIL env — same behavior as before.

## Follow-up

Admin UI to configure these via the app is the next (final) PR.