### PR TITLE
metoda płatności

### DIFF
--- a/src/components/gabinet/package-purchase-drawer.tsx
+++ b/src/components/gabinet/package-purchase-drawer.tsx
@@ -256,7 +256,7 @@ export function PackagePurchaseDrawer({
             </Label>
           </div>
 
-          {splitPayment && selectedPkg && (
+          {splitPayment && (
             <div className="rounded-lg border p-3 space-y-3">
               <div className="grid grid-cols-2 gap-3">
                 <div className="rounded-md border p-2 space-y-2">
@@ -329,7 +329,7 @@ export function PackagePurchaseDrawer({
               >
                 <span>
                   {t("gabinet.packages.splitSum", "Sum")}: {splitTotal.toFixed(2)} /{" "}
-                  {expectedTotal.toFixed(2)} {selectedPkg.currency ?? "PLN"}
+                  {expectedTotal.toFixed(2)} {selectedPkg?.currency ?? "PLN"}
                 </span>
                 {splitSameMethod ? (
                   <span>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #417.

Closes #417

---

## Claude summary

Committed.

Summary: In `src/components/gabinet/package-purchase-drawer.tsx`, the split-payment UI was gated on both `splitPayment` and `selectedPkg`, so clicking "Podziel płatność" before picking a package (the exact state shown in the screenshot) silently rendered nothing. I dropped the `selectedPkg` requirement so the two payment-method tiles appear immediately when the box is ticked, and made `selectedPkg.currency` access optional to handle the no-package case. The Buy button still requires a selected package.