### PR TITLE
Filtry

### DIFF
--- a/src/components/layout/sidebar-context.tsx
+++ b/src/components/layout/sidebar-context.tsx
@@ -36,7 +36,10 @@ export function useSidebarDispatch(actionId: string, handler: () => void) {
   const { lastDispatch } = useSidebarActions();
   const handlerRef = useRef(handler);
   handlerRef.current = handler;
-  const seenRef = useRef(0);
+  // Initialize to the current dispatch seq so that stale dispatches from a
+  // previous page (still sitting in context state) are not replayed when this
+  // component mounts after navigation.
+  const seenRef = useRef(lastDispatch?.seq ?? 0);
 
   useEffect(() => {
     if (lastDispatch && lastDispatch.id === actionId && lastDispatch.seq > seenRef.current) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #368.

Closes #368

---

## Claude summary

Fixed and committed.

Root cause: `useSidebarDispatch` initialized its `seenRef` to `0`, so when a user clicked "Filtry" on the calendar (dispatching `openFilter` with `seq=1`) and then navigated to another tab that also calls `useSidebarDispatch("openFilter", ...)` (e.g. Patients, Treatments, Employees, Documents, Packages, CRM Activities/Contacts/etc.), the new page's hook saw `lastDispatch.seq (1) > 0` on mount and immediately fired the handler — opening the filter dialog by itself.

Fix in `src/components/layout/sidebar-context.tsx:42`: initialize `seenRef` to `lastDispatch?.seq ?? 0` so any dispatch already sitting in context state at mount time is treated as already seen. Only dispatches that occur after mount will trigger the handler.