### PR TITLE
Podświetlenie

### DIFF
--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -154,10 +154,40 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
         className="relative flex-1 select-none"
         onMouseDown={dragHandler.handleMouseDown}
       >
+        {/* Closed hours background — entire day when clinic is closed */}
+        {workStartTop === null && (
+          <div
+            className="pointer-events-none absolute inset-0 bg-muted/60"
+            style={{ height: `${HOURS.length * 60}px` }}
+          />
+        )}
+
+        {/* Closed: before clinic opens */}
+        {workStartTop !== null && workStartTop > 0 && (
+          <div
+            className="pointer-events-none absolute left-0 right-0 bg-muted/60"
+            style={{
+              top: 0,
+              height: `${workStartTop}px`,
+            }}
+          />
+        )}
+
+        {/* Closed: after clinic closes */}
+        {workEndTop !== null && workEndTop < HOURS.length * 60 && (
+          <div
+            className="pointer-events-none absolute left-0 right-0 bg-muted/60"
+            style={{
+              top: `${workEndTop}px`,
+              height: `${HOURS.length * 60 - workEndTop}px`,
+            }}
+          />
+        )}
+
         {/* Working hours background */}
         {workStartTop !== null && workEndTop !== null && (
           <div
-            className="absolute left-0 right-0 bg-primary/5 border-y border-primary/10"
+            className="pointer-events-none absolute left-0 right-0 bg-primary/5 border-y border-primary/10"
             style={{
               top: `${workStartTop}px`,
               height: `${workEndTop - workStartTop}px`,
@@ -168,7 +198,7 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
         {/* Break time background */}
         {breakStartTop !== null && breakEndTop !== null && (
           <div
-            className="absolute left-0 right-0 bg-orange-100/50 border-y border-orange-200/50"
+            className="pointer-events-none absolute left-0 right-0 bg-orange-100/50 border-y border-orange-200/50"
             style={{
               top: `${breakStartTop}px`,
               height: `${breakEndTop - breakStartTop}px`,

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -189,11 +189,39 @@ function WeekDayColumn({
         className="relative select-none"
         onMouseDown={dragHandler.handleMouseDown}
       >
-        {/* Working hours background for this day */}
+        {/* Closed hours background — entire day when clinic is closed */}
+        {!schedule && (
+          <div
+            className="pointer-events-none absolute inset-0 bg-muted/60 z-0"
+            style={{ height: `${HOURS.length * 60}px` }}
+          />
+        )}
+
+        {/* Working / closed / break hour backgrounds */}
         {schedule && (
           <>
+            {/* Closed: before clinic opens */}
+            {timeToTop(schedule.startTime) > 0 && (
+              <div
+                className="pointer-events-none absolute left-0 right-0 bg-muted/60 z-0"
+                style={{
+                  top: 0,
+                  height: `${timeToTop(schedule.startTime)}px`,
+                }}
+              />
+            )}
+            {/* Closed: after clinic closes */}
+            {timeToTop(schedule.endTime) < HOURS.length * 60 && (
+              <div
+                className="pointer-events-none absolute left-0 right-0 bg-muted/60 z-0"
+                style={{
+                  top: `${timeToTop(schedule.endTime)}px`,
+                  height: `${HOURS.length * 60 - timeToTop(schedule.endTime)}px`,
+                }}
+              />
+            )}
             <div
-              className="absolute left-0 right-0 bg-primary/5 border-y border-primary/10 z-0"
+              className="pointer-events-none absolute left-0 right-0 bg-primary/5 border-y border-primary/10 z-0"
               style={{
                 top: `${timeToTop(schedule.startTime)}px`,
                 height: `${timeToTop(schedule.endTime) - timeToTop(schedule.startTime)}px`,
@@ -201,7 +229,7 @@ function WeekDayColumn({
             />
             {schedule.breakStart && schedule.breakEnd && (
               <div
-                className="absolute left-0 right-0 bg-orange-100/50 border-y border-orange-200/50 z-0"
+                className="pointer-events-none absolute left-0 right-0 bg-orange-100/50 border-y border-orange-200/50 z-0"
                 style={{
                   top: `${timeToTop(schedule.breakStart)}px`,
                   height: `${timeToTop(schedule.breakEnd) - timeToTop(schedule.breakStart)}px`,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #357.

Closes #357

---

## Claude summary

Committed. The fix addresses the issue: closed clinic hours are now highlighted with a muted gray overlay in both day and week views of `/dashboard/gabinet/calendar`. The overlay covers:

- The block before opening time (e.g. before 9:00)
- The block after closing time (e.g. after 18:00)
- The entire day column when the clinic is closed that day

I also added `pointer-events-none` to the background overlays so they don't interfere with the drag-to-create handler. Typecheck passes.