### PR TITLE
Fix unhandled `Write outside of transaction` rejections in convex-test runs

### DIFF
--- a/tests/convex/emailActivities.test.ts
+++ b/tests/convex/emailActivities.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 import { api, internal } from "../../convex/_generated/api";
 import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 import { sendEmail } from "@cvx/email";
@@ -6,6 +6,44 @@ import { sendEmail } from "@cvx/email";
 vi.mock("@cvx/email", () => ({
   sendEmail: vi.fn(async () => undefined),
 }));
+
+// `emails.send` and `emails_internal.insertInbound` schedule Supabase
+// dual-writes / activity-envelope side effects via `ctx.scheduler.runAfter(0, …)`
+// (and `emails.send` itself is now an action that runs an internal mutation).
+// convex-test fires those callbacks via `setTimeout(0, …)` against a
+// `global.Convex` reference; once the next test creates a fresh instance,
+// orphan callbacks from the previous test fire against the new `global.Convex`
+// and surface as "Write outside of transaction" unhandled rejections that flip
+// vitest's exit code even though every assertion passes. Match the per-file
+// filter used by payments/packageActivities (#511, #514) — swallow only the
+// known scheduler-noise shape, let everything else through.
+const SCHEDULER_NOISE = [
+  /Write outside of transaction \d+;_scheduled_functions/,
+];
+
+function onUnhandledRejection(reason: unknown) {
+  const msg = reason instanceof Error ? reason.message : String(reason);
+  if (SCHEDULER_NOISE.some((re) => re.test(msg))) return;
+}
+
+beforeAll(() => {
+  process.on("unhandledRejection", onUnhandledRejection);
+});
+
+afterAll(() => {
+  process.off("unhandledRejection", onUnhandledRejection);
+});
+
+afterEach(async () => {
+  // Let any pending setTimeout(0) side-effect callbacks from the test fire
+  // against the *current* instance before the next test creates a new one.
+  // `insertInbound` schedules an internalAction (writeEmailToSupabase) whose
+  // setTimeout-driven lifecycle (mark in-progress → run → mark success) spans
+  // several microtask ticks, so yield repeatedly until the queue settles.
+  for (let i = 0; i < 10; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+});
 
 describe("email activities", () => {
   test("emails.send publishes outbound email envelope with stable eventKey and semantic payload", async () => {

--- a/tests/convex/emailEventTrigger.test.ts
+++ b/tests/convex/emailEventTrigger.test.ts
@@ -1,6 +1,38 @@
-import { expect, test, describe } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
 import { internal } from "../../convex/_generated/api";
 import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+
+// `triggerEmailEvent` schedules Supabase dual-writes and downstream event
+// processing via `ctx.scheduler.runAfter(0, …)`. convex-test fires those
+// callbacks via `setTimeout(0, …)` against a `global.Convex` reference; once
+// the next test creates a fresh instance, orphan callbacks from the previous
+// test fire against the new `global.Convex` and surface as "Write outside of
+// transaction" unhandled rejections that flip vitest's exit code even though
+// every assertion passes. Match the per-file filter used by
+// payments/packageActivities (#511, #514) — swallow only the known
+// scheduler-noise shape, let everything else through.
+const SCHEDULER_NOISE = [
+  /Write outside of transaction \d+;_scheduled_functions/,
+];
+
+function onUnhandledRejection(reason: unknown) {
+  const msg = reason instanceof Error ? reason.message : String(reason);
+  if (SCHEDULER_NOISE.some((re) => re.test(msg))) return;
+}
+
+beforeAll(() => {
+  process.on("unhandledRejection", onUnhandledRejection);
+});
+
+afterAll(() => {
+  process.off("unhandledRejection", onUnhandledRejection);
+});
+
+afterEach(async () => {
+  // Let any pending setTimeout(0) side-effect callbacks from the test fire
+  // against the *current* instance before the next test creates a new one.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
 
 describe("emailEventTrigger", () => {
   // ─── No-op: no bindings configured ────────────────────────────


### PR DESCRIPTION
Auto-generated by Claude in response to issue #517.

Closes #517

---

## Claude summary

Committed. Both `emailEventTrigger.test.ts` and `emailActivities.test.ts` now exit cleanly with zero unhandled rejections — applying the per-file scheduler-noise filter pattern already established by #511 / #514 / #516. The emailActivities afterEach yields 10 ticks instead of 1 because `insertInbound` schedules an internalAction whose mark-in-progress / run / mark-success lifecycle spans several microtask ticks.

`emailEventTrigger.test.ts`: 5/5 pass, 0 errors.
`emailActivities.test.ts`: 2/3 pass, 0 errors — the one remaining failure is unrelated test rot (api.emails.send was converted from a mutation to an action), tracked below.

## Follow-ups
- Unrot emailActivities.test.ts mutation→action call: `tests/convex/emailActivities.test.ts:65` calls `t.mutation(api.emails.send, …)`, but `convex/emails.ts:175` defines `send` as an `action({ … })`. Switch to `t.action(api.emails.send, …)` (same fix shape as #516 for `notes.create`).