### PR TITLE
Reuse the helper inside `calendar/appointment-card.tsx`

### DIFF
--- a/src/components/gabinet/calendar/appointment-card.tsx
+++ b/src/components/gabinet/calendar/appointment-card.tsx
@@ -1,3 +1,5 @@
+import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
+
 export interface AppointmentTag {
   name: string;
   color: string;
@@ -14,15 +16,6 @@ interface AppointmentCardProps {
   onClick?: () => void;
 }
 
-const STATUS_COLORS: Record<string, string> = {
-  scheduled: "bg-blue-100 border-blue-300 text-blue-800",
-  confirmed: "bg-green-100 border-green-300 text-green-800",
-  in_progress: "bg-yellow-100 border-yellow-300 text-yellow-800",
-  completed: "bg-gray-100 border-gray-300 text-gray-600",
-  cancelled: "bg-red-50 border-red-200 text-red-400 line-through",
-  no_show: "bg-orange-50 border-orange-200 text-orange-400",
-};
-
 export function AppointmentCard({
   startTime,
   endTime,
@@ -33,12 +26,13 @@ export function AppointmentCard({
   tags,
   onClick,
 }: AppointmentCardProps) {
-  const cls = STATUS_COLORS[status] ?? STATUS_COLORS.scheduled;
+  const cls = appointmentStatusBadgeClass(status);
+  const strike = status === "cancelled" ? " line-through" : "";
 
   return (
     <button
       onClick={onClick}
-      className={`w-full h-full overflow-hidden rounded border-l-4 px-2 py-1 text-left text-xs transition-opacity hover:opacity-80 ${cls}`}
+      className={`w-full h-full overflow-hidden rounded border-l-4 px-2 py-1 text-left text-xs transition-opacity hover:opacity-80 ${cls}${strike}`}
       style={color ? { borderLeftColor: color } : undefined}
     >
       <div className="flex items-start justify-between gap-1">

--- a/src/lib/gabinet-appointment-status.ts
+++ b/src/lib/gabinet-appointment-status.ts
@@ -1,10 +1,10 @@
 /**
  * Shared visual tokens for gabinet appointment statuses.
  *
- * Colors mirror the calendar legend (see
- * `src/components/gabinet/calendar/appointment-card.tsx`) so that status
- * badges across the patient profile, appointment history, and dashboard
- * read with the same color the user sees on the calendar tiles.
+ * Used by status badges (patient profile, appointment history, dashboard,
+ * employee detail) and by the calendar tile in
+ * `src/components/gabinet/calendar/appointment-card.tsx`, so the same color
+ * reads consistently wherever a status is shown.
  */
 
 export const APPOINTMENT_STATUS_BADGE_CLASSES: Record<string, string> = {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #441.

Closes #441

---

## Claude summary

Done. Consolidated the calendar tile's status palette by routing `appointment-card.tsx` through the shared `appointmentStatusBadgeClass()` helper in `src/lib/gabinet-appointment-status.ts` (already used by 5 other status displays). Dropped the local `STATUS_COLORS` map. Kept the `line-through` for cancelled status as a calendar-tile-specific cue, since inline badges elsewhere do not strike through. Updated the helper's doc comment to reflect that the calendar now consumes it rather than being mirrored by it.

The canonical palette is now the lighter badge palette (e.g. `bg-blue-50` / `border-blue-200` / `text-blue-700` with dark-mode variants) instead of the calendar's previously more saturated `bg-blue-100` / `border-blue-300` / `text-blue-800` — a deliberate, single-source choice that prevents future drift. Committed as `4d6c47e`.