### PR TITLE
Podgląd wizyty

### DIFF
--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -169,6 +169,10 @@ export function DraggableAppointment({
         sideOffset={8}
         collisionPadding={12}
         onOpenAutoFocus={(e) => e.preventDefault()}
+        // Keep the popover open when focus leaves the window (e.g. the user
+        // activates a screenshot tool like Snipping Tool); otherwise the
+        // preview disappears before it can be captured.
+        onFocusOutside={(e) => e.preventDefault()}
         // Popover content is portaled in the DOM but still part of the React
         // tree, so React synthetic events bubble through to the calendar grid's
         // onMouseDown handler and trigger a "create appointment" slot click.


### PR DESCRIPTION
Auto-generated by Claude in response to issue #374.

Closes #374

---

## Claude summary

Committed the fix.

The user reported that the appointment preview popover on the gabinet calendar disappears whenever they try to take a screenshot of it. The root cause is Radix Popover's `onFocusOutside` handler: when a screenshot utility (Windows Snipping Tool, Greenshot, etc.) takes window focus, the popover treats it as an outside interaction and closes. The fix calls `e.preventDefault()` on `onFocusOutside` in `src/components/gabinet/calendar/draggable-appointment.tsx:175`, so the preview stays visible while focus is on a screenshot tool. Outside clicks, Escape, and the Cancel button continue to close it as before.