### PR TITLE
Blad podczas przesuwania wizyty w kalendarzu

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2452,6 +2452,25 @@
         "pastConfirm": {
           "message": "The selected time has already passed. Do you want to add the appointment?"
         }
+      },
+      "rescheduled": "Appointment rescheduled",
+      "rescheduleFailed": "Could not reschedule the appointment.",
+      "resized": "Appointment duration updated",
+      "resizeFailed": "Could not change appointment duration.",
+      "errors": {
+        "conflict": "This time conflicts with another appointment.",
+        "conflictNamed": "This time conflicts with another calendar event.",
+        "roomConflict": "The room is occupied at this time.",
+        "employeeLeave": "Employee is on leave at this time.",
+        "employeeNotWorking": "Employee does not work on this day.",
+        "outsideEmployeeHours": "Outside employee working hours.",
+        "clinicClosed": "Clinic is closed on this day.",
+        "outsideClinicHours": "Outside clinic working hours.",
+        "notFound": "Appointment not found. Refresh the calendar and try again.",
+        "permissionDenied": "You do not have permission to edit this appointment.",
+        "invalidStatusTransition": "Cannot change the appointment status from its current value.",
+        "invalidArguments": "Could not save changes — invalid appointment data.",
+        "blockedNotDraggable": "Google events cannot be moved from the calendar."
       }
     },
     "appointmentDetail": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2463,6 +2463,25 @@
         "pastConfirm": {
           "message": "Wybrany termin już minął. Czy chcesz dodać wizytę?"
         }
