### PR TITLE
Extend inline category creation to remaining CategoryPicker call sites

### DIFF
--- a/src/components/crm/activity-form.tsx
+++ b/src/components/crm/activity-form.tsx
@@ -92,6 +92,7 @@ interface ActivityFormProps {
   customFieldDefs?: CustomFieldDef[];
   tagDefinitions?: TagDef[];
   categoryDefinitions?: CategoryDef[];
+  organizationId?: Id<"organizations">;
 }
 
 export function ActivityForm({
@@ -106,6 +107,7 @@ export function ActivityForm({
   customFieldDefs = [],
   tagDefinitions = [],
   categoryDefinitions = [],
+  organizationId,
 }: ActivityFormProps) {
   const { t } = useTranslation();
 
@@ -568,10 +570,16 @@ export function ActivityForm({
         )}
 
         {/* Category */}
-        {categoryDefinitions.length > 0 && (
+        {organizationId && (
           <div className="space-y-1.5">
             <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
-            <CategoryPicker categories={categoryDefinitions} selectedId={categoryId} onChange={setCategoryId} />
+            <CategoryPicker
+              categories={categoryDefinitions}
+              selectedId={categoryId}
+              onChange={setCategoryId}
+              organizationId={organizationId}
+              entityType="activity"
+            />
           </div>
         )}
 

--- a/src/components/forms/call-form.tsx
+++ b/src/components/forms/call-form.tsx
@@ -52,6 +52,7 @@ interface CallFormProps {
   isSubmitting?: boolean;
   tagDefinitions?: TagDef[];
   categoryDefinitions?: CategoryDef[];
+  organizationId?: Id<"organizations">;
 }
 
 export function CallForm({
@@ -61,6 +62,7 @@ export function CallForm({
   isSubmitting = false,
   tagDefinitions = [],
   categoryDefinitions = [],
+  organizationId,
 }: CallFormProps) {
   const { t } = useTranslation();
   const [outcome, setOutcome] = useState<CallOutcome>(
@@ -115,10 +117,16 @@ export function CallForm({
             <TagsPicker tags={tagDefinitions} selectedIds={tagIds} onChange={setTagIds} />
           </div>
         )}
-        {categoryDefinitions.length > 0 && (
+        {organizationId && (
           <div className="space-y-1.5">
             <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
-            <CategoryPicker categories={categoryDefinitions} selectedId={categoryId} onChange={setCategoryId} />
+            <CategoryPicker
+              categories={categoryDefinitions}
+              selectedId={categoryId}
+              onChange={setCategoryId}
+              organizationId={organizationId}
+              entityType="call"
+            />
           </div>
         )}
       </div>

--- a/src/components/forms/company-form.tsx
+++ b/src/components/forms/company-form.tsx
@@ -87,6 +87,7 @@ interface CompanyFormProps {
   onCancel: () => void;
   isSubmitting?: boolean;
   extraFields?: React.ReactNode;
+  organizationId?: Id<"organizations">;
 }
 
 export function CompanyForm({
@@ -99,6 +100,7 @@ export function CompanyForm({
   onCancel,
   isSubmitting = false,
   extraFields,
+  organizationId,
 }: CompanyFormProps) {
   const { t } = useTranslation();
   const [name, setName] = useState(initialData?.name ?? "");
@@ -270,13 +272,15 @@ export function CompanyForm({
             />
           </div>
         )}
-        {categoryDefinitions.length > 0 && (
+        {organizationId && (
           <div className="space-y-1.5 sm:col-span-2">
             <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
             <CategoryPicker
               categories={categoryDefinitions}
               selectedId={categoryId}
               onChange={setCategoryId}
+              organizationId={organizationId}
+              entityType="company"
             />
           </div>
         )}

--- a/src/components/forms/contact-form.tsx
+++ b/src/components/forms/contact-form.tsx
@@ -62,6 +62,7 @@ interface ContactFormProps {
   extraFields?: React.ReactNode;
   tagDefinitions?: TagDef[];
   categoryDefinitions?: CategoryDef[];
+  organizationId?: Id<"organizations">;
 }
 
 export function ContactForm({
@@ -75,6 +76,7 @@ export function ContactForm({
   extraFields,
   tagDefinitions = [],
   categoryDefinitions = [],
+  organizationId,
 }: ContactFormProps) {
   const { t } = useTranslation();
   const [firstName, setFirstName] = useState(initialData?.firstName ?? "");
@@ -218,13 +220,15 @@ export function ContactForm({
             />
           </div>
         )}
-        {categoryDefinitions.length > 0 && (
+        {organizationId && (
           <div className="space-y-1.5 sm:col-span-2">
             <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
             <CategoryPicker
               categories={categoryDefinitions}
               selectedId={categoryId}
               onChange={setCategoryId}
+              organizationId={organizationId}
+              entityType="contact"
             />
           </div>
         )}

--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -335,10 +335,16 @@ export function EmployeeForm({
           <TagsPicker tags={tagDefinitions} selectedIds={tagIds} onChange={setTagIds} />
         </div>
       )}
-      {categoryDefinitions.length > 0 && (
+      {organizationId && (
         <div className="space-y-1.5 sm:col-span-2">
           <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
-          <CategoryPicker categories={categoryDefinitions} selectedId={categoryId} onChange={setCategoryId} />
+          <CategoryPicker
+            categories={categoryDefinitions}
+            selectedId={categoryId}
+            onChange={setCategoryId}
+            organizationId={organizationId}
+            entityType="gabinetEmployee"
+          />
         </div>
       )}
 

--- a/src/components/forms/lead-form.tsx
+++ b/src/components/forms/lead-form.tsx
@@ -86,6 +86,7 @@ interface LeadFormProps {
   onCancel: () => void;
   isSubmitting?: boolean;
   extraFields?: React.ReactNode;
+  organizationId?: Id<"organizations">;
 }
 
 const statusOptions: LeadStatus[] = ["open", "won", "lost", "archived"];
@@ -103,6 +104,7 @@ export function LeadForm({
   onCancel,
   isSubmitting = false,
   extraFields,
+  organizationId,
 }: LeadFormProps) {
   const { t } = useTranslation();
   const [title, setTitle] = useState(initialData?.title ?? "");
@@ -273,13 +275,15 @@ export function LeadForm({
             />
           </div>
         )}
-        {categoryDefinitions.length > 0 && (
+        {organizationId && (
           <div className="space-y-1.5 sm:col-span-2">
             <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
             <CategoryPicker
               categories={categoryDefinitions}
               selectedId={categoryId}
               onChange={setCategoryId}
+              organizationId={organizationId}
+              entityType="lead"
             />
           </div>
         )}

--- a/src/components/forms/patient-form.tsx
+++ b/src/components/forms/patient-form.tsx
@@ -59,6 +59,7 @@ interface PatientFormProps {
   isSubmitting?: boolean;
   tagDefinitions?: TagDef[];
   categoryDefinitions?: CategoryDef[];
+  organizationId?: Id<"organizations">;
 }
 
 export function PatientForm({
@@ -68,6 +69,7 @@ export function PatientForm({
   isSubmitting = false,
   tagDefinitions = [],
   categoryDefinitions = [],
+  organizationId,
 }: PatientFormProps) {
   const { t } = useTranslation();
   const [firstName, setFirstName] = useState(initialData?.firstName ?? "");
@@ -276,10 +278,16 @@ export function PatientForm({
           <TagsPicker tags={tagDefinitions} selectedIds={tagIds} onChange={setTagIds} />
         </div>
       )}
-      {categoryDefinitions.length > 0 && (
+      {organizationId && (
         <div className="space-y-1.5 sm:col-span-2">
           <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
-          <CategoryPicker categories={categoryDefinitions} selectedId={categoryId} onChange={setCategoryId} />
+          <CategoryPicker
+            categories={categoryDefinitions}
+            selectedId={categoryId}
+            onChange={setCategoryId}
+            organizationId={organizationId}
+            entityType="gabinetPatient"
+          />
         </div>
       )}
 

--- a/src/components/forms/product-form.tsx
+++ b/src/components/forms/product-form.tsx
@@ -40,6 +40,7 @@ interface ProductFormProps {
   isSubmitting?: boolean;
   tagDefinitions?: TagDef[];
   categoryDefinitions?: CategoryDef[];
+  organizationId?: Id<"organizations">;
 }
 
 export function ProductForm({
@@ -49,6 +50,7 @@ export function ProductForm({
   isSubmitting = false,
   tagDefinitions = [],
   categoryDefinitions = [],
+  organizationId,
 }: ProductFormProps) {
   const { t } = useTranslation();
   const [name, setName] = useState(initialData?.name ?? "");
@@ -145,13 +147,15 @@ export function ProductForm({
             />
           </div>
         )}
-        {categoryDefinitions.length > 0 && (
+        {organizationId && (
           <div className="space-y-1.5 sm:col-span-2">
             <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
             <CategoryPicker
               categories={categoryDefinitions}
               selectedId={categoryId}
               onChange={setCategoryId}
+              organizationId={organizationId}
+              entityType="product"
             />
           </div>
         )}

--- a/src/components/gabinet/appointment-form.tsx
+++ b/src/components/gabinet/appointment-form.tsx
@@ -901,10 +901,16 @@ export function AppointmentForm({
       )}
 
       {/* Category */}
-      {categoryDefinitions && categoryDefinitions.length > 0 && (
+      {organizationId && (
         <div className="space-y-1.5">
           <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
-          <CategoryPicker categories={categoryDefinitions} selectedId={categoryId} onChange={setCategoryId} />
+          <CategoryPicker
+            categories={categoryDefinitions ?? []}
+            selectedId={categoryId}
+            onChange={setCategoryId}
+            organizationId={organizationId}
+            entityType="gabinetAppointment"
+          />
         </div>
       )}
 

--- a/src/routes/_app/_auth/dashboard/_layout.activities.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.activities.index.tsx
@@ -490,12 +490,16 @@ function ActivitiesPage() {
               <TagsPicker tags={tags} selectedIds={tagIds} onChange={setTagIds} />
             </div>
           )}
-          {categories.length > 0 && (
-            <div className="space-y-1.5">
-              <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
-              <CategoryPicker categories={categories} selectedId={categoryId} onChange={setCategoryId} />
-            </div>
-          )}
+          <div className="space-y-1.5">
+            <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
+            <CategoryPicker
+              categories={categories}
+              selectedId={categoryId}
+              onChange={setCategoryId}
+              organizationId={organizationId}
+              entityType="activity"
+            />
+          </div>
         </div>
       </SidePanel>
 

--- a/src/routes/_app/_auth/dashboard/_layout.calls.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calls.index.tsx
@@ -421,12 +421,16 @@ function CallsPage() {
               <TagsPicker tags={tags} selectedIds={tagIds} onChange={setTagIds} />
             </div>
           )}
-          {categories.length > 0 && (
-            <div className="space-y-1.5">
-              <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
-              <CategoryPicker categories={categories} selectedId={categoryId} onChange={setCategoryId} />
-            </div>
-          )}
+          <div className="space-y-1.5">
+            <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
+            <CategoryPicker
+              categories={categories}
+              selectedId={categoryId}
+              onChange={setCategoryId}
+              organizationId={organizationId}
+              entityType="call"
+            />
+          </div>
         </div>
       </SidePanel>
 

--- a/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
@@ -450,12 +450,16 @@ function CompaniesIndex() {
                   <TagsPicker tags={tags} selectedIds={tagIds} onChange={setTagIds} />
                 </div>
               )}
-              {categories.length > 0 && (
-                <div className="space-y-1.5">
-                  <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
-                  <CategoryPicker categories={categories} selectedId={categoryId} onChange={setCategoryId} />
-                </div>
-              )}
+              <div className="space-y-1.5">
+                <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
+                <CategoryPicker
+                  categories={categories}
+                  selectedId={categoryId}
+                  onChange={setCategoryId}
+                  organizationId={organizationId}
+                  entityType="company"
+                />
+              </div>
             </>
           }
         />

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
@@ -425,6 +425,7 @@ function ContactsIndex() {
           customFieldDefinitions={cfDefs}
           tagDefinitions={tags}
           categoryDefinitions={categories}
+          organizationId={organizationId}
         />
       </SidePanel>
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -602,12 +602,16 @@ function CreateEmployeeSheet({
               <TagsPicker tags={tags} selectedIds={tagIds} onChange={setTagIds} />
             </div>
           )}
-          {categories.length > 0 && (
-            <div className="space-y-1.5">
-              <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
-              <CategoryPicker categories={categories} selectedId={categoryId} onChange={setCategoryId} />
-            </div>
-          )}
+          <div className="space-y-1.5">
+            <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
+            <CategoryPicker
+              categories={categories}
+              selectedId={categoryId}
+              onChange={setCategoryId}
+              organizationId={organizationId}
+              entityType="gabinetEmployee"
+            />
+          </div>
         </div>
 
         <SheetFooter>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -473,12 +473,16 @@ function PatientsIndex() {
             <TagsPicker tags={tags} selectedIds={tagIds} onChange={setTagIds} />
           </div>
         )}
-        {categories.length > 0 && (
-          <div className="space-y-1.5">
-            <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
-            <CategoryPicker categories={categories} selectedId={categoryId} onChange={setCategoryId} />
-          </div>
-        )}
+        <div className="space-y-1.5">
+          <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
+          <CategoryPicker
+            categories={categories}
+            selectedId={categoryId}
+            onChange={setCategoryId}
+            organizationId={organizationId}
+            entityType="gabinetPatient"
+          />
+        </div>
       </SidePanel>
 
       <TagsManagerSlideout

--- a/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
@@ -673,12 +673,16 @@ function LeadsIndex() {
                   <TagsPicker tags={tags} selectedIds={tagIds} onChange={setTagIds} />
                 </div>
               )}
-              {categories.length > 0 && (
-                <div className="space-y-1.5">
-                  <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
-                  <CategoryPicker categories={categories} selectedId={categoryId} onChange={setCategoryId} />
-                </div>
-              )}
+              <div className="space-y-1.5">
+                <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
+                <CategoryPicker
+                  categories={categories}
+                  selectedId={categoryId}
+                  onChange={setCategoryId}
+                  organizationId={organizationId}
+                  entityType="lead"
+                />
+              </div>
             </>
           }
           onSubmit={async (data, customFieldRecord) => {

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -403,12 +403,16 @@ function ProductsPage() {
               <TagsPicker tags={tags} selectedIds={tagIds} onChange={setTagIds} />
             </div>
           )}
-          {categories.length > 0 && (
-            <div className="space-y-1.5">
-              <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
-              <CategoryPicker categories={categories} selectedId={categoryId} onChange={setCategoryId} />
-            </div>
-          )}
+          <div className="space-y-1.5">
+            <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
+            <CategoryPicker
+              categories={categories}
+              selectedId={categoryId}
+              onChange={setCategoryId}
+              organizationId={organizationId}
+              entityType="product"
+            />
+          </div>
         </div>
       </SidePanel>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #470.

Closes #470

---

## Claude summary

Committed as `8ead71c`. Extended the inline category-creation pattern from #446 to the remaining CategoryPicker call sites.

Summary of changes:
- Form components (`activity-form`, `call-form`, `company-form`, `contact-form`, `employee-form`, `lead-form`, `patient-form`, `product-form`, `appointment-form`) accept an optional `organizationId` prop and, when supplied, gate the category section on it (instead of `categoryDefinitions.length > 0`) plus pass `organizationId` and the matching `entityType` to `CategoryPicker` so the "Add new" affordance appears.
- Index routes (`contacts`, `companies`, `leads`, `products`, `calls`, `activities`, `gabinet.patients`, `gabinet.employees`) now always render the picker and forward `organizationId` + `entityType`. Callers that don't opt in (e.g. detail-page edit drawers that never passed `categoryDefinitions`) continue to behave as before — no picker.
- All `entityType` strings verified against `entityTypeValidator` in `convex/schema.ts:85`.
- Typecheck against `tsconfig.app.json` shows the same 15 pre-existing errors as `main`; none of them touch the modified files.