### PR TITLE
powiadomienia

### DIFF
--- a/convex/gabinet/nudges.ts
+++ b/convex/gabinet/nudges.ts
@@ -38,6 +38,7 @@ export const getAppointmentNudges = action({
         message: "sidebar.nudges.gabinet.appointments.unconfirmedSms",
         messageValues: { count },
         severity: "yellow",
+        link: "/dashboard/gabinet/calendar?nudge=unconfirmed-today",
       },
     ];
   },
@@ -64,6 +65,7 @@ export const getLeaveNudges = action({
         message: "sidebar.nudges.gabinet.leave.pendingApproval",
         messageValues: { count },
         severity: "red",
+        link: "/dashboard/gabinet/settings/leaves?nudge=pending",
       },
     ];
   },
@@ -98,6 +100,7 @@ export const getPackageNudges = action({
         message: "sidebar.nudges.gabinet.packages.expiringSoon",
         messageValues: { count: expiring.length },
         severity: "yellow",
+        link: "/dashboard/gabinet/packages?nudge=expiring",
       });
     }
 
@@ -112,6 +115,7 @@ export const getPackageNudges = action({
         message: "sidebar.nudges.gabinet.packages.noUsage",
         messageValues: { count: noUsage.length },
         severity: "yellow",
+        link: "/dashboard/gabinet/packages?nudge=no-usage",
       });
     }
 
@@ -161,6 +165,7 @@ export const getPatientNudges = action({
         message: "sidebar.nudges.gabinet.patients.missingContact",
         messageValues: { count: missingContact.length },
         severity: "yellow",
+        link: "/dashboard/gabinet/patients?nudge=missing-contact",
       });
     }
 
@@ -187,6 +192,7 @@ export const getPatientNudges = action({
         message: "sidebar.nudges.gabinet.patients.noRecentVisit",
         messageValues: { count: noRecentVisit.length },
         severity: "yellow",
+        link: "/dashboard/gabinet/patients?nudge=no-recent-visit",
       });
     }
 
@@ -215,6 +221,7 @@ export const getTreatmentNudges = action({
           message: "sidebar.nudges.gabinet.treatments.noPrice",
           messageValues: { count: noPrice.length },
           severity: "yellow",
+          link: "/dashboard/gabinet/treatments?nudge=no-price",
         },
       ];
     }
@@ -269,6 +276,7 @@ export const getAll = action({
         message: "sidebar.nudges.gabinet.appointments.unconfirmedSms",
         messageValues: { count: unconfirmed },
         severity: "yellow",
+        link: "/dashboard/gabinet/calendar?nudge=unconfirmed-today",
       });
     }
 
@@ -278,6 +286,7 @@ export const getAll = action({
         message: "sidebar.nudges.gabinet.leave.pendingApproval",
         messageValues: { count: pendingLeaves.length },
         severity: "red",
+        link: "/dashboard/gabinet/settings/leaves?nudge=pending",
       });
     }
 
@@ -294,6 +303,7 @@ export const getAll = action({
         message: "sidebar.nudges.gabinet.packages.expiringSoon",
         messageValues: { count: expiring.length },
         severity: "yellow",
+        link: "/dashboard/gabinet/packages?nudge=expiring",
       });
     }
     const packagesWithUsage = new Set(
@@ -307,6 +317,7 @@ export const getAll = action({
         message: "sidebar.nudges.gabinet.packages.noUsage",
         messageValues: { count: noUsage.length },
         severity: "yellow",
+        link: "/dashboard/gabinet/packages?nudge=no-usage",
       });
     }
 
@@ -336,6 +347,7 @@ export const getAll = action({
         message: "sidebar.nudges.gabinet.patients.missingContact",
         messageValues: { count: missingContact.length },
         severity: "yellow",
+        link: "/dashboard/gabinet/patients?nudge=missing-contact",
       });
     }
 
@@ -352,6 +364,7 @@ export const getAll = action({
         message: "sidebar.nudges.gabinet.patients.noRecentVisit",
         messageValues: { count: noRecentVisit.length },
         severity: "yellow",
+        link: "/dashboard/gabinet/patients?nudge=no-recent-visit",
       });
     }
 
