### PR TITLE
Fix rotted unit tests in `tests/convex/avatarConsistency.test.ts`

### DIFF
--- a/tests/convex/_setup.ts
+++ b/tests/convex/_setup.ts
@@ -6,7 +6,19 @@
  * implementation. Registered via `setupFiles` in convex/vitest.config.ts.
  */
 
+import { webcrypto } from "node:crypto";
 import { beforeEach, vi } from "vitest";
+
+// convex-test calls `crypto.subtle.digest` when storing blobs. Node 19+
+// exposes `crypto` as a global, but on Node 18 it lives only on
+// `node:crypto`. Polyfill so storage-touching tests run consistently
+// regardless of the host Node version.
+if (typeof globalThis.crypto === "undefined") {
+  Object.defineProperty(globalThis, "crypto", {
+    value: webcrypto,
+    configurable: true,
+  });
+}
 
 vi.mock("@cvx/_helpers/supabaseDb", async () => {
   const { createInMemorySupabaseDb } = await import("./_supabase_inmemory");


### PR DESCRIPTION
Auto-generated by Claude in response to issue #508.

Closes #508

---

## Claude summary

Fixed and committed. 

Root cause: `avatarConsistency.test.ts` calls `ctx.storage.store(new Blob(...))`, which makes `convex-test` compute a SHA-256 hash over the blob using `crypto.subtle.digest`. On Node 18, `crypto` isn't on the global scope without `--experimental-global-webcrypto`, so the test threw `ReferenceError: crypto is not defined`.

Fix: in `tests/convex/_setup.ts`, polyfill `globalThis.crypto` from `node:crypto`'s `webcrypto` if not already present. Both tests now pass, and there are no regressions (the rest of the suite has the same pass/fail count as before, minus the 2 avatar tests which now pass).

## Follow-ups
- Add a unit-tests job to CI: the issue references a "CI unit-tests job" with `continue-on-error`, but `.github/workflows/` only contains `e2e.yml` — the unit-tests job needs to be created before `continue-on-error` can be removed
- Unrot remaining failing convex tests: 8 test files in `tests/convex/` still fail (write-outside-transaction errors, etc.) — separate from #508 but block the same CI goal