### PR TITLE
Invalidate `supabaseKeys.activities` after appointment mutations

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -373,6 +373,7 @@ function AppointmentDetail() {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetAppointments.all }),
       queryClient.invalidateQueries({ queryKey: supabaseKeys.scheduledActivities.all }),
+      queryClient.invalidateQueries({ queryKey: supabaseKeys.activities.all }),
     ]);
   };
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #391.

Closes #391

---

## Claude summary

Fixed and committed. Added `supabaseKeys.activities.all` to the `invalidateAppointmentCaches` Promise.all in `src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx:376`, so the per-entity activity timeline (`useSupabaseActivitiesByEntity`, which keys off `supabaseKeys.activities.list(orgId)`) now refreshes after status changes, edits, tag updates, and cancellations — all of which call `logActivity` on the backend.