### PR TITLE
Build Supabase test infrastructure for convex-test suites

### DIFF
--- a/convex/vitest.config.ts
+++ b/convex/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   },
   test: {
     include: ["**/*.test.ts", "../tests/convex/**/*.test.ts"],
+    setupFiles: ["../tests/convex/_setup.ts"],
     server: { deps: { inline: ["convex-test"] } },
   },
 });

--- a/tests/convex/_setup.ts
+++ b/tests/convex/_setup.ts
@@ -1,0 +1,29 @@
+/**
+ * Vitest global setup for Convex test suites.
+ *
+ * Hoists vi.mock() calls that swap the two Supabase entry points used by
+ * Convex code with in-memory stand-ins. See _supabase_inmemory.ts for the
+ * implementation. Registered via `setupFiles` in convex/vitest.config.ts.
+ */
+
+import { beforeEach, vi } from "vitest";
+
+vi.mock("@cvx/_helpers/supabaseDb", async () => {
+  const { createInMemorySupabaseDb } = await import("./_supabase_inmemory");
+  return { createSupabaseDb: createInMemorySupabaseDb };
+});
+
+vi.mock("@cvx/supabase/client", async () => {
+  const { createStubServiceRoleClient, stubUpsertWithFkRetry } = await import(
+    "./_supabase_inmemory"
+  );
+  return {
+    createServiceRoleClient: createStubServiceRoleClient,
+    upsertWithFkRetry: stubUpsertWithFkRetry,
+  };
+});
+
+beforeEach(async () => {
+  const { resetInMemoryStore } = await import("./_supabase_inmemory");
+  resetInMemoryStore();
+});

