### PR TITLE
mail

### DIFF
--- a/convex/email/templates/invitationEmail.tsx
+++ b/convex/email/templates/invitationEmail.tsx
@@ -26,6 +26,21 @@ type InvitationEmailOptions = {
   replyTo?: string;
 };
 
+const ROLE_LABELS_PL: Record<string, string> = {
+  owner: "właściciela",
+  admin: "administratora",
+  member: "członka zespołu",
+  viewer: "obserwatora",
+};
+
+function translateRole(role: string): string {
+  return ROLE_LABELS_PL[role] ?? role;
+}
+
+export function buildInvitationSubject(orgName: string) {
+  return `Zaproszenie do ${orgName}`;
+}
+
 /**
  * Templates.
  */
@@ -36,10 +51,11 @@ export function InvitationEmail({
   role,
   token,
 }: InvitationEmailOptions) {
+  const roleLabel = translateRole(role);
   return (
     <Html>
       <Head />
-      <Preview>You've been invited to join {orgName}</Preview>
+      <Preview>Zaproszenie do {orgName}</Preview>
       <Body
         style={{
           backgroundColor: "#ffffff",
@@ -49,14 +65,14 @@ export function InvitationEmail({
       >
         <Container style={{ margin: "0 auto", padding: "20px 0 48px" }}>
           <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
-            Hello {email}!
+            Cześć {email}!
           </Text>
           <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
-            You've been invited to join <strong>{orgName}</strong> as a {role}{" "}
-            by {inviterName}.
+            {inviterName} zaprasza Cię do dołączenia do organizacji{" "}
+            <strong>{orgName}</strong> w roli {roleLabel}.
           </Text>
           <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
-            Click the button below to accept the invitation.
+            Kliknij przycisk poniżej, aby zaakceptować zaproszenie.
           </Text>
           <Button
             href={`${SITE_URL}/invite/${token}`}
@@ -71,15 +87,15 @@ export function InvitationEmail({
               fontSize: "14px",
             }}
           >
-            Accept Invitation
+            Zaakceptuj zaproszenie
           </Button>
           <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
-            If you didn't expect this invitation, you can safely ignore this
-            email.
+            Jeśli nie spodziewałeś się tego zaproszenia, możesz zignorować tę
+            wiadomość.
           </Text>
           <Hr style={{ borderColor: "#cccccc", margin: "20px 0" }} />
           <Text style={{ color: "#8898aa", fontSize: "12px" }}>
-            This invitation was sent to {email}.
+            To zaproszenie zostało wysłane na adres {email}.
           </Text>
         </Container>
       </Body>
@@ -122,7 +138,7 @@ export async function sendInvitationEmail({
 
   await sendEmail({
     to: email,
-    subject: `You've been invited to join ${orgName}`,
+    subject: buildInvitationSubject(orgName),
     html,
     ...(from ? { from } : {}),
     ...(replyTo ? { replyTo } : {}),

--- a/convex/email/templates/subscriptionEmail.tsx
+++ b/convex/email/templates/subscriptionEmail.tsx
@@ -26,7 +26,7 @@ export function SubscriptionSuccessEmail({ email }: SubscriptionEmailOptions) {
   return (
     <Html>
       <Head />
-      <Preview>Successfully Subscribed to PRO</Preview>
+      <Preview>Subskrypcja PRO aktywowana</Preview>
       <Body
         style={{
           backgroundColor: "#ffffff",
@@ -42,15 +42,15 @@ export function SubscriptionSuccessEmail({ email }: SubscriptionEmailOptions) {
             alt=""
           />
           <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
-            Hello {email}!
+            Cześć {email}!
           </Text>
           <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
-            Your subscription to PRO has been successfully processed.
+            Twoja subskrypcja PRO została pomyślnie aktywowana.
             <br />
-            We hope you enjoy the new features!
+            Życzymy udanego korzystania z nowych funkcji!
           </Text>
           <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
-            The <Link href={process.env.SITE_URL ?? "https://app.example.com"}>Unify</Link> team.
+            Zespół <Link href={process.env.SITE_URL ?? "https://app.example.com"}>Unify</Link>.
           </Text>
           <Hr style={{ borderColor: "#cccccc", margin: "20px 0" }} />
           <Text style={{ color: "#8898aa", fontSize: "12px" }}>
@@ -66,7 +66,7 @@ export function SubscriptionErrorEmail({ email }: SubscriptionEmailOptions) {
   return (
     <Html>
       <Head />
-      <Preview>Subscription Issue - Customer Support</Preview>
+      <Preview>Problem z subskrypcją — wsparcie klienta</Preview>
       <Body
         style={{
           backgroundColor: "#ffffff",
@@ -82,15 +82,15 @@ export function SubscriptionErrorEmail({ email }: SubscriptionEmailOptions) {
             alt=""
           />
           <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
-            Hello {email}.
+            Cześć {email}.
           </Text>
           <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
-            We were unable to process your subscription to PRO tier.
+            Nie udało nam się przetworzyć Twojej subskrypcji planu PRO.
             <br />
-            But don't worry, we'll not charge you anything.
+            Nie martw się — nie pobierzemy od Ciebie żadnej opłaty.
           </Text>
           <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
-            The <Link href={process.env.SITE_URL ?? "https://app.example.com"}>Unify</Link> team.
+            Zespół <Link href={process.env.SITE_URL ?? "https://app.example.com"}>Unify</Link>.
           </Text>
           <Hr style={{ borderColor: "#cccccc", margin: "20px 0" }} />
           <Text style={{ color: "#8898aa", fontSize: "12px" }}>
@@ -124,7 +124,7 @@ export async function sendSubscriptionSuccessEmail({
 
   await sendEmail({
     to: email,
-    subject: "Successfully Subscribed to PRO",
+    subject: "Subskrypcja PRO została aktywowana",
     html,
   });
 }
@@ -137,7 +137,7 @@ export async function sendSubscriptionErrorEmail({
 
   await sendEmail({
     to: email,
-    subject: "Subscription Issue - Customer Support",
+    subject: "Problem z subskrypcją — wsparcie klienta",
     html,
   });
 }

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -12,6 +12,7 @@ import { createNotificationDirect } from "./notifications";
 import {
   sendInvitationEmail,
   renderInvitationEmail,
+  buildInvitationSubject,
 } from "./email/templates/invitationEmail";
 import { sendViaResend, sendViaMailgun } from "./email/providers";
 
@@ -175,7 +176,7 @@ export const _sendInvitationEmail = internalAction({
         await sendViaResend(
           {
             to: args.email,
-            subject: `You've been invited to join ${ctxInfo.orgName}`,
+            subject: buildInvitationSubject(ctxInfo.orgName),
             html,
             from,
             replyTo,
@@ -202,7 +203,7 @@ export const _sendInvitationEmail = internalAction({
         await sendViaMailgun(
           {
             to: args.email,
-            subject: `You've been invited to join ${ctxInfo.orgName}`,
+            subject: buildInvitationSubject(ctxInfo.orgName),
             html,
             from,
             replyTo,

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -630,8 +630,8 @@ export const _getEmailContext = internalQuery({
     const org = await ctx.db.get(args.organizationId);
     const inviter = await ctx.db.get(args.inviterUserId as Id<"users">);
     return {
-      orgName: org?.name ?? "your team",
-      inviterName: inviter?.name ?? inviter?.email ?? "A teammate",
+      orgName: org?.name ?? "Twój zespół",
+      inviterName: inviter?.name ?? inviter?.email ?? "Członek zespołu",
     };
   },
 });

--- a/convex/otp/VerificationCodeEmail.tsx
+++ b/convex/otp/VerificationCodeEmail.tsx
@@ -21,18 +21,17 @@ export function VerificationCodeEmail({
         <Head />
         <Container className="container px-20 font-sans">
           <Heading className="text-xl font-bold mb-4">
-            {/* TODO: Update with your app name */}
-            Sign in to Convex SaaS
+            Zaloguj się do CRM Kolabo
           </Heading>
           <Text className="text-sm">
-            Please enter the following code on the sign in page.
+            Wprowadź poniższy kod na stronie logowania.
           </Text>
           <Section className="text-center">
-            <Text className="font-semibold">Verification code</Text>
+            <Text className="font-semibold">Kod weryfikacyjny</Text>
             <Text className="font-bold text-4xl">{code}</Text>
             <Text>
-              (This code is valid for{" "}
-              {Math.floor((+expires - Date.now()) / (60 * 60 * 1000))} hours)
+              (Kod jest ważny przez{" "}
+              {Math.floor((+expires - Date.now()) / (60 * 60 * 1000))} godz.)
             </Text>
           </Section>
         </Container>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #397.

Closes #397

---

## Claude summary

Committed as `807f5b0`. Typecheck passes cleanly.

Here is the full inventory of static (in-code, hardcoded) system email templates and their current state:

Static system email templates — inventory

1. `convex/email/templates/invitationEmail.tsx` — zaproszenie do zespołu. Już po polsku (PR #406). Uwaga: w `convex/invitations.ts:633-634` znajdowały się dwa angielskie fallbacki (`"your team"`, `"A teammate"`) wstawiane do polskiego szablonu, gdy brak danych w bazie — to było prawdopodobne źródło raportu „mail nadal po angielsku”. Teraz: `"Twój zespół"`, `"Członek zespołu"`.

2. `convex/email/templates/subscriptionEmail.tsx` — sukces/błąd subskrypcji Stripe (`SubscriptionSuccessEmail`, `SubscriptionErrorEmail`). Było całkowicie po angielsku. Przetłumaczone: preview, treść, tematy (`"Subskrypcja PRO została aktywowana"`, `"Problem z subskrypcją — wsparcie klienta"`).

3. `convex/otp/VerificationCodeEmail.tsx` + `convex/otp/ResendOTP.ts` — kod weryfikacyjny do logowania (auth OTP). Temat w `ResendOTP.ts` był już PL (`"Zaloguj się do CRM Kolabo"`), ale ciało wiadomości w `VerificationCodeEmail.tsx` było po angielsku. Przetłumaczone (nagłówek, instrukcje, etykieta „Kod weryfikacyjny”, okno ważności w godzinach).

4. `convex/signingEmails.ts` — prośba o podpis dokumentu + powiadomienie o złożeniu podpisu. Już po polsku.

5. `convex/documents/signing.ts` — wysyłka formularza do podpisu (Gmail/Resend). Już po polsku.

6. `convex/gabinet/patientAuth.ts` (`_sendOtpEmail`) — OTP portalu pacjenta. Już po polsku.

Templates poza zakresem (siedzą w bazie, nie w kodzie)

7. `convex/emailTemplateSeed.ts` (~40 szablonów dla CRM/Gabinet) i `convex/seedTemplates.ts` — to są szablony seedowane do tabeli `emailTemplates`, edytowalne przez użytkownika. Mają już po dwie wersje (PL + EN), seedowane są obie — wybór języka odbywa się przez `locale` rekordu, nie zmiana kodu.

8. `convex/emails.ts` — to nie statyczne szablony, tylko user-composed e-maile (skrzynka CRM).

Po tej zmianie wszystkie statyczne (hardcoded) szablony systemowe są po polsku.