### PR TITLE
ostrzeżenie w kalendarzu - termin

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2520,6 +2520,209 @@ export const getFullDetail = action({
   },
 });
 
+export type AppointmentWarningCode =
+  | "past"
+  | "qualification"
+  | "leave"
+  | "outsideHours"
+  | "conflict";
+
+export const getWarnings = action({
+  args: {
+    organizationId: v.id("organizations"),
+    appointmentId: v.string(),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ warnings: AppointmentWarningCode[] }> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const perm = (await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      {
+        organizationId: args.organizationId,
+        feature: "gabinet_appointments",
+        action: "view",
+      },
+    )) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    const db = createSupabaseDb();
+    const orgIdStr = String(args.organizationId);
+    const appt = (await db.get(
+      "gabinetAppointments",
+      args.appointmentId,
+    )) as Record<string, unknown> | null;
+    if (!appt || String(appt.organizationId) !== orgIdStr) {
+      return { warnings: [] };
+    }
+
+    const status = String(appt.status);
+    if (status === "cancelled" || status === "no_show") {
+      return { warnings: [] };
+    }
+
+    const date = String(appt.date);
+    const startTime = String(appt.startTime);
+    const endTime = String(appt.endTime);
+    const employeeUserId = String(appt.employeeId);
+    const treatmentId = appt.treatmentId ? String(appt.treatmentId) : null;
+    const roomId = appt.roomId ? String(appt.roomId) : undefined;
+
+    const warnings = new Set<AppointmentWarningCode>();
+
+    // 1. Past appointment — only flag if not yet completed
+    if (status !== "completed") {
+      const now = new Date();
+      const apptEnd = new Date(`${date}T${endTime.slice(0, 8)}`);
+      if (!Number.isNaN(apptEnd.getTime()) && apptEnd.getTime() < now.getTime()) {
+        warnings.add("past");
+      }
+    }
+
+    // 2. Qualification — only if treatment specified
+    if (treatmentId) {
+      const qual = await checkEmployeeQualificationSupabase(db, {
+        organizationId: orgIdStr,
+        userId: employeeUserId,
+        treatmentId,
+      });
+      if (!qual.qualified) warnings.add("qualification");
+    }
+
+    // 3. Leave — overlapping approved leave on this date / time
+    const leaves = (await db
+      .query("gabinetLeaves")
+      .eq("organizationId", orgIdStr)
+      .eq("userId", employeeUserId)
+      .collect()) as Array<Record<string, unknown>>;
+    const toMin = (t: string) => {
+      const [h, m] = t.split(":").map(Number);
+      return h * 60 + m;
+    };
+    const reqStartMin = toMin(startTime);
+    const reqEndMin = toMin(endTime);
+    for (const leave of leaves) {
+      if (leave.status !== "approved") continue;
+      const ls = String(leave.startDate ?? "");
+      const le = String(leave.endDate ?? "");
+      if (ls > date || le < date) continue;
+      if (!leave.startTime) {
+        warnings.add("leave");
+        break;
+      }
+      if (leave.startTime && leave.endTime) {
+        const lStart = toMin(String(leave.startTime));
+        const lEnd = toMin(String(leave.endTime));
+        if (reqStartMin < lEnd && reqEndMin > lStart) {
+          warnings.add("leave");
+          break;
+        }
+      }
+    }
+
+    // 4. Outside hours — employee schedule or clinic hours
+    const dayOfWeek = new Date(date + "T00:00:00").getDay();
+    const empScheduleCandidates = (await db
+      .query("gabinetEmployeeSchedules")
+      .eq("organizationId", orgIdStr)
+      .eq("userId", employeeUserId)
+      .eq("dayOfWeek", dayOfWeek)
+      .collect()) as Array<Record<string, unknown>>;
+    const matchingSchedule = empScheduleCandidates
+      .filter((c) => {
+        const ef = c.effectiveFrom as string | undefined;
+        const et = c.effectiveTo as string | undefined;
+        if (ef && date < ef) return false;
+        if (et && date > et) return false;
+        return true;
+      })
+      .sort((a, b) => {
+        const ea = a.effectiveFrom as string | undefined;
+        const eb = b.effectiveFrom as string | undefined;
+        if (ea && eb) return eb.localeCompare(ea);
+        if (ea) return -1;
+        if (eb) return 1;
+        return 0;
+      })[0];
+
+    if (matchingSchedule) {
+      if (!matchingSchedule.isWorking) {
+        warnings.add("outsideHours");
+      } else {
+        const sStart = toMin(String(matchingSchedule.startTime));
+        const sEnd = toMin(String(matchingSchedule.endTime));
+        if (reqStartMin < sStart || reqEndMin > sEnd) {
+          warnings.add("outsideHours");
+        }
+      }
+    } else {
+      const clinicHoursRows = (await db
+        .query("gabinetWorkingHours")
+        .eq("organizationId", orgIdStr)
+        .eq("dayOfWeek", dayOfWeek)
+        .take(1)
+        .collect()) as Array<Record<string, unknown>>;
+      const clinic = clinicHoursRows[0];
+      if (!clinic || !clinic.isOpen) {
+        warnings.add("outsideHours");
+      } else {
+        const sStart = toMin(String(clinic.startTime));
+        const sEnd = toMin(String(clinic.endTime));
+        if (reqStartMin < sStart || reqEndMin > sEnd) {
+          warnings.add("outsideHours");
+        }
+      }
+    }
+
+    // 5. Conflict with other appointments / room / external activities
+    const sameDayAppointments = (await db
+      .query("gabinetAppointments")
+      .eq("organizationId", orgIdStr)
+      .eq("employeeId", employeeUserId)
+      .eq("date", date)
+      .collect()) as Array<Record<string, unknown>>;
+    for (const other of sameDayAppointments) {
+      const otherId = String(other._id ?? other.id ?? "");
+      if (otherId === String(args.appointmentId)) continue;
+      const oStatus = String(other.status);
+      if (oStatus === "cancelled" || oStatus === "no_show") continue;
+      const oStart = toMin(String(other.startTime));
+      const oEnd = toMin(String(other.endTime));
+      if (reqStartMin < oEnd && reqEndMin > oStart) {
+        warnings.add("conflict");
+        break;
+      }
+    }
+
+    if (!warnings.has("conflict") && roomId) {
+      const roomAppointments = (await db
+        .query("gabinetAppointments")
+        .eq("organizationId", orgIdStr)
+        .eq("roomId", roomId)
+        .eq("date", date)
+        .collect()) as Array<Record<string, unknown>>;
+      for (const other of roomAppointments) {
+        const otherId = String(other._id ?? other.id ?? "");
+        if (otherId === String(args.appointmentId)) continue;
+        const oStatus = String(other.status);
+        if (oStatus === "cancelled" || oStatus === "no_show") continue;
+        if (
+          String(other.startTime) < endTime &&
+          String(other.endTime) > startTime
+        ) {
+          warnings.add("conflict");
+          break;
+        }
+      }
+    }
+
+    return { warnings: Array.from(warnings) };
+  },
+});
+
 export const getPhotoUrls = query({
   args: {
     organizationId: v.id("organizations"),

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2441,7 +2441,15 @@
       "room": "Room",
       "autoLocation": "Auto (from schedule)",
       "roomConflict": "Room is occupied at this time",
-      "equipmentWarning": "Required equipment not at this location"
+      "equipmentWarning": "Required equipment not at this location",
+      "warnings": {
+        "title": "Warning",
+        "past": "Appointment is in the past",
+        "qualification": "Employee is not qualified for this treatment",
+        "leave": "Employee is on leave at this time",
+        "outsideHours": "Outside clinic working hours",
+        "conflict": "Conflicts with another appointment"
+      }
     },
     "appointmentDetail": {
       "title": "Appointment Details",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2452,7 +2452,15 @@
       "room": "Gabinet",
       "autoLocation": "Auto (z grafiku)",
       "roomConflict": "Gabinet zajęty w tym terminie",
-      "equipmentWarning": "Brak wymaganego sprzętu w tej lokalizacji"
+      "equipmentWarning": "Brak wymaganego sprzętu w tej lokalizacji",
+      "warnings": {
+        "title": "Ostrzeżenie",
+        "past": "Termin w przeszłości",
+        "qualification": "Pracownik nie ma kwalifikacji do tego zabiegu",
+        "leave": "Pracownik jest na urlopie w tym terminie",
+        "outsideHours": "Termin poza godzinami pracy gabinetu",
+        "conflict": "Kolizja terminów z inną wizytą"
+      }
     },
     "appointmentDetail": {
       "title": "Szczegóły wizyty",

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -30,7 +30,7 @@ import {
   Stethoscope,
   User,
 } from "@/lib/ez-icons";
-import { ExternalLink } from "lucide-react";
+import { AlertTriangle, ExternalLink } from "lucide-react";
 
 const VALID_TRANSITIONS: Record<string, string[]> = {
   pending_confirmation: ["scheduled", "confirmed", "cancelled"],
@@ -76,6 +76,7 @@ export function AppointmentPreviewContent({
 
   const getFullDetail = useAction(api.gabinet.appointments.getFullDetail);
   const updateAppointment = useAction(api.gabinet.appointments.update);
+  const getWarnings = useAction(api.gabinet.appointments.getWarnings);
 
   const { data: detail, isLoading, refetch } = useQuery({
     queryKey: ["gabinet.appointment.fullDetail", organizationId, appointmentId],
@@ -86,6 +87,17 @@ export function AppointmentPreviewContent({
       }),
     enabled: !!organizationId && !!appointmentId,
   });
+
+  const { data: warningsData } = useQuery({
+    queryKey: ["gabinet.appointment.warnings", organizationId, appointmentId],
+    queryFn: () =>
+      getWarnings({
+        organizationId,
+        appointmentId,
+      }),
+    enabled: !!organizationId && !!appointmentId,
+  });
+  const warnings = warningsData?.warnings ?? [];
 
   const [status, setStatus] = useState<AppointmentStatus | "">("");
   const [date, setDate] = useState("");
@@ -222,6 +234,20 @@ export function AppointmentPreviewContent({
           </div>
         )}
       </div>
+
+      {warnings.length > 0 && (
+        <div className="space-y-1 rounded-md border border-amber-200 bg-amber-50 px-2.5 py-2 text-xs text-amber-800 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-400">
+          <div className="flex items-center gap-1.5 font-medium">
+            <AlertTriangle className="size-3.5 shrink-0" />
+            {t("gabinet.appointments.warnings.title", "Ostrzeżenie")}
+          </div>
+          <ul className="ml-5 list-disc space-y-0.5">
+            {warnings.map((w) => (
+              <li key={w}>{t(`gabinet.appointments.warnings.${w}`)}</li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       <Separator />
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #366.

Closes #366

---

## Claude summary

Implemented the warning panel inside the calendar appointment preview popover. When you click an appointment on the day/week calendar, the popover now shows an amber alert box (matching the existing equipment-warning style: `border-amber-200 bg-amber-50 text-amber-800` + `AlertTriangle` icon) listing every issue that applies:

- `past` — appointment end time is in the past (and not yet completed)
- `qualification` — assigned employee is not qualified for the treatment
- `leave` — overlaps an approved employee leave
- `outsideHours` — outside employee schedule or clinic working hours
- `conflict` — collides with another appointment or room booking on the same day

Backend: a new `getWarnings` action in `convex/gabinet/appointments.ts` reuses the same lookup tables as `_availability_supabase.ts` (`gabinetEmployeeSchedules`, `gabinetWorkingHours`, `gabinetLeaves`, `gabinetAppointments`) but computes each warning independently so all simultaneous problems are surfaced (the existing `checkConflictSupabase` short-circuits on the first reason — fine for booking-time blocking, wrong for a status panel).

Frontend: `appointment-preview-content.tsx` now runs a second `useQuery` against `getWarnings` and renders the warning panel between the patient header and the employee/date row.

Translations added under `gabinet.appointments.warnings.{title,past,qualification,leave,outsideHours,conflict}` for PL and EN.

Typecheck passes. Committed as `f6a5c17`.