### PR TITLE
Wire nudge=unused filter on /dashboard/products

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -668,6 +668,9 @@
     "taxRate": "Tax Rate (%)",
     "activate": "Activate",
     "deactivate": "Deactivate",
+    "nudgeFilter": {
+      "unused": "Showing products not used in any deal."
+    },
     "views": {
       "all": "All Products",
       "active": "Active Products"

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -668,6 +668,9 @@
     "taxRate": "Stawka podatku (%)",
     "activate": "Aktywuj",
     "deactivate": "Dezaktywuj",
+    "nudgeFilter": {
+      "unused": "Pokazywane są produkty nieużywane w żadnej transakcji."
+    },
     "views": {
       "all": "Wszystkie produkty",
       "active": "Aktywne produkty"

--- a/src/hooks/use-supabase-products.ts
+++ b/src/hooks/use-supabase-products.ts
@@ -52,3 +52,40 @@ export function useSupabaseProductsList(
     enabled: enabled && isReady && !!organizationId,
   } satisfies UseQueryOptions<MappedProduct[], Error>);
 }
+
+// ---------------------------------------------------------------------------
+// Used Product IDs (for nudge=unused filter)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the set of product IDs that appear in at least one deal_products row
+ * for the given organization. The products index page uses the inverse set to
+ * apply the `nudge=unused` filter (products NOT in this set are "unused").
+ *
+ * Mirrors the backend logic in convex/nudges.ts (getProductsNudges).
+ */
+export function useSupabaseUsedProductIds(
+  organizationId: string,
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  return useQuery<Set<string>, Error>({
+    queryKey: ["supabase", "dealProducts", "usedProductIds", organizationId],
+    queryFn: async (): Promise<Set<string>> => {
+      if (!client) throw new Error("Supabase client not ready");
+
+      const { data, error } = await client
+        .from("deal_products")
+        .select("product_id")
+        .eq("organization_id", organizationId);
+
+      if (error) throw error;
+      return new Set(
+        ((data ?? []) as { product_id: string }[]).map((dp) => dp.product_id),
+      );
+    },
+    enabled: enabled && isReady && !!organizationId,
+  } satisfies UseQueryOptions<Set<string>, Error>);
+}

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -1,9 +1,12 @@
 import { useState, useMemo } from "react";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { useAction } from "convex/react";
 import { useTranslation } from "react-i18next";
 import { api } from "@cvx/_generated/api";
-import { useSupabaseProductsList } from "@/hooks/use-supabase-products";
+import {
+  useSupabaseProductsList,
+  useSupabaseUsedProductIds,
+} from "@/hooks/use-supabase-products";
 import { useOrganization } from "@/components/org-context";
 import { PageHeader } from "@/components/layout/page-header";
 import { CrmDataTable, useColumnVisibility, useAllColumns, type CrmColumn } from "@/components/crm/enhanced-data-table";
@@ -14,7 +17,7 @@ import { Label } from "@/components/ui/label";
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
-import { Plus, Pencil, Trash2, Power, Upload, Download } from "@/lib/ez-icons";
+import { Plus, Pencil, Trash2, Power, Upload, Download, X } from "@/lib/ez-icons";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { CsvImportDialog } from "@/components/csv/csv-import-dialog";
 import type { SavedView, FieldDef, FilterCondition } from "@/components/crm/types";
@@ -29,10 +32,21 @@ import { CategoriesManagerSlideout } from "@/components/categories-tags/categori
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
 
+type ProductsNudgeFilter = "unused";
+
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/products/"
 )({
   component: ProductsPage,
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { nudge?: ProductsNudgeFilter } => {
+    const nudge =
+      search.nudge === "unused"
+        ? (search.nudge as ProductsNudgeFilter)
+        : undefined;
+    return { nudge };
+  },
 });
 
 type Product = MappedProduct;
@@ -56,6 +70,8 @@ function formatCurrency(amount: number): string {
 function ProductsPage() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
+  const navigate = useNavigate();
+  const { nudge: nudgeFilter } = useSearch({ from: Route.id });
   const systemViews: SavedView[] = useMemo(() => [
     { id: "all", name: t('products.views.all'), isSystem: true, isDefault: true },
     { id: "active", name: t('products.views.active'), isSystem: true, isDefault: false },
@@ -113,11 +129,17 @@ function ProductsPage() {
   const [categoryId, setCategoryId] = useState<Id<"categoryDefinitions"> | undefined>(undefined);
 
   const { data: allProducts = [], isLoading } = useSupabaseProductsList(organizationId);
+  const { data: usedProductIds } = useSupabaseUsedProductIds(organizationId, {
+    enabled: nudgeFilter === "unused",
+  });
 
   const products = useMemo(() => {
     let data = allProducts;
     if (activeViewId === "active") {
       data = allProducts.filter((p) => p.isActive);
+    }
+    if (nudgeFilter === "unused" && usedProductIds) {
+      data = data.filter((p) => !usedProductIds.has(p._id));
     }
     data = applyFilters(data);
     data = applyFilterConditions(data, activeFilters);
@@ -129,7 +151,7 @@ function ProductsPage() {
       );
     }
     return data;
-  }, [activeViewId, allProducts, applyFilters, activeFilters, searchValue]);
+  }, [activeViewId, allProducts, applyFilters, activeFilters, searchValue, nudgeFilter, usedProductIds]);
 
   const createProduct = useAction(api.products.create);
   const updateProduct = useAction(api.products.update);
@@ -270,6 +292,31 @@ function ProductsPage() {
           </Button>
         }
       />
+
+      {nudgeFilter === "unused" && (
+        <div className="flex items-center justify-between rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+          <span>
+            {t("products.nudgeFilter.unused", {
+              defaultValue:
+                "Pokazywane są produkty nieużywane w żadnej transakcji.",
+            })}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 text-xs"
+            onClick={() =>
+              navigate({
+                to: "/dashboard/products",
+                search: { nudge: undefined },
+              })
+            }
+          >
+            <X className="h-3.5 w-3.5" variant="stroke" />
+            {t("common.clearFilters")}
+          </Button>
+        </div>
+      )}
 
       <DataListFilterBar
         views={views}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #645.

Closes #645

---

## Claude summary

Wired the `nudge=unused` filter on `/dashboard/products` following the same pattern as the recent calls/leads/inbox nudge fixes:

- Added `useSupabaseUsedProductIds` hook in `src/hooks/use-supabase-products.ts` that fetches all `deal_products` rows for the org and returns a `Set<string>` of product IDs in use (mirroring `getProductsNudges` in `convex/nudges.ts`).
- Updated `src/routes/_app/_auth/dashboard/_layout.products.index.tsx` with `validateSearch` for `nudge=unused`, a filter that excludes products present in the used-ID set, and a dismissable amber banner with a clear-filter button.
- Added `products.nudgeFilter.unused` strings to PL/EN translations.

Typecheck and lint pass clean.