### PR TITLE
Fix portal session read/write split

### DIFF
--- a/convex/_helpers/portalSession.ts
+++ b/convex/_helpers/portalSession.ts
@@ -1,39 +1,11 @@
-import { Id } from "../_generated/dataModel";
-import { QueryCtx, MutationCtx } from "../_generated/server";
 import type { SupabaseDb } from "./supabaseDb";
 
 /**
- * Validate a patient-portal session token and return the associated
- * patient + organization IDs.  Shared between gabinet/patientPortal and
- * documents/documents (patient-portal queries).
- */
-export async function validatePortalSession(
-  ctx: QueryCtx | MutationCtx,
-  tokenHash: string,
-): Promise<{
-  patientId: Id<"gabinetPatients">;
-  organizationId: Id<"organizations">;
-}> {
-  const session = await ctx.db
-    .query("gabinetPortalSessions")
-    .withIndex("by_token", (q) => q.eq("tokenHash", tokenHash))
-    .first();
-
-  if (!session || !session.isActive || Date.now() > session.expiresAt) {
-    throw new Error("Invalid or expired session");
-  }
-
-  return {
-    patientId: session.patientId,
-    organizationId: session.organizationId,
-  };
-}
-
-/**
- * Supabase counterpart of {@link validatePortalSession}. Use from Convex
- * actions: `gabinetPortalSessions` is Supabase-only since the dual-write
- * cleanup, so portal queries reading it through `ctx.db` always throw
- * "Invalid or expired session".
+ * Validate a patient-portal session token via Supabase.
+ *
+ * `gabinetPortalSessions` is Supabase-only since the dual-write cleanup, so
+ * portal session validation must hit Supabase — a Convex `ctx.db` reader
+ * would never see rows written by the OTP flow (#540).
  */
 export async function validatePortalSessionSupabase(
   db: SupabaseDb,

--- a/convex/gabinet/patientAuth.ts
+++ b/convex/gabinet/patientAuth.ts
@@ -1,6 +1,7 @@
 import { query, action, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
+import { validatePortalSessionSupabase } from "../_helpers/portalSession";
 import { v } from "convex/values";
 import { sendEmail } from "@cvx/email";
 import { AUTH_RESEND_KEY } from "@cvx/env";
@@ -262,28 +263,36 @@ export const getOrgBySlug = query({
   },
 });
 
-export const getPortalSession = query({
+// `gabinetPortalSessions` is Supabase-only since the dual-write cleanup, so
+// this must be an action that reads from Supabase. A Convex `query` over
+// `ctx.db` would never see rows written by the OTP flow (#540).
+export const getPortalSession = action({
   args: {
     tokenHash: v.string(),
   },
-  handler: async (ctx, args) => {
-    const session = await ctx.db
-      .query("gabinetPortalSessions")
-      .withIndex("by_token", (q) => q.eq("tokenHash", args.tokenHash))
-      .first();
+  handler: async (_ctx, args): Promise<{
+    patientId: string;
+    organizationId: string;
+    patientName: string;
+    patientEmail: string | undefined;
+  } | null> => {
+    const db = createSupabaseDb();
 
-    if (!session || !session.isActive || Date.now() > session.expiresAt) {
+    let validated: { patientId: string; organizationId: string };
+    try {
+      validated = await validatePortalSessionSupabase(db, args.tokenHash);
+    } catch {
       return null;
     }
 
-    const patient = await ctx.db.get(session.patientId);
+    const patient = await db.get("gabinetPatients", validated.patientId);
     if (!patient) return null;
 
     return {
-      patientId: patient._id,
-      organizationId: session.organizationId,
+      patientId: validated.patientId,
+      organizationId: validated.organizationId,
       patientName: `${patient.firstName} ${patient.lastName}`,
-      patientEmail: patient.email,
+      patientEmail: (patient.email as string | null) ?? undefined,
     };
   },
 });

--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -3,27 +3,13 @@ import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
 import { Id } from "../_generated/dataModel";
-import {
-  validatePortalSession,
-  validatePortalSessionSupabase,
-} from "../_helpers/portalSession";
+import { validatePortalSessionSupabase } from "../_helpers/portalSession";
 import { createNotificationDirect } from "../notifications";
 import {
   getAvailableSlotsSupabase,
   checkEmployeeQualificationSupabase,
   checkConflictSupabase,
 } from "./_availability_supabase";
-
-// ---------------------------------------------------------------------------
-// Internal query: validate portal session via Supabase
-// ---------------------------------------------------------------------------
-
-export const _validatePortalSessionQuery = internalQuery({
-  args: { tokenHash: v.string() },
-  handler: async (ctx, args) => {
-    return await validatePortalSession(ctx, args.tokenHash);
-  },
-});
 
 // ---------------------------------------------------------------------------
 // Patient-portal reads (actions — gabinetPortalSessions and all dependent

--- a/src/routes/_app/patient/_layout.tsx
+++ b/src/routes/_app/patient/_layout.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute, Outlet, Link, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
-import { convexQuery } from "@convex-dev/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { Button } from "@/components/ui/button";
@@ -16,14 +15,15 @@ function PatientLayout() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const logout = useAction(api.gabinet.patientAuth.logoutPortal);
+  const getPortalSession = useAction(api.gabinet.patientAuth.getPortalSession);
 
   const token = typeof window !== "undefined" ? localStorage.getItem("patientPortalToken") : null;
 
-  const { data: session, isLoading } = useQuery(
-    convexQuery(api.gabinet.patientAuth.getPortalSession, {
-      tokenHash: token ?? "",
-    })
-  );
+  const { data: session, isLoading } = useQuery({
+    queryKey: ["gabinet.patientAuth.getPortalSession", token ?? ""],
+    queryFn: () => getPortalSession({ tokenHash: token ?? "" }),
+    enabled: !!token,
+  });
 
   useEffect(() => {
     if (!isLoading && !session) {

--- a/tests/convex/patientAuth.test.ts
+++ b/tests/convex/patientAuth.test.ts
@@ -302,10 +302,8 @@ describe("verifyPortalOtp", () => {
 // ---------------------------------------------------------------------------
 // getPortalSession
 //
-// This query still reads from convex-test's ctx.db (see
-// convex/gabinet/patientAuth.ts:getPortalSession). The patientAuth actions
-// write to Supabase, so the query and the action layers do not share state
-// today — these tests therefore seed the session directly into ctx.db.
+// Now an action that reads `gabinetPortalSessions` from Supabase, matching
+// where the OTP flow writes (#540). Seed via `seedPortalSession`.
 // ---------------------------------------------------------------------------
 describe("getPortalSession", () => {
   test("returns session for valid active token", async () => {
@@ -314,25 +312,21 @@ describe("getPortalSession", () => {
     const token = "valid-session-token-for-test";
     const now = Date.now();
 
-    await t.run(async (ctx) => {
-      await ctx.db.insert("gabinetPortalSessions", {
-        patientId,
-        organizationId,
-        tokenHash: token,
-        isActive: true,
-        lastAccessedAt: now,
-        createdAt: now,
-        expiresAt: now + 30 * 24 * 60 * 60 * 1000,
-      });
+    await seedPortalSession(String(patientId), String(organizationId), {
+      tokenHash: token,
+      isActive: true,
+      lastAccessedAt: now,
+      createdAt: now,
+      expiresAt: now + 30 * 24 * 60 * 60 * 1000,
     });
 
-    const session = await t.withIdentity(identity).query(
+    const session = await t.withIdentity(identity).action(
       api.gabinet.patientAuth.getPortalSession,
       { tokenHash: token },
     );
 
     expect(session).not.toBeNull();
-    expect(session!.patientId).toBe(patientId);
+    expect(session!.patientId).toBe(String(patientId));
   });
 
   test("returns null for inactive session", async () => {
@@ -341,19 +335,15 @@ describe("getPortalSession", () => {
     const token = "inactive-session-token";
     const now = Date.now();
 
-    await t.run(async (ctx) => {
-      await ctx.db.insert("gabinetPortalSessions", {
-        patientId,
-        organizationId,
-        tokenHash: token,
-        isActive: false,
-        lastAccessedAt: now,
-        createdAt: now,
-        expiresAt: now + 30 * 24 * 60 * 60 * 1000,
-      });
+    await seedPortalSession(String(patientId), String(organizationId), {
+      tokenHash: token,
+      isActive: false,
+      lastAccessedAt: now,
+      createdAt: now,
+      expiresAt: now + 30 * 24 * 60 * 60 * 1000,
     });
 
-    const session = await t.withIdentity(identity).query(
+    const session = await t.withIdentity(identity).action(
       api.gabinet.patientAuth.getPortalSession,
       { tokenHash: token },
     );
@@ -367,19 +357,15 @@ describe("getPortalSession", () => {
     const token = "expired-session-token";
     const now = Date.now();
 
-    await t.run(async (ctx) => {
-      await ctx.db.insert("gabinetPortalSessions", {
-        patientId,
-        organizationId,
-        tokenHash: token,
-        isActive: true,
-        lastAccessedAt: now,
-        createdAt: now,
-        expiresAt: now - 1000,
-      });
+    await seedPortalSession(String(patientId), String(organizationId), {
+      tokenHash: token,
+      isActive: true,
+      lastAccessedAt: now,
+      createdAt: now,
+      expiresAt: now - 1000,
     });
 
-    const session = await t.withIdentity(identity).query(
+    const session = await t.withIdentity(identity).action(
       api.gabinet.patientAuth.getPortalSession,
       { tokenHash: token },
     );
@@ -392,9 +378,7 @@ describe("getPortalSession", () => {
 // Full auth flow integration
 //
 // Verify against the Supabase store (the action layer's source of truth),
-// not the convex-test ctx.db. The `getPortalSession` Convex query is not
-// exercised here because it reads from a different store than the actions
-// write to.
+// which is also where `getPortalSession` now reads from (#540).
 // ---------------------------------------------------------------------------
 describe("full OTP auth flow", () => {
   test("send → verify → logout flips session active state", async () => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #540.

Closes #540

---

## Claude summary

Committed.

Summary of the fix for #540:

The OTP flow writes `gabinetPortalSessions` to Supabase, but the read paths were still hitting Convex `ctx.db`, so freshly-issued sessions looked invalid to every consumer. Three read paths were affected:

`convex/gabinet/patientAuth.ts:getPortalSession` — converted from a Convex `query` to an `action` that validates the token via `validatePortalSessionSupabase` and loads the patient from Supabase. The patient layout (`src/routes/_app/patient/_layout.tsx`) now drives this through `useAction` + `useQuery`, matching the rest of the patient portal.

`convex/_helpers/portalSession.ts:validatePortalSession` — deleted. It was only referenced by `_validatePortalSessionQuery` in `patientPortal.ts`, which itself was never called, so the dead wrapper was removed too.

Tests in `tests/convex/patientAuth.test.ts:getPortalSession` were updated to seed via the in-memory Supabase mock and invoke `getPortalSession` as an action. All 15 patientAuth tests pass; pre-existing failures in `automation.test.ts` are unrelated (confirmed against the unmodified baseline).