### PR TITLE
Reuse formatAppointmentError in appointment-dialog.tsx and appointment-preview-c

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -6,6 +6,7 @@ import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
+import { formatAppointmentError } from "@/lib/format-action-error";
 import { UntitledAlert } from "@/components/ui/untitled-alert";
 import { format } from "date-fns";
 import { pl } from "date-fns/locale";
@@ -547,8 +548,12 @@ export function AppointmentDialog({
       toast.success(t("gabinet.appointments.created"));
       onOpenChange(false);
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      toast.error(msg);
+      toast.error(
+        formatAppointmentError(e, t, {
+          key: "gabinet.appointments.createFailed",
+          defaultValue: "Nie udało się utworzyć wizyty.",
+        }),
+      );
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #436.

Closes #436

---

## Claude summary

Routed `createAppointment` failures in `src/components/gabinet/calendar/appointment-dialog.tsx:550` through `formatAppointmentError`, matching the pattern already used by calendar drag/resize and the appointment preview save flow.

`appointment-preview-content.tsx` was already handled by PR #459 (issue #432) — its `handleSave` uses `formatAppointmentError`. The remaining `handleSavePhone` call site uses `extractActionErrorMessage` against `gabinet.patients.update`, which is a different action whose errors don't match the appointment-specific mapping, so it's intentionally left alone.

## Follow-ups
- Replace raw e.message toast in appointment-dialog handleCreatePatient: src/components/gabinet/calendar/appointment-dialog.tsx:475 still toasts raw Convex banner from patients.create; should use extractActionErrorMessage with a friendly fallback for consistency