### PR TITLE
Fix rotted unit tests in `tests/convex/emailActivities.test.ts`

### DIFF
--- a/tests/convex/emailActivities.test.ts
+++ b/tests/convex/emailActivities.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 import { api, internal } from "../../convex/_generated/api";
 import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
 import { sendEmail } from "@cvx/email";
 
 vi.mock("@cvx/email", () => ({
@@ -50,19 +51,21 @@ describe("email activities", () => {
     const t = createTestCtx();
     const { organizationId, userId, identity } = await seedTestUser(t);
 
-    await t.run(async (ctx) => {
-      const now = Date.now();
-      await ctx.db.insert("emailAccounts", {
-        organizationId,
-        fromName: "Support",
-        fromEmail: "support@example.com",
-        isDefault: true,
-        createdAt: now,
-        updatedAt: now,
-      });
+    // `emails.send` is now an action that reads the default email account
+    // through `createSupabaseDb()`. Seed it into the in-memory Supabase
+    // mock (installed by `tests/convex/_setup.ts`) so the action resolves
+    // the sender address instead of throwing "No default email account".
+    const now = Date.now();
+    await createSupabaseDb().insert("emailAccounts", {
+      organizationId: String(organizationId),
+      fromName: "Support",
+      fromEmail: "support@example.com",
+      isDefault: true,
+      createdAt: now,
+      updatedAt: now,
     });
 
-    const emailId = await t.withIdentity(identity).mutation(api.emails.send, {
+    const emailId = await t.withIdentity(identity).action(api.emails.send, {
       organizationId,
       to: ["client@example.com"],
       subject: "Welcome aboard",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #515.

Closes #515

---

## Claude summary

Fixed and committed. Summary of the change:

The `emails.send` outbound envelope test was rotted because `emails.send` was converted from a Convex mutation to an action that reads the default email account through `createSupabaseDb()`. The test still called `t.mutation()` and seeded into `ctx.db`, which broke two ways:
1. `t.mutation(api.emails.send, ...)` threw `Expected a mutation function`.
2. The seeded `emailAccounts` row lived in Convex, not Supabase, so the action wouldn't have found it either.

The fix in `tests/convex/emailActivities.test.ts:50-73`:
- Switch the call to `t.action(api.emails.send, ...)`.
- Seed the default email account via the in-memory Supabase mock (`createSupabaseDb().insert(...)`) installed by `tests/convex/_setup.ts`.

The two inbound tests already passed unchanged; the scheduler-noise filter from #517 is preserved. Verified all 3 tests pass with exit code 0 under `cd convex && npx vitest run ../tests/convex/emailActivities.test.ts`.