@@ -363,6 +376,7 @@ export const getAll = action({
         message: "sidebar.nudges.gabinet.treatments.noPrice",
         messageValues: { count: noPrice.length },
         severity: "yellow",
+        link: "/dashboard/gabinet/treatments?nudge=no-price",
       });
     }
 

--- a/convex/nudges.ts
+++ b/convex/nudges.ts
@@ -9,6 +9,9 @@ export interface NudgeData {
   messageValues?: Record<string, string | number>;
   severity: "red" | "yellow" | "green";
   icon?: string;
+  /** Optional destination URL (pathname + optional query string) that opens
+   *  the list of items the nudge refers to. */
+  link?: string;
 }
 
 async function verify(ctx: any, organizationId: string) {
@@ -41,6 +44,7 @@ export const getInsightsNudges = action({
         message: "sidebar.nudges.insights.closingThisWeek",
         messageValues: { count: closingThisWeek.length },
         severity: "red",
+        link: "/dashboard/leads?nudge=closing-this-week",
       });
     }
 
@@ -52,6 +56,7 @@ export const getInsightsNudges = action({
         message: "sidebar.nudges.insights.overdueActivities",
         messageValues: { count: overdue.length },
         severity: "yellow",
+        link: "/dashboard/activities?nudge=overdue",
       });
     }
 
@@ -94,6 +99,7 @@ export const getDealsNudges = action({
           message: "sidebar.nudges.deals.stale",
           messageValues: { count: staleLeads.length },
           severity: "yellow",
+          link: "/dashboard/leads?nudge=stale",
         },
       ];
     }
@@ -129,6 +135,7 @@ export const getContactsNudges = action({
           message: "sidebar.nudges.contacts.unlinkedCompany",
           messageValues: { count: unlinked.length },
           severity: "yellow",
+          link: "/dashboard/contacts?nudge=unlinked-company",
         },
       ];
     }
@@ -159,6 +166,7 @@ export const getInboxNudges = action({
           message: "sidebar.nudges.inbox.unanswered",
           messageValues: { count: unanswered.length },
           severity: "red",
+          link: "/dashboard/inbox?nudge=unanswered",
         },
       ];
     }
@@ -192,6 +200,7 @@ export const getActivitiesNudges = action({
           message: "sidebar.nudges.activities.overdueOldest",
           messageValues: { count: overdue.length, days: daysOld },
           severity: "red",
+          link: "/dashboard/activities?nudge=overdue",
         },
       ];
     }
@@ -218,6 +227,7 @@ export const getDocumentsNudges = action({
           message: "sidebar.nudges.documents.pendingApproval",
           messageValues: { count: pending.length },
           severity: "yellow",
+          link: "/dashboard/documents?nudge=pending-approval",
         },
       ];
     }
@@ -256,6 +266,7 @@ export const getCalendarNudges = action({
           message: "sidebar.nudges.calendar.yesterdayOverdue",
           messageValues: { count: yesterdayOverdue.length },
           severity: "yellow",
+          link: "/dashboard/calendar?nudge=yesterday-overdue",
         },
       ];
     }
@@ -298,6 +309,7 @@ export const getCompaniesNudges = action({
         message: "sidebar.nudges.companies.noContacts",
         messageValues: { count: noContacts.length },
         severity: "yellow",
+        link: "/dashboard/companies?nudge=no-contacts",
       });
     }
 
@@ -307,6 +319,7 @@ export const getCompaniesNudges = action({
         message: "sidebar.nudges.companies.noIndustry",
         messageValues: { count: noIndustry.length },
         severity: "yellow",
+        link: "/dashboard/companies?nudge=no-industry",
       });
     }
 
@@ -337,6 +350,7 @@ export const getCallsNudges = action({
           message: "sidebar.nudges.calls.noOutcome",
           messageValues: { count: noOutcome.length },
           severity: "yellow",
+          link: "/dashboard/calls?nudge=no-outcome",
         },
       ];
     }
@@ -369,6 +383,7 @@ export const getProductsNudges = action({
           message: "sidebar.nudges.products.unused",
           messageValues: { count: unused.length },
           severity: "yellow",
+          link: "/dashboard/products?nudge=unused",
         },
       ];
     }
