### PR TITLE
Wire nudge=stale and nudge=closing-this-week filters on /dashboard/leads

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -385,6 +385,10 @@
     "byStage": "Deals by stage",
     "wonByDay": "Won deals by day",
     "confirmDelete": "Delete this deal?",
+    "nudgeFilter": {
+      "stale": "Showing open deals with no activity in the last 7 days.",
+      "closingThisWeek": "Showing open deals with a close date within the next 7 days."
+    },
     "views": {
       "all": "All Deals",
       "myDeals": "My Deals",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -384,6 +384,10 @@
     "byStage": "Transakcje wg etapu",
     "wonByDay": "Wygrane transakcje wg dnia",
     "confirmDelete": "Czy na pewno chcesz usunąć tę transakcję?",
+    "nudgeFilter": {
+      "stale": "Pokazywane są otwarte transakcje bez aktywności w ostatnich 7 dniach.",
+      "closingThisWeek": "Pokazywane są otwarte transakcje z terminem zamknięcia w najbliższych 7 dniach."
+    },
     "views": {
       "all": "Wszystkie transakcje",
       "myDeals": "Moje transakcje",

--- a/src/hooks/use-supabase-activities.ts
+++ b/src/hooks/use-supabase-activities.ts
@@ -9,6 +9,52 @@ import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { mapActivityFromSupabase, type MappedActivity } from "@/lib/supabase/mappers";
 
 // ---------------------------------------------------------------------------
+// Lead IDs with Recent Activity (for nudge=stale filter)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the set of lead IDs that have had at least one activity within the
+ * last `days` window. The leads index page uses the inverse set to apply the
+ * `nudge=stale` filter (leads NOT in this set are "stale").
+ *
+ * Mirrors the backend logic in convex/nudges.ts (getDealsNudges).
+ */
+export function useSupabaseLeadIdsWithRecentActivity(
+  organizationId: string,
+  days: number = 7,
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  return useQuery<Set<string>, Error>({
+    queryKey: [
+      ...supabaseKeys.activities.list(organizationId),
+      "leadIdsWithRecentActivity",
+      days,
+    ],
+    queryFn: async (): Promise<Set<string>> => {
+      if (!client) throw new Error("Supabase client not ready");
+
+      const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+
+      const { data, error } = await client
+        .from("activities")
+        .select("entity_id")
+        .eq("organization_id", organizationId)
+        .eq("entity_type", "lead")
+        .gte("created_at", cutoff);
+
+      if (error) throw error;
+      return new Set(
+        ((data ?? []) as { entity_id: string }[]).map((a) => a.entity_id),
+      );
+    },
+    enabled: enabled && isReady && !!organizationId,
+  } satisfies UseQueryOptions<Set<string>, Error>);
+}
+
+// ---------------------------------------------------------------------------
 // Activities by Entity
 // ---------------------------------------------------------------------------
 

--- a/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
@@ -1,8 +1,9 @@
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useSupabasePipelinesList, useSupabaseAllPipelineStages } from "@/hooks/use-supabase-pipelines";
 import { useSupabaseLeadsList } from "@/hooks/use-supabase-leads";
+import { useSupabaseLeadIdsWithRecentActivity } from "@/hooks/use-supabase-activities";
 import { useSupabaseOrganizationMembers } from "@/hooks/use-supabase-organizations";
 import { useSupabaseCompaniesList } from "@/hooks/use-supabase-companies";
 import { useOrganization } from "@/components/org-context";
@@ -35,6 +36,7 @@ import {
   XCircle,
   Trash2,
   Upload,
+  X,
 } from "@/lib/ez-icons";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { Download } from "@/lib/ez-icons";
@@ -56,8 +58,17 @@ import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { Label } from "@/components/ui/label";
 
+type LeadNudgeFilter = "stale" | "closing-this-week";
+
 export const Route = createFileRoute("/_app/_auth/dashboard/_layout/leads/")({
   component: LeadsIndex,
+  validateSearch: (search: Record<string, unknown>): { nudge?: LeadNudgeFilter } => {
+    const nudge =
+      search.nudge === "stale" || search.nudge === "closing-this-week"
+        ? (search.nudge as LeadNudgeFilter)
+        : undefined;
+    return { nudge };
+  },
 });
 
 type Lead = MappedLead;
@@ -85,6 +96,7 @@ function LeadsIndex() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
+  const { nudge: nudgeFilter } = useSearch({ from: Route.id });
   const updateLead = useAction(api.leads.update);
   const removeLead = useAction(api.leads.remove);
   const createLead = useAction(api.leads.create);
@@ -205,6 +217,12 @@ function LeadsIndex() {
     { limit: 100 },
   );
 
+  const { data: leadIdsWithRecentActivity } = useSupabaseLeadIdsWithRecentActivity(
+    organizationId,
+    7,
+    { enabled: nudgeFilter === "stale" },
+  );
+
   const { data: members } = useSupabaseOrganizationMembers(organizationId);
 
   const { data: companiesRaw } = useSupabaseCompaniesList(
@@ -249,8 +267,21 @@ function LeadsIndex() {
         data = data.filter((l) => l.status === "won");
         break;
     }
+    if (nudgeFilter === "closing-this-week") {
+      const weekEnd = Date.now() + 7 * 24 * 60 * 60 * 1000;
+      data = data.filter(
+        (l) =>
+          l.status === "open" &&
+          l.expectedCloseDate !== undefined &&
+          l.expectedCloseDate <= weekEnd,
+      );
+    } else if (nudgeFilter === "stale" && leadIdsWithRecentActivity) {
+      data = data.filter(
+        (l) => l.status === "open" && !leadIdsWithRecentActivity.has(l._id),
+      );
+    }
     return applyFilters(data);
-  }, [leads, activeViewId, applyFilters, activeFilters]);
+  }, [leads, activeViewId, applyFilters, activeFilters, nudgeFilter, leadIdsWithRecentActivity]);
 
   const leadIds = useMemo(
     () => filteredLeads.map((l) => l._id),
@@ -547,6 +578,36 @@ function LeadsIndex() {
           </div>
         }
       />
+
+      {nudgeFilter && (
+        <div className="flex items-center justify-between rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+          <span>
+            {nudgeFilter === "stale"
+              ? t("deals.nudgeFilter.stale", {
+                  defaultValue:
+                    "Pokazywane są otwarte transakcje bez aktywności w ostatnich 7 dniach.",
+                })
+              : t("deals.nudgeFilter.closingThisWeek", {
+                  defaultValue:
+                    "Pokazywane są otwarte transakcje z terminem zamknięcia w najbliższych 7 dniach.",
+                })}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 text-xs"
+            onClick={() =>
+              navigate({
+                to: "/dashboard/leads",
+                search: { nudge: undefined },
+              })
+            }
+          >
+            <X className="h-3.5 w-3.5" variant="stroke" />
+            {t("common.clearFilters")}
+          </Button>
+        </div>
+      )}
 
       <DataListFilterBar
         views={views}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #638.

Closes #638

---

## Claude summary

Wired both lead nudge filters on the leads index page, mirroring the no-recent-visit pattern from #637.

Changes:
- `src/routes/_app/_auth/dashboard/_layout.leads.index.tsx`: added `validateSearch` accepting `nudge?: "stale" | "closing-this-week"`, applied filters in `filteredLeads`, and rendered a dismissable amber banner with a clear button.
- `src/hooks/use-supabase-activities.ts`: added `useSupabaseLeadIdsWithRecentActivity` that returns the set of lead IDs with activities created in the last N days (only fetched when `nudge=stale`).
- `closing-this-week`: pure client-side filter using the already-loaded leads, requires `status === "open"` and `expectedCloseDate <= now + 7d`.
- `stale`: filters open leads NOT in the recent-activity set (mirrors backend `getDealsNudges` in `convex/nudges.ts:67`).
- Translations added to `deals.nudgeFilter.{stale,closingThisWeek}` in PL and EN.

Typecheck passes (`tsc -p tsconfig.app.json` clean). Committed as `ea9eecc`.