### PR TITLE
zegar

### DIFF
--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -114,7 +114,6 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
   const isToday = date === `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
   const currentMinutes = now.getHours() * 60 + now.getMinutes();
   const currentLineTop = ((currentMinutes - 7 * 60) / 60) * 60;
-  const currentTimeLabel = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
 
   const slots = useMemo(() => buildSlots(slotMinutes), [slotMinutes]);
   const showSubdivisions = slotMinutes === 60;
@@ -171,18 +170,6 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
             </span>
           </div>
         ))}
-
-        {/* Current time label in gutter */}
-        {isToday && currentLineTop > 0 && currentLineTop < HOURS.length * 60 && (
-          <div
-            className="pointer-events-none absolute right-0 z-30 -translate-y-1/2"
-            style={{ top: `${currentLineTop}px` }}
-          >
-            <span className="mr-1 rounded bg-red-500 px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white shadow-sm">
-              {currentTimeLabel}
-            </span>
-          </div>
-        )}
       </div>
 
       {/* Grid + appointments */}

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -341,11 +341,8 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotD
   const dates = useMemo(() => getWeekDates(weekStart), [weekStart]);
   const now = useCurrentTime();
   const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
-  const todayInWeek = dates.includes(today);
   const currentMinutes = now.getHours() * 60 + now.getMinutes();
   const currentTimeTop = ((currentMinutes - 7 * 60) / 60) * 60;
-  const showCurrentTime = todayInWeek && currentTimeTop > 0 && currentTimeTop < HOURS.length * 60;
-  const currentTimeLabel = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
   const slots = useMemo(() => buildSlots(slotMinutes), [slotMinutes]);
 
   const layoutsByDate = useMemo(() => {
@@ -374,18 +371,6 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotD
             </span>
           </div>
         ))}
-
-        {/* Current time label in gutter */}
-        {showCurrentTime && (
-          <div
-            className="pointer-events-none absolute right-0 z-30 -translate-y-1/2"
-            style={{ top: `${currentTimeTop + 32}px` }}
-          >
-            <span className="mr-1 rounded bg-red-500 px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white shadow-sm">
-              {currentTimeLabel}
-            </span>
-          </div>
-        )}
       </div>
 
       {/* Day columns */}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #376.

Closes #376

---

## Claude summary

Removed the red HH:MM clock badge from the time-axis gutter in both day and week views of the gabinet calendar. The horizontal current-time line and its red dot still mark the current position; only the digital-clock label was dropped. Typecheck passes.

If the user intended a more aggressive removal (e.g., the entire current-time line/dot, or some other "clock" element I missed in the screenshot), they can follow up and I'll widen the cut.