### PR TITLE
widok

### DIFF
--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -206,7 +206,7 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
           />
         )}
 
-        {/* Hour lines */}
+        {/* Hour lines with 15-minute subdivisions */}
         {HOURS.map((h) => (
           <DroppableSlot
             key={h}
@@ -215,7 +215,11 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
             time={`${String(h).padStart(2, "0")}:00`}
             className="h-[60px] border-b border-dashed border-muted"
           >
-            <div className="h-full w-full cursor-pointer hover:bg-muted/30" />
+            <div className="relative h-full w-full cursor-pointer hover:bg-muted/30">
+              <div className="pointer-events-none absolute left-0 right-0 top-[15px] border-t border-dashed border-muted/40" />
+              <div className="pointer-events-none absolute left-0 right-0 top-[30px] border-t border-dashed border-muted/60" />
+              <div className="pointer-events-none absolute left-0 right-0 top-[45px] border-t border-dashed border-muted/40" />
+            </div>
           </DroppableSlot>
         ))}
 

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -247,7 +247,11 @@ function WeekDayColumn({
             time={`${String(h).padStart(2, "0")}:00`}
             className="h-[60px] border-b border-dashed border-muted"
           >
-            <div className="h-full w-full cursor-pointer hover:bg-muted/20" />
+            <div className="relative h-full w-full cursor-pointer hover:bg-muted/20">
+              <div className="pointer-events-none absolute left-0 right-0 top-[15px] border-t border-dashed border-muted/40" />
+              <div className="pointer-events-none absolute left-0 right-0 top-[30px] border-t border-dashed border-muted/60" />
+              <div className="pointer-events-none absolute left-0 right-0 top-[45px] border-t border-dashed border-muted/40" />
+            </div>
           </DroppableSlot>
         ))}
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #358.

Closes #358

---

## Claude summary

Committed. Summary of the change:

The gabinet calendar day view (`src/components/gabinet/calendar/calendar-day-view.tsx:209-224`) and week view (`src/components/gabinet/calendar/calendar-week-view.tsx:242-256`) previously rendered only hourly dividers, even though appointment drag/resize already snaps to 15-minute increments (`snapMinutes: 15`). I added three thin dashed horizontal lines per hour cell at the 15, 30, and 45 minute marks. The 30-minute (half-hour) line is rendered at `border-muted/60` while the quarter-hour lines use `border-muted/40`, giving a subtle visual hierarchy. The hour boundary keeps its existing dashed `border-muted` line as the strongest separator. Lines are `pointer-events-none` so click/drag-to-create behavior on slots is unchanged. Typecheck on the modified files passes (remaining repo-wide errors are pre-existing and unrelated).