### PR TITLE
kategorie zabiegi

### DIFF
--- a/src/components/categories-tags/category-picker.tsx
+++ b/src/components/categories-tags/category-picker.tsx
@@ -1,6 +1,8 @@
 import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { LayersTwo02, XClose, ChevronRight } from "@untitledui/icons";
+import { useAction } from "convex/react";
+import { useQueryClient } from "@tanstack/react-query";
+import { LayersTwo02, XClose, ChevronRight, Plus } from "@untitledui/icons";
 import { Button } from "@untitled/base/buttons/button";
 import { Input } from "@untitled/base/input/input";
 import { Badge } from "@untitled/base/badges/badges";
@@ -9,7 +11,10 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { api } from "@cvx/_generated/api";
 import { Id } from "@cvx/_generated/dataModel";
+import type { EntityType } from "@cvx/schema";
+import { TAG_COLOR_PALETTE } from "./color-palette";
 
 interface CategoryDef {
   _id: Id<"categoryDefinitions">;
@@ -23,6 +28,10 @@ interface CategoryPickerProps {
   selectedId: Id<"categoryDefinitions"> | undefined;
   onChange: (categoryId: Id<"categoryDefinitions"> | undefined) => void;
   placeholder?: string;
+  // When provided, the picker shows an inline "Add new category" affordance
+  // that creates a category via categoryDefinitions.create and auto-selects it.
+  organizationId?: Id<"organizations">;
+  entityType?: EntityType;
 }
 
 interface CategoryNode extends CategoryDef {
@@ -51,10 +60,25 @@ function buildTree(categories: CategoryDef[]): CategoryNode[] {
   return roots;
 }
 
-export function CategoryPicker({ categories, selectedId, onChange, placeholder }: CategoryPickerProps) {
+export function CategoryPicker({
+  categories,
+  selectedId,
+  onChange,
+  placeholder,
+  organizationId,
+  entityType,
+}: CategoryPickerProps) {
   const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const createCategory = useAction(api.categoryDefinitions.create);
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const [addingNew, setAddingNew] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newColor, setNewColor] = useState<string>(TAG_COLOR_PALETTE[0]);
+  const [isCreating, setIsCreating] = useState(false);
+
+  const canCreate = !!organizationId && !!entityType;
 
   const tree = useMemo(() => buildTree(categories), [categories]);
 
@@ -73,6 +97,33 @@ export function CategoryPicker({ categories, selectedId, onChange, placeholder }
   const handleSelect = (categoryId: Id<"categoryDefinitions">) => {
     onChange(selectedId === categoryId ? undefined : categoryId);
     setOpen(false);
+  };
+
+  const resetAddForm = () => {
+    setAddingNew(false);
+    setNewName("");
+    setNewColor(TAG_COLOR_PALETTE[0]);
+  };
+
+  const handleCreate = async () => {
+    if (!canCreate || !newName.trim() || isCreating) return;
+    setIsCreating(true);
+    try {
+      const newId = (await createCategory({
+        organizationId: organizationId!,
+        entityType: entityType!,
+        name: newName.trim(),
+        color: newColor,
+      })) as Id<"categoryDefinitions">;
+      await queryClient.invalidateQueries({
+        queryKey: ["categoryDefinitions.list", organizationId, entityType],
+      });
+      onChange(newId);
+      resetAddForm();
+      setOpen(false);
+    } finally {
+      setIsCreating(false);
+    }
   };
 
   const renderNode = (node: CategoryNode) => (
@@ -163,6 +214,67 @@ export function CategoryPicker({ categories, selectedId, onChange, placeholder }
               </p>
             )}
           </div>
+          {canCreate && (
+            <div className="border-t border-border-secondary p-2">
+              {addingNew ? (
+                <div className="flex flex-col gap-2">
+                  <Input
+                    size="sm"
+                    placeholder={t("categories.newName", { defaultValue: "Nazwa kategorii" })}
+                    value={newName}
+                    onChange={setNewName}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        handleCreate();
+                      } else if (e.key === "Escape") {
+                        e.preventDefault();
+                        resetAddForm();
+                      }
+                    }}
+                    autoFocus
+                  />
+                  <div className="flex flex-wrap gap-1.5">
+                    {TAG_COLOR_PALETTE.map((color) => (
+                      <button
+                        key={color}
+                        type="button"
+                        onClick={() => setNewColor(color)}
+                        className={`h-5 w-5 rounded-full border-2 transition-all ${
+                          newColor === color ? "border-fg-primary scale-110" : "border-transparent"
+                        }`}
+                        style={{ backgroundColor: color }}
+                      />
+                    ))}
+                  </div>
+                  <div className="flex gap-1">
+                    <Button
+                      size="sm"
+                      color="primary"
+                      onClick={handleCreate}
+                      isDisabled={!newName.trim() || isCreating}
+                    >
+                      {isCreating
+                        ? t("common.saving", { defaultValue: "Zapisywanie..." })
+                        : t("common.add", { defaultValue: "Dodaj" })}
+                    </Button>
+                    <Button size="sm" color="secondary" onClick={resetAddForm}>
+                      {t("common.cancel", { defaultValue: "Anuluj" })}
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <Button
+                  size="sm"
+                  color="link-color"
+                  iconLeading={Plus}
+                  onClick={() => setAddingNew(true)}
+                >
+                  {t("categories.addCategory", { defaultValue: "Dodaj kategorię" })}
+                </Button>
+              )}
+            </div>
+          )}
         </PopoverContent>
       </Popover>
     </div>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -515,12 +515,16 @@ function TreatmentsIndex() {
               <TagsPicker tags={tags} selectedIds={tagIds} onChange={setTagIds} />
             </div>
           )}
-          {categories.length > 0 && (
-            <div className="space-y-1.5">
-              <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
-              <CategoryPicker categories={categories} selectedId={categoryId} onChange={setCategoryId} />
-            </div>
-          )}
+          <div className="space-y-1.5">
+            <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
+            <CategoryPicker
+              categories={categories}
+              selectedId={categoryId}
+              onChange={setCategoryId}
+              organizationId={organizationId}
+              entityType="gabinetTreatment"
+            />
+          </div>
         </TreatmentForm>
       </SidePanel>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #446.

Closes #446

---

## Claude summary

Committed.

Summary: On the treatments page, the category picker now lets users either pick an existing category or add a new one inline. I added optional `organizationId`/`entityType` props to `CategoryPicker` (`src/components/categories-tags/category-picker.tsx`); when supplied, the popover gains an "Add new category" form (name + color palette) that calls `categoryDefinitions.create`, invalidates the React Query cache, and auto-selects the new category. I then wired those props on the treatments page (`_layout.gabinet.treatments.index.tsx`) and removed the `categories.length > 0` guard so users can add the first category directly from the create/edit form. All other 14+ `CategoryPicker` consumers are untouched — without the new optional props the "Add new" affordance doesn't render, so behavior elsewhere is unchanged.

I couldn't run typecheck/lint (no `node_modules` in this worktree), but the code paths follow the existing patterns used in `categories-manager-slideout.tsx` for the create action and color palette.

## Follow-ups
- Extend inline category creation to remaining CategoryPicker call sites: contacts, leads, companies, products, calls, activities, patients, employees, appointments forms all still gate the picker on `categories.length > 0` and lack an "add new" path.
- Decide fate of legacy free-text `category` field on `gabinetTreatments`: the form keeps both a plain-text `category` Input and the structured `categoryId` picker, which is confusing UX and duplicates state.