### PR TITLE
Audit `processIncomingMessage` Convex appointment lookup in convex/gabinet/appoi

### DIFF
--- a/convex/gabinet/appointmentSms.ts
+++ b/convex/gabinet/appointmentSms.ts
@@ -494,13 +494,25 @@ export const processIncomingMessage = internalMutation({
     const matchingPatientId = matchingOutbound?.patientId as
       | Id<"gabinetPatients">
       | undefined;
+
+    const supabaseDb = createSupabaseDb();
     const matchingAppointment = matchingAppointmentId
-      ? await ctx.db.get(matchingAppointmentId)
+      ? await supabaseDb.get<{
+          organizationId?: string;
+          employeeId?: string;
+        }>("gabinetAppointments", String(matchingAppointmentId))
       : null;
+    const matchingAppointmentBelongsToOrg =
+      !!matchingAppointment &&
+      String(matchingAppointment.organizationId) === String(config.organizationId);
+    const matchingAppointmentEmployeeId =
+      matchingAppointmentBelongsToOrg && matchingAppointment?.employeeId
+        ? (matchingAppointment.employeeId as Id<"users">)
+        : undefined;
 
     if (
-      matchingAppointment &&
-      matchingAppointment.organizationId === config.organizationId &&
+      matchingAppointmentBelongsToOrg &&
+      matchingAppointmentEmployeeId &&
       (matchingAppointmentId || matchingPatientId)
     ) {
       await logSmsSharedActivities(ctx, {
@@ -509,7 +521,7 @@ export const processIncomingMessage = internalMutation({
         patientId: matchingPatientId,
         action: "sms_received",
         description: `Received appointment confirmation reply: ${normalizedBody}`,
-        performedBy: matchingAppointment.employeeId,
+        performedBy: matchingAppointmentEmployeeId,
         metadata: {
           appointmentSmsEventId: eventId,
           direction: "inbound",
@@ -531,7 +543,7 @@ export const processIncomingMessage = internalMutation({
       entityId: matchingOutbound?.appointmentId
         ? String(matchingOutbound.appointmentId)
         : undefined,
-      actorUserId: matchingAppointment?.employeeId,
+      actorUserId: matchingAppointmentEmployeeId,
       correlationKey: matchingOutbound?.correlationKey,
       eventIdempotencyKey: `automation-event:${config.organizationId}:${args.idempotencyKey}`,
       payload: JSON.stringify({


### PR DESCRIPTION
Auto-generated by Claude in response to issue #458.

Closes #458

---

## Claude summary

Committed. Summary:

The `processIncomingMessage` mutation at `convex/gabinet/appointmentSms.ts:497-499` was casting the Supabase UUID stored in `appointmentSmsEvents.appointmentId` (typed as `v.string()`) to `Id<"gabinetAppointments">` and calling `ctx.db.get()` against Convex. Since appointments are Supabase-primary, this lookup always returned null in production. The downstream guard never matched, so the inbound `sms_received` activity envelope was never published and `automation.emitEvent` was emitted without `actorUserId`.

The fix mirrors the pattern already applied in `queueConfirmationRequest`, `queueAutomationSms`, and `applySmsReplyTransition` (recent PRs #478, #482): read the appointment from Supabase via `createSupabaseDb().get("gabinetAppointments", ...)`, compare `organizationId` as strings, and reuse a single `matchingAppointmentEmployeeId` (cast `Id<"users">`) for both the activity log and the automation event. Typecheck passes on `convex/tsconfig.json`.