### PR TITLE
Add `noUncheckedIndexedAccess`-style typing to `SupabaseQueryBuilder` in `convex

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -1,4 +1,6 @@
+import type { TableNames } from "../_generated/dataModel";
 import { createServiceRoleClient, upsertWithFkRetry } from "../supabase/client";
+import type { SupabaseRow } from "./supabaseRows";
 
 const TABLE_MAP: Record<string, string> = {
   users: "users",
@@ -116,10 +118,53 @@ function resolveTable(convexTable: string): string {
   return mapped;
 }
 
-export function createSupabaseDb() {
+// Typed surface for `createSupabaseDb()`.
+//
+// `query()` returns a `SupabaseQueryBuilder<SupabaseRow<TableName>>` when
+// called with a Convex table name, so callers like
+// `db.query("gabinetLoyaltyPoints").first()` see real field types and no
+// longer need a `(row.balance as number)` cast per access (root cause of
+// the #585 typecheck breakage).
+//
+// A fallback overload preserves explicit-generic call sites
+// (`db.query<{ order?: number }>("sources")`) and tables that live only in
+// Supabase, like `recentlyViewed` (#544/#567 removed it from the Convex
+// schema but the code still reads/writes the Postgres row).
+//
+// `get` / `getMany` / `insert` / `patch` / `delete` retain their original
+// loose signatures for the same reason — tightening them ripples into
+// `noteAuthors.filter(...)`-style type predicates across dozens of files,
+// which is intentionally out of scope here. They can be tightened in a
+// follow-up.
+export interface SupabaseDb {
+  get<T = Record<string, unknown>>(table: string, id: string): Promise<T | null>;
+  getMany<T = Record<string, unknown>>(
+    table: string,
+    ids: string[],
+  ): Promise<T[]>;
+
+  insert(table: string, row: Record<string, unknown>): Promise<string>;
+  patch(
+    table: string,
+    id: string,
+    updates: Record<string, unknown>,
+  ): Promise<void>;
+  delete(table: string, id: string): Promise<void>;
+
+  query<TableName extends TableNames>(
+    table: TableName,
+  ): SupabaseQueryBuilder<SupabaseRow<TableName>>;
+  query<T = Record<string, unknown>>(
+    table: string,
+  ): SupabaseQueryBuilder<T>;
+
+  raw(): ReturnType<typeof createServiceRoleClient>;
+}
+
+export function createSupabaseDb(): SupabaseDb {
   const client = createServiceRoleClient();
 
-  return {
+  const api = {
     async get<T = Record<string, unknown>>(table: string, id: string): Promise<T | null> {
       const { data, error } = await client
         .from(resolveTable(table))
@@ -172,15 +217,17 @@ export function createSupabaseDb() {
       if (error) throw new Error(`supabaseDb.delete(${table}, ${id}): ${error.message}`);
     },
 
-    query<T = Record<string, unknown>>(table: string) {
+    query(table: string) {
       const pgTable = resolveTable(table);
-      return new SupabaseQueryBuilder<T>(client, pgTable);
+      return new SupabaseQueryBuilder(client, pgTable);
     },
 
     raw() {
       return client;
     },
   };
+
+  return api as unknown as SupabaseDb;
 }
 
 class SupabaseQueryBuilder<T = Record<string, unknown>> {
@@ -297,5 +344,3 @@ class SupabaseQueryBuilder<T = Record<string, unknown>> {
     return this.first();
   }
 }
-
-export type SupabaseDb = ReturnType<typeof createSupabaseDb>;

--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -633,7 +633,7 @@ export const listByPatientToken = action({
       new Set(
         unique
           .map((d) => d.templateId)
-          .filter((id): id is string => typeof id === "string" && id.length > 0),
+          .filter((id): id is NonNullable<typeof id> => typeof id === "string" && id.length > 0),
       ),
     );
     const templates = await db.getMany("formTemplates", templateIds);

--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -93,7 +93,7 @@ export const getMyAppointments = action({
       new Set(
         appointments
           .map((a) => a.treatmentId)
-          .filter((id): id is string => typeof id === "string" && id.length > 0),
+          .filter((id): id is NonNullable<typeof id> => typeof id === "string" && id.length > 0),
       ),
     );
     const treatments = await db.getMany("gabinetTreatments", treatmentIds);
@@ -139,7 +139,7 @@ export const getMyPackages = action({
       new Set(
         usages
           .map((u) => u.packageId)
-          .filter((id): id is string => typeof id === "string" && id.length > 0),
+          .filter((id): id is NonNullable<typeof id> => typeof id === "string" && id.length > 0),
       ),
     );
     const pkgs = await db.getMany("gabinetTreatmentPackages", packageIds);

--- a/convex/google/calendarSyncHelpers_supabase.ts
+++ b/convex/google/calendarSyncHelpers_supabase.ts
@@ -25,7 +25,7 @@ export async function findPatientByEmailSupabase(
     .take(1)
     .collect();
   const first = rows[0];
-  return first ? { id: String(first.id ?? first._id) } : null;
+  return first ? { id: String(first._id) } : null;
 }
 
 export async function createSkeletonPatientSupabase(
@@ -65,7 +65,7 @@ export async function findTreatmentByNameSupabase(
     const name = ((t.name as string) ?? "").toLowerCase();
     return name && (name === term || term.includes(name) || name.includes(term));
   });
-  return match ? { id: String(match.id ?? match._id), name: String(match.name) } : null;
+  return match ? { id: String(match._id), name: String(match.name) } : null;
 }
 
 export async function findEmployeeByUserIdSupabase(
@@ -81,7 +81,7 @@ export async function findEmployeeByUserIdSupabase(
     .collect();
   const first = rows[0];
   return first
-    ? { id: String(first.id ?? first._id), userId: String(first.userId) }
+    ? { id: String(first._id), userId: String(first.userId) }
     : null;
 }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #596.

Closes #596

---

## Claude summary

Committed `ca72eea`. The change adds a `query<TableName extends TableNames>` overload to the `SupabaseDb` interface that returns `SupabaseQueryBuilder<SupabaseRow<TableName>>`, so callers like `db.query("gabinetLoyaltyPoints").first()` get the real row shape (with `_id`, typed columns, etc.) instead of `Record<string, unknown>` — exactly the table→row mapping the issue requested. A fallback `query<T>(table: string)` overload preserves explicit-generic call sites and Supabase-only tables (`recentlyViewed`).

Three concrete simplifications fall out of the new typing: the calendar-sync helpers drop the `first.id ?? first._id` fallback (the typed row guarantees `_id`), and the patient-portal / document `templateId` filters use `id is NonNullable<typeof id>` so the `Id<…>` brand survives the narrow instead of being collapsed to `string`. `convex` typecheck passes (`tsc -p convex/tsconfig.json --noEmit` exits 0), as do `tsconfig.app` and `tsconfig.node`. Test suite has 18 pre-existing failures on `main` unrelated to this change.

`get` / `getMany` / `insert` / `patch` / `delete` are intentionally left with loose `Record<string, unknown>` signatures — the inline comment explains why, and matches the issue body's "consider table→row type mapping so `db.query(…)` returns a typed builder" framing. Tightening the rest is a follow-up.

## Follow-ups
- Tighten `SupabaseDb.get`/`getMany`/`insert`/`patch` return and parameter types to `SupabaseRow<TableName>` via overloads: same pattern as `query()`, but ripples through `noteAuthors.filter(...)`-style predicates across dozens of files so deferred from #596.
- Drop the temporary `as unknown as SupabaseDb` cast in `createSupabaseDb`: the cast is only needed because the inline object literal's `query` method has a single signature; switching to a class or explicit overload signatures on the literal would let TS infer the interface directly.