### PR TITLE
Wire nudge=pending-approval filter on /dashboard/documents

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -556,6 +556,9 @@
     "changeStatus": "Change Document Status",
     "byStatus": "Documents by status",
     "sentByDay": "Sent documents by day",
+    "nudgeFilter": {
+      "pendingApproval": "Showing documents awaiting signature/approval."
+    },
     "status": {
       "draft": "Draft",
       "sent": "Sent",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -556,6 +556,9 @@
     "changeStatus": "Zmień status dokumentu",
     "byStatus": "Dokumenty wg statusu",
     "sentByDay": "Wysłane dokumenty wg dnia",
+    "nudgeFilter": {
+      "pendingApproval": "Pokazywane są dokumenty oczekujące na podpis / zatwierdzenie."
+    },
     "status": {
       "draft": "Szkic",
       "sent": "Wysłany",

--- a/src/routes/_app/_auth/dashboard/_layout.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.documents.index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
@@ -19,7 +19,7 @@ import {
   SheetTitle,
   SheetDescription,
 } from "@/components/ui/sheet";
-import { FileText, Eye, Trash2 } from "@/lib/ez-icons";
+import { FileText, Eye, Trash2, X } from "@/lib/ez-icons";
 import { AvatarLabelGroup } from "@untitled/base/avatar/avatar-label-group";
 import { useState, useMemo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
@@ -44,10 +44,21 @@ import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 // Route
 // ---------------------------------------------------------------------------
 
+type DocumentsNudgeFilter = "pending-approval";
+
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/documents/",
 )({
   component: DocumentsPage,
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { nudge?: DocumentsNudgeFilter } => {
+    const nudge =
+      search.nudge === "pending-approval"
+        ? (search.nudge as DocumentsNudgeFilter)
+        : undefined;
+    return { nudge };
+  },
 });
 
 // ---------------------------------------------------------------------------
@@ -95,6 +106,7 @@ function DocumentsPage() {
   const { t, i18n } = useTranslation();
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
+  const { nudge: nudgeFilter } = useSearch({ from: Route.id });
   const lang = i18n.language === "en" ? "en" : "pl";
 
   // --- Tags & Categories ---
@@ -293,8 +305,11 @@ function DocumentsPage() {
       (doc) => ({ ...doc, category: getCategoryKey(doc.templateId) }),
     );
 
-    // System view filter (status-based)
-    if (activeViewId && activeViewId !== "all") {
+    // nudge=pending-approval: documents awaiting signature/approval
+    if (nudgeFilter === "pending-approval") {
+      data = data.filter((d) => d.status === "pending_signature");
+    } else if (activeViewId && activeViewId !== "all") {
+      // System view filter (status-based)
       if (STATUS_OPTIONS.includes(activeViewId as FormDocumentStatus)) {
         data = data.filter((d) => d.status === activeViewId);
       }
@@ -309,7 +324,7 @@ function DocumentsPage() {
     }
 
     return data;
-  }, [documents, activeViewId, applyFilters, activeFilters, searchValue, getCategoryKey]);
+  }, [documents, activeViewId, applyFilters, activeFilters, searchValue, getCategoryKey, nudgeFilter]);
 
   // --- Selected document for viewer ---
   const selectedDoc = useMemo(() => {
@@ -459,6 +474,31 @@ function DocumentsPage() {
           </Button>
         }
       />
+
+      {nudgeFilter === "pending-approval" && (
+        <div className="flex items-center justify-between rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+          <span>
+            {t("documents.nudgeFilter.pendingApproval", {
+              defaultValue:
+                "Pokazywane są dokumenty oczekujące na podpis / zatwierdzenie.",
+            })}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 text-xs"
+            onClick={() =>
+              navigate({
+                to: "/dashboard/documents",
+                search: { nudge: undefined },
+              })
+            }
+          >
+            <X className="h-3.5 w-3.5" variant="stroke" />
+            {t("common.clearFilters")}
+          </Button>
+        </div>
+      )}
 
       <DataListFilterBar
         views={views}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #643.

Closes #643

---

## Claude summary

Wired `nudge=pending-approval` on `/dashboard/documents`. The route now adds a `validateSearch` for the query param, filters the form documents list to `status === "pending_signature"` when the nudge is active, and renders a dismissable amber banner with a clear button — mirroring the pattern from #642 (inbox) and #639 (activities). Translations added in PL/EN. Typecheck passes.

One discrepancy worth flagging: the backend nudge in `convex/nudges.ts:223,519` queries the legacy CRM `documents` table for `status === "sent"`, but `/dashboard/documents` actually shows `form_documents`. I mapped "pending approval" to the page's closest semantic status (`pending_signature`), but the underlying data-source mismatch is worth a follow-up.

## Follow-ups
- Align documents nudge backend with /dashboard/documents data source: convex/nudges.ts:219,433 query the legacy "documents" table while the page shows form_documents — the nudge count and the filtered list may diverge