### PR TITLE
Port patient portal `getBookableTreatments` to return `categoryId`

### DIFF
--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -180,27 +180,64 @@ export const getMyLoyaltyTransactions = query({
 // ---------------------------------------------------------------------------
 
 /** List active treatments available for booking. */
-export const getBookableTreatments = query({
+export const getBookableTreatments = action({
   args: { tokenHash: v.string() },
-  handler: async (ctx, args) => {
-    const { organizationId } = await validatePortalSession(ctx, args.tokenHash);
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
 
-    const treatments = await ctx.db
+    // Validate session via Supabase (matches bookFromPortal — the Convex
+    // gabinetPortalSessions table is no longer the source of truth).
+    const session = await db
+      .query("gabinetPortalSessions")
+      .eq("tokenHash", args.tokenHash)
+      .first();
+    if (
+      !session ||
+      !session.isActive ||
+      Date.now() > (session.expiresAt as number)
+    ) {
+      throw new Error("Invalid or expired session");
+    }
+    const organizationId = String(session.organizationId);
+
+    const treatments = await db
       .query("gabinetTreatments")
-      .withIndex("by_orgAndActive", (q) =>
-        q.eq("organizationId", organizationId).eq("isActive", true),
-      )
+      .eq("organizationId", organizationId)
+      .eq("isActive", true)
       .collect();
 
-    return treatments.map((t) => ({
-      _id: t._id,
-      name: t.name,
-      description: t.description,
-      category: t.category,
-      duration: t.duration,
-      price: t.price,
-      currency: t.currency ?? "PLN",
-    }));
+    // Resolve structured `categoryId` → name so newly created treatments
+    // (which only set categoryId) group correctly on the booking page. Fall
+    // back to the legacy free-text `category` string for records created
+    // before structured categories (see #471, #492).
+    const categories = await db
+      .query("categoryDefinitions")
+      .eq("organizationId", organizationId)
+      .eq("entityType", "gabinetTreatment")
+      .collect();
+    const categoryNameById = new Map<string, string>();
+    for (const c of categories) {
+      if (!c.isDeleted) categoryNameById.set(String(c._id), String(c.name));
+    }
+
+    return treatments.map((t) => {
+      let resolvedCategory: string | null = null;
+      if (t.categoryId) {
+        resolvedCategory = categoryNameById.get(String(t.categoryId)) ?? null;
+      }
+      if (!resolvedCategory && typeof t.category === "string") {
+        resolvedCategory = t.category;
+      }
+      return {
+        _id: t._id as string,
+        name: t.name as string,
+        description: (t.description as string | null) ?? undefined,
+        category: resolvedCategory,
+        duration: t.duration as number,
+        price: t.price as number,
+        currency: (t.currency as string | null) ?? "PLN",
+      };
+    });
   },
 });
 

--- a/src/routes/_app/patient/_layout.book.tsx
+++ b/src/routes/_app/patient/_layout.book.tsx
@@ -50,9 +50,14 @@ function PatientBooking() {
 
   const bookMutation = useAction(api.gabinet.patientPortal.bookFromPortal);
 
-  const { data: treatments } = useQuery(
-    convexQuery(api.gabinet.patientPortal.getBookableTreatments, { tokenHash }),
+  const getBookableTreatments = useAction(
+    api.gabinet.patientPortal.getBookableTreatments,
   );
+  const { data: treatments } = useQuery({
+    queryKey: ["gabinet.patientPortal.getBookableTreatments", tokenHash],
+    queryFn: () => getBookableTreatments({ tokenHash }),
+    enabled: !!tokenHash,
+  });
 
   const { data: employees } = useQuery({
     ...convexQuery(api.gabinet.patientPortal.getQualifiedEmployees, {
@@ -114,7 +119,13 @@ function PatientBooking() {
   const handleSelectTreatment = (
     treatment: NonNullable<typeof treatments>[number],
   ) => {
-    setSelectedTreatment(treatment);
+    setSelectedTreatment({
+      _id: treatment._id as Id<"gabinetTreatments">,
+      name: treatment.name,
+      duration: treatment.duration,
+      price: treatment.price,
+      currency: treatment.currency,
+    });
     setSelectedEmployee(null);
     setAnyEmployee(false);
     setSelectedDate(undefined);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #494.

Closes #494

---

## Claude summary

Committed as `ee50ebd`. Summary:

Changed `getBookableTreatments` in `convex/gabinet/patientPortal.ts:183` from a Convex `query` to a Supabase-backed `action` that:
1. Validates the portal session via Supabase (matching `bookFromPortal`)
2. Reads treatments from Supabase
3. Loads `categoryDefinitions` for the org and builds an id→name map
4. Returns each treatment's resolved category name, falling back to the legacy free-text `category` string for records created before structured categories

Updated `src/routes/_app/patient/_layout.book.tsx` to invoke it via `useAction` + `useQuery` (same pattern as the neighboring `getPublicAvailableSlots` call site). The existing `groupedTreatments` logic keeps grouping by the same `category` string field, so the UI gets the right groups automatically.

While investigating I also noticed the data-source mismatch was already breaking real portal sessions (Convex DB no longer has portal sessions or treatments) — the action conversion fixes both the categoryId resolution and that latent bug.

## Follow-ups
- Port `getQualifiedEmployees` in convex/gabinet/patientPortal.ts to Supabase: same anti-pattern as `getBookableTreatments` — reads `gabinetEmployees` from `ctx.db` via `validatePortalSession`, but those rows live in Supabase only, so the query throws for any real portal session.
- Audit remaining `validatePortalSession`-using queries: `getMyProfile`, `getMyAppointments`, `getMyDocuments`, `getMyLoyaltyPoints`, `getMyLoyaltyTransactions` all read `gabinetPortalSessions` from Convex `ctx.db`, which has been Supabase-only since the dual-write cleanup; they likely all need the same action-conversion treatment.