+      },
+      "rescheduled": "Wizyta przeniesiona",
+      "rescheduleFailed": "Nie udało się przenieść wizyty.",
+      "resized": "Długość wizyty zmieniona",
+      "resizeFailed": "Nie udało się zmienić długości wizyty.",
+      "errors": {
+        "conflict": "Termin koliduje z inną wizytą.",
+        "conflictNamed": "Termin koliduje z innym wydarzeniem w kalendarzu.",
+        "roomConflict": "Gabinet jest zajęty w tym terminie.",
+        "employeeLeave": "Pracownik jest na urlopie w tym terminie.",
+        "employeeNotWorking": "Pracownik nie pracuje w tym dniu.",
+        "outsideEmployeeHours": "Termin poza godzinami pracy pracownika.",
+        "clinicClosed": "Gabinet jest zamknięty w tym dniu.",
+        "outsideClinicHours": "Termin poza godzinami pracy gabinetu.",
+        "notFound": "Nie znaleziono wizyty. Odśwież kalendarz i spróbuj ponownie.",
+        "permissionDenied": "Brak uprawnień do edycji tej wizyty.",
+        "invalidStatusTransition": "Nie można zmienić statusu wizyty z bieżącej wartości.",
+        "invalidArguments": "Nie udało się zapisać zmian — nieprawidłowe dane wizyty.",
+        "blockedNotDraggable": "Wydarzeń z Google nie można przesuwać w kalendarzu."
       }
     },
     "appointmentDetail": {

--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -1,0 +1,128 @@
+import type { TFunction } from "i18next";
+
+// Convex Action errors arrive on the client as plain `Error` instances whose
+// `.message` is wrapped with the framework's diagnostic prefix, e.g.:
+//
+//   [CONVEX A(gabinet/appointments:update)] [Request ID: xxxx] Server Error
+//   Uncaught Error: Conflicts with existing appointment
+//       at handler (../convex/gabinet/appointments.ts:1286:13)
+//       ...
+//   Called by client
+//
+// `extractActionErrorMessage` peels off this wrapping and returns the inner
+// thrown message so it can be shown to end users.
+export function extractActionErrorMessage(err: unknown): string {
+  if (err instanceof Error && err.message) {
+    return cleanConvexMessage(err.message);
+  }
+  if (typeof err === "string") return cleanConvexMessage(err);
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+function cleanConvexMessage(raw: string): string {
+  let msg = raw;
+
+  // Drop the leading "[CONVEX ...] [Request ID: ...] Server Error" banner.
+  msg = msg.replace(/^\s*\[CONVEX[^\]]*\][^\n]*\n?/i, "");
+  msg = msg.replace(/^\s*\[Request ID:[^\]]*\][^\n]*\n?/i, "");
+  msg = msg.replace(/^\s*Server Error\s*\n?/i, "");
+
+  // Convex wraps the thrown reason as "Uncaught Error: <msg>" (or similar).
+  const uncaught = msg.match(
+    /Uncaught\s+(?:Error|ConvexError|ArgumentValidationError|TypeError)\s*:\s*([^\n]+)/i,
+  );
+  if (uncaught) {
+    return uncaught[1].trim();
+  }
+
+  // Strip stack trace lines and any "Called by client" suffix.
+  const firstLine = msg.split(/\r?\n/).find((line) => line.trim().length > 0);
+  return (firstLine ?? msg).trim();
+}
+
+const APPOINTMENT_ERROR_MAP: Array<{
+  test: (msg: string) => boolean;
+  key: string;
+  fallback: string;
+}> = [
+  {
+    test: (m) => /conflicts with existing appointment|time slot conflict/i.test(m),
+    key: "gabinet.appointments.errors.conflict",
+    fallback: "Termin koliduje z inną wizytą.",
+  },
+  {
+    test: (m) => /room is occupied/i.test(m),
+    key: "gabinet.appointments.errors.roomConflict",
+    fallback: "Gabinet jest zajęty w tym terminie.",
+  },
+  {
+    test: (m) => /employee is on leave|conflicts with employee leave/i.test(m),
+    key: "gabinet.appointments.errors.employeeLeave",
+    fallback: "Pracownik jest na urlopie w tym terminie.",
+  },
+  {
+    test: (m) => /employee is not working on this day/i.test(m),
+    key: "gabinet.appointments.errors.employeeNotWorking",
+    fallback: "Pracownik nie pracuje w tym dniu.",
+  },
+  {
+    test: (m) => /outside employee working hours/i.test(m),
+    key: "gabinet.appointments.errors.outsideEmployeeHours",
+    fallback: "Termin poza godzinami pracy pracownika.",
+  },
+  {
+    test: (m) => /clinic is closed on this day/i.test(m),
+    key: "gabinet.appointments.errors.clinicClosed",
+    fallback: "Gabinet jest zamknięty w tym dniu.",
+  },
+  {
+    test: (m) => /outside clinic working hours/i.test(m),
+    key: "gabinet.appointments.errors.outsideClinicHours",
+    fallback: "Termin poza godzinami pracy gabinetu.",
+  },
+  {
+    test: (m) => /^conflicts with:/i.test(m),
+    key: "gabinet.appointments.errors.conflictNamed",
+    fallback: "Termin koliduje z innym wydarzeniem w kalendarzu.",
+  },
+  {
+    test: (m) => /appointment not found/i.test(m),
+    key: "gabinet.appointments.errors.notFound",
+    fallback: "Nie znaleziono wizyty. Odśwież kalendarz i spróbuj ponownie.",
+  },
+  {
+    test: (m) => /permission denied/i.test(m),
+    key: "gabinet.appointments.errors.permissionDenied",
+    fallback: "Brak uprawnień do edycji tej wizyty.",
+  },
+  {
+    test: (m) => /cannot transition from/i.test(m),
+    key: "gabinet.appointments.errors.invalidStatusTransition",
+    fallback: "Nie można zmienić statusu wizyty z bieżącej wartości.",
+  },
+  {
+    test: (m) => /argumentvalidationerror|value does not match validator/i.test(m),
+    key: "gabinet.appointments.errors.invalidArguments",
+    fallback: "Nie udało się zapisać zmian — nieprawidłowe dane wizyty.",
+  },
+];
+
+// Convert a Convex action error into a user-friendly toast message.
+// Falls back to a provided generic message when nothing matches.
+export function formatAppointmentError(
+  err: unknown,
+  t: TFunction,
+  fallback: { key: string; defaultValue: string },
+): string {
+  const inner = extractActionErrorMessage(err);
+  for (const entry of APPOINTMENT_ERROR_MAP) {
+    if (entry.test(inner)) {
+      return t(entry.key, { defaultValue: entry.fallback });
+    }
+  }
+  return t(fallback.key, { defaultValue: fallback.defaultValue });
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -52,6 +52,7 @@ import { useSupabaseGabinetWorkingHoursList } from "@/hooks/use-supabase-gabinet
 import { useSupabaseScheduledActivitiesByDateRange } from "@/hooks/use-supabase-scheduled-activities";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
+import { formatAppointmentError } from "@/lib/format-action-error";
 
 export const Route = createLazyFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/calendar/",
@@ -489,13 +490,12 @@ function GabinetCalendarPage() {
         void queryClient.invalidateQueries({
           queryKey: supabaseKeys.gabinetAppointments.all,
         });
-      } catch (e: any) {
+      } catch (e: unknown) {
         toast.error(
-          e.message ??
-            t(
-              "gabinet.appointments.resizeFailed",
-              "Failed to resize appointment",
-            ),
+          formatAppointmentError(e, t, {
+            key: "gabinet.appointments.resizeFailed",
+            defaultValue: "Nie udało się zmienić długości wizyty.",
+          }),
         );
       }
     },
