### PR TITLE
Invalidate `gabinetAppointments` cache after edits/cancels/status changes too

### DIFF
--- a/src/components/gabinet/change-employee-modal.tsx
+++ b/src/components/gabinet/change-employee-modal.tsx
@@ -1,8 +1,9 @@
 import { useState, useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { useTranslation } from "react-i18next";
 import { format } from "date-fns";
 import { pl } from "date-fns/locale";
@@ -132,6 +133,7 @@ export function ChangeEmployeeModal({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const updateAppointment = useAction(api.gabinet.appointments.update);
+  const queryClient = useQueryClient();
 
   // Fetch all active employees
   const listEmployeesAction = useAction(api.gabinet.employees.listAll);
@@ -256,6 +258,11 @@ export function ChangeEmployeeModal({
           ),
         );
       }
+      // Refresh Supabase-backed appointment lists (calendar, dashboards).
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetAppointments.all }),
+        queryClient.invalidateQueries({ queryKey: supabaseKeys.scheduledActivities.all }),
+      ]);
       onOpenChange(false);
       setSelectedId(null);
       setUseNewSlot(false);

--- a/src/routes/_app/_auth/dashboard/_layout.calendar.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calendar.tsx
@@ -1,11 +1,12 @@
 import { createFileRoute, useSearch } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useWideContent } from "@/hooks/use-wide-content";
 import { useAction } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { usePermission } from "@/hooks/use-permission";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
 import {
   useSupabaseScheduledActivitiesByDateRange,
   type CalendarScheduledActivity,
@@ -269,6 +270,7 @@ function UnifiedCalendarPage() {
   const updateAppointment = useAction(
     api.gabinet.appointments.update
   );
+  const queryClient = useQueryClient();
 
   // Navigation
   const navigate = useCallback(
@@ -355,12 +357,19 @@ function UnifiedCalendarPage() {
           });
         }
 
+        // Refresh Supabase-backed reads — Convex actions don't invalidate
+        // the React Query cache automatically.
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: supabaseKeys.scheduledActivities.all }),
+          queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetAppointments.all }),
+        ]);
+
         toast.success(t("calendar.eventMoved", "Event moved"));
       } catch (err: any) {
         toast.error(err.message ?? t("calendar.moveFailed", "Failed to move event"));
       }
     },
-    [editPerm.allowed, events, organizationId, updateActivity, updateAppointment, t]
+    [editPerm.allowed, events, organizationId, updateActivity, updateAppointment, queryClient, t]
   );
 
   return (

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from "react";
 import { createLazyFileRoute, useNavigate } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
 import { Button } from "@/components/ui/button";
 import {
@@ -363,6 +364,17 @@ function AppointmentDetail() {
   const updateStatus = useAction(api.gabinet.appointments.updateStatus);
   const updateAppointment = useAction(api.gabinet.appointments.update);
   const trackView = useAction(api.recentlyViewed.track);
+  const queryClient = useQueryClient();
+
+  // Refresh the Supabase-backed appointment lists (calendar, dashboards, etc.)
+  // after a Convex action mutates the appointment — Convex actions do not
+  // automatically invalidate the React Query cache for Supabase reads.
+  const invalidateAppointmentCaches = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetAppointments.all }),
+      queryClient.invalidateQueries({ queryKey: supabaseKeys.scheduledActivities.all }),
+    ]);
+  };
 
   // Payment actions (Supabase-primary)
   const createPayment = useAction(api.payments.create);
@@ -469,6 +481,7 @@ function AppointmentDetail() {
         appointmentId: detail.appointment._id,
         tagIds: newTagIds,
       });
+      await invalidateAppointmentCaches();
       refetch();
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : t("common.error");
@@ -757,6 +770,7 @@ function AppointmentDetail() {
         status: newStatus as "scheduled" | "confirmed" | "in_progress" | "completed" | "cancelled" | "no_show" | "pending_confirmation",
       });
       toast.success(t("gabinet.appointments.statusUpdated"));
+      await invalidateAppointmentCaches();
       refetch();
 
       // When completing: the backend auto-generates after_completion docs.
@@ -809,6 +823,7 @@ function AppointmentDetail() {
       toast.success(t("gabinet.appointments.cancelled"));
       setCancelDialogOpen(false);
       setCancelReason("");
+      await invalidateAppointmentCaches();
       refetch();
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : t("common.error");


### PR DESCRIPTION
Auto-generated by Claude in response to issue #316.

Closes #316

---

## Claude summary

Committed as `0461f88`. Summary of what changed:

In `src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx`, added an `invalidateAppointmentCaches` helper that invalidates both `supabaseKeys.gabinetAppointments.all` and `supabaseKeys.scheduledActivities.all`, and wired it into the tag change, status change, and cancel-confirm handlers (the latter two being the actual `updateStatus`/cancel-via-`update` call sites the issue calls out, plus tag change which is an edit that affects the calendar pills).

In `src/components/gabinet/change-employee-modal.tsx`, added invalidation after the `updateAppointment` call so swapping an employee or rebooking refreshes the calendar.

In `src/routes/_app/_auth/dashboard/_layout.calendar.tsx`, added the same invalidation to the unified calendar drag-reschedule handler, which calls `scheduledActivities.update` and (for gabinet events) `gabinet.appointments.update` but previously did not invalidate any cache.

I deliberately skipped the documentation-tab.tsx handlers (interview notes, clinical remarks, treatment parameters, photos, body chart): those edit fields that don't appear in any Supabase-backed list/calendar view, so the missing-invalidation symptom from #312 doesn't apply.