### PR TITLE
Audit remaining `validatePortalSession`-using queries

### DIFF
--- a/convex/_helpers/portalSession.ts
+++ b/convex/_helpers/portalSession.ts
@@ -1,5 +1,6 @@
 import { Id } from "../_generated/dataModel";
 import { QueryCtx, MutationCtx } from "../_generated/server";
+import type { SupabaseDb } from "./supabaseDb";
 
 /**
  * Validate a patient-portal session token and return the associated
@@ -25,5 +26,34 @@ export async function validatePortalSession(
   return {
     patientId: session.patientId,
     organizationId: session.organizationId,
+  };
+}
+
+/**
+ * Supabase counterpart of {@link validatePortalSession}. Use from Convex
+ * actions: `gabinetPortalSessions` is Supabase-only since the dual-write
+ * cleanup, so portal queries reading it through `ctx.db` always throw
+ * "Invalid or expired session".
+ */
+export async function validatePortalSessionSupabase(
+  db: SupabaseDb,
+  tokenHash: string,
+): Promise<{ patientId: string; organizationId: string }> {
+  const session = await db
+    .query("gabinetPortalSessions")
+    .eq("tokenHash", tokenHash)
+    .first();
+
+  if (
+    !session ||
+    !session.isActive ||
+    Date.now() > (session.expiresAt as number)
+  ) {
+    throw new Error("Invalid or expired session");
+  }
+
+  return {
+    patientId: String(session.patientId),
+    organizationId: String(session.organizationId),
   };
 }

--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -3,7 +3,7 @@ import { internal } from "../_generated/api";
 import { v } from "convex/values";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { verifyOrgAccess } from "../_helpers/auth";
-import { validatePortalSession } from "../_helpers/portalSession";
+import { validatePortalSessionSupabase } from "../_helpers/portalSession";
 import { formDocumentStatusValidator } from "../schema/documents";
 import { resolveComponentsInContent } from "./resolveComponents";
 import type { FormDocumentRow } from "../_helpers/supabaseRows";
@@ -579,40 +579,40 @@ export const remove = action({
 });
 
 // ---------------------------------------------------------------------------
-// Patient-portal query (token-based auth, no org context)
+// Patient-portal read (token-based auth, no org context). Reads from
+// Supabase: `gabinetPortalSessions`, `gabinetAppointments`, `formDocuments`
+// and `formTemplates` are all Supabase-only since the dual-write cleanup.
 // ---------------------------------------------------------------------------
 
