### PR TITLE
zmiana zabiegu

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1208,7 +1208,7 @@ export const create = action({
 export const update = action({
   args: {
     organizationId: v.id("organizations"),
-    appointmentId: v.id("gabinetAppointments"),
+    appointmentId: v.string(),
     date: v.optional(v.string()),
     startTime: v.optional(v.string()),
     endTime: v.optional(v.string()),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #418.

Closes #418

---

## Claude summary

Committed. Summary:

The Save button in the calendar appointment preview popover (`appointment-preview-content.tsx`) was failing silently because `convex/gabinet/appointments.ts:1211` declared `appointmentId: v.id("gabinetAppointments")`, while appointments are now stored in Supabase with UUID strings (`6af1ccc1-…`). Every update request was rejected by Convex with `ArgumentValidationError` before the handler ran — confirmed by the Jam console log. The user noticed this when changing the treatment, but the bug would have affected any field edit on this popover. Switched the validator to `v.string()` to match the surrounding Supabase-backed actions; the handler already treats the ID as a string.

## Follow-ups
- Audit remaining `v.id("gabinetAppointments")` validators in convex/gabinet: line 1655 (`getDocumentGateStatus`) and convex/gabinet/appointmentSms.ts:160,239,1452 (`updateStatus` may also be affected) — likely the same Supabase-UUID mismatch.
- Surface action errors in `appointment-preview-content.tsx` handleSave: toasting the raw message would have made this user-visible instead of "save button doesn't work."