### PR TITLE
Fix tsconfig.app.json typecheck errors in patient portal routes

### DIFF
--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -102,18 +102,19 @@ export const getMyAppointments = action({
       treatmentNameById.set(String(t._id), String(t.name ?? "Unknown"));
     }
 
-    const enriched = appointments.map((appt) => ({
-      _id: String(appt._id),
-      date: appt.date as string,
-      startTime: appt.startTime as string,
-      endTime: appt.endTime as string,
-      status: appt.status as string,
-      treatmentName:
-        (appt.treatmentId &&
-          treatmentNameById.get(String(appt.treatmentId))) ??
-        "Unknown",
-      notes: (appt.notes as string | null) ?? undefined,
-    }));
+    const enriched = appointments.map((appt) => {
+      const treatmentId = appt.treatmentId as string | null | undefined;
+      return {
+        _id: String(appt._id),
+        date: appt.date as string,
+        startTime: appt.startTime as string,
+        endTime: appt.endTime as string,
+        status: appt.status as string,
+        treatmentName:
+          (treatmentId && treatmentNameById.get(treatmentId)) ?? "Unknown",
+        notes: (appt.notes as string | null) ?? undefined,
+      };
+    });
 
     return enriched.sort((a, b) => b.date.localeCompare(a.date));
   },
@@ -148,8 +149,19 @@ export const getMyPackages = action({
     }
 
     return usages.map((u) => ({
-      ...u,
+      _id: String(u._id),
+      packageId: String(u.packageId),
       packageName: packageNameById.get(String(u.packageId)) ?? "Unknown",
+      status: u.status as string,
+      purchasedAt: (u.purchasedAt as number | null) ?? 0,
+      expiresAt: (u.expiresAt as number | null) ?? null,
+      paidAmount: (u.paidAmount as number | null) ?? 0,
+      treatmentsUsed:
+        (u.treatmentsUsed as Array<{
+          treatmentId: string;
+          usedCount: number;
+          totalCount: number;
+        }> | null) ?? [],
     }));
   },
 });
@@ -163,11 +175,19 @@ export const getMyLoyaltyBalance = action({
       args.tokenHash,
     );
 
-    return await db
+    const row = await db
       .query("gabinetLoyaltyPoints")
       .eq("organizationId", organizationId)
       .eq("patientId", patientId)
       .first();
+    if (!row) return null;
+
+    return {
+      balance: (row.balance as number | null) ?? 0,
+      lifetimeEarned: (row.lifetimeEarned as number | null) ?? 0,
+      lifetimeSpent: (row.lifetimeSpent as number | null) ?? 0,
+      tier: (row.tier as string | null) ?? null,
+    };
   },
 });
 
@@ -186,9 +206,15 @@ export const getMyLoyaltyTransactions = action({
       .eq("patientId", patientId)
       .collect();
 
-    return transactions.sort(
-      (a, b) => (b.createdAt as number) - (a.createdAt as number),
-    );
+    return transactions
+      .map((tx) => ({
+        _id: String(tx._id),
+        type: tx.type as string,
+        points: (tx.points as number | null) ?? 0,
+        reason: (tx.reason as string | null) ?? "",
+        createdAt: (tx.createdAt as number | null) ?? 0,
+      }))
+      .sort((a, b) => b.createdAt - a.createdAt);
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #585.

Closes #585

---

## Claude summary

Fixed and committed (50e9b60). All 26 TS2322/TS2339/TS2345/TS2769/TS7006 errors in `_layout.{loyalty,packages,index}.tsx` are resolved by typing the Supabase-backed patient portal actions explicitly. The 15 remaining `tsc -p tsconfig.app.json` errors (TS4023 / TS2742) are pre-existing on main and out of scope for #585.

Summary of changes in `convex/gabinet/patientPortal.ts`:
- `getMyAppointments`: extracted `treatmentId` as `string | null | undefined` so the `&&` fallback no longer narrows `unknown` to `{}` in the `treatmentName` field.
- `getMyPackages`: replaced `{ ...u, packageName }` (which collapsed to `{ packageName: string }`) with an explicit projection (`_id`, `packageId`, `status`, `expiresAt`, `purchasedAt`, `paidAmount`, `treatmentsUsed`).
- `getMyLoyaltyBalance`: projects to `{ balance, lifetimeEarned, lifetimeSpent, tier }` and returns `null` if no row exists.
- `getMyLoyaltyTransactions`: projects to `{ _id, type, points, reason, createdAt }` and sorts by typed `createdAt`.

No frontend route files were modified — fixing the action return types propagates correctly through `useAction` + `useQuery`.

## Follow-ups
- Resolve TS2742 inferred-type errors in convex modules: `convex/init.ts:64`, `convex/migrations/backfillMailProviders.ts:8,48`, `convex/migrations/emailTemplateMigrations.ts:4,38,55,79`, `convex/stripe.ts:97`, `convex/gabinet/reminders.ts:7` all fail tsconfig.app.json because exported handlers reference internal convex registration types — add explicit annotations.
- Resolve TS4023 re-export-name errors with `composite: true`: `convex/gabinet/appointments.ts:758` (`TimeSlot`), `src/components/application/breadcrumbs/breadcrumbs.tsx:32` (`BreadcrumbItemProps`), `src/components/shared-assets/illustrations/index.tsx:7` (`IllustrationProps` from multiple modules) — switch to `import type` re-exports or add explicit type annotations.
- Add `noUncheckedIndexedAccess`-style typing to `SupabaseQueryBuilder` in `convex/_helpers/supabaseDb.ts`: the default `Record<string, unknown>` generic forces every consumer to write `as string` casts and is the root cause of #585-class typecheck breakage; consider table→row type mapping so `db.query("gabinetLoyaltyPoints")` returns a typed builder.