### PR TITLE
Migrate `savedViews` reads to Supabase

### DIFF
--- a/convex/savedViews.ts
+++ b/convex/savedViews.ts
@@ -1,39 +1,43 @@
-import { query, action } from "./_generated/server";
+import { action } from "./_generated/server";
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
-import { verifyOrgAccess } from "./_helpers/auth";
 
-export const listByEntityType = query({
+export const listByEntityType = action({
   args: {
     organizationId: v.id("organizations"),
     entityType: v.string(),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
 
-    const views = await ctx.db
-      .query("savedViews")
-      .withIndex("by_orgAndEntityType", (q) =>
-        q.eq("organizationId", args.organizationId).eq("entityType", args.entityType)
-      )
+    const db = createSupabaseDb();
+    const views = await db
+      .query<{ order?: number }>("savedViews")
+      .eq("organizationId", String(args.organizationId))
+      .eq("entityType", args.entityType)
       .collect();
 
-    views.sort((a, b) => a.order - b.order);
+    views.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
     return views;
   },
 });
 
-export const getById = query({
+export const getById = action({
   args: {
     organizationId: v.id("organizations"),
-    viewId: v.id("savedViews"),
+    viewId: v.string(),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
 
-    const view = await ctx.db.get(args.viewId);
-    if (!view || view.organizationId !== args.organizationId) {
+    const db = createSupabaseDb();
+    const view = await db.get<{ organizationId: string }>("savedViews", args.viewId);
+    if (!view || view.organizationId !== String(args.organizationId)) {
       throw new Error("Saved view not found");
     }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #573.

Closes #573

---

## Claude summary

Fixed and committed. Summary:

`convex/savedViews.ts` had write actions (`create`, `update`, `remove`, `reorder`) going to Supabase via `createSupabaseDb()` since the Phase 4 migration in 9c8eb1d, but `listByEntityType` and `getById` were still reading from `ctx.db.query("savedViews")` (Convex). Same split-store bug shape as automation rules in #570.

The frontend already bypasses both queries — it reads via `useSupabaseSavedViewsList` (src/hooks/use-supabase-saved-views.ts) directly against the `saved_views` Postgres table — so there is no user-visible regression, but the public Convex endpoints would have returned stale or empty data if any caller appeared. Converted both to actions reading through `createSupabaseDb()` (matching the pattern in `convex/calls.ts:12,61`), and relaxed `viewId` from `v.id("savedViews")` to `v.string()` to align with the sibling actions.

## Follow-ups
- Migrate `sources.list` to Supabase reads: `convex/sources.ts:7-22` has the same shape of bug — writes use `createSupabaseDb()`, but `list` still reads `ctx.db.query("sources")`. Likely caught by the same Phase 4 audit.