### PR TITLE
Kierunkowy

### DIFF
--- a/src/components/forms/patient-form.tsx
+++ b/src/components/forms/patient-form.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { PhoneInput } from "@/components/ui/phone-input";
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
 import {
   Select,
@@ -155,10 +156,9 @@ export function PatientForm({
           <Label>
             {t("common.phone")} <span className="text-destructive">*</span>
           </Label>
-          <Input
-            type="tel"
+          <PhoneInput
             value={phone}
-            onChange={(e) => setPhone(e.target.value)}
+            onChange={setPhone}
             required
           />
         </div>
@@ -238,10 +238,9 @@ export function PatientForm({
           </div>
           <div className="space-y-1.5">
             <Label>{t("gabinet.patients.emergencyContactPhone")}</Label>
-            <Input
-              type="tel"
+            <PhoneInput
               value={emergencyContactPhone}
-              onChange={(e) => setEmergencyContactPhone(e.target.value)}
+              onChange={setEmergencyContactPhone}
             />
           </div>
         </div>

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -1,0 +1,157 @@
+import { useState, useMemo } from "react";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type Country = {
+  code: string;
+  iso: string;
+  flag: string;
+  name: string;
+};
+
+const COUNTRIES: Country[] = [
+  { code: "+48", iso: "PL", flag: "🇵🇱", name: "Polska" },
+  { code: "+49", iso: "DE", flag: "🇩🇪", name: "Niemcy" },
+  { code: "+44", iso: "GB", flag: "🇬🇧", name: "Wielka Brytania" },
+  { code: "+1", iso: "US", flag: "🇺🇸", name: "USA / Kanada" },
+  { code: "+33", iso: "FR", flag: "🇫🇷", name: "Francja" },
+  { code: "+39", iso: "IT", flag: "🇮🇹", name: "Włochy" },
+  { code: "+34", iso: "ES", flag: "🇪🇸", name: "Hiszpania" },
+  { code: "+31", iso: "NL", flag: "🇳🇱", name: "Holandia" },
+  { code: "+32", iso: "BE", flag: "🇧🇪", name: "Belgia" },
+  { code: "+43", iso: "AT", flag: "🇦🇹", name: "Austria" },
+  { code: "+41", iso: "CH", flag: "🇨🇭", name: "Szwajcaria" },
+  { code: "+420", iso: "CZ", flag: "🇨🇿", name: "Czechy" },
+  { code: "+421", iso: "SK", flag: "🇸🇰", name: "Słowacja" },
+  { code: "+380", iso: "UA", flag: "🇺🇦", name: "Ukraina" },
+  { code: "+375", iso: "BY", flag: "🇧🇾", name: "Białoruś" },
+  { code: "+370", iso: "LT", flag: "🇱🇹", name: "Litwa" },
+  { code: "+371", iso: "LV", flag: "🇱🇻", name: "Łotwa" },
+  { code: "+372", iso: "EE", flag: "🇪🇪", name: "Estonia" },
+  { code: "+353", iso: "IE", flag: "🇮🇪", name: "Irlandia" },
+  { code: "+46", iso: "SE", flag: "🇸🇪", name: "Szwecja" },
+  { code: "+47", iso: "NO", flag: "🇳🇴", name: "Norwegia" },
+  { code: "+45", iso: "DK", flag: "🇩🇰", name: "Dania" },
+  { code: "+358", iso: "FI", flag: "🇫🇮", name: "Finlandia" },
+  { code: "+351", iso: "PT", flag: "🇵🇹", name: "Portugalia" },
+  { code: "+30", iso: "GR", flag: "🇬🇷", name: "Grecja" },
+  { code: "+40", iso: "RO", flag: "🇷🇴", name: "Rumunia" },
+  { code: "+36", iso: "HU", flag: "🇭🇺", name: "Węgry" },
+  { code: "+359", iso: "BG", flag: "🇧🇬", name: "Bułgaria" },
+  { code: "+385", iso: "HR", flag: "🇭🇷", name: "Chorwacja" },
+  { code: "+386", iso: "SI", flag: "🇸🇮", name: "Słowenia" },
+  { code: "+7", iso: "RU", flag: "🇷🇺", name: "Rosja / Kazachstan" },
+  { code: "+90", iso: "TR", flag: "🇹🇷", name: "Turcja" },
+];
+
+const DEFAULT_DIAL_CODE = "+48";
+
+const SORTED_CODES = [...COUNTRIES].sort(
+  (a, b) => b.code.length - a.code.length,
+);
+
+function detectDialCode(
+  raw: string,
+): { dialCode: string; rest: string } | null {
+  let v = raw.trim();
+  if (v.startsWith("00")) v = "+" + v.slice(2);
+  if (!v.startsWith("+")) return null;
+  for (const c of SORTED_CODES) {
+    if (v.startsWith(c.code)) {
+      return { dialCode: c.code, rest: v.slice(c.code.length).trimStart() };
+    }
+  }
+  return null;
+}
+
+function parseInitialValue(value: string): { dialCode: string; number: string } {
+  if (!value) return { dialCode: DEFAULT_DIAL_CODE, number: "" };
+  const detected = detectDialCode(value);
+  if (detected) return { dialCode: detected.dialCode, number: detected.rest };
+  return { dialCode: DEFAULT_DIAL_CODE, number: value };
+}
+
+function combine(dialCode: string, number: string): string {
+  const trimmed = number.trim();
+  return trimmed ? `${dialCode} ${trimmed}` : "";
+}
+
+interface PhoneInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  required?: boolean;
+  id?: string;
+  placeholder?: string;
+  className?: string;
+}
+
+export function PhoneInput({
+  value,
+  onChange,
+  required,
+  id,
+  placeholder,
+  className,
+}: PhoneInputProps) {
+  const [{ dialCode, number }, setState] = useState(() =>
+    parseInitialValue(value),
+  );
+
+  const isKnown = useMemo(
+    () => COUNTRIES.some((c) => c.code === dialCode),
+    [dialCode],
+  );
+
+  const handleNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = e.target.value;
+    const detected = detectDialCode(v);
+    if (detected) {
+      setState({ dialCode: detected.dialCode, number: detected.rest });
+      onChange(combine(detected.dialCode, detected.rest));
+    } else {
+      setState({ dialCode, number: v });
+      onChange(combine(dialCode, v));
+    }
+  };
+
+  const handleDialChange = (newDial: string) => {
+    setState({ dialCode: newDial, number });
+    onChange(combine(newDial, number));
+  };
+
+  return (
+    <div className={`flex gap-2 ${className ?? ""}`}>
+      <Select value={isKnown ? dialCode : DEFAULT_DIAL_CODE} onValueChange={handleDialChange}>
+        <SelectTrigger className="w-[110px] shrink-0" size="sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {COUNTRIES.map((c) => (
+              <SelectItem key={c.iso} value={c.code}>
+                <span className="mr-1">{c.flag}</span>
+                {c.code}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+      <Input
+        type="tel"
+        id={id}
+        value={number}
+        onChange={handleNumberChange}
+        required={required}
+        placeholder={placeholder}
+        className="flex-1"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #634.

Closes #634

---

## Claude summary

Committed. Summary of the change:

I added a reusable `PhoneInput` component at `src/components/ui/phone-input.tsx:1` that renders a country dial-code `Select` (default `+48`, ~30 popular countries) next to the existing tel `Input`. When the user types/pastes a value beginning with `+` or `00`, it detects the longest matching dial code and moves it into the selector while leaving the local number in the text field. The combined value (`"+48 123456789"`) is emitted via `onChange` so existing storage stays a single string.

I wired it into `src/components/forms/patient-form.tsx:159` for the main patient phone and `src/components/forms/patient-form.tsx:241` for the emergency contact phone — these are the fields exposed in the patient card (kart klienta) the issue references. Legacy phones stored without a prefix render with `+48` selected automatically (`parseInitialValue` falls back to default).

Verified the only existing TypeScript error in the project (`package-purchase-drawer.tsx` deep-instantiation, unrelated) is unchanged.