### PR TITLE
Wire nudge=unanswered filter on /dashboard/inbox

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1796,6 +1796,9 @@
       "sent": "Sent",
       "starred": "Starred"
     },
+    "nudgeFilter": {
+      "unanswered": "Showing threads with an unread inbound message older than 2 days."
+    },
     "thread": {
       "noMessages": "No messages in this thread.",
       "from": "From",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1804,6 +1804,9 @@
       "sent": "Wysłane",
       "starred": "Oznaczone gwiazdką"
     },
+    "nudgeFilter": {
+      "unanswered": "Pokazywane są wątki z nieodczytaną wiadomością przychodzącą starszą niż 2 dni."
+    },
     "thread": {
       "noMessages": "Brak wiadomości w tym wątku.",
       "from": "Od",

--- a/src/components/email/inbox-list.tsx
+++ b/src/components/email/inbox-list.tsx
@@ -17,6 +17,7 @@ interface InboxListProps {
   onSelectThread: (threadId: string, emailId: string) => void;
   filter: FilterTab;
   mailProviderId?: Id<"mailProviders">;
+  unansweredOnly?: boolean;
 }
 
 export function InboxList({
@@ -25,6 +26,7 @@ export function InboxList({
   onSelectThread,
   filter,
   mailProviderId,
+  unansweredOnly = false,
 }: InboxListProps) {
   const { t } = useTranslation();
   const [search, setSearch] = useState("");
@@ -61,8 +63,19 @@ export function InboxList({
     if (filter === "starred") {
       result = result.filter((e) => e.isStarred);
     }
+    // nudge=unanswered: latest thread message is inbound and unread/older than 2 days
+    // (mirrors backend logic in convex/nudges.ts getInboxNudges)
+    if (unansweredOnly) {
+      const twoDaysAgo = Date.now() - 48 * 60 * 60 * 1000;
+      result = result.filter(
+        (e) =>
+          e.direction === "inbound" &&
+          !e.isRead &&
+          (e.sentAt ?? 0) < twoDaysAgo,
+      );
+    }
     return result.sort((a, b) => b.sentAt - a.sentAt);
-  }, [emails, filter]);
+  }, [emails, filter, unansweredOnly]);
 
   const handleToggleStar = async (
     e: React.MouseEvent,

--- a/src/routes/_app/_auth/dashboard/_layout.inbox.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.inbox.index.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from "react";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
@@ -21,20 +21,31 @@ import type { FilterTab } from "@/components/email/inbox-list";
 import { ThreadView } from "@/components/email/thread-view";
 import { ComposeDialog } from "@/components/email/compose-dialog";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Pencil, Mail, RefreshCw } from "@/lib/ez-icons";
+import { Pencil, Mail, RefreshCw, X } from "@/lib/ez-icons";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { useSidebarSlot } from "@/components/layout/sidebar-slot-context";
 import { toast } from "sonner";
+
+type InboxNudgeFilter = "unanswered";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/inbox/"
 )({
   component: InboxPage,
+  validateSearch: (search: Record<string, unknown>): { nudge?: InboxNudgeFilter } => {
+    const nudge =
+      search.nudge === "unanswered"
+        ? (search.nudge as InboxNudgeFilter)
+        : undefined;
+    return { nudge };
+  },
 });
 
 function InboxPage() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
+  const navigate = useNavigate();
+  const { nudge: nudgeFilter } = useSearch({ from: Route.id });
 
   const { data: googleConnection } = useQuery(
     // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
@@ -196,6 +207,7 @@ function InboxPage() {
             onSelectThread={handleSelectThread}
             filter={filter}
             mailProviderId={selectedMailbox !== "all" ? selectedMailbox as Id<"mailProviders"> : undefined}
+            unansweredOnly={nudgeFilter === "unanswered"}
           />
         </div>
       </div>
@@ -210,6 +222,30 @@ function InboxPage() {
 
       {/* Right panel: thread view */}
       <div className="flex flex-1 flex-col min-w-0 overflow-hidden">
+        {nudgeFilter === "unanswered" && (
+          <div className="flex shrink-0 items-center justify-between border-b border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+            <span>
+              {t("inbox.nudgeFilter.unanswered", {
+                defaultValue:
+                  "Pokazywane są wątki z nieodczytaną wiadomością przychodzącą starszą niż 2 dni.",
+              })}
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 text-xs"
+              onClick={() =>
+                navigate({
+                  to: "/dashboard/inbox",
+                  search: { nudge: undefined },
+                })
+              }
+            >
+              <X className="h-3.5 w-3.5" variant="stroke" />
+              {t("common.clearFilters")}
+            </Button>
+          </div>
+        )}
         {/* Filter tabs */}
         <div className="shrink-0 border-b px-4 py-2">
           <Tabs


### PR DESCRIPTION
Auto-generated by Claude in response to issue #642.

Closes #642

---

## Claude summary

Wired the `nudge=unanswered` filter on `/dashboard/inbox`. Summary:

- `_layout.inbox.index.tsx`: added `validateSearch` for `?nudge=unanswered`, reads the param via `useSearch`, passes `unansweredOnly` to `InboxList`, and renders a dismissable amber banner at the top of the right panel with a Clear button.
- `inbox-list.tsx`: added optional `unansweredOnly` prop. When true, threads are filtered client-side to those whose latest email is `direction === "inbound" && !isRead && sentAt < (now - 48h)`, mirroring `convex/nudges.ts getInboxNudges` exactly.
- Added `inbox.nudgeFilter.unanswered` keys to PL/EN locales.

Committed as `17377b6` on `claude/issue-642`.