### PR TITLE
Refresh DocumentationTab after photo upload/remove and notes saves

### DIFF
--- a/src/components/gabinet/documentation-tab.tsx
+++ b/src/components/gabinet/documentation-tab.tsx
@@ -88,6 +88,7 @@ interface DocumentationTabProps {
     photos?: Photo[];
   };
   treatmentParameters?: TreatmentParamDefinition[];
+  onChanged?: () => void | Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -99,6 +100,7 @@ export function DocumentationTab({
   appointmentId,
   appointment,
   treatmentParameters,
+  onChanged,
 }: DocumentationTabProps) {
   const { t } = useTranslation();
   const updateAppointment = useAction(api.gabinet.appointments.update);
@@ -152,6 +154,7 @@ export function DocumentationTab({
         treatmentParameterValues: JSON.stringify(paramValues),
       });
       toast.success(t("common.saved"));
+      await onChanged?.();
     } catch (err: any) {
       toast.error(err.message ?? t("common.error"));
     } finally {
@@ -174,6 +177,7 @@ export function DocumentationTab({
         interviewNotes: interview || undefined,
       });
       toast.success(t("common.saved"));
+      await onChanged?.();
     } catch (err: any) {
       toast.error(err.message ?? t("common.error"));
     } finally {
@@ -196,6 +200,7 @@ export function DocumentationTab({
         clinicalRemarks: remarks || undefined,
       });
       toast.success(t("common.saved"));
+      await onChanged?.();
     } catch (err: any) {
       toast.error(err.message ?? t("common.error"));
     } finally {
@@ -266,6 +271,7 @@ export function DocumentationTab({
                   photos: [...photosRef.current, newPhoto],
                 });
                 toast.success(t("common.saved"));
+                await onChanged?.();
                 resolve();
               } catch (err: any) {
                 toast.error(err.message ?? t("common.error"));
@@ -293,7 +299,7 @@ export function DocumentationTab({
         URL.revokeObjectURL(preview);
       }
     },
-    [generateUploadUrl, updateAppointment, organizationId, appointmentId, t],
+    [generateUploadUrl, updateAppointment, organizationId, appointmentId, t, onChanged],
   );
 
   const handleRemovePhoto = async (storageId: Id<"_storage">) => {
@@ -305,6 +311,7 @@ export function DocumentationTab({
         photos: updated,
       });
       toast.success(t("common.saved"));
+      await onChanged?.();
     } catch (err: any) {
       toast.error(err.message ?? t("common.error"));
     }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -2156,6 +2156,10 @@ function AppointmentDetail() {
           appointmentId={appointment._id}
           appointment={appointment}
           treatmentParameters={treatment?.parameters as any}
+          onChanged={async () => {
+            await invalidateAppointmentCaches();
+            await refetch();
+          }}
         />
       ),
     },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #390.

Closes #390

---

## Claude summary

Committed.

Summary: the bug was real. `DocumentationTab` called `updateAppointment` but never told the parent route to refetch `getFullDetail`, so the `appointment` prop (and thus the rendered photo grid and rich-text editors bound to `appointment.interviewNotes` / `appointment.clinicalRemarks`) stayed stale until a hard reload.

Fix: added an optional `onChanged?: () => void | Promise<void>` prop to `DocumentationTab` (`src/components/gabinet/documentation-tab.tsx`), awaited it after each successful mutation (params save, interview save, remarks save, photo upload, photo remove), and wired the parent route (`_layout.gabinet.appointments.$appointmentId.lazy.tsx:2154`) to pass a callback that calls `invalidateAppointmentCaches()` + `refetch()` — matching the pattern already used for status changes and tag edits in the same file.