### PR TITLE
15 min

### DIFF
--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -22,13 +22,28 @@ interface CalendarDayViewProps {
   onSlotDragSelect?: (date: string, startTime: string, endTime: string) => void;
   onAppointmentResize?: (id: string, newEndTime: string) => void;
   workingHours?: { startTime: string; endTime: string; breakStart?: string; breakEnd?: string } | null;
+  slotMinutes?: 15 | 30 | 60;
 }
 
 const HOURS = Array.from({ length: 14 }, (_, i) => i + 7); // 07:00 – 20:00
+const HOUR_HEIGHT = 60; // 1 minute = 1px
 
 function timeToTop(time: string): number {
   const [h, m] = time.split(":").map(Number);
   return ((h - 7) * 60 + m);
+}
+
+function buildSlots(slotMinutes: number) {
+  const slotsPerHour = 60 / slotMinutes;
+  const slotHeight = HOUR_HEIGHT / slotsPerHour;
+  const totalSlots = HOURS.length * slotsPerHour;
+  return Array.from({ length: totalSlots }, (_, i) => {
+    const minutesFromStart = i * slotMinutes;
+    const h = 7 + Math.floor(minutesFromStart / 60);
+    const m = minutesFromStart % 60;
+    const time = `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+    return { time, h, m, slotHeight, isHourMark: m === 0 };
+  });
 }
 
 // Google Calendar-style cascading layout: each overlapping appointment
@@ -94,12 +109,15 @@ function layoutAppointments(appts: Appointment[]): LayoutedAppointment[] {
   return result;
 }
 
-export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSelect, onAppointmentResize, workingHours }: CalendarDayViewProps) {
+export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSelect, onAppointmentResize, workingHours, slotMinutes = 60 }: CalendarDayViewProps) {
   const now = useCurrentTime();
   const isToday = date === `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
   const currentMinutes = now.getHours() * 60 + now.getMinutes();
   const currentLineTop = ((currentMinutes - 7 * 60) / 60) * 60;
   const currentTimeLabel = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+
+  const slots = useMemo(() => buildSlots(slotMinutes), [slotMinutes]);
+  const showSubdivisions = slotMinutes === 60;
 
   const layouts = useMemo(() => layoutAppointments(appointments), [appointments]);
 
@@ -122,8 +140,8 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
   const dragHandler = useDragToCreate({
     hoursStart: 7,
     hoursCount: HOURS.length,
-    hourHeight: 60,
-    snapMinutes: 15,
+    hourHeight: HOUR_HEIGHT,
+    snapMinutes: Math.min(15, slotMinutes),
     minDragDistance: 8,
     onClick: handleClick,
     onDragSelect: handleDragSelect,
@@ -140,10 +158,16 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
     <div className="relative flex h-full overflow-y-auto">
       {/* Time labels */}
       <div className="sticky left-0 z-10 w-16 shrink-0 border-r bg-background">
-        {HOURS.map((h) => (
-          <div key={h} className="flex h-[60px] items-start justify-end pr-2 pt-0">
-            <span className="text-xs text-muted-foreground">
-              {String(h).padStart(2, "0")}:00
+        {slots.map((s) => (
+          <div
+            key={s.time}
+            className="flex items-start justify-end pr-2 pt-0"
+            style={{ height: `${s.slotHeight}px` }}
+          >
+            <span
+              className={`${s.isHourMark ? "text-xs font-medium text-muted-foreground" : "text-[10px] text-muted-foreground/60"} leading-none`}
+            >
+              {s.time}
             </span>
           </div>
         ))}
@@ -219,19 +243,24 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
           />
         )}
 
-        {/* Hour lines with 15-minute subdivisions */}
-        {HOURS.map((h) => (
+        {/* Slot rows — solid border at hour marks, faded at sub-slot marks */}
+        {slots.map((s) => (
           <DroppableSlot
-            key={h}
-            id={`${date}-${h}`}
+            key={s.time}
+            id={`${date}-${s.time}`}
             date={date}
-            time={`${String(h).padStart(2, "0")}:00`}
-            className="h-[60px] border-b border-dashed border-muted"
+            time={s.time}
+            className={`border-b border-dashed ${s.isHourMark ? "border-muted" : "border-muted/40"}`}
+            style={{ height: `${s.slotHeight}px` }}
           >
             <div className="relative h-full w-full cursor-pointer hover:bg-muted/30">
-              <div className="pointer-events-none absolute left-0 right-0 top-[15px] border-t border-dashed border-muted/40" />
-              <div className="pointer-events-none absolute left-0 right-0 top-[30px] border-t border-dashed border-muted/60" />
-              <div className="pointer-events-none absolute left-0 right-0 top-[45px] border-t border-dashed border-muted/40" />
+              {showSubdivisions && (
+                <>
+                  <div className="pointer-events-none absolute left-0 right-0 top-[15px] border-t border-dashed border-muted/40" />
+                  <div className="pointer-events-none absolute left-0 right-0 top-[30px] border-t border-dashed border-muted/60" />
+                  <div className="pointer-events-none absolute left-0 right-0 top-[45px] border-t border-dashed border-muted/40" />
+                </>
+              )}
             </div>
           </DroppableSlot>
         ))}
@@ -283,8 +312,8 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
                 {...appt}
                 date={date}
                 onResize={onAppointmentResize}
-                hourHeight={60}
-                snapMinutes={15}
+                hourHeight={HOUR_HEIGHT}
+                snapMinutes={Math.min(15, slotMinutes)}
               />
             </div>
           );

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -26,10 +26,25 @@ interface CalendarWeekViewProps {
   onDayHeaderClick?: (date: string) => void;
   selectedDate?: string;
   employeeSchedules?: Map<string, { startTime: string; endTime: string; breakStart?: string; breakEnd?: string }>;
+  slotMinutes?: 15 | 30 | 60;
 }
 
 const HOURS = Array.from({ length: 14 }, (_, i) => i + 7);
+const HOUR_HEIGHT = 60; // 1 minute = 1px
 const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function buildSlots(slotMinutes: number) {
+  const slotsPerHour = 60 / slotMinutes;
+  const slotHeight = HOUR_HEIGHT / slotsPerHour;
+  const totalSlots = HOURS.length * slotsPerHour;
+  return Array.from({ length: totalSlots }, (_, i) => {
+    const minutesFromStart = i * slotMinutes;
+    const h = 7 + Math.floor(minutesFromStart / 60);
+    const m = minutesFromStart % 60;
+    const time = `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+    return { time, h, m, slotHeight, isHourMark: m === 0 };
+  });
+}
 
 function getWeekDates(start: string): string[] {
   const d = new Date(start + "T00:00:00");
@@ -126,6 +141,8 @@ interface WeekDayColumnProps {
   onSlotDragSelect?: (date: string, startTime: string, endTime: string) => void;
   onAppointmentResize?: (id: string, newEndTime: string) => void;
   onDayHeaderClick?: (date: string) => void;
+  slotMinutes: 15 | 30 | 60;
+  slots: ReturnType<typeof buildSlots>;
 }
 
 function WeekDayColumn({
@@ -140,7 +157,10 @@ function WeekDayColumn({
   onSlotDragSelect,
   onAppointmentResize,
   onDayHeaderClick,
+  slotMinutes,
+  slots,
 }: WeekDayColumnProps) {
+  const showSubdivisions = slotMinutes === 60;
   const handleClick = useCallback(
     (time: string) => onSlotClick?.(date, time),
     [onSlotClick, date],
@@ -154,8 +174,8 @@ function WeekDayColumn({
   const dragHandler = useDragToCreate({
     hoursStart: 7,
     hoursCount: HOURS.length,
-    hourHeight: 60,
-    snapMinutes: 15,
+    hourHeight: HOUR_HEIGHT,
+    snapMinutes: Math.min(15, slotMinutes),
     minDragDistance: 8,
     onClick: handleClick,
     onDragSelect: handleDragSelect,
@@ -239,18 +259,23 @@ function WeekDayColumn({
           </>
         )}
 
-        {HOURS.map((h) => (
+        {slots.map((s) => (
           <DroppableSlot
-            key={h}
-            id={`${date}-${h}`}
+            key={s.time}
+            id={`${date}-${s.time}`}
             date={date}
-            time={`${String(h).padStart(2, "0")}:00`}
-            className="h-[60px] border-b border-dashed border-muted"
+            time={s.time}
+            className={`border-b border-dashed ${s.isHourMark ? "border-muted" : "border-muted/40"}`}
+            style={{ height: `${s.slotHeight}px` }}
           >
             <div className="relative h-full w-full cursor-pointer hover:bg-muted/20">
-              <div className="pointer-events-none absolute left-0 right-0 top-[15px] border-t border-dashed border-muted/40" />
-              <div className="pointer-events-none absolute left-0 right-0 top-[30px] border-t border-dashed border-muted/60" />
-              <div className="pointer-events-none absolute left-0 right-0 top-[45px] border-t border-dashed border-muted/40" />
+              {showSubdivisions && (
+                <>
+                  <div className="pointer-events-none absolute left-0 right-0 top-[15px] border-t border-dashed border-muted/40" />
+                  <div className="pointer-events-none absolute left-0 right-0 top-[30px] border-t border-dashed border-muted/60" />
+                  <div className="pointer-events-none absolute left-0 right-0 top-[45px] border-t border-dashed border-muted/40" />
+                </>
+              )}
             </div>
           </DroppableSlot>
         ))}
@@ -301,8 +326,8 @@ function WeekDayColumn({
               <DraggableAppointment
                 {...appt}
                 onResize={onAppointmentResize}
-                hourHeight={60}
-                snapMinutes={15}
+                hourHeight={HOUR_HEIGHT}
+                snapMinutes={Math.min(15, slotMinutes)}
               />
             </div>
           );
@@ -312,7 +337,7 @@ function WeekDayColumn({
   );
 }
 
-export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotDragSelect, onAppointmentResize, onDayHeaderClick, selectedDate, employeeSchedules }: CalendarWeekViewProps) {
+export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotDragSelect, onAppointmentResize, onDayHeaderClick, selectedDate, employeeSchedules, slotMinutes = 60 }: CalendarWeekViewProps) {
   const dates = useMemo(() => getWeekDates(weekStart), [weekStart]);
   const now = useCurrentTime();
   const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
@@ -321,6 +346,7 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotD
   const currentTimeTop = ((currentMinutes - 7 * 60) / 60) * 60;
   const showCurrentTime = todayInWeek && currentTimeTop > 0 && currentTimeTop < HOURS.length * 60;
   const currentTimeLabel = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+  const slots = useMemo(() => buildSlots(slotMinutes), [slotMinutes]);
 
   const layoutsByDate = useMemo(() => {
     const map = new Map<string, LayoutedAppointment[]>();
@@ -335,9 +361,17 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotD
     <div className="flex h-full overflow-auto">
       {/* Time labels */}
       <div className="sticky left-0 z-10 w-14 shrink-0 border-r bg-background pt-8">
-        {HOURS.map((h) => (
-          <div key={h} className="flex h-[60px] items-start justify-end pr-2">
-            <span className="text-xs text-muted-foreground">{String(h).padStart(2, "0")}:00</span>
+        {slots.map((s) => (
+          <div
+            key={s.time}
+            className="flex items-start justify-end pr-2"
+            style={{ height: `${s.slotHeight}px` }}
+          >
+            <span
+              className={`${s.isHourMark ? "text-xs font-medium text-muted-foreground" : "text-[10px] text-muted-foreground/60"} leading-none`}
+            >
+              {s.time}
+            </span>
           </div>
         ))}
 
@@ -375,6 +409,8 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotD
             onSlotDragSelect={onSlotDragSelect}
             onAppointmentResize={onAppointmentResize}
             onDayHeaderClick={onDayHeaderClick}
+            slotMinutes={slotMinutes}
+            slots={slots}
           />
         );
       })}

--- a/src/components/gabinet/calendar/droppable-slot.tsx
+++ b/src/components/gabinet/calendar/droppable-slot.tsx
@@ -1,5 +1,5 @@
 import { useDroppable } from "@dnd-kit/core";
-import { ReactNode } from "react";
+import { CSSProperties, ReactNode } from "react";
 
 interface DroppableSlotProps {
   id: string;
@@ -7,9 +7,10 @@ interface DroppableSlotProps {
   time: string;
   children?: ReactNode;
   className?: string;
+  style?: CSSProperties;
 }
 
-export function DroppableSlot({ id, date, time, children, className }: DroppableSlotProps) {
+export function DroppableSlot({ id, date, time, children, className, style }: DroppableSlotProps) {
   const { isOver, setNodeRef } = useDroppable({
     id,
     data: {
@@ -23,6 +24,7 @@ export function DroppableSlot({ id, date, time, children, className }: Droppable
     <div
       ref={setNodeRef}
       className={`${className ?? ""} ${isOver ? "bg-primary/20 ring-2 ring-primary/50" : ""}`}
+      style={style}
     >
       {children}
     </div>

--- a/src/components/gabinet/calendar/use-drag-to-create.ts
+++ b/src/components/gabinet/calendar/use-drag-to-create.ts
@@ -40,14 +40,17 @@ export function useDragToCreate({
     [hoursStart, hoursCount, hourHeight, snapMinutes],
   );
 
-  const yToHourTime = useCallback(
+  const yToSlotTime = useCallback(
     (y: number) => {
       const totalHeight = hoursCount * hourHeight;
       const clamped = Math.max(0, Math.min(totalHeight - 1, y));
-      const hour = Math.floor(clamped / hourHeight) + hoursStart;
-      return `${String(hour).padStart(2, "0")}:00`;
+      const totalMinutes =
+        Math.floor((clamped / hourHeight) * 60 / snapMinutes) * snapMinutes;
+      const h = Math.floor(totalMinutes / 60) + hoursStart;
+      const m = totalMinutes % 60;
+      return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
     },
-    [hoursStart, hoursCount, hourHeight],
+    [hoursStart, hoursCount, hourHeight, snapMinutes],
   );
 
   const handleMouseDown = useCallback(
@@ -85,13 +88,13 @@ export function useDragToCreate({
             return;
           }
         }
-        onClick(yToHourTime(startY));
+        onClick(yToSlotTime(startY));
       };
 
       window.addEventListener("mousemove", handleMove);
       window.addEventListener("mouseup", handleUp);
     },
-    [minDragDistance, yToSnappedTime, yToHourTime, onClick, onDragSelect],
+    [minDragDistance, yToSnappedTime, yToSlotTime, onClick, onDragSelect],
   );
 
   return {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -60,6 +60,8 @@ export const Route = createLazyFileRoute(
 });
 
 type ViewMode = "day" | "week" | "month";
+type SlotMinutes = 15 | 30 | 60;
+const SLOT_OPTIONS: SlotMinutes[] = [60, 30, 15];
 
 function getMonday(date: Date): Date {
   const d = new Date(date);
@@ -85,6 +87,7 @@ function GabinetCalendarPage() {
   useWideContent(true);
 
   const [viewMode, setViewMode] = useState<ViewMode>("week");
+  const [slotMinutes, setSlotMinutes] = useState<SlotMinutes>(60);
   const [currentDate, setCurrentDate] = useState(new Date());
   const [employeeFilter, setEmployeeFilter] = useState<string>("all");
   const [treatmentFilter, setTreatmentFilter] = useState<string>("all");
@@ -687,6 +690,24 @@ function GabinetCalendarPage() {
                 ))}
               </div>
 
+              {/* Slot size switcher (only meaningful for day/week) */}
+              {viewMode !== "month" && (
+                <div className="flex rounded-md border" aria-label={t("gabinet.calendar.slotSize", "Rozdzielczość")}>
+                  {SLOT_OPTIONS.map((opt) => (
+                    <Button
+                      key={opt}
+                      variant={slotMinutes === opt ? "default" : "ghost"}
+                      size="sm"
+                      className="h-7 rounded-none first:rounded-l-md last:rounded-r-md text-xs px-2"
+                      onClick={() => setSlotMinutes(opt)}
+                      title={t("gabinet.calendar.slotSize", "Rozdzielczość")}
+                    >
+                      {opt} min
+                    </Button>
+                  ))}
+                </div>
+              )}
+
               {/* Create button */}
               <Button
                 size="sm"
@@ -861,6 +882,7 @@ function GabinetCalendarPage() {
               onSlotDragSelect={handleSlotDragSelect}
               onAppointmentResize={handleAppointmentResize}
               workingHours={dayWorkingHours}
+              slotMinutes={slotMinutes}
             />
           )}
           {viewMode === "week" && (
@@ -873,6 +895,7 @@ function GabinetCalendarPage() {
               onDayHeaderClick={handleDayClick}
               selectedDate={formatDateStr(currentDate)}
               employeeSchedules={employeeSchedules}
+              slotMinutes={slotMinutes}
             />
           )}
           {viewMode === "month" && (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #365.

Closes #365

---

## Claude summary

Committed. Summary of changes:

Added a slot-size toggle (60 / 30 / 15 min) to the gabinet calendar toolbar (`_layout.gabinet.calendar.index.lazy.tsx`), shown alongside the existing day/week/month switcher and hidden on month view. The selected slot interval is threaded into `CalendarDayView` and `CalendarWeekView`, where the time gutter renders one labeled row per slot (hour marks emphasized, sub-slots in lighter type) and droppable grid rows match. The 15-minute subdivision lines from #362 are kept only when slot=60min so they don't double up. Click-to-create now snaps to the active slot interval via an updated `yToSlotTime` helper in `use-drag-to-create.ts`. Existing position math is unchanged (1px = 1min throughout), so the working-hours background, current-time bar, drag-resize, and overlap layout all keep working.

Typecheck on the changed files is clean (only pre-existing warnings unrelated to this change remain).