### PR TITLE
Kategorie

### DIFF
--- a/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
+++ b/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
@@ -97,7 +97,7 @@ export function GabinetQuickActionsDropdown() {
           </DropdownMenuItem>
           <DropdownMenuItem
             className="px-3 py-2.5 text-sm"
-            onSelect={() => navigate({ to: "/dashboard/gabinet/settings" })}
+            onSelect={() => navigate({ to: "/dashboard/gabinet/settings/scheduling" })}
           >
             <Settings className="text-foreground size-5" />
             {t("sidebar.gabinet.goToSettings", "Ustawienia")}

--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -136,7 +136,7 @@ export const gabinetManifest: ModuleManifest = {
         },
         { labelKey: "nav.actions.categoryFilter", icon: Tag, dispatch: "openFilter" },
         { labelKey: "nav.actions.sortByPrice", icon: TrendingUp, dispatch: "sortByPrice" },
-        { labelKey: "nav.actions.manageCategories", icon: Settings, href: "/dashboard/gabinet/settings" },
+        { labelKey: "nav.actions.manageCategories", icon: Settings, dispatch: "manageCategories" },
       ],
     },
     {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #328.

Closes #328

---

## Claude summary

Fixed. The "Kategorie" action button on the treatments page was wired to `href: "/dashboard/gabinet/settings"`, a route that doesn't exist — so it landed on the "Not Found" screen shown in the screenshot. The treatments page already registers a `manageCategories` sidebar dispatch (`src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx:70`) that opens the `CategoriesManagerSlideout`, so I changed the manifest action to use `dispatch: "manageCategories"` instead of the dead URL.

I also fixed the gabinet workspace quick-actions dropdown (`src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx:100`), which had the same bad target — pointed it at `/dashboard/gabinet/settings/scheduling` (first item in the settings nav).

## Follow-ups
- Add an index route for /dashboard/gabinet/settings: either a redirect to scheduling or a real overview page, so direct URL visits don't hit "Not Found"