### PR TITLE
Fix rotted unit tests in `tests/convex/packageActivities.test.ts`

### DIFF
--- a/tests/convex/packageActivities.test.ts
+++ b/tests/convex/packageActivities.test.ts
@@ -1,6 +1,38 @@
-import { describe, expect, test } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
 import { api } from "../../convex/_generated/api";
 import { createTestCtx, seedGabinetPrereqs, seedTestUser } from "../../convex/_test_helpers";
+
+// `packages.{create,purchasePackage}` are actions that schedule activity
+// envelope / Supabase dual-writes via `ctx.scheduler.runAfter(0, …)`.
+// convex-test fires those via `setTimeout(0, …)` against a `global.Convex`
+// reference; once the next test creates a fresh instance, orphan callbacks
+// from the previous test fire against the new `global.Convex` and surface as
+// "Write outside of transaction" unhandled rejections that flip vitest's
+// exit code even though every assertion passes. Match the per-file filter
+// used by payments.test.ts (#511) — swallow only the known scheduler-noise
+// shape, let everything else through.
+const SCHEDULER_NOISE = [
+  /Write outside of transaction \d+;_scheduled_functions/,
+];
+
+function onUnhandledRejection(reason: unknown) {
+  const msg = reason instanceof Error ? reason.message : String(reason);
+  if (SCHEDULER_NOISE.some((re) => re.test(msg))) return;
+}
+
+beforeAll(() => {
+  process.on("unhandledRejection", onUnhandledRejection);
+});
+
+afterAll(() => {
+  process.off("unhandledRejection", onUnhandledRejection);
+});
+
+afterEach(async () => {
+  // Let any pending setTimeout(0) side-effect callbacks from the test fire
+  // against the *current* instance before the next test creates a new one.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
 
 describe("package activities", () => {
   test("purchasePackage publishes semantic package_assigned envelope", async () => {
@@ -12,7 +44,7 @@ describe("package activities", () => {
       userId,
     );
 
-    const packageId = await t.withIdentity(identity).mutation(api.gabinet.packages.create, {
+    const packageId = await t.withIdentity(identity).action(api.gabinet.packages.create, {
       organizationId,
       name: "Starter package",
       treatments: [
@@ -24,7 +56,7 @@ describe("package activities", () => {
       totalPrice: 400,
     });
 
-    const usageId = await t.withIdentity(identity).mutation(
+    const usageId = await t.withIdentity(identity).action(
       api.gabinet.packages.purchasePackage,
       {
         organizationId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #514.

Closes #514

---

## Claude summary

Committed. Summary:

The `purchasePackage` envelope test was failing because `gabinet.packages.create` and `gabinet.packages.purchasePackage` were refactored from mutations into actions (delegating to internal mutations for the DB work), but the test still called them via `t.mutation(...)`. Switched both calls to `t.action(...)`.

Also added the same scheduler-noise filter introduced for payments in #511 (`afterEach` microtask yield + `process.on("unhandledRejection")` swallowing only `Write outside of transaction N;_scheduled_functions`), since `publishActivityEnvelope` in `convex/_helpers/activityEnvelope.ts:167` schedules `writeActivityRef` via `ctx.scheduler.runAfter(0, …)` — the same orphan-callback shape that flips vitest's exit code in sibling suites.

Verified: 1 test passes, exit code 0.