### PR TITLE
Resolve TS2742 inferred-type errors in convex modules

### DIFF
--- a/convex/gabinet/reminders.ts
+++ b/convex/gabinet/reminders.ts
@@ -1,10 +1,15 @@
+import type { RegisteredMutation } from "convex/server";
 import { internalMutation } from "../_generated/server";
 
 /**
  * Appointment reminder cron — finds tomorrow's appointments and logs reminders.
  * In production, integrate with Resend to send email reminders.
  */
-export const sendDailyReminders = internalMutation({
+export const sendDailyReminders: RegisteredMutation<
+  "internal",
+  Record<string, never>,
+  Promise<{ sent: number }>
+> = internalMutation({
   handler: async (ctx) => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);

--- a/convex/init.ts
+++ b/convex/init.ts
@@ -1,4 +1,5 @@
 import { asyncMap } from "convex-helpers";
+import type { RegisteredAction } from "convex/server";
 import { ERRORS } from "~/errors";
 import { internalAction, internalMutation } from "@cvx/_generated/server";
 import schema, {
@@ -61,7 +62,11 @@ export const insertSeedPlan = internalMutation({
   },
 });
 
-export default internalAction(async (ctx) => {
+const init: RegisteredAction<
+  "internal",
+  Record<string, never>,
+  Promise<void>
+> = internalAction(async (ctx) => {
   /**
    * Stripe Products.
    */
@@ -172,3 +177,5 @@ export default internalAction(async (ctx) => {
     "🎉 Visit: https://dashboard.stripe.com/test/products to see your products.",
   );
 });
+
+export default init;

--- a/convex/migrations/backfillMailProviders.ts
+++ b/convex/migrations/backfillMailProviders.ts
@@ -1,3 +1,4 @@
+import type { RegisteredMutation } from "convex/server";
 import { internalMutation } from "../_generated/server";
 
 /**
@@ -5,7 +6,11 @@ import { internalMutation } from "../_generated/server";
  * then match emails to mailProviders by org + fromEmail.
  * Run in batches until processed === 0.
  */
-export const backfillEmailProviders = internalMutation({
+export const backfillEmailProviders: RegisteredMutation<
+  "internal",
+  Record<string, never>,
+  Promise<{ processed: number }>
+> = internalMutation({
   handler: async (ctx) => {
     // 1. Rename provider "gmail" -> "google"
     const gmailEmails = await ctx.db
@@ -45,7 +50,11 @@ export const backfillEmailProviders = internalMutation({
  * Migration: Convert existing emailAccounts to mailProviders.
  * Run once after deploying the new schema.
  */
-export const migrateEmailAccounts = internalMutation({
+export const migrateEmailAccounts: RegisteredMutation<
+  "internal",
+  Record<string, never>,
+  Promise<{ migrated: number }>
+> = internalMutation({
   handler: async (ctx) => {
     const accounts = await ctx.db.query("emailAccounts").collect();
     let migrated = 0;

--- a/convex/migrations/emailTemplateMigrations.ts
+++ b/convex/migrations/emailTemplateMigrations.ts
@@ -1,7 +1,12 @@
+import type { RegisteredMutation } from "convex/server";
 import { internalMutation } from "../_generated/server";
 
 /** Migration 1: Copy emailLayouts data into emailBrandConfig */
-export const migrateLayoutsToBrandConfig = internalMutation({
+export const migrateLayoutsToBrandConfig: RegisteredMutation<
+  "internal",
+  Record<string, never>,
+  Promise<{ migrated: number }>
+> = internalMutation({
   handler: async (ctx) => {
     const layouts = await ctx.db.query("emailLayouts").collect();
     let migrated = 0;
@@ -35,7 +40,11 @@ export const migrateLayoutsToBrandConfig = internalMutation({
 });
 
 /** Migration 2: Extract requiredSources from variables array */
-export const migrateVariablesToRequiredSources = internalMutation({
+export const migrateVariablesToRequiredSources: RegisteredMutation<
+  "internal",
+  Record<string, never>,
+  Promise<{ migrated: number }>
+> = internalMutation({
   handler: async (ctx) => {
     const templates = await ctx.db.query("emailTemplates").collect();
     let migrated = 0;
@@ -52,7 +61,11 @@ export const migrateVariablesToRequiredSources = internalMutation({
 });
 
 /** Migration 3: Extract renderedHtml from GrapesJS body JSON */
-export const migrateBodyToRenderedHtml = internalMutation({
+export const migrateBodyToRenderedHtml: RegisteredMutation<
+  "internal",
+  Record<string, never>,
+  Promise<{ migrated: number }>
+> = internalMutation({
   handler: async (ctx) => {
     const templates = await ctx.db
       .query("emailTemplates")
@@ -76,7 +89,11 @@ export const migrateBodyToRenderedHtml = internalMutation({
 });
 
 /** Migration 4: Add templateSlug to emailEventBindings for locale-aware lookup */
-export const migrateEventBindingsToSlug = internalMutation({
+export const migrateEventBindingsToSlug: RegisteredMutation<
+  "internal",
+  Record<string, never>,
+  Promise<{ migrated: number }>
+> = internalMutation({
   handler: async (ctx) => {
     const bindings = await ctx.db.query("emailEventBindings").collect();
     let migrated = 0;

--- a/convex/stripe.ts
+++ b/convex/stripe.ts
@@ -1,10 +1,12 @@
 import Stripe from "stripe";
+import type { RegisteredQuery } from "convex/server";
 import {
   action,
   internalAction,
   internalMutation,
   internalQuery,
 } from "@cvx/_generated/server";
+import type { Doc } from "@cvx/_generated/dataModel";
 import { v } from "convex/values";
 import { ERRORS } from "~/errors";
 import { auth } from "@cvx/auth";
@@ -94,7 +96,11 @@ export const PREAUTH_createStripeCustomer = internalAction({
   },
 });
 
-export const UNAUTH_getDefaultPlan = internalQuery({
+export const UNAUTH_getDefaultPlan: RegisteredQuery<
+  "internal",
+  Record<string, never>,
+  Promise<Doc<"plans"> | null>
+> = internalQuery({
   handler: async (ctx) => {
     return ctx.db
       .query("plans")


### PR DESCRIPTION
Auto-generated by Claude in response to issue #594.

Closes #594

---

## Claude summary

Committed as `72c432a`.

Summary: All 8 TS2742 errors listed in the issue are resolved by adding explicit `RegisteredMutation` / `RegisteredQuery` / `RegisteredAction` annotations (imported from the public `convex/server` entry point) to the affected internal handler exports. Verified with `tsc -p tsconfig.app.json` and `tsc -p convex/tsconfig.json` — no TS2742 errors remain; the 6 remaining `tsc` errors in `tsconfig.app.json` (TS4023 in `convex/gabinet/appointments.ts`, `breadcrumbs.tsx`, `illustrations/index.tsx`) are pre-existing and out of scope.

## Follow-ups
- Fix TS4023 on `_getAvailableSlotsQuery` in convex/gabinet/appointments.ts:758: `TimeSlot` from `_availability` is not re-exported, blocking d.ts emit
- Re-export `BreadcrumbItemProps` from src/components/application/breadcrumbs/breadcrumb-item: TS4023 on `Breadcrumbs` const at breadcrumbs.tsx:32
- Re-export `IllustrationProps` from each illustration module (box, cloud, credit-card, documents, ...): TS4023 chain in src/components/shared-assets/illustrations/index.tsx:7