### PR TITLE
Investigate `recentlyViewed.ts` and `supabase/backfill.ts` implicit-any TS error

### DIFF
--- a/convex/recentlyViewed.ts
+++ b/convex/recentlyViewed.ts
@@ -63,13 +63,19 @@ export const track = action({
   },
 });
 
+type RecentlyViewedItem = {
+  entityId: string;
+  entityLabel: string;
+  viewedAt: number;
+};
+
 export const list = action({
   args: {
     organizationId: v.id("organizations"),
     entityType: v.string(),
     limit: v.optional(v.number()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<RecentlyViewedItem[]> => {
     const authResult = await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
@@ -78,11 +84,7 @@ export const list = action({
 
     const db = createSupabaseDb();
     const items = await db
-      .query<{
-        entityId: string;
-        entityLabel: string;
-        viewedAt: number;
-      }>("recentlyViewed")
+      .query<RecentlyViewedItem>("recentlyViewed")
       .eq("organizationId", String(args.organizationId))
       .eq("userId", String(authResult.userId))
       .eq("entityType", args.entityType)


### PR DESCRIPTION
Auto-generated by Claude in response to issue #584.

Closes #584

---

## Claude summary

Done. Convex typecheck now passes clean (`exit=0` vs. the 10 errors before).

The root cause was a self-referential type inference chain: `list`'s handler calls `ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, …)`, whose result type flows through `_generated/api`, which itself embeds `list`'s inferred type — TS gave up and fell back to `any`, and the `any` cascaded into `items.map((item) => …)`. The same shape of cycle in `backfill.ts` (queries calling siblings in the same file via `internal`) was downstream of this one: breaking the cycle here lets every `_listX` inferred return land, which retypes the `.map((p)/(a)/(t)/(e)/(u) => …)` callbacks.

Fix: annotate `list`'s handler with `Promise<RecentlyViewedItem[]>` and reuse the named shape in `db.query<RecentlyViewedItem>("recentlyViewed")`. No code-flow change.

A prior attempt to land this same fix existed on `claude/issue-576` (commit `8e7467a`) but never reached `main`. The CI workflow change from that commit (adding `tsc -p convex/tsconfig.json` to the e2e job) is not included here since it's the subject of separate issue #576 — landing the gate without the fix would have made CI red.

Note: `tsc -p tsconfig.app.json` still has 29 lines of pre-existing unrelated i18next errors in `src/routes/_app/patient/_layout.{index,loyalty,packages}.tsx`. These are out of scope for #584 (different files, different error class) and pre-date this branch.

## Follow-ups
- Fix i18next `Trans`/`t()` typing errors in patient portal routes: 29 TS errors in `src/routes/_app/patient/_layout.{index,loyalty,packages}.tsx` block `npm run typecheck` independently of #584