### PR TITLE
Align remaining test files with action-based appointments API

### DIFF
--- a/tests/convex/appointmentStateMachine.test.ts
+++ b/tests/convex/appointmentStateMachine.test.ts
@@ -45,7 +45,7 @@ async function createAppointment(
     endTime?: string;
   },
 ) {
-  return t.withIdentity(identity).mutation(api.gabinet.appointments.create, {
+  return t.withIdentity(identity).action(api.gabinet.appointments.create, {
     organizationId: args.organizationId,
     patientId: args.patientId,
     treatmentId: args.treatmentId,
@@ -82,7 +82,7 @@ describe("appointment state machine", () => {
       organizationId, patientId, treatmentId, employeeId: userId,
     });
 
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId,
       appointmentId: apptId,
       status: "confirmed",
@@ -108,7 +108,7 @@ describe("appointment state machine", () => {
       });
     });
 
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId,
       appointmentId: apptId,
       status: "confirmed",
@@ -127,10 +127,10 @@ describe("appointment state machine", () => {
       organizationId, patientId, treatmentId, employeeId: userId,
     });
 
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId, appointmentId: apptId, status: "confirmed",
     });
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId, appointmentId: apptId, status: "in_progress",
     });
 
@@ -147,13 +147,13 @@ describe("appointment state machine", () => {
       organizationId, patientId, treatmentId, employeeId: userId,
     });
 
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId, appointmentId: apptId, status: "confirmed",
     });
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId, appointmentId: apptId, status: "in_progress",
     });
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId, appointmentId: apptId, status: "completed",
     });
 
@@ -170,7 +170,7 @@ describe("appointment state machine", () => {
       organizationId, patientId, treatmentId, employeeId: userId,
     });
 
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId, appointmentId: apptId, status: "cancelled",
     });
 
@@ -187,7 +187,7 @@ describe("appointment state machine", () => {
       organizationId, patientId, treatmentId, employeeId: userId,
     });
 
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId, appointmentId: apptId, status: "no_show",
     });
 
@@ -206,7 +206,7 @@ describe("appointment state machine", () => {
     });
 
     await expect(
-      t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+      t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
         organizationId, appointmentId: apptId, status: "completed",
       }),
     ).rejects.toThrow("Cannot transition from scheduled to completed");
@@ -222,7 +222,7 @@ describe("appointment state machine", () => {
     });
 
     await expect(
-      t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+      t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
         organizationId, appointmentId: apptId, status: "in_progress",
       }),
     ).rejects.toThrow("Cannot transition from scheduled to in_progress");
@@ -238,19 +238,19 @@ describe("appointment state machine", () => {
     });
 
     // Go through full lifecycle
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId, appointmentId: apptId, status: "confirmed",
     });
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId, appointmentId: apptId, status: "in_progress",
     });
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId, appointmentId: apptId, status: "completed",
     });
 
     // Try any further transition — should fail
     await expect(
-      t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+      t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
         organizationId, appointmentId: apptId, status: "cancelled",
       }),
     ).rejects.toThrow("Cannot transition from completed to cancelled");
@@ -265,12 +265,12 @@ describe("appointment state machine", () => {
       organizationId, patientId, treatmentId, employeeId: userId,
     });
 
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId, appointmentId: apptId, status: "cancelled",
     });
 
     await expect(
-      t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+      t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
         organizationId, appointmentId: apptId, status: "scheduled",
       }),
     ).rejects.toThrow("Cannot transition from cancelled to scheduled");
@@ -307,13 +307,13 @@ describe("appointment state machine", () => {
       organizationId, patientId, treatmentId, employeeId: userId,
     });
 
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId, appointmentId: apptId, status: "confirmed",
     });
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId, appointmentId: apptId, status: "in_progress",
     });
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.updateStatus, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
       organizationId, appointmentId: apptId, status: "completed",
     });
 

