### PR TITLE
Add range/offset support to `SupabaseQueryBuilder`

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -190,6 +190,8 @@ class SupabaseQueryBuilder<T = Record<string, unknown>> {
   private orderField: string | null = null;
   private orderAsc = true;
   private limitN: number | null = null;
+  private rangeFrom: number | null = null;
+  private rangeTo: number | null = null;
 
   constructor(client: ReturnType<typeof createServiceRoleClient>, table: string) {
     this.client = client;
@@ -237,11 +239,43 @@ class SupabaseQueryBuilder<T = Record<string, unknown>> {
     return this;
   }
 
+  /**
+   * Inclusive range for offset-based pagination. Mirrors PostgREST's
+   * `.range(from, to)` semantics: both endpoints are inclusive, so
+   * `range(0, 9)` returns up to 10 rows starting at offset 0.
+   */
+  range(from: number, to: number) {
+    this.rangeFrom = from;
+    this.rangeTo = to;
+    return this;
+  }
+
+  /**
+   * Skip the first `n` rows. Combine with `.take(limit)` for paged reads.
+   * Implemented on top of `range`; cannot be combined with an explicit
+   * `.range()` call.
+   */
+  offset(n: number) {
+    this.rangeFrom = n;
+    return this;
+  }
+
   async collect(): Promise<T[]> {
     let q = this.client.from(this.table).select("*");
     for (const f of this.filters) q = f(q);
     if (this.orderField) q = q.order(this.orderField, { ascending: this.orderAsc });
-    if (this.limitN) q = q.limit(this.limitN);
+    if (this.rangeFrom !== null) {
+      const from = this.rangeFrom;
+      const to =
+        this.rangeTo !== null
+          ? this.rangeTo
+          : this.limitN !== null
+            ? from + this.limitN - 1
+            : from + 999;
+      q = q.range(from, to);
+    } else if (this.limitN) {
+      q = q.limit(this.limitN);
+    }
     const { data, error } = await q;
     if (error) throw new Error(`supabaseDb.query(${this.table}).collect(): ${error.message}`);
     return (data ?? []).map(mapRowFromSnake) as T[];

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -31,17 +31,32 @@ export const list = action({
       organizationId: args.organizationId,
     });
 
+    const { numItems, cursor } = args.paginationOpts;
+    const offset = cursor ? Number(cursor) : 0;
+    if (!Number.isFinite(offset) || offset < 0) {
+      throw new Error("Invalid pagination cursor");
+    }
+
     const db = createSupabaseDb();
     let q = db
       .query("payments")
       .eq("organizationId", String(args.organizationId));
     if (args.status) q = q.eq("status", args.status);
+
+    // Fetch numItems + 1 to detect whether more rows remain.
     const rows = await q
       .order("createdAt", false)
-      .take(args.paginationOpts.numItems)
+      .range(offset, offset + numItems)
       .collect();
 
-    return { page: rows, isDone: true, continueCursor: "" };
+    const hasMore = rows.length > numItems;
+    const page = hasMore ? rows.slice(0, numItems) : rows;
+
+    return {
+      page,
+      isDone: !hasMore,
+      continueCursor: hasMore ? String(offset + numItems) : "",
+    };
   },
 });
 

--- a/tests/convex/_supabase_inmemory.ts
+++ b/tests/convex/_supabase_inmemory.ts
@@ -127,6 +127,8 @@ class InMemoryQueryBuilder<T = Record<string, unknown>> {
   private orderField: string | null = null;
   private orderAsc = true;
   private limitN: number | null = null;
+  private rangeFrom: number | null = null;
+  private rangeTo: number | null = null;
 
   constructor(table: string) {
     this.table = table;
@@ -173,6 +175,17 @@ class InMemoryQueryBuilder<T = Record<string, unknown>> {
     return this;
   }
 
+  range(from: number, to: number) {
+    this.rangeFrom = from;
+    this.rangeTo = to;
+    return this;
+  }
+
+  offset(n: number) {
+    this.rangeFrom = n;
+    return this;
+  }
+
   private materialize(): T[] {
     let rows = Array.from(getTable(this.table).values());
     for (const f of this.filters) rows = rows.filter(f);
@@ -190,7 +203,18 @@ class InMemoryQueryBuilder<T = Record<string, unknown>> {
         return 0;
       });
     }
-    if (this.limitN !== null) rows = rows.slice(0, this.limitN);
+    if (this.rangeFrom !== null) {
+      const from = this.rangeFrom;
+      const to =
+        this.rangeTo !== null
+          ? this.rangeTo
+          : this.limitN !== null
+            ? from + this.limitN - 1
+            : rows.length - 1;
+      rows = rows.slice(from, to + 1);
+    } else if (this.limitN !== null) {
+      rows = rows.slice(0, this.limitN);
+    }
     return rows.map((r) => withConvexId({ ...r })) as T[];
   }
 

--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -204,6 +204,54 @@ describe("payments", () => {
     expect(summary.byMethod.cash.total).toBe(350);
   });
 
+  test("list paginates results via cursor (offset)", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    // Create 5 payments
+    for (let i = 0; i < 5; i++) {
+      await t.withIdentity(identity).action(api.payments.create, {
+        organizationId,
+        amount: 10 + i,
+        currency: "USD",
+        paymentMethod: "cash",
+      });
+    }
+
+    // First page: 2 items, more remaining
+    const page1 = await t.withIdentity(identity).action(api.payments.list, {
+      organizationId,
+      paginationOpts: { numItems: 2, cursor: null },
+    });
+    expect(page1.page).toHaveLength(2);
+    expect(page1.isDone).toBe(false);
+    expect(page1.continueCursor).toBe("2");
+
+    // Second page using returned cursor
+    const page2 = await t.withIdentity(identity).action(api.payments.list, {
+      organizationId,
+      paginationOpts: { numItems: 2, cursor: page1.continueCursor },
+    });
+    expect(page2.page).toHaveLength(2);
+    expect(page2.isDone).toBe(false);
+    expect(page2.continueCursor).toBe("4");
+
+    // Third (last) page: only one row left
+    const page3 = await t.withIdentity(identity).action(api.payments.list, {
+      organizationId,
+      paginationOpts: { numItems: 2, cursor: page2.continueCursor },
+    });
+    expect(page3.page).toHaveLength(1);
+    expect(page3.isDone).toBe(true);
+    expect(page3.continueCursor).toBe("");
+
+    // No overlap between pages
+    const allIds = [...page1.page, ...page2.page, ...page3.page].map(
+      (p: any) => p._id,
+    );
+    expect(new Set(allIds).size).toBe(5);
+  });
+
   test("markPaid can change payment method", async () => {
     const t = createTestCtx();
     const { organizationId, identity } = await seedTestUser(t);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #504.

Closes #504

---

## Claude summary

Committed `0415772`. Summary:

`SupabaseQueryBuilder` now exposes `.range(from, to)` and `.offset(n)` (PostgREST-style inclusive endpoints), mirrored in the in-memory test mock. `payments.list` now does real cursor-based pagination: it parses the cursor as an offset, fetches `numItems + 1` via `.range()` to detect more rows, and returns honest `isDone`/`continueCursor` values. Added a multi-page test that exercises three sequential pages and verifies no overlap.

Verified: all 9 payments tests pass; convex typecheck clean.