### PR TITLE
feat(admin): pick email provider (env Resend / custom Resend / Mailgun)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -59,6 +59,7 @@ import type * as documents_seed from "../documents/seed.js";
 import type * as documents_signing from "../documents/signing.js";
 import type * as documents_templates from "../documents/templates.js";
 import type * as email_index from "../email/index.js";
+import type * as email_providers from "../email/providers.js";
 import type * as email_templates_invitationEmail from "../email/templates/invitationEmail.js";
 import type * as email_templates_subscriptionEmail from "../email/templates/subscriptionEmail.js";
 import type * as emailAccounts from "../emailAccounts.js";
@@ -276,6 +277,7 @@ declare const fullApi: ApiFromModules<{
   "documents/signing": typeof documents_signing;
   "documents/templates": typeof documents_templates;
   "email/index": typeof email_index;
+  "email/providers": typeof email_providers;
   "email/templates/invitationEmail": typeof email_templates_invitationEmail;
   "email/templates/subscriptionEmail": typeof email_templates_subscriptionEmail;
   emailAccounts: typeof emailAccounts;

--- a/convex/email/providers.ts
+++ b/convex/email/providers.ts
@@ -1,0 +1,82 @@
+// Multi-provider send dispatch for platform-level emails.
+//
+// Each helper takes the rendered email + per-provider credentials and POSTs
+// to the provider's API. Errors throw so the caller can log+swallow as it
+// sees fit (the invitations action does this already).
+//
+// Google/Microsoft are NOT implemented here — they require OAuth tokens
+// scoped to a specific mailbox, not API keys, and there's no platform-level
+// OAuth flow yet. Use Resend or Mailgun.
+
+export type ProviderEmail = {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+  from?: string;
+  replyTo?: string;
+};
+
+export async function sendViaResend(
+  email: ProviderEmail,
+  cfg: { apiKey: string },
+) {
+  if (!email.from) {
+    throw new Error("sendViaResend: from is required when using a custom Resend key");
+  }
+  const body = {
+    from: email.from,
+    to: email.to,
+    subject: email.subject,
+    html: email.html,
+    ...(email.text ? { text: email.text } : {}),
+    ...(email.replyTo ? { reply_to: email.replyTo } : {}),
+  };
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${cfg.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`Resend send failed (${res.status}): ${detail}`);
+  }
+}
+
+export async function sendViaMailgun(
+  email: ProviderEmail,
+  cfg: { apiKey: string; domain: string; region: "us" | "eu" },
+) {
+  if (!email.from) {
+    throw new Error("sendViaMailgun: from is required");
+  }
+  const base =
+    cfg.region === "eu"
+      ? "https://api.eu.mailgun.net/v3"
+      : "https://api.mailgun.net/v3";
+
+  const form = new URLSearchParams();
+  form.set("from", email.from);
+  form.set("to", email.to);
+  form.set("subject", email.subject);
+  form.set("html", email.html);
+  if (email.text) form.set("text", email.text);
+  if (email.replyTo) form.set("h:Reply-To", email.replyTo);
+
+  const auth = "Basic " + Buffer.from(`api:${cfg.apiKey}`).toString("base64");
+  const res = await fetch(`${base}/${encodeURIComponent(cfg.domain)}/messages`, {
+    method: "POST",
+    headers: {
+      Authorization: auth,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: form.toString(),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`Mailgun send failed (${res.status}): ${detail}`);
+  }
+}

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -9,7 +9,11 @@ import { orgRoleValidator } from "@cvx/schema";
 import { logActivity } from "./_helpers/activities";
 import { logAudit } from "./auditLog";
 import { createNotificationDirect } from "./notifications";
-import { sendInvitationEmail } from "./email/templates/invitationEmail";
+import {
+  sendInvitationEmail,
+  renderInvitationEmail,
+} from "./email/templates/invitationEmail";
+import { sendViaResend, sendViaMailgun } from "./email/providers";
 
 export const listPending = query({
   args: { organizationId: v.id("organizations") },
@@ -145,17 +149,84 @@ export const _sendInvitationEmail = internalAction({
       }),
       ctx.runQuery(internal.platformSettings._getInternal, {}),
     ]);
+
+    const fromName = platformSettings?.invitationFromName;
+    const fromEmail = platformSettings?.invitationFromEmail;
+    const replyTo = platformSettings?.invitationReplyToEmail;
+    const from =
+      fromName && fromEmail ? `${fromName} <${fromEmail}>` : fromEmail || undefined;
+
     try {
-      await sendInvitationEmail({
-        email: args.email,
-        orgName: ctxInfo.orgName,
-        inviterName: ctxInfo.inviterName,
-        role: args.role,
-        token: args.token,
-        fromName: platformSettings?.invitationFromName,
-        fromEmail: platformSettings?.invitationFromEmail,
-        replyTo: platformSettings?.invitationReplyToEmail,
-      });
+      const provider = platformSettings?.provider;
+      // Resend with admin-provided API key (overrides env)
+      if (provider === "resend" && platformSettings?.resendApiKey) {
+        if (!from) {
+          throw new Error(
+            "Provider 'resend' requires invitationFromEmail to be set in /admin/email-config",
+          );
+        }
+        const html = renderInvitationEmail({
+          email: args.email,
+          orgName: ctxInfo.orgName,
+          inviterName: ctxInfo.inviterName,
+          role: args.role,
+          token: args.token,
+        });
+        await sendViaResend(
+          {
+            to: args.email,
+            subject: `You've been invited to join ${ctxInfo.orgName}`,
+            html,
+            from,
+            replyTo,
+          },
+          { apiKey: platformSettings.resendApiKey },
+        );
+      } else if (
+        provider === "mailgun" &&
+        platformSettings?.mailgunApiKey &&
+        platformSettings?.mailgunDomain
+      ) {
+        if (!from) {
+          throw new Error(
+            "Provider 'mailgun' requires invitationFromEmail to be set in /admin/email-config",
+          );
+        }
+        const html = renderInvitationEmail({
+          email: args.email,
+          orgName: ctxInfo.orgName,
+          inviterName: ctxInfo.inviterName,
+          role: args.role,
+          token: args.token,
+        });
+        await sendViaMailgun(
+          {
+            to: args.email,
+            subject: `You've been invited to join ${ctxInfo.orgName}`,
+            html,
+            from,
+            replyTo,
+          },
+          {
+            apiKey: platformSettings.mailgunApiKey,
+            domain: platformSettings.mailgunDomain,
+            region: platformSettings.mailgunRegion ?? "us",
+          },
+        );
+      } else {
+        // Fallback: env-based Resend (AUTH_RESEND_KEY + AUTH_EMAIL) — same
+        // behavior as before any platform provider was configured.
+        await sendInvitationEmail({
+          email: args.email,
+          orgName: ctxInfo.orgName,
+          inviterName: ctxInfo.inviterName,
+          role: args.role,
+          token: args.token,
+          fromName,
+          fromEmail,
+          replyTo,
+        });
+      }
     } catch (e) {
       console.error(
         `[invitations._sendInvitationEmail] failed for ${args.email} (invitation ${args.invitationId}):`,

--- a/convex/platformSettings.ts
+++ b/convex/platformSettings.ts
@@ -8,14 +8,20 @@ import {
 import { requirePlatformAdmin } from "./_helpers/auth";
 
 // Get the current platform settings (singleton). Returns null if not yet
-// configured. Reading is allowed for any authenticated context — the
-// invitation-send action needs the From overrides at runtime — so we don't
-// guard this with requirePlatformAdmin. There are no secrets in the row.
+// configured. Reading is allowed for any authenticated context but API key
+// values are masked — only `hasResendApiKey` / `hasMailgunApiKey` booleans
+// are returned. The internal variant below returns full row for server use.
 export const get = query({
   args: {},
   handler: async (ctx) => {
     const row = await ctx.db.query("platformSettings").first();
-    return row ?? null;
+    if (!row) return null;
+    const { resendApiKey, mailgunApiKey, ...safe } = row;
+    return {
+      ...safe,
+      hasResendApiKey: Boolean(resendApiKey),
+      hasMailgunApiKey: Boolean(mailgunApiKey),
+    };
   },
 });
 
@@ -31,35 +37,56 @@ export const _getInternal = internalQuery({
 });
 
 // Upsert the singleton settings row. Platform admin only.
-// The frontend admin form (PR #295+) sends the full set of fields each save;
+// The frontend admin form sends the full set of fields each save;
 // undefined keys clear the override and fall back to env-based defaults.
 export const set = mutation({
   args: {
     invitationFromName: v.optional(v.string()),
     invitationFromEmail: v.optional(v.string()),
     invitationReplyToEmail: v.optional(v.string()),
+    provider: v.optional(
+      v.union(v.literal("resend"), v.literal("mailgun")),
+    ),
+    resendApiKey: v.optional(v.string()),
+    mailgunApiKey: v.optional(v.string()),
+    mailgunDomain: v.optional(v.string()),
+    mailgunRegion: v.optional(
+      v.union(v.literal("us"), v.literal("eu")),
+    ),
   },
   handler: async (ctx, args) => {
     const user = await requirePlatformAdmin(ctx);
     const existing = await ctx.db.query("platformSettings").first();
     const now = Date.now();
-    if (existing) {
-      await ctx.db.patch(existing._id, {
-        invitationFromName: args.invitationFromName,
-        invitationFromEmail: args.invitationFromEmail,
-        invitationReplyToEmail: args.invitationReplyToEmail,
-        updatedAt: now,
-        updatedBy: user._id,
-      });
-      return existing._id;
-    }
-    return await ctx.db.insert("platformSettings", {
+    // API key fields: undefined in args = "don't touch" (preserve existing);
+    // explicit empty string from the form is treated the same as undefined
+    // (no accidental clearing). To clear a key, use the dedicated future
+    // "Remove key" button (out of scope here).
+    const resendApiKey =
+      args.resendApiKey && args.resendApiKey.length > 0
+        ? args.resendApiKey
+        : existing?.resendApiKey;
+    const mailgunApiKey =
+      args.mailgunApiKey && args.mailgunApiKey.length > 0
+        ? args.mailgunApiKey
+        : existing?.mailgunApiKey;
+    const payload = {
       invitationFromName: args.invitationFromName,
       invitationFromEmail: args.invitationFromEmail,
       invitationReplyToEmail: args.invitationReplyToEmail,
+      provider: args.provider,
+      resendApiKey,
+      mailgunApiKey,
+      mailgunDomain: args.mailgunDomain,
+      mailgunRegion: args.mailgunRegion,
       updatedAt: now,
       updatedBy: user._id,
-    });
+    };
+    if (existing) {
+      await ctx.db.patch(existing._id, payload);
+      return existing._id;
+    }
+    return await ctx.db.insert("platformSettings", payload);
   },
 });
 

--- a/convex/schema/platform.ts
+++ b/convex/schema/platform.ts
@@ -272,10 +272,27 @@ export function createPlatformTables({
   // Used for things like the From name/email used on platform-sent emails
   // (invitations, password resets, etc.) so they represent Quera (the
   // platform) rather than any individual tenant gabinet.
+  //
+  // Provider:
+  //   When `provider` is unset the platform falls back to env-based Resend
+  //   (AUTH_RESEND_KEY / AUTH_EMAIL). When set, sends go through the chosen
+  //   provider using the corresponding credential fields below.
+  //   Google/Microsoft are intentionally not supported here yet — they need
+  //   an OAuth flow that doesn't exist for platform-scope credentials.
   platformSettings: defineTable({
     invitationFromName: v.optional(v.string()),
     invitationFromEmail: v.optional(v.string()),
     invitationReplyToEmail: v.optional(v.string()),
+    // Provider selection (optional — unset = env Resend fallback)
+    provider: v.optional(
+      v.union(v.literal("resend"), v.literal("mailgun")),
+    ),
+    resendApiKey: v.optional(v.string()),
+    mailgunApiKey: v.optional(v.string()),
+    mailgunDomain: v.optional(v.string()),
+    mailgunRegion: v.optional(
+      v.union(v.literal("us"), v.literal("eu")),
+    ),
     updatedAt: v.number(),
     updatedBy: v.optional(v.id("users")),
   }),

--- a/src/routes/_app/_auth/admin.email-config.tsx
+++ b/src/routes/_app/_auth/admin.email-config.tsx
@@ -9,10 +9,19 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 export const Route = createFileRoute("/_app/_auth/admin/email-config")({
   component: AdminEmailConfig,
 });
+
+type ProviderChoice = "env" | "resend" | "mailgun";
 
 function AdminEmailConfig() {
   const { data: user, isLoading: userLoading } = useQuery(
@@ -25,13 +34,24 @@ function AdminEmailConfig() {
   const [fromName, setFromName] = useState("");
   const [fromEmail, setFromEmail] = useState("");
   const [replyTo, setReplyTo] = useState("");
+  const [provider, setProvider] = useState<ProviderChoice>("env");
+  const [resendApiKey, setResendApiKey] = useState("");
+  const [mailgunApiKey, setMailgunApiKey] = useState("");
+  const [mailgunDomain, setMailgunDomain] = useState("");
+  const [mailgunRegion, setMailgunRegion] = useState<"us" | "eu">("us");
 
-  // Sync local form state when settings load / change
   useEffect(() => {
     if (settings) {
       setFromName(settings.invitationFromName ?? "");
       setFromEmail(settings.invitationFromEmail ?? "");
       setReplyTo(settings.invitationReplyToEmail ?? "");
+      setProvider(settings.provider ?? "env");
+      setMailgunDomain(settings.mailgunDomain ?? "");
+      setMailgunRegion(settings.mailgunRegion ?? "us");
+      // Never prefill the API key inputs — they're masked. User leaves blank
+      // to keep existing, or types a new value to replace.
+      setResendApiKey("");
+      setMailgunApiKey("");
     }
   }, [settings]);
 
@@ -75,67 +95,176 @@ function AdminEmailConfig() {
       invitationFromName: fromName.trim() || undefined,
       invitationFromEmail: fromEmail.trim() || undefined,
       invitationReplyToEmail: replyTo.trim() || undefined,
+      provider: provider === "env" ? undefined : provider,
+      resendApiKey: resendApiKey.trim() || undefined,
+      mailgunApiKey: mailgunApiKey.trim() || undefined,
+      mailgunDomain: mailgunDomain.trim() || undefined,
+      mailgunRegion: provider === "mailgun" ? mailgunRegion : undefined,
     });
   };
 
+  const disabled = settingsLoading || saveMutation.isPending;
+
   return (
     <div className="mx-auto max-w-3xl space-y-6 p-8">
-      <div className="space-y-1">
-        <h1 className="text-2xl font-semibold tracking-tight">Platform admin · Email</h1>
-        <p className="text-sm text-muted-foreground">
-          Global email configuration used by platform-level messages (invitations,
-          password resets) — separate from per-gabinet mail providers.
-        </p>
+      <div className="flex items-center justify-between">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Platform admin · Email
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Global email configuration used by platform-level messages
+            (invitations, password resets) — separate from per-gabinet mail
+            providers.
+          </p>
+        </div>
+        <Link to="/admin" className="text-sm underline">
+          ← Back
+        </Link>
       </div>
 
       <Card>
         <CardHeader>
-          <CardTitle>Invitation email</CardTitle>
+          <CardTitle>Provider</CardTitle>
           <CardDescription>
-            From and reply-to addresses on team-invite emails. Leave blank to fall
-            back to the <code>AUTH_EMAIL</code> environment value.
+            Where the platform sends from. Leave on "Default" to use the
+            <code className="mx-1">AUTH_RESEND_KEY</code> environment variable
+            (no admin config needed). Pick Resend or Mailgun to override with
+            your own API key.
           </CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSave} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="fromName">From name</Label>
-              <Input
-                id="fromName"
-                placeholder="Quera"
-                value={fromName}
-                onChange={(e) => setFromName(e.target.value)}
-                disabled={settingsLoading || saveMutation.isPending}
-              />
+              <Label htmlFor="provider">Provider</Label>
+              <Select
+                value={provider}
+                onValueChange={(v) => setProvider(v as ProviderChoice)}
+                disabled={disabled}
+              >
+                <SelectTrigger id="provider">
+                  <SelectValue placeholder="Choose provider" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="env">Default (env Resend)</SelectItem>
+                  <SelectItem value="resend">Resend (custom API key)</SelectItem>
+                  <SelectItem value="mailgun">Mailgun</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="fromEmail">From email</Label>
-              <Input
-                id="fromEmail"
-                type="email"
-                placeholder="noreply@quera.helloalex.pl"
-                value={fromEmail}
-                onChange={(e) => setFromEmail(e.target.value)}
-                disabled={settingsLoading || saveMutation.isPending}
-              />
-              <p className="text-xs text-muted-foreground">
-                Both name and email must be set together for the override to
-                apply.
-              </p>
+
+            {provider === "resend" && (
+              <div className="space-y-2 rounded-md border border-dashed p-4">
+                <Label htmlFor="resendApiKey">Resend API key</Label>
+                <Input
+                  id="resendApiKey"
+                  type="password"
+                  autoComplete="off"
+                  placeholder={
+                    settings?.hasResendApiKey
+                      ? "•••••••• (leave blank to keep existing)"
+                      : "re_..."
+                  }
+                  value={resendApiKey}
+                  onChange={(e) => setResendApiKey(e.target.value)}
+                  disabled={disabled}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Used only for platform-level sends. Per-gabinet mail providers
+                  are not affected.
+                </p>
+              </div>
+            )}
+
+            {provider === "mailgun" && (
+              <div className="space-y-3 rounded-md border border-dashed p-4">
+                <div className="space-y-2">
+                  <Label htmlFor="mailgunApiKey">Mailgun API key</Label>
+                  <Input
+                    id="mailgunApiKey"
+                    type="password"
+                    autoComplete="off"
+                    placeholder={
+                      settings?.hasMailgunApiKey
+                        ? "•••••••• (leave blank to keep existing)"
+                        : "key-..."
+                    }
+                    value={mailgunApiKey}
+                    onChange={(e) => setMailgunApiKey(e.target.value)}
+                    disabled={disabled}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="mailgunDomain">Domain</Label>
+                  <Input
+                    id="mailgunDomain"
+                    placeholder="mg.helloalex.pl"
+                    value={mailgunDomain}
+                    onChange={(e) => setMailgunDomain(e.target.value)}
+                    disabled={disabled}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="mailgunRegion">Region</Label>
+                  <Select
+                    value={mailgunRegion}
+                    onValueChange={(v) => setMailgunRegion(v as "us" | "eu")}
+                    disabled={disabled}
+                  >
+                    <SelectTrigger id="mailgunRegion">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="us">US (api.mailgun.net)</SelectItem>
+                      <SelectItem value="eu">EU (api.eu.mailgun.net)</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            )}
+
+            <div className="border-t pt-4 space-y-4">
+              <h3 className="text-sm font-medium">Invitation email From</h3>
+              <div className="space-y-2">
+                <Label htmlFor="fromName">From name</Label>
+                <Input
+                  id="fromName"
+                  placeholder="Quera"
+                  value={fromName}
+                  onChange={(e) => setFromName(e.target.value)}
+                  disabled={disabled}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="fromEmail">From email</Label>
+                <Input
+                  id="fromEmail"
+                  type="email"
+                  placeholder="noreply@quera.helloalex.pl"
+                  value={fromEmail}
+                  onChange={(e) => setFromEmail(e.target.value)}
+                  disabled={disabled}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Required when using Resend (custom key) or Mailgun. With
+                  Default env Resend, falls back to <code>AUTH_EMAIL</code>.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="replyTo">Reply-to (optional)</Label>
+                <Input
+                  id="replyTo"
+                  type="email"
+                  placeholder="support@quera.helloalex.pl"
+                  value={replyTo}
+                  onChange={(e) => setReplyTo(e.target.value)}
+                  disabled={disabled}
+                />
+              </div>
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="replyTo">Reply-to (optional)</Label>
-              <Input
-                id="replyTo"
-                type="email"
-                placeholder="support@quera.helloalex.pl"
-                value={replyTo}
-                onChange={(e) => setReplyTo(e.target.value)}
-                disabled={settingsLoading || saveMutation.isPending}
-              />
-            </div>
+
             <div className="flex items-center gap-3 pt-2">
-              <Button type="submit" disabled={saveMutation.isPending}>
+              <Button type="submit" disabled={disabled}>
                 {saveMutation.isPending ? "Saving…" : "Save"}
               </Button>
               {settings?.updatedAt && (


### PR DESCRIPTION
Extends /admin/email-config so the platform admin can pick which provider sends platform emails, not just override the From address.

## Backend

- platformSettings gains: provider, resendApiKey, mailgunApiKey, mailgunDomain, mailgunRegion
- New convex/email/providers.ts — sendViaResend + sendViaMailgun (raw POST to api.resend.com / api.mailgun.net)
- _sendInvitationEmail dispatches: custom Resend / Mailgun / env Resend (default)
- API keys masked on read (get returns hasResendApiKey / hasMailgunApiKey booleans); set preserves existing key if blank

## UI

- Provider dropdown — Default (env Resend) / Resend custom / Mailgun
- Conditional credential fields per provider
- Mailgun region selector (US / EU)
- Password inputs for keys, never prefilled, 'leave blank to keep' placeholder

## Not in scope

Google/Microsoft providers — they need OAuth flow per mailbox, not API keys. Follow-up.