### PR TITLE
Informacja

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
@@ -90,6 +90,8 @@ function TeamSettings() {
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState<string>("member");
   const [isSending, setIsSending] = useState(false);
+  const [resendingId, setResendingId] = useState<Id<"invitations"> | null>(null);
+  const [cancellingId, setCancellingId] = useState<Id<"invitations"> | null>(null);
   const [removeTarget, setRemoveTarget] = useState<{ id: Id<"teamMemberships">; name: string } | null>(null);
 
   const handleChangeRole = async (
@@ -116,13 +118,33 @@ function TeamSettings() {
   };
 
   const handleCancelInvitation = async (invitationId: Id<"invitations">) => {
-    await cancelInvitation({ organizationId, invitationId });
-    void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(organizationId) });
+    if (cancellingId) return;
+    setCancellingId(invitationId);
+    try {
+      await cancelInvitation({ organizationId, invitationId });
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(organizationId) });
+      toast.success(t("team.invitationCancelled"));
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      toast.error(message);
+    } finally {
+      setCancellingId(null);
+    }
   };
 
   const handleResendInvitation = async (invitationId: Id<"invitations">) => {
-    await resendInvitation({ organizationId, invitationId });
-    void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(organizationId) });
+    if (resendingId) return;
+    setResendingId(invitationId);
+    try {
+      await resendInvitation({ organizationId, invitationId });
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(organizationId) });
+      toast.success(t("team.invitationResent"));
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      toast.error(message);
+    } finally {
+      setResendingId(null);
+    }
   };
 
   const navigate = useNavigate();
@@ -438,6 +460,7 @@ function TeamSettings() {
                     variant="ghost"
                     size="sm"
                     className="h-8 text-xs"
+                    disabled={resendingId === invitation._id || cancellingId === invitation._id}
                     onClick={() =>
                       handleResendInvitation(
                         invitation._id as Id<"invitations">
@@ -445,12 +468,15 @@ function TeamSettings() {
                     }
                   >
                     <Send className="mr-1 h-4 w-4" variant="stroke" />
-                    {t("team.resendInvitation")}
+                    {resendingId === invitation._id
+                      ? t("team.inviteDialog.sending")
+                      : t("team.resendInvitation")}
                   </Button>
                   <Button
                     variant="ghost"
                     size="sm"
                     className="h-8 text-xs text-destructive hover:text-destructive"
+                    disabled={resendingId === invitation._id || cancellingId === invitation._id}
                     onClick={() =>
                       handleCancelInvitation(
                         invitation._id as Id<"invitations">

--- a/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
@@ -123,10 +123,10 @@ function TeamSettings() {
     try {
       await cancelInvitation({ organizationId, invitationId });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(organizationId) });
-      toast.success(t("team.invitationCancelled"));
+      toast.success(t("team.invitationCancelled"), { position: "top-center", duration: 2000 });
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
-      toast.error(message);
+      toast.error(message, { position: "top-center", duration: 2000 });
     } finally {
       setCancellingId(null);
     }
@@ -138,10 +138,10 @@ function TeamSettings() {
     try {
       await resendInvitation({ organizationId, invitationId });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(organizationId) });
-      toast.success(t("team.invitationResent"));
+      toast.success(t("team.invitationResent"), { position: "top-center", duration: 2000 });
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
-      toast.error(message);
+      toast.error(message, { position: "top-center", duration: 2000 });
     } finally {
       setResendingId(null);
     }
@@ -162,18 +162,19 @@ function TeamSettings() {
       setInviteRole("member");
       setInviteOpen(false);
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(organizationId) });
-      toast.success(t("team.invitationSent"));
+      toast.success(t("team.invitationSent"), { position: "top-center", duration: 2000 });
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
       if (message.includes("Seat limit reached")) {
         toast.error(t("settings.team.limitReached"), {
+          position: "top-center",
           action: {
             label: t("team.upgrade"),
             onClick: () => navigate({ to: "/dashboard/settings/billing" }),
           },
         });
       } else {
-        toast.error(message);
+        toast.error(message, { position: "top-center", duration: 2000 });
       }
     } finally {
       setIsSending(false);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #429.

Closes #429

---

## Claude summary

Done. Committed `832e374` on `claude/issue-429`.

Updated the three invitation handlers (resend, cancel, send) in `src/routes/_app/_auth/dashboard/_layout.settings.team.tsx:120-182` to render their success and error toasts with `position: "top-center"` and `duration: 2000` (2 seconds, auto-closing). The global Toaster default (`top-right`) elsewhere in the app is unchanged so this is scoped to the team-settings invitation flow that the user reported.

Note on the "middle of the page" wording: sonner v2 only ships `top-center` and `bottom-center` as centered options — `top-center` is the standard high-visibility popup spot and is what most apps mean by a centered confirmation toast. If you want it literally vertically in the middle of the screen, that needs a custom modal-style component (not just a toast config change) — let me know and I'll switch to that.