### PR TITLE
hamburger 2

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -54,7 +54,7 @@ import { useTree } from "@headless-tree/react";
 import {
   Plus,
   FileText,
-  MoreHorizontal,
+  Menu,
   Pencil,
   Trash2,
   CopyIcon,
@@ -357,7 +357,7 @@ function TemplateTree({
                           className="h-6 w-6 opacity-0 group-hover/folder:opacity-100 transition-opacity shrink-0"
                           onClick={(e) => e.stopPropagation()}
                         >
-                          <MoreHorizontal className="h-3.5 w-3.5" />
+                          <Menu className="h-3.5 w-3.5" />
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
@@ -446,7 +446,7 @@ function TemplateTree({
                       className="h-7 w-7 shrink-0 opacity-0 group-hover/tpl:opacity-100 transition-opacity"
                       onClick={(e) => e.stopPropagation()}
                     >
-                      <MoreHorizontal className="h-3.5 w-3.5" />
+                      <Menu className="h-3.5 w-3.5" />
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #295.

Closes #295

---

## Claude summary

Committed. Swapped both `MoreHorizontal` icon usages (folder dropdown trigger and template dropdown trigger) for `Menu` on `_layout.settings.form-templates.index.tsx`, matching the previous hamburger fix from #292/#293. The `Menu` icon was already wired up in `src/lib/ez-icons/` by that prior PR, so this was a 3-line change.

Note: typecheck not run — no `node_modules` in this worktree, same situation as #292.