### PR TITLE
Remove unrelated stale `appointmentId` typing noise

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1208,7 +1208,7 @@ export const create = action({
 export const update = action({
   args: {
     organizationId: v.id("organizations"),
-    appointmentId: v.string(),
+    appointmentId: v.id("gabinetAppointments"),
     date: v.optional(v.string()),
     startTime: v.optional(v.string()),
     endTime: v.optional(v.string()),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #304.

Closes #304

---

## Claude summary

Changed `appointmentId: v.string()` to `appointmentId: v.id("gabinetAppointments")` on `gabinet.appointments.update` (convex/gabinet/appointments.ts:1211). All four frontend callers already pass `Id<"gabinetAppointments">`, and downstream uses (Supabase `db.get`/`db.patch`, `_updateSideEffects`, conflict check) accept string and remain compatible since `Id<T>` is a branded string. Convex typecheck on the changed file passes; the unrelated pre-existing TS errors in the repo are identical before and after the patch.