### PR TITLE
Mozliwosc definiowania minimalnego czasu w gridzie w kalendarzu

### DIFF
--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -22,7 +22,7 @@ interface CalendarDayViewProps {
   onSlotDragSelect?: (date: string, startTime: string, endTime: string) => void;
   onAppointmentResize?: (id: string, newEndTime: string) => void;
   workingHours?: { startTime: string; endTime: string; breakStart?: string; breakEnd?: string } | null;
-  slotMinutes?: 15 | 30 | 60;
+  slotMinutes?: 5 | 10 | 15 | 30 | 60;
 }
 
 const HOURS = Array.from({ length: 14 }, (_, i) => i + 7); // 07:00 – 20:00
@@ -159,19 +159,25 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
     <div className="relative flex h-full overflow-y-auto">
       {/* Time labels */}
       <div className="sticky left-0 z-10 w-16 shrink-0 border-r bg-background relative">
-        {slots.map((s) => (
-          <div
-            key={s.time}
-            className="flex items-start justify-end pr-2 pt-0"
-            style={{ height: `${s.slotHeight}px` }}
-          >
-            <span
-              className={`${s.isHourMark ? "text-xs font-medium text-muted-foreground" : "text-[10px] text-muted-foreground/60"} leading-none`}
+        {slots.map((s) => {
+          // For small slot heights, only render the hour label so text doesn't overlap.
+          const showLabel = s.isHourMark || s.slotHeight >= 15;
+          return (
+            <div
+              key={s.time}
+              className="flex items-start justify-end pr-2 pt-0"
+              style={{ height: `${s.slotHeight}px` }}
             >
-              {s.time}
-            </span>
-          </div>
-        ))}
+              {showLabel && (
+                <span
+                  className={`${s.isHourMark ? "text-xs font-medium text-muted-foreground" : "text-[10px] text-muted-foreground/60"} leading-none`}
+                >
+                  {s.time}
+                </span>
+              )}
+            </div>
+          );
+        })}
         {showCurrentTime && (
           <div
             className="pointer-events-none absolute right-1 z-30 rounded bg-red-500 px-1 py-0.5 text-[10px] font-semibold leading-none text-white shadow"

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -26,7 +26,7 @@ interface CalendarWeekViewProps {
   onDayHeaderClick?: (date: string) => void;
   selectedDate?: string;
   employeeSchedules?: Map<string, { startTime: string; endTime: string; breakStart?: string; breakEnd?: string }>;
-  slotMinutes?: 15 | 30 | 60;
+  slotMinutes?: 5 | 10 | 15 | 30 | 60;
 }
 
 const HOURS = Array.from({ length: 14 }, (_, i) => i + 7);
@@ -141,7 +141,7 @@ interface WeekDayColumnProps {
   onSlotDragSelect?: (date: string, startTime: string, endTime: string) => void;
   onAppointmentResize?: (id: string, newEndTime: string) => void;
   onDayHeaderClick?: (date: string) => void;
-  slotMinutes: 15 | 30 | 60;
+  slotMinutes: 5 | 10 | 15 | 30 | 60;
   slots: ReturnType<typeof buildSlots>;
 }
 
@@ -361,19 +361,25 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotD
     <div className="flex h-full overflow-auto">
       {/* Time labels */}
       <div className="sticky left-0 z-10 w-14 shrink-0 border-r bg-background pt-8 relative">
-        {slots.map((s) => (
-          <div
-            key={s.time}
-            className="flex items-start justify-end pr-2"
-            style={{ height: `${s.slotHeight}px` }}
-          >
-            <span
-              className={`${s.isHourMark ? "text-xs font-medium text-muted-foreground" : "text-[10px] text-muted-foreground/60"} leading-none`}
+        {slots.map((s) => {
+          // For small slot heights, only render the hour label so text doesn't overlap.
+          const showLabel = s.isHourMark || s.slotHeight >= 15;
+          return (
+            <div
+              key={s.time}
+              className="flex items-start justify-end pr-2"
+              style={{ height: `${s.slotHeight}px` }}
             >
-              {s.time}
-            </span>
-          </div>
-        ))}
+              {showLabel && (
+                <span
+                  className={`${s.isHourMark ? "text-xs font-medium text-muted-foreground" : "text-[10px] text-muted-foreground/60"} leading-none`}
+                >
+                  {s.time}
+                </span>
+              )}
+            </div>
+          );
+        })}
         {showCurrentTime && (
           <div
             className="pointer-events-none absolute right-1 z-30 rounded bg-red-500 px-1 py-0.5 text-[10px] font-semibold leading-none text-white shadow"

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -61,8 +61,16 @@ export const Route = createLazyFileRoute(
 });
 
 type ViewMode = "day" | "week" | "month";
-type SlotMinutes = 15 | 30 | 60;
-const SLOT_OPTIONS: SlotMinutes[] = [60, 30, 15];
+type SlotMinutes = 5 | 10 | 15 | 30 | 60;
+const SLOT_OPTIONS: SlotMinutes[] = [60, 30, 15, 10, 5];
+const SLOT_STORAGE_KEY = "gabinet.calendar.slotMinutes";
+
+function readStoredSlotMinutes(): SlotMinutes {
+  if (typeof window === "undefined") return 60;
+  const raw = window.localStorage.getItem(SLOT_STORAGE_KEY);
+  const n = raw ? Number(raw) : NaN;
+  return (SLOT_OPTIONS as number[]).includes(n) ? (n as SlotMinutes) : 60;
+}
 
 function getMonday(date: Date): Date {
   const d = new Date(date);
@@ -88,7 +96,13 @@ function GabinetCalendarPage() {
   useWideContent(true);
 
   const [viewMode, setViewMode] = useState<ViewMode>("week");
-  const [slotMinutes, setSlotMinutes] = useState<SlotMinutes>(60);
+  const [slotMinutes, setSlotMinutesState] = useState<SlotMinutes>(readStoredSlotMinutes);
+  const setSlotMinutes = useCallback((next: SlotMinutes) => {
+    setSlotMinutesState(next);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(SLOT_STORAGE_KEY, String(next));
+    }
+  }, []);
   const [currentDate, setCurrentDate] = useState(new Date());
   const [employeeFilter, setEmployeeFilter] = useState<string>("all");
   const [treatmentFilter, setTreatmentFilter] = useState<string>("all");


### PR DESCRIPTION
Auto-generated by Claude in response to issue #423.

Closes #423

---

## Claude summary

Committed as `729d19b`.

The calendar page already had a slot-size switcher in the toolbar with 15/30/60-minute options (`src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx:64`). The user wanted finer granularity and for the choice to behave like a setting (persistent), so I:

- Extended `SlotMinutes` to `5 | 10 | 15 | 30 | 60` and added the two new buttons to the toolbar group.
- Persisted the selection in `localStorage` under `gabinet.calendar.slotMinutes` so the choice survives reloads and navigation.
- Suppressed non-hour time labels in the time-axis column when slot height drops below 15 px (calendar-day-view.tsx, calendar-week-view.tsx) to prevent label overlap at 5- and 10-minute resolutions.

`snapMinutes` for drag-to-create/resize already uses `Math.min(15, slotMinutes)`, so it correctly falls to 5 or 10 minutes at the new resolutions without further changes.