### PR TITLE
Apply same status colors to gabinet dashboard and employee detail

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -77,6 +77,7 @@ import type { MappedGabinetEmployee } from "@/lib/supabase/mappers/gabinet/emplo
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { useSidebarSlot } from "@/components/layout/sidebar-slot-context";
+import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/employees/$employeeId"
@@ -950,13 +951,8 @@ function AppointmentsTabContent({
                     </p>
                   </div>
                   <Badge
-                    variant={
-                      apt.status === "completed"
-                        ? "default"
-                        : apt.status === "cancelled" || apt.status === "no_show"
-                          ? "destructive"
-                          : "secondary"
-                    }
+                    variant="outline"
+                    className={appointmentStatusBadgeClass(apt.status)}
                   >
                     {t(`gabinet.appointments.statuses.${apt.status}`)}
                   </Badge>
@@ -1427,14 +1423,6 @@ function UpcomingAgenda({
     return [...groups.entries()].slice(0, 7); // Show up to 7 days
   }, [upcoming]);
 
-  const statusColors: Record<string, string> = {
-    scheduled: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
-    confirmed: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
-    pending_confirmation: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
-    in_progress: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
-    completed: "bg-gray-100 text-gray-600 dark:bg-gray-800/50 dark:text-gray-400",
-  };
-
   const formatDayHeader = (dateStr: string) => {
     const d = new Date(dateStr + "T00:00:00");
     if (dateStr === today) return t("gabinet.employees.agenda.today");
@@ -1527,8 +1515,8 @@ function UpcomingAgenda({
                       </p>
                     </div>
                     <Badge
-                      variant="secondary"
-                      className={`text-xs ${statusColors[apt.status] ?? ""}`}
+                      variant="outline"
+                      className={`text-xs ${appointmentStatusBadgeClass(apt.status)}`}
                     >
                       {t(`gabinet.appointments.statuses.${apt.status}`)}
                     </Badge>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
@@ -21,6 +21,7 @@ import { useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import type { ReactNode } from "react";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
+import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
 
 import {
   CalendarCheck,
@@ -125,17 +126,6 @@ function GabinetDashboard() {
   const totalPatients = patientsData?.length ?? 0;
   const totalTreatments = treatments?.length ?? 0;
   const todayCount = enrichedAppointments.length;
-
-  const statusColor = (s: string) => {
-    switch (s) {
-      case "scheduled": return "outline" as const;
-      case "confirmed": return "default" as const;
-      case "in_progress": return "default" as const;
-      case "completed": return "secondary" as const;
-      case "cancelled": return "destructive" as const;
-      default: return "secondary" as const;
-    }
-  };
 
   // --- Build sparkline chart data for statistics cards ---
   const appointmentChartData = (weeklyAppointments ?? []).map((d) => ({
@@ -406,7 +396,10 @@ function GabinetDashboard() {
                         {a.startTime}–{a.endTime} · {a.treatmentName}
                       </p>
                     </div>
-                    <Badge variant={statusColor(a.status)}>
+                    <Badge
+                      variant="outline"
+                      className={appointmentStatusBadgeClass(a.status)}
+                    >
                       {t(`gabinet.appointments.statuses.${a.status}`)}
                     </Badge>
                   </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #440.

Closes #440

---

## Claude summary

Committed as `460943b`.

Switched three appointment status badges to `appointmentStatusBadgeClass()` for visual consistency with the calendar legend and patient profile:
- `_layout.gabinet.index.tsx:409` — dashboard "today's appointments" list (removed local `statusColor()` helper)
- `_layout.gabinet.employees.$employeeId.tsx:957` — employee appointments tab badge (removed inline ternary)
- `_layout.gabinet.employees.$employeeId.tsx:1531` — employee upcoming agenda badge (removed local `statusColors` map)

All three now render `<Badge variant="outline" className={appointmentStatusBadgeClass(status)}>`, matching the pattern already used in `_layout.gabinet.patients.$patientId.tsx:352` and `_layout.gabinet.appointments.$appointmentId.lazy.tsx`.

The remaining `statusColors` map at `_layout.gabinet.employees.$employeeId.tsx:889` styles full calendar tile backgrounds (not a Badge) and was out of scope for this issue.