### PR TITLE
Podgląd wizyta

### DIFF
--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -169,6 +169,11 @@ export function DraggableAppointment({
         sideOffset={8}
         collisionPadding={12}
         onOpenAutoFocus={(e) => e.preventDefault()}
+        // Popover content is portaled in the DOM but still part of the React
+        // tree, so React synthetic events bubble through to the calendar grid's
+        // onMouseDown handler and trigger a "create appointment" slot click.
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
       >
         <AppointmentPreviewContent
           appointmentId={_id}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #372.

Closes #372

---

## Claude summary

Committed.

Root cause: the appointment preview popover's content is rendered via Radix Portal (so the DOM lives in `<body>`), but React synthetic events still bubble through the React component tree. Clicking any control inside the popover (status select, date/time inputs, notes, buttons) bubbled `onMouseDown` up through the React tree to the calendar grid container's `onMouseDown={dragHandler.handleMouseDown}` in `useDragToCreate`. That handler then registered window mouseup listeners and treated the release as a slot click, opening the "new appointment" dialog.

Fix: stop propagation of `onMouseDown` and `onClick` at `PopoverContent` in `src/components/gabinet/calendar/draggable-appointment.tsx`. This isolates popover events from the calendar grid without affecting Radix's outside-click dismiss logic (which uses native document listeners, not React synthetic events).

Commit: `a663d6f` on `claude/issue-372`.