### PR TITLE
hamburger 2

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -54,7 +54,7 @@ import { useTree } from "@headless-tree/react";
 import {
   Plus,
   FileText,
-  MoreHorizontal,
+  Menu,
   Pencil,
   Trash2,
   CopyIcon,
@@ -357,7 +357,7 @@ function TemplateTree({
                           className="h-6 w-6 opacity-0 group-hover/folder:opacity-100 transition-opacity shrink-0"
                           onClick={(e) => e.stopPropagation()}
                         >
-                          <MoreHorizontal className="h-3.5 w-3.5" />
+                          <Menu className="h-3.5 w-3.5" />
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
@@ -446,7 +446,7 @@ function TemplateTree({
                       className="h-7 w-7 shrink-0 opacity-0 group-hover/tpl:opacity-100 transition-opacity"
                       onClick={(e) => e.stopPropagation()}
                     >
-                      <MoreHorizontal className="h-3.5 w-3.5" />
+                      <Menu className="h-3.5 w-3.5" />
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #295.

Closes #295

---

## Claude summary

Committed b7a3ba1. Swapped both `MoreHorizontal` dropdown-trigger icons on `_layout.settings.form-templates.index.tsx` (folder menu line 361, template menu line 450) to the hamburger `Menu` icon, and wired `Menu` up in `src/lib/ez-icons/` (mapped to hugeicons `menu-01`) since it wasn't exported in this branch — despite the prior PR comment on the issue claiming it was.

Typecheck not run: no `node_modules` in this worktree, same situation as #292/#293.

Note: the local branch is `claude/issue-19` (not `claude/issue-295`) per the worktree's existing checkout — the commit subject references #295 to keep traceability to the issue.