### PR TITLE
tłumaczenie split

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2616,6 +2616,7 @@
       "installmentsPaid": "paid",
       "installmentIndex": "Installment {{n}}",
       "splitPayment": "Split payment",
+      "splitFirstInstallment": "Split first installment",
       "firstMethod": "First method",
       "secondMethod": "Second method",
       "splitSum": "Sum",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2627,6 +2627,7 @@
       "installmentsPaid": "opłaconych",
       "installmentIndex": "Rata {{n}}",
       "splitPayment": "Podziel płatność",
+      "splitFirstInstallment": "Podziel pierwszą ratę",
       "firstMethod": "Pierwsza metoda",
       "secondMethod": "Druga metoda",
       "splitSum": "Suma",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #632.

Closes #632

---

## Claude summary

Fixed. The screenshot showed "Split first installment" rendering in English on the patient detail page. The label uses the i18n key `gabinet.packages.splitFirstInstallment` in `src/components/gabinet/package-purchase-drawer.tsx:365`, but that key was missing from both `public/locales/pl/translation.json` and `public/locales/en/translation.json`, so i18next was falling back to the inline default string. Added the entry to both locale files (Polish: "Podziel pierwszą ratę"; English: "Split first installment") and committed as cacbf5a.