### PR TITLE
odświeżanie

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -1,10 +1,11 @@
 import { useState, useMemo, useCallback, useEffect } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction, useConvex } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { UntitledAlert } from "@/components/ui/untitled-alert";
 import { format } from "date-fns";
 import { pl } from "date-fns/locale";
@@ -116,6 +117,7 @@ export function AppointmentDialog({
   const createAppointment = useAction(api.gabinet.appointments.create);
   const findNextSlotAction = useAction(api.gabinet.scheduling.findNextAvailableSlot);
   const convex = useConvex();
+  const queryClient = useQueryClient();
 
   // -------------------------------------------------------------------------
   // Data queries
@@ -459,6 +461,12 @@ export function AppointmentDialog({
         locationId: locationId ? (locationId as Id<"gabinetLocations">) : undefined,
         roomId: roomId ? (roomId as Id<"gabinetRooms">) : undefined,
       });
+      // Refresh the calendar immediately — Convex actions don't invalidate
+      // the Supabase React Query cache automatically.
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetAppointments.all }),
+        queryClient.invalidateQueries({ queryKey: supabaseKeys.scheduledActivities.all }),
+      ]);
       toast.success(t("gabinet.appointments.created"));
       onOpenChange(false);
     } catch (e: unknown) {
@@ -481,7 +489,10 @@ export function AppointmentDialog({
     isRecurring,
     frequency,
     recurringCount,
+    locationId,
+    roomId,
     onOpenChange,
+    queryClient,
     t,
   ]);
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #312.

Closes #312

---

## Claude summary

Fixed. The calendar reads appointments from Supabase via React Query, but the new-appointment dialog's `handleSubmit` only invoked the Convex `createAppointment` action without invalidating the Supabase cache — so the newly created appointment stayed hidden until the user reloaded the page. I added `useQueryClient` to the dialog and now invalidate both `supabaseKeys.gabinetAppointments.all` and `supabaseKeys.scheduledActivities.all` immediately after the create succeeds. The drag-reschedule handler at `_layout.gabinet.calendar.index.lazy.tsx:541` already does the same thing for `gabinetAppointments`, so this matches the existing pattern.

## Follow-ups
- Invalidate Supabase caches in global quick-create flows in `src/routes/_app/_auth/dashboard/_layout.tsx`: all 13 entity create handlers (contact, company, lead, patient, appointment, treatment, package, employee, activity, leave, invitation, product, call) call Convex actions without `queryClient.invalidateQueries`, so any list view backed by Supabase React Query stays stale after a global create until reload
- Invalidate `gabinetAppointments` cache after edits/cancels/status changes too: audit `appointments.update`, `cancel`, `complete`, etc. call sites for the same missing Supabase invalidation pattern this PR fixes for `create`