### PR TITLE
Wire nudge=no-recent-visit filter on gabinet patients page

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1923,7 +1923,8 @@
       "emptyDescription": "Add your first client to get started",
       "confirmDelete": "Are you sure you want to deactivate this client?",
       "nudgeFilter": {
-        "missingContact": "Showing clients with no phone or email."
+        "missingContact": "Showing clients with no phone or email.",
+        "noRecentVisit": "Showing clients with no visit in the last 90 days."
       },
       "views": {
         "all": "All Clients",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1931,7 +1931,8 @@
       "emptyDescription": "Dodaj pierwszego klienta, aby rozpocząć",
       "confirmDelete": "Czy na pewno chcesz dezaktywować tego klienta?",
       "nudgeFilter": {
-        "missingContact": "Pokazywani są klienci bez telefonu i e-maila."
+        "missingContact": "Pokazywani są klienci bez telefonu i e-maila.",
+        "noRecentVisit": "Pokazywani są klienci bez wizyty w ostatnich 90 dniach."
       },
       "views": {
         "all": "Wszyscy klienci",

--- a/src/hooks/use-supabase-gabinet-appointments.ts
+++ b/src/hooks/use-supabase-gabinet-appointments.ts
@@ -151,6 +151,55 @@ export function useSupabaseGabinetAppointmentsByEmployee(
 }
 
 // ---------------------------------------------------------------------------
+// Recent Visit Patient IDs (for nudge filtering)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the set of patient IDs that have at least one non-cancelled,
+ * non-no-show appointment within the last `days` days. Used by the patients
+ * page to apply the `nudge=no-recent-visit` filter (the inverse — patients
+ * NOT in this set have had no recent visit).
+ *
+ * Mirrors the backend logic in convex/gabinet/nudges.ts.
+ */
+export function useSupabaseGabinetRecentVisitPatientIds(
+  organizationId: string,
+  days: number = 90,
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  return useQuery<Set<string>, Error>({
+    queryKey: [
+      ...supabaseKeys.gabinetAppointments.list(organizationId),
+      "recentVisitPatientIds",
+      days,
+    ],
+    queryFn: async (): Promise<Set<string>> => {
+      if (!client) throw new Error("Supabase client not ready");
+
+      const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .split("T")[0];
+
+      const { data, error } = await client
+        .from("gabinet_appointments")
+        .select("patient_id")
+        .eq("organization_id", organizationId)
+        .gte("date", cutoff)
+        .not("status", "in", '("cancelled","no_show")');
+
+      if (error) throw error;
+      return new Set(
+        ((data ?? []) as { patient_id: string }[]).map((a) => a.patient_id),
+      );
+    },
+    enabled: enabled && isReady && !!organizationId,
+  } satisfies UseQueryOptions<Set<string>, Error>);
+}
+
+// ---------------------------------------------------------------------------
 // Single Appointment
 // ---------------------------------------------------------------------------
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useNavigate, useSearch, Link } from "@tanstack/react-r
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
+import { useSupabaseGabinetRecentVisitPatientIds } from "@/hooks/use-supabase-gabinet-appointments";
 import { useOrganization } from "@/components/org-context";
 import { PageHeader } from "@/components/layout/page-header";
 import { CrmDataTable, useColumnVisibility, useAllColumns, type CrmColumn } from "@/components/crm/enhanced-data-table";
@@ -31,14 +32,17 @@ import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { Label } from "@/components/ui/label";
 import { plateJsonToText } from "@/components/gabinet/rich-text-editor";
 
-type PatientNudgeFilter = "missing-contact";
+type PatientNudgeFilter = "missing-contact" | "no-recent-visit";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/patients/",
 )({
   component: PatientsIndex,
   validateSearch: (search: Record<string, unknown>): { nudge?: PatientNudgeFilter } => {
-    const nudge = search.nudge === "missing-contact" ? "missing-contact" : undefined;
+    const nudge =
+      search.nudge === "missing-contact" || search.nudge === "no-recent-visit"
+        ? (search.nudge as PatientNudgeFilter)
+        : undefined;
     return { nudge };
   },
 });
@@ -154,6 +158,11 @@ function PatientsIndex() {
   );
 
   const { data: patients = [], isLoading } = useSupabaseGabinetPatientsList(organizationId);
+  const { data: recentVisitPatientIds } = useSupabaseGabinetRecentVisitPatientIds(
+    organizationId,
+    90,
+    { enabled: nudgeFilter === "no-recent-visit" },
+  );
 
   const {
     views,
@@ -185,6 +194,8 @@ function PatientsIndex() {
     data = applyFilterConditions(data, activeFilters);
     if (nudgeFilter === "missing-contact") {
       data = data.filter((p) => !p.phone && !p.email);
+    } else if (nudgeFilter === "no-recent-visit" && recentVisitPatientIds) {
+      data = data.filter((p) => !recentVisitPatientIds.has(p._id));
     }
     const q = searchValue.trim().toLowerCase();
     if (q) {
@@ -197,7 +208,7 @@ function PatientsIndex() {
       );
     }
     return data;
-  }, [patients, activeViewId, applyFilters, activeFilters, searchValue, nudgeFilter]);
+  }, [patients, activeViewId, applyFilters, activeFilters, searchValue, nudgeFilter, recentVisitPatientIds]);
 
   const patientsByDay = useMemo<MiniChartData[]>(() => {
     const dayMap = new Map<string, number>();
@@ -396,12 +407,17 @@ function PatientsIndex() {
         }
       />
 
-      {nudgeFilter === "missing-contact" && (
+      {nudgeFilter && (
         <div className="flex items-center justify-between rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
           <span>
-            {t("gabinet.patients.nudgeFilter.missingContact", {
-              defaultValue: "Pokazywani są klienci bez telefonu i e-maila.",
-            })}
+            {nudgeFilter === "missing-contact"
+              ? t("gabinet.patients.nudgeFilter.missingContact", {
+                  defaultValue: "Pokazywani są klienci bez telefonu i e-maila.",
+                })
+              : t("gabinet.patients.nudgeFilter.noRecentVisit", {
+                  defaultValue:
+                    "Pokazywani są klienci bez wizyty w ostatnich 90 dniach.",
+                })}
           </span>
           <Button
             variant="ghost"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #637.

Closes #637

---

## Claude summary

Committed as `9e77e84`.

## Summary

Wired the `nudge=no-recent-visit` query param on `/dashboard/gabinet/patients` so the link from the sidebar nudge actually filters the list.

What changed:
- `src/hooks/use-supabase-gabinet-appointments.ts:154` — new `useSupabaseGabinetRecentVisitPatientIds(orgId, days)` hook that returns a `Set<string>` of patient IDs with a non-cancelled, non-no-show appointment in the last N days. Mirrors the backend predicate in `convex/gabinet/nudges.ts:181-185` and `src/hooks/use-supabase-gabinet-dashboard.ts:419-429`.
- `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx` — `validateSearch` now accepts `no-recent-visit`; the filter is applied as the inverse of the recent-visit set (only enabled when the nudge is active to avoid unnecessary fetches); the amber banner shows for both nudge values.
- `public/locales/{pl,en}/translation.json` — added `gabinet.patients.nudgeFilter.noRecentVisit` strings.

Typecheck shows only the pre-existing TanStack-Router `TS2589` depth error (same line in `useSearch({ from: Route.id })` that was there before this PR) — verified by re-running typecheck on a clean stash.