### PR TITLE
Fix `setEmployeeSchedule` existence check to honor `effectiveFrom` in convex/gab

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -188,11 +188,15 @@ export const setEmployeeSchedule = action({
     const now = Date.now();
     const db = createSupabaseDb();
 
-    const existing = await db.query("gabinetEmployeeSchedules")
+    const candidates = await db.query("gabinetEmployeeSchedules")
       .eq("organizationId", String(args.organizationId))
       .eq("userId", args.userId)
       .eq("dayOfWeek", args.dayOfWeek)
-      .first();
+      .collect();
+
+    const existing = candidates.find(
+      (c) => ((c.effectiveFrom as string | null | undefined) ?? "") === (args.effectiveFrom ?? "")
+    );
 
     const data: Record<string, unknown> = {
       startTime: args.startTime,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #349.

Closes #349

---

## Claude summary

Fixed in `convex/gabinet/scheduling.ts:191-199`. The `.first()` lookup that only matched (org, user, day) is replaced with a `.collect()` + `.find()` that also matches `effectiveFrom`, so saving one period no longer clobbers a different period's row (or the default row) for the same day. Mirrors the existing pattern in `saveSchedulePeriod` and the recent fix in `bulkSetEmployeeSchedule` (#348).