### PR TITLE
fix(tests): unrot conflictChecking unit tests (#509)

### DIFF
--- a/tests/convex/conflictChecking.test.ts
+++ b/tests/convex/conflictChecking.test.ts
@@ -1,6 +1,55 @@
-import { expect, test, describe } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { api } from "../../convex/_generated/api";
 import { createTestCtx, seedTestUser, seedGabinetPrereqs } from "../../convex/_test_helpers";
+
+// Conflict-checking tests assert on the create action's reject/resolve
+// behavior. The action also `runAfter(0, …)` schedules side-effect jobs
+// (SMS, automation events, reminders). convex-test runs those via
+// `setTimeout(0, …)` against a `global.Convex` reference; once the next
+// test creates a fresh test instance, the orphan callbacks from the
+// previous test fire against the new `global.Convex` and surface as
+// "Write outside of transaction" / null-state unhandled rejections that
+// fail the suite (even though every assertion in the test passed).
+//
+// Same pattern as appointmentStateMachine.test.ts: install a per-file
+// unhandledRejection filter that silently consumes ONLY the two known
+// convex-test scheduler error shapes. Unknown rejections fall through.
+const SCHEDULER_NOISE = [
+  /Write outside of transaction \d+;_scheduled_functions/,
+  /Cannot read properties of null \(reading 'state'\)/,
+];
+
+function onUnhandledRejection(reason: unknown) {
+  const msg = reason instanceof Error ? reason.message : String(reason);
+  if (SCHEDULER_NOISE.some((re) => re.test(msg))) return;
+  // Other rejections are left to vitest's own listener.
+}
+
+beforeAll(() => {
+  process.on("unhandledRejection", onUnhandledRejection);
+});
+
+afterAll(() => {
+  process.off("unhandledRejection", onUnhandledRejection);
+});
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      text: async () => JSON.stringify({ sid: "SM_TEST_123" }),
+    })) as unknown as typeof fetch,
+  );
+});
+
+afterEach(async () => {
+  // Let any pending setTimeout(0) side-effect callbacks from the test fire
+  // against the *current* instance before the next test creates a new one.
+  // Anything still queued past this yield is handled by the swallower above.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  vi.unstubAllGlobals();
+});
 
 describe("conflict checking", () => {
   test("cannot double-book same employee at same time", async () => {


### PR DESCRIPTION
## Summary
- Mirrors the swallow-scheduler-noise pattern from `appointmentStateMachine.test.ts` (commit c0accd8) to fix unhandled rejections that flipped the process exit code to 1 in `tests/convex/conflictChecking.test.ts`.
- The `gabinet.appointments.create` action schedules side-effect jobs (SMS, automation events, reminders) via `setTimeout(0)`. Once the next test creates a fresh convex-test instance, orphan callbacks from the previous test fire against the new `global.Convex` and surface as `Write outside of transaction _scheduled_functions` / null-state unhandled rejections that fail the suite even when every assertion passed.
- Installs a per-file `unhandledRejection` filter that silently consumes only the two known scheduler-noise shapes, stubs `global.fetch` (the SMS path issues one), and yields in `afterEach` so pending `setTimeout(0)` callbacks fire against the current Convex instance.

Closes #509.

## Test plan
- [x] `cd convex && npx vitest run ../tests/convex/conflictChecking.test.ts` → 5 passed, exit 0