### PR TITLE
możliwość zapisania po terminie

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -1118,12 +1118,7 @@ export function AppointmentDialog({
                   selected={selectedDate}
                   onSelect={handleDateSelect}
                   locale={dateFnsLocale}
-                  disabled={(date) => {
-                    if (!calendarEnabled) return true;
-                    const today = new Date();
-                    today.setHours(0, 0, 0, 0);
-                    return date < today;
-                  }}
+                  disabled={(_date) => !calendarEnabled}
                   className="w-full rounded-md"
                   classNames={{
                     root: "w-full",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #616.

Closes #616

---

## Claude summary

Committed.

Summary: The appointment dialog already had the past-slot warning and yes/no confirmation popup wired up (from PR #614/#617), but the Calendar component was hard-blocking past dates via its `disabled` callback at `src/components/gabinet/calendar/appointment-dialog.tsx:1121`. Removed that restriction so users can pick a past date — the existing `isPastSlot` warning at the bottom and the "Czy chcesz dodać wizytę?" yes/no popup now actually trigger, and clicking YES saves the backdated appointment.