### PR TITLE
Document the canonical test command in CLAUDE.md or a TESTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -639,6 +639,10 @@ The project mixes shadcn/ui (Radix) and Untitled UI (react-aria) components. The
 
 4. When reverting changes, use `git checkout -- <file>` per file. NEVER use `git stash drop` without showing the user what's being discarded.
 
+## Running Tests
+
+Convex unit tests MUST be run via `npm run test:unit` (which does `cd convex && vitest run`). Running bare `vitest` from the repo root used to silently skip the setup file; #578 added a root `vitest.config.ts` that pins `test.root` to `./convex` so `npx vitest` from root now works too. If you ever see `Error: SUPABASE_URL not configured` from a test, that is the diagnostic that vitest was invoked from the wrong cwd / wrong config and `tests/convex/_setup.ts` (which installs the in-memory Supabase stubs) never ran. See `TESTING.md` for details.
+
 ## Key Files
 
 - `convex/schema.ts` — full database schema (~1290 lines)

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,40 @@
+# Testing
+
+## Canonical command
+
+Run the Convex unit-test suite via the npm script:
+
+```sh
+npm run test:unit
+```
+
+That script is `cd convex && vitest run` (see `package.json`). The `cd convex` matters — `convex/vitest.config.ts` resolves `include`, `setupFiles`, and the `@cvx` / `~` aliases relative to the `convex/` directory.
+
+## Running vitest directly
+
+If you need to run vitest yourself (e.g. with a `--filter`, `--reporter`, or `-t` flag), pick ONE of:
+
+```sh
+# From the repo root — uses ./vitest.config.ts, which re-exports the convex
+# config with test.root pinned to ./convex (added in #578).
+npx vitest run
+
+# From the repo root — explicit config flag, identical effect.
+npx vitest run --config convex/vitest.config.ts
+
+# From convex/ — what `npm run test:unit` does.
+cd convex && npx vitest run
+```
+
+All three discover the same files and load `tests/convex/_setup.ts`, which installs the in-memory Supabase stubs.
+
+## Diagnostic: `SUPABASE_URL not configured`
+
+If you see this error in test output:
+
+```
+Error: SUPABASE_URL not configured
+    at createServiceRoleClient (convex/supabase/client.ts:6)
+```
+
+…it almost always means vitest was invoked from the wrong cwd or with the wrong config, so `tests/convex/_setup.ts` never ran and the real `createServiceRoleClient` is being called instead of the in-memory stub. Re-run via `npm run test:unit` (or one of the alternatives above). It is not an environment problem — the test suite never needs a real `SUPABASE_URL`.


### PR DESCRIPTION
Auto-generated by Claude in response to issue #579.

Closes #579

---

## Claude summary

Done. Committed in `8d5d107` on branch `claude/issue-579`.

Changes:
- New `TESTING.md` at the repo root: canonical command is `npm run test:unit`; lists the three equivalent invocations (bare `npx vitest` from root works since #578); documents `Error: SUPABASE_URL not configured` as the diagnostic that vitest was invoked from the wrong cwd / config and `tests/convex/_setup.ts` never ran.
- New "Running Tests" section in `CLAUDE.md` summarising the rule and pointing at `TESTING.md`.