### PR TITLE
notatki medyczne 

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -36,6 +36,7 @@ import {
 
 import { useTranslation } from "react-i18next";
 import { PatientPackagesCard } from "@/components/gabinet/patient-packages-card";
+import { plateJsonToText } from "@/components/gabinet/rich-text-editor";
 import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
 
 export const Route = createFileRoute(
@@ -145,18 +146,22 @@ function PatientDetail() {
           </div>
         </div>
       </div>
-      {patient.medicalNotes && (
-        <div className="space-y-2">
-          <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
-            {t("gabinet.patients.medicalNotes")}
-          </p>
-          <div className="rounded-md border p-2.5">
-            <p className="text-xs text-muted-foreground whitespace-pre-wrap">
-              {patient.medicalNotes}
+      {(() => {
+        const medicalNotesText = plateJsonToText(patient.medicalNotes ?? undefined).trim();
+        if (!medicalNotesText) return null;
+        return (
+          <div className="space-y-2">
+            <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+              {t("gabinet.patients.medicalNotes")}
             </p>
+            <div className="rounded-md border p-2.5">
+              <p className="text-xs text-muted-foreground whitespace-pre-wrap">
+                {medicalNotesText}
+              </p>
+            </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
       <PatientPackagesCard
         patientId={patientId}
         organizationId={organizationId}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -29,6 +29,7 @@ import { CategoriesManagerSlideout } from "@/components/categories-tags/categori
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { Label } from "@/components/ui/label";
+import { plateJsonToText } from "@/components/gabinet/rich-text-editor";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/patients/",
@@ -290,7 +291,7 @@ function PatientsIndex() {
       {
         id: "medicalNotes",
         label: t("gabinet.patients.medicalNotes"),
-        render: (item) => item.medicalNotes ?? "—",
+        render: (item) => plateJsonToText(item.medicalNotes ?? undefined).trim() || "—",
       },
       {
         id: "createdAt",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #623.

Closes #623

---

## Claude summary

Fixed and committed. The patient sidebar and patient list column were rendering raw Plate editor JSON (e.g. `[{"type":"p","children":[{"text":"Pani chora na głowę"}]...}]`) because `patient.medicalNotes` is stored as a serialized Plate document by the `RichTextEditor` in `patient-form.tsx:267`, but the display sites were dumping the string as-is.

The fix uses the existing `plateJsonToText` helper from `src/components/gabinet/rich-text-editor.tsx:142` — the same pattern already used for notes on contact, lead, company, employee, and appointment detail pages. Applied in:
- `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx:149-164` — sidebar "Notatki medyczne" block (also now hides the block when extracted text is empty, since older `"" ` JSON wrappers would otherwise still render an empty card).
- `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx:294` — the optional table column.

The editor itself already round-trips JSON correctly via `parseValue`, so editing existing notes continues to work.