### PR TITLE
zapisz

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -184,13 +184,20 @@ export function AppointmentPreviewContent({
     return all.filter((tr) => (tr.name ?? "").toLowerCase().includes(q));
   })();
 
-  const dirty =
+  const phoneDirty =
+    isEditingPhone &&
+    phoneInput.trim().length > 0 &&
+    phoneInput.trim() !== (patient?.phone ?? "");
+
+  const apptDirty =
     status !== initialStatus ||
     date !== appointment.date ||
     startTime !== appointment.startTime.slice(0, 5) ||
     endTime !== appointment.endTime.slice(0, 5) ||
     internalNotes !== (appointment.internalNotes ?? "") ||
     treatmentId !== initialTreatmentId;
+
+  const dirty = phoneDirty || apptDirty;
 
   const handleSavePhone = async () => {
     const trimmed = phoneInput.trim();
@@ -229,29 +236,53 @@ export function AppointmentPreviewContent({
     if (!dirty || saving) return;
     setSaving(true);
     try {
-      const args: Parameters<typeof updateAppointment>[0] = {
-        organizationId,
-        appointmentId: appointment._id as Id<"gabinetAppointments">,
-      };
-      if (date !== appointment.date) args.date = date;
-      if (startTime !== appointment.startTime.slice(0, 5))
-        args.startTime = startTime;
-      if (endTime !== appointment.endTime.slice(0, 5)) args.endTime = endTime;
-      if (status && status !== initialStatus) args.status = status;
-      if (internalNotes !== (appointment.internalNotes ?? ""))
-        args.internalNotes = internalNotes;
-      if (treatmentId && treatmentId !== initialTreatmentId)
-        args.treatmentId = treatmentId;
+      if (phoneDirty && patient?._id) {
+        await updatePatient({
+          organizationId,
+          patientId: patient._id,
+          phone: phoneInput.trim(),
+        });
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: supabaseKeys.gabinetPatients.detail(
+              organizationId,
+              patient._id,
+            ),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: supabaseKeys.gabinetPatients.list(organizationId),
+          }),
+        ]);
+        setIsEditingPhone(false);
+        setPhoneInput("");
+      }
 
-      await updateAppointment(args);
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: supabaseKeys.gabinetAppointments.all,
-        }),
-        queryClient.invalidateQueries({
-          queryKey: supabaseKeys.scheduledActivities.all,
-        }),
-      ]);
+      if (apptDirty) {
+        const args: Parameters<typeof updateAppointment>[0] = {
+          organizationId,
+          appointmentId: appointment._id as Id<"gabinetAppointments">,
+        };
+        if (date !== appointment.date) args.date = date;
+        if (startTime !== appointment.startTime.slice(0, 5))
+          args.startTime = startTime;
+        if (endTime !== appointment.endTime.slice(0, 5)) args.endTime = endTime;
+        if (status && status !== initialStatus) args.status = status;
+        if (internalNotes !== (appointment.internalNotes ?? ""))
+          args.internalNotes = internalNotes;
+        if (treatmentId && treatmentId !== initialTreatmentId)
+          args.treatmentId = treatmentId;
+
+        await updateAppointment(args);
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: supabaseKeys.gabinetAppointments.all,
+          }),
+          queryClient.invalidateQueries({
+            queryKey: supabaseKeys.scheduledActivities.all,
+          }),
+        ]);
+      }
+
       await refetch();
       toast.success(t("gabinet.appointments.updated"));
       onClose();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #400.

Closes #400

---

## Claude summary

Fix committed.

The bug: in the appointment quick-edit popover on `/dashboard/gabinet/calendar`, the patient had no phone, so the user clicked "+ Dodaj telefon", typed `605552264` in the inline editor, then clicked the main "Zapisz" button at the bottom. The button stayed disabled because the `dirty` check in `appointment-preview-content.tsx:187` only watched status/date/time/notes/treatment — the inline phone input had its own separate save (the small ✓ icon next to the input) that wasn't discoverable.

The fix adds a `phoneDirty` check (active when `isEditingPhone` and the input differs from the current phone) into the main `dirty` flag, and `handleSave` now persists the phone via `updatePatient` before falling through to the appointment update. The standalone ✓ button still works for users who prefer that flow.