### PR TITLE
Wire nudge=no-outcome filter on /dashboard/calls

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -696,6 +696,9 @@
     "callDate": "Call Date",
     "note": "Note",
     "addCallNotes": "Add call notes...",
+    "nudgeFilter": {
+      "noOutcome": "Showing calls with no outcome recorded."
+    },
     "outcomes": {
       "busy": "Busy",
       "leftVoiceMessage": "Left Voice Message",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -696,6 +696,9 @@
     "callDate": "Data połączenia",
     "note": "Notatka",
     "addCallNotes": "Dodaj notatki z połączenia...",
+    "nudgeFilter": {
+      "noOutcome": "Pokazywane są połączenia bez zapisanego wyniku."
+    },
     "outcomes": {
       "busy": "Zajęty",
       "leftVoiceMessage": "Zostawiono wiadomość głosową",

--- a/src/routes/_app/_auth/dashboard/_layout.calls.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calls.index.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { useTranslation } from "react-i18next";
@@ -25,7 +25,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { callOutcomeOptions } from "@/lib/options";
-import { Plus, Pencil, Trash2 } from "@/lib/ez-icons";
+import { Plus, Pencil, Trash2, X } from "@/lib/ez-icons";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import type { SavedView, FieldDef, FilterCondition } from "@/components/crm/types";
 import { Id } from "@cvx/_generated/dataModel";
@@ -39,10 +39,21 @@ import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { AvatarLabelGroup } from "@untitled/base/avatar/avatar-label-group";
 
+type CallsNudgeFilter = "no-outcome";
+
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/calls/"
 )({
   component: CallsPage,
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { nudge?: CallsNudgeFilter } => {
+    const nudge =
+      search.nudge === "no-outcome"
+        ? (search.nudge as CallsNudgeFilter)
+        : undefined;
+    return { nudge };
+  },
 });
 
 type Call = MappedCall;
@@ -59,6 +70,8 @@ const OUTCOME_CONFIG: Record<CallOutcome, { color: string; labelKey: string }> =
 function CallsPage() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
+  const navigate = useNavigate();
+  const { nudge: nudgeFilter } = useSearch({ from: Route.id });
   const systemViews: SavedView[] = useMemo(() => [
     { id: "all", name: t('calls.views.all'), isSystem: true, isDefault: true },
   ], [t]);
@@ -132,12 +145,16 @@ function CallsPage() {
     enabled: callIds.length > 0,
   });
   const calls = useMemo(() => {
-    const withConditions = applyFilterConditions(allCalls, activeFilters);
+    let data = allCalls;
+    if (nudgeFilter === "no-outcome") {
+      data = data.filter((c: any) => !c.outcome);
+    }
+    const withConditions = applyFilterConditions(data, activeFilters);
     const filtered = applyFilters(withConditions) as typeof allCalls;
     if (!searchValue.trim()) return filtered;
     const q = searchValue.toLowerCase();
     return filtered.filter((c: any) => c.note?.toLowerCase().includes(q));
-  }, [allCalls, activeFilters, applyFilters, searchValue]);
+  }, [allCalls, activeFilters, applyFilters, searchValue, nudgeFilter]);
 
   const createCall = useAction(api.calls.create);
   const updateCall = useAction(api.calls.update);
@@ -336,6 +353,30 @@ function CallsPage() {
           </Button>
         }
       />
+
+      {nudgeFilter === "no-outcome" && (
+        <div className="flex items-center justify-between rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+          <span>
+            {t("calls.nudgeFilter.noOutcome", {
+              defaultValue: "Pokazywane są połączenia bez zapisanego wyniku.",
+            })}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 text-xs"
+            onClick={() =>
+              navigate({
+                to: "/dashboard/calls",
+                search: { nudge: undefined },
+              })
+            }
+          >
+            <X className="h-3.5 w-3.5" variant="stroke" />
+            {t("common.clearFilters")}
+          </Button>
+        </div>
+      )}
 
       <DataListFilterBar
         views={views}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #644.

Closes #644

---

## Claude summary

Committed. Summary of changes:

Wired the `nudge=no-outcome` query param on `/dashboard/calls`. When set, the page filters the calls list to entries where `outcome` is missing/empty and shows a dismissable amber banner with a clear-filter button. Added `calls.nudgeFilter.noOutcome` to PL/EN translations. Followed the same pattern as the prior nudge wirings (#643, #642, etc.).

Files changed:
- `src/routes/_app/_auth/dashboard/_layout.calls.index.tsx` — added `validateSearch`, `useSearch`, filter logic, and banner
- `public/locales/en/translation.json` and `public/locales/pl/translation.json` — added `calls.nudgeFilter.noOutcome`

Typecheck passes.