### PR TITLE
zmiana godzin

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -672,6 +672,7 @@ export function AppointmentPreviewContent({
             </Label>
             <Input
               type="time"
+              step={900}
               value={startTime}
               onChange={(e) => setStartTime(e.target.value)}
               className="h-8 w-[88px] text-sm"
@@ -683,6 +684,7 @@ export function AppointmentPreviewContent({
             </Label>
             <Input
               type="time"
+              step={900}
               value={endTime}
               onChange={(e) => setEndTime(e.target.value)}
               className="h-8 w-[88px] text-sm"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #613.

Closes #613

---

## Claude summary

Fix committed. The Od/Do (`<input type="time">`) fields in the appointment preview popover at `src/components/gabinet/calendar/appointment-preview-content.tsx:673-689` had no `step` attribute, so Chrome's native time picker defaulted to 1-minute increments. Setting `step={900}` (900 seconds = 15 minutes) makes the picker advance in quarter-hour steps, matching the calendar's slot resolution.