### PR TITLE
godzina

### DIFF
--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -114,6 +114,8 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
   const isToday = date === `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
   const currentMinutes = now.getHours() * 60 + now.getMinutes();
   const currentLineTop = ((currentMinutes - 7 * 60) / 60) * 60;
+  const currentTimeLabel = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+  const showCurrentTime = isToday && currentLineTop > 0 && currentLineTop < HOURS.length * 60;
 
   const slots = useMemo(() => buildSlots(slotMinutes), [slotMinutes]);
   const showSubdivisions = slotMinutes === 60;
@@ -156,7 +158,7 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
   return (
     <div className="relative flex h-full overflow-y-auto">
       {/* Time labels */}
-      <div className="sticky left-0 z-10 w-16 shrink-0 border-r bg-background">
+      <div className="sticky left-0 z-10 w-16 shrink-0 border-r bg-background relative">
         {slots.map((s) => (
           <div
             key={s.time}
@@ -170,6 +172,14 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
             </span>
           </div>
         ))}
+        {showCurrentTime && (
+          <div
+            className="pointer-events-none absolute right-1 z-30 rounded bg-red-500 px-1 py-0.5 text-[10px] font-semibold leading-none text-white shadow"
+            style={{ top: `${currentLineTop}px`, transform: "translateY(-50%)" }}
+          >
+            {currentTimeLabel}
+          </div>
+        )}
       </div>
 
       {/* Grid + appointments */}

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -343,6 +343,9 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotD
   const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
   const currentMinutes = now.getHours() * 60 + now.getMinutes();
   const currentTimeTop = ((currentMinutes - 7 * 60) / 60) * 60;
+  const currentTimeLabel = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+  const todayInView = dates.includes(today);
+  const showCurrentTime = todayInView && currentTimeTop > 0 && currentTimeTop < HOURS.length * 60;
   const slots = useMemo(() => buildSlots(slotMinutes), [slotMinutes]);
 
   const layoutsByDate = useMemo(() => {
@@ -357,7 +360,7 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotD
   return (
     <div className="flex h-full overflow-auto">
       {/* Time labels */}
-      <div className="sticky left-0 z-10 w-14 shrink-0 border-r bg-background pt-8">
+      <div className="sticky left-0 z-10 w-14 shrink-0 border-r bg-background pt-8 relative">
         {slots.map((s) => (
           <div
             key={s.time}
@@ -371,6 +374,14 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotD
             </span>
           </div>
         ))}
+        {showCurrentTime && (
+          <div
+            className="pointer-events-none absolute right-1 z-30 rounded bg-red-500 px-1 py-0.5 text-[10px] font-semibold leading-none text-white shadow"
+            style={{ top: `${32 + currentTimeTop}px`, transform: "translateY(-50%)" }}
+          >
+            {currentTimeLabel}
+          </div>
+        )}
       </div>
 
       {/* Day columns */}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #394.

Closes #394

---

## Claude summary

Committed. Summary:

Added a small red `HH:MM` pill in the time gutter at the position of the existing red current-time indicator line on the gabinet calendar (`/dashboard/gabinet/calendar`). It appears in both day view (`src/components/gabinet/calendar/calendar-day-view.tsx`) and week view (`src/components/gabinet/calendar/calendar-week-view.tsx`), only when today is within the displayed range and the current time falls inside the visible 07:00–21:00 window. The pill updates every minute via the existing `useCurrentTime` hook.