### PR TITLE
Fix rotted unit tests in `tests/convex/payments.test.ts`

### DIFF
--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -1,6 +1,38 @@
-import { expect, test, describe } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
 import { api } from "../../convex/_generated/api";
 import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+
+// payments.{create,markPaid,refund} schedule audit-log / activity-envelope
+// dual-writes via `ctx.scheduler.runAfter(0, …)`. convex-test fires those via
+// `setTimeout(0, …)` against a `global.Convex` reference; once the next test
+// creates a fresh instance, the orphan callbacks from the previous test fire
+// against the new `global.Convex` and surface as "Write outside of
+// transaction" unhandled rejections that fail the suite even though every
+// assertion passes. Match the per-file filter used by appointmentStateMachine
+// (see #506) — swallow only the known scheduler noise shape, let everything
+// else through to vitest's listener.
+const SCHEDULER_NOISE = [
+  /Write outside of transaction \d+;_scheduled_functions/,
+];
+
+function onUnhandledRejection(reason: unknown) {
+  const msg = reason instanceof Error ? reason.message : String(reason);
+  if (SCHEDULER_NOISE.some((re) => re.test(msg))) return;
+}
+
+beforeAll(() => {
+  process.on("unhandledRejection", onUnhandledRejection);
+});
+
+afterAll(() => {
+  process.off("unhandledRejection", onUnhandledRejection);
+});
+
+afterEach(async () => {
+  // Let any pending setTimeout(0) side-effect callbacks from the test fire
+  // against the *current* instance before the next test creates a new one.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
 
 describe("payments", () => {
   test("create a pending payment when status is explicit", async () => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #511.

Closes #511

---

## Claude summary

Fixed. The 9 `tests/convex/payments.test.ts` tests all passed their assertions even before this change — the suite failed because action handlers fire `ctx.scheduler.runAfter(0, …)` for audit-log / activity-envelope dual-writes, and those orphan `setTimeout(0)` callbacks land against the next test's `global.Convex` instance, throwing `Write outside of transaction N;_scheduled_functions` as unhandled rejections. Vitest 4 flips the exit code to 1 on unhandled errors even when every assertion passes.

The fix mirrors the per-file pattern landed in #506 (`appointmentStateMachine`): a scoped `process.on("unhandledRejection")` filter that swallows only that one known noise shape, plus an `afterEach` microtask yield so pending callbacks have a chance to fire against the current instance. Verified: 9 passed, 0 unhandled errors, exit 0 under `cd convex && vitest run ../tests/convex/payments.test.ts`.