### PR TITLE
feat(admin): manage platform-admin role from /admin/users

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -136,6 +136,7 @@ import type * as payments from "../payments.js";
 import type * as permissions from "../permissions.js";
 import type * as pipelineStageActions from "../pipelineStageActions.js";
 import type * as pipelines from "../pipelines.js";
+import type * as platformAdmins from "../platformAdmins.js";
 import type * as platformSettings from "../platformSettings.js";
 import type * as productSubscriptions from "../productSubscriptions.js";
 import type * as products from "../products.js";
@@ -352,6 +353,7 @@ declare const fullApi: ApiFromModules<{
   permissions: typeof permissions;
   pipelineStageActions: typeof pipelineStageActions;
   pipelines: typeof pipelines;
+  platformAdmins: typeof platformAdmins;
   platformSettings: typeof platformSettings;
   productSubscriptions: typeof productSubscriptions;
   products: typeof products;

--- a/convex/platformAdmins.ts
+++ b/convex/platformAdmins.ts
@@ -1,0 +1,64 @@
+import { v } from "convex/values";
+import { query, mutation } from "./_generated/server";
+import { requirePlatformAdmin } from "./_helpers/auth";
+
+// List all users with their platform-admin flag. Used by the /admin/users
+// page to render the toggle. Platform admin only — this exposes user emails
+// across the entire deployment.
+export const list = query({
+  args: {},
+  handler: async (ctx) => {
+    await requirePlatformAdmin(ctx);
+    const users = await ctx.db.query("users").collect();
+    return users
+      .map((u) => ({
+        _id: u._id,
+        name: u.name ?? null,
+        email: u.email ?? null,
+        isPlatformAdmin: Boolean(u.isPlatformAdmin),
+        createdAt: u._creationTime,
+      }))
+      .sort((a, b) => {
+        // Platform admins first, then alphabetical by email
+        if (a.isPlatformAdmin !== b.isPlatformAdmin) {
+          return a.isPlatformAdmin ? -1 : 1;
+        }
+        return (a.email ?? "").localeCompare(b.email ?? "");
+      });
+  },
+});
+
+// Toggle isPlatformAdmin for a target user. Platform admin only. Prevents
+// removing the last platform admin (would lock the system out of /admin).
+export const setRole = mutation({
+  args: {
+    userId: v.id("users"),
+    isPlatformAdmin: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const actor = await requirePlatformAdmin(ctx);
+
+    if (!args.isPlatformAdmin) {
+      // About to demote someone — ensure at least one platform admin remains.
+      const allAdmins = await ctx.db.query("users").collect();
+      const remainingAdmins = allAdmins.filter(
+        (u) => u.isPlatformAdmin && u._id !== args.userId,
+      );
+      if (remainingAdmins.length === 0) {
+        throw new Error(
+          "Cannot remove the last platform admin — promote another user first.",
+        );
+      }
+    }
+
+    const target = await ctx.db.get(args.userId);
+    if (!target) throw new Error("User not found");
+
+    await ctx.db.patch(args.userId, { isPlatformAdmin: args.isPlatformAdmin });
+    return {
+      userId: args.userId,
+      isPlatformAdmin: args.isPlatformAdmin,
+      actorId: actor._id,
+    };
+  },
+});

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as AppLoginLayoutRouteImport } from './routes/_app/login/_layout'
 import { Route as AppInviteTokenRouteImport } from './routes/_app/invite.$token'
 import { Route as AppPatientLayoutIndexRouteImport } from './routes/_app/patient/_layout.index'
 import { Route as AppLoginLayoutIndexRouteImport } from './routes/_app/login/_layout.index'
+import { Route as AppAuthAdminIndexRouteImport } from './routes/_app/_auth/admin.index'
 import { Route as AppPatientLayoutProfileRouteImport } from './routes/_app/patient/_layout.profile'
 import { Route as AppPatientLayoutPackagesRouteImport } from './routes/_app/patient/_layout.packages'
 import { Route as AppPatientLayoutLoyaltyRouteImport } from './routes/_app/patient/_layout.loyalty'
