### PR TITLE
klient data dodania

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1971,7 +1971,8 @@
       "noHistoryDesc": "Client has no previous appointments",
       "patient": "Client",
       "lastAppointments": "Client's recent appointments",
-      "totalAppointments": "Total Appointments"
+      "totalAppointments": "Total Appointments",
+      "added": "Added"
     },
     "treatments": {
       "title": "Treatments",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1979,7 +1979,8 @@
       "noHistoryDesc": "Klient nie ma wcześniejszych wizyt",
       "patient": "Klient",
       "lastAppointments": "Ostatnie wizyty klienta",
-      "totalAppointments": "Łącznie wizyt"
+      "totalAppointments": "Łącznie wizyt",
+      "added": "Dodano"
     },
     "treatments": {
       "title": "Zabiegi",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -251,7 +251,7 @@ function PatientDetail() {
                   />
                   <div>
                     <p className="text-sm text-muted-foreground">
-                      {t("common.created")}
+                      {t("gabinet.patients.added")}
                     </p>
                     <p className="font-medium">
                       {patient


### PR DESCRIPTION
Auto-generated by Claude in response to issue #635.

Closes #635

---

## Claude summary

Committed. Summary of changes:

- Added `gabinet.patients.added` key: "Dodano" (PL) / "Added" (EN) in both translation files
- Updated the patient detail page (`src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx:254`) to use the new key instead of the global `common.created`

I scoped the change to a new patient-specific key rather than modifying `common.created` (which is used in 15+ files for tables and other entity views) — that preserves "Utworzono" everywhere else and only changes the label on the patient detail card the user pointed to.