### PR TITLE
brak widoku

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.tsx
@@ -1,39 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
-import { useOrganization } from "@/components/org-context";
-import { useTagDefinitions } from "@/hooks/use-tag-definitions";
-import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
-import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
-import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
 
 export const Route = createFileRoute(
-  "/_app/_auth/dashboard/_layout/gabinet/calendar/"
-)({
-  component: CalendarIndex,
-});
-
-function CalendarIndex() {
-  const { organizationId } = useOrganization();
-  const { tags } = useTagDefinitions(organizationId);
-  const { categories } = useCategoryDefinitions(organizationId, "gabinetAppointment");
-  const [tagsSlideoutOpen, setTagsSlideoutOpen] = useState(false);
-  const [categoriesSlideoutOpen, setCategoriesSlideoutOpen] = useState(false);
-
-  return (
-    <>
-      <TagsManagerSlideout
-        isOpen={tagsSlideoutOpen}
-        onOpenChange={setTagsSlideoutOpen}
-        organizationId={organizationId}
-        tags={tags}
-      />
-      <CategoriesManagerSlideout
-        isOpen={categoriesSlideoutOpen}
-        onOpenChange={setCategoriesSlideoutOpen}
-        organizationId={organizationId}
-        entityType="gabinetAppointment"
-        categories={categories}
-      />
-    </>
-  );
-}
+  "/_app/_auth/dashboard/_layout/gabinet/calendar/",
+)({});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #361.

Closes #361

---

## Claude summary

Fix committed.

Summary: The calendar route had a stray non-lazy `component: CalendarIndex` in `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.tsx:12` that only rendered two `isOpen=false` slideouts (no UI ever opens them — gabinet `manifest.ts:98-107` has no `manageTags`/`manageCategories` dispatch for the calendar pane). That synchronous empty component shadowed the real `GabinetCalendarPage` in the sibling `.lazy.tsx` file on a fresh hard refresh, producing a blank page. Soft F5 reloads could still resolve the lazy component from cache, which is why the bug looked intermittent. I aligned the file to the convention used by every other lazy-paired route (`_layout.gabinet.reports.tsx`, `_layout.contacts.$contactId.tsx`, etc.): just `createFileRoute(...)({});`.