@@ -29,6 +30,7 @@ import { Route as AppPatientLayoutBookRouteImport } from './routes/_app/patient/
 import { Route as AppPatientLayoutAppointmentsRouteImport } from './routes/_app/patient/_layout.appointments'
 import { Route as AppAuthOnboardingLayoutRouteImport } from './routes/_app/_auth/onboarding/_layout'
 import { Route as AppAuthDashboardLayoutRouteImport } from './routes/_app/_auth/dashboard/_layout'
+import { Route as AppAuthAdminUsersRouteImport } from './routes/_app/_auth/admin.users'
 import { Route as AppAuthAdminEmailConfigRouteImport } from './routes/_app/_auth/admin.email-config'
 import { Route as AppAuthDashboardLayoutIndexRouteImport } from './routes/_app/_auth/dashboard/_layout.index'
 import { Route as AppAuthOnboardingLayoutUsernameRouteImport } from './routes/_app/_auth/onboarding/_layout.username'
@@ -169,6 +171,11 @@ const AppLoginLayoutIndexRoute = AppLoginLayoutIndexRouteImport.update({
   path: '/',
   getParentRoute: () => AppLoginLayoutRoute,
 } as any)
+const AppAuthAdminIndexRoute = AppAuthAdminIndexRouteImport.update({
+  id: '/admin/',
+  path: '/admin/',
+  getParentRoute: () => AppAuthRoute,
+} as any)
 const AppPatientLayoutProfileRoute = AppPatientLayoutProfileRouteImport.update({
   id: '/profile',
   path: '/profile',
@@ -210,6 +217,11 @@ const AppAuthOnboardingLayoutRoute = AppAuthOnboardingLayoutRouteImport.update({
 const AppAuthDashboardLayoutRoute = AppAuthDashboardLayoutRouteImport.update({
   id: '/dashboard/_layout',
   path: '/dashboard',
+  getParentRoute: () => AppAuthRoute,
+} as any)
+const AppAuthAdminUsersRoute = AppAuthAdminUsersRouteImport.update({
+  id: '/admin/users',
+  path: '/admin/users',
   getParentRoute: () => AppAuthRoute,
 } as any)
 const AppAuthAdminEmailConfigRoute = AppAuthAdminEmailConfigRouteImport.update({
@@ -728,6 +740,7 @@ export interface FileRoutesByFullPath {
   '/patient/login': typeof AppPatientLoginRoute
   '/sign/form/$token': typeof SignFormTokenRoute
   '/admin/email-config': typeof AppAuthAdminEmailConfigRoute
+  '/admin/users': typeof AppAuthAdminUsersRoute
   '/dashboard': typeof AppAuthDashboardLayoutRouteWithChildren
   '/onboarding': typeof AppAuthOnboardingLayoutRouteWithChildren
   '/patient/appointments': typeof AppPatientLayoutAppointmentsRoute
@@ -736,6 +749,7 @@ export interface FileRoutesByFullPath {
   '/patient/loyalty': typeof AppPatientLayoutLoyaltyRoute
   '/patient/packages': typeof AppPatientLayoutPackagesRoute
   '/patient/profile': typeof AppPatientLayoutProfileRoute
+  '/admin/': typeof AppAuthAdminIndexRoute
   '/login/': typeof AppLoginLayoutIndexRoute
   '/patient/': typeof AppPatientLayoutIndexRoute
   '/dashboard/calendar': typeof AppAuthDashboardLayoutCalendarRoute
@@ -827,6 +841,7 @@ export interface FileRoutesByTo {
   '/patient/login': typeof AppPatientLoginRoute
   '/sign/form/$token': typeof SignFormTokenRoute
   '/admin/email-config': typeof AppAuthAdminEmailConfigRoute
+  '/admin/users': typeof AppAuthAdminUsersRoute
   '/onboarding': typeof AppAuthOnboardingLayoutRouteWithChildren
   '/patient/appointments': typeof AppPatientLayoutAppointmentsRoute
   '/patient/book': typeof AppPatientLayoutBookRoute
@@ -834,6 +849,7 @@ export interface FileRoutesByTo {
   '/patient/loyalty': typeof AppPatientLayoutLoyaltyRoute
   '/patient/packages': typeof AppPatientLayoutPackagesRoute
   '/patient/profile': typeof AppPatientLayoutProfileRoute
+  '/admin': typeof AppAuthAdminIndexRoute
   '/login': typeof AppLoginLayoutIndexRoute
   '/patient': typeof AppPatientLayoutIndexRoute
   '/dashboard/calendar': typeof AppAuthDashboardLayoutCalendarRoute
@@ -924,6 +940,7 @@ export interface FileRoutesById {
   '/_app/patient/login': typeof AppPatientLoginRoute
   '/sign/form/$token': typeof SignFormTokenRoute
   '/_app/_auth/admin/email-config': typeof AppAuthAdminEmailConfigRoute
+  '/_app/_auth/admin/users': typeof AppAuthAdminUsersRoute
   '/_app/_auth/dashboard/_layout': typeof AppAuthDashboardLayoutRouteWithChildren
   '/_app/_auth/onboarding/_layout': typeof AppAuthOnboardingLayoutRouteWithChildren
   '/_app/patient/_layout/appointments': typeof AppPatientLayoutAppointmentsRoute
@@ -932,6 +949,7 @@ export interface FileRoutesById {
   '/_app/patient/_layout/loyalty': typeof AppPatientLayoutLoyaltyRoute
   '/_app/patient/_layout/packages': typeof AppPatientLayoutPackagesRoute
   '/_app/patient/_layout/profile': typeof AppPatientLayoutProfileRoute
+  '/_app/_auth/admin/': typeof AppAuthAdminIndexRoute
   '/_app/login/_layout/': typeof AppLoginLayoutIndexRoute
   '/_app/patient/_layout/': typeof AppPatientLayoutIndexRoute
   '/_app/_auth/dashboard/_layout/calendar': typeof AppAuthDashboardLayoutCalendarRoute
@@ -1027,6 +1045,7 @@ export interface FileRouteTypes {
     | '/patient/login'
     | '/sign/form/$token'
     | '/admin/email-config'
+    | '/admin/users'
     | '/dashboard'
     | '/onboarding'
     | '/patient/appointments'
@@ -1035,6 +1054,7 @@ export interface FileRouteTypes {
     | '/patient/loyalty'
     | '/patient/packages'
     | '/patient/profile'
+    | '/admin/'
     | '/login/'
     | '/patient/'
     | '/dashboard/calendar'
@@ -1126,6 +1146,7 @@ export interface FileRouteTypes {
     | '/patient/login'
     | '/sign/form/$token'
     | '/admin/email-config'
+    | '/admin/users'
     | '/onboarding'
     | '/patient/appointments'
     | '/patient/book'
@@ -1133,6 +1154,7 @@ export interface FileRouteTypes {
     | '/patient/loyalty'
     | '/patient/packages'
     | '/patient/profile'
+    | '/admin'
     | '/login'
     | '/patient'
     | '/dashboard/calendar'
@@ -1222,6 +1244,7 @@ export interface FileRouteTypes {
     | '/_app/patient/login'
     | '/sign/form/$token'
     | '/_app/_auth/admin/email-config'
+    | '/_app/_auth/admin/users'
     | '/_app/_auth/dashboard/_layout'
     | '/_app/_auth/onboarding/_layout'
     | '/_app/patient/_layout/appointments'
@@ -1230,6 +1253,7 @@ export interface FileRouteTypes {
     | '/_app/patient/_layout/loyalty'
     | '/_app/patient/_layout/packages'
     | '/_app/patient/_layout/profile'
+    | '/_app/_auth/admin/'
     | '/_app/login/_layout/'
     | '/_app/patient/_layout/'
     | '/_app/_auth/dashboard/_layout/calendar'
@@ -1408,6 +1432,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppLoginLayoutIndexRouteImport
       parentRoute: typeof AppLoginLayoutRoute
     }
+    '/_app/_auth/admin/': {
+      id: '/_app/_auth/admin/'
+      path: '/admin'
+      fullPath: '/admin/'
+      preLoaderRoute: typeof AppAuthAdminIndexRouteImport
+      parentRoute: typeof AppAuthRoute
+    }
     '/_app/patient/_layout/profile': {
       id: '/_app/patient/_layout/profile'
       path: '/profile'
@@ -1462,6 +1493,13 @@ declare module '@tanstack/react-router' {
       path: '/dashboard'
       fullPath: '/dashboard'
       preLoaderRoute: typeof AppAuthDashboardLayoutRouteImport
+      parentRoute: typeof AppAuthRoute
+    }
+    '/_app/_auth/admin/users': {
+      id: '/_app/_auth/admin/users'
+      path: '/admin/users'
+      fullPath: '/admin/users'
+      preLoaderRoute: typeof AppAuthAdminUsersRouteImport
       parentRoute: typeof AppAuthRoute
     }
     '/_app/_auth/admin/email-config': {
@@ -2378,14 +2416,18 @@ const AppAuthOnboardingLayoutRouteWithChildren =
 
 interface AppAuthRouteChildren {
   AppAuthAdminEmailConfigRoute: typeof AppAuthAdminEmailConfigRoute
+  AppAuthAdminUsersRoute: typeof AppAuthAdminUsersRoute
   AppAuthDashboardLayoutRoute: typeof AppAuthDashboardLayoutRouteWithChildren
   AppAuthOnboardingLayoutRoute: typeof AppAuthOnboardingLayoutRouteWithChildren
+  AppAuthAdminIndexRoute: typeof AppAuthAdminIndexRoute
 }
 
 const AppAuthRouteChildren: AppAuthRouteChildren = {
   AppAuthAdminEmailConfigRoute: AppAuthAdminEmailConfigRoute,
+  AppAuthAdminUsersRoute: AppAuthAdminUsersRoute,
   AppAuthDashboardLayoutRoute: AppAuthDashboardLayoutRouteWithChildren,
   AppAuthOnboardingLayoutRoute: AppAuthOnboardingLayoutRouteWithChildren,
+  AppAuthAdminIndexRoute: AppAuthAdminIndexRoute,
 }
 
 const AppAuthRouteWithChildren =

--- a/src/routes/_app/_auth/admin.index.tsx
+++ b/src/routes/_app/_auth/admin.index.tsx
@@ -1,0 +1,76 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { convexQuery } from "@convex-dev/react-query";
+import { api } from "@cvx/_generated/api";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export const Route = createFileRoute("/_app/_auth/admin/")({
+  component: AdminIndex,
+});
+
+function AdminIndex() {
+  const { data: user, isLoading } = useQuery(
+    convexQuery(api.app.getCurrentUser, {}),
+  );
+
+  if (isLoading) {
+    return <div className="p-8 text-sm text-muted-foreground">Loading…</div>;
+  }
+
+  if (!user?.isPlatformAdmin) {
+    return (
+      <div className="mx-auto max-w-2xl p-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>403 — Platform admin required</CardTitle>
+            <CardDescription>
+              This page is only accessible to platform administrators.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Link to="/dashboard" className="text-sm underline">
+              Back to dashboard
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-8">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Platform admin</h1>
+        <p className="text-sm text-muted-foreground">
+          Quera-level configuration. Distinct from per-gabinet settings.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Link to="/admin/email-config" className="block">
+          <Card className="h-full transition hover:border-foreground/20">
+            <CardHeader>
+              <CardTitle>Email configuration</CardTitle>
+              <CardDescription>
+                From / Reply-to addresses used on platform emails like
+                invitations and password resets.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </Link>
+
+        <Link to="/admin/users" className="block">
+          <Card className="h-full transition hover:border-foreground/20">
+            <CardHeader>
+              <CardTitle>Platform administrators</CardTitle>
+              <CardDescription>
+                Grant or revoke platform admin role for users. Platform admins
+                can access this section.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/_app/_auth/admin.users.tsx
+++ b/src/routes/_app/_auth/admin.users.tsx
@@ -1,0 +1,137 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { api } from "@cvx/_generated/api";
+import { Id } from "@cvx/_generated/dataModel";
+import { toast } from "sonner";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+export const Route = createFileRoute("/_app/_auth/admin/users")({
+  component: AdminUsers,
+});
+
+function AdminUsers() {
+  const queryClient = useQueryClient();
+
+  const { data: viewer, isLoading: viewerLoading } = useQuery(
+    convexQuery(api.app.getCurrentUser, {}),
+  );
+
+  const usersQuery = useQuery({
+    ...convexQuery(api.platformAdmins.list, {}),
+    enabled: Boolean(viewer?.isPlatformAdmin),
+  });
+
+  const setRoleMutation = useMutation({
+    mutationFn: useConvexMutation(api.platformAdmins.setRole),
+    onSuccess: () => {
+      toast.success("Role updated");
+      queryClient.invalidateQueries({ queryKey: ["convexQuery"] });
+    },
+    onError: (e: Error) => {
+      toast.error(e.message || "Failed to update role");
+    },
+  });
+
+  if (viewerLoading) {
+    return <div className="p-8 text-sm text-muted-foreground">Loading…</div>;
+  }
+
+  if (!viewer?.isPlatformAdmin) {
+    return (
+      <div className="mx-auto max-w-2xl p-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>403 — Platform admin required</CardTitle>
+            <CardDescription>
+              This page is only accessible to platform administrators.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Link to="/dashboard" className="text-sm underline">
+              Back to dashboard
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const users = usersQuery.data ?? [];
+
+  const handleToggle = (userId: Id<"users">, current: boolean) => {
+    setRoleMutation.mutate({ userId, isPlatformAdmin: !current });
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-8">
+      <div className="flex items-center justify-between">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight">Platform admin · Users</h1>
+          <p className="text-sm text-muted-foreground">
+            Toggle the platform-admin role. Cannot remove the last admin.
+          </p>
+        </div>
+        <Link to="/admin" className="text-sm underline">
+          ← Back
+        </Link>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>All users ({users.length})</CardTitle>
+          <CardDescription>
+            Platform admins (highlighted) can access /admin pages and configure
+            global settings.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0">
+          <div className="divide-y">
+            {usersQuery.isLoading && (
+              <div className="p-6 text-sm text-muted-foreground">Loading users…</div>
+            )}
+            {!usersQuery.isLoading && users.length === 0 && (
+              <div className="p-6 text-sm text-muted-foreground">No users found.</div>
+            )}
+            {users.map((u) => {
+              const isSelf = u._id === viewer._id;
+              return (
+                <div
+                  key={u._id}
+                  className="flex items-center justify-between gap-4 p-4"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate font-medium">
+                        {u.name || u.email || "(no name)"}
+                      </span>
+                      {u.isPlatformAdmin && (
+                        <Badge variant="default">Platform admin</Badge>
+                      )}
+                      {isSelf && <Badge variant="outline">You</Badge>}
+                    </div>
+                    {u.email && (
+                      <div className="truncate text-xs text-muted-foreground">
+                        {u.email}
+                      </div>
+                    )}
+                  </div>
+                  <Button
+                    size="sm"
+                    variant={u.isPlatformAdmin ? "outline" : "default"}
+                    disabled={setRoleMutation.isPending}
+                    onClick={() => handleToggle(u._id, u.isPlatformAdmin)}
+                  >
+                    {u.isPlatformAdmin ? "Revoke admin" : "Grant admin"}
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds UI to grant/revoke the platform-admin role.

## Backend (convex/platformAdmins.ts)

- list query (admin-only) — all users with isPlatformAdmin flag
- setRole mutation (admin-only) — refuses to remove the last admin so the system can't lock itself out

## UI

- /admin landing — two cards: Email config + Users
- /admin/users — list with grant/revoke buttons