### PR TITLE
kategoria

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -25,7 +25,6 @@ import type { Id } from "@cvx/_generated/dataModel";
 export interface TreatmentFormData {
   name: string;
   description?: string;
-  category?: string;
   duration: number;
   price: number;
   currency?: string;
@@ -47,6 +46,7 @@ interface TreatmentFormProps {
   onSubmit: (data: TreatmentFormData) => void;
   onCancel: () => void;
   isSubmitting?: boolean;
+  categorySelector?: React.ReactNode;
   children?: React.ReactNode;
 }
 
@@ -67,12 +67,12 @@ export function TreatmentForm({
   onSubmit,
   onCancel,
   isSubmitting = false,
+  categorySelector,
   children,
 }: TreatmentFormProps) {
   const { t } = useTranslation();
   const [name, setName] = useState(initialData?.name ?? "");
   const [description, setDescription] = useState(initialData?.description ?? "");
-  const [category, setCategory] = useState(initialData?.category ?? "");
   const [duration, setDuration] = useState(String(initialData?.duration ?? ""));
   const [price, setPrice] = useState(String(initialData?.price ?? ""));
   const [currency, setCurrency] = useState(initialData?.currency ?? "PLN");
@@ -120,7 +120,6 @@ export function TreatmentForm({
     onSubmit({
       name,
       description: description || undefined,
-      category: category || undefined,
       duration: parseInt(duration) || 30,
       price: parseFloat(price) || 0,
       currency: currency || undefined,
@@ -198,10 +197,7 @@ export function TreatmentForm({
         </div>
         <div className="space-y-1.5">
           <Label>{t("gabinet.treatments.category")}</Label>
-          <Input
-            value={category}
-            onChange={(e) => setCategory(e.target.value)}
-          />
+          {categorySelector}
         </div>
         <div className="space-y-1.5">
           <Label>{t("gabinet.treatments.sortOrder")}</Label>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -12,6 +12,8 @@ import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { SidePanel } from "@/components/crm/side-panel";
 import { TreatmentForm } from "@/components/gabinet/treatment-form";
 import type { TreatmentFormData } from "@/components/gabinet/treatment-form";
+import { CategoryPicker } from "@/components/categories-tags/category-picker";
+import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import {
   EntityDetailLayout,
   type DetailField,
@@ -102,6 +104,7 @@ function TreatmentDetail() {
   // State
   const [editPanelOpen, setEditPanelOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [editCategoryId, setEditCategoryId] = useState<Id<"categoryDefinitions"> | undefined>(undefined);
 
   // Parameters tab state
   type ParamType = "text" | "number" | "checkbox" | "radio" | "select";
@@ -155,6 +158,8 @@ function TreatmentDetail() {
     organizationId,
     treatmentId,
   );
+
+  const { categories } = useCategoryDefinitions(organizationId, "gabinetTreatment");
 
   const getDetailedStatsAction = useAction(api.gabinet.treatments.getTreatmentDetailedStats);
   const listTreatmentAppointmentsAction = useAction(api.gabinet.treatments.listTreatmentAppointments);
@@ -252,13 +257,22 @@ function TreatmentDetail() {
     return () => setShellSidebarMode("default");
   }, [setShellSidebarMode]);
 
+  const categoryName = useMemo(() => {
+    if (!treatment) return null;
+    if (treatment.categoryId) {
+      const match = categories.find((c) => c._id === treatment.categoryId);
+      if (match) return match.name;
+    }
+    return treatment.category ?? null;
+  }, [treatment, categories]);
+
   // Build fields for EntityDetailLayout sidebar
   const detailFields: DetailField[] = useMemo(() => {
     if (!treatment) return [];
     const fields: DetailField[] = [
       { label: t("gabinet.treatments.price"), value: formatCurrency(treatment.price, treatment.currency ?? undefined), fieldKey: "price" },
       { label: t("gabinet.treatments.duration"), value: `${treatment.duration} min`, fieldKey: "duration" },
-      { label: t("gabinet.treatments.category"), value: treatment.category ?? "—", fieldKey: "category" },
+      { label: t("gabinet.treatments.category"), value: categoryName ?? "—", fieldKey: "category" },
     ];
     if (treatment.taxRate != null) {
       fields.push({ label: t("gabinet.treatments.taxRate"), value: `${treatment.taxRate}%`, fieldKey: "taxRate" });
@@ -276,7 +290,7 @@ function TreatmentDetail() {
       fields.push({ label: t("gabinet.treatments.treatmentCount", "Liczba zabiegów"), value: <Badge variant="outline" className="text-[10px]">{treatment.treatmentCount}x</Badge>, fieldKey: "count" });
     }
     return fields;
-  }, [treatment, equipmentList, t]);
+  }, [treatment, equipmentList, t, categoryName]);
 
   // Derived: unassigned employees (those that don't have this treatment in qualifiedTreatmentIds)
   const assignedEmployeeIds = useMemo(() => {
@@ -364,6 +378,7 @@ function TreatmentDetail() {
         organizationId,
         treatmentId: treatmentId as Id<"gabinetTreatments">,
         ...formData,
+        categoryId: editCategoryId,
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatments.detail(organizationId, treatmentId) });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatments.list(organizationId) });
@@ -1155,9 +1170,12 @@ function TreatmentDetail() {
         notFound={!treatment && !isLoading}
         onBack={() => navigate({ to: "/dashboard/gabinet/treatments" })}
         title={treatment?.name ?? ""}
-        subtitle={treatment?.category ?? t("gabinet.treatments.treatment")}
+        subtitle={categoryName ?? t("gabinet.treatments.treatment")}
         avatarFallback={treatment?.name?.slice(0, 2).toUpperCase()}
-        onEdit={() => setEditPanelOpen(true)}
+        onEdit={() => {
+          setEditCategoryId(treatment?.categoryId as Id<"categoryDefinitions"> | undefined);
+          setEditPanelOpen(true);
+        }}
         secondaryActions={[
           {
             label: treatment?.isActive
@@ -1186,7 +1204,6 @@ function TreatmentDetail() {
             initialData={{
               name: treatment.name,
               description: treatment.description ?? undefined,
-              category: treatment.category ?? undefined,
               duration: treatment.duration,
               price: treatment.price,
               currency: treatment.currency ?? undefined,
@@ -1204,6 +1221,15 @@ function TreatmentDetail() {
             onSubmit={handleEditSubmit}
             onCancel={() => setEditPanelOpen(false)}
             isSubmitting={isSubmitting}
+            categorySelector={
+              <CategoryPicker
+                categories={categories}
+                selectedId={editCategoryId}
+                onChange={setEditCategoryId}
+                organizationId={organizationId}
+                entityType="gabinetTreatment"
+              />
+            }
           />
         </SidePanel>
       )}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -195,6 +195,23 @@ function TreatmentsIndex() {
     return data;
   }, [allTreatments, activeViewId, applyFilters, activeFilters, searchValue]);
 
+  const categoryNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const cat of categories) map.set(cat._id, cat.name);
+    return map;
+  }, [categories]);
+
+  const getCategoryLabel = useCallback(
+    (item: Treatment) => {
+      if (item.categoryId) {
+        const name = categoryNameById.get(item.categoryId);
+        if (name) return name;
+      }
+      return item.category ?? null;
+    },
+    [categoryNameById],
+  );
+
   const columns: CrmColumn<Treatment>[] = useMemo(
     () => [
       {
@@ -230,8 +247,8 @@ function TreatmentsIndex() {
         id: "category",
         label: t("gabinet.treatments.category"),
         sortable: true,
-        render: (item) => item.category ?? "—",
-        getSortValue: (item) => item.category ?? "",
+        render: (item) => getCategoryLabel(item) ?? "—",
+        getSortValue: (item) => getCategoryLabel(item) ?? "",
       },
       {
         id: "duration",
@@ -264,7 +281,7 @@ function TreatmentsIndex() {
         ),
       },
     ],
-    [t],
+    [t, getCategoryLabel],
   );
 
   const { allColumns, defaultHidden } = useAllColumns(columns, filterableFields);
@@ -479,7 +496,6 @@ function TreatmentsIndex() {
               ? {
                   name: editingTreatment.name,
                   description: editingTreatment.description ?? undefined,
-                  category: editingTreatment.category ?? undefined,
                   duration: editingTreatment.duration,
                   price: editingTreatment.price,
                   currency: editingTreatment.currency ?? undefined,
@@ -508,15 +524,7 @@ function TreatmentsIndex() {
             setEditingTreatment(null);
           }}
           isSubmitting={isSubmitting}
-        >
-          {tags.length > 0 && (
-            <div className="space-y-1.5">
-              <Label>{t('common.tags', { defaultValue: "Tagi" })}</Label>
-              <TagsPicker tags={tags} selectedIds={tagIds} onChange={setTagIds} />
-            </div>
-          )}
-          <div className="space-y-1.5">
-            <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
+          categorySelector={
             <CategoryPicker
               categories={categories}
               selectedId={categoryId}
@@ -524,7 +532,14 @@ function TreatmentsIndex() {
               organizationId={organizationId}
               entityType="gabinetTreatment"
             />
-          </div>
+          }
+        >
+          {tags.length > 0 && (
+            <div className="space-y-1.5">
+              <Label>{t('common.tags', { defaultValue: "Tagi" })}</Label>
+              <TagsPicker tags={tags} selectedIds={tagIds} onChange={setTagIds} />
+            </div>
+          )}
         </TreatmentForm>
       </SidePanel>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #447.

Closes #447

---

## Claude summary

Committed as `46e3cf3`. Summary of what I did:

The treatments form previously showed two competing "Kategoria" controls — a legacy free-text Input inside the form grid, and the new `CategoryPicker` (with the "Dodaj kategorię" affordance from #446) tacked on at the bottom via children. I consolidated them by adding a `categorySelector` slot prop to `TreatmentForm` that renders in place of the old text input, and removed the now-unused `category` form state/field.

The picker is wired into both entry points: the index page's create/edit panel (moved out of `children` into the slot) and the detail page's edit panel (added `useCategoryDefinitions`, `editCategoryId` state, and the `categorySelector` prop). I also updated the table column, detail subtitle, and detail sidebar to display the chosen category name via `categoryId` lookup with a fallback to the legacy text — otherwise picking a category would have had no visible effect.