### PR TITLE
zegar

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -24,7 +24,6 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Calendar,
-  Clock,
   Mail,
   Phone,
   Stethoscope,
@@ -340,7 +339,6 @@ export function AppointmentPreviewContent({
 
         <div className="space-y-1">
           <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
-            <Clock className="mr-1 inline size-3" />
             {t("gabinet.appointments.internalNotes")}
           </Label>
           <Textarea


### PR DESCRIPTION
Auto-generated by Claude in response to issue #379.

Closes #379

---

## Claude summary

Removed the stray `<Clock>` icon from the "Internal notes" label in `src/components/gabinet/calendar/appointment-preview-content.tsx`. The screenshots showed it rendering as a huge clock face inside the appointment preview popover because the easier-icon custom element didn't honor `size-3` there; the icon also didn't semantically fit a notes label. Committed as a fix referencing #379.