### PR TITLE
Decide fate of legacy free-text `category` field on `gabinetTreatments`

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -85,7 +85,6 @@ export const create = action({
     organizationId: v.id("organizations"),
     name: v.string(),
     description: v.optional(v.string()),
-    category: v.optional(v.string()),
     duration: v.number(),
     price: v.number(),
     currency: v.optional(v.string()),
@@ -124,7 +123,6 @@ export const create = action({
       organizationId: String(args.organizationId),
       name: args.name,
       description: args.description ?? null,
-      category: args.category ?? null,
       duration: args.duration,
       price: args.price,
       currency: args.currency ?? null,
@@ -189,7 +187,6 @@ export const update = action({
     treatmentId: v.string(),
     name: v.optional(v.string()),
     description: v.optional(v.string()),
-    category: v.optional(v.string()),
     duration: v.optional(v.number()),
     price: v.optional(v.number()),
     currency: v.optional(v.string()),
@@ -350,29 +347,6 @@ export const _removeSideEffects = internalMutation({
       description: `Deleted treatment "${args.treatmentName}"`,
       performedBy: deletedByUserId,
     });
-  },
-});
-
-export const listByCategory = query({
-  args: {
-    organizationId: v.id("organizations"),
-    category: v.string(),
-  },
-  handler: async (ctx, args) => {
-    const { user } = await verifyOrgAccess(ctx, args.organizationId);
-    const perm = await checkPermission(ctx, args.organizationId, "gabinet_treatments", "view");
-    if (!perm.allowed) throw new Error("Permission denied");
-
-    const results = await ctx.db
-      .query("gabinetTreatments")
-      .withIndex("by_orgAndCategory", (q) =>
-        q.eq("organizationId", args.organizationId).eq("category", args.category)
-      )
-      .collect();
-    if (perm.scope === "own") {
-      return results.filter((r) => r.createdBy === user._id);
-    }
-    return results;
   },
 });
 

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -87,6 +87,9 @@ export function createGabinetTables({
     organizationId: v.id("organizations"),
     name: v.string(),
     description: v.optional(v.string()),
+    // Legacy free-text category. Superseded by `categoryId` (see below) which
+    // references `categoryDefinitions`. Read-only fallback for records created
+    // before structured categories — no longer written by the app. See #471.
     category: v.optional(v.string()),
     duration: v.number(),
     price: v.number(),
@@ -140,7 +143,6 @@ export function createGabinetTables({
     updatedAt: v.number(),
   })
     .index("by_org", ["organizationId"])
-    .index("by_orgAndCategory", ["organizationId", "category"])
     .index("by_orgAndActive", ["organizationId", "isActive"])
     .searchIndex("search_treatments", {
       searchField: "name",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -136,7 +136,6 @@ function TreatmentsIndex() {
   const filterableFields = useMemo(
     (): FieldDef[] => [
       { id: "name", label: t("gabinet.treatments.name"), type: "text" },
-      { id: "category", label: t("gabinet.treatments.category"), type: "text" },
       { id: "price", label: t("gabinet.treatments.price"), type: "number" },
       { id: "duration", label: t("gabinet.treatments.duration"), type: "number" },
       {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #471.

Closes #471

---

## Claude summary

Decision and implementation summary for issue #471:

The form-side duplication was already resolved by PR #447/#472 — `TreatmentForm` no longer renders a free-text `category` Input; the `categorySelector` slot is the structured `CategoryPicker`. What was left to "decide" was the fate of the legacy `category` field at the schema/backend level and the duplicate filter still hanging around.

The decision is to treat `category` as a read-only fallback for legacy records and stop writing to it from the app, rather than dropping the column outright (existing data still renders via the fallback paths in list, detail, and patient portal). Concrete changes in commit `00770af`:

- `convex/gabinet/treatments.ts` — removed `category` from `create` and `update` validators; removed the now-dead `listByCategory` query.
- `convex/schema/gabinet.ts` — removed the unused `by_orgAndCategory` index (no remaining callers) and annotated the `category` field with a comment explaining it's a legacy read-only fallback.
- `src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx` — removed the duplicate `category` text filter (the structured `categoryId` select filter right below it covers this).

Typecheck couldn't run (no `node_modules` in this worktree), but the changes are pure deletions of unused code plus a comment — no new types or call sites introduced.

## Follow-ups
- Backfill legacy `gabinetTreatments.category` strings to structured `categoryId`: write a one-off migration that creates `categoryDefinitions` for each distinct legacy category string per org and links treatments to them, so we can eventually drop the `category` column entirely.
- Update gabinet seed to use `categoryId` instead of `category`: `convex/gabinet/seed.ts:141` still writes the legacy free-text field; should seed `categoryDefinitions` first and link via `categoryId`.
- Port patient portal `getBookableTreatments` to return `categoryId`: `convex/gabinet/patientPortal.ts:199` and the booking page (`src/routes/_app/patient/_layout.book.tsx:197`) group by free-text `category`; should resolve `categoryId` → name via `categoryDefinitions` so newly created treatments group correctly in patient booking.
- Resolve `treatment.category` document variable from `categoryId`: `convex/documents/scopeResolver.ts:467` and `src/lib/document-variables.ts:80` still render documents using the legacy free-text field — when `categoryId` is set, the variable should resolve to the linked category name.