### PR TITLE
Resolve TS4023 re-export-name errors with `composite

### DIFF
--- a/convex/gabinet/_availability.ts
+++ b/convex/gabinet/_availability.ts
@@ -14,7 +14,7 @@ function minutesToTime(m: number): string {
   return `${String(h).padStart(2, "0")}:${String(min).padStart(2, "0")}`;
 }
 
-interface TimeSlot {
+export interface TimeSlot {
   start: string; // "HH:MM"
   end: string;
 }

--- a/src/components/application/breadcrumbs/breadcrumb-item.tsx
+++ b/src/components/application/breadcrumbs/breadcrumb-item.tsx
@@ -64,7 +64,7 @@ const BreadcrumbBase = ({ href, children, icon: Icon, type = "text", current, cl
     );
 };
 
-interface BreadcrumbItemProps extends AriaBreadcrumbProps {
+export interface BreadcrumbItemProps extends AriaBreadcrumbProps {
     href?: string;
     divider?: "chevron" | "slash";
     type?: BreadcrumbType;

--- a/src/components/shared-assets/illustrations/box.tsx
+++ b/src/components/shared-assets/illustrations/box.tsx
@@ -2,7 +2,7 @@ import type { HTMLAttributes } from "react";
 import { UploadCloud02 } from "@untitledui/icons";
 import { cx } from "@/lib/utils/cx";
 
-interface IllustrationProps extends HTMLAttributes<HTMLDivElement> {
+export interface IllustrationProps extends HTMLAttributes<HTMLDivElement> {
     size?: "sm" | "md" | "lg";
     svgClassName?: string;
     childrenClassName?: string;

--- a/src/components/shared-assets/illustrations/cloud.tsx
+++ b/src/components/shared-assets/illustrations/cloud.tsx
@@ -2,7 +2,7 @@ import type { HTMLAttributes } from "react";
 import { SearchLg } from "@untitledui/icons";
 import { cx } from "@/lib/utils/cx";
 
-interface IllustrationProps extends HTMLAttributes<HTMLDivElement> {
+export interface IllustrationProps extends HTMLAttributes<HTMLDivElement> {
     size?: "sm" | "md" | "lg";
     svgClassName?: string;
     childrenClassName?: string;

--- a/src/components/shared-assets/illustrations/credit-card.tsx
+++ b/src/components/shared-assets/illustrations/credit-card.tsx
@@ -2,7 +2,7 @@ import type { HTMLAttributes } from "react";
 import { AlertCircle } from "@untitledui/icons";
 import { cx } from "@/lib/utils/cx";
 
-interface IllustrationProps extends HTMLAttributes<HTMLDivElement> {
+export interface IllustrationProps extends HTMLAttributes<HTMLDivElement> {
     size?: "sm" | "md" | "lg";
     svgClassName?: string;
     childrenClassName?: string;

--- a/src/components/shared-assets/illustrations/documents.tsx
+++ b/src/components/shared-assets/illustrations/documents.tsx
@@ -2,7 +2,7 @@ import type { HTMLAttributes } from "react";
 import { UploadCloud02 } from "@untitledui/icons";
 import { cx } from "@/lib/utils/cx";
 
-interface IllustrationProps extends HTMLAttributes<HTMLDivElement> {
+export interface IllustrationProps extends HTMLAttributes<HTMLDivElement> {
     size?: "sm" | "md" | "lg";
     svgClassName?: string;
     childrenClassName?: string;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #595.

Closes #595

---

## Claude summary

Fixed all three TS4023 errors by exporting the locally-declared `TimeSlot`, `BreadcrumbItemProps`, and `IllustrationProps` interfaces so the composite-mode declaration emitter can name them. `npm run typecheck` now passes cleanly across `tsconfig.app.json`, `tsconfig.node.json`, and `convex/tsconfig.json`. Committed on `claude/issue-595` as 51b4c4b.