### PR TITLE
Fix payments.ts list/getRevenueSummary queries to read from Supabase

### DIFF
--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -1,9 +1,8 @@
-import { query, action, internalMutation } from "./_generated/server";
+import { action, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
-import { verifyOrgAccess } from "./_helpers/auth";
 import { logAudit } from "./auditLog";
 import { logActivity } from "./_helpers/activities";
 
@@ -21,43 +20,46 @@ const paymentStatusValidator = v.union(
   v.literal("cancelled"),
 );
 
-export const list = query({
+export const list = action({
   args: {
     organizationId: v.id("organizations"),
     paginationOpts: paginationOptsValidator,
     status: v.optional(paymentStatusValidator),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
 
-    if (args.status) {
-      return await ctx.db
-        .query("payments")
-        .withIndex("by_orgAndStatus", (q) =>
-          q.eq("organizationId", args.organizationId).eq("status", args.status!)
-        )
-        .order("desc")
-        .paginate(args.paginationOpts);
-    }
-
-    return await ctx.db
+    const db = createSupabaseDb();
+    let q = db
       .query("payments")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .order("desc")
-      .paginate(args.paginationOpts);
+      .eq("organizationId", String(args.organizationId));
+    if (args.status) q = q.eq("status", args.status);
+    const rows = await q
+      .order("createdAt", false)
+      .take(args.paginationOpts.numItems)
+      .collect();
+
+    return { page: rows, isDone: true, continueCursor: "" };
   },
 });
 
-export const getByAppointment = query({
+export const getByAppointment = action({
   args: {
     organizationId: v.id("organizations"),
     appointmentId: v.id("gabinetAppointments"),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    return await ctx.db
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+
+    const db = createSupabaseDb();
+    return await db
       .query("payments")
-      .withIndex("by_appointment", (q) => q.eq("appointmentId", args.appointmentId))
+      .eq("organizationId", String(args.organizationId))
+      .eq("appointmentId", String(args.appointmentId))
       .first();
   },
 });
@@ -308,32 +310,35 @@ export const _refundSideEffects = internalMutation({
 });
 
 /** Revenue summary for a time range */
-export const getRevenueSummary = query({
+export const getRevenueSummary = action({
   args: {
     organizationId: v.id("organizations"),
     startDate: v.number(),
     endDate: v.number(),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
 
-    const payments = await ctx.db
-      .query("payments")
-      .withIndex("by_orgAndStatus", (q) =>
-        q.eq("organizationId", args.organizationId).eq("status", "completed")
-      )
+    const db = createSupabaseDb();
+    const payments = await db
+      .query<{
+        amount: number;
+        paymentMethod: string;
+        paidAt: number | null;
+      }>("payments")
+      .eq("organizationId", String(args.organizationId))
+      .eq("status", "completed")
+      .gte("paidAt", args.startDate)
+      .lte("paidAt", args.endDate)
       .collect();
 
-    const filtered = payments.filter(
-      (p) => p.paidAt && p.paidAt >= args.startDate && p.paidAt <= args.endDate
-    );
+    const total = payments.reduce((sum, p) => sum + p.amount, 0);
+    const count = payments.length;
 
-    const total = filtered.reduce((sum, p) => sum + p.amount, 0);
-    const count = filtered.length;
-
-    // Group by payment method
     const byMethod: Record<string, { count: number; total: number }> = {};
-    for (const p of filtered) {
+    for (const p of payments) {
       if (!byMethod[p.paymentMethod]) {
         byMethod[p.paymentMethod] = { count: 0, total: 0 };
       }

--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -20,7 +20,7 @@ describe("payments", () => {
 
     expect(paymentId).toBeTruthy();
 
-    const result = await t.withIdentity(identity).query(api.payments.list, {
+    const result = await t.withIdentity(identity).action(api.payments.list, {
       organizationId,
       paginationOpts: { numItems: 10, cursor: null },
     });
@@ -46,7 +46,7 @@ describe("payments", () => {
 
     expect(paymentId).toBeTruthy();
 
-    const result = await t.withIdentity(identity).query(api.payments.list, {
+    const result = await t.withIdentity(identity).action(api.payments.list, {
       organizationId,
       paginationOpts: { numItems: 10, cursor: null },
     });
@@ -76,7 +76,7 @@ describe("payments", () => {
       paymentId,
     });
 
-    const result = await t.withIdentity(identity).query(api.payments.list, {
+    const result = await t.withIdentity(identity).action(api.payments.list, {
       organizationId,
       paginationOpts: { numItems: 10, cursor: null },
       status: "completed",
@@ -130,7 +130,7 @@ describe("payments", () => {
       reason: "Patient request",
     });
 
-    const result = await t.withIdentity(identity).query(api.payments.list, {
+    const result = await t.withIdentity(identity).action(api.payments.list, {
       organizationId,
       paginationOpts: { numItems: 10, cursor: null },
     });
@@ -190,7 +190,7 @@ describe("payments", () => {
       status: "pending",
     });
 
-    const summary = await t.withIdentity(identity).query(
+    const summary = await t.withIdentity(identity).action(
       api.payments.getRevenueSummary,
       {
         organizationId,
@@ -225,7 +225,7 @@ describe("payments", () => {
       paymentMethod: "card",
     });
 
-    const result = await t.withIdentity(identity).query(api.payments.list, {
+    const result = await t.withIdentity(identity).action(api.payments.list, {
       organizationId,
       paginationOpts: { numItems: 10, cursor: null },
     });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #486.

Closes #486

---

## Claude summary

Fix committed. Summary:

`convex/payments.ts` had `list`, `getByAppointment`, and `getRevenueSummary` defined as `query` functions calling `ctx.db.query("payments")`, but no `payments` table is defined in `convex/schema.ts` and writes go to Supabase via `createSupabaseDb()`. Any call to these would throw at runtime.

Changes:
- Converted the three handlers from `query` to `action`, reading from Supabase via the same `createSupabaseDb()` wrapper used by `create`/`markPaid`/`refund`/`listByPackageUsage`. Auth swapped from in-handler `verifyOrgAccess` to the action-friendly `ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, ...)`.
- `list` keeps the `{ page, isDone, continueCursor }` shape; pagination is take-first-N for now since `SupabaseQueryBuilder` lacks range/offset.
- `getRevenueSummary` now uses Supabase `gte`/`lte` on `paidAt` directly instead of fetching everything and filtering in memory.
- Removed the unused `query` import and `verifyOrgAccess` helper import.
- Updated `tests/convex/payments.test.ts` to call these via `.action()` instead of `.query()`.

Typecheck passes for `convex/tsconfig.json`. The payments tests still fail with the pre-existing `SUPABASE_URL not configured` error (same as before my change — `create`/`markPaid`/`refund` already required Supabase and the test env has no mock), so the test environment cannot exercise this code path without separate work.

## Follow-ups
- Mock or stub Supabase in convex-test setup: every payments test fails with `SUPABASE_URL not configured` because `createSupabaseDb()` is called inside `create`/`markPaid`/`refund`/`list`/etc. and the test harness has no env vars or fake client. Tests in `tests/convex/payments.test.ts` are effectively dead until this is addressed.
- Audit `convex/calls.ts` for the same bug: it imports `createSupabaseDb` and the comment claims "Supabase is now primary for call writes", but `list`/`getById` still read via `ctx.db.query("calls")` / `ctx.db.get(callId)` and `calls` is no longer in `convex/schema.ts`.
- Add range/offset support to `SupabaseQueryBuilder`: `payments.list` had to drop real pagination (returns `isDone: true` after `take(numItems)`) because the builder only exposes `.take(n)`.