### PR TITLE
Resolve `treatment.category` document variable from `categoryId`

### DIFF
--- a/convex/documents/scopeResolver.ts
+++ b/convex/documents/scopeResolver.ts
@@ -111,6 +111,7 @@ async function fetchAppointment(
     scope.treatment = flattenEntity(
       treatment as unknown as Record<string, unknown>,
     );
+    await resolveTreatmentCategory(ctx, scope.treatment, treatment.categoryId);
   }
 
   // Employee — employeeId is a users ID; look up gabinetEmployees via by_orgAndUser
@@ -196,9 +197,29 @@ async function fetchTreatment(
   const treatment = await ctx.db.get(treatmentId);
   if (!treatment || treatment.organizationId !== orgId) return {};
 
-  return {
-    treatment: flattenEntity(treatment as unknown as Record<string, unknown>),
-  };
+  const treatmentScope = flattenEntity(
+    treatment as unknown as Record<string, unknown>,
+  );
+  await resolveTreatmentCategory(ctx, treatmentScope, treatment.categoryId);
+  return { treatment: treatmentScope };
+}
+
+/**
+ * Resolve `treatment.category` from a structured `categoryId` so document
+ * templates using {{treatment.category}} render the linked category name.
+ * Falls back to the legacy free-text `category` field already present on the
+ * flattened entity when no `categoryId` is set (see #471, #495).
+ */
+async function resolveTreatmentCategory(
+  ctx: QueryCtx,
+  treatmentScope: Record<string, unknown>,
+  categoryId: Id<"categoryDefinitions"> | undefined,
+): Promise<void> {
+  if (!categoryId) return;
+  const category = await ctx.db.get(categoryId);
+  if (category && !category.isDeleted) {
+    treatmentScope.category = category.name;
+  }
 }
 
 async function fetchContact(

--- a/convex/documents/scopeResolver_supabase.ts
+++ b/convex/documents/scopeResolver_supabase.ts
@@ -72,7 +72,10 @@ async function fetchAppointmentScope(
 
   if (appointment.treatmentId) {
     const treatment = await db.get("gabinetTreatments", String(appointment.treatmentId));
-    if (treatment) scope.treatment = flattenEntity(treatment);
+    if (treatment) {
+      scope.treatment = flattenEntity(treatment);
+      await resolveTreatmentCategoryName(db, scope.treatment, treatment.categoryId);
+    }
   }
 
   if (appointment.employeeId) {
@@ -119,7 +122,27 @@ async function fetchTreatmentScope(
 ): Promise<ScopeData> {
   const treatment = await db.get("gabinetTreatments", treatmentId);
   if (!treatment || String(treatment.organizationId) !== orgId) return {};
-  return { treatment: flattenEntity(treatment) };
+  const treatmentScope = flattenEntity(treatment);
+  await resolveTreatmentCategoryName(db, treatmentScope, treatment.categoryId);
+  return { treatment: treatmentScope };
+}
+
+/**
+ * Resolve `treatment.category` from a structured `categoryId` so document
+ * templates using {{treatment.category}} render the linked category name.
+ * Falls back to the legacy free-text `category` field already present on the
+ * flattened entity when no `categoryId` is set (see #471, #495).
+ */
+async function resolveTreatmentCategoryName(
+  db: SupabaseDb,
+  treatmentScope: Record<string, unknown>,
+  categoryId: unknown,
+): Promise<void> {
+  if (!categoryId) return;
+  const category = await db.get("categoryDefinitions", String(categoryId));
+  if (category && !category.isDeleted) {
+    treatmentScope.category = category.name;
+  }
 }
 
 async function fetchContactScope(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #495.

Closes #495

---

## Claude summary

Fix committed. Summary:

Both document scope resolvers (`convex/documents/scopeResolver.ts` and `convex/documents/scopeResolver_supabase.ts`) flattened the treatment row and exposed only the legacy free-text `category` column for the `{{treatment.category}}` template variable. After PR #471 stopped writing that column, new treatments only carry `categoryId`, leaving the variable blank.

The fix adds a small `resolveTreatmentCategory` / `resolveTreatmentCategoryName` helper in each resolver that looks up `categoryDefinitions` by `categoryId` and overrides `treatment.category` with the linked name (mirroring the pattern already in `convex/gabinet/patientPortal.ts:209-230` from #494). The legacy free-text value still flows through `flattenEntity` for older records that have no `categoryId`. The `src/lib/document-variables.ts:80` reference is just the UI variable registry — no change needed there since the variable name stays the same.