### PR TITLE
Add typecheck verification step that does not require installed node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint . --ignore-pattern convex/_generated --report-unused-disable-directives",
     "typecheck": "tsc -p tsconfig.app.json && tsc -p tsconfig.node.json && tsc -p convex/tsconfig.json",
+    "typecheck:portable": "node scripts/typecheck-portable.mjs",
     "preview": "vite preview",
     "status:watch": "node scripts/status/watch-status.mjs",
     "status:update": "node scripts/status/update-status.mjs",

--- a/scripts/typecheck-portable.mjs
+++ b/scripts/typecheck-portable.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+/**
+ * typecheck-portable.mjs
+ *
+ * Runs `tsc` against the project's tsconfigs even when this checkout has no
+ * local `node_modules`. Used for local PR validation in fresh git worktrees
+ * where running `npm ci` would be wasteful or impossible. CI keeps using the
+ * regular `npm run typecheck`.
+ *
+ * Resolution order for a usable `node_modules`:
+ *   1. `./node_modules/.bin/tsc` (already installed — just runs `tsc`).
+ *   2. `$TYPECHECK_NODE_MODULES` if set and points at a real `node_modules`.
+ *   3. Sibling `node_modules` of the main repo, discovered from `.git`
+ *      (works when this checkout is a `git worktree add`-ed sibling).
+ *
+ * When borrowing, a symlink `./node_modules` is created for the duration of
+ * the run and removed on exit so subsequent `npm ci` is not surprised.
+ */
+
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  symlinkSync,
+  unlinkSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(__dirname, "..");
+const LOCAL_NODE_MODULES = join(PROJECT_ROOT, "node_modules");
+
+const TSCONFIGS = [
+  "tsconfig.app.json",
+  "tsconfig.node.json",
+  "convex/tsconfig.json",
+];
+
+function hasTsc(nodeModulesDir) {
+  return existsSync(join(nodeModulesDir, ".bin", "tsc"));
+}
+
+function discoverWorktreeMainRepo() {
+  const gitPath = join(PROJECT_ROOT, ".git");
+  if (!existsSync(gitPath)) return null;
+  if (!lstatSync(gitPath).isFile()) return null; // regular repo, not a worktree
+  const match = readFileSync(gitPath, "utf-8").match(/^gitdir:\s*(.+)$/m);
+  if (!match) return null;
+  const gitdir = match[1].trim();
+  const idx = gitdir.indexOf("/.git/worktrees/");
+  if (idx === -1) return null;
+  return gitdir.slice(0, idx);
+}
+
+function findDonorNodeModules() {
+  if (process.env.TYPECHECK_NODE_MODULES) {
+    const p = resolve(process.env.TYPECHECK_NODE_MODULES);
+    if (hasTsc(p)) return p;
+    console.error(
+      `typecheck-portable: TYPECHECK_NODE_MODULES=${p} has no .bin/tsc; ignoring.`,
+    );
+  }
+  const mainRepo = discoverWorktreeMainRepo();
+  if (mainRepo) {
+    const candidate = join(mainRepo, "node_modules");
+    if (hasTsc(candidate)) return candidate;
+  }
+  return null;
+}
+
+let createdSymlink = false;
+let exitCode = 0;
+
+function cleanup() {
+  if (!createdSymlink) return;
+  try {
+    unlinkSync(LOCAL_NODE_MODULES);
+  } catch {
+    // Best-effort cleanup; leaving a dangling symlink is not catastrophic.
+  }
+}
+
+process.on("SIGINT", () => {
+  cleanup();
+  process.exit(130);
+});
+process.on("SIGTERM", () => {
+  cleanup();
+  process.exit(143);
+});
+
+try {
+  if (!hasTsc(LOCAL_NODE_MODULES)) {
+    const donor = findDonorNodeModules();
+    if (!donor) {
+      console.error(
+        "typecheck-portable: no local node_modules and no donor found.",
+      );
+      console.error(
+        "  Either run `npm ci`, or set TYPECHECK_NODE_MODULES=/path/to/node_modules.",
+      );
+      process.exit(1);
+    }
+    if (existsSync(LOCAL_NODE_MODULES)) {
+      console.error(
+        `typecheck-portable: ${LOCAL_NODE_MODULES} exists but lacks .bin/tsc; aborting.`,
+      );
+      process.exit(1);
+    }
+    console.log(`typecheck-portable: borrowing node_modules from ${donor}`);
+    symlinkSync(donor, LOCAL_NODE_MODULES, "dir");
+    createdSymlink = true;
+  }
+
+  const tscBin = join(LOCAL_NODE_MODULES, ".bin", "tsc");
+  for (const cfg of TSCONFIGS) {
+    const r = spawnSync(tscBin, ["-p", cfg], {
+      stdio: "inherit",
+      cwd: PROJECT_ROOT,
+    });
+    if (r.status !== 0) {
+      exitCode = r.status ?? 1;
+      break;
+    }
+  }
+} finally {
+  cleanup();
+}
+
+process.exit(exitCode);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #320.

Closes #320

---

## Claude summary

Commit landed cleanly (the `Permission denied` was a tmp-file write attempted by the shell hook after the commit, not the commit itself).

Summary: added `scripts/typecheck-portable.mjs` and `npm run typecheck:portable`. The script detects when the current checkout lacks `node_modules`, finds a usable one via `$TYPECHECK_NODE_MODULES` or the main repo discovered through `.git` (when this checkout is a git worktree), creates a temporary symlink, runs `tsc` against the three project tsconfigs, and removes the symlink on exit. Verified in this worktree: it borrowed from `/home/claude-bot/repo/node_modules`, ran the typecheck, exited 1 with a real diagnostic, and left no stray symlink behind. CI keeps using the unchanged `npm run typecheck`.

## Follow-ups
- Fix TS2589 "Type instantiation is excessively deep" in `src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx:46`: pre-existing typecheck failure surfaced by `typecheck:portable`; main is currently red on `tsc -p tsconfig.app.json`.