### PR TITLE
Fix `bulkSetEmployeeSchedule` not filtering by `effectiveFrom`

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -253,11 +253,15 @@ export const bulkSetEmployeeSchedule = action({
     const db = createSupabaseDb();
 
     for (const h of args.hours) {
-      const existing = await db.query("gabinetEmployeeSchedules")
+      const candidates = await db.query("gabinetEmployeeSchedules")
         .eq("organizationId", String(args.organizationId))
         .eq("userId", args.userId)
         .eq("dayOfWeek", h.dayOfWeek)
-        .first();
+        .collect();
+
+      const existing = candidates.find(
+        (c) => !((c.effectiveFrom as string | null | undefined) ?? "")
+      );
 
       if (existing) {
         await db.patch("gabinetEmployeeSchedules", existing._id as string, {
@@ -279,6 +283,8 @@ export const bulkSetEmployeeSchedule = action({
           isWorking: h.isWorking,
           breakStart: h.breakStart ?? null,
           breakEnd: h.breakEnd ?? null,
+          effectiveFrom: null,
+          effectiveTo: null,
           locationId: h.locationId ?? null,
           createdBy: authResult.userId,
           createdAt: now,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #343.

Closes #343

---

## Claude summary

Fixed and committed. The change in `convex/gabinet/scheduling.ts` replaces the `.first()` lookup with a `.collect()` plus a `.find()` that selects only the row with an empty `effectiveFrom`, so saving the default schedule no longer overwrites dated period rows for the same (org, user, day). New inserts now set `effectiveFrom`/`effectiveTo` to `null` explicitly. The pattern mirrors `saveSchedulePeriod` further down in the same file. Pre-existing TS2589 error on line 41 is unrelated (verified by stashing the change and re-running typecheck).

## Follow-ups
- Fix `setEmployeeSchedule` existence check to honor `effectiveFrom` in convex/gabinet/scheduling.ts: lines 191-195 have the same `.first()` lookup that ignores `effectiveFrom`, so calling it for one period can clobber a different period's row for the same (org, user, day).