### PR TITLE
Dodaj status Wizyta zakończona @claude

### DIFF
--- a/convex/gabinet/_e2eTest.ts
+++ b/convex/gabinet/_e2eTest.ts
@@ -226,7 +226,7 @@ export const runAll = internalMutation({
     // ============================================================
     const VALID_TRANSITIONS: Record<string, string[]> = {
       scheduled: ["confirmed", "cancelled", "no_show"],
-      confirmed: ["in_progress", "cancelled", "no_show"],
+      confirmed: ["in_progress", "completed", "cancelled", "no_show"],
       in_progress: ["completed", "cancelled"],
       completed: [],
       cancelled: [],

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -45,7 +45,7 @@ import { checkDocumentGate } from "./_helpers/documentGate";
 const VALID_TRANSITIONS: Record<string, string[]> = {
   pending_confirmation: ["scheduled", "confirmed", "cancelled"],
   scheduled: ["confirmed", "cancelled", "no_show"],
-  confirmed: ["in_progress", "cancelled", "no_show"],
+  confirmed: ["in_progress", "completed", "cancelled", "no_show"],
   in_progress: ["completed", "cancelled"],
   completed: [],
   cancelled: [],

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -122,7 +122,7 @@ const statusColors: Record<
 const VALID_TRANSITIONS: Record<string, string[]> = {
   pending_confirmation: ["scheduled", "confirmed", "cancelled"],
   scheduled: ["confirmed", "cancelled", "no_show"],
-  confirmed: ["in_progress", "cancelled", "no_show"],
+  confirmed: ["in_progress", "completed", "cancelled", "no_show"],
   in_progress: ["completed", "cancelled"],
   completed: [],
   cancelled: [],


### PR DESCRIPTION
Auto-generated by Claude in response to issue #66.

Closes #66

---

## Claude summary

Committed.

## Summary

The appointment status state machine previously required passing through `in_progress` before reaching `completed`. From the screenshot (appointment in `Potwierdzona` / confirmed), the user could only pick `W trakcie`, `Anulowana`, or `Nieobecność` — there was no direct way to mark the visit as finished.

The fix adds `"completed"` to `confirmed`'s allowed transitions in all three places that mirror the state machine: the frontend dropdown (`_layout.gabinet.appointments.$appointmentId.lazy.tsx:125`), the Convex mutation guards used by both `appointments.update` and `appointments.updateStatus` (`convex/gabinet/appointments.ts:48`), and the e2e self-test transition table (`convex/gabinet/_e2eTest.ts:229`). Existing side effects already handle the `completed` target (auto-generation of after-completion documents, scheduledActivity sync, activity log/audit entries), so no additional wiring was needed. The `"Zakończona"` translation key already exists in `public/locales/pl/translation.json`.

Note: the "before_start" document gate, which today only triggers on the `in_progress` transition, will not run when skipping straight from `confirmed` to `completed`. That matches the system's existing comment that there is no gate on completion, but it's worth flagging if the product expects pre-visit consent forms to be enforced before a visit can be closed.