-export const listByPatientToken = query({
+export const listByPatientToken = action({
   args: { tokenHash: v.string() },
-  handler: async (ctx, args) => {
-    const { patientId, organizationId } = await validatePortalSession(
-      ctx,
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
+    const { patientId, organizationId } = await validatePortalSessionSupabase(
+      db,
       args.tokenHash,
     );
 
     // 1. Documents linked directly to the patient
-    const patientDocs = await ctx.db
+    const patientDocs = await db
       .query("formDocuments")
-      .withIndex("by_entity", (q) =>
-        q.eq("entityType", "patient").eq("entityId", patientId),
-      )
+      .eq("entityType", "patient")
+      .eq("entityId", patientId)
       .collect();
 
     // 2. Documents linked to the patient's appointments
-    const appointments = await ctx.db
+    const appointments = await db
       .query("gabinetAppointments")
-      .withIndex("by_orgAndPatient", (q) =>
-        q.eq("organizationId", organizationId).eq("patientId", patientId),
-      )
+      .eq("organizationId", organizationId)
+      .eq("patientId", patientId)
       .collect();
 
     const appointmentDocArrays = await Promise.all(
       appointments.map((appt) =>
-        ctx.db
+        db
           .query("formDocuments")
-          .withIndex("by_entity", (q) =>
-            q.eq("entityType", "appointment").eq("entityId", appt._id),
-          )
+          .eq("entityType", "appointment")
+          .eq("entityId", String(appt._id))
           .collect(),
       ),
     );
@@ -621,35 +621,48 @@ export const listByPatientToken = query({
     const allDocs = [...patientDocs, ...appointmentDocArrays.flat()];
     const seen = new Set<string>();
     const unique = allDocs.filter((d) => {
-      if (d.organizationId !== organizationId) return false;
-      if (seen.has(d._id)) return false;
-      seen.add(d._id);
+      if (String(d.organizationId) !== organizationId) return false;
+      const id = String(d._id);
+      if (seen.has(id)) return false;
+      seen.add(id);
       return true;
     });
 
-    // Enrich with template info for frontend rendering
-    const enriched = await Promise.all(
-      unique.map(async (doc) => {
-        const template = await ctx.db.get(doc.templateId);
-        return {
-          _id: doc._id,
-          title: doc.title,
-          status: doc.status,
-          entityType: doc.entityType,
-          entityId: doc.entityId,
-          responseData: doc.responseData,
-          signatureData: doc.signatureData,
-          signedAt: doc.signedAt,
-          signingToken: doc.signingToken,
-          createdAt: doc.createdAt,
-          updatedAt: doc.updatedAt,
-          templateName: template?.name ?? "",
-          category: template?.category ?? "custom",
-          formJson: template?.formJson ?? "{}",
-          requiresSignature: template?.requiresSignature ?? false,
-        };
-      }),
+    // Batch-fetch templates to avoid N+1 reads.
+    const templateIds = Array.from(
+      new Set(
+        unique
+          .map((d) => d.templateId)
+          .filter((id): id is string => typeof id === "string" && id.length > 0),
+      ),
     );
+    const templates = await db.getMany("formTemplates", templateIds);
+    const templateById = new Map<string, Record<string, unknown>>();
+    for (const t of templates) {
+      templateById.set(String(t._id), t);
+    }
+
+    const enriched = unique.map((doc) => {
+      const template = templateById.get(String(doc.templateId));
+      return {
+        _id: String(doc._id),
+        title: doc.title as string,
+        status: doc.status as string,
+        entityType: doc.entityType as string,
+        entityId: doc.entityId as string,
+        responseData: doc.responseData as string,
+        signatureData: (doc.signatureData as string | null) ?? undefined,
+        signedAt: (doc.signedAt as number | null) ?? undefined,
+        signingToken: (doc.signingToken as string | null) ?? undefined,
+        createdAt: doc.createdAt as number,
+        updatedAt: doc.updatedAt as number,
+        templateName: (template?.name as string | undefined) ?? "",
+        category: (template?.category as string | undefined) ?? "custom",
+        formJson: (template?.formJson as string | undefined) ?? "{}",
+        requiresSignature:
+          (template?.requiresSignature as boolean | undefined) ?? false,
+      };
+    });
 
     return enriched.sort((a, b) => b.createdAt - a.createdAt);
   },

--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -1,9 +1,12 @@
-import { query, action, internalMutation, internalQuery } from "../_generated/server";
+import { action, internalMutation, internalQuery } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
 import { Id } from "../_generated/dataModel";
-import { validatePortalSession } from "../_helpers/portalSession";
+import {
+  validatePortalSession,
+  validatePortalSessionSupabase,
+} from "../_helpers/portalSession";
 import { createNotificationDirect } from "../notifications";
 import {
   getAvailableSlotsSupabase,
@@ -23,25 +26,40 @@ export const _validatePortalSessionQuery = internalQuery({
 });
 
 // ---------------------------------------------------------------------------
-// Queries (unchanged — still read from Convex ctx.db)
+// Patient-portal reads (actions — gabinetPortalSessions and all dependent
+// gabinet/* tables are Supabase-only since the dual-write cleanup, so these
+// must hit Supabase rather than Convex ctx.db).
 // ---------------------------------------------------------------------------
 
-export const getMyProfile = query({
+export const getMyProfile = action({
   args: { tokenHash: v.string() },
-  handler: async (ctx, args) => {
-    const { patientId } = await validatePortalSession(ctx, args.tokenHash);
-    const patient = await ctx.db.get(patientId);
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
+    const { patientId } = await validatePortalSessionSupabase(db, args.tokenHash);
+
+    const patient = await db.get("gabinetPatients", patientId);
     if (!patient) throw new Error("Patient not found");
 
+    const address = patient.address as
+      | {
+          street?: string;
+          city?: string;
+          postalCode?: string;
+        }
+      | null
+      | undefined;
+
     return {
-      firstName: patient.firstName,
-      lastName: patient.lastName,
-      email: patient.email,
-      phone: patient.phone,
-      address: patient.address,
-      emergencyContactName: patient.emergencyContactName,
-      emergencyContactPhone: patient.emergencyContactPhone,
-      dateOfBirth: patient.dateOfBirth,
+      firstName: (patient.firstName as string | null) ?? "",
+      lastName: (patient.lastName as string | null) ?? "",
+      email: (patient.email as string | null) ?? undefined,
+      phone: (patient.phone as string | null) ?? undefined,
+      address: address ?? undefined,
+      emergencyContactName:
+        (patient.emergencyContactName as string | null) ?? undefined,
+      emergencyContactPhone:
+        (patient.emergencyContactPhone as string | null) ?? undefined,
+      dateOfBirth: (patient.dateOfBirth as string | null) ?? undefined,
     };
   },
 });
@@ -79,99 +97,122 @@ export const updateMyProfile = action({
   },
 });
 
-export const getMyAppointments = query({
+export const getMyAppointments = action({
   args: { tokenHash: v.string() },
-  handler: async (ctx, args) => {
-    const { patientId, organizationId } = await validatePortalSession(
-      ctx,
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
+    const { patientId, organizationId } = await validatePortalSessionSupabase(
+      db,
       args.tokenHash,
     );
 
-    const appointments = await ctx.db
+    const appointments = await db
       .query("gabinetAppointments")
-      .withIndex("by_orgAndPatient", (q) =>
-        q.eq("organizationId", organizationId).eq("patientId", patientId),
-      )
+      .eq("organizationId", organizationId)
+      .eq("patientId", patientId)
       .collect();
 
-    // Enrich with treatment names
-    const enriched = await Promise.all(
-      appointments.map(async (appt) => {
-        const treatment = appt.treatmentId ? await ctx.db.get(appt.treatmentId) : null;
-        return {
-          _id: appt._id,
-          date: appt.date,
-          startTime: appt.startTime,
-          endTime: appt.endTime,
-          status: appt.status,
-          treatmentName: treatment?.name ?? "Unknown",
-          notes: appt.notes,
-        };
-      }),
+    // Resolve treatment names in one batch to avoid N+1 reads against Supabase.
+    const treatmentIds = Array.from(
+      new Set(
+        appointments
+          .map((a) => a.treatmentId)
+          .filter((id): id is string => typeof id === "string" && id.length > 0),
+      ),
     );
+    const treatments = await db.getMany("gabinetTreatments", treatmentIds);
+    const treatmentNameById = new Map<string, string>();
+    for (const t of treatments) {
+      treatmentNameById.set(String(t._id), String(t.name ?? "Unknown"));
+    }
+
+    const enriched = appointments.map((appt) => ({
+      _id: String(appt._id),
+      date: appt.date as string,
+      startTime: appt.startTime as string,
+      endTime: appt.endTime as string,
+      status: appt.status as string,
+      treatmentName:
+        (appt.treatmentId &&
+          treatmentNameById.get(String(appt.treatmentId))) ??
+        "Unknown",
+      notes: (appt.notes as string | null) ?? undefined,
+    }));
 
     return enriched.sort((a, b) => b.date.localeCompare(a.date));
   },
 });
 
-export const getMyPackages = query({
+export const getMyPackages = action({
   args: { tokenHash: v.string() },
-  handler: async (ctx, args) => {
-    const { patientId, organizationId } = await validatePortalSession(
-      ctx,
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
+    const { patientId, organizationId } = await validatePortalSessionSupabase(
+      db,
       args.tokenHash,
     );
 
-    const usages = await ctx.db
+    const usages = await db
       .query("gabinetPackageUsage")
-      .withIndex("by_orgAndPatient", (q) =>
-        q.eq("organizationId", organizationId).eq("patientId", patientId),
-      )
+      .eq("organizationId", organizationId)
+      .eq("patientId", patientId)
       .collect();
 
-    // Enrich with package names
-    return await Promise.all(
-      usages.map(async (u) => {
-        const pkg = await ctx.db.get(u.packageId);
-        return { ...u, packageName: pkg?.name ?? "Unknown" };
-      }),
+    const packageIds = Array.from(
+      new Set(
+        usages
+          .map((u) => u.packageId)
+          .filter((id): id is string => typeof id === "string" && id.length > 0),
+      ),
     );
+    const pkgs = await db.getMany("gabinetTreatmentPackages", packageIds);
+    const packageNameById = new Map<string, string>();
+    for (const p of pkgs) {
+      packageNameById.set(String(p._id), String(p.name ?? "Unknown"));
+    }
+
+    return usages.map((u) => ({
+      ...u,
+      packageName: packageNameById.get(String(u.packageId)) ?? "Unknown",
+    }));
   },
 });
 
-export const getMyLoyaltyBalance = query({
+export const getMyLoyaltyBalance = action({
   args: { tokenHash: v.string() },
-  handler: async (ctx, args) => {
-    const { patientId, organizationId } = await validatePortalSession(
-      ctx,
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
+    const { patientId, organizationId } = await validatePortalSessionSupabase(
+      db,
       args.tokenHash,
     );
 
-    return await ctx.db
+    return await db
       .query("gabinetLoyaltyPoints")
-      .withIndex("by_orgAndPatient", (q) =>
-        q.eq("organizationId", organizationId).eq("patientId", patientId),
-      )
+      .eq("organizationId", organizationId)
+      .eq("patientId", patientId)
       .first();
   },
 });
 
-export const getMyLoyaltyTransactions = query({
+export const getMyLoyaltyTransactions = action({
   args: { tokenHash: v.string() },
-  handler: async (ctx, args) => {
-    const { patientId, organizationId } = await validatePortalSession(
-      ctx,
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
+    const { patientId, organizationId } = await validatePortalSessionSupabase(
+      db,
       args.tokenHash,
     );
 
-    const transactions = await ctx.db
+    const transactions = await db
       .query("gabinetLoyaltyTransactions")
-      .withIndex("by_orgAndPatient", (q) =>
-        q.eq("organizationId", organizationId).eq("patientId", patientId),
-      )
+      .eq("organizationId", organizationId)
+      .eq("patientId", patientId)
       .collect();
 
-    return transactions.sort((a, b) => b.createdAt - a.createdAt);
+    return transactions.sort(
+      (a, b) => (b.createdAt as number) - (a.createdAt as number),
+    );
   },
 });
 

--- a/src/routes/_app/patient/_layout.appointments.tsx
+++ b/src/routes/_app/patient/_layout.appointments.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -43,9 +42,14 @@ function PatientAppointments() {
       ? (localStorage.getItem("patientPortalToken") ?? "")
       : "";
 
-  const { data: appointments } = useQuery(
-    convexQuery(api.gabinet.patientPortal.getMyAppointments, { tokenHash }),
+  const getMyAppointments = useAction(
+    api.gabinet.patientPortal.getMyAppointments,
   );
+  const { data: appointments } = useQuery({
+    queryKey: ["gabinet.patientPortal.getMyAppointments", tokenHash],
+    queryFn: () => getMyAppointments({ tokenHash }),
+    enabled: !!tokenHash,
+  });
 
   const requestReschedule = useAction(
     api.gabinet.patientPortal.requestReschedule,

--- a/src/routes/_app/patient/_layout.documents.tsx
+++ b/src/routes/_app/patient/_layout.documents.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { Button } from "@/components/ui/button";
 import {
@@ -29,9 +28,14 @@ function PatientDocuments() {
       ? (localStorage.getItem("patientPortalToken") ?? "")
       : "";
 
-  const { data: formDocuments } = useQuery(
-    convexQuery(api.documents.documents.listByPatientToken, { tokenHash }),
+  const listByPatientToken = useAction(
+    api.documents.documents.listByPatientToken,
   );
+  const { data: formDocuments } = useQuery({
+    queryKey: ["documents.documents.listByPatientToken", tokenHash],
+    queryFn: () => listByPatientToken({ tokenHash }),
+    enabled: !!tokenHash,
+  });
 
   const recordSignature = useAction(
     api.documents.documents.recordSignature,

--- a/src/routes/_app/patient/_layout.index.tsx
+++ b/src/routes/_app/patient/_layout.index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
-import { convexQuery } from "@convex-dev/react-query";
+import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -24,17 +24,30 @@ function PatientDashboard() {
   const { t } = useTranslation();
   const { tokenHash } = usePortalToken();
 
-  const { data: profile } = useQuery(
-    convexQuery(api.gabinet.patientPortal.getMyProfile, { tokenHash }),
-  );
+  const getMyProfile = useAction(api.gabinet.patientPortal.getMyProfile);
+  const { data: profile } = useQuery({
+    queryKey: ["gabinet.patientPortal.getMyProfile", tokenHash],
+    queryFn: () => getMyProfile({ tokenHash }),
+    enabled: !!tokenHash,
+  });
 
-  const { data: appointments } = useQuery(
-    convexQuery(api.gabinet.patientPortal.getMyAppointments, { tokenHash }),
+  const getMyAppointments = useAction(
+    api.gabinet.patientPortal.getMyAppointments,
   );
+  const { data: appointments } = useQuery({
+    queryKey: ["gabinet.patientPortal.getMyAppointments", tokenHash],
+    queryFn: () => getMyAppointments({ tokenHash }),
+    enabled: !!tokenHash,
+  });
 
-  const { data: loyaltyBalance } = useQuery(
-    convexQuery(api.gabinet.patientPortal.getMyLoyaltyBalance, { tokenHash }),
+  const getMyLoyaltyBalance = useAction(
+    api.gabinet.patientPortal.getMyLoyaltyBalance,
   );
+  const { data: loyaltyBalance } = useQuery({
+    queryKey: ["gabinet.patientPortal.getMyLoyaltyBalance", tokenHash],
+    queryFn: () => getMyLoyaltyBalance({ tokenHash }),
+    enabled: !!tokenHash,
+  });
 
   const upcoming = useMemo(() => {
     const today = new Date().toISOString().split("T")[0];

--- a/src/routes/_app/patient/_layout.loyalty.tsx
+++ b/src/routes/_app/patient/_layout.loyalty.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
-import { convexQuery } from "@convex-dev/react-query";
+import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { Badge } from "@/components/ui/badge";
 import { useTranslation } from "react-i18next";
@@ -13,13 +13,23 @@ function PatientLoyalty() {
   const { t } = useTranslation();
   const tokenHash = typeof window !== "undefined" ? localStorage.getItem("patientPortalToken") ?? "" : "";
 
-  const { data: balance } = useQuery(
-    convexQuery(api.gabinet.patientPortal.getMyLoyaltyBalance, { tokenHash })
+  const getMyLoyaltyBalance = useAction(
+    api.gabinet.patientPortal.getMyLoyaltyBalance,
   );
+  const { data: balance } = useQuery({
+    queryKey: ["gabinet.patientPortal.getMyLoyaltyBalance", tokenHash],
+    queryFn: () => getMyLoyaltyBalance({ tokenHash }),
+    enabled: !!tokenHash,
+  });
 
-  const { data: transactions } = useQuery(
-    convexQuery(api.gabinet.patientPortal.getMyLoyaltyTransactions, { tokenHash })
+  const getMyLoyaltyTransactions = useAction(
+    api.gabinet.patientPortal.getMyLoyaltyTransactions,
   );
+  const { data: transactions } = useQuery({
+    queryKey: ["gabinet.patientPortal.getMyLoyaltyTransactions", tokenHash],
+    queryFn: () => getMyLoyaltyTransactions({ tokenHash }),
+    enabled: !!tokenHash,
+  });
 
   const tierColor = (tier?: string) => {
     switch (tier) {

--- a/src/routes/_app/patient/_layout.packages.tsx
+++ b/src/routes/_app/patient/_layout.packages.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
-import { convexQuery } from "@convex-dev/react-query";
+import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
@@ -14,9 +14,12 @@ function PatientPackages() {
   const { t } = useTranslation();
   const tokenHash = typeof window !== "undefined" ? localStorage.getItem("patientPortalToken") ?? "" : "";
 
-  const { data: packages } = useQuery(
-    convexQuery(api.gabinet.patientPortal.getMyPackages, { tokenHash })
-  );
+  const getMyPackages = useAction(api.gabinet.patientPortal.getMyPackages);
+  const { data: packages } = useQuery({
+    queryKey: ["gabinet.patientPortal.getMyPackages", tokenHash],
+    queryFn: () => getMyPackages({ tokenHash }),
+    enabled: !!tokenHash,
+  });
 
   const statusColor = (s: string) => {
     switch (s) {

--- a/src/routes/_app/patient/_layout.profile.tsx
+++ b/src/routes/_app/patient/_layout.profile.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -19,10 +18,13 @@ function PatientProfile() {
   const tokenHash = typeof window !== "undefined" ? localStorage.getItem("patientPortalToken") ?? "" : "";
 
   const updateProfile = useAction(api.gabinet.patientPortal.updateMyProfile);
+  const getMyProfile = useAction(api.gabinet.patientPortal.getMyProfile);
 
-  const { data: profile } = useQuery(
-    convexQuery(api.gabinet.patientPortal.getMyProfile, { tokenHash })
-  );
+  const { data: profile } = useQuery({
+    queryKey: ["gabinet.patientPortal.getMyProfile", tokenHash],
+    queryFn: () => getMyProfile({ tokenHash }),
+    enabled: !!tokenHash,
+  });
 
   const [phone, setPhone] = useState("");
   const [street, setStreet] = useState("");


### PR DESCRIPTION
Auto-generated by Claude in response to issue #522.

Closes #522

---

## Claude summary

Fixed and committed. Summary of what I did:

Triage confirmed the bug: `gabinetPortalSessions` (and all dependent gabinet/* tables) have been Supabase-only since the dual-write cleanup. The six patient-portal queries that called `validatePortalSession` (which reads from `ctx.db`) would throw "Invalid or expired session" for every real portal user — same anti-pattern as #494 and #521.

Changes:
- Added `validatePortalSessionSupabase` helper in `convex/_helpers/portalSession.ts` alongside the existing Convex-ctx one, so the six new actions stay readable.
- Converted `getMyProfile`, `getMyAppointments`, `getMyPackages`, `getMyLoyaltyBalance`, `getMyLoyaltyTransactions` in `convex/gabinet/patientPortal.ts` from `query` to `action`, reading from Supabase. Batched per-row lookups for treatments/packages via `db.getMany` to avoid N+1.
- Converted `listByPatientToken` in `convex/documents/documents.ts` the same way, reading `formDocuments`/`formTemplates`/`gabinetAppointments` from Supabase.
- Updated the six patient-portal route components (`_layout.index`, `_layout.profile`, `_layout.appointments`, `_layout.packages`, `_layout.loyalty`, `_layout.documents`) to use `useAction` + `useQuery` instead of `convexQuery`.

Verification: typecheck error count unchanged from baseline (141 → 141; the patient-route `any`-parameter errors are pre-existing and unrelated to this fix — they also affected #494/#521 PRs). No tests reference these queries.

## Follow-ups
- Remove dead `_validatePortalSessionQuery` in convex/gabinet/patientPortal.ts: `internalQuery` that's defined but never referenced from anywhere
- Convert `getPortalSession` in convex/gabinet/patientAuth.ts to a Supabase-backed action: same root cause — it reads `gabinetPortalSessions` from `ctx.db` (currently returns null instead of throwing, so the symptom is "session loop" rather than an exception); used by every patient-portal route via `_layout.tsx`
- Refactor existing inline Supabase session checks in updateMyProfile/getBookableTreatments/getQualifiedEmployees/getPublicAvailableSlots/bookFromPortal/requestReschedule to use the new `validatePortalSessionSupabase` helper: deferred to keep #522 diff focused, but the duplication is now 6+ call sites