### PR TITLE
Wire nudge=unlinked-company filter on /dashboard/contacts

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -431,6 +431,9 @@
     "byDay": "Contacts by day",
     "bySource": "Contacts by source",
     "confirmDelete": "Delete this contact?",
+    "nudgeFilter": {
+      "unlinkedCompany": "Showing contacts not linked to any company."
+    },
     "views": {
       "all": "All Contacts",
       "my": "My Contacts",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -430,6 +430,9 @@
     "byDay": "Kontakty wg dnia",
     "bySource": "Kontakty wg źródła",
     "confirmDelete": "Czy na pewno chcesz usunąć ten kontakt?",
+    "nudgeFilter": {
+      "unlinkedCompany": "Pokazywane są kontakty bez przypisanej firmy."
+    },
     "views": {
       "all": "Wszystkie kontakty",
       "my": "Moje kontakty",

--- a/src/hooks/use-supabase-relationships.ts
+++ b/src/hooks/use-supabase-relationships.ts
@@ -167,3 +167,46 @@ export function useSupabaseRelationshipsByEntity(
     enabled: enabled && isReady && !!organizationId && !!entityId,
   } satisfies UseQueryOptions<MappedRelationship[], Error>);
 }
+
+// ---------------------------------------------------------------------------
+// Contact IDs Linked to a Company (for nudge filtering)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the set of contact IDs that have at least one
+ * `contact -> company` relationship row in the org. Used by the contacts page
+ * to apply the `nudge=unlinked-company` filter (the inverse — contacts NOT in
+ * this set are unlinked).
+ *
+ * Mirrors the backend logic in convex/nudges.ts.
+ */
+export function useSupabaseContactIdsLinkedToCompany(
+  organizationId: string,
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  return useQuery<Set<string>, Error>({
+    queryKey: [
+      ...supabaseKeys.objectRelationships.list(organizationId),
+      "contactIdsLinkedToCompany",
+    ],
+    queryFn: async (): Promise<Set<string>> => {
+      if (!client) throw new Error("Supabase client not ready");
+
+      const { data, error } = await client
+        .from("object_relationships")
+        .select("source_id")
+        .eq("organization_id", organizationId)
+        .eq("source_type", "contact")
+        .eq("target_type", "company");
+
+      if (error) throw error;
+      return new Set(
+        ((data ?? []) as { source_id: string }[]).map((r) => r.source_id),
+      );
+    },
+    enabled: enabled && isReady && !!organizationId,
+  } satisfies UseQueryOptions<Set<string>, Error>);
+}

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
@@ -1,7 +1,8 @@
-import { createFileRoute, useNavigate, Link } from "@tanstack/react-router";
+import { createFileRoute, useNavigate, useSearch, Link } from "@tanstack/react-router";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useSupabaseContactsList } from "@/hooks/use-supabase-contacts";
+import { useSupabaseContactIdsLinkedToCompany } from "@/hooks/use-supabase-relationships";
 import { useOrganization } from "@/components/org-context";
 import { PageHeader } from "@/components/layout/page-header";
 import { CrmDataTable, type CrmColumn, useColumnVisibility, useAllColumns } from "@/components/crm/enhanced-data-table";
@@ -11,7 +12,7 @@ import { SidePanel } from "@/components/crm/side-panel";
 import { ContactForm } from "@/components/forms/contact-form";
 import { Button } from "@/components/ui/button";
 import { AvatarLabelGroup } from "@untitled/base/avatar/avatar-label-group";
-import { Plus, Trash2, Upload, Download } from "@/lib/ez-icons";
+import { Plus, Trash2, Upload, Download, X } from "@/lib/ez-icons";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { CsvImportDialog } from "@/components/csv/csv-import-dialog";
 import type { MappedContact } from "@/lib/supabase/mappers/contacts";
@@ -27,10 +28,19 @@ import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
 import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
 
+type ContactNudgeFilter = "unlinked-company";
+
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/contacts/"
 )({
   component: ContactsIndex,
+  validateSearch: (search: Record<string, unknown>): { nudge?: ContactNudgeFilter } => {
+    const nudge =
+      search.nudge === "unlinked-company"
+        ? (search.nudge as ContactNudgeFilter)
+        : undefined;
+    return { nudge };
+  },
 });
 
 type Contact = MappedContact;
@@ -39,6 +49,7 @@ function ContactsIndex() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
+  const { nudge: nudgeFilter } = useSearch({ from: Route.id });
   const createContact = useAction(api.contacts.create);
   const removeContact = useAction(api.contacts.remove);
   const setCustomFieldValues = useAction(api.customFields.setValues);
@@ -83,6 +94,10 @@ function ContactsIndex() {
   ], [t, tags, categories]);
 
   const { data: contacts = [], isLoading } = useSupabaseContactsList(organizationId);
+  const { data: contactIdsLinkedToCompany } = useSupabaseContactIdsLinkedToCompany(
+    organizationId,
+    { enabled: nudgeFilter === "unlinked-company" },
+  );
 
   const contactIds = useMemo(() => contacts.map((c) => c._id), [contacts]);
 
@@ -117,8 +132,11 @@ function ContactsIndex() {
       default:
         data = contacts;
     }
+    if (nudgeFilter === "unlinked-company" && contactIdsLinkedToCompany) {
+      data = data.filter((c) => !contactIdsLinkedToCompany.has(c._id));
+    }
     return applyFilters(data);
-  }, [contacts, activeViewId, applyFilters]);
+  }, [contacts, activeViewId, applyFilters, nudgeFilter, contactIdsLinkedToCompany]);
 
   const searchedContacts = useMemo(() => {
     let result = filteredContacts;
@@ -345,6 +363,30 @@ function ContactsIndex() {
           </Button>
         }
       />
+
+      {nudgeFilter === "unlinked-company" && (
+        <div className="flex items-center justify-between rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+          <span>
+            {t("contacts.nudgeFilter.unlinkedCompany", {
+              defaultValue: "Pokazywane są kontakty bez przypisanej firmy.",
+            })}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 text-xs"
+            onClick={() =>
+              navigate({
+                to: "/dashboard/contacts",
+                search: { nudge: undefined },
+              })
+            }
+          >
+            <X className="h-3.5 w-3.5" variant="stroke" />
+            {t("common.clearFilters")}
+          </Button>
+        </div>
+      )}
 
       <DataListFilterBar
         views={views}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #640.

Closes #640

---

## Claude summary

Wired up `nudge=unlinked-company` on `/dashboard/contacts` following the same pattern as #637/#638/#639.

Summary of the fix:
- Added `useSupabaseContactIdsLinkedToCompany` in `src/hooks/use-supabase-relationships.ts` — returns the set of contact IDs that have at least one `contact -> company` row in `object_relationships` (mirrors the backend logic in `convex/nudges.ts:123-131`).
- Updated `_layout.contacts.index.tsx`: added `validateSearch` for `nudge`, read it via `useSearch`, gated the new hook on the active nudge, and filtered `filteredContacts` to exclude any contact present in the linked-set.
- Added a dismissable amber banner with a "clear filters" button that navigates back to `/dashboard/contacts` with no nudge.
- Added `contacts.nudgeFilter.unlinkedCompany` i18n keys (PL + EN).

Note on the issue text: it said "where companyId is null", but the contacts table has no `companyId` column — companies are linked via the polymorphic `objectRelationships` table. The filter uses the relationship-based definition, which is what the nudge actually counts.

Verified with `node scripts/typecheck-portable.mjs`: no new errors (one pre-existing TS2589 in `_layout.leads.index.tsx` is unrelated). Committed as `cc4451f`.