### PR TITLE
Opcja

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2578,7 +2578,7 @@
         "transfer": "Transfer",
         "other": "Other"
       },
-      "splitPayment": "Split payment between two methods",
+      "splitPayment": "Split payment",
       "firstMethod": "First method",
       "secondMethod": "Second method",
       "splitSum": "Sum",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2589,7 +2589,7 @@
         "transfer": "Przelew",
         "other": "Inna"
       },
-      "splitPayment": "Podziel płatność na dwie metody",
+      "splitPayment": "Podziel płatność",
       "firstMethod": "Pierwsza metoda",
       "secondMethod": "Druga metoda",
       "splitSum": "Suma",

--- a/src/components/gabinet/package-purchase-drawer.tsx
+++ b/src/components/gabinet/package-purchase-drawer.tsx
@@ -252,7 +252,7 @@ export function PackagePurchaseDrawer({
               onCheckedChange={(v) => setSplitPayment(v === true)}
             />
             <Label htmlFor="split-payment" className="cursor-pointer text-sm font-normal">
-              {t("gabinet.packages.splitPayment", "Split payment between two methods")}
+              {t("gabinet.packages.splitPayment", "Split payment")}
             </Label>
           </div>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #389.

Closes #389

---

## Claude summary

Renamed the split-payment checkbox label in the package purchase drawer from "Podziel płatność na dwie metody" to "Podziel płatność" (and the English fallback from "Split payment between two methods" to "Split payment"). Updated both translation files and the in-code i18n fallback in `src/components/gabinet/package-purchase-drawer.tsx:255`. Committed as `990cb1a`.