### PR TITLE
Fix rotted unit tests in `tests/convex/recentlyViewed.test.ts`

### DIFF
--- a/convex/recentlyViewed.ts
+++ b/convex/recentlyViewed.ts
@@ -1,8 +1,7 @@
-import { query, action } from "./_generated/server";
+import { action } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
-import { verifyOrgAccess } from "./_helpers/auth";
 
 export const track = action({
   args: {
@@ -64,26 +63,32 @@ export const track = action({
   },
 });
 
-export const list = query({
+export const list = action({
   args: {
     organizationId: v.id("organizations"),
     entityType: v.string(),
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const { user } = await verifyOrgAccess(ctx, args.organizationId);
+    const authResult = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
     const limit = args.limit ?? 3;
 
-    const items = await ctx.db
-      .query("recentlyViewed")
-      .withIndex("by_user_type", (q) =>
-        q
-          .eq("organizationId", args.organizationId)
-          .eq("userId", user._id)
-          .eq("entityType", args.entityType)
-      )
-      .order("desc")
-      .take(limit);
+    const db = createSupabaseDb();
+    const items = await db
+      .query<{
+        entityId: string;
+        entityLabel: string;
+        viewedAt: number;
+      }>("recentlyViewed")
+      .eq("organizationId", String(args.organizationId))
+      .eq("userId", String(authResult.userId))
+      .eq("entityType", args.entityType)
+      .order("viewedAt", false)
+      .take(limit)
+      .collect();
 
     return items.map((item) => ({
       entityId: item.entityId,

--- a/src/components/sidebar-widgets/recent-items.tsx
+++ b/src/components/sidebar-widgets/recent-items.tsx
@@ -1,8 +1,15 @@
-import { useQuery } from "convex/react";
+import { useAction } from "convex/react";
+import { useQuery } from "@tanstack/react-query";
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
 import { Clock } from "@/lib/ez-icons";
+
+interface RecentItem {
+  entityId: string;
+  entityLabel: string;
+  viewedAt: number;
+}
 
 interface RecentItemsProps {
   organizationId: Id<"organizations">;
@@ -12,10 +19,15 @@ interface RecentItemsProps {
 
 export function RecentItems({ organizationId, entityType, linkPrefix }: RecentItemsProps) {
   const { t } = useTranslation();
-  const items = useQuery(api.recentlyViewed.list, {
-    organizationId,
-    entityType,
-    limit: 3,
+  const listRecentlyViewed = useAction(api.recentlyViewed.list);
+  const { data: items } = useQuery({
+    queryKey: ["recentlyViewed.list", organizationId, entityType],
+    queryFn: () =>
+      listRecentlyViewed({
+        organizationId,
+        entityType,
+        limit: 3,
+      }) as unknown as Promise<RecentItem[]>,
   });
 
   if (!items?.length) return null;

--- a/tests/convex/recentlyViewed.test.ts
+++ b/tests/convex/recentlyViewed.test.ts
@@ -19,14 +19,14 @@ describe("recentlyViewed", () => {
     const t = createCtx();
     const { organizationId, identity } = await seedTestUser(t);
 
-    await t.withIdentity(identity).mutation(api.recentlyViewed.track, {
+    await t.withIdentity(identity).action(api.recentlyViewed.track, {
       organizationId,
       entityType: "contacts",
       entityId: "test-id-1",
       entityLabel: "Jan Kowalski",
     });
 
-    const items = await t.withIdentity(identity).query(api.recentlyViewed.list, {
+    const items = await t.withIdentity(identity).action(api.recentlyViewed.list, {
       organizationId,
       entityType: "contacts",
       limit: 3,
@@ -41,20 +41,20 @@ describe("recentlyViewed", () => {
     const t = createCtx();
     const { organizationId, identity } = await seedTestUser(t);
 
-    await t.withIdentity(identity).mutation(api.recentlyViewed.track, {
+    await t.withIdentity(identity).action(api.recentlyViewed.track, {
       organizationId,
       entityType: "contacts",
       entityId: "test-id-1",
       entityLabel: "Jan K.",
     });
-    await t.withIdentity(identity).mutation(api.recentlyViewed.track, {
+    await t.withIdentity(identity).action(api.recentlyViewed.track, {
       organizationId,
       entityType: "contacts",
       entityId: "test-id-1",
       entityLabel: "Jan Kowalski",
     });
 
-    const items = await t.withIdentity(identity).query(api.recentlyViewed.list, {
+    const items = await t.withIdentity(identity).action(api.recentlyViewed.list, {
       organizationId,
       entityType: "contacts",
       limit: 10,
@@ -68,26 +68,33 @@ describe("recentlyViewed", () => {
     const t = createCtx();
     const { organizationId, identity } = await seedTestUser(t);
 
-    await t.withIdentity(identity).mutation(api.recentlyViewed.track, {
+    // Space the calls out so Date.now() advances between them — without a
+    // gap, all three tracks can land on the same millisecond and the
+    // viewedAt-desc ordering becomes a tie.
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+    await t.withIdentity(identity).action(api.recentlyViewed.track, {
       organizationId,
       entityType: "contacts",
       entityId: "id-1",
       entityLabel: "First",
     });
-    await t.withIdentity(identity).mutation(api.recentlyViewed.track, {
+    await sleep(2);
+    await t.withIdentity(identity).action(api.recentlyViewed.track, {
       organizationId,
       entityType: "contacts",
       entityId: "id-2",
       entityLabel: "Second",
     });
-    await t.withIdentity(identity).mutation(api.recentlyViewed.track, {
+    await sleep(2);
+    await t.withIdentity(identity).action(api.recentlyViewed.track, {
       organizationId,
       entityType: "contacts",
       entityId: "id-3",
       entityLabel: "Third",
     });
 
-    const items = await t.withIdentity(identity).query(api.recentlyViewed.list, {
+    const items = await t.withIdentity(identity).action(api.recentlyViewed.list, {
       organizationId,
       entityType: "contacts",
       limit: 3,
@@ -104,7 +111,7 @@ describe("recentlyViewed", () => {
     const { organizationId, identity } = await seedTestUser(t);
 
     for (let i = 0; i < 5; i++) {
-      await t.withIdentity(identity).mutation(api.recentlyViewed.track, {
+      await t.withIdentity(identity).action(api.recentlyViewed.track, {
         organizationId,
         entityType: "contacts",
         entityId: `id-${i}`,
@@ -112,7 +119,7 @@ describe("recentlyViewed", () => {
       });
     }
 
-    const items = await t.withIdentity(identity).query(api.recentlyViewed.list, {
+    const items = await t.withIdentity(identity).action(api.recentlyViewed.list, {
       organizationId,
       entityType: "contacts",
       limit: 2,
@@ -125,25 +132,25 @@ describe("recentlyViewed", () => {
     const t = createCtx();
     const { organizationId, identity } = await seedTestUser(t);
 
-    await t.withIdentity(identity).mutation(api.recentlyViewed.track, {
+    await t.withIdentity(identity).action(api.recentlyViewed.track, {
       organizationId,
       entityType: "contacts",
       entityId: "contact-1",
       entityLabel: "Contact One",
     });
-    await t.withIdentity(identity).mutation(api.recentlyViewed.track, {
+    await t.withIdentity(identity).action(api.recentlyViewed.track, {
       organizationId,
       entityType: "companies",
       entityId: "company-1",
       entityLabel: "Company One",
     });
 
-    const contacts = await t.withIdentity(identity).query(api.recentlyViewed.list, {
+    const contacts = await t.withIdentity(identity).action(api.recentlyViewed.list, {
       organizationId,
       entityType: "contacts",
       limit: 10,
     });
-    const companies = await t.withIdentity(identity).query(api.recentlyViewed.list, {
+    const companies = await t.withIdentity(identity).action(api.recentlyViewed.list, {
       organizationId,
       entityType: "companies",
       limit: 10,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #512.

Closes #512

---

## Claude summary

Committed as `bdcb381`. Summary:

Root cause: `recentlyViewed.track` writes to Supabase (Phase 4 migration), but `recentlyViewed.list` was still a Convex query reading from `ctx.db`. The two halves of the API talk to different stores, so the tests (and the live `RecentItems` sidebar) never saw data written by `track`.

Fix:
- `convex/recentlyViewed.ts:66` — convert `list` from query to action, read from Supabase via `createSupabaseDb()`, matching the payments unrot pattern in PR #501.
- `tests/convex/recentlyViewed.test.ts` — call `track`/`list` with `.action(...)`; add a 2ms gap between the three `track` calls in the ordering test so `Date.now()` advances and the `viewedAt`-desc sort doesn't tie.
- `src/components/sidebar-widgets/recent-items.tsx:15` — drive the action through `useAction` + `@tanstack/react-query`'s `useQuery`, matching the pattern used by `patient-packages-card.tsx`.

Verification: 5/5 `recentlyViewed` tests pass; `tsc --noEmit` is clean.

## Follow-ups
- Add a stable secondary sort to `recentlyViewed.list` Supabase query: relying on `viewedAt` desc alone is non-deterministic when two tracks land on the same millisecond; the Supabase schema (`supabase/migrations/00001_initial_schema.sql:460`) has no `created_at` column to tie-break, so production ordering of rapid views is undefined.
- Stop seeding `recentlyViewed` into Convex `ctx.db`: `convex/crm/seed.ts:515` still writes via `ctx.db.insert("recentlyViewed", …)` but the read path now goes through Supabase, so seeded recent items will never appear in the sidebar.
- Remove `recentlyViewed` from Convex `schema/platform.ts` if it's truly Supabase-only: the table at `convex/schema/platform.ts:281` is unused at runtime after this fix and is misleading to future readers.