### PR TITLE
feat(admin): /admin/email-config page for platform email overrides

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as AppPatientLayoutBookRouteImport } from './routes/_app/patient/
 import { Route as AppPatientLayoutAppointmentsRouteImport } from './routes/_app/patient/_layout.appointments'
 import { Route as AppAuthOnboardingLayoutRouteImport } from './routes/_app/_auth/onboarding/_layout'
 import { Route as AppAuthDashboardLayoutRouteImport } from './routes/_app/_auth/dashboard/_layout'
+import { Route as AppAuthAdminEmailConfigRouteImport } from './routes/_app/_auth/admin.email-config'
 import { Route as AppAuthDashboardLayoutIndexRouteImport } from './routes/_app/_auth/dashboard/_layout.index'
 import { Route as AppAuthOnboardingLayoutUsernameRouteImport } from './routes/_app/_auth/onboarding/_layout.username'
 import { Route as AppAuthDashboardLayoutSetupRouteImport } from './routes/_app/_auth/dashboard/_layout.setup'
@@ -209,6 +210,11 @@ const AppAuthOnboardingLayoutRoute = AppAuthOnboardingLayoutRouteImport.update({
 const AppAuthDashboardLayoutRoute = AppAuthDashboardLayoutRouteImport.update({
   id: '/dashboard/_layout',
   path: '/dashboard',
+  getParentRoute: () => AppAuthRoute,
+} as any)
+const AppAuthAdminEmailConfigRoute = AppAuthAdminEmailConfigRouteImport.update({
+  id: '/admin/email-config',
+  path: '/admin/email-config',
   getParentRoute: () => AppAuthRoute,
 } as any)
 const AppAuthDashboardLayoutIndexRoute =
@@ -721,6 +727,7 @@ export interface FileRoutesByFullPath {
   '/patient': typeof AppPatientLayoutRouteWithChildren
   '/patient/login': typeof AppPatientLoginRoute
   '/sign/form/$token': typeof SignFormTokenRoute
+  '/admin/email-config': typeof AppAuthAdminEmailConfigRoute
   '/dashboard': typeof AppAuthDashboardLayoutRouteWithChildren
   '/onboarding': typeof AppAuthOnboardingLayoutRouteWithChildren
   '/patient/appointments': typeof AppPatientLayoutAppointmentsRoute
@@ -819,6 +826,7 @@ export interface FileRoutesByTo {
   '/invite/$token': typeof AppInviteTokenRoute
   '/patient/login': typeof AppPatientLoginRoute
   '/sign/form/$token': typeof SignFormTokenRoute
+  '/admin/email-config': typeof AppAuthAdminEmailConfigRoute
   '/onboarding': typeof AppAuthOnboardingLayoutRouteWithChildren
   '/patient/appointments': typeof AppPatientLayoutAppointmentsRoute
   '/patient/book': typeof AppPatientLayoutBookRoute
@@ -915,6 +923,7 @@ export interface FileRoutesById {
   '/_app/patient/_layout': typeof AppPatientLayoutRouteWithChildren
   '/_app/patient/login': typeof AppPatientLoginRoute
   '/sign/form/$token': typeof SignFormTokenRoute
+  '/_app/_auth/admin/email-config': typeof AppAuthAdminEmailConfigRoute
   '/_app/_auth/dashboard/_layout': typeof AppAuthDashboardLayoutRouteWithChildren
   '/_app/_auth/onboarding/_layout': typeof AppAuthOnboardingLayoutRouteWithChildren
   '/_app/patient/_layout/appointments': typeof AppPatientLayoutAppointmentsRoute
@@ -1017,6 +1026,7 @@ export interface FileRouteTypes {
     | '/patient'
     | '/patient/login'
     | '/sign/form/$token'
+    | '/admin/email-config'
     | '/dashboard'
     | '/onboarding'
     | '/patient/appointments'
@@ -1115,6 +1125,7 @@ export interface FileRouteTypes {
     | '/invite/$token'
     | '/patient/login'
     | '/sign/form/$token'
+    | '/admin/email-config'
     | '/onboarding'
     | '/patient/appointments'
     | '/patient/book'
@@ -1210,6 +1221,7 @@ export interface FileRouteTypes {
     | '/_app/patient/_layout'
     | '/_app/patient/login'
     | '/sign/form/$token'
+    | '/_app/_auth/admin/email-config'
     | '/_app/_auth/dashboard/_layout'
     | '/_app/_auth/onboarding/_layout'
     | '/_app/patient/_layout/appointments'
@@ -1450,6 +1462,13 @@ declare module '@tanstack/react-router' {
       path: '/dashboard'
       fullPath: '/dashboard'
       preLoaderRoute: typeof AppAuthDashboardLayoutRouteImport
+      parentRoute: typeof AppAuthRoute
+    }
+    '/_app/_auth/admin/email-config': {
+      id: '/_app/_auth/admin/email-config'
+      path: '/admin/email-config'
+      fullPath: '/admin/email-config'
+      preLoaderRoute: typeof AppAuthAdminEmailConfigRouteImport
       parentRoute: typeof AppAuthRoute
     }
     '/_app/_auth/dashboard/_layout/': {
@@ -2358,11 +2377,13 @@ const AppAuthOnboardingLayoutRouteWithChildren =
   )
 
 interface AppAuthRouteChildren {
+  AppAuthAdminEmailConfigRoute: typeof AppAuthAdminEmailConfigRoute
   AppAuthDashboardLayoutRoute: typeof AppAuthDashboardLayoutRouteWithChildren
   AppAuthOnboardingLayoutRoute: typeof AppAuthOnboardingLayoutRouteWithChildren
 }
 
 const AppAuthRouteChildren: AppAuthRouteChildren = {
+  AppAuthAdminEmailConfigRoute: AppAuthAdminEmailConfigRoute,
   AppAuthDashboardLayoutRoute: AppAuthDashboardLayoutRouteWithChildren,
   AppAuthOnboardingLayoutRoute: AppAuthOnboardingLayoutRouteWithChildren,
 }

--- a/src/routes/_app/_auth/admin.email-config.tsx
+++ b/src/routes/_app/_auth/admin.email-config.tsx
@@ -1,0 +1,152 @@
+import { useState, useEffect } from "react";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { useMutation } from "@tanstack/react-query";
+import { api } from "@cvx/_generated/api";
+import { toast } from "sonner";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export const Route = createFileRoute("/_app/_auth/admin/email-config")({
+  component: AdminEmailConfig,
+});
+
+function AdminEmailConfig() {
+  const { data: user, isLoading: userLoading } = useQuery(
+    convexQuery(api.app.getCurrentUser, {}),
+  );
+  const { data: settings, isLoading: settingsLoading } = useQuery(
+    convexQuery(api.platformSettings.get, {}),
+  );
+
+  const [fromName, setFromName] = useState("");
+  const [fromEmail, setFromEmail] = useState("");
+  const [replyTo, setReplyTo] = useState("");
+
+  // Sync local form state when settings load / change
+  useEffect(() => {
+    if (settings) {
+      setFromName(settings.invitationFromName ?? "");
+      setFromEmail(settings.invitationFromEmail ?? "");
+      setReplyTo(settings.invitationReplyToEmail ?? "");
+    }
+  }, [settings]);
+
+  const saveMutation = useMutation({
+    mutationFn: useConvexMutation(api.platformSettings.set),
+    onSuccess: () => {
+      toast.success("Platform email settings saved");
+    },
+    onError: (e: Error) => {
+      toast.error(e.message || "Failed to save settings");
+    },
+  });
+
+  if (userLoading) {
+    return <div className="p-8 text-sm text-muted-foreground">Loading…</div>;
+  }
+
+  if (!user?.isPlatformAdmin) {
+    return (
+      <div className="mx-auto max-w-2xl p-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>403 — Platform admin required</CardTitle>
+            <CardDescription>
+              This page is only accessible to platform administrators.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Link to="/dashboard" className="text-sm underline">
+              Back to dashboard
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const handleSave = (e: React.FormEvent) => {
+    e.preventDefault();
+    saveMutation.mutate({
+      invitationFromName: fromName.trim() || undefined,
+      invitationFromEmail: fromEmail.trim() || undefined,
+      invitationReplyToEmail: replyTo.trim() || undefined,
+    });
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-8">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Platform admin · Email</h1>
+        <p className="text-sm text-muted-foreground">
+          Global email configuration used by platform-level messages (invitations,
+          password resets) — separate from per-gabinet mail providers.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Invitation email</CardTitle>
+          <CardDescription>
+            From and reply-to addresses on team-invite emails. Leave blank to fall
+            back to the <code>AUTH_EMAIL</code> environment value.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSave} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="fromName">From name</Label>
+              <Input
+                id="fromName"
+                placeholder="Quera"
+                value={fromName}
+                onChange={(e) => setFromName(e.target.value)}
+                disabled={settingsLoading || saveMutation.isPending}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="fromEmail">From email</Label>
+              <Input
+                id="fromEmail"
+                type="email"
+                placeholder="noreply@quera.helloalex.pl"
+                value={fromEmail}
+                onChange={(e) => setFromEmail(e.target.value)}
+                disabled={settingsLoading || saveMutation.isPending}
+              />
+              <p className="text-xs text-muted-foreground">
+                Both name and email must be set together for the override to
+                apply.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="replyTo">Reply-to (optional)</Label>
+              <Input
+                id="replyTo"
+                type="email"
+                placeholder="support@quera.helloalex.pl"
+                value={replyTo}
+                onChange={(e) => setReplyTo(e.target.value)}
+                disabled={settingsLoading || saveMutation.isPending}
+              />
+            </div>
+            <div className="flex items-center gap-3 pt-2">
+              <Button type="submit" disabled={saveMutation.isPending}>
+                {saveMutation.isPending ? "Saving…" : "Save"}
+              </Button>
+              {settings?.updatedAt && (
+                <span className="text-xs text-muted-foreground">
+                  Last updated {new Date(settings.updatedAt).toLocaleString()}
+                </span>
+              )}
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
Final PR of the platform-email-config series.

## What

New route `/admin/email-config` — minimal form to set the From name / From email / Reply-to used by platform-level emails (invitations).

## Guards

- Page renders a 403 card if `user.isPlatformAdmin` is falsy
- The `platformSettings.set` mutation server-side also enforces `requirePlatformAdmin` — UI can't bypass

## Series recap

- #294 — actually send invitation emails
- #296 — `platformSettings` backend (table + role + helper + queries) + wire overrides into send
- this PR — admin UI to configure them

## Deploy notes

- Convex backend already deployed to dev (helpful-mule-867) via `npx convex dev --once` during dev
- Platform admin bootstrap done: `amiesak@gmail.com` already granted on dev
- Frontend bundle needs rebuild + push to `/home/quera/webapps/quera` for the route to be reachable in the browser

## Access

After this lands and frontend deploys, navigate to:
https://www.quera-dev.helloalex.pl/admin/email-config