### PR TITLE
Remove the `"https

### DIFF
--- a/convex/email/templates/subscriptionEmail.tsx
+++ b/convex/email/templates/subscriptionEmail.tsx
@@ -50,7 +50,7 @@ export function SubscriptionSuccessEmail({ email }: SubscriptionEmailOptions) {
             We hope you enjoy the new features!
           </Text>
           <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
-            The <Link href={process.env.SITE_URL ?? "https://app.example.com"}>Unify</Link> team.
+            The <Link href={SITE_URL}>Unify</Link> team.
           </Text>
           <Hr style={{ borderColor: "#cccccc", margin: "20px 0" }} />
           <Text style={{ color: "#8898aa", fontSize: "12px" }}>
@@ -90,7 +90,7 @@ export function SubscriptionErrorEmail({ email }: SubscriptionEmailOptions) {
             But don't worry, we'll not charge you anything.
           </Text>
           <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
-            The <Link href={process.env.SITE_URL ?? "https://app.example.com"}>Unify</Link> team.
+            The <Link href={SITE_URL}>Unify</Link> team.
           </Text>
           <Hr style={{ borderColor: "#cccccc", margin: "20px 0" }} />
           <Text style={{ color: "#8898aa", fontSize: "12px" }}>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #426.

Closes #426

---

## Claude summary

Replaced the `process.env.SITE_URL ?? "https://app.example.com"` placeholder fallback at lines 53 and 93 of `convex/email/templates/subscriptionEmail.tsx` with the `SITE_URL` already imported from `@cvx/env` — matching the pattern the same file already uses on line 39 for the logo image, and aligning with the precedent set in #396. Committed as `821b6ad`.

Note: I couldn't run `npm run typecheck` because `node_modules` isn't installed in this worktree, but the change is a trivial reference swap to a symbol already imported and in use in the same file.