### PR TITLE
Migrate `sources.list` to Supabase reads

### DIFF
--- a/convex/sources.ts
+++ b/convex/sources.ts
@@ -1,22 +1,24 @@
-import { query, action } from "./_generated/server";
+import { action } from "./_generated/server";
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
-import { verifyOrgAccess } from "./_helpers/auth";
 
-export const list = query({
+export const list = action({
   args: {
     organizationId: v.id("organizations"),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
 
-    const sources = await ctx.db
-      .query("sources")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+    const db = createSupabaseDb();
+    const sources = await db
+      .query<{ order?: number }>("sources")
+      .eq("organizationId", String(args.organizationId))
       .collect();
 
-    sources.sort((a, b) => a.order - b.order);
+    sources.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
     return sources;
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #581.

Closes #581

---

## Claude summary

Committed.

Summary: `convex/sources.ts:7-22` had the documented bug — `list` was a Convex query reading `ctx.db.query("sources")` while all writes (`create`/`update`/`remove`/`reorder`/`seed`) had been moved to Supabase via `createSupabaseDb()`. Converted `list` to an action using the same pattern from the savedViews fix in #580: drops `verifyOrgAccess` from `_helpers/auth` (queries-only), uses `internal._helpers.authAction.verifyOrgAccess`, and reads via `createSupabaseDb().query("sources").eq("organizationId", ...)`. The frontend already reads through `useSupabaseSourcesList` (`src/hooks/use-supabase-sources.ts:18`), so this only realigns the public Convex endpoint with the store of record. Typecheck clean for `convex/sources.ts`; pre-existing 18 test failures in `automation.test.ts` are unrelated (verified by stashing the change).