--- a/tests/convex/automation.test.ts
+++ b/tests/convex/automation.test.ts
@@ -104,7 +104,7 @@ async function createAppointment(
     endTime?: string;
   },
 ) {
-  return t.withIdentity(identity).mutation(api.gabinet.appointments.create, {
+  return t.withIdentity(identity).action(api.gabinet.appointments.create, {
     organizationId: args.organizationId,
     patientId: args.patientId,
     treatmentId: args.treatmentId,
@@ -120,7 +120,7 @@ describe("automation lifecycle", () => {
     const t = createManagedTestCtx();
     const { organizationId, userId, identity } = await seedTestUser(t);
 
-    const ruleId = await t.withIdentity(identity).mutation(api.automation.createRule, {
+    const ruleId = await t.withIdentity(identity).action(api.automation.createRule, {
       organizationId,
       name: "Appointment SMS",
       description: "Send patient SMS after appointment creation",
@@ -163,7 +163,7 @@ describe("automation lifecycle", () => {
     const t = createManagedTestCtx();
     const { organizationId, identity } = await seedTestUser(t);
 
-    const ruleId = await t.withIdentity(identity).mutation(api.automation.createRule, {
+    const ruleId = await t.withIdentity(identity).action(api.automation.createRule, {
       organizationId,
       name: "Initial rule",
       description: "Before update",
@@ -182,7 +182,7 @@ describe("automation lifecycle", () => {
       enabled: true,
     });
 
-    await t.withIdentity(identity).mutation(api.automation.updateRule, {
+    await t.withIdentity(identity).action(api.automation.updateRule, {
       organizationId,
       ruleId,
       name: "Updated rule",
@@ -223,7 +223,7 @@ describe("automation lifecycle", () => {
     const secondUser = await seedSecondUser(t, firstUser.organizationId);
     const otherOrg = await seedTestUser(t);
 
-    const keepRuleId = await t.withIdentity(firstUser.identity).mutation(api.automation.createRule, {
+    const keepRuleId = await t.withIdentity(firstUser.identity).action(api.automation.createRule, {
       organizationId: firstUser.organizationId,
       name: "Keep me",
       module: "gabinet",
@@ -241,7 +241,7 @@ describe("automation lifecycle", () => {
       enabled: true,
     });
 
-    const deleteRuleId = await t.withIdentity(secondUser.identity).mutation(api.automation.createRule, {
+    const deleteRuleId = await t.withIdentity(secondUser.identity).action(api.automation.createRule, {
       organizationId: firstUser.organizationId,
       name: "Delete me",
       module: "gabinet",
@@ -258,7 +258,7 @@ describe("automation lifecycle", () => {
       enabled: true,
     });
 
-    const otherOrgRuleId = await t.withIdentity(otherOrg.identity).mutation(api.automation.createRule, {
+    const otherOrgRuleId = await t.withIdentity(otherOrg.identity).action(api.automation.createRule, {
       organizationId: otherOrg.organizationId,
       name: "Other org",
       module: "gabinet",
@@ -276,13 +276,13 @@ describe("automation lifecycle", () => {
     });
 
     await expect(
-      t.withIdentity(firstUser.identity).mutation(api.automation.deleteRule, {
+      t.withIdentity(firstUser.identity).action(api.automation.deleteRule, {
         organizationId: firstUser.organizationId,
         ruleId: otherOrgRuleId,
       }),
     ).rejects.toThrow("Automation rule not found");
 
-    await t.withIdentity(firstUser.identity).mutation(api.automation.deleteRule, {
+    await t.withIdentity(firstUser.identity).action(api.automation.deleteRule, {
       organizationId: firstUser.organizationId,
       ruleId: deleteRuleId,
     });
@@ -305,7 +305,7 @@ describe("automation lifecycle", () => {
       userId,
     );
 
-    await t.withIdentity(identity).mutation(api.automation.createRule, {
+    await t.withIdentity(identity).action(api.automation.createRule, {
       organizationId,
       name: "Notify employee",
       module: "gabinet",
@@ -371,7 +371,7 @@ describe("automation lifecycle", () => {
     const t = createManagedTestCtx();
     const { organizationId, userId, identity } = await seedTestUser(t);
 
-    await t.withIdentity(identity).mutation(api.automation.createRule, {
+    await t.withIdentity(identity).action(api.automation.createRule, {
       organizationId,
       name: "Notify patient creator",
       module: "gabinet",
@@ -390,7 +390,7 @@ describe("automation lifecycle", () => {
       enabled: true,
     });
 
-    const patientId = await t.withIdentity(identity).mutation(api.gabinet.patients.create, {
+    const patientId = await t.withIdentity(identity).action(api.gabinet.patients.create, {
       organizationId,
       firstName: "Anna",
       lastName: "Nowak",
@@ -446,7 +446,7 @@ describe("automation lifecycle", () => {
 
     await setPatientPhone(t, patientId, "500600700");
 
-    await t.withIdentity(identity).mutation(api.automation.createRule, {
+    await t.withIdentity(identity).action(api.automation.createRule, {
       organizationId,
       name: "Send patient SMS",
       module: "gabinet",
@@ -672,7 +672,7 @@ describe("automation lifecycle", () => {
     const t = createManagedTestCtx();
     const { organizationId, identity } = await seedTestUser(t);
 
-    await t.withIdentity(identity).mutation(api.automation.createRule, {
+    await t.withIdentity(identity).action(api.automation.createRule, {
       organizationId,
       name: "Graph rule",
       module: "gabinet",
@@ -716,7 +716,7 @@ describe("automation lifecycle", () => {
       enabled: true,
     });
 
-    await t.withIdentity(identity).mutation(api.automation.createRule, {
+    await t.withIdentity(identity).action(api.automation.createRule, {
       organizationId,
       name: "Legacy triggerless rule",
       module: "gabinet",
@@ -772,7 +772,7 @@ describe("automation lifecycle", () => {
       });
     });
 
-    await t.withIdentity(identity).mutation(api.automation.createRule, {
+    await t.withIdentity(identity).action(api.automation.createRule, {
       organizationId,
       name: "Send manual email",
       module: "gabinet",
@@ -873,7 +873,7 @@ describe("automation lifecycle", () => {
       });
     });
 
-    await t.withIdentity(identity).mutation(api.automation.createRule, {
+    await t.withIdentity(identity).action(api.automation.createRule, {
       organizationId,
       name: "Send template email",
       module: "gabinet",
@@ -947,7 +947,7 @@ describe("automation lifecycle", () => {
       userId,
     );
 
-    await t.withIdentity(identity).mutation(api.automation.createRule, {
+    await t.withIdentity(identity).action(api.automation.createRule, {
       organizationId,
       name: "Tag patient from automation",
       module: "gabinet",
@@ -1008,13 +1008,13 @@ describe("automation lifecycle", () => {
     const t = createManagedTestCtx();
     const { organizationId, identity } = await seedTestUser(t);
 
-    const leadId = await t.withIdentity(identity).mutation(api.leads.create, {
+    const leadId = await t.withIdentity(identity).action(api.leads.create, {
       organizationId,
       title: "Automation Lead",
       status: "open",
     });
 
-    await t.withIdentity(identity).mutation(api.automation.createRule, {
+    await t.withIdentity(identity).action(api.automation.createRule, {
       organizationId,
       name: "Annotate lead status changes",
       module: "crm",
@@ -1034,7 +1034,7 @@ describe("automation lifecycle", () => {
       enabled: true,
     });
 
-    await t.withIdentity(identity).mutation(api.leads.update, {
+    await t.withIdentity(identity).action(api.leads.update, {
       organizationId,
       leadId,
       status: "won",
@@ -1072,13 +1072,13 @@ describe("automation lifecycle", () => {
     const t = createManagedTestCtx();
     const { organizationId, identity } = await seedTestUser(t);
 
-    const leadId = await t.withIdentity(identity).mutation(api.leads.create, {
+    const leadId = await t.withIdentity(identity).action(api.leads.create, {
       organizationId,
       title: "Unsupported lead update",
       status: "open",
     });
 
-    await t.withIdentity(identity).mutation(api.automation.createRule, {
+    await t.withIdentity(identity).action(api.automation.createRule, {
       organizationId,
       name: "Attempt custom lead field update",
       module: "crm",
@@ -1098,7 +1098,7 @@ describe("automation lifecycle", () => {
       enabled: true,
     });
 
-    await t.withIdentity(identity).mutation(api.leads.update, {
+    await t.withIdentity(identity).action(api.leads.update, {
       organizationId,
       leadId,
       status: "lost",
@@ -1137,14 +1137,14 @@ describe("automation lifecycle", () => {
 
     await setMemberLeadEditScope(t, admin.identity, admin.organizationId, "none");
 
-    const leadId = await t.withIdentity(admin.identity).mutation(api.leads.create, {
+    const leadId = await t.withIdentity(admin.identity).action(api.leads.create, {
       organizationId: admin.organizationId,
       title: "RBAC deny lead",
       status: "open",
       assignedTo: member.userId,
     });
 
-    await t.withIdentity(admin.identity).mutation(api.automation.createRule, {
+    await t.withIdentity(admin.identity).action(api.automation.createRule, {
       organizationId: admin.organizationId,
       name: "Member tries lead update without edit permission",
       module: "crm",
@@ -1205,13 +1205,13 @@ describe("automation lifecycle", () => {
 
     await setMemberLeadEditScope(t, admin.identity, admin.organizationId, "own");
 
-    const leadId = await t.withIdentity(admin.identity).mutation(api.leads.create, {
+    const leadId = await t.withIdentity(admin.identity).action(api.leads.create, {
       organizationId: admin.organizationId,
       title: "RBAC own-scope lead",
       status: "open",
     });
 
-    await t.withIdentity(admin.identity).mutation(api.automation.createRule, {
+    await t.withIdentity(admin.identity).action(api.automation.createRule, {
       organizationId: admin.organizationId,
       name: "Member own-scope check",
       module: "crm",
@@ -1272,13 +1272,13 @@ describe("automation lifecycle", () => {
 
     await setMemberLeadEditScope(t, admin.identity, admin.organizationId, "all");
 
-    const leadId = await t.withIdentity(admin.identity).mutation(api.leads.create, {
+    const leadId = await t.withIdentity(admin.identity).action(api.leads.create, {
       organizationId: admin.organizationId,
       title: "RBAC allow lead",
       status: "open",
     });
 
-    await t.withIdentity(admin.identity).mutation(api.automation.createRule, {
+    await t.withIdentity(admin.identity).action(api.automation.createRule, {
       organizationId: admin.organizationId,
       name: "Member can update lead with all scope",
       module: "crm",
@@ -1345,7 +1345,7 @@ describe("automation lifecycle", () => {
 
     await setPatientPhone(t, patientId, "500600700");
 
-    await t.withIdentity(identity).mutation(api.automation.createRule, {
+    await t.withIdentity(identity).action(api.automation.createRule, {
       organizationId,
       name: "Send request SMS",
       module: "gabinet",

--- a/tests/convex/conflictChecking.test.ts
+++ b/tests/convex/conflictChecking.test.ts
@@ -9,7 +9,7 @@ describe("conflict checking", () => {
     const { patientId, treatmentId } = await seedGabinetPrereqs(t, organizationId, userId);
 
     // Create first appointment 09:00-09:30
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.create, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.create, {
       organizationId,
       patientId,
       treatmentId,
@@ -21,7 +21,7 @@ describe("conflict checking", () => {
 
     // Try to create overlapping appointment for same employee
     await expect(
-      t.withIdentity(identity).mutation(api.gabinet.appointments.create, {
+      t.withIdentity(identity).action(api.gabinet.appointments.create, {
         organizationId,
         patientId,
         treatmentId,
@@ -39,7 +39,7 @@ describe("conflict checking", () => {
     const { patientId, treatmentId } = await seedGabinetPrereqs(t, organizationId, userId);
 
     // 09:00-09:30
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.create, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.create, {
       organizationId,
       patientId,
       treatmentId,
@@ -50,7 +50,7 @@ describe("conflict checking", () => {
     });
 
     // 09:30-10:00 — immediately after, should be fine
-    const apptId = await t.withIdentity(identity).mutation(
+    const apptId = await t.withIdentity(identity).action(
       api.gabinet.appointments.create,
       {
         organizationId,
@@ -100,7 +100,7 @@ describe("conflict checking", () => {
     });
 
     // Employee 1: 09:00-09:30
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.create, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.create, {
       organizationId,
       patientId,
       treatmentId,
@@ -111,7 +111,7 @@ describe("conflict checking", () => {
     });
 
     // Employee 2: same time, should be allowed
-    const apptId = await t.withIdentity(identity).mutation(
+    const apptId = await t.withIdentity(identity).action(
       api.gabinet.appointments.create,
       {
         organizationId,
@@ -133,7 +133,7 @@ describe("conflict checking", () => {
     const { patientId, treatmentId } = await seedGabinetPrereqs(t, organizationId, userId);
 
     // Day 1
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.create, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.create, {
       organizationId,
       patientId,
       treatmentId,
@@ -144,7 +144,7 @@ describe("conflict checking", () => {
     });
 
     // Day 2 — same time, different date
-    const apptId = await t.withIdentity(identity).mutation(
+    const apptId = await t.withIdentity(identity).action(
       api.gabinet.appointments.create,
       {
         organizationId,
@@ -166,7 +166,7 @@ describe("conflict checking", () => {
     const { patientId, treatmentId } = await seedGabinetPrereqs(t, organizationId, userId);
 
     // Create and cancel appointment
-    const apptId = await t.withIdentity(identity).mutation(
+    const apptId = await t.withIdentity(identity).action(
       api.gabinet.appointments.create,
       {
         organizationId,
@@ -179,13 +179,13 @@ describe("conflict checking", () => {
       },
     );
 
-    await t.withIdentity(identity).mutation(api.gabinet.appointments.cancel, {
+    await t.withIdentity(identity).action(api.gabinet.appointments.cancel, {
       organizationId,
       appointmentId: apptId,
     });
 
     // Same slot should now be available
-    const newApptId = await t.withIdentity(identity).mutation(
+    const newApptId = await t.withIdentity(identity).action(
       api.gabinet.appointments.create,
       {
         organizationId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #499.

Closes #499

---

## Claude summary

Committed. Summary:

Aligned three test suites with the action-based gabinet/automation/leads APIs by switching `t.mutation(...)` to `t.action(...)` for calls that now target actions:
- `tests/convex/appointmentStateMachine.test.ts` — `appointments.create`, `appointments.updateStatus`
- `tests/convex/conflictChecking.test.ts` — `appointments.create`, `appointments.cancel`
- `tests/convex/automation.test.ts` — `appointments.create`, `patients.create`, `automation.{createRule,updateRule,deleteRule}`, `leads.{create,update}`

Kept `permissions.updateOrgPermissions` and `internal.automation.emitEvent` on `.mutation` since they really are (internal)mutations.

After the fix, vitest no longer surfaces "Expected a mutation function" — the suites now fail uniformly on the unrelated "Clinic is closed on this day" / Supabase-mock gap, which is the broader infrastructure item already tracked separately (and matches the disposition used in PRs #497 / #485).