### PR TITLE
ostrzeżenie w kalendarzu - termin

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -433,6 +433,12 @@ export function AppointmentDialog({
       )
     : "";
 
+  const isPastSlot = useMemo(() => {
+    if (!dateStr || !selectedSlot?.start) return false;
+    const slotStart = new Date(`${dateStr}T${selectedSlot.start}:00`);
+    return slotStart.getTime() < Date.now();
+  }, [dateStr, selectedSlot]);
+
   const canSubmit =
     !!patientId &&
     !!treatmentId &&
@@ -1144,6 +1150,18 @@ export function AppointmentDialog({
                           </span>
                         </div>
                       </div>
+
+                      {isPastSlot && (
+                        <div className="space-y-1 rounded-md border border-amber-200 bg-amber-50 px-2.5 py-2 text-xs text-amber-800 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-400">
+                          <div className="flex items-center gap-1.5 font-medium">
+                            <AlertTriangle className="size-3.5 shrink-0" />
+                            {t("gabinet.appointments.warnings.title")}
+                          </div>
+                          <ul className="ml-5 list-disc space-y-0.5">
+                            <li>{t("gabinet.appointments.warnings.past")}</li>
+                          </ul>
+                        </div>
+                      )}
 
                       <Button
                         className="w-full"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #366.

Closes #366

---

## Claude summary

Committed as `bff24ad` on `claude/issue-396`.

Summary: added a past-time warning to the appointment create dialog in `src/components/gabinet/calendar/appointment-dialog.tsx`. When the selected slot's date + start time is before now (e.g. user clicks a slot earlier than the current hour on today's calendar, or drags-to-create on a passed time), an amber alert box appears above the Confirm button using the same `border-amber-200 bg-amber-50 text-amber-800` style and `AlertTriangle` icon as the existing equipment warning and the preview-popover warnings panel. Reuses the already-translated `gabinet.appointments.warnings.title` and `gabinet.appointments.warnings.past` strings — no new translations needed. Typecheck passes.

Note: the branch this worktree is on is `claude/issue-396` (not `claude/issue-366` as the task brief suggested), but the commit message references #366.