### PR TITLE
Kolor plakietek wizyt

### DIFF
--- a/src/lib/gabinet-appointment-status.ts
+++ b/src/lib/gabinet-appointment-status.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared visual tokens for gabinet appointment statuses.
+ *
+ * Colors mirror the calendar legend (see
+ * `src/components/gabinet/calendar/appointment-card.tsx`) so that status
+ * badges across the patient profile, appointment history, and dashboard
+ * read with the same color the user sees on the calendar tiles.
+ */
+
+export const APPOINTMENT_STATUS_BADGE_CLASSES: Record<string, string> = {
+  pending_confirmation:
+    "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-400",
+  scheduled:
+    "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-400",
+  confirmed:
+    "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-400",
+  in_progress:
+    "border-yellow-200 bg-yellow-50 text-yellow-800 dark:border-yellow-800 dark:bg-yellow-950/40 dark:text-yellow-400",
+  completed:
+    "border-gray-200 bg-gray-100 text-gray-700 dark:border-gray-700 dark:bg-gray-800/50 dark:text-gray-300",
+  cancelled:
+    "border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400",
+  no_show:
+    "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-800 dark:bg-orange-950/40 dark:text-orange-400",
+};
+
+export function appointmentStatusBadgeClass(status: string): string {
+  return (
+    APPOINTMENT_STATUS_BADGE_CLASSES[status] ??
+    APPOINTMENT_STATUS_BADGE_CLASSES.scheduled
+  );
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -100,25 +100,13 @@ import { Link } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
+import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
 
 export const Route = createLazyFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/appointments/$appointmentId",
 )({
   component: AppointmentDetail,
 });
-
-const statusColors: Record<
-  string,
-  "default" | "secondary" | "destructive" | "outline"
-> = {
-  pending_confirmation: "outline",
-  scheduled: "secondary",
-  confirmed: "default",
-  in_progress: "default",
-  completed: "default",
-  cancelled: "destructive",
-  no_show: "destructive",
-};
 
 const VALID_TRANSITIONS: Record<string, string[]> = {
   pending_confirmation: ["scheduled", "confirmed", "cancelled"],
@@ -1302,7 +1290,10 @@ function AppointmentDetail() {
                 <Badge variant={smsSummary.tone}>
                   {t(smsSummary.labelKey)}
                 </Badge>
-                <Badge variant="outline">
+                <Badge
+                  variant="outline"
+                  className={appointmentStatusBadgeClass(appointment.status)}
+                >
                   {t(`gabinet.appointments.statuses.${appointment.status}`)}
                 </Badge>
               </div>
@@ -1696,9 +1687,8 @@ function AppointmentDetail() {
                             </p>
                           </div>
                           <Badge
-                            variant={
-                              statusColors[appt.status] ?? "secondary"
-                            }
+                            variant="outline"
+                            className={appointmentStatusBadgeClass(appt.status)}
                           >
                             {t(
                               `gabinet.appointments.statuses.${appt.status}`,

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -36,6 +36,7 @@ import {
 
 import { useTranslation } from "react-i18next";
 import { PatientPackagesCard } from "@/components/gabinet/patient-packages-card";
+import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/patients/$patientId",
@@ -347,15 +348,8 @@ function PatientDetail() {
                         </p>
                       </div>
                       <Badge
-                        variant={
-                          apt.status === "completed"
-                            ? "default"
-                            : apt.status === "cancelled"
-                              ? "destructive"
-                              : apt.status === "no_show"
-                                ? "destructive"
-                                : "secondary"
-                        }
+                        variant="outline"
+                        className={appointmentStatusBadgeClass(apt.status)}
                       >
                         {t(
                           `gabinet.appointments.statuses.${apt.status}`,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #422.

Closes #422

---

## Claude summary

Committed. Summary of the fix:

The patient appointment list (patient profile → Appointments tab) and the patient history timeline (appointment detail) were rendering status badges with shadcn's `secondary`/`outline` variants, so statuses like "confirmed" and "in_progress" looked white/gray even though the calendar uses distinct colors. I added a shared helper at `src/lib/gabinet-appointment-status.ts` that mirrors the calendar's per-status palette (blue/green/yellow/gray/red/orange/amber, with dark-mode variants matching the existing `bg-emerald-50/dark:bg-emerald-950/40` pattern used elsewhere in the app), and applied it to:

- `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx` — appointments tab badges
- `src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx` — patient history timeline and SMS card status badge (also removed the now-unused `statusColors` map)

## Follow-ups
- Apply same status colors to gabinet dashboard and employee detail: `_layout.gabinet.index.tsx:409` and `_layout.gabinet.employees.$employeeId.tsx:957,1531` still use plain Badge variants for appointment status — switch them to `appointmentStatusBadgeClass()` for consistency.
- Reuse the helper inside `calendar/appointment-card.tsx`: it has its own `STATUS_COLORS` map. Currently the calendar tile uses a slightly different (more saturated) palette; deciding on one canonical set and consolidating would prevent future drift.