### PR TITLE
Fix automation.test.ts "Supabase update returned malformed response

### DIFF
--- a/convex/supabase/automationRuns.ts
+++ b/convex/supabase/automationRuns.ts
@@ -86,7 +86,7 @@ export const updateRun = internalAction({
       .update(row)
       .eq("id", args.runId)
       .select("id")
-      .single();
+      .maybeSingle();
 
     if (error) {
       const msg = `Supabase update failed for automation run ${args.runId}: ${error.message} (code=${error.code})`;
@@ -94,8 +94,13 @@ export const updateRun = internalAction({
       throw new Error(msg);
     }
 
-    if (!data || typeof data.id !== "string") {
-      throw new Error("Supabase update returned malformed response: missing id");
+    if (!data) {
+      // Row doesn't exist in Supabase yet (Convex-primary create hasn't mirrored).
+      // Don't throw — auxiliary audit trail.
+      console.warn(
+        `Automation run ${args.runId} not found in Supabase; skipping update.`,
+      );
+      return { success: false, id: args.runId };
     }
 
     console.info(`Automation run updated in Supabase id=${data.id} org=${args.organizationId}`);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #559.

Closes #559

---

## Claude summary

Fixed and committed. The `updateRun` action in `convex/supabase/automationRuns.ts:84-107` now uses `.maybeSingle()` and soft-returns `{ success: false }` with a warning when the Supabase row doesn't exist yet, matching the existing pattern in `updateRunStep` at `automationRunSteps.ts:108-128`. The "Supabase update returned malformed response: missing id" error no longer fires in test logs.

Note: the automation test file still has 18 pre-existing failures unrelated to this fix — they're caused by a separate test/migration mismatch (automation rules now persist to Supabase via `createSupabaseDb()` in `convex/automation.ts:812`, but the tests still query Convex via `ctx.db.get(ruleId)`). Those failures predate this branch and remain identical with or without my fix.

## Follow-ups
- Migrate automation.test.ts assertions from Convex ctx.db to in-memory Supabase store: automationRules/Runs were moved to createSupabaseDb() but tests still call ctx.db.get(ruleId) which returns undefined — 18 tests fail because of this storage mismatch, not the line 98 bug.