@@ -534,6 +534,18 @@ function GabinetCalendarPage() {
         );
         if (!originalAppt) return;
 
+        // Google-synced blocked-time entries are not real gabinetAppointments;
+        // attempting to update them would 404 server-side. Reject silently.
+        if (originalAppt.status === "blocked") {
+          toast.error(
+            t(
+              "gabinet.appointments.errors.blockedNotDraggable",
+              "Wydarzeń z Google nie można przesuwać w kalendarzu.",
+            ),
+          );
+          return;
+        }
+
         // Calculate new end time based on original duration
         const [startH, startM] = originalAppt.startTime.split(":").map(Number);
         const [endH, endM] = originalAppt.endTime.split(":").map(Number);
@@ -558,18 +570,17 @@ function GabinetCalendarPage() {
           );
           // Invalidate Supabase appointments cache after Convex mutation
           void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetAppointments.all });
-        } catch (e: any) {
+        } catch (e: unknown) {
           toast.error(
-            e.message ??
-              t(
-                "gabinet.appointments.rescheduleFailed",
-                "Failed to reschedule",
-              ),
+            formatAppointmentError(e, t, {
+              key: "gabinet.appointments.rescheduleFailed",
+              defaultValue: "Nie udało się przenieść wizyty.",
+            }),
           );
         }
       }
     },
-    [organizationId, updateAppointment, viewAppointments, t],
+    [organizationId, updateAppointment, viewAppointments, queryClient, t],
   );
 
   // Title


### PR DESCRIPTION
Auto-generated by Claude in response to issue #419.

Closes #419

---

## Claude summary

Triage and summary:

The original drag failure shown in the Jam recording (11:44 UTC, May 19) was caused by `appointmentId: v.id("gabinetAppointments")` rejecting the Supabase UUID string. That root-cause was already fixed in commit `ffc6d8c` (PR #430, merged 14:19 same day). I verified `convex/gabinet/appointments.ts:1211` is now `appointmentId: v.string()`.

The second part of the request — surface friendly errors instead of raw Convex text — was still open. Real conflict cases (`_availability_supabase.ts` returns English reasons like "Conflicts with existing appointment", "Employee is on leave", etc.) would otherwise still ship to the toast as `[CONVEX A(...)] Server Error\nUncaught Error: ...\nCalled by client`.

What changed:

- New helper `src/lib/format-action-error.ts` strips the Convex framework wrapping (`[CONVEX A(...)]`, `Server Error`, `Uncaught Error:`, stack trace, `Called by client`) and maps the inner reason to an i18n key. Covers all messages thrown from `gabinet.appointments.update` and the conflict checker.
- `_layout.gabinet.calendar.index.lazy.tsx` drag-end and resize handlers now use `formatAppointmentError` instead of dumping `e.message`. Also rejects drag of Google-synced "blocked" entries with a translated message (would have produced a server-side "Appointment not found").
- Added Polish + English entries under `gabinet.appointments.errors.*`, plus localized `rescheduled` / `resized` / `*Failed` strings (previously fell back to hard-coded English).
- Fixed a stale `useCallback` dep (queryClient missing).

Typecheck (`scripts/typecheck-portable.mjs`) passes. Locale JSON parses cleanly.

## Follow-ups
- Reuse formatAppointmentError in appointment-dialog.tsx and appointment-preview-content.tsx: both still toast raw `e.message` from the same Convex action, so create/save flows can hit the same ugly error banner