### PR TITLE
link

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -433,6 +433,12 @@ export function AppointmentDialog({
       )
     : "";
 
+  const isPastSlot = useMemo(() => {
+    if (!dateStr || !selectedSlot?.start) return false;
+    const slotStart = new Date(`${dateStr}T${selectedSlot.start}:00`);
+    return slotStart.getTime() < Date.now();
+  }, [dateStr, selectedSlot]);
+
   const canSubmit =
     !!patientId &&
     !!treatmentId &&
@@ -1144,6 +1150,18 @@ export function AppointmentDialog({
                           </span>
                         </div>
                       </div>
+
+                      {isPastSlot && (
+                        <div className="space-y-1 rounded-md border border-amber-200 bg-amber-50 px-2.5 py-2 text-xs text-amber-800 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-400">
+                          <div className="flex items-center gap-1.5 font-medium">
+                            <AlertTriangle className="size-3.5 shrink-0" />
+                            {t("gabinet.appointments.warnings.title")}
+                          </div>
+                          <ul className="ml-5 list-disc space-y-0.5">
+                            <li>{t("gabinet.appointments.warnings.past")}</li>
+                          </ul>
+                        </div>
+                      )}
 
                       <Button
                         className="w-full"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #396.

Closes #396

---

## Claude summary

Committed. Here is the full picture for the issue.

Audit of all live email senders (every place that renders a URL into an outbound email):

`convex/email/templates/invitationEmail.tsx:78` — uses `${SITE_URL}/invite/${token}`. Correct. Depends on the `SITE_URL` env var on the Convex deployment.

`convex/email/templates/subscriptionEmail.tsx:39, 53, 93` — uses `SITE_URL`, with a `"https://app.example.com"` fallback for the "Unify team" footer link if the env var is unset. Dormant when `SITE_URL` is set.

`convex/documents/signing.ts:18` — uses `SITE_URL ?? process.env.APP_URL ?? "http://localhost:5173"`. Correct.

`convex/signingEmails.ts` — was the odd one out: it read only `process.env.APP_URL` with a `"https://app.example.com"` placeholder, never `SITE_URL`. That means even after you set `SITE_URL` correctly on Convex, signing-request emails sent through `signatureRequests.ts` would still have rendered with the wrong host. This is the bug I just fixed in commit b76d69e — it now uses the same `SITE_URL ?? APP_URL ?? localhost` chain.

`convex/gabinet/patientAuth.ts` (patient portal OTP) and `convex/otp/ResendOTP.ts` (login OTP) — neither renders any URL, just an OTP code. No host issue.

`convex/emailSending.ts` / `emailTemplateSeed.ts` — the seeded templates contain `{{current_user.invitation_url}}`, `{{current_user.signing_url}}`, etc. as placeholders, but nothing in the code currently populates those variables when calling `sendTemplateEmail`, so those URLs would render as literal `{{...}}` strings if those templates ever fired. That is a separate latent issue, listed below.

On running the convex env commands: I cannot. The bot worktree has no `CONVEX_DEPLOY_KEY` and no logged-in convex session, and on top of that the bundled `node_modules/convex` CLI errors out on the Node 18 runtime here (`SyntaxError: Invalid flags supplied to RegExp constructor 'v'`). Even if both of those were fine, `npx convex env set` writes deployment config tied to your account, not source code — it has to be run from a machine logged in to your Convex project. From your repo root, please run yourself:

```
npx convex env set SITE_URL https://www.quera-dev.helloalex.pl
npx convex env set SITE_URL https://www.quera-dev.helloalex.pl --prod
```

After that, the next invitation email AND the next signing-request email will both render with `https://www.quera-dev.helloalex.pl/...`. To verify, send yourself one fresh test invitation (Settings → Team → Invite) and one fresh signing request, and confirm the button hosts. The previously delivered invitation email you pasted is frozen with the old URL — only newly sent ones are affected.

## Follow-ups
- Populate URL substitution variables in stored email templates: `convex/emailSending.ts` does not inject values for `{{current_user.invitation_url}}`, `{{current_user.verification_url}}`, `{{current_user.reset_url}}`, `{{current_user.signing_url}}`, or `{{patient.portal_url}}` referenced by `convex/emailTemplateSeed.ts`, so those placeholders would render as literal text if these templates are ever sent
- Remove the `"https://app.example.com"` placeholder fallback in `convex/email/templates/subscriptionEmail.tsx:53,93`: same anti-pattern as the signingEmails.ts bug fixed in #396 — silently shows a wrong domain if SITE_URL is unset instead of failing loudly