### PR TITLE
Surface action errors in `appointment-preview-content.tsx` handleSave

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2457,6 +2457,7 @@
       "rescheduleFailed": "Could not reschedule the appointment.",
       "resized": "Appointment duration updated",
       "resizeFailed": "Could not change appointment duration.",
+      "updateFailed": "Could not save the changes.",
       "errors": {
         "conflict": "This time conflicts with another appointment.",
         "conflictNamed": "This time conflicts with another calendar event.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2468,6 +2468,7 @@
       "rescheduleFailed": "Nie udało się przenieść wizyty.",
       "resized": "Długość wizyty zmieniona",
       "resizeFailed": "Nie udało się zmienić długości wizyty.",
+      "updateFailed": "Nie udało się zapisać zmian.",
       "errors": {
         "conflict": "Termin koliduje z inną wizytą.",
         "conflictNamed": "Termin koliduje z innym wydarzeniem w kalendarzu.",

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -8,6 +8,10 @@ import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
+import {
+  extractActionErrorMessage,
+  formatAppointmentError,
+} from "@/lib/format-action-error";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -225,8 +229,8 @@ export function AppointmentPreviewContent({
       setPhoneInput("");
       toast.success(t("gabinet.appointmentDetail.phoneAdded"));
     } catch (error: unknown) {
-      const msg = error instanceof Error ? error.message : t("common.error");
-      toast.error(msg);
+      console.error("[appointment-preview] phone save failed", error);
+      toast.error(extractActionErrorMessage(error) || t("common.error"));
     } finally {
       setSavingPhone(false);
     }
@@ -287,8 +291,13 @@ export function AppointmentPreviewContent({
       toast.success(t("gabinet.appointments.updated"));
       onClose();
     } catch (error: unknown) {
-      const msg = error instanceof Error ? error.message : t("common.error");
-      toast.error(msg);
+      console.error("[appointment-preview] save failed", error);
+      toast.error(
+        formatAppointmentError(error, t, {
+          key: "gabinet.appointments.updateFailed",
+          defaultValue: "Nie udało się zapisać zmian.",
+        }),
+      );
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #432.

Closes #432

---

## Claude summary

Committed `f0f97d7`. Summary of the fix for issue #432:

`handleSave` and `handleSavePhone` in `src/components/gabinet/calendar/appointment-preview-content.tsx` were toasting `error.message` directly. For Convex action failures (like the `ArgumentValidationError` that caused #418) this dumps the verbose `[CONVEX A(...)] Server Error\nUncaught Error: ...` wrapper, which is easy to overlook as a "the button doesn't work."

The repo already has `src/lib/format-action-error.ts` — used by the sibling calendar handlers at `_layout.gabinet.calendar.index.lazy.tsx:509,589` — which strips the Convex wrapping and maps known appointment errors to translated messages. I routed both catch blocks through these helpers:

- `handleSave` → `formatAppointmentError(error, t, { key: "gabinet.appointments.updateFailed", defaultValue: "Nie udało się zapisać zmian." })`. This catches the same conflicts / leave / permission / `invalidArguments` cases as the drag-resize and reschedule handlers.
- `handleSavePhone` → `extractActionErrorMessage(error)` (no appointment-specific mapping needed; just clean the Convex prefix).
- Both now also `console.error(error)` so the raw stack stays inspectable in DevTools, addressing the original Jam-only debuggability gap.

Added `gabinet.appointments.updateFailed` to PL and EN translation files. Typecheck passes (`npm run typecheck:portable` exits 0).