@@ -431,6 +446,7 @@ export const getAll = action({
         message: "sidebar.nudges.insights.closingThisWeek",
         messageValues: { count: closingThisWeek.length },
         severity: "red",
+        link: "/dashboard/leads?nudge=closing-this-week",
       });
     }
     const overdueActivities = (scheduled as any[]).filter(
@@ -441,6 +457,7 @@ export const getAll = action({
         message: "sidebar.nudges.insights.overdueActivities",
         messageValues: { count: overdueActivities.length },
         severity: "yellow",
+        link: "/dashboard/activities?nudge=overdue",
       });
     }
 
@@ -463,6 +480,7 @@ export const getAll = action({
         message: "sidebar.nudges.deals.stale",
         messageValues: { count: staleLeads.length },
         severity: "yellow",
+        link: "/dashboard/leads?nudge=stale",
       });
     }
 
@@ -480,6 +498,7 @@ export const getAll = action({
         message: "sidebar.nudges.contacts.unlinkedCompany",
         messageValues: { count: unlinkedContacts.length },
         severity: "yellow",
+        link: "/dashboard/contacts?nudge=unlinked-company",
       });
     }
 
@@ -492,6 +511,7 @@ export const getAll = action({
         message: "sidebar.nudges.inbox.unanswered",
         messageValues: { count: unanswered.length },
         severity: "red",
+        link: "/dashboard/inbox?nudge=unanswered",
       });
     }
 
@@ -502,6 +522,7 @@ export const getAll = action({
         message: "sidebar.nudges.documents.pendingApproval",
         messageValues: { count: pendingDocs.length },
         severity: "yellow",
+        link: "/dashboard/documents?nudge=pending-approval",
       });
     }
 
@@ -526,6 +547,7 @@ export const getAll = action({
         message: "sidebar.nudges.companies.noContacts",
         messageValues: { count: noContacts.length },
         severity: "yellow",
+        link: "/dashboard/companies?nudge=no-contacts",
       });
     }
     const noIndustry = (companies as any[]).filter((c) => !c.industry);
@@ -534,6 +556,7 @@ export const getAll = action({
         message: "sidebar.nudges.companies.noIndustry",
         messageValues: { count: noIndustry.length },
         severity: "yellow",
+        link: "/dashboard/companies?nudge=no-industry",
       });
     }
 
@@ -545,6 +568,7 @@ export const getAll = action({
         message: "sidebar.nudges.calls.noOutcome",
         messageValues: { count: noOutcome.length },
         severity: "yellow",
+        link: "/dashboard/calls?nudge=no-outcome",
       });
     }
 
@@ -560,6 +584,7 @@ export const getAll = action({
         message: "sidebar.nudges.products.unused",
         messageValues: { count: unusedProducts.length },
         severity: "yellow",
+        link: "/dashboard/products?nudge=unused",
       });
     }
 
@@ -578,6 +603,7 @@ export const getAll = action({
           message: "sidebar.nudges.activities.overdueOldest",
           messageValues: { count: overdue.length, days: daysOld },
           severity: "red",
+          link: "/dashboard/activities?nudge=overdue",
         });
       }
       const yesterdayOverdue = userScheduled.filter(
@@ -592,6 +618,7 @@ export const getAll = action({
           message: "sidebar.nudges.calendar.yesterdayOverdue",
           messageValues: { count: yesterdayOverdue.length },
           severity: "yellow",
+          link: "/dashboard/calendar?nudge=yesterday-overdue",
         });
       }
     }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1922,6 +1922,9 @@
       "emptyTitle": "No clients yet",
       "emptyDescription": "Add your first client to get started",
       "confirmDelete": "Are you sure you want to deactivate this client?",
