### PR TITLE
anulowanie wizyty

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -100,6 +100,7 @@ export function AppointmentPreviewContent({
 
   const getFullDetail = useAction(api.gabinet.appointments.getFullDetail);
   const updateAppointment = useAction(api.gabinet.appointments.update);
+  const updateStatus = useAction(api.gabinet.appointments.updateStatus);
   const updatePatient = useAction(api.gabinet.patients.update);
   const getWarnings = useAction(api.gabinet.appointments.getWarnings);
   const listActiveTreatments = useAction(api.gabinet.treatments.listActive);
@@ -140,6 +141,7 @@ export function AppointmentPreviewContent({
   const [treatmentOpen, setTreatmentOpen] = useState(false);
   const [treatmentSearch, setTreatmentSearch] = useState("");
   const [saving, setSaving] = useState(false);
+  const [savingStatus, setSavingStatus] = useState(false);
   const [isEditingPhone, setIsEditingPhone] = useState(false);
   const [phoneInput, setPhoneInput] = useState("");
   const [savingPhone, setSavingPhone] = useState(false);
@@ -194,7 +196,6 @@ export function AppointmentPreviewContent({
     phoneInput.trim() !== (patient?.phone ?? "");
 
   const apptDirty =
-    status !== initialStatus ||
     date !== appointment.date ||
     startTime !== appointment.startTime.slice(0, 5) ||
     endTime !== appointment.endTime.slice(0, 5) ||
@@ -236,6 +237,41 @@ export function AppointmentPreviewContent({
     }
   };
 
+  const handleStatusChange = async (newStatus: AppointmentStatus) => {
+    if (newStatus === initialStatus || savingStatus) return;
+    const previous = status;
+    setStatus(newStatus);
+    setSavingStatus(true);
+    try {
+      await updateStatus({
+        organizationId,
+        appointmentId: appointment._id,
+        status: newStatus,
+      });
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: supabaseKeys.gabinetAppointments.all,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: supabaseKeys.scheduledActivities.all,
+        }),
+      ]);
+      await refetch();
+      toast.success(t("gabinet.appointments.statusUpdated"));
+    } catch (error: unknown) {
+      setStatus(previous);
+      console.error("[appointment-preview] status update failed", error);
+      toast.error(
+        formatAppointmentError(error, t, {
+          key: "gabinet.appointments.updateFailed",
+          defaultValue: "Nie udało się zapisać zmian.",
+        }),
+      );
+    } finally {
+      setSavingStatus(false);
+    }
+  };
+
   const handleSave = async () => {
     if (!dirty || saving) return;
     setSaving(true);
@@ -270,7 +306,6 @@ export function AppointmentPreviewContent({
         if (startTime !== appointment.startTime.slice(0, 5))
           args.startTime = startTime;
         if (endTime !== appointment.endTime.slice(0, 5)) args.endTime = endTime;
-        if (status && status !== initialStatus) args.status = status;
         if (internalNotes !== (appointment.internalNotes ?? ""))
           args.internalNotes = internalNotes;
         if (treatmentId && treatmentId !== initialTreatmentId)
@@ -515,8 +550,8 @@ export function AppointmentPreviewContent({
           </Label>
           <Select
             value={status}
-            onValueChange={(v) => setStatus(v as AppointmentStatus)}
-            disabled={availableTransitions.length === 0}
+            onValueChange={(v) => handleStatusChange(v as AppointmentStatus)}
+            disabled={availableTransitions.length === 0 || savingStatus}
           >
             <SelectTrigger className="h-8 text-sm">
               <SelectValue />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #449.

Closes #449

---

## Claude summary

Committed. Summary of the fix:

The calendar appointment preview popover's Zapisz button was reported as "not working" after a status change. Two issues converged: (1) UX-wise, "change dropdown → click Save" is non-obvious for a quick action; (2) even when the save did go through, the preview used the generic `appointments.update` action which only patches the status row in Supabase and skips the dedicated `_updateStatusSideEffects` cascade — so cancellation emails/SMS to the patient, scheduled reminder cancellation, and completion-time auto-doc generation never ran.

The fix switches the Select dropdown to auto-save via the dedicated `appointments.updateStatus` action (the same one used by the full appointment detail page). Status is removed from `apptDirty`/`handleSave` so the Zapisz button now only covers date/time/notes/treatment edits, and a `savingStatus` flag disables the dropdown during the in-flight update. On failure the status is reverted optimistically and the error is routed through the existing `formatAppointmentError` helper.

## Follow-ups
- Unify status-change UX between calendar preview and appointment detail page: detail page opens a cancellation-reason dialog and a document-gate dialog before `in_progress`; preview currently skips both, so users get different behavior depending on entry point.