### PR TITLE
Przejście do karty klienta

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -191,9 +191,20 @@ export function AppointmentPreviewContent({
       <div className="space-y-1.5">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-semibold leading-tight">
-              {patientFullName}
-            </p>
+            {patient?._id ? (
+              <Link
+                to="/dashboard/gabinet/patients/$patientId"
+                params={{ patientId: patient._id }}
+                onClick={onClose}
+                className="block truncate text-sm font-semibold leading-tight hover:underline focus:underline focus:outline-none"
+              >
+                {patientFullName}
+              </Link>
+            ) : (
+              <p className="truncate text-sm font-semibold leading-tight">
+                {patientFullName}
+              </p>
+            )}
             {treatment?.name && (
               <p className="mt-0.5 flex items-center gap-1 truncate text-xs text-muted-foreground">
                 <Stethoscope className="size-3 shrink-0" />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #384.

Closes #384

---

## Claude summary

Committed. The patient's full name in the calendar appointment preview popover is now a clickable link to `/dashboard/gabinet/patients/$patientId`, matching the pattern already used by the "View profile" dropdown in the full appointment view (lazy file line 557). Falls back to a plain `<p>` if the appointment somehow has no patient. Clicking also calls `onClose` so the popover dismisses cleanly when navigating away.