+      "nudgeFilter": {
+        "missingContact": "Showing clients with no phone or email."
+      },
       "views": {
         "all": "All Clients",
         "active": "Active",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1930,6 +1930,9 @@
       "emptyTitle": "Brak klientów",
       "emptyDescription": "Dodaj pierwszego klienta, aby rozpocząć",
       "confirmDelete": "Czy na pewno chcesz dezaktywować tego klienta?",
+      "nudgeFilter": {
+        "missingContact": "Pokazywani są klienci bez telefonu i e-maila."
+      },
       "views": {
         "all": "Wszyscy klienci",
         "active": "Aktywni",

--- a/src/components/notifications/nudges-badge.tsx
+++ b/src/components/notifications/nudges-badge.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "@tanstack/react-router";
 import {
   AlertTriangle,
   AlertCircle,
   CheckCircle,
+  ChevronRight,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -39,8 +41,17 @@ const severityConfig = {
 
 export function NudgesBadge() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const { nudges, totalCount, isLoading } = useNudges();
   const [open, setOpen] = useState(false);
+
+  const handleNudgeClick = (link: string) => {
+    setOpen(false);
+    // Use the raw URL (path + optional ?search) so we can keep nudge link
+    // definitions co-located in the backend without needing per-route typed
+    // search params here.
+    navigate({ to: link });
+  };
 
   // Auto-refresh nudges every 60 seconds
   useEffect(() => {
@@ -119,11 +130,9 @@ export function NudgesBadge() {
               {nudges.map((nudge, idx) => {
                 const nudgeConfig = severityConfig[nudge.severity];
                 const NudgeIcon = nudgeConfig.Icon;
-                return (
-                  <div
-                    key={`${nudge.message}-${idx}`}
-                    className="flex items-start gap-3 px-4 py-3 hover:bg-muted/50 transition-colors"
-                  >
+                const isClickable = !!nudge.link;
+                const content = (
+                  <>
                     <div
                       className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md ${nudgeConfig.bgClass}`}
                     >
@@ -139,6 +148,29 @@ export function NudgesBadge() {
                         })}
                       </p>
                     </div>
+                    {isClickable && (
+                      <ChevronRight className="mt-1.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                    )}
+                  </>
+                );
+                if (isClickable) {
+                  return (
+                    <button
+                      key={`${nudge.message}-${idx}`}
+                      type="button"
+                      onClick={() => handleNudgeClick(nudge.link!)}
+                      className="flex w-full items-start gap-3 px-4 py-3 text-left hover:bg-muted/50 transition-colors"
+                    >
+                      {content}
+                    </button>
+                  );
+                }
+                return (
+                  <div
+                    key={`${nudge.message}-${idx}`}
+                    className="flex items-start gap-3 px-4 py-3 hover:bg-muted/50 transition-colors"
+                  >
+                    {content}
                   </div>
                 );
               })}

--- a/src/contexts/nudges-context.tsx
+++ b/src/contexts/nudges-context.tsx
@@ -10,6 +10,9 @@ export interface NudgeData {
   messageValues?: Record<string, string | number>;
   severity: "red" | "yellow" | "green";
   icon?: string;
+  /** Optional destination URL (pathname + optional query string) that opens
+   *  the list of items the nudge refers to. */
+  link?: string;
 }
 
 interface NudgesContextValue {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useNavigate, Link } from "@tanstack/react-router";
+import { createFileRoute, useNavigate, useSearch, Link } from "@tanstack/react-router";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
@@ -12,7 +12,7 @@ import { PatientForm } from "@/components/forms/patient-form";
 import { Button } from "@/components/ui/button";
 import { AvatarLabelGroup } from "@untitled/base/avatar/avatar-label-group";
 import { Badge } from "@/components/ui/badge";
-import { Plus, Trash2, Download } from "@/lib/ez-icons";
+import { Plus, Trash2, Download, X } from "@/lib/ez-icons";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { Id } from "@cvx/_generated/dataModel";
@@ -31,10 +31,16 @@ import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { Label } from "@/components/ui/label";
 import { plateJsonToText } from "@/components/gabinet/rich-text-editor";
 
+type PatientNudgeFilter = "missing-contact";
+
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/patients/",
 )({
   component: PatientsIndex,
+  validateSearch: (search: Record<string, unknown>): { nudge?: PatientNudgeFilter } => {
+    const nudge = search.nudge === "missing-contact" ? "missing-contact" : undefined;
+    return { nudge };
+  },
 });
 
 type Patient = MappedGabinetPatient;
@@ -43,6 +49,7 @@ function PatientsIndex() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
+  const { nudge: nudgeFilter } = useSearch({ from: Route.id });
   const createPatient = useAction(api.gabinet.patients.create);
   const removePatient = useAction(api.gabinet.patients.remove);
 
@@ -176,6 +183,9 @@ function PatientsIndex() {
     }
     data = applyFilters(data);
     data = applyFilterConditions(data, activeFilters);
+    if (nudgeFilter === "missing-contact") {
+      data = data.filter((p) => !p.phone && !p.email);
+    }
     const q = searchValue.trim().toLowerCase();
     if (q) {
       data = data.filter(
@@ -187,7 +197,7 @@ function PatientsIndex() {
       );
     }
     return data;
-  }, [patients, activeViewId, applyFilters, activeFilters, searchValue]);
+  }, [patients, activeViewId, applyFilters, activeFilters, searchValue, nudgeFilter]);
 
   const patientsByDay = useMemo<MiniChartData[]>(() => {
     const dayMap = new Map<string, number>();
@@ -385,6 +395,30 @@ function PatientsIndex() {
           </Button>
         }
       />
+
+      {nudgeFilter === "missing-contact" && (
+        <div className="flex items-center justify-between rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+          <span>
+            {t("gabinet.patients.nudgeFilter.missingContact", {
+              defaultValue: "Pokazywani są klienci bez telefonu i e-maila.",
+            })}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 text-xs"
+            onClick={() =>
+              navigate({
+                to: "/dashboard/gabinet/patients",
+                search: { nudge: undefined },
+              })
+            }
+          >
+            <X className="h-3.5 w-3.5" variant="stroke" />
+            {t("common.clearFilters")}
+          </Button>
+        </div>
+      )}
 
       <DataListFilterBar
         views={views}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #625.

Closes #625

---

## Claude summary

Committed as `cd5ed2a`.

Summary: nudges in the bell dropdown are now clickable. Each backend nudge carries an optional `link` (path + `?nudge=<id>`). For the issue's exact example — clients with no phone — clicking the nudge takes you to `/dashboard/gabinet/patients?nudge=missing-contact`, where `validateSearch` parses the param, the list filters to patients with no phone AND no email, and a dismissible amber banner appears above the table with a "clear" button. Other nudges navigate to their list page but don't yet filter; those are listed as follow-ups so they can each be tracked individually (each route needs its own `validateSearch` + filter logic).

Pre-existing typecheck errors (`TS2589` in `convex/nudges.ts` and `src/contexts/nudges-context.tsx`) exist on main too — verified by stashing the diff — and are not introduced by this change.

## Follow-ups
- Wire nudge=no-recent-visit filter on gabinet patients page: requires fetching recent appointments client-side or a backend filter action; today the link navigates but does not filter
- Wire nudge=stale and nudge=closing-this-week filters on /dashboard/leads: add validateSearch and apply to leads list
- Wire nudge=overdue filter on /dashboard/activities: filter scheduledActivities to those with dueDate < now and status != done
- Wire nudge=unlinked-company filter on /dashboard/contacts: filter contacts where companyId is null
- Wire nudge=no-contacts and nudge=no-industry filters on /dashboard/companies: two distinct filters on the same page
- Wire nudge=unanswered filter on /dashboard/inbox: filter to threads where last message is inbound and unreplied
- Wire nudge=pending-approval filter on /dashboard/documents: filter to documents with approval status pending
- Wire nudge=no-outcome filter on /dashboard/calls: filter to calls with no outcome recorded
- Wire nudge=unused filter on /dashboard/products: filter to products not used in any deal
- Wire nudge=yesterday-overdue filter on /dashboard/calendar: highlight or filter to overdue activities from yesterday
- Wire nudge=unconfirmed-today filter on /dashboard/gabinet/calendar: highlight today's appointments not yet confirmed via SMS
- Wire nudge=pending filter on /dashboard/gabinet/settings/leaves: filter to leave requests awaiting approval
- Wire nudge=expiring and nudge=no-usage filters on /dashboard/gabinet/packages: two distinct filters on the same page
- Wire nudge=no-price filter on /dashboard/gabinet/treatments: filter to treatments with no price or price=0
- Investigate TS2589 in convex/nudges.ts:18 and src/contexts/nudges-context.tsx:39: pre-existing "type instantiation excessively deep" errors block `npm run build` on main