### PR TITLE
Unrot `recentlyViewed > returns items ordered by most recent first` test

### DIFF
--- a/tests/convex/_supabase_inmemory.ts
+++ b/tests/convex/_supabase_inmemory.ts
@@ -124,8 +124,7 @@ export function createInMemorySupabaseDb() {
 class InMemoryQueryBuilder<T = Record<string, unknown>> {
   private table: string;
   private filters: Array<(row: Row) => boolean> = [];
-  private orderField: string | null = null;
-  private orderAsc = true;
+  private orderBy: Array<{ field: string; ascending: boolean }> = [];
   private limitN: number | null = null;
   private rangeFrom: number | null = null;
   private rangeTo: number | null = null;
@@ -165,8 +164,7 @@ class InMemoryQueryBuilder<T = Record<string, unknown>> {
   }
 
   order(field: string, ascending = true) {
-    this.orderField = field;
-    this.orderAsc = ascending;
+    this.orderBy.push({ field, ascending });
     return this;
   }
 
@@ -189,17 +187,19 @@ class InMemoryQueryBuilder<T = Record<string, unknown>> {
   private materialize(): T[] {
     let rows = Array.from(getTable(this.table).values());
     for (const f of this.filters) rows = rows.filter(f);
-    if (this.orderField) {
-      const field = this.orderField;
-      const dir = this.orderAsc ? 1 : -1;
+    if (this.orderBy.length > 0) {
+      const orderBy = this.orderBy;
       rows = rows.slice().sort((a, b) => {
-        const va = a[field] as any;
-        const vb = b[field] as any;
-        if (va === vb) return 0;
-        if (va == null) return 1;
-        if (vb == null) return -1;
-        if (va < vb) return -1 * dir;
-        if (va > vb) return 1 * dir;
+        for (const { field, ascending } of orderBy) {
+          const va = a[field] as any;
+          const vb = b[field] as any;
+          if (va === vb) continue;
+          const dir = ascending ? 1 : -1;
+          if (va == null) return 1;
+          if (vb == null) return -1;
+          if (va < vb) return -1 * dir;
+          if (va > vb) return 1 * dir;
+        }
         return 0;
       });
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #577.

Closes #577

---

## Claude summary

Fixed and committed.

Root cause: PR #564 added a secondary `.order("id", false)` tiebreaker to `recentlyViewed.list` so identical `viewed_at` values would sort deterministically. The production `SupabaseQueryBuilder` composes multiple `.order()` calls into an array, but the in-memory mock in `tests/convex/_supabase_inmemory.ts` kept a single `orderField`/`orderAsc` pair — the second call clobbered the first, so the test effectively sorted by random UUID and `items[2].entityLabel` was rarely "First".

Fix: replaced the mock's single-order state with an `orderBy: Array<{field, ascending}>` and updated `materialize()` to iterate through all sort keys with the first non-equal pair winning. Now the mock matches production semantics.

Verified: `tests/convex/recentlyViewed.test.ts` — all 5 tests pass. The 18 failing tests in `automation.test.ts` are pre-existing on `origin/main` and unrelated to this issue.

## Follow-ups
- Unrot automation.test.ts on origin/main: 18 tests fail deterministically on a fresh clone, including `send_sms_request action stays compatible with legacy SMS execution path` (steps[0].status is "skipped" not "processed") and runs ending in `status: "processed"` when test expected something else. Independent of #577.