### PR TITLE
widok wizyty

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2384,6 +2384,7 @@
       },
       "created": "Appointment created",
       "updated": "Appointment updated",
+      "openFullView": "Open full view",
       "noAppointments": "No appointments",
       "availableSlots": "Available slots",
       "noAvailableSlots": "No available slots for this employee on this date.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2395,6 +2395,7 @@
       },
       "created": "Wizyta utworzona",
       "updated": "Wizyta zaktualizowana",
+      "openFullView": "Otwórz pełny widok",
       "noAppointments": "Brak wizyt",
       "availableSlots": "Dostępne terminy",
       "noAvailableSlots": "Brak dostępnych terminów dla tego pracownika w tym dniu.",

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -1,0 +1,361 @@
+import { useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAction } from "convex/react";
+import { useTranslation } from "react-i18next";
+import { Link } from "@tanstack/react-router";
+import { toast } from "sonner";
+import { api } from "@cvx/_generated/api";
+import type { Id } from "@cvx/_generated/dataModel";
+import { useOrganization } from "@/components/org-context";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Calendar,
+  Clock,
+  Mail,
+  Phone,
+  Stethoscope,
+  User,
+} from "@/lib/ez-icons";
+import { ExternalLink } from "lucide-react";
+
+const VALID_TRANSITIONS: Record<string, string[]> = {
+  pending_confirmation: ["scheduled", "confirmed", "cancelled"],
+  scheduled: ["confirmed", "cancelled", "no_show"],
+  confirmed: ["in_progress", "completed", "cancelled", "no_show"],
+  in_progress: ["completed", "cancelled"],
+  completed: [],
+  cancelled: [],
+  no_show: [],
+};
+
+const STATUS_DOT_COLORS: Record<string, string> = {
+  pending_confirmation: "bg-amber-400",
+  scheduled: "bg-blue-400",
+  confirmed: "bg-emerald-400",
+  in_progress: "bg-yellow-400",
+  completed: "bg-gray-400",
+  cancelled: "bg-red-400",
+  no_show: "bg-orange-400",
+};
+
+type AppointmentStatus =
+  | "pending_confirmation"
+  | "scheduled"
+  | "confirmed"
+  | "in_progress"
+  | "completed"
+  | "cancelled"
+  | "no_show";
+
+interface AppointmentPreviewContentProps {
+  appointmentId: string;
+  onClose: () => void;
+}
+
+export function AppointmentPreviewContent({
+  appointmentId,
+  onClose,
+}: AppointmentPreviewContentProps) {
+  const { t, i18n } = useTranslation();
+  const { organizationId } = useOrganization();
+  const queryClient = useQueryClient();
+
+  const getFullDetail = useAction(api.gabinet.appointments.getFullDetail);
+  const updateAppointment = useAction(api.gabinet.appointments.update);
+
+  const { data: detail, isLoading, refetch } = useQuery({
+    queryKey: ["gabinet.appointment.fullDetail", organizationId, appointmentId],
+    queryFn: () =>
+      getFullDetail({
+        organizationId,
+        appointmentId,
+      }),
+    enabled: !!organizationId && !!appointmentId,
+  });
+
+  const [status, setStatus] = useState<AppointmentStatus | "">("");
+  const [date, setDate] = useState("");
+  const [startTime, setStartTime] = useState("");
+  const [endTime, setEndTime] = useState("");
+  const [internalNotes, setInternalNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!detail) return;
+    const appt = detail.appointment;
+    setStatus(appt.status as AppointmentStatus);
+    setDate(appt.date);
+    setStartTime(appt.startTime.slice(0, 5));
+    setEndTime(appt.endTime.slice(0, 5));
+    setInternalNotes(appt.internalNotes ?? "");
+  }, [detail]);
+
+  if (isLoading || !detail) {
+    return (
+      <div className="space-y-3 p-1">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-9 w-full" />
+      </div>
+    );
+  }
+
+  const { appointment, patient, treatment, employee } = detail;
+  const initialStatus = appointment.status as AppointmentStatus;
+  const availableTransitions = VALID_TRANSITIONS[initialStatus] ?? [];
+  const employeeName = employee?.name ?? employee?.email ?? "-";
+  const patientFullName = patient
+    ? `${patient.firstName ?? ""} ${patient.lastName ?? ""}`.trim()
+    : "-";
+
+  const dirty =
+    status !== initialStatus ||
+    date !== appointment.date ||
+    startTime !== appointment.startTime.slice(0, 5) ||
+    endTime !== appointment.endTime.slice(0, 5) ||
+    internalNotes !== (appointment.internalNotes ?? "");
+
+  const handleSave = async () => {
+    if (!dirty || saving) return;
+    setSaving(true);
+    try {
+      const args: Parameters<typeof updateAppointment>[0] = {
+        organizationId,
+        appointmentId: appointment._id as Id<"gabinetAppointments">,
+      };
+      if (date !== appointment.date) args.date = date;
+      if (startTime !== appointment.startTime.slice(0, 5))
+        args.startTime = startTime;
+      if (endTime !== appointment.endTime.slice(0, 5)) args.endTime = endTime;
+      if (status && status !== initialStatus) args.status = status;
+      if (internalNotes !== (appointment.internalNotes ?? ""))
+        args.internalNotes = internalNotes;
+
+      await updateAppointment(args);
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: supabaseKeys.gabinetAppointments.all,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: supabaseKeys.scheduledActivities.all,
+        }),
+      ]);
+      await refetch();
+      toast.success(t("gabinet.appointments.updated"));
+      onClose();
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : t("common.error");
+      toast.error(msg);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const formatDateLabel = (d: string) =>
+    new Date(d + "T00:00:00").toLocaleDateString(i18n.language, {
+      weekday: "short",
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+
+  return (
+    <div className="space-y-3">
+      {/* Header — patient + treatment */}
+      <div className="space-y-1.5">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-semibold leading-tight">
+              {patientFullName}
+            </p>
+            {treatment?.name && (
+              <p className="mt-0.5 flex items-center gap-1 truncate text-xs text-muted-foreground">
+                <Stethoscope className="size-3 shrink-0" />
+                {treatment.name}
+              </p>
+            )}
+          </div>
+          <Badge variant="outline" className="shrink-0 text-[10px]">
+            <span
+              className={`mr-1 inline-block h-1.5 w-1.5 rounded-full ${STATUS_DOT_COLORS[initialStatus] ?? "bg-muted-foreground"}`}
+            />
+            {t(`gabinet.appointments.statuses.${initialStatus}`)}
+          </Badge>
+        </div>
+
+        {/* Quick contact links */}
+        {(patient?.phone || patient?.email) && (
+          <div className="flex flex-wrap gap-1.5 text-xs">
+            {patient?.phone && (
+              <a
+                href={`tel:${patient.phone}`}
+                className="inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                <Phone className="size-3" />
+                {patient.phone}
+              </a>
+            )}
+            {patient?.email && (
+              <a
+                href={`mailto:${patient.email}`}
+                className="inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                <Mail className="size-3" />
+                {patient.email}
+              </a>
+            )}
+          </div>
+        )}
+      </div>
+
+      <Separator />
+
+      {/* Employee + Date summary */}
+      <div className="grid grid-cols-2 gap-2 text-xs">
+        <div className="flex items-center gap-1.5 text-muted-foreground">
+          <User className="size-3" />
+          <span className="truncate">{employeeName}</span>
+        </div>
+        <div className="flex items-center gap-1.5 text-muted-foreground">
+          <Calendar className="size-3" />
+          <span className="truncate">{formatDateLabel(appointment.date)}</span>
+        </div>
+      </div>
+
+      <Separator />
+
+      {/* Edit fields */}
+      <div className="space-y-2.5">
+        <div className="space-y-1">
+          <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
+            {t("gabinet.appointmentDetail.changeStatus")}
+          </Label>
+          <Select
+            value={status}
+            onValueChange={(v) => setStatus(v as AppointmentStatus)}
+            disabled={availableTransitions.length === 0}
+          >
+            <SelectTrigger className="h-8 text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={initialStatus} disabled>
+                <span className="flex items-center gap-2">
+                  <span
+                    className={`inline-block h-1.5 w-1.5 rounded-full ${STATUS_DOT_COLORS[initialStatus] ?? "bg-muted-foreground"}`}
+                  />
+                  {t(`gabinet.appointments.statuses.${initialStatus}`)}
+                </span>
+              </SelectItem>
+              {availableTransitions.map((s) => (
+                <SelectItem key={s} value={s}>
+                  <span className="flex items-center gap-2">
+                    <span
+                      className={`inline-block h-1.5 w-1.5 rounded-full ${STATUS_DOT_COLORS[s] ?? "bg-muted-foreground"}`}
+                    />
+                    {t(`gabinet.appointments.statuses.${s}`)}
+                  </span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="grid grid-cols-[1fr_auto_auto] items-end gap-1.5">
+          <div className="space-y-1">
+            <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
+              {t("common.date")}
+            </Label>
+            <Input
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="h-8 text-sm"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
+              {t("common.from", "Od")}
+            </Label>
+            <Input
+              type="time"
+              value={startTime}
+              onChange={(e) => setStartTime(e.target.value)}
+              className="h-8 w-[88px] text-sm"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
+              {t("common.to", "Do")}
+            </Label>
+            <Input
+              type="time"
+              value={endTime}
+              onChange={(e) => setEndTime(e.target.value)}
+              className="h-8 w-[88px] text-sm"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
+            <Clock className="mr-1 inline size-3" />
+            {t("gabinet.appointments.internalNotes")}
+          </Label>
+          <Textarea
+            value={internalNotes}
+            onChange={(e) => setInternalNotes(e.target.value)}
+            placeholder={t("gabinet.appointments.internalNotesPlaceholder")}
+            className="min-h-[60px] text-sm"
+          />
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between gap-2 pt-1">
+        <Button asChild variant="ghost" size="sm" className="h-8 text-xs">
+          <Link
+            to="/dashboard/gabinet/appointments/$appointmentId"
+            params={{ appointmentId: appointment._id }}
+          >
+            <ExternalLink className="mr-1 size-3" />
+            {t("gabinet.appointments.openFullView", "Otwórz pełny widok")}
+          </Link>
+        </Button>
+        <div className="flex gap-1.5">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 text-xs"
+            onClick={onClose}
+          >
+            {t("common.cancel")}
+          </Button>
+          <Button
+            size="sm"
+            className="h-8 text-xs"
+            disabled={!dirty || saving}
+            onClick={handleSave}
+          >
+            {saving ? t("common.saving") : t("common.save")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -20,7 +20,6 @@ interface CalendarDayViewProps {
   appointments: Appointment[];
   onSlotClick?: (time: string) => void;
   onSlotDragSelect?: (date: string, startTime: string, endTime: string) => void;
-  onAppointmentClick?: (id: string) => void;
   onAppointmentResize?: (id: string, newEndTime: string) => void;
   workingHours?: { startTime: string; endTime: string; breakStart?: string; breakEnd?: string } | null;
 }
@@ -95,7 +94,7 @@ function layoutAppointments(appts: Appointment[]): LayoutedAppointment[] {
   return result;
 }
 
-export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSelect, onAppointmentClick, onAppointmentResize, workingHours }: CalendarDayViewProps) {
+export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSelect, onAppointmentResize, workingHours }: CalendarDayViewProps) {
   const now = useCurrentTime();
   const isToday = date === `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
   const currentMinutes = now.getHours() * 60 + now.getMinutes();
@@ -283,7 +282,6 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
               <DraggableAppointment
                 {...appt}
                 date={date}
-                onAppointmentClick={onAppointmentClick}
                 onResize={onAppointmentResize}
                 hourHeight={60}
                 snapMinutes={15}

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -22,7 +22,6 @@ interface CalendarWeekViewProps {
   appointments: Appointment[];
   onSlotClick?: (date: string, time: string) => void;
   onSlotDragSelect?: (date: string, startTime: string, endTime: string) => void;
-  onAppointmentClick?: (id: string) => void;
   onAppointmentResize?: (id: string, newEndTime: string) => void;
   onDayHeaderClick?: (date: string) => void;
   selectedDate?: string;
@@ -125,7 +124,6 @@ interface WeekDayColumnProps {
   currentTimeTop: number | null;
   onSlotClick?: (date: string, time: string) => void;
   onSlotDragSelect?: (date: string, startTime: string, endTime: string) => void;
-  onAppointmentClick?: (id: string) => void;
   onAppointmentResize?: (id: string, newEndTime: string) => void;
   onDayHeaderClick?: (date: string) => void;
 }
@@ -140,7 +138,6 @@ function WeekDayColumn({
   currentTimeTop,
   onSlotClick,
   onSlotDragSelect,
-  onAppointmentClick,
   onAppointmentResize,
   onDayHeaderClick,
 }: WeekDayColumnProps) {
@@ -303,7 +300,6 @@ function WeekDayColumn({
             >
               <DraggableAppointment
                 {...appt}
-                onAppointmentClick={onAppointmentClick}
                 onResize={onAppointmentResize}
                 hourHeight={60}
                 snapMinutes={15}
@@ -316,7 +312,7 @@ function WeekDayColumn({
   );
 }
 
-export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotDragSelect, onAppointmentClick, onAppointmentResize, onDayHeaderClick, selectedDate, employeeSchedules }: CalendarWeekViewProps) {
+export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotDragSelect, onAppointmentResize, onDayHeaderClick, selectedDate, employeeSchedules }: CalendarWeekViewProps) {
   const dates = useMemo(() => getWeekDates(weekStart), [weekStart]);
   const now = useCurrentTime();
   const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
@@ -377,7 +373,6 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotD
             currentTimeTop={isToday ? currentTimeTop : null}
             onSlotClick={onSlotClick}
             onSlotDragSelect={onSlotDragSelect}
-            onAppointmentClick={onAppointmentClick}
             onAppointmentResize={onAppointmentResize}
             onDayHeaderClick={onDayHeaderClick}
           />

--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -1,6 +1,12 @@
 import { useDraggable } from "@dnd-kit/core";
 import { useCallback, useState } from "react";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@/components/ui/popover";
 import { AppointmentCard, type AppointmentTag } from "./appointment-card";
+import { AppointmentPreviewContent } from "./appointment-preview-content";
 
 interface Appointment {
   _id: string;
@@ -15,7 +21,6 @@ interface Appointment {
 }
 
 interface DraggableAppointmentProps extends Appointment {
-  onAppointmentClick?: (id: string) => void;
   onResize?: (id: string, newEndTime: string) => void;
   hourHeight?: number;
   snapMinutes?: number;
@@ -42,7 +47,6 @@ export function DraggableAppointment({
   status,
   color,
   tags,
-  onAppointmentClick,
   onResize,
   hourHeight = 60,
   snapMinutes = 15,
@@ -59,6 +63,10 @@ export function DraggableAppointment({
   });
 
   const [previewEndTime, setPreviewEndTime] = useState<string | null>(null);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  // Suppress popover open when the click follows a drag — useDraggable triggers
+  // onClick after a successful drop, which would otherwise pop the preview.
+  const isPopoverDisabled = status === "blocked";
 
   const startMinutes = timeToMinutes(startTime);
   const originalEndMinutes = timeToMinutes(endTime);
@@ -108,7 +116,12 @@ export function DraggableAppointment({
       ? (timeToMinutes(previewEndTime) - startMinutes) * pxPerMinute
       : null;
 
-  return (
+  const handleCardClick = () => {
+    if (isDragging || isPopoverDisabled) return;
+    setPopoverOpen((o) => !o);
+  };
+
+  const card = (
     <div
       ref={setNodeRef}
       {...listeners}
@@ -127,7 +140,7 @@ export function DraggableAppointment({
         status={status}
         color={color}
         tags={tags}
-        onClick={() => onAppointmentClick?.(_id)}
+        onClick={handleCardClick}
       />
       {onResize && status !== "blocked" && (
         <div
@@ -142,5 +155,26 @@ export function DraggableAppointment({
         </div>
       )}
     </div>
+  );
+
+  if (isPopoverDisabled) return card;
+
+  return (
+    <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+      <PopoverAnchor asChild>{card}</PopoverAnchor>
+      <PopoverContent
+        className="w-96 p-3"
+        align="start"
+        side="right"
+        sideOffset={8}
+        collisionPadding={12}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <AppointmentPreviewContent
+          appointmentId={_id}
+          onClose={() => setPopoverOpen(false)}
+        />
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -9,6 +9,8 @@ const Popover = PopoverPrimitive.Root
 
 const PopoverTrigger = PopoverPrimitive.Trigger
 
+const PopoverAnchor = PopoverPrimitive.Anchor
+
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
@@ -28,4 +30,4 @@ const PopoverContent = React.forwardRef<
 ))
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
-export { Popover, PopoverTrigger, PopoverContent }
+export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -1,4 +1,4 @@
-import { createLazyFileRoute, useNavigate } from "@tanstack/react-router";
+import { createLazyFileRoute } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
@@ -80,7 +80,6 @@ function formatDateStr(d: Date): string {
 function GabinetCalendarPage() {
   const { t, i18n } = useTranslation();
   const { organizationId } = useOrganization();
-  const navigate = useNavigate();
 
   // Indicate this page has wide content (hides Column 2 on 1024-1400px screens)
   useWideContent(true);
@@ -472,17 +471,6 @@ function GabinetCalendarPage() {
     setViewMode("day");
   }, []);
 
-  const handleAppointmentClick = useCallback(
-    (id: string) => {
-      // Navigate to full-page appointment detail
-      navigate({
-        to: "/dashboard/gabinet/appointments/$appointmentId",
-        params: { appointmentId: id },
-      });
-    },
-    [navigate],
-  );
-
   // Resize handler (called when user drags an appointment's bottom edge)
   const handleAppointmentResize = useCallback(
     async (id: string, newEndTime: string) => {
@@ -871,7 +859,6 @@ function GabinetCalendarPage() {
                 handleSlotClick(formatDateStr(currentDate), time)
               }
               onSlotDragSelect={handleSlotDragSelect}
-              onAppointmentClick={handleAppointmentClick}
               onAppointmentResize={handleAppointmentResize}
               workingHours={dayWorkingHours}
             />
@@ -882,7 +869,6 @@ function GabinetCalendarPage() {
               appointments={viewAppointments}
               onSlotClick={handleSlotClick}
               onSlotDragSelect={handleSlotDragSelect}
-              onAppointmentClick={handleAppointmentClick}
               onAppointmentResize={handleAppointmentResize}
               onDayHeaderClick={handleDayClick}
               selectedDate={formatDateStr(currentDate)}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #364.

Closes #364

---

## Claude summary

Committed `4d606dd`. The feature is on the branch and ready for PR.

Summary of what was implemented in this commit (the work was already started in the worktree — I verified, typechecked, and committed it):

Clicking an appointment in the gabinet calendar (day/week views) now opens a Radix popover anchored to the appointment card instead of navigating to the full detail page. The popover shows patient name, treatment, status badge, tap-to-call/email links, employee, and date, plus inline editable fields for status, date, start/end time, and internal notes. A "Open full view" button in the footer preserves access to the full detail page.

Files changed: `src/components/ui/popover.tsx` (exports `PopoverAnchor`), new `src/components/gabinet/calendar/appointment-preview-content.tsx`, `draggable-appointment.tsx` (wraps card in Popover+Anchor and toggles on click, skipping when dragging or status is "blocked"), `calendar-day-view.tsx`/`calendar-week-view.tsx` (drop unused `onAppointmentClick` prop), calendar route (removes the navigate-on-click handler), and PL/EN translations for the new "Open full view" string. Verified no new TypeScript errors and no new lint warnings on the changed files. The unrelated `package-lock.json` engines-field sync was left uncommitted.