--- a/tests/convex/_supabase_inmemory.ts
+++ b/tests/convex/_supabase_inmemory.ts
@@ -1,0 +1,275 @@
+/**
+ * In-memory mock for `@cvx/_helpers/supabaseDb` and `@cvx/supabase/client`.
+ *
+ * Many Convex actions (payments, gabinet/appointments, gabinet/patients,
+ * documents, etc.) read/write through `createSupabaseDb()` instead of
+ * `ctx.db`. Internal dual-write actions in `convex/supabase/*` use the
+ * raw `createServiceRoleClient()` / `upsertWithFkRetry()` helpers. Both
+ * throw "SUPABASE_URL not configured" under vitest.
+ *
+ * This module provides:
+ *   - createInMemorySupabaseDb() — same API as createSupabaseDb()
+ *   - createStubServiceRoleClient() — a tiny no-op stand-in for the raw client
+ *   - stubUpsertWithFkRetry() — best-effort upsert that just echoes the id
+ *   - resetInMemoryStore() — clears all tables (called in beforeEach)
+ *
+ * Wired up globally via `tests/convex/_setup.ts` (vitest setupFile).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+type Row = Record<string, unknown> & { id?: string };
+
+const inMemoryStore = new Map<string, Map<string, Row>>();
+
+function getTable(name: string): Map<string, Row> {
+  let t = inMemoryStore.get(name);
+  if (!t) {
+    t = new Map();
+    inMemoryStore.set(name, t);
+  }
+  return t;
+}
+
+export function resetInMemoryStore() {
+  inMemoryStore.clear();
+}
+
+function withConvexId<T extends Row>(row: T): T {
+  if (!("_id" in row) && row.id !== undefined) {
+    return { ...row, _id: row.id } as T;
+  }
+  return row;
+}
+
+function randomId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `mem_${Math.random().toString(36).slice(2)}_${Date.now()}`;
+}
+
+export function createInMemorySupabaseDb() {
+  return {
+    async get<T = Record<string, unknown>>(
+      table: string,
+      id: string,
+    ): Promise<T | null> {
+      const row = getTable(table).get(id);
+      return row ? (withConvexId({ ...row }) as T) : null;
+    },
+
+    async getMany<T = Record<string, unknown>>(
+      table: string,
+      ids: string[],
+    ): Promise<T[]> {
+      if (ids.length === 0) return [];
+      const t = getTable(table);
+      const out: T[] = [];
+      for (const id of ids) {
+        const row = t.get(id);
+        if (row) out.push(withConvexId({ ...row }) as T);
+      }
+      return out;
+    },
+
+    async insert(
+      table: string,
+      row: Record<string, unknown>,
+    ): Promise<string> {
+      const id = row._id
+        ? String(row._id)
+        : row.id
+          ? String(row.id)
+          : randomId();
+      const stored: Row = { ...row, id };
+      delete (stored as any)._id;
+      getTable(table).set(id, stored);
+      return id;
+    },
+
+    async patch(
+      table: string,
+      id: string,
+      updates: Record<string, unknown>,
+    ): Promise<void> {
+      const t = getTable(table);
+      const existing = t.get(id);
+      if (!existing) {
+        throw new Error(
+          `supabaseDb(inmemory).patch(${table}, ${id}): row not found`,
+        );
+      }
+      const next: Row = { ...existing, ...updates, id };
+      delete (next as any)._id;
+      t.set(id, next);
+    },
+
+    async delete(table: string, id: string): Promise<void> {
+      getTable(table).delete(id);
+    },
+
+    query<T = Record<string, unknown>>(table: string) {
+      return new InMemoryQueryBuilder<T>(table);
+    },
+
+    raw() {
+      throw new Error(
+        "supabaseDb(inmemory).raw(): raw client access is not available under vitest",
+      );
+    },
+  };
+}
+
+class InMemoryQueryBuilder<T = Record<string, unknown>> {
+  private table: string;
+  private filters: Array<(row: Row) => boolean> = [];
+  private orderField: string | null = null;
+  private orderAsc = true;
+  private limitN: number | null = null;
+
+  constructor(table: string) {
+    this.table = table;
+  }
+
+  eq(field: string, value: unknown) {
+    this.filters.push((r) => r[field] === value);
+    return this;
+  }
+
+  neq(field: string, value: unknown) {
+    this.filters.push((r) => r[field] !== value);
+    return this;
+  }
+
+  gt(field: string, value: unknown) {
+    this.filters.push((r) => (r[field] as any) > (value as any));
+    return this;
+  }
+
+  gte(field: string, value: unknown) {
+    this.filters.push((r) => (r[field] as any) >= (value as any));
+    return this;
+  }
+
+  lt(field: string, value: unknown) {
+    this.filters.push((r) => (r[field] as any) < (value as any));
+    return this;
+  }
+
+  lte(field: string, value: unknown) {
+    this.filters.push((r) => (r[field] as any) <= (value as any));
+    return this;
+  }
+
+  order(field: string, ascending = true) {
+    this.orderField = field;
+    this.orderAsc = ascending;
+    return this;
+  }
+
+  take(n: number) {
+    this.limitN = n;
+    return this;
+  }
+
+  private materialize(): T[] {
+    let rows = Array.from(getTable(this.table).values());
+    for (const f of this.filters) rows = rows.filter(f);
+    if (this.orderField) {
+      const field = this.orderField;
+      const dir = this.orderAsc ? 1 : -1;
+      rows = rows.slice().sort((a, b) => {
+        const va = a[field] as any;
+        const vb = b[field] as any;
+        if (va === vb) return 0;
+        if (va == null) return 1;
+        if (vb == null) return -1;
+        if (va < vb) return -1 * dir;
+        if (va > vb) return 1 * dir;
+        return 0;
+      });
+    }
+    if (this.limitN !== null) rows = rows.slice(0, this.limitN);
+    return rows.map((r) => withConvexId({ ...r })) as T[];
+  }
+
+  async collect(): Promise<T[]> {
+    return this.materialize();
+  }
+
+  async first(): Promise<T | null> {
+    const rows = this.materialize();
+    return rows.length > 0 ? rows[0] : null;
+  }
+
+  async unique(): Promise<T | null> {
+    return this.first();
+  }
+}
+
+/**
+ * Stub for `createServiceRoleClient()` from `@cvx/supabase/client`.
+ *
+ * Used by internal dual-write actions in convex/supabase/*. These are
+ * best-effort (errors are logged but never break the flow). The stub
+ * returns a chainable query builder whose terminal calls resolve to
+ * `{ data: null, error: null }` so the actions complete silently.
+ */
+export function createStubServiceRoleClient() {
+  return {
+    from(_table: string) {
+      return new StubTableQuery();
+    },
+  };
+}
+
+class StubTableQuery {
+  select(_cols?: string) {
+    return this;
+  }
+  insert(_row: any) {
+    return this;
+  }
+  upsert(_row: any, _opts?: any) {
+    return this;
+  }
+  update(_row: any) {
+    return this;
+  }
+  delete() {
+    return this;
+  }
+  eq(_field: string, _value: unknown) {
+    return this;
+  }
+  in(_field: string, _values: unknown[]) {
+    return this;
+  }
+  order(_field: string, _opts?: any) {
+    return this;
+  }
+  limit(_n: number) {
+    return this;
+  }
+  async single() {
+    return { data: null, error: null };
+  }
+  async maybeSingle() {
+    return { data: null, error: null };
+  }
+  then(onfulfilled?: any, onrejected?: any) {
+    return Promise.resolve({ data: [], error: null }).then(
+      onfulfilled,
+      onrejected,
+    );
+  }
+}
+
+export async function stubUpsertWithFkRetry(
+  _client: unknown,
+  _table: string,
+  row: Record<string, unknown>,
+): Promise<{ id: string }> {
+  return { id: row.id ? String(row.id) : randomId() };
+}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #498.

Closes #498

---

## Claude summary

Committed. Here's a summary of what was built.

The Supabase test infrastructure now exists as three pieces:

`tests/convex/_supabase_inmemory.ts` — an in-memory implementation that mirrors the `createSupabaseDb()` API (get/getMany/insert/patch/delete + query builder with eq/neq/gt/gte/lt/lte/order/take/collect/first/unique) backed by a module-level `Map<table, Map<id, row>>`. Also exports `createStubServiceRoleClient()` and `stubUpsertWithFkRetry()` for the lower-level raw client used by the convex/supabase/* dual-write actions.

`tests/convex/_setup.ts` — hoists `vi.mock()` calls for `@cvx/_helpers/supabaseDb` and `@cvx/supabase/client` and clears the in-memory store in `beforeEach`.

`convex/vitest.config.ts` — adds `setupFiles: ["../tests/convex/_setup.ts"]` so every suite gets it automatically.

Results: payments.test.ts goes from 8/8 failing to 8/8 passing. Every "SUPABASE_URL not configured" error is gone from the suite (verified by grep: 0 occurrences). Overall suite count: 77 → 69 failing tests, with the remaining failures coming from unrelated pre-existing issues.

## Follow-ups
- Fix "Write outside of transaction _scheduled_functions" in convex-test: many tests trigger scheduler.runAfter calls that leak past the transaction window — visible in activityEnvelope, emailActivities, emailEventTrigger, appointmentSms, payments unhandled rejections
- Fix `~/errors` resolution in convex/email/index.ts under vitest: seatLimits.test.ts fails because invitations.create chain pulls in invitationEmail.tsx which imports `~/errors` and vitest can't resolve it (works in Convex deploy because of bundler aliasing)
- Convert `organizations.removeMember` back to a mutation or update seatLimits.test.ts: test calls it as `t.mutation` but the function is now an action, breaking the "removing a member decreases seat count" assertion
- Fix patientAuth.test.ts wholesale: all 15 tests fail with the same setup error — likely a dependency on internal scheduler or auth wiring not yet covered by the new mock
- Re-evaluate need for docker-compose.test.yml: the docker-compose.test.yml + supabase/migrations approach is no longer needed for unit tests now that the in-memory mock works; either delete or repurpose for integration tests