### PR TITLE
etykiety 

### DIFF
--- a/src/components/categories-tags/tags-picker.tsx
+++ b/src/components/categories-tags/tags-picker.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Tag01, XClose } from "@untitledui/icons";
-import { Button } from "@untitled/base/buttons/button";
+import { styles as buttonStyles } from "@untitled/base/buttons/button";
 import { Input } from "@untitled/base/input/input";
 import { CheckboxBase } from "@untitled/base/checkbox/checkbox";
 import { Badge } from "@untitled/base/badges/badges";
@@ -10,6 +10,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { cx } from "@/lib/utils/cx";
 import { Id } from "@cvx/_generated/dataModel";
 
 interface TagDef {
@@ -93,9 +94,19 @@ export function TagsPicker({ tags, selectedIds, onChange, placeholder }: TagsPic
 
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <Button size="sm" color="secondary" iconLeading={Tag01}>
-            {placeholder ?? t("tags.assign", { defaultValue: "Tagi" })}
-          </Button>
+          <button
+            type="button"
+            className={cx(
+              buttonStyles.common.root,
+              buttonStyles.sizes.sm.root,
+              buttonStyles.colors.secondary.root,
+            )}
+          >
+            <Tag01 data-icon="leading" className={buttonStyles.common.icon} />
+            <span data-text className="transition-inherit-all px-0.5">
+              {placeholder ?? t("tags.assign", { defaultValue: "Tagi" })}
+            </span>
+          </button>
         </PopoverTrigger>
         <PopoverContent className="w-60 p-0" align="start">
           <div className="p-2">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #631.

Closes #631

---

## Claude summary

Fix committed. Summary:

The TagsPicker's "Tagi" button in the appointment preview popover on `/dashboard/gabinet/calendar` didn't respond to clicks. Root cause: `<PopoverTrigger asChild>` wrapping the UTUI Button (`src/components/base/buttons/button.tsx`) — that Button is a plain function component (no `forwardRef`) rendering `react-aria-components` AriaButton, whose press-based handling doesn't reliably accept Radix Slot's injected `onClick` and ref. The neighboring treatment picker in the same popover works because it uses a native button as the trigger.

Fix in `src/components/categories-tags/tags-picker.tsx:95-110`: replaced the UTUI Button trigger with a native `<button>` that reuses UTUI's exported style tokens (`styles.common.root`, `styles.sizes.sm.root`, `styles.colors.secondary.root`) so the look is unchanged. Native buttons play correctly with Radix's `asChild` pattern.

Typecheck passes (the 2 errors reported in `convex/nudges.ts` and `src/contexts/nudges-context.tsx` are pre-existing on main and unrelated).

## Follow-ups
- Apply the same fix to CategoryPicker: `src/components/categories-tags/category-picker.tsx:178-181` uses the identical `<PopoverTrigger asChild><Button …>` pattern with the UTUI Button and is latently broken in the same way; it just hasn't been reported because it isn't yet rendered inside another Radix Popover.
- Make UTUI Button forwardRef-compatible: `src/components/base/buttons/button.tsx` is a non-`forwardRef` function component; this silently breaks any Radix `asChild` integration and would prevent future bugs of this shape.