### PR TITLE
Migrate automation engine's SMS preset and gabinet-template email handlers off c

### DIFF
--- a/convex/documentDataSources.ts
+++ b/convex/documentDataSources.ts
@@ -113,6 +113,7 @@ export const PLATFORM_DATA_SOURCES: DataSourceDefinition[] = [
 // ---------------------------------------------------------------------------
 
 import { CRM_DATA_SOURCES } from "./crm/documentDataSources";
+import { GABINET_DATA_SOURCES } from "./gabinet/documentDataSources";
 
 // ---------------------------------------------------------------------------
 // Aggregate registry
@@ -121,6 +122,7 @@ import { CRM_DATA_SOURCES } from "./crm/documentDataSources";
 export const ALL_DATA_SOURCES: DataSourceDefinition[] = [
   ...PLATFORM_DATA_SOURCES,
   ...CRM_DATA_SOURCES,
+  ...GABINET_DATA_SOURCES,
 ];
 
 // ---------------------------------------------------------------------------

--- a/convex/gabinet/documentDataSources.ts
+++ b/convex/gabinet/documentDataSources.ts
@@ -1,0 +1,51 @@
+import type { DataSourceDefinition } from "../documentDataSources";
+
+const patientSource: DataSourceDefinition = {
+  key: "patient",
+  label: "Klient",
+  module: "gabinet",
+  fields: [
+    { key: "firstName", label: "Imię", type: "text" },
+    { key: "lastName", label: "Nazwisko", type: "text" },
+    { key: "fullName", label: "Imię i nazwisko", type: "text" },
+    { key: "pesel", label: "PESEL", type: "pesel" },
+    { key: "dateOfBirth", label: "Data urodzenia", type: "date" },
+    { key: "phone", label: "Telefon", type: "phone" },
+    { key: "email", label: "E-mail", type: "email" },
+    { key: "address", label: "Adres", type: "text" },
+    { key: "allergies", label: "Alergie", type: "textarea" },
+    { key: "bloodType", label: "Grupa krwi", type: "text" },
+    { key: "emergencyContact", label: "Kontakt awaryjny", type: "text" },
+  ],
+  resolve: async (ctx, patientId): Promise<Record<string, string>> => {
+    if (!patientId) return {};
+    const patient = (await ctx.db.get(patientId as any)) as any;
+    if (!patient) return {};
+    return {
+      firstName: patient.firstName ?? "",
+      lastName: patient.lastName ?? "",
+      fullName: [patient.firstName, patient.lastName].filter(Boolean).join(" "),
+      pesel: patient.pesel ?? "",
+      dateOfBirth: patient.dateOfBirth ?? "",
+      phone: patient.phone ?? "",
+      email: patient.email ?? "",
+      address: [
+        patient.address?.street,
+        patient.address?.postalCode,
+        patient.address?.city,
+      ]
+        .filter(Boolean)
+        .join(", "),
+      allergies: patient.allergies ?? "",
+      bloodType: patient.bloodType ?? "",
+      emergencyContact: [
+        patient.emergencyContactName,
+        patient.emergencyContactPhone,
+      ]
+        .filter(Boolean)
+        .join(" — "),
+    };
+  },
+};
+
+export const GABINET_DATA_SOURCES: DataSourceDefinition[] = [patientSource];

--- a/tests/convex/automation.test.ts
+++ b/tests/convex/automation.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { api, internal } from "../../convex/_generated/api";
 import { DEFAULT_PERMISSIONS } from "../../convex/_helpers/permissions";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
 import {
   createTestCtx,
   seedGabinetPrereqs,
@@ -51,11 +52,19 @@ async function setPatientPhone(
   patientId: any,
   phone: string,
 ) {
+  const now = Date.now();
   await t.run(async (ctx) => {
     await ctx.db.patch(patientId, {
       phone,
-      updatedAt: Date.now(),
+      updatedAt: now,
     });
+  });
+  // Gabinet appointment + SMS actions read patient via createSupabaseDb
+  // (Supabase-primary), so mirror the update there too.
+  const db = createSupabaseDb();
+  await db.patch("gabinetPatients", String(patientId), {
+    phone,
+    updatedAt: now,
   });
 }
 
@@ -64,11 +73,17 @@ async function setPatientEmail(
   patientId: any,
   email: string,
 ) {
+  const now = Date.now();
   await t.run(async (ctx) => {
     await ctx.db.patch(patientId, {
       email,
-      updatedAt: Date.now(),
+      updatedAt: now,
     });
+  });
+  const db = createSupabaseDb();
+  await db.patch("gabinetPatients", String(patientId), {
+    email,
+    updatedAt: now,
   });
 }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #574.

Closes #574

---

## Claude summary

Fixed and committed.

Summary: The 3 failing tests in issue #574 had two root causes — the gabinet `patient` data source had been removed from the document-data-source registry (so template variables like `{{patient.fullName}}` no longer resolved), and the test helpers `setPatientPhone` / `setPatientEmail` only patched Convex while gabinet appointment + SMS actions read the patient via `createSupabaseDb` (Supabase-primary). 

The fix re-adds `convex/gabinet/documentDataSources.ts` with the `patient` source, registers it in `ALL_DATA_SOURCES`, and mirrors the test-helper patches into the in-memory Supabase mock. All 3 tests now pass. The 4 remaining `lead status changed update_field` failures are #560's responsibility (referenced explicitly in #574's body as "Same class of bug as #560") and out of scope here.

Note: PR #610 on `origin/main` already squash-merged the same fix (PRs #560 + #537). This branch is 14 commits behind main; the merge / fast-forward will harmlessly subsume this commit. I went ahead and committed the targeted fix anyway so #574 has a concrete PR-able change rather than just a "close as already-fixed" pointer.