### PR TITLE
Tighten `SupabaseDb.get`/`getMany`/`insert`/`patch` return and parameter types t

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -131,24 +131,43 @@ function resolveTable(convexTable: string): string {
 // Supabase, like `recentlyViewed` (#544/#567 removed it from the Convex
 // schema but the code still reads/writes the Postgres row).
 //
-// `get` / `getMany` / `insert` / `patch` / `delete` retain their original
-// loose signatures for the same reason — tightening them ripples into
-// `noteAuthors.filter(...)`-style type predicates across dozens of files,
-// which is intentionally out of scope here. They can be tightened in a
-// follow-up.
+// `get` / `getMany` mirror the typed-overload pattern used by `query()`:
+// calling them with a Convex table literal yields a `SupabaseRow<TableName>`
+// instead of `Record<string, unknown>`, so callers don't need per-field
+// `as` casts. A fallback overload with the original loose signature
+// preserves explicit-generic call sites (e.g. `db.get<{ orgId: string }>`)
+// and Supabase-only tables that don't appear in `TableNames`.
+//
+// `insert` / `patch` are intentionally left loose. The typed-overload
+// shape we'd want — `row: Partial<SupabaseRow<TableName>>` — uses
+// `Doc<TableName>` distributively over the full Convex schema union and
+// triggers TS2589 ("type instantiation is excessively deep") in every
+// caller of the `SupabaseDb` interface, not just at the insert/patch
+// call site. `delete` takes no row payload so it stays loose as well.
 export interface SupabaseDb {
+  get<TableName extends TableNames>(
+    table: TableName,
+    id: string,
+  ): Promise<SupabaseRow<TableName> | null>;
   get<T = Record<string, unknown>>(table: string, id: string): Promise<T | null>;
+
+  getMany<TableName extends TableNames>(
+    table: TableName,
+    ids: string[],
+  ): Promise<SupabaseRow<TableName>[]>;
   getMany<T = Record<string, unknown>>(
     table: string,
     ids: string[],
   ): Promise<T[]>;
 
   insert(table: string, row: Record<string, unknown>): Promise<string>;
+
   patch(
     table: string,
     id: string,
     updates: Record<string, unknown>,
   ): Promise<void>;
+
   delete(table: string, id: string): Promise<void>;
 
   query<TableName extends TableNames>(

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -27,6 +27,7 @@ import type {
   GabinetEmployeeRow,
   GabinetPatientRow,
   GabinetTreatmentRow,
+  GabinetTreatmentPackageRow,
   GabinetPackageUsageRow,
   GabinetLoyaltyTransactionRow,
   AppointmentWorkflowHistoryRow,
@@ -34,6 +35,7 @@ import type {
   PaymentRow,
   NoteRow,
   SupabasePaginationResult,
+  SupabaseRow,
 } from "../_helpers/supabaseRows";
 import { logAudit } from "../auditLog";
 import { createNotificationDirect } from "../notifications";
@@ -2415,8 +2417,8 @@ export const getFullDetail = action({
     );
     const treatmentMap = new Map<string, GabinetTreatmentRow>(
       historyTreatments
-        .filter((t): t is Record<string, unknown> => t !== null)
-        .map((t) => [String(t._id), t as unknown as GabinetTreatmentRow]),
+        .filter((t): t is GabinetTreatmentRow => t !== null)
+        .map((t) => [String(t._id), t]),
     );
 
     // Enrich package usage
@@ -2438,14 +2440,14 @@ export const getFullDetail = action({
       Promise.all(pkgUsagePkgIds.map((id) => db.get("gabinetTreatmentPackages", id))),
       Promise.all(pkgUsageTreatmentIds.map((id) => db.get("gabinetTreatments", id))),
     ]);
-    const pkgDefMap = new Map<string, Record<string, unknown>>(
+    const pkgDefMap = new Map<string, GabinetTreatmentPackageRow>(
       pkgDefs
-        .filter((p): p is Record<string, unknown> => p !== null)
+        .filter((p): p is GabinetTreatmentPackageRow => p !== null)
         .map((p) => [String(p._id), p]),
     );
-    const pkgTreatmentMap = new Map<string, Record<string, unknown>>(
+    const pkgTreatmentMap = new Map<string, GabinetTreatmentRow>(
       pkgTreatmentDefs
-        .filter((t): t is Record<string, unknown> => t !== null)
+        .filter((t): t is GabinetTreatmentRow => t !== null)
         .map((t) => [String(t._id), t]),
     );
 
@@ -2486,11 +2488,8 @@ export const getFullDetail = action({
     );
     const noteAuthorMap = new Map<string, string | null>(
       noteAuthors
-        .filter((u): u is Record<string, unknown> => u !== null)
-        .map((u) => [
-          String(u._id),
-          (u.name as string | null) ?? (u.email as string | null),
-        ]),
+        .filter((u): u is SupabaseRow<"users"> => u !== null)
+        .map((u) => [String(u._id), u.name ?? u.email ?? null]),
     );
     const enrichedNotes: AppointmentFullDetailNote[] = notes.map((n) => ({
       ...n,

--- a/convex/gabinet/nudges.ts
+++ b/convex/gabinet/nudges.ts
@@ -2,6 +2,7 @@ import { action } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { v } from "convex/values";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
+import type { SupabaseRow } from "../_helpers/supabaseRows";
 import type { NudgeData } from "../nudges";
 
 // All gabinet nudges are Supabase-primary actions now — business tables
@@ -145,8 +146,8 @@ export const getPatientNudges = action({
     );
     const contactById = new Map(
       contacts
-        .filter((c): c is Record<string, any> => c !== null)
-        .map((c) => [String(c._id ?? c.id), c]),
+        .filter((c): c is SupabaseRow<"contacts"> => c !== null)
+        .map((c) => [String(c._id), c]),
     );
 
     const missingContact = patients.filter((patient) => {
@@ -322,8 +323,8 @@ export const getAll = action({
     );
     const contactById = new Map(
       contacts
-        .filter((c): c is Record<string, any> => c !== null)
-        .map((c) => [String(c._id ?? c.id), c]),
+        .filter((c): c is SupabaseRow<"contacts"> => c !== null)
+        .map((c) => [String(c._id), c]),
     );
     const missingContact = (patients as any[]).filter((patient) => {
       if (!patient.contactId) return true;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #603.

Closes #603

---

## Claude summary

Committed. Summary:

I tightened `SupabaseDb.get` and `SupabaseDb.getMany` with typed overloads that mirror the existing `query()` pattern: calling `db.get("users", id)` now returns `SupabaseRow<"users"> | null` instead of `Record<string, unknown> | null`. The original loose signatures stay as fallback overloads for explicit-generic call sites and Supabase-only tables.

I fixed the ripple in the `.filter((x): x is Record<string, unknown> => x !== null)` predicates the issue called out — four sites in `convex/gabinet/appointments.ts` and two in `convex/gabinet/nudges.ts`. Each now uses the concrete row type as the type guard.

I did *not* tighten `insert` / `patch`. The natural `row: Partial<SupabaseRow<TableName>>` overload triggers TS2589 ("type instantiation excessively deep") in every caller of the `SupabaseDb` interface — 1474 errors across the whole convex tree, not just at insert/patch call sites. The issue is `Doc<TableName>` distributing over the full Convex schema union inside a generic-overload constraint. The code comment now documents this limit so future work doesn't re-tread the same path.

All three `tsc` passes (`convex/tsconfig.json`, `tsconfig.app.json`, `tsconfig.node.json`) succeed. Unit tests show 18 pre-existing failures in `automation.test.ts` that are present on `c6e3a3b` (parent commit) without my changes — unrelated.

## Follow-ups
- Investigate TS2589 from `Partial<SupabaseRow<TableName>>` in SupabaseDb overloads: the natural tightening for `insert`/`patch` ripples a "type instantiation excessively deep" error to every caller; needs either a non-distributive helper, a per-call typed wrapper, or a schema-shape simplification before insert/patch can be tightened.
- Fix 18 pre-existing automation.test.ts failures: tests like "createRule persists the expected rule shape" and "send_sms_request action stays compatible with legacy SMS execution path" are failing on main, unrelated to type tightening.