### PR TITLE
Audit `logSmsSharedActivities` patient lookup in convex/gabinet/appointmentSms.t

### DIFF
--- a/convex/gabinet/appointmentSms.ts
+++ b/convex/gabinet/appointmentSms.ts
@@ -89,9 +89,17 @@ async function logSmsSharedActivities(
       entityId: args.patientId,
     });
 
-    const patient = await ctx.db.get(args.patientId);
-    if (patient?.organizationId === args.organizationId && patient.contactId) {
-      patientContactId = patient.contactId;
+    const db = createSupabaseDb();
+    const patient = await db.get<{
+      organizationId?: string;
+      contactId?: string | null;
+    }>("gabinetPatients", String(args.patientId));
+    if (
+      patient &&
+      String(patient.organizationId) === String(args.organizationId) &&
+      patient.contactId
+    ) {
+      patientContactId = patient.contactId as Id<"contacts">;
     }
   }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #457.

Closes #457

---

## Claude summary

Fixed and committed. `logSmsSharedActivities` in `convex/gabinet/appointmentSms.ts:85-103` now reads the patient through `createSupabaseDb()` so the `contactId` resolves for Supabase-primary patients, restoring the missing contact target on SMS activity envelopes. `tsc -p convex/tsconfig.json --noEmit` passes.