### PR TITLE
dodaj możliwość zakończenia wizyty tutaj

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -44,7 +44,7 @@ import { checkDocumentGate } from "./_helpers/documentGate";
 
 const VALID_TRANSITIONS: Record<string, string[]> = {
   pending_confirmation: ["scheduled", "confirmed", "cancelled"],
-  scheduled: ["confirmed", "cancelled", "no_show"],
+  scheduled: ["confirmed", "in_progress", "completed", "cancelled", "no_show"],
   confirmed: ["in_progress", "completed", "cancelled", "no_show"],
   in_progress: ["completed", "cancelled"],
   completed: [],

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -54,7 +54,7 @@ import {
 
 const VALID_TRANSITIONS: Record<string, string[]> = {
   pending_confirmation: ["scheduled", "confirmed", "cancelled"],
-  scheduled: ["confirmed", "cancelled", "no_show"],
+  scheduled: ["confirmed", "in_progress", "completed", "cancelled", "no_show"],
   confirmed: ["in_progress", "completed", "cancelled", "no_show"],
   in_progress: ["completed", "cancelled"],
   completed: [],

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -122,7 +122,7 @@ const statusColors: Record<
 
 const VALID_TRANSITIONS: Record<string, string[]> = {
   pending_confirmation: ["scheduled", "confirmed", "cancelled"],
-  scheduled: ["confirmed", "cancelled", "no_show"],
+  scheduled: ["confirmed", "in_progress", "completed", "cancelled", "no_show"],
   confirmed: ["in_progress", "completed", "cancelled", "no_show"],
   in_progress: ["completed", "cancelled"],
   completed: [],


### PR DESCRIPTION
Auto-generated by Claude in response to issue #393.

Closes #393

---

## Claude summary

Committed `757d527`.

Summary: the user was looking at a "scheduled" appointment in the calendar preview popup and wanted to mark it as completed. The status state machine (`VALID_TRANSITIONS`) only allowed `confirmed`/`cancelled`/`no_show` from `scheduled`, forcing a two-step transition through `confirmed` first. I added `in_progress` and `completed` to the allowed transitions from `scheduled` in all three places the map is defined (backend guard in `convex/gabinet/appointments.ts`, the calendar preview popup, and the full appointment detail page). Now the user sees "Zakończona" directly in the status dropdown and can save in one click.