### PR TITLE
Fix TS2589 "Type instantiation is excessively deep" in `src/routes/_app/_auth/da

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
@@ -120,6 +120,7 @@ function TimetablePage() {
   const queryClient = useQueryClient();
 
   const bulkSetEmployeeSchedule = useAction(
+    // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
     api.gabinet.scheduling.bulkSetEmployeeSchedule,
   );
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #326.

Closes #326

---

## Claude summary

Fix committed. The TS2589 "Type instantiation is excessively deep" error was actually surfacing now at `src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx:123` (the timetable page added in #322 after #320 was filed), not at `scheduling.tsx:46` which the issue title referenced. Both files use the same `useAction(api.gabinet.scheduling.*)` pattern, but TS2589 is non-deterministic — it fires at whichever Convex `useAction` call site hits the depth limit first in a given build.

The codebase already has ~25 instances of this exact `// @ts-ignore — TS2589: deep type instantiation in Convex codegen` suppression (e.g. `_layout.gabinet.settings.leaves.tsx:58-62`, `_layout.gabinet.packages.index.tsx:129-137`). I applied the same one-line suppression. After the fix, `node scripts/typecheck-portable.mjs` exits 0 across all three tsconfigs.

## Follow-ups
- Investigate root cause of widespread Convex TS2589 suppressions: ~25 sites in this repo use `@ts-ignore` for Convex `useAction`/`useMutation` calls; worth checking whether shrinking `api.d.ts` (e.g. per-module barrels) or upgrading Convex resolves it instead of papering over each site.