### PR TITLE
ostrzeżenie

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2444,7 +2444,7 @@
       "equipmentWarning": "Required equipment not at this location",
       "warnings": {
         "title": "Warning",
-        "past": "Appointment is in the past",
+        "past": "Appointment has passed",
         "qualification": "Employee is not qualified for this treatment",
         "leave": "Employee is on leave at this time",
         "outsideHours": "Outside clinic working hours",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2455,7 +2455,7 @@
       "equipmentWarning": "Brak wymaganego sprzętu w tej lokalizacji",
       "warnings": {
         "title": "Ostrzeżenie",
-        "past": "Termin w przeszłości",
+        "past": "Termin minął",
         "qualification": "Pracownik nie ma kwalifikacji do tego zabiegu",
         "leave": "Pracownik jest na urlopie w tym terminie",
         "outsideHours": "Termin poza godzinami pracy gabinetu",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #428.

Closes #428

---

## Claude summary

Committed.

Summary: The user's first screenshot showed the inline past-time warning saying "Termin w przeszłości"; the follow-up screenshot showed the existing TAK/NIE popup confirmation dialog (added in PR #415, src/components/gabinet/calendar/appointment-dialog.tsx:1299) with the comment "dokładnie o to mi chodzi" — confirming the popup already does what they want (clicking TAK calls `performCreate()` at line 1340 and saves the appointment).

The only change needed was the requested text replacement: the inline warning at appointment-dialog.tsx:1259 now reads "Termin minął" instead of "Termin w przeszłości" (PL) and "Appointment has passed" instead of "Appointment is in the past" (EN).