### PR TITLE
Surface dated schedule periods on the timetable page

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2115,7 +2115,11 @@
       "searchPlaceholder": "Search employee...",
       "empty": "No active employees to display in the timetable.",
       "usingDefaults": "Default hours",
-      "editTitle": "Edit employee schedule"
+      "editTitle": "Edit employee schedule",
+      "datedPeriodsCount_one": "{{count}} dated period",
+      "datedPeriodsCount_other": "{{count}} dated periods",
+      "datedPeriodsHint": "Manage dated schedule periods for this employee from the edit panel.",
+      "activePeriodHint": "Currently active dated schedule period (shown columns reflect it)."
     },
     "scheduling": {
       "title": "Working Hours",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2123,7 +2123,13 @@
       "searchPlaceholder": "Szukaj pracownika...",
       "empty": "Brak aktywnych pracowników do wyświetlenia grafiku.",
       "usingDefaults": "Godziny domyślne",
-      "editTitle": "Edytuj grafik pracownika"
+      "editTitle": "Edytuj grafik pracownika",
+      "datedPeriodsCount_one": "{{count}} okres datowany",
+      "datedPeriodsCount_few": "{{count}} okresy datowane",
+      "datedPeriodsCount_many": "{{count}} okresów datowanych",
+      "datedPeriodsCount_other": "{{count}} okresów datowanych",
+      "datedPeriodsHint": "Zarządzaj datowanymi okresami grafiku tego pracownika w panelu edycji.",
+      "activePeriodHint": "Aktualnie obowiązujący okres datowany (kolumny pokazują jego godziny)."
     },
     "scheduling": {
       "title": "Godziny pracy",

--- a/src/components/gabinet/flexible-schedule-editor.tsx
+++ b/src/components/gabinet/flexible-schedule-editor.tsx
@@ -1,0 +1,599 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import type { FunctionArgs } from "convex/server";
+import { api } from "@cvx/_generated/api";
+import { Id } from "@cvx/_generated/dataModel";
+import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
+import type { MappedGabinetEmployeeSchedule } from "@/lib/supabase/mappers/gabinet/employee-schedules";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Clock, Pencil, Plus, Trash2 } from "@/lib/ez-icons";
+
+export interface FlexibleClinicHours {
+  dayOfWeek: number;
+  startTime: string;
+  endTime: string;
+  isOpen: boolean;
+  breakStart?: string;
+  breakEnd?: string;
+}
+
+export interface SchedulePeriod {
+  effectiveFrom?: string;
+  effectiveTo?: string;
+  entries: Array<{
+    dayOfWeek: number;
+    startTime: string;
+    endTime: string;
+    isWorking: boolean;
+    breakStart?: string;
+    breakEnd?: string;
+    locationId?: string;
+  }>;
+}
+
+interface DaySchedule {
+  dayOfWeek: number;
+  startTime: string;
+  endTime: string;
+  isWorking: boolean;
+  breakStart: string;
+  breakEnd: string;
+  locationId: string;
+}
+
+const DAY_NAMES_EN = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+const DAY_NAMES_PL = [
+  "Niedziela",
+  "Poniedziałek",
+  "Wtorek",
+  "Środa",
+  "Czwartek",
+  "Piątek",
+  "Sobota",
+];
+
+export function groupSchedulesIntoPeriods(
+  schedules: MappedGabinetEmployeeSchedule[] | undefined,
+): SchedulePeriod[] {
+  if (!schedules) return [];
+  const periodMap = new Map<string, MappedGabinetEmployeeSchedule[]>();
+  for (const entry of schedules) {
+    const key = entry.effectiveFrom ?? "";
+    if (!periodMap.has(key)) periodMap.set(key, []);
+    periodMap.get(key)!.push(entry);
+  }
+  return [...periodMap.entries()]
+    .map(([from, entries]) => ({
+      effectiveFrom: from || undefined,
+      effectiveTo: entries[0]?.effectiveTo ?? undefined,
+      entries: entries
+        .map((e) => ({
+          dayOfWeek: e.dayOfWeek,
+          startTime: e.startTime,
+          endTime: e.endTime,
+          isWorking: e.isWorking,
+          breakStart: e.breakStart,
+          breakEnd: e.breakEnd,
+          locationId: e.locationId,
+        }))
+        .sort((a, b) => a.dayOfWeek - b.dayOfWeek),
+    }))
+    .sort((a, b) =>
+      (a.effectiveFrom ?? "").localeCompare(b.effectiveFrom ?? ""),
+    );
+}
+
+/**
+ * Return the period that is active for the given ISO date (YYYY-MM-DD).
+ * Priority: dated period covering the date wins over the default period.
+ */
+export function findActivePeriod(
+  periods: SchedulePeriod[],
+  date: string,
+): SchedulePeriod | undefined {
+  const dated = periods.filter((p) => p.effectiveFrom);
+  const activeDated = dated.find(
+    (p) =>
+      (!p.effectiveFrom || p.effectiveFrom <= date) &&
+      (!p.effectiveTo || p.effectiveTo >= date),
+  );
+  if (activeDated) return activeDated;
+  return periods.find((p) => !p.effectiveFrom);
+}
+
+export function FlexibleScheduleEditor({
+  organizationId,
+  userId,
+  periods,
+  clinicHours,
+  onSavePeriod,
+  onRemovePeriod,
+  onSaveLegacy,
+  onManageLeaves,
+}: {
+  organizationId: Id<"organizations">;
+  userId: Id<"users">;
+  periods: SchedulePeriod[];
+  clinicHours: FlexibleClinicHours[];
+  onSavePeriod: (
+    args: FunctionArgs<typeof api.gabinet.scheduling.saveSchedulePeriod>,
+  ) => Promise<void>;
+  onRemovePeriod: (
+    args: FunctionArgs<typeof api.gabinet.scheduling.removeSchedulePeriod>,
+  ) => Promise<void>;
+  onSaveLegacy: (
+    args: FunctionArgs<typeof api.gabinet.scheduling.bulkSetEmployeeSchedule>,
+  ) => Promise<void>;
+  onManageLeaves?: () => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const { data: locations } = useSupabaseGabinetLocationsList(organizationId);
+  const [saving, setSaving] = useState(false);
+  const [editingPeriodKey, setEditingPeriodKey] = useState<string | null>(null);
+  const [addingNew, setAddingNew] = useState(false);
+  const [periodFrom, setPeriodFrom] = useState("");
+  const [periodTo, setPeriodTo] = useState("");
+  const [periodHours, setPeriodHours] = useState<DaySchedule[]>(() =>
+    buildDefaultSchedule(clinicHours),
+  );
+
+  function buildDefaultSchedule(
+    clinic: FlexibleClinicHours[],
+  ): DaySchedule[] {
+    return Array.from({ length: 7 }, (_, i) => {
+      const clinicDay = clinic.find((h) => h.dayOfWeek === i);
+      if (clinicDay) {
+        return {
+          dayOfWeek: i,
+          startTime: clinicDay.startTime,
+          endTime: clinicDay.endTime,
+          isWorking: clinicDay.isOpen,
+          breakStart: clinicDay.breakStart ?? "",
+          breakEnd: clinicDay.breakEnd ?? "",
+          locationId: "",
+        };
+      }
+      return {
+        dayOfWeek: i,
+        startTime: "08:00",
+        endTime: "17:00",
+        isWorking: i >= 1 && i <= 5,
+        breakStart: "",
+        breakEnd: "",
+        locationId: "",
+      };
+    });
+  }
+
+  const dayNames = i18n.language === "pl" ? DAY_NAMES_PL : DAY_NAMES_EN;
+
+  const openEditPeriod = (period: SchedulePeriod) => {
+    setEditingPeriodKey(period.effectiveFrom ?? "");
+    setPeriodFrom(period.effectiveFrom ?? "");
+    setPeriodTo(period.effectiveTo ?? "");
+    const hours = Array.from({ length: 7 }, (_, i) => {
+      const entry = period.entries.find((e) => e.dayOfWeek === i);
+      return {
+        dayOfWeek: i,
+        startTime: entry?.startTime ?? "08:00",
+        endTime: entry?.endTime ?? "17:00",
+        isWorking: entry?.isWorking ?? (i >= 1 && i <= 5),
+        breakStart: entry?.breakStart ?? "",
+        breakEnd: entry?.breakEnd ?? "",
+        locationId: entry?.locationId ?? "",
+      };
+    });
+    setPeriodHours(hours);
+    setAddingNew(false);
+  };
+
+  const openNewPeriod = () => {
+    setAddingNew(true);
+    setEditingPeriodKey(null);
+    setPeriodFrom("");
+    setPeriodTo("");
+    setPeriodHours(buildDefaultSchedule(clinicHours));
+  };
+
+  const cancelEdit = () => {
+    setEditingPeriodKey(null);
+    setAddingNew(false);
+  };
+
+  const updateDay = (
+    dayOfWeek: number,
+    field: keyof DaySchedule,
+    value: string | boolean,
+  ) => {
+    setPeriodHours((prev) =>
+      prev.map((h) =>
+        h.dayOfWeek === dayOfWeek ? { ...h, [field]: value } : h,
+      ),
+    );
+  };
+
+  const handleSavePeriod = async () => {
+    setSaving(true);
+    try {
+      if (periodFrom || periodTo) {
+        await onSavePeriod({
+          organizationId,
+          userId,
+          effectiveFrom: periodFrom || undefined,
+          effectiveTo: periodTo || undefined,
+          hours: periodHours.map((h) => ({
+            dayOfWeek: h.dayOfWeek,
+            startTime: h.startTime,
+            endTime: h.endTime,
+            isWorking: h.isWorking,
+            breakStart: h.breakStart || undefined,
+            breakEnd: h.breakEnd || undefined,
+            locationId: h.locationId || undefined,
+          })),
+        });
+      } else {
+        await onSaveLegacy({
+          organizationId,
+          userId,
+          hours: periodHours.map((h) => ({
+            dayOfWeek: h.dayOfWeek,
+            startTime: h.startTime,
+            endTime: h.endTime,
+            isWorking: h.isWorking,
+            breakStart: h.breakStart || undefined,
+            breakEnd: h.breakEnd || undefined,
+            locationId: h.locationId || undefined,
+          })),
+        });
+      }
+      toast.success(t("common.saved"));
+      cancelEdit();
+    } catch (e: any) {
+      toast.error(e.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDeletePeriod = async (effectiveFrom?: string) => {
+    if (!window.confirm(t("gabinet.employees.schedule.confirmDeletePeriod")))
+      return;
+    try {
+      await onRemovePeriod({
+        organizationId,
+        userId,
+        effectiveFrom: effectiveFrom || undefined,
+      });
+      toast.success(t("common.deleted"));
+    } catch (e: any) {
+      toast.error(e.message);
+    }
+  };
+
+  const isEditing = editingPeriodKey !== null || addingNew;
+  const today = new Date().toISOString().split("T")[0];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="font-semibold flex items-center gap-2">
+            <Clock className="h-4 w-4" variant="stroke" />
+            {t("gabinet.employees.tabs.schedule")}
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            {periods.length > 0
+              ? t("gabinet.employees.schedule.hasOverrides")
+              : t("gabinet.employees.schedule.usingClinicDefaults")}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          {onManageLeaves && (
+            <Button variant="outline" size="sm" onClick={onManageLeaves}>
+              {t("gabinet.employees.schedule.manageLeaves")}
+            </Button>
+          )}
+          {!isEditing && (
+            <Button size="sm" onClick={openNewPeriod}>
+              <Plus className="mr-1 h-4 w-4" variant="stroke" />
+              {t("gabinet.employees.schedule.addPeriod")}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {!isEditing && periods.length > 0 && (
+        <div className="space-y-3">
+          {periods.map((period, idx) => {
+            const isActive =
+              (!period.effectiveFrom || period.effectiveFrom <= today) &&
+              (!period.effectiveTo || period.effectiveTo >= today);
+            const label = period.effectiveFrom
+              ? `${period.effectiveFrom}${period.effectiveTo ? ` — ${period.effectiveTo}` : ` — ${t("gabinet.employees.schedule.ongoing")}`}`
+              : t("gabinet.employees.schedule.defaultPeriod");
+            return (
+              <Card
+                key={period.effectiveFrom ?? `default-${idx}`}
+                className={`p-4 ${isActive ? "border-primary/50" : ""}`}
+              >
+                <div className="flex items-center justify-between mb-3">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">{label}</span>
+                    {isActive && (
+                      <Badge variant="default" className="text-xs">
+                        {t("gabinet.employees.schedule.active")}
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="flex gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => openEditPeriod(period)}
+                    >
+                      <Pencil className="h-3.5 w-3.5" variant="stroke" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-destructive"
+                      onClick={() => handleDeletePeriod(period.effectiveFrom)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" variant="stroke" />
+                    </Button>
+                  </div>
+                </div>
+                <div className="grid grid-cols-7 gap-1 text-xs">
+                  {Array.from({ length: 7 }, (_, i) => {
+                    const entry = period.entries.find(
+                      (e) => e.dayOfWeek === i,
+                    );
+                    return (
+                      <div
+                        key={i}
+                        className={`text-center p-1 rounded ${entry?.isWorking ? "bg-primary/10" : "bg-muted text-muted-foreground"}`}
+                      >
+                        <div className="font-medium">
+                          {dayNames[i].substring(0, 3)}
+                        </div>
+                        {entry?.isWorking ? (
+                          <div>
+                            {entry.startTime}–{entry.endTime}
+                          </div>
+                        ) : (
+                          <div>—</div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      {!isEditing && periods.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-8 text-center">
+          <Clock
+            className="h-8 w-8 text-muted-foreground/40 mb-2"
+            variant="stroke"
+          />
+          <p className="text-sm text-muted-foreground mb-3">
+            {t("gabinet.employees.schedule.usingClinicDefaults")}
+          </p>
+          <Button size="sm" onClick={openNewPeriod}>
+            <Plus className="mr-1 h-4 w-4" variant="stroke" />
+            {t("gabinet.employees.schedule.addPeriod")}
+          </Button>
+        </div>
+      )}
+
+      {isEditing && (
+        <Card className="p-4">
+          <div className="space-y-4">
+            <h4 className="font-medium">
+              {addingNew
+                ? t("gabinet.employees.schedule.newPeriod")
+                : t("gabinet.employees.schedule.editPeriod")}
+            </h4>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1.5">
+                <Label>
+                  {t("gabinet.employees.schedule.effectiveFrom")}
+                </Label>
+                <Input
+                  type="date"
+                  value={periodFrom}
+                  onChange={(e) => setPeriodFrom(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  {t("gabinet.employees.schedule.effectiveFromHint")}
+                </p>
+              </div>
+              <div className="space-y-1.5">
+                <Label>{t("gabinet.employees.schedule.effectiveTo")}</Label>
+                <Input
+                  type="date"
+                  value={periodTo}
+                  onChange={(e) => setPeriodTo(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  {t("gabinet.employees.schedule.effectiveToHint")}
+                </p>
+              </div>
+            </div>
+
+            <div className="rounded-lg border">
+              <div className="grid grid-cols-[140px_50px_1fr_1fr_2fr_1fr] gap-2 border-b bg-muted/50 px-3 py-2 text-xs font-medium text-muted-foreground">
+                <span>{t("gabinet.scheduling.day")}</span>
+                <span>{t("gabinet.scheduling.open")}</span>
+                <span>{t("gabinet.scheduling.start")}</span>
+                <span>{t("gabinet.scheduling.end")}</span>
+                <span>{t("gabinet.schedules.break")}</span>
+                <span>{t("gabinet.appointments.location")}</span>
+              </div>
+
+              {periodHours.map((h) => {
+                const hasBreak = Boolean(h.breakStart || h.breakEnd);
+                return (
+                  <div
+                    key={h.dayOfWeek}
+                    className="grid grid-cols-[140px_50px_1fr_1fr_2fr_1fr] items-center gap-2 border-b px-3 py-1.5 last:border-b-0"
+                  >
+                    <span className="text-sm font-medium">
+                      {dayNames[h.dayOfWeek]}
+                    </span>
+                    <Checkbox
+                      checked={h.isWorking}
+                      onCheckedChange={(checked) =>
+                        updateDay(h.dayOfWeek, "isWorking", checked as boolean)
+                      }
+                    />
+                    <Input
+                      type="time"
+                      className="h-7 w-22"
+                      value={h.startTime}
+                      onChange={(e) =>
+                        updateDay(h.dayOfWeek, "startTime", e.target.value)
+                      }
+                      disabled={!h.isWorking}
+                    />
+                    <Input
+                      type="time"
+                      className="h-7 w-22"
+                      value={h.endTime}
+                      onChange={(e) =>
+                        updateDay(h.dayOfWeek, "endTime", e.target.value)
+                      }
+                      disabled={!h.isWorking}
+                    />
+                    {hasBreak ? (
+                      <div className="flex items-center gap-1">
+                        <Input
+                          type="time"
+                          className="h-7 w-22"
+                          value={h.breakStart}
+                          onChange={(e) =>
+                            updateDay(
+                              h.dayOfWeek,
+                              "breakStart",
+                              e.target.value,
+                            )
+                          }
+                          disabled={!h.isWorking}
+                        />
+                        <span className="text-xs text-muted-foreground">–</span>
+                        <Input
+                          type="time"
+                          className="h-7 w-22"
+                          value={h.breakEnd}
+                          onChange={(e) =>
+                            updateDay(h.dayOfWeek, "breakEnd", e.target.value)
+                          }
+                          disabled={!h.isWorking}
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                          onClick={() => {
+                            updateDay(h.dayOfWeek, "breakStart", "");
+                            updateDay(h.dayOfWeek, "breakEnd", "");
+                          }}
+                          disabled={!h.isWorking}
+                          aria-label={t("gabinet.scheduling.removeBreak")}
+                          title={t("gabinet.scheduling.removeBreak")}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" variant="stroke" />
+                        </Button>
+                      </div>
+                    ) : (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-7 justify-self-start text-xs"
+                        onClick={() => {
+                          updateDay(h.dayOfWeek, "breakStart", "12:00");
+                          updateDay(h.dayOfWeek, "breakEnd", "13:00");
+                        }}
+                        disabled={!h.isWorking}
+                      >
+                        <Plus className="mr-1 h-3.5 w-3.5" variant="stroke" />
+                        {t("gabinet.scheduling.addBreak")}
+                      </Button>
+                    )}
+                    <Select
+                      value={h.locationId || "none"}
+                      onValueChange={(val) =>
+                        updateDay(
+                          h.dayOfWeek,
+                          "locationId",
+                          val === "none" ? "" : val,
+                        )
+                      }
+                      disabled={!h.isWorking}
+                    >
+                      <SelectTrigger className="h-7 text-xs">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="none">
+                          {t("common.none")}
+                        </SelectItem>
+                        {locations
+                          ?.filter((l) => l.isActive)
+                          .map((l) => (
+                            <SelectItem key={l._id} value={l._id}>
+                              {l.name}
+                            </SelectItem>
+                          ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" size="sm" onClick={cancelEdit}>
+                {t("common.cancel")}
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleSavePeriod}
+                disabled={saving}
+              >
+                {saving ? t("common.saving") : t("common.save")}
+              </Button>
+            </div>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -15,7 +15,10 @@ import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
 import { useSupabaseScheduledActivitiesByEntity } from "@/hooks/use-supabase-scheduled-activities";
 import { useSupabaseNotesByEntity } from "@/hooks/use-supabase-notes";
 import { useSupabaseGabinetAppointmentsByEmployee } from "@/hooks/use-supabase-gabinet-appointments";
-import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
+import {
+  FlexibleScheduleEditor,
+  groupSchedulesIntoPeriods,
+} from "@/components/gabinet/flexible-schedule-editor";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import {
   EntityDetailLayout,
@@ -29,7 +32,6 @@ import { activitiesToFeedEntries } from "@/components/crm/activity-feed-adapter"
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -57,10 +59,8 @@ import {
   X,
   Calendar,
   ClipboardList,
-  Clock,
   User,
   Plus,
-  Trash2,
   Briefcase,
   Mail,
   Phone,
@@ -287,22 +287,10 @@ function EmployeeDetail() {
   }, [employeePatients, clientSearch, clientStatusFilter, clientTreatmentFilter]);
 
   // Feature 3: Group schedule entries into periods by effectiveFrom
-  const schedulePeriods = useMemo(() => {
-    if (!employeeScheduleData) return [];
-    const periodMap = new Map<string, typeof employeeScheduleData>();
-    for (const entry of employeeScheduleData) {
-      const key = entry.effectiveFrom ?? "";
-      if (!periodMap.has(key)) periodMap.set(key, []);
-      periodMap.get(key)!.push(entry);
-    }
-    return [...periodMap.entries()]
-      .map(([from, entries]) => ({
-        effectiveFrom: from || undefined,
-        effectiveTo: entries[0]?.effectiveTo ?? undefined,
-        entries: entries.sort((a, b) => a.dayOfWeek - b.dayOfWeek),
-      }))
-      .sort((a, b) => (a.effectiveFrom ?? "").localeCompare(b.effectiveFrom ?? ""));
-  }, [employeeScheduleData]);
+  const schedulePeriods = useMemo(
+    () => groupSchedulesIntoPeriods(employeeScheduleData),
+    [employeeScheduleData],
+  );
 
   // Track recently viewed
   useEffect(() => {
@@ -664,6 +652,7 @@ function EmployeeDetail() {
           onSavePeriod={async (a) => { await saveSchedulePeriod(a); invalidateScheduleCache(); }}
           onRemovePeriod={async (a) => { await removeSchedulePeriod(a); invalidateScheduleCache(); }}
           onSaveLegacy={async (a) => { await bulkSetEmployeeSchedule(a); invalidateScheduleCache(); }}
+          onManageLeaves={() => navigate({ to: "/dashboard/gabinet/settings/leaves" })}
         />
       ),
     },
@@ -1400,460 +1389,6 @@ function EditEmployeeDrawer({
         </div>
       </div>
     </SidePanel>
-  );
-}
-
-// --- Flexible schedule editor with multiple periods ---
-
-const DAY_NAMES_EN = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-const DAY_NAMES_PL = ["Niedziela", "Poniedziałek", "Wtorek", "Środa", "Czwartek", "Piątek", "Sobota"];
-
-interface DaySchedule {
-  dayOfWeek: number;
-  startTime: string;
-  endTime: string;
-  isWorking: boolean;
-  breakStart: string;
-  breakEnd: string;
-  locationId: string;
-}
-
-interface SchedulePeriod {
-  effectiveFrom?: string;
-  effectiveTo?: string;
-  entries: Array<{
-    dayOfWeek: number;
-    startTime: string;
-    endTime: string;
-    isWorking: boolean;
-    breakStart?: string;
-    breakEnd?: string;
-    locationId?: string;
-  }>;
-}
-
-function FlexibleScheduleEditor({
-  organizationId,
-  userId,
-  periods,
-  clinicHours,
-  onSavePeriod,
-  onRemovePeriod,
-  onSaveLegacy,
-}: {
-  organizationId: Id<"organizations">;
-  userId: Id<"users">;
-  periods: SchedulePeriod[];
-  clinicHours: Array<{
-    dayOfWeek: number;
-    startTime: string;
-    endTime: string;
-    isOpen: boolean;
-    breakStart?: string;
-    breakEnd?: string;
-  }>;
-  onSavePeriod: (args: FunctionArgs<typeof api.gabinet.scheduling.saveSchedulePeriod>) => Promise<void>;
-  onRemovePeriod: (args: FunctionArgs<typeof api.gabinet.scheduling.removeSchedulePeriod>) => Promise<void>;
-  onSaveLegacy: (args: FunctionArgs<typeof api.gabinet.scheduling.bulkSetEmployeeSchedule>) => Promise<void>;
-}) {
-  const { t, i18n } = useTranslation();
-  const { data: locations } = useSupabaseGabinetLocationsList(organizationId);
-  const [saving, setSaving] = useState(false);
-  const [editingPeriodKey, setEditingPeriodKey] = useState<string | null>(null);
-  const [addingNew, setAddingNew] = useState(false);
-  const [periodFrom, setPeriodFrom] = useState("");
-  const [periodTo, setPeriodTo] = useState("");
-  const [periodHours, setPeriodHours] = useState<DaySchedule[]>(() => buildDefaultSchedule(clinicHours));
-
-  function buildDefaultSchedule(clinic: typeof clinicHours): DaySchedule[] {
-    return Array.from({ length: 7 }, (_, i) => {
-      const clinicDay = clinic.find((h) => h.dayOfWeek === i);
-      if (clinicDay) {
-        return {
-          dayOfWeek: i,
-          startTime: clinicDay.startTime,
-          endTime: clinicDay.endTime,
-          isWorking: clinicDay.isOpen,
-          breakStart: clinicDay.breakStart ?? "",
-          breakEnd: clinicDay.breakEnd ?? "",
-          locationId: "",
-        };
-      }
-      return {
-        dayOfWeek: i,
-        startTime: "08:00",
-        endTime: "17:00",
-        isWorking: i >= 1 && i <= 5,
-        breakStart: "",
-        breakEnd: "",
-        locationId: "",
-      };
-    });
-  }
-
-  const dayNames = i18n.language === "pl" ? DAY_NAMES_PL : DAY_NAMES_EN;
-
-  const openEditPeriod = (period: SchedulePeriod) => {
-    setEditingPeriodKey(period.effectiveFrom ?? "");
-    setPeriodFrom(period.effectiveFrom ?? "");
-    setPeriodTo(period.effectiveTo ?? "");
-    const hours = Array.from({ length: 7 }, (_, i) => {
-      const entry = period.entries.find((e) => e.dayOfWeek === i);
-      return {
-        dayOfWeek: i,
-        startTime: entry?.startTime ?? "08:00",
-        endTime: entry?.endTime ?? "17:00",
-        isWorking: entry?.isWorking ?? (i >= 1 && i <= 5),
-        breakStart: entry?.breakStart ?? "",
-        breakEnd: entry?.breakEnd ?? "",
-        locationId: entry?.locationId ?? "",
-      };
-    });
-    setPeriodHours(hours);
-    setAddingNew(false);
-  };
-
-  const openNewPeriod = () => {
-    setAddingNew(true);
-    setEditingPeriodKey(null);
-    setPeriodFrom("");
-    setPeriodTo("");
-    setPeriodHours(buildDefaultSchedule(clinicHours));
-  };
-
-  const cancelEdit = () => {
-    setEditingPeriodKey(null);
-    setAddingNew(false);
-  };
-
-  const updateDay = (dayOfWeek: number, field: keyof DaySchedule, value: string | boolean) => {
-    setPeriodHours((prev) =>
-      prev.map((h) => (h.dayOfWeek === dayOfWeek ? { ...h, [field]: value } : h))
-    );
-  };
-
-  const handleSavePeriod = async () => {
-    setSaving(true);
-    try {
-      if (periodFrom || periodTo) {
-        // Save as a dated period
-        await onSavePeriod({
-          organizationId,
-          userId,
-          effectiveFrom: periodFrom || undefined,
-          effectiveTo: periodTo || undefined,
-          hours: periodHours.map((h) => ({
-            dayOfWeek: h.dayOfWeek,
-            startTime: h.startTime,
-            endTime: h.endTime,
-            isWorking: h.isWorking,
-            breakStart: h.breakStart || undefined,
-            breakEnd: h.breakEnd || undefined,
-            locationId: h.locationId || undefined,
-          })),
-        });
-      } else {
-        // Default period: use legacy bulk save (no dates)
-        await onSaveLegacy({
-          organizationId,
-          userId,
-          hours: periodHours.map((h) => ({
-            dayOfWeek: h.dayOfWeek,
-            startTime: h.startTime,
-            endTime: h.endTime,
-            isWorking: h.isWorking,
-            breakStart: h.breakStart || undefined,
-            breakEnd: h.breakEnd || undefined,
-            locationId: h.locationId || undefined,
-          })),
-        });
-      }
-      toast.success(t("common.saved"));
-      cancelEdit();
-    } catch (e: any) {
-      toast.error(e.message);
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleDeletePeriod = async (effectiveFrom?: string) => {
-    if (!window.confirm(t("gabinet.employees.schedule.confirmDeletePeriod"))) return;
-    try {
-      await onRemovePeriod({
-        organizationId,
-        userId,
-        effectiveFrom: effectiveFrom || undefined,
-      });
-      toast.success(t("common.deleted"));
-    } catch (e: any) {
-      toast.error(e.message);
-    }
-  };
-
-  const isEditing = editingPeriodKey !== null || addingNew;
-
-  // Determine which period is currently active based on today's date
-  const today = new Date().toISOString().split("T")[0];
-
-  return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <h3 className="font-semibold flex items-center gap-2">
-            <Clock className="h-4 w-4" variant="stroke" />
-            {t("gabinet.employees.tabs.schedule")}
-          </h3>
-          <p className="text-sm text-muted-foreground">
-            {periods.length > 0
-              ? t("gabinet.employees.schedule.hasOverrides")
-              : t("gabinet.employees.schedule.usingClinicDefaults")}
-          </p>
-        </div>
-        <div className="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => window.location.href = "/dashboard/gabinet/settings/leaves"}
-          >
-            {t("gabinet.employees.schedule.manageLeaves")}
-          </Button>
-          {!isEditing && (
-            <Button size="sm" onClick={openNewPeriod}>
-              <Plus className="mr-1 h-4 w-4" variant="stroke" />
-              {t("gabinet.employees.schedule.addPeriod")}
-            </Button>
-          )}
-        </div>
-      </div>
-
-      {/* Existing periods list */}
-      {!isEditing && periods.length > 0 && (
-        <div className="space-y-3">
-          {periods.map((period, idx) => {
-            const isActive =
-              (!period.effectiveFrom || period.effectiveFrom <= today) &&
-              (!period.effectiveTo || period.effectiveTo >= today);
-            const label = period.effectiveFrom
-              ? `${period.effectiveFrom}${period.effectiveTo ? ` — ${period.effectiveTo}` : ` — ${t("gabinet.employees.schedule.ongoing")}`}`
-              : t("gabinet.employees.schedule.defaultPeriod");
-            return (
-              <Card key={period.effectiveFrom ?? `default-${idx}`} className={`p-4 ${isActive ? "border-primary/50" : ""}`}>
-                <div className="flex items-center justify-between mb-3">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium">{label}</span>
-                    {isActive && (
-                      <Badge variant="default" className="text-xs">
-                        {t("gabinet.employees.schedule.active")}
-                      </Badge>
-                    )}
-                  </div>
-                  <div className="flex gap-1">
-                    <Button variant="ghost" size="sm" onClick={() => openEditPeriod(period)}>
-                      <Pencil className="h-3.5 w-3.5" variant="stroke" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="text-destructive"
-                      onClick={() => handleDeletePeriod(period.effectiveFrom)}
-                    >
-                      <Trash2 className="h-3.5 w-3.5" variant="stroke" />
-                    </Button>
-                  </div>
-                </div>
-                {/* Compact schedule summary */}
-                <div className="grid grid-cols-7 gap-1 text-xs">
-                  {Array.from({ length: 7 }, (_, i) => {
-                    const entry = period.entries.find((e) => e.dayOfWeek === i);
-                    return (
-                      <div key={i} className={`text-center p-1 rounded ${entry?.isWorking ? "bg-primary/10" : "bg-muted text-muted-foreground"}`}>
-                        <div className="font-medium">{dayNames[i].substring(0, 3)}</div>
-                        {entry?.isWorking ? (
-                          <div>{entry.startTime}–{entry.endTime}</div>
-                        ) : (
-                          <div>—</div>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-              </Card>
-            );
-          })}
-        </div>
-      )}
-
-      {/* Empty state */}
-      {!isEditing && periods.length === 0 && (
-        <div className="flex flex-col items-center justify-center py-8 text-center">
-          <Clock className="h-8 w-8 text-muted-foreground/40 mb-2" variant="stroke" />
-          <p className="text-sm text-muted-foreground mb-3">
-            {t("gabinet.employees.schedule.usingClinicDefaults")}
-          </p>
-          <Button size="sm" onClick={openNewPeriod}>
-            <Plus className="mr-1 h-4 w-4" variant="stroke" />
-            {t("gabinet.employees.schedule.addPeriod")}
-          </Button>
-        </div>
-      )}
-
-      {/* Period editor form */}
-      {isEditing && (
-        <Card className="p-4">
-          <div className="space-y-4">
-            <h4 className="font-medium">
-              {addingNew
-                ? t("gabinet.employees.schedule.newPeriod")
-                : t("gabinet.employees.schedule.editPeriod")}
-            </h4>
-
-            {/* Date range */}
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-1.5">
-                <Label>{t("gabinet.employees.schedule.effectiveFrom")}</Label>
-                <Input
-                  type="date"
-                  value={periodFrom}
-                  onChange={(e) => setPeriodFrom(e.target.value)}
-                />
-                <p className="text-xs text-muted-foreground">
-                  {t("gabinet.employees.schedule.effectiveFromHint")}
-                </p>
-              </div>
-              <div className="space-y-1.5">
-                <Label>{t("gabinet.employees.schedule.effectiveTo")}</Label>
-                <Input
-                  type="date"
-                  value={periodTo}
-                  onChange={(e) => setPeriodTo(e.target.value)}
-                />
-                <p className="text-xs text-muted-foreground">
-                  {t("gabinet.employees.schedule.effectiveToHint")}
-                </p>
-              </div>
-            </div>
-
-            {/* Weekly schedule grid */}
-            <div className="rounded-lg border">
-              <div className="grid grid-cols-[140px_50px_1fr_1fr_2fr_1fr] gap-2 border-b bg-muted/50 px-3 py-2 text-xs font-medium text-muted-foreground">
-                <span>{t("gabinet.scheduling.day")}</span>
-                <span>{t("gabinet.scheduling.open")}</span>
-                <span>{t("gabinet.scheduling.start")}</span>
-                <span>{t("gabinet.scheduling.end")}</span>
-                <span>{t("gabinet.schedules.break")}</span>
-                <span>{t("gabinet.appointments.location")}</span>
-              </div>
-
-              {periodHours.map((h) => {
-                const hasBreak = Boolean(h.breakStart || h.breakEnd);
-                return (
-                <div
-                  key={h.dayOfWeek}
-                  className="grid grid-cols-[140px_50px_1fr_1fr_2fr_1fr] items-center gap-2 border-b px-3 py-1.5 last:border-b-0"
-                >
-                  <span className="text-sm font-medium">{dayNames[h.dayOfWeek]}</span>
-                  <Checkbox
-                    checked={h.isWorking}
-                    onCheckedChange={(checked) => updateDay(h.dayOfWeek, "isWorking", checked as boolean)}
-                  />
-                  <Input
-                    type="time"
-                    className="h-7 w-22"
-                    value={h.startTime}
-                    onChange={(e) => updateDay(h.dayOfWeek, "startTime", e.target.value)}
-                    disabled={!h.isWorking}
-                  />
-                  <Input
-                    type="time"
-                    className="h-7 w-22"
-                    value={h.endTime}
-                    onChange={(e) => updateDay(h.dayOfWeek, "endTime", e.target.value)}
-                    disabled={!h.isWorking}
-                  />
-                  {hasBreak ? (
-                    <div className="flex items-center gap-1">
-                      <Input
-                        type="time"
-                        className="h-7 w-22"
-                        value={h.breakStart}
-                        onChange={(e) => updateDay(h.dayOfWeek, "breakStart", e.target.value)}
-                        disabled={!h.isWorking}
-                      />
-                      <span className="text-xs text-muted-foreground">–</span>
-                      <Input
-                        type="time"
-                        className="h-7 w-22"
-                        value={h.breakEnd}
-                        onChange={(e) => updateDay(h.dayOfWeek, "breakEnd", e.target.value)}
-                        disabled={!h.isWorking}
-                      />
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7 text-muted-foreground hover:text-destructive"
-                        onClick={() => {
-                          updateDay(h.dayOfWeek, "breakStart", "");
-                          updateDay(h.dayOfWeek, "breakEnd", "");
-                        }}
-                        disabled={!h.isWorking}
-                        aria-label={t("gabinet.scheduling.removeBreak")}
-                        title={t("gabinet.scheduling.removeBreak")}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" variant="stroke" />
-                      </Button>
-                    </div>
-                  ) : (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="h-7 justify-self-start text-xs"
-                      onClick={() => {
-                        updateDay(h.dayOfWeek, "breakStart", "12:00");
-                        updateDay(h.dayOfWeek, "breakEnd", "13:00");
-                      }}
-                      disabled={!h.isWorking}
-                    >
-                      <Plus className="mr-1 h-3.5 w-3.5" variant="stroke" />
-                      {t("gabinet.scheduling.addBreak")}
-                    </Button>
-                  )}
-                  <Select
-                    value={h.locationId || "none"}
-                    onValueChange={(val) => updateDay(h.dayOfWeek, "locationId", val === "none" ? "" : val)}
-                    disabled={!h.isWorking}
-                  >
-                    <SelectTrigger className="h-7 text-xs">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="none">{t("common.none")}</SelectItem>
-                      {locations?.filter((l) => l.isActive).map((l) => (
-                        <SelectItem key={l._id} value={l._id}>
-                          {l.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                );
-              })}
-            </div>
-
-            <div className="flex justify-end gap-2">
-              <Button variant="outline" size="sm" onClick={cancelEdit}>
-                {t("common.cancel")}
-              </Button>
-              <Button size="sm" onClick={handleSavePeriod} disabled={saving}>
-                {saving ? t("common.saving") : t("common.save")}
-              </Button>
-            </div>
-          </div>
-        </Card>
-      )}
-    </div>
   );
 }
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
@@ -1,7 +1,8 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
+import { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
 import { useSupabaseGabinetEmployeeSchedulesList } from "@/hooks/use-supabase-gabinet-employee-schedules";
@@ -12,20 +13,23 @@ import { SectionHeader } from "@untitled/app/section-headers/section-headers";
 import { UntitledAlert } from "@/components/ui/untitled-alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import {
   Sheet,
   SheetContent,
   SheetDescription,
-  SheetFooter,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
-import { Pencil, Plus, Trash2 } from "@/lib/ez-icons";
-import { useMemo, useState, useEffect } from "react";
+import { Pencil } from "@/lib/ez-icons";
+import {
+  FlexibleScheduleEditor,
+  findActivePeriod,
+  groupSchedulesIntoPeriods,
+  type SchedulePeriod,
+} from "@/components/gabinet/flexible-schedule-editor";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { toast } from "sonner";
 import type { MappedGabinetEmployee } from "@/lib/supabase/mappers/gabinet/employees";
 import type { MappedGabinetEmployeeSchedule } from "@/lib/supabase/mappers/gabinet/employee-schedules";
 import type { MappedGabinetWorkingHours } from "@/lib/supabase/mappers/gabinet/working-hours";
@@ -41,18 +45,18 @@ const DAY_NAMES_PL = ["Pn", "Wt", "Śr", "Cz", "Pt", "So", "Nd"];
 // Display order: Mon..Sun. Convex/Supabase stores dayOfWeek 0=Sun..6=Sat.
 const DISPLAY_ORDER = [1, 2, 3, 4, 5, 6, 0];
 
-interface DaySchedule {
+interface DisplayEntry {
   dayOfWeek: number;
   startTime: string;
   endTime: string;
   isWorking: boolean;
-  breakStart: string;
-  breakEnd: string;
+  breakStart?: string;
+  breakEnd?: string;
 }
 
-function buildDefaultSchedule(
+function buildClinicFallback(
   clinicHours: MappedGabinetWorkingHours[] | undefined,
-): DaySchedule[] {
+): DisplayEntry[] {
   return Array.from({ length: 7 }, (_, i) => {
     const clinicDay = clinicHours?.find((h) => h.dayOfWeek === i);
     if (clinicDay) {
@@ -61,8 +65,8 @@ function buildDefaultSchedule(
         startTime: clinicDay.startTime,
         endTime: clinicDay.endTime,
         isWorking: clinicDay.isOpen,
-        breakStart: clinicDay.breakStart ?? "",
-        breakEnd: clinicDay.breakEnd ?? "",
+        breakStart: clinicDay.breakStart ?? undefined,
+        breakEnd: clinicDay.breakEnd ?? undefined,
       };
     }
     return {
@@ -70,58 +74,83 @@ function buildDefaultSchedule(
       startTime: "08:00",
       endTime: "17:00",
       isWorking: i >= 1 && i <= 5,
-      breakStart: "",
-      breakEnd: "",
     };
   });
 }
 
-function buildEmployeeSchedule(
+interface ResolvedEmployeeSchedule {
+  entries: DisplayEntry[];
+  activePeriod?: SchedulePeriod;
+  totalPeriods: number;
+  datedPeriods: number;
+  hasOverrides: boolean;
+}
+
+function resolveEmployeeSchedule(
   employee: MappedGabinetEmployee,
   schedules: MappedGabinetEmployeeSchedule[] | undefined,
   clinicHours: MappedGabinetWorkingHours[] | undefined,
-): { entries: DaySchedule[]; hasOverrides: boolean } {
-  // Use only default-period entries (those without effectiveFrom)
-  const own = (schedules ?? []).filter(
-    (s) => s.userId === employee.userId && !s.effectiveFrom,
-  );
-  if (own.length === 0) {
-    return { entries: buildDefaultSchedule(clinicHours), hasOverrides: false };
-  }
-  const entries = Array.from({ length: 7 }, (_, i) => {
-    const found = own.find((e) => e.dayOfWeek === i);
-    if (found) {
-      return {
-        dayOfWeek: i,
-        startTime: found.startTime,
-        endTime: found.endTime,
-        isWorking: found.isWorking,
-        breakStart: found.breakStart ?? "",
-        breakEnd: found.breakEnd ?? "",
-      };
-    }
-    // Fallback to clinic default for missing days
-    const clinicDay = clinicHours?.find((h) => h.dayOfWeek === i);
+  today: string,
+): ResolvedEmployeeSchedule {
+  const own = (schedules ?? []).filter((s) => s.userId === employee.userId);
+  const periods = groupSchedulesIntoPeriods(own);
+  const fallback = buildClinicFallback(clinicHours);
+
+  if (periods.length === 0) {
     return {
-      dayOfWeek: i,
-      startTime: clinicDay?.startTime ?? "08:00",
-      endTime: clinicDay?.endTime ?? "17:00",
-      isWorking: clinicDay?.isOpen ?? (i >= 1 && i <= 5),
-      breakStart: clinicDay?.breakStart ?? "",
-      breakEnd: clinicDay?.breakEnd ?? "",
+      entries: fallback,
+      totalPeriods: 0,
+      datedPeriods: 0,
+      hasOverrides: false,
     };
-  });
-  return { entries, hasOverrides: true };
+  }
+
+  const datedPeriods = periods.filter((p) => p.effectiveFrom).length;
+  const activePeriod = findActivePeriod(periods, today);
+
+  const entries: DisplayEntry[] = activePeriod
+    ? Array.from({ length: 7 }, (_, i) => {
+        const found = activePeriod.entries.find((e) => e.dayOfWeek === i);
+        if (found) {
+          return {
+            dayOfWeek: i,
+            startTime: found.startTime,
+            endTime: found.endTime,
+            isWorking: found.isWorking,
+            breakStart: found.breakStart,
+            breakEnd: found.breakEnd,
+          };
+        }
+        return fallback[i];
+      })
+    : fallback;
+
+  return {
+    entries,
+    activePeriod,
+    totalPeriods: periods.length,
+    datedPeriods,
+    hasOverrides: true,
+  };
 }
 
 function TimetablePage() {
   const { t, i18n } = useTranslation();
   const { organizationId } = useOrganization();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const bulkSetEmployeeSchedule = useAction(
     // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
     api.gabinet.scheduling.bulkSetEmployeeSchedule,
+  );
+  const saveSchedulePeriod = useAction(
+    // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
+    api.gabinet.scheduling.saveSchedulePeriod,
+  );
+  const removeSchedulePeriod = useAction(
+    // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
+    api.gabinet.scheduling.removeSchedulePeriod,
   );
 
   const { data: employees } = useSupabaseGabinetEmployeesList(organizationId, {
@@ -132,6 +161,7 @@ function TimetablePage() {
   const { data: members } = useSupabaseOrganizationMembers(organizationId);
 
   const dayNames = i18n.language === "pl" ? DAY_NAMES_PL : DAY_NAMES_EN;
+  const today = new Date().toISOString().split("T")[0];
 
   const userMap = useMemo(() => {
     const map = new Map<string, { name: string | null; email: string | null }>();
@@ -186,24 +216,30 @@ function TimetablePage() {
     });
   };
 
-  const handleSave = async (
-    employee: MappedGabinetEmployee,
-    hours: DaySchedule[],
-  ) => {
-    await bulkSetEmployeeSchedule({
-      organizationId,
-      userId: employee.userId,
-      hours: hours.map((h) => ({
+  const editingEmployeeSchedules = useMemo(() => {
+    if (!editingEmployee) return undefined;
+    return (schedules ?? []).filter(
+      (s) => s.userId === editingEmployee.userId,
+    );
+  }, [schedules, editingEmployee]);
+
+  const editingEmployeePeriods = useMemo(
+    () => groupSchedulesIntoPeriods(editingEmployeeSchedules),
+    [editingEmployeeSchedules],
+  );
+
+  const clinicHoursForEditor = useMemo(
+    () =>
+      (clinicHours ?? []).map((h) => ({
         dayOfWeek: h.dayOfWeek,
         startTime: h.startTime,
         endTime: h.endTime,
-        isWorking: h.isWorking,
-        breakStart: h.breakStart || undefined,
-        breakEnd: h.breakEnd || undefined,
+        isOpen: h.isOpen,
+        breakStart: h.breakStart ?? undefined,
+        breakEnd: h.breakEnd ?? undefined,
       })),
-    });
-    invalidateScheduleCache();
-  };
+    [clinicHours],
+  );
 
   return (
     <div className="flex h-full w-full flex-col gap-6">
@@ -255,17 +291,26 @@ function TimetablePage() {
               </tr>
             )}
             {sortedEmployees.map((emp) => {
-              const { entries, hasOverrides } = buildEmployeeSchedule(
-                emp,
-                schedules,
-                clinicHours,
-              );
+              const {
+                entries,
+                activePeriod,
+                datedPeriods,
+                hasOverrides,
+              } = resolveEmployeeSchedule(emp, schedules, clinicHours, today);
+              const activeDatedLabel =
+                activePeriod?.effectiveFrom
+                  ? `${activePeriod.effectiveFrom}${
+                      activePeriod.effectiveTo
+                        ? ` — ${activePeriod.effectiveTo}`
+                        : ` — ${t("gabinet.employees.schedule.ongoing")}`
+                    }`
+                  : null;
               return (
                 <tr key={emp._id} className="border-b last:border-b-0">
                   <td className="px-4 py-2 align-middle">
                     <div className="flex flex-col">
                       <span className="font-medium">{employeeName(emp)}</span>
-                      <div className="flex items-center gap-1.5 mt-0.5">
+                      <div className="flex flex-wrap items-center gap-1.5 mt-0.5">
                         {emp.specialization && (
                           <span className="text-xs text-muted-foreground">
                             {emp.specialization}
@@ -274,6 +319,26 @@ function TimetablePage() {
                         {!hasOverrides && (
                           <Badge variant="outline" className="text-[10px] h-4 px-1">
                             {t("gabinet.timetable.usingDefaults")}
+                          </Badge>
+                        )}
+                        {activeDatedLabel && (
+                          <Badge
+                            variant="default"
+                            className="text-[10px] h-4 px-1"
+                            title={t("gabinet.timetable.activePeriodHint")}
+                          >
+                            {activeDatedLabel}
+                          </Badge>
+                        )}
+                        {datedPeriods > 0 && (
+                          <Badge
+                            variant="secondary"
+                            className="text-[10px] h-4 px-1"
+                            title={t("gabinet.timetable.datedPeriodsHint")}
+                          >
+                            {t("gabinet.timetable.datedPeriodsCount", {
+                              count: datedPeriods,
+                            })}
                           </Badge>
                         )}
                       </div>
@@ -321,221 +386,47 @@ function TimetablePage() {
       </div>
 
       {editingEmployee && (
-        <EmployeeScheduleEditor
-          employee={editingEmployee}
-          employeeName={employeeName(editingEmployee)}
-          schedules={schedules}
-          clinicHours={clinicHours}
-          onClose={() => setEditingEmployee(null)}
-          onSave={async (hours) => {
-            await handleSave(editingEmployee, hours);
-          }}
-        />
+        <Sheet
+          open
+          onOpenChange={(open) => !open && setEditingEmployee(null)}
+        >
+          <SheetContent
+            side="right"
+            className="flex flex-col sm:max-w-[760px] overflow-y-auto"
+          >
+            <SheetHeader>
+              <SheetTitle>{t("gabinet.timetable.editTitle")}</SheetTitle>
+              <SheetDescription>
+                {employeeName(editingEmployee)}
+              </SheetDescription>
+            </SheetHeader>
+
+            <div className="flex-1 overflow-y-auto py-4">
+              <FlexibleScheduleEditor
+                organizationId={organizationId as Id<"organizations">}
+                userId={editingEmployee.userId as Id<"users">}
+                periods={editingEmployeePeriods}
+                clinicHours={clinicHoursForEditor}
+                onSavePeriod={async (a) => {
+                  await saveSchedulePeriod(a);
+                  invalidateScheduleCache();
+                }}
+                onRemovePeriod={async (a) => {
+                  await removeSchedulePeriod(a);
+                  invalidateScheduleCache();
+                }}
+                onSaveLegacy={async (a) => {
+                  await bulkSetEmployeeSchedule(a);
+                  invalidateScheduleCache();
+                }}
+                onManageLeaves={() =>
+                  navigate({ to: "/dashboard/gabinet/settings/leaves" })
+                }
+              />
+            </div>
+          </SheetContent>
+        </Sheet>
       )}
     </div>
-  );
-}
-
-function EmployeeScheduleEditor({
-  employee,
-  employeeName,
-  schedules,
-  clinicHours,
-  onClose,
-  onSave,
-}: {
-  employee: MappedGabinetEmployee;
-  employeeName: string;
-  schedules: MappedGabinetEmployeeSchedule[] | undefined;
-  clinicHours: MappedGabinetWorkingHours[] | undefined;
-  onClose: () => void;
-  onSave: (hours: DaySchedule[]) => Promise<void>;
-}) {
-  const { t, i18n } = useTranslation();
-  const dayFull =
-    i18n.language === "pl"
-      ? ["Niedziela", "Poniedziałek", "Wtorek", "Środa", "Czwartek", "Piątek", "Sobota"]
-      : ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-
-  const [hours, setHours] = useState<DaySchedule[]>(() => {
-    const { entries } = buildEmployeeSchedule(employee, schedules, clinicHours);
-    return entries;
-  });
-  const [saving, setSaving] = useState(false);
-
-  // Re-init if the editor is reopened for a different employee (or data refreshes)
-  useEffect(() => {
-    const { entries } = buildEmployeeSchedule(employee, schedules, clinicHours);
-    setHours(entries);
-  }, [employee._id]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const updateDay = (
-    dayOfWeek: number,
-    field: keyof DaySchedule,
-    value: string | boolean,
-  ) => {
-    setHours((prev) =>
-      prev.map((h) => (h.dayOfWeek === dayOfWeek ? { ...h, [field]: value } : h)),
-    );
-  };
-
-  const timeErrors = hours.filter(
-    (h) => h.isWorking && h.endTime <= h.startTime,
-  );
-  const breakErrors = hours.filter(
-    (h) =>
-      h.isWorking &&
-      h.breakStart &&
-      h.breakEnd &&
-      h.breakEnd <= h.breakStart,
-  );
-
-  const handleSubmit = async () => {
-    if (timeErrors.length > 0) {
-      toast.error(
-        t("gabinet.scheduling.validationEndAfterStart", {
-          days: timeErrors.map((h) => dayFull[h.dayOfWeek]).join(", "),
-        }),
-      );
-      return;
-    }
-    if (breakErrors.length > 0) {
-      toast.error(
-        t("gabinet.scheduling.validationBreakEndAfterStart", {
-          days: breakErrors.map((h) => dayFull[h.dayOfWeek]).join(", "),
-        }),
-      );
-      return;
-    }
-    setSaving(true);
-    try {
-      await onSave(hours);
-      toast.success(t("common.saved"));
-      onClose();
-    } catch (e: any) {
-      toast.error(e.message);
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <Sheet open onOpenChange={(open) => !open && onClose()}>
-      <SheetContent side="right" className="flex flex-col sm:max-w-[560px]">
-        <SheetHeader>
-          <SheetTitle>{t("gabinet.timetable.editTitle")}</SheetTitle>
-          <SheetDescription>{employeeName}</SheetDescription>
-        </SheetHeader>
-
-        <div className="flex-1 overflow-y-auto py-4">
-          <div className="rounded-lg border">
-            <div className="grid grid-cols-[140px_50px_1fr_1fr_2fr] gap-2 border-b bg-muted/50 px-3 py-2 text-xs font-medium text-muted-foreground">
-              <span>{t("gabinet.scheduling.day")}</span>
-              <span>{t("gabinet.scheduling.open")}</span>
-              <span>{t("gabinet.scheduling.start")}</span>
-              <span>{t("gabinet.scheduling.end")}</span>
-              <span>{t("gabinet.schedules.break")}</span>
-            </div>
-
-            {DISPLAY_ORDER.map((dayIdx) => {
-              const h = hours.find((x) => x.dayOfWeek === dayIdx)!;
-              const hasBreak = Boolean(h.breakStart || h.breakEnd);
-              const hasTimeError = h.isWorking && h.endTime <= h.startTime;
-              const hasBreakError =
-                h.isWorking && h.breakStart && h.breakEnd && h.breakEnd <= h.breakStart;
-              return (
-                <div
-                  key={dayIdx}
-                  className={`grid grid-cols-[140px_50px_1fr_1fr_2fr] items-center gap-2 border-b px-3 py-1.5 last:border-b-0 ${hasTimeError || hasBreakError ? "bg-red-50 dark:bg-red-950/20" : ""}`}
-                >
-                  <span className="text-sm font-medium">{dayFull[dayIdx]}</span>
-                  <Checkbox
-                    checked={h.isWorking}
-                    onCheckedChange={(checked) =>
-                      updateDay(dayIdx, "isWorking", checked as boolean)
-                    }
-                  />
-                  <Input
-                    type="time"
-                    className="h-7"
-                    value={h.startTime}
-                    onChange={(e) => updateDay(dayIdx, "startTime", e.target.value)}
-                    disabled={!h.isWorking}
-                  />
-                  <Input
-                    type="time"
-                    className="h-7"
-                    value={h.endTime}
-                    onChange={(e) => updateDay(dayIdx, "endTime", e.target.value)}
-                    disabled={!h.isWorking}
-                  />
-                  {hasBreak ? (
-                    <div className="flex items-center gap-1">
-                      <Input
-                        type="time"
-                        className="h-7"
-                        value={h.breakStart}
-                        onChange={(e) =>
-                          updateDay(dayIdx, "breakStart", e.target.value)
-                        }
-                        disabled={!h.isWorking}
-                      />
-                      <span className="text-xs text-muted-foreground">–</span>
-                      <Input
-                        type="time"
-                        className="h-7"
-                        value={h.breakEnd}
-                        onChange={(e) =>
-                          updateDay(dayIdx, "breakEnd", e.target.value)
-                        }
-                        disabled={!h.isWorking}
-                      />
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7 text-muted-foreground hover:text-destructive"
-                        onClick={() => {
-                          updateDay(dayIdx, "breakStart", "");
-                          updateDay(dayIdx, "breakEnd", "");
-                        }}
-                        disabled={!h.isWorking}
-                        aria-label={t("gabinet.scheduling.removeBreak")}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" variant="stroke" />
-                      </Button>
-                    </div>
-                  ) : (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="h-7 justify-self-start text-xs"
-                      onClick={() => {
-                        updateDay(dayIdx, "breakStart", "12:00");
-                        updateDay(dayIdx, "breakEnd", "13:00");
-                      }}
-                      disabled={!h.isWorking}
-                    >
-                      <Plus className="mr-1 h-3.5 w-3.5" variant="stroke" />
-                      {t("gabinet.scheduling.addBreak")}
-                    </Button>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </div>
-
-        <SheetFooter className="border-t pt-4">
-          <Button variant="outline" onClick={onClose} disabled={saving}>
-            {t("common.cancel")}
-          </Button>
-          <Button onClick={handleSubmit} disabled={saving}>
-            {saving ? t("common.saving") : t("common.save")}
-          </Button>
-        </SheetFooter>
-      </SheetContent>
-    </Sheet>
   );
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #331.

Closes #331

---

## Claude summary

Committed.

Summary: I extracted the existing `FlexibleScheduleEditor` (previously inline in the employee detail route) into a shared component at `src/components/gabinet/flexible-schedule-editor.tsx`, alongside a `groupSchedulesIntoPeriods` helper and a `findActivePeriod` helper. The timetable page now uses it inside the edit Sheet so admins can manage default and dated periods together, and the grid resolves the period active for today (dated overrides take priority over default), with row badges showing the active dated range and a count of dated periods.

Verified: typecheck on changed files is clean (no new errors vs. baseline), lint on changed files reports only pre-existing warnings (the new shared component triggers the standard `react-refresh/only-export-components` warning shared by other helper-and-component modules, and `any` in toast.error catch blocks matches the surrounding pattern).

## Follow-ups
- Fix `bulkSetEmployeeSchedule` not filtering by `effectiveFrom`: in `convex/gabinet/scheduling.ts:255-260`, the existence check matches the first row for (org, user, day), which can clobber dated period rows when saving the default schedule.