### PR TITLE
przenieś niżej

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -645,11 +645,11 @@ export function AppointmentDialog({
 
         {/* 3-panel layout: stacks vertically on mobile */}
         <div className="relative flex flex-col md:flex-row md:h-[600px]">
-          {/* Centered past-slot warning overlay */}
+          {/* Past-slot warning overlay (positioned near bottom so it doesn't cover the calendar grid) */}
           {isPastSlot && selectedSlot && (
             <div
               role="alert"
-              className="pointer-events-none absolute left-1/2 top-1/2 z-20 w-[min(90%,22rem)] -translate-x-1/2 -translate-y-1/2"
+              className="pointer-events-none absolute left-1/2 bottom-4 z-20 w-[min(90%,22rem)] -translate-x-1/2"
             >
               <div className="pointer-events-auto space-y-1 rounded-md border border-red-600 bg-red-600 px-3 py-2.5 text-xs text-white shadow-lg dark:border-red-700 dark:bg-red-700">
                 <div className="flex items-center gap-1.5 font-semibold">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #614.

Closes #614

---

## Claude summary

Fixed and committed. The "Termin minął" warning in the gabinet appointment-creation dialog was absolutely positioned with `top-1/2 -translate-y-1/2`, which made it float over the middle of the calendar grid and obscure date numbers. Changed to `bottom-4` so it sits near the bottom of the dialog instead — calendar dates remain readable while the warning stays clearly visible (single change in `src/components/gabinet/calendar/appointment-dialog.tsx:652`).