### PR TITLE
Port `getQualifiedEmployees` in convex/gabinet/patientPortal.ts to Supabase

### DIFF
--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -242,44 +242,61 @@ export const getBookableTreatments = action({
 });
 
 /** List active employees qualified for a given treatment. */
-export const getQualifiedEmployees = query({
+export const getQualifiedEmployees = action({
   args: {
     tokenHash: v.string(),
-    treatmentId: v.id("gabinetTreatments"),
+    treatmentId: v.string(),
   },
-  handler: async (ctx, args) => {
-    const { organizationId } = await validatePortalSession(ctx, args.tokenHash);
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
 
-    const employees = await ctx.db
+    // Validate session via Supabase (matches bookFromPortal — the Convex
+    // gabinetPortalSessions table is no longer the source of truth).
+    const session = await db
+      .query("gabinetPortalSessions")
+      .eq("tokenHash", args.tokenHash)
+      .first();
+    if (
+      !session ||
+      !session.isActive ||
+      Date.now() > (session.expiresAt as number)
+    ) {
+      throw new Error("Invalid or expired session");
+    }
+    const organizationId = String(session.organizationId);
+
+    const employees = await db
       .query("gabinetEmployees")
-      .withIndex("by_orgAndActive", (q) =>
-        q.eq("organizationId", organizationId).eq("isActive", true),
-      )
+      .eq("organizationId", organizationId)
+      .eq("isActive", true)
       .collect();
 
-    // Filter to those qualified for the treatment
-    const qualified = employees.filter(
-      (e) =>
-        e.qualifiedTreatmentIds.length === 0 ||
-        e.qualifiedTreatmentIds.includes(args.treatmentId),
-    );
+    // Filter to those qualified for the treatment (empty list ⇒ qualified
+    // for everything, matching the original Convex behaviour).
+    const qualified = employees.filter((e) => {
+      const qualifiedIds = (e.qualifiedTreatmentIds as string[] | undefined) ?? [];
+      return qualifiedIds.length === 0 || qualifiedIds.includes(args.treatmentId);
+    });
 
-    // Resolve user names
-    const enriched = await Promise.all(
+    // Resolve user names from Supabase, falling back to names stored on
+    // the employee row itself.
+    return await Promise.all(
       qualified.map(async (e) => {
-        const user = await ctx.db.get(e.userId);
+        const user = await db.get("users", String(e.userId)).catch(() => null);
+        const userName = (user?.name as string | null) ?? null;
         return {
-          _id: e._id,
-          userId: e.userId,
-          firstName: e.firstName ?? user?.name?.split(" ")[0] ?? "",
+          _id: e._id as string,
+          userId: e.userId as string,
+          firstName:
+            (e.firstName as string | null) ?? userName?.split(" ")[0] ?? "",
           lastName:
-            e.lastName ?? user?.name?.split(" ").slice(1).join(" ") ?? "",
-          specialization: e.specialization,
+            (e.lastName as string | null) ??
+            userName?.split(" ").slice(1).join(" ") ??
+            "",
+          specialization: (e.specialization as string | null) ?? undefined,
         };
       }),
     );
-
-    return enriched;
   },
 });
 

--- a/src/routes/_app/patient/_layout.book.tsx
+++ b/src/routes/_app/patient/_layout.book.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
@@ -59,12 +58,21 @@ function PatientBooking() {
     enabled: !!tokenHash,
   });
 
+  const getQualifiedEmployees = useAction(
+    api.gabinet.patientPortal.getQualifiedEmployees,
+  );
   const { data: employees } = useQuery({
-    ...convexQuery(api.gabinet.patientPortal.getQualifiedEmployees, {
+    queryKey: [
+      "gabinet.patientPortal.getQualifiedEmployees",
       tokenHash,
-      treatmentId: selectedTreatment?._id ?? ("" as Id<"gabinetTreatments">),
-    }),
-    enabled: !!selectedTreatment,
+      selectedTreatment?._id,
+    ],
+    queryFn: () =>
+      getQualifiedEmployees({
+        tokenHash,
+        treatmentId: (selectedTreatment?._id as string) ?? "",
+      }),
+    enabled: !!tokenHash && !!selectedTreatment,
   });
 
   const dateStr = selectedDate
@@ -137,7 +145,7 @@ function PatientBooking() {
     employee: NonNullable<typeof employees>[number],
   ) => {
     setSelectedEmployee({
-      userId: employee.userId,
+      userId: employee.userId as Id<"users">,
       firstName: employee.firstName,
       lastName: employee.lastName,
     });
@@ -163,7 +171,7 @@ function PatientBooking() {
     // If "any employee" was chosen, pick the first qualified employee for slot lookup
     if (anyEmployee && employees && employees.length > 0) {
       setSelectedEmployee({
-        userId: employees[0].userId,
+        userId: employees[0].userId as Id<"users">,
         firstName: employees[0].firstName,
         lastName: employees[0].lastName,
       });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #521.

Closes #521

---

## Claude summary

Committed. Same anti-pattern as #494: `getQualifiedEmployees` was reading `gabinetPortalSessions` and `gabinetEmployees` from Convex `ctx.db`, but both tables are Supabase-only now. Converted the query to an action that validates the session via Supabase, reads employees from Supabase, and resolves user names via Supabase `users` (with the employee row's `firstName`/`lastName` as fallback — matching the original behaviour). Updated the booking page to invoke it via `useAction` + `useQuery` and removed the now-unused `convexQuery` import. Backend typecheck is clean; the three pre-existing app-side `implicit any` warnings on the booking page are unchanged.