### PR TITLE
Fix tests/convex import paths

### DIFF
--- a/convex/vitest.config.ts
+++ b/convex/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     },
   },
   test: {
+    include: ["**/*.test.ts", "../tests/convex/**/*.test.ts"],
     server: { deps: { inline: ["convex-test"] } },
   },
 });

--- a/tests/convex/activityEnvelope.test.ts
+++ b/tests/convex/activityEnvelope.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "vitest";
-import { api } from "../_generated/api";
-import type { Id } from "../_generated/dataModel";
-import { createTestCtx, seedTestUser } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import type { Id } from "../../convex/_generated/dataModel";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 import {
   publishActivityEnvelope,
   type ActivityEnvelopeTarget,
-} from "../_helpers/activityEnvelope";
-import { logActivity } from "../_helpers/activities";
+} from "../../convex/_helpers/activityEnvelope";
+import { logActivity } from "../../convex/_helpers/activities";
 
 async function listActivities(
   t: ReturnType<typeof createTestCtx>,

--- a/tests/convex/appointmentSms.test.ts
+++ b/tests/convex/appointmentSms.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { api, internal } from "../_generated/api";
+import { api, internal } from "../../convex/_generated/api";
 import {
   createTestCtx,
   seedGabinetPrereqs,
   seedSecondUser,
   seedTestUser,
-} from "../_test_helpers";
+} from "../../convex/_test_helpers";
 
 const activeContexts = new Set<ReturnType<typeof createTestCtx>>();
 

--- a/tests/convex/appointmentStateMachine.test.ts
+++ b/tests/convex/appointmentStateMachine.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { api } from "../_generated/api";
-import { createTestCtx, seedTestUser, seedGabinetPrereqs } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser, seedGabinetPrereqs } from "../../convex/_test_helpers";
 
 const activeContexts = new Set<ReturnType<typeof createTestCtx>>();
 

--- a/tests/convex/automation.test.ts
+++ b/tests/convex/automation.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { api, internal } from "../_generated/api";
-import { DEFAULT_PERMISSIONS } from "../_helpers/permissions";
+import { api, internal } from "../../convex/_generated/api";
+import { DEFAULT_PERMISSIONS } from "../../convex/_helpers/permissions";
 import {
   createTestCtx,
   seedGabinetPrereqs,
   seedSecondUser,
   seedTestUser,
-} from "../_test_helpers";
+} from "../../convex/_test_helpers";
 
 const activeContexts = new Set<ReturnType<typeof createTestCtx>>();
 

--- a/tests/convex/avatarConsistency.test.ts
+++ b/tests/convex/avatarConsistency.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "vitest";
-import { api } from "../_generated/api";
-import { createTestCtx, seedTestUser } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 
 describe("updateUserImage", () => {
   test("caches storage URL in image field when imageId is set", async () => {

--- a/tests/convex/conflictChecking.test.ts
+++ b/tests/convex/conflictChecking.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "vitest";
-import { api } from "../_generated/api";
-import { createTestCtx, seedTestUser, seedGabinetPrereqs } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser, seedGabinetPrereqs } from "../../convex/_test_helpers";
 
 describe("conflict checking", () => {
   test("cannot double-book same employee at same time", async () => {

--- a/tests/convex/emailActivities.test.ts
+++ b/tests/convex/emailActivities.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
-import { api, internal } from "../_generated/api";
-import { createTestCtx, seedTestUser } from "../_test_helpers";
+import { api, internal } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 import { sendEmail } from "@cvx/email";
 
 vi.mock("@cvx/email", () => ({

--- a/tests/convex/emailEventTrigger.test.ts
+++ b/tests/convex/emailEventTrigger.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "vitest";
-import { internal } from "../_generated/api";
-import { createTestCtx, seedTestUser } from "../_test_helpers";
+import { internal } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 
 describe("emailEventTrigger", () => {
   // ─── No-op: no bindings configured ────────────────────────────

--- a/tests/convex/packageActivities.test.ts
+++ b/tests/convex/packageActivities.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { api } from "../_generated/api";
-import { createTestCtx, seedGabinetPrereqs, seedTestUser } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedGabinetPrereqs, seedTestUser } from "../../convex/_test_helpers";
 
 describe("package activities", () => {
   test("purchasePackage publishes semantic package_assigned envelope", async () => {

--- a/tests/convex/patientAuth.test.ts
+++ b/tests/convex/patientAuth.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, describe } from "vitest";
 import { createHash } from "crypto";
-import { api } from "../_generated/api";
-import { createTestCtx, seedTestUser, seedGabinetPrereqs } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser, seedGabinetPrereqs } from "../../convex/_test_helpers";
 
 /** SHA-256 helper matching what the production code uses. */
 function sha256Sync(input: string): string {

--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "vitest";
-import { api } from "../_generated/api";
-import { createTestCtx, seedTestUser } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 
 describe("payments", () => {
   test("create a pending payment", async () => {

--- a/tests/convex/productAccess.test.ts
+++ b/tests/convex/productAccess.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "vitest";
-import { api } from "../_generated/api";
-import { createTestCtx, seedTestUser } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 
 describe("verifyProductAccess", () => {
   test("grace period: allows access when no subscriptions exist globally", async () => {

--- a/tests/convex/recentlyViewed.test.ts
+++ b/tests/convex/recentlyViewed.test.ts
@@ -1,14 +1,14 @@
 import { expect, test, describe } from "vitest";
 import { convexTest } from "convex-test";
-import { api } from "../_generated/api";
-import schema from "../schema";
-import { seedTestUser } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import schema from "../../convex/schema";
+import { seedTestUser } from "../../convex/_test_helpers";
 
 const modules = (
   import.meta as ImportMeta & {
     glob: (pattern: string) => Record<string, () => Promise<unknown>>;
   }
-).glob("../**/*.*s");
+).glob("../../convex/**/*.*s");
 
 function createCtx() {
   return convexTest(schema, modules);

--- a/tests/convex/seatLimits.test.ts
+++ b/tests/convex/seatLimits.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe } from "vitest";
-import { api } from "../_generated/api";
-import { createTestCtx, seedTestUser, seedSecondUser } from "../_test_helpers";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser, seedSecondUser } from "../../convex/_test_helpers";
 
 describe("checkSeatLimit via getSeatUsage", () => {
   test("returns 1 seat used for org with only owner (free tier default)", async () => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #97.

Closes #97

---

## Claude summary

Committed `f301e91` on top of current main. Branch reset confirmed clean (main → fix only).

Summary of changes:
- 14 test files in `tests/convex/` had `../X` imports (resolved to nonexistent `tests/X/`); rewrote each to `../../convex/X` so they reach real Convex codegen, helpers, and schema. Also fixed `recentlyViewed.test.ts`'s `import.meta.glob` pattern.
- `convex/vitest.config.ts`: added `include` pattern `["**/*.test.ts", "../tests/convex/**/*.test.ts"]` so `npm run test:unit` (which `cd`s into `convex/`) discovers sibling tests.

Verified: `npx vitest list` now discovers all 15 test files (was 0). `emailShell.test.ts` passes 7/7. Other tests fail at runtime because `convex/_test_helpers.ts` is a stub — this is a pre-existing, tracked issue (#121).