### PR TITLE
Remove `recentlyViewed` from Convex `schema/platform.ts` if it's truly Supabase-

### DIFF
--- a/convex/schema/platform.ts
+++ b/convex/schema/platform.ts
@@ -278,17 +278,6 @@ export function createPlatformTables({
     .index("by_organizationId_ts", ["organizationId", "ts"])
     .index("by_scope_ts", ["scope", "ts"]),
 
-  recentlyViewed: defineTable({
-    organizationId: v.id("organizations"),
-    userId: v.id("users"),
-    entityType: v.string(),
-    entityId: v.string(),
-    entityLabel: v.string(),
-    viewedAt: v.number(),
-  })
-    .index("by_user_type", ["organizationId", "userId", "entityType", "viewedAt"])
-    .index("by_entity", ["entityId"]),
-
   // Singleton-style table: holds global platform configuration that is NOT
   // scoped to any organization. There should be at most ONE row here; the
   // queries/mutations in convex/platformSettings.ts enforce that invariant.


### PR DESCRIPTION
Auto-generated by Claude in response to issue #545.

Closes #545

---

## Claude summary

Removed the dead `recentlyViewed` table from `convex/schema/platform.ts`. Verified the runtime path goes through Supabase via `createSupabaseDb()` in `convex/recentlyViewed.ts:19`, with no Convex code referencing `ctx.db.recentlyViewed` (only a stale doc plan mentions it). Typecheck shows no new errors from this change — pre-existing `recentlyViewed.ts` inference errors and an unrelated ordering-test flake reproduce on `main`.