### PR TITLE
Update appointmentSms tests for action-based appointments.create

### DIFF
--- a/tests/convex/appointmentSms.test.ts
+++ b/tests/convex/appointmentSms.test.ts
@@ -50,7 +50,7 @@ async function createAppointment(
     endTime?: string;
   },
 ) {
-  return t.withIdentity(identity).mutation(api.gabinet.appointments.create, {
+  return t.withIdentity(identity).action(api.gabinet.appointments.create, {
     organizationId: args.organizationId,
     patientId: args.patientId,
     treatmentId: args.treatmentId,
@@ -481,17 +481,17 @@ describe("appointment SMS flow", () => {
       employeeId: userId,
     });
 
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId,
       appointmentId,
       status: "confirmed",
     });
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId,
       appointmentId,
       status: "in_progress",
     });
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId,
       appointmentId,
       status: "completed",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #479.

Closes #479

---

## Claude summary

Committed. Switched the four `t.withIdentity(...).mutation(...)` calls in `tests/convex/appointmentSms.test.ts` (one for `appointments.create`, three for `appointments.updateStatus`) to `.action(...)`, resolving the "Expected a mutation function" failure for all 4 tests. This mirrors the recent `payments.test.ts` fix (PR #485). The tests now fail uniformly on the missing Supabase test environment, which is a much larger, codebase-wide gap and out of scope here.

## Follow-ups
- Build Supabase test infrastructure for convex-test suites: actions in `payments`, `gabinet/appointments`, and other Supabase-primary modules call `createSupabaseDb()` which throws "SUPABASE_URL not configured" under vitest. Either mock `@cvx/_helpers/supabaseDb` to delegate to convex-test's in-memory DB, or run tests against a local Supabase (docker) instance with seeded schema. Until then, post-migration tests cannot actually pass end-to-end even after API-shape fixes.
- Align remaining test files with action-based appointments API: `tests/convex/appointmentStateMachine.test.ts`, `tests/convex/conflictChecking.test.ts`, and `tests/convex/automation.test.ts` still call `api.gabinet.appointments.create` (and related, including `appointments.cancel`, `leads.create`, `automation.createRule`) via `.mutation`, failing with the same "Expected a mutation function" error.
- Add convex unit tests to CI: `.github/workflows/e2e.yml` runs only Playwright; `npm run test:unit` is never executed, so test-shape regressions like #479 land on main unnoticed.