### PR TITLE
Add a root-level vitest.config.ts that re-exports convex/vitest.config.ts so bar

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -9,5 +9,5 @@
     "strict": true,
     "noEmit": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts", "convex/vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { defineConfig, mergeConfig } from "vitest/config";
+import convexConfig from "./convex/vitest.config";
+
+// Pin test.root to ./convex so include/setupFiles paths in convex/vitest.config.ts
+// resolve the same way as `cd convex && vitest`.
+export default mergeConfig(
+  convexConfig,
+  defineConfig({
+    test: {
+      root: path.resolve(__dirname, "convex"),
+    },
+  }),
+);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #578.

Closes #578

---

## Claude summary

Added a root-level `vitest.config.ts` that imports `convex/vitest.config.ts` and merges in `test.root: ./convex`, so relative `include`/`setupFiles` paths resolve identically whether you run `npx vitest` from the repo root or `cd convex && vitest`.

Verification: `npx vitest list` from the root and from `convex/` both discover 114 tests, and `npx vitest run tests/convex/seatLimits.test.ts` from the root passes (10/10). `tsconfig.node.json` also updated to typecheck the new config alongside the existing `vite.config.ts`; `tsc -p tsconfig.node.json` passes.

Committed as `ebc4f5a` on `claude/issue-578`.