### PR TITLE
etykiety

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -66,6 +66,9 @@ import {
   Plus,
   X,
 } from "lucide-react";
+import { TagsPicker } from "@/components/categories-tags/tags-picker";
+import { useTagDefinitions } from "@/hooks/use-tag-definitions";
+import { useSidebarActions } from "@/components/layout/sidebar-context";
 
 const VALID_TRANSITIONS: Record<string, string[]> = {
   pending_confirmation: ["scheduled", "confirmed", "cancelled"],
@@ -151,6 +154,7 @@ export function AppointmentPreviewContent({
   const [treatmentId, setTreatmentId] = useState("");
   const [treatmentOpen, setTreatmentOpen] = useState(false);
   const [treatmentSearch, setTreatmentSearch] = useState("");
+  const [tagIds, setTagIds] = useState<Array<Id<"tagDefinitions">>>([]);
   const [saving, setSaving] = useState(false);
   const [savingStatus, setSavingStatus] = useState(false);
   const [isEditingPhone, setIsEditingPhone] = useState(false);
@@ -159,6 +163,9 @@ export function AppointmentPreviewContent({
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [cancelReason, setCancelReason] = useState("");
   const [gateDialogOpen, setGateDialogOpen] = useState(false);
+
+  const { tags: tagDefinitions } = useTagDefinitions(organizationId);
+  const { dispatch } = useSidebarActions();
 
   const docCounts = useAppointmentDocumentCounts(appointmentId, organizationId);
 
@@ -171,6 +178,9 @@ export function AppointmentPreviewContent({
     setEndTime(appt.endTime.slice(0, 5));
     setInternalNotes(appt.internalNotes ?? "");
     setTreatmentId(appt.treatmentId ? String(appt.treatmentId) : "");
+    setTagIds(
+      (appt.tagIds ?? []).map((id) => id as Id<"tagDefinitions">),
+    );
   }, [detail]);
 
   if (isLoading || !detail) {
@@ -211,12 +221,19 @@ export function AppointmentPreviewContent({
     phoneInput.trim().length > 0 &&
     phoneInput.trim() !== (patient?.phone ?? "");
 
+  const initialTagIds = (appointment.tagIds ?? []).map((id) => String(id));
+  const currentTagIds = tagIds.map((id) => String(id));
+  const tagsDirty =
+    initialTagIds.length !== currentTagIds.length ||
+    initialTagIds.some((id) => !currentTagIds.includes(id));
+
   const apptDirty =
     date !== appointment.date ||
     startTime !== appointment.startTime.slice(0, 5) ||
     endTime !== appointment.endTime.slice(0, 5) ||
     internalNotes !== (appointment.internalNotes ?? "") ||
-    treatmentId !== initialTreatmentId;
+    treatmentId !== initialTreatmentId ||
+    tagsDirty;
 
   const dirty = phoneDirty || apptDirty;
 
@@ -384,6 +401,7 @@ export function AppointmentPreviewContent({
           args.internalNotes = internalNotes;
         if (treatmentId && treatmentId !== initialTreatmentId)
           args.treatmentId = treatmentId;
+        if (tagsDirty) args.tagIds = tagIds.map((id) => String(id));
 
         await updateAppointment(args);
         await Promise.all([
@@ -652,6 +670,35 @@ export function AppointmentPreviewContent({
               ))}
             </SelectContent>
           </Select>
+        </div>
+
+        <div className="space-y-1">
+          <div className="flex items-center justify-between gap-2">
+            <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
+              {t("gabinet.appointmentDetail.tags", { defaultValue: "Etykiety" })}
+            </Label>
+            <button
+              type="button"
+              onClick={() => dispatch("manageTags")}
+              className="text-[11px] font-medium text-primary hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring rounded"
+            >
+              {t("gabinet.appointmentDetail.manageTags", {
+                defaultValue: "Zarządzaj",
+              })}
+            </button>
+          </div>
+          <TagsPicker
+            tags={tagDefinitions}
+            selectedIds={tagIds}
+            onChange={setTagIds}
+            placeholder={
+              tagDefinitions.length === 0
+                ? t("gabinet.appointmentDetail.addFirstTagHint", {
+                    defaultValue: 'Dodaj pierwszy tag w "Zarządzaj"',
+                  })
+                : t("tags.assign", { defaultValue: "Tagi" })
+            }
+          />
         </div>
 
         <div className="grid grid-cols-[1fr_auto_auto] items-end gap-1.5">

--- a/src/components/layout/app-footer.tsx
+++ b/src/components/layout/app-footer.tsx
@@ -72,6 +72,7 @@ const gabinetRouteActions: Record<string, FooterAction[]> = {
     { labelKey: "nav.actions.bookAppointment", icon: CalendarCheck, quickCreate: "appointment" },
     { labelKey: "nav.actions.filters", icon: Filter, action: "openFilter" },
     { labelKey: "nav.actions.addPatient", icon: UserPlus, quickCreate: "patient" },
+    { labelKey: "nav.actions.manageTags", icon: Tag, action: "manageTags" },
     { labelKey: "nav.actions.printSchedule", icon: Download, action: "printSchedule" },
   ],
   patients: [

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -51,6 +51,7 @@ import { useSupabaseGabinetEmployeeSchedulesList } from "@/hooks/use-supabase-ga
 import { useSupabaseGabinetWorkingHoursList } from "@/hooks/use-supabase-gabinet-working-hours";
 import { useSupabaseScheduledActivitiesByDateRange } from "@/hooks/use-supabase-scheduled-activities";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
+import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatAppointmentError } from "@/lib/format-action-error";
 
@@ -112,6 +113,9 @@ function GabinetCalendarPage() {
 
   // Filter dialog
   const [filterOpen, setFilterOpen] = useState(false);
+
+  // Tags manager slideout
+  const [tagsSlideoutOpen, setTagsSlideoutOpen] = useState(false);
 
   // Dialog state
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -455,6 +459,7 @@ function GabinetCalendarPage() {
   // Sidebar dispatch handlers
   useSidebarDispatch("goToToday", goToday);
   useSidebarDispatch("openFilter", () => setFilterOpen(true));
+  useSidebarDispatch("manageTags", () => setTagsSlideoutOpen(true));
 
   // Click-to-create handler
   const handleSlotClick = useCallback(
@@ -947,6 +952,13 @@ function GabinetCalendarPage() {
 
       {/* Print-only schedule table */}
       <PrintSchedule date={printDate} appointments={printAppointments} />
+
+      <TagsManagerSlideout
+        isOpen={tagsSlideoutOpen}
+        onOpenChange={setTagsSlideoutOpen}
+        organizationId={organizationId}
+        tags={tagDefinitions}
+      />
 
       {/* Drag overlay - shows appointment being dragged */}
       <DragOverlay>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #621.

Closes #621

---

## Claude summary

Committed as `ae4a891`.

Summary of changes for #621:

1. `src/components/gabinet/calendar/appointment-preview-content.tsx` — adds an "Etykiety" section right below the existing "Zmień status" select. It uses the existing `TagsPicker` and persists selections through the existing `tagIds` field on `gabinetAppointments` via the already-supported `update` action. A small "Zarządzaj" link next to the label dispatches `manageTags` to open the manager.

2. `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx` — mounts `TagsManagerSlideout` and wires `useSidebarDispatch("manageTags", …)` so both the footer button and the in-preview "Zarządzaj" link open it. Reuses the `tagDefinitions` already fetched on this page.

3. `src/components/layout/app-footer.tsx` — adds a `Zarządzaj tagami` footer action on the gabinet calendar route, matching the pattern used on `patients`, `leads`, `contacts`, etc.

Where to add labels to the dropdown: on the calendar page, click "Zarządzaj tagami" in the footer (or the "Zarządzaj" link inside the appointment popover's Etykiety section) → the right-side slideout lets you create, rename, recolor, or remove organization-wide tags, which then appear in every appointment's picker.

Frontend and Convex typechecks both pass; ESLint reports no issues on the changed files.