### PR TITLE
Add a stable secondary sort to `recentlyViewed.list` Supabase query

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -187,8 +187,7 @@ class SupabaseQueryBuilder<T = Record<string, unknown>> {
   private client: ReturnType<typeof createServiceRoleClient>;
   private table: string;
   private filters: Array<(q: any) => any> = [];
-  private orderField: string | null = null;
-  private orderAsc = true;
+  private orderBy: Array<{ field: string; ascending: boolean }> = [];
   private limitN: number | null = null;
   private rangeFrom: number | null = null;
   private rangeTo: number | null = null;
@@ -229,8 +228,7 @@ class SupabaseQueryBuilder<T = Record<string, unknown>> {
   }
 
   order(field: string, ascending = true) {
-    this.orderField = toSnakeCase(field);
-    this.orderAsc = ascending;
+    this.orderBy.push({ field: toSnakeCase(field), ascending });
     return this;
   }
 
@@ -263,7 +261,9 @@ class SupabaseQueryBuilder<T = Record<string, unknown>> {
   async collect(): Promise<T[]> {
     let q = this.client.from(this.table).select("*");
     for (const f of this.filters) q = f(q);
-    if (this.orderField) q = q.order(this.orderField, { ascending: this.orderAsc });
+    for (const { field, ascending } of this.orderBy) {
+      q = q.order(field, { ascending });
+    }
     if (this.rangeFrom !== null) {
       const from = this.rangeFrom;
       const to =
@@ -284,7 +284,9 @@ class SupabaseQueryBuilder<T = Record<string, unknown>> {
   async first(): Promise<T | null> {
     let q = this.client.from(this.table).select("*");
     for (const f of this.filters) q = f(q);
-    if (this.orderField) q = q.order(this.orderField, { ascending: this.orderAsc });
+    for (const { field, ascending } of this.orderBy) {
+      q = q.order(field, { ascending });
+    }
     q = q.limit(1);
     const { data, error } = await q;
     if (error) throw new Error(`supabaseDb.query(${this.table}).first(): ${error.message}`);

--- a/convex/recentlyViewed.ts
+++ b/convex/recentlyViewed.ts
@@ -87,6 +87,7 @@ export const list = action({
       .eq("userId", String(authResult.userId))
       .eq("entityType", args.entityType)
       .order("viewedAt", false)
+      .order("id", false)
       .take(limit)
       .collect();
 

--- a/src/hooks/use-supabase-recently-viewed.ts
+++ b/src/hooks/use-supabase-recently-viewed.ts
@@ -30,6 +30,7 @@ export function useSupabaseRecentlyViewed(
 
       const { data, error } = await query
         .order("viewed_at", { ascending: false })
+        .order("id", { ascending: false })
         .limit(limit);
 
       if (error) throw error;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #543.

Closes #543

---

## Claude summary

Triage confirmed the bug. The `recently_viewed` table at `supabase/migrations/00001_initial_schema.sql:460` has only `id` (TEXT PK, UUID) and `viewed_at` — no `created_at`. The existing test in `tests/convex/recentlyViewed.test.ts:71-74` even works around the ambiguity with a `sleep(2)`.

Fix in commit `b1239a5` adds `id` desc as a stable secondary sort in three places:
- `convex/recentlyViewed.ts:90` — the `list` action's query
- `src/hooks/use-supabase-recently-viewed.ts:33` — the frontend hook
- `convex/_helpers/supabaseDb.ts` — extended `SupabaseQueryBuilder` to accumulate multiple `.order()` calls into an `orderBy` array applied in insertion order (Supabase-js already supports chained `.order()` natively, so no change needed on the hook's client)

Sorting by `id` (UUID) doesn't reflect insertion order on same-millisecond ties, but it makes the ordering deterministic, which is what the issue asks for. Couldn't run tests/typecheck — no `node_modules` in this worktree.