### PR TITLE
Show tag pills on appointment cards in the calendar

### DIFF
--- a/src/components/gabinet/calendar/appointment-card.tsx
+++ b/src/components/gabinet/calendar/appointment-card.tsx
@@ -1,3 +1,8 @@
+export interface AppointmentTag {
+  name: string;
+  color: string;
+}
+
 interface AppointmentCardProps {
   startTime: string;
   endTime: string;
@@ -5,6 +10,7 @@ interface AppointmentCardProps {
   treatmentName: string;
   status: string;
   color?: string;
+  tags?: AppointmentTag[];
   onClick?: () => void;
 }
 
@@ -24,6 +30,7 @@ export function AppointmentCard({
   treatmentName,
   status,
   color,
+  tags,
   onClick,
 }: AppointmentCardProps) {
   const cls = STATUS_COLORS[status] ?? STATUS_COLORS.scheduled;
@@ -34,7 +41,21 @@ export function AppointmentCard({
       className={`w-full h-full overflow-hidden rounded border-l-4 px-2 py-1 text-left text-xs transition-opacity hover:opacity-80 ${cls}`}
       style={color ? { borderLeftColor: color } : undefined}
     >
-      <div className="font-medium truncate">{patientName}</div>
+      <div className="flex items-start justify-between gap-1">
+        <div className="font-medium truncate flex-1">{patientName}</div>
+        {tags && tags.length > 0 && (
+          <div className="flex shrink-0 items-center gap-0.5 pt-0.5">
+            {tags.map((tag, i) => (
+              <span
+                key={`${tag.name}-${i}`}
+                title={tag.name}
+                className="inline-block h-1.5 w-1.5 rounded-full ring-1 ring-white/60"
+                style={{ backgroundColor: tag.color }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
       <div className="truncate opacity-75">{treatmentName}</div>
       <div className="opacity-60">{startTime}–{endTime}</div>
     </button>

--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -11,6 +11,7 @@ interface Appointment {
   treatmentName: string;
   status: string;
   color?: string;
+  tags?: Array<{ name: string; color: string }>;
 }
 
 interface CalendarDayViewProps {

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -13,6 +13,7 @@ interface Appointment {
   treatmentName: string;
   status: string;
   color?: string;
+  tags?: Array<{ name: string; color: string }>;
 }
 
 interface CalendarWeekViewProps {

--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -1,5 +1,5 @@
 import { useDraggable } from "@dnd-kit/core";
-import { AppointmentCard } from "./appointment-card";
+import { AppointmentCard, type AppointmentTag } from "./appointment-card";
 
 interface Appointment {
   _id: string;
@@ -10,6 +10,7 @@ interface Appointment {
   treatmentName: string;
   status: string;
   color?: string;
+  tags?: AppointmentTag[];
 }
 
 interface DraggableAppointmentProps extends Appointment {
@@ -25,6 +26,7 @@ export function DraggableAppointment({
   treatmentName,
   status,
   color,
+  tags,
   onAppointmentClick,
 }: DraggableAppointmentProps) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
@@ -53,6 +55,7 @@ export function DraggableAppointment({
         treatmentName={treatmentName}
         status={status}
         color={color}
+        tags={tags}
         onClick={() => onAppointmentClick?.(_id)}
       />
     </div>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -50,6 +50,7 @@ import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-t
 import { useSupabaseGabinetEmployeeSchedulesList } from "@/hooks/use-supabase-gabinet-employee-schedules";
 import { useSupabaseGabinetWorkingHoursList } from "@/hooks/use-supabase-gabinet-working-hours";
 import { useSupabaseScheduledActivitiesByDateRange } from "@/hooks/use-supabase-scheduled-activities";
+import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 
 export const Route = createLazyFileRoute(
@@ -116,6 +117,7 @@ function GabinetCalendarPage() {
     treatmentName: string;
     status: string;
     color?: string;
+    tags?: Array<{ name: string; color: string }>;
   } | null>(null);
 
   // Mutations
@@ -240,6 +242,21 @@ function GabinetCalendarPage() {
     return map;
   }, [treatments]);
 
+  // Fetch tag definitions to render colored pills on appointment cards
+  const { tags: tagDefinitions } = useTagDefinitions(organizationId);
+  const tagMap = useMemo(() => {
+    const map = new Map<string, { name: string; color: string }>();
+    for (const tag of tagDefinitions ?? []) {
+      if (tag?._id) {
+        map.set(String(tag._id), {
+          name: String(tag.name ?? ""),
+          color: String(tag.color ?? "#9ca3af"),
+        });
+      }
+    }
+    return map;
+  }, [tagDefinitions]);
+
   const userMap = useMemo(() => {
     const map = new Map<string, string>();
     members?.forEach((m) => {
@@ -313,6 +330,7 @@ function GabinetCalendarPage() {
       treatmentName: string;
       status: string;
       color?: string;
+      tags?: Array<{ name: string; color: string }>;
     }> = [];
 
     if (rawAppointments) {
@@ -326,6 +344,9 @@ function GabinetCalendarPage() {
           if (!name.toLowerCase().includes(searchLower)) continue;
         }
         const treatment = treatmentMap.get(a.treatmentId as string);
+        const tags = a.tagIds
+          ?.map((id) => tagMap.get(String(id)))
+          .filter((t): t is { name: string; color: string } => !!t);
         items.push({
           _id: a._id,
           date: a.date,
@@ -335,6 +356,7 @@ function GabinetCalendarPage() {
           treatmentName: treatment?.name ?? "",
           status: a.status,
           color: a.color ?? treatment?.color,
+          tags: tags && tags.length > 0 ? tags : undefined,
         });
       }
     }
@@ -370,7 +392,7 @@ function GabinetCalendarPage() {
     }
 
     return items;
-  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
+  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, tagMap, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
 
   // Build print-friendly appointment data for the current day
   const printDate = formatDateStr(currentDate);
@@ -873,6 +895,7 @@ function GabinetCalendarPage() {
               treatmentName={activeAppointment.treatmentName}
               status={activeAppointment.status}
               color={activeAppointment.color}
+              tags={activeAppointment.tags}
             />
           </div>
         ) : null}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #302.

Closes #302

---

## Claude summary

Committed.

Summary: appointment cards in the day and week calendar views now render small colored dots (one per tag) on the right side of the patient-name row, with each tag's name shown as a tooltip on hover. The lazy calendar route fetches `tagDefinitions`, builds an id→{name,color} map, and resolves each appointment's `tagIds` into a `tags` array before passing them down through `DraggableAppointment` to `AppointmentCard`. Month view (which only shows a per-day count) was left as-is since there is no per-appointment card to attach dots to. Typecheck passes on the changed files; the remaining errors from `tsc` are pre-existing in unrelated files.