### PR TITLE
feat(gabinet): drag-to-resize handle on calendar appointments (#317)

### DIFF
--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -20,6 +20,7 @@ interface CalendarDayViewProps {
   onSlotClick?: (time: string) => void;
   onSlotDragSelect?: (date: string, startTime: string, endTime: string) => void;
   onAppointmentClick?: (id: string) => void;
+  onAppointmentResize?: (id: string, newEndTime: string) => void;
   workingHours?: { startTime: string; endTime: string; breakStart?: string; breakEnd?: string } | null;
 }
 
@@ -93,7 +94,7 @@ function layoutAppointments(appts: Appointment[]): LayoutedAppointment[] {
   return result;
 }
 
-export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSelect, onAppointmentClick, workingHours }: CalendarDayViewProps) {
+export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSelect, onAppointmentClick, onAppointmentResize, workingHours }: CalendarDayViewProps) {
   const now = new Date();
   const isToday = date === `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
   const currentMinutes = now.getHours() * 60 + now.getMinutes();
@@ -235,6 +236,9 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
                 {...appt}
                 date={date}
                 onAppointmentClick={onAppointmentClick}
+                onResize={onAppointmentResize}
+                hourHeight={60}
+                snapMinutes={15}
               />
             </div>
           );

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -22,6 +22,7 @@ interface CalendarWeekViewProps {
   onSlotClick?: (date: string, time: string) => void;
   onSlotDragSelect?: (date: string, startTime: string, endTime: string) => void;
   onAppointmentClick?: (id: string) => void;
+  onAppointmentResize?: (id: string, newEndTime: string) => void;
   onDayHeaderClick?: (date: string) => void;
   selectedDate?: string;
   employeeSchedules?: Map<string, { startTime: string; endTime: string; breakStart?: string; breakEnd?: string }>;
@@ -123,6 +124,7 @@ interface WeekDayColumnProps {
   onSlotClick?: (date: string, time: string) => void;
   onSlotDragSelect?: (date: string, startTime: string, endTime: string) => void;
   onAppointmentClick?: (id: string) => void;
+  onAppointmentResize?: (id: string, newEndTime: string) => void;
   onDayHeaderClick?: (date: string) => void;
 }
 
@@ -136,6 +138,7 @@ function WeekDayColumn({
   onSlotClick,
   onSlotDragSelect,
   onAppointmentClick,
+  onAppointmentResize,
   onDayHeaderClick,
 }: WeekDayColumnProps) {
   const handleClick = useCallback(
@@ -256,6 +259,9 @@ function WeekDayColumn({
               <DraggableAppointment
                 {...appt}
                 onAppointmentClick={onAppointmentClick}
+                onResize={onAppointmentResize}
+                hourHeight={60}
+                snapMinutes={15}
               />
             </div>
           );
@@ -265,7 +271,7 @@ function WeekDayColumn({
   );
 }
 
-export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotDragSelect, onAppointmentClick, onDayHeaderClick, selectedDate, employeeSchedules }: CalendarWeekViewProps) {
+export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotDragSelect, onAppointmentClick, onAppointmentResize, onDayHeaderClick, selectedDate, employeeSchedules }: CalendarWeekViewProps) {
   const dates = useMemo(() => getWeekDates(weekStart), [weekStart]);
   const now = new Date();
   const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
@@ -309,6 +315,7 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotD
             onSlotClick={onSlotClick}
             onSlotDragSelect={onSlotDragSelect}
             onAppointmentClick={onAppointmentClick}
+            onAppointmentResize={onAppointmentResize}
             onDayHeaderClick={onDayHeaderClick}
           />
         );

--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -1,4 +1,5 @@
 import { useDraggable } from "@dnd-kit/core";
+import { useCallback, useState } from "react";
 import { AppointmentCard, type AppointmentTag } from "./appointment-card";
 
 interface Appointment {
@@ -15,6 +16,20 @@ interface Appointment {
 
 interface DraggableAppointmentProps extends Appointment {
   onAppointmentClick?: (id: string) => void;
+  onResize?: (id: string, newEndTime: string) => void;
+  hourHeight?: number;
+  snapMinutes?: number;
+}
+
+function timeToMinutes(t: string): number {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function minutesToTime(min: number): string {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
 }
 
 export function DraggableAppointment({
@@ -28,6 +43,9 @@ export function DraggableAppointment({
   color,
   tags,
   onAppointmentClick,
+  onResize,
+  hourHeight = 60,
+  snapMinutes = 15,
 }: DraggableAppointmentProps) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: _id,
@@ -40,17 +58,70 @@ export function DraggableAppointment({
     },
   });
 
+  const [previewEndTime, setPreviewEndTime] = useState<string | null>(null);
+
+  const startMinutes = timeToMinutes(startTime);
+  const originalEndMinutes = timeToMinutes(endTime);
+  const pxPerMinute = hourHeight / 60;
+
+  const handleResizeStart = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0 || !onResize) return;
+      e.stopPropagation();
+      e.preventDefault();
+      const initialY = e.clientY;
+
+      const calcEndMinutes = (clientY: number) => {
+        const deltaPx = clientY - initialY;
+        const deltaMin = deltaPx / pxPerMinute;
+        const snappedDelta = Math.round(deltaMin / snapMinutes) * snapMinutes;
+        return Math.max(
+          startMinutes + snapMinutes,
+          originalEndMinutes + snappedDelta,
+        );
+      };
+
+      const handleMove = (ev: PointerEvent) => {
+        setPreviewEndTime(minutesToTime(calcEndMinutes(ev.clientY)));
+      };
+
+      const handleUp = (ev: PointerEvent) => {
+        window.removeEventListener("pointermove", handleMove);
+        window.removeEventListener("pointerup", handleUp);
+        const finalEndMinutes = calcEndMinutes(ev.clientY);
+        setPreviewEndTime(null);
+
+        if (finalEndMinutes !== originalEndMinutes) {
+          onResize(_id, minutesToTime(finalEndMinutes));
+        }
+      };
+
+      window.addEventListener("pointermove", handleMove);
+      window.addEventListener("pointerup", handleUp);
+    },
+    [_id, onResize, originalEndMinutes, pxPerMinute, snapMinutes, startMinutes],
+  );
+
+  const displayEndTime = previewEndTime ?? endTime;
+  const previewHeightPx =
+    previewEndTime !== null
+      ? (timeToMinutes(previewEndTime) - startMinutes) * pxPerMinute
+      : null;
+
   return (
     <div
       ref={setNodeRef}
       {...listeners}
       {...attributes}
       data-appointment-card="true"
-      className={`h-full ${isDragging ? "opacity-50 cursor-grabbing" : "cursor-grab"}`}
+      className={`relative h-full ${isDragging ? "opacity-50 cursor-grabbing" : "cursor-grab"}`}
+      style={
+        previewHeightPx !== null ? { height: `${previewHeightPx}px` } : undefined
+      }
     >
       <AppointmentCard
         startTime={startTime}
-        endTime={endTime}
+        endTime={displayEndTime}
         patientName={patientName}
         treatmentName={treatmentName}
         status={status}
@@ -58,6 +129,18 @@ export function DraggableAppointment({
         tags={tags}
         onClick={() => onAppointmentClick?.(_id)}
       />
+      {onResize && status !== "blocked" && (
+        <div
+          onPointerDown={handleResizeStart}
+          onMouseDown={(e) => e.stopPropagation()}
+          data-resize-handle="true"
+          className="group/resize absolute bottom-0 left-0 right-0 z-20 h-2.5 cursor-ns-resize"
+          aria-label="Resize appointment"
+          title="Drag to resize"
+        >
+          <div className="absolute bottom-0.5 left-1/2 h-0.5 w-7 -translate-x-1/2 rounded-full bg-foreground/30 transition-colors group-hover/resize:bg-foreground/70" />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -483,6 +483,34 @@ function GabinetCalendarPage() {
     [navigate],
   );
 
+  // Resize handler (called when user drags an appointment's bottom edge)
+  const handleAppointmentResize = useCallback(
+    async (id: string, newEndTime: string) => {
+      try {
+        await updateAppointment({
+          organizationId,
+          appointmentId: id as Id<"gabinetAppointments">,
+          endTime: newEndTime,
+        });
+        toast.success(
+          t("gabinet.appointments.resized", "Appointment resized"),
+        );
+        void queryClient.invalidateQueries({
+          queryKey: supabaseKeys.gabinetAppointments.all,
+        });
+      } catch (e: any) {
+        toast.error(
+          e.message ??
+            t(
+              "gabinet.appointments.resizeFailed",
+              "Failed to resize appointment",
+            ),
+        );
+      }
+    },
+    [organizationId, updateAppointment, queryClient, t],
+  );
+
   // DnD handlers
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
@@ -844,6 +872,7 @@ function GabinetCalendarPage() {
               }
               onSlotDragSelect={handleSlotDragSelect}
               onAppointmentClick={handleAppointmentClick}
+              onAppointmentResize={handleAppointmentResize}
               workingHours={dayWorkingHours}
             />
           )}
@@ -854,6 +883,7 @@ function GabinetCalendarPage() {
               onSlotClick={handleSlotClick}
               onSlotDragSelect={handleSlotDragSelect}
               onAppointmentClick={handleAppointmentClick}
+              onAppointmentResize={handleAppointmentResize}
               onDayHeaderClick={handleDayClick}
               selectedDate={formatDateStr(currentDate)}
               employeeSchedules={employeeSchedules}


### PR DESCRIPTION
## Summary
- Adds a bottom-edge resize handle to appointment cards in the day and week calendar views, so users can shorten or extend a visit by dragging without opening the edit dialog.
- The handle snaps to 15-minute increments, shows a live height + end-time preview while dragging, enforces a 15-minute minimum duration, and persists the new `endTime` via the existing `gabinet.appointments.update` action.
- Hidden for Google-synced blocked-time entries (no underlying appointment to mutate).

Closes #317

## Test plan
- [ ] Open `/dashboard/gabinet/calendar` in day view, hover the bottom edge of an appointment — see the cursor change to `ns-resize` and a subtle pill indicator.
- [ ] Drag down/up: appointment height tracks the cursor in 15-min steps; preview end time updates inside the card.
- [ ] Release: toast confirms the new duration; appointment re-renders at the new size after the Supabase cache invalidates.
- [ ] Repeat in week view (each day column).
- [ ] Confirm Google-synced blocked time blocks have no handle.
- [ ] Drag handle past start time → enforced 15-min minimum (handle stops shrinking).
- [ ] Time-conflict with another appointment → backend rejects, toast shows error, original size restored on next refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)