### PR TITLE
Wire nudge=unconfirmed-today filter on /dashboard/gabinet/calendar

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2590,6 +2590,9 @@
       "allStatuses": "All statuses",
       "clearFilters": "Clear filters",
       "print": "Print",
+      "nudgeFilter": {
+        "unconfirmedToday": "Showing today's appointments not yet confirmed (status: scheduled)."
+      },
       "view": {
         "day": "Day",
         "week": "Week",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2601,6 +2601,9 @@
       "allStatuses": "Wszystkie statusy",
       "clearFilters": "Wyczyść filtry",
       "print": "Drukuj",
+      "nudgeFilter": {
+        "unconfirmedToday": "Pokazywane są dzisiejsze wizyty jeszcze niepotwierdzone (status: zaplanowana)."
+      },
       "view": {
         "day": "Dzień",
         "week": "Tydzień",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -1,4 +1,4 @@
-import { createLazyFileRoute } from "@tanstack/react-router";
+import { createLazyFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
@@ -92,11 +92,16 @@ function formatDateStr(d: Date): string {
 function GabinetCalendarPage() {
   const { t, i18n } = useTranslation();
   const { organizationId } = useOrganization();
+  const search = useSearch({ from: "/_app/_auth/dashboard/_layout/gabinet/calendar/" });
+  const routeNavigate = useNavigate();
+  const nudgeFilter = search.nudge;
 
   // Indicate this page has wide content (hides Column 2 on 1024-1400px screens)
   useWideContent(true);
 
-  const [viewMode, setViewMode] = useState<ViewMode>("week");
+  const [viewMode, setViewMode] = useState<ViewMode>(
+    nudgeFilter === "unconfirmed-today" ? "day" : "week",
+  );
   const [slotMinutes, setSlotMinutesState] = useState<SlotMinutes>(readStoredSlotMinutes);
   const setSlotMinutes = useCallback((next: SlotMinutes) => {
     setSlotMinutesState(next);
@@ -107,7 +112,9 @@ function GabinetCalendarPage() {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [employeeFilter, setEmployeeFilter] = useState<string>("all");
   const [treatmentFilter, setTreatmentFilter] = useState<string>("all");
-  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [statusFilter, setStatusFilter] = useState<string>(
+    nudgeFilter === "unconfirmed-today" ? "scheduled" : "all",
+  );
   const [locationFilter, setLocationFilter] = useState<string>("all");
   const [clientSearch, setClientSearch] = useState("");
 
@@ -672,6 +679,32 @@ function GabinetCalendarPage() {
       onDragEnd={handleDragEnd}
     >
       <div className="flex h-[calc(100vh-4rem)] flex-col">
+        {nudgeFilter === "unconfirmed-today" && (
+          <div className="flex shrink-0 items-center justify-between border-b border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+            <span>
+              {t("gabinet.calendar.nudgeFilter.unconfirmedToday", {
+                defaultValue:
+                  "Pokazywane są dzisiejsze wizyty jeszcze niepotwierdzone (status: zaplanowana).",
+              })}
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 text-xs"
+              onClick={() => {
+                setStatusFilter("all");
+                routeNavigate({
+                  to: "/dashboard/gabinet/calendar",
+                  search: { nudge: undefined },
+                });
+              }}
+            >
+              <X className="h-3.5 w-3.5" variant="stroke" />
+              {t("common.clearFilters")}
+            </Button>
+          </div>
+        )}
+
         {/* Toolbar */}
         <div className="flex shrink-0 flex-col gap-2 border-b bg-background px-4 py-3">
           {/* Row 1: nav arrows + date title + view switcher + actions */}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.tsx
@@ -1,5 +1,16 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+type CalendarNudgeFilter = "unconfirmed-today";
+
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/calendar/",
-)({});
+)({
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { nudge?: CalendarNudgeFilter } => ({
+    nudge:
+      search.nudge === "unconfirmed-today"
+        ? (search.nudge as CalendarNudgeFilter)
+        : undefined,
+  }),
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #647.

Closes #647

---

## Claude summary

Committed. Summary of changes:

The `nudge=unconfirmed-today` link from the sidebar appointment nudge (defined in `convex/gabinet/nudges.ts:41,279`) was previously navigating to `/dashboard/gabinet/calendar?nudge=unconfirmed-today` but the page ignored the query param.

I wired it up by adding `validateSearch` on the route (`_layout.gabinet.calendar.index.tsx`), and in the lazy component:
- Initial `viewMode` is forced to `"day"` when the nudge is active (today's date is already the default for `currentDate`)
- Initial `statusFilter` is pre-selected as `"scheduled"`, which matches the backend criterion (`a.status === "scheduled"` = not yet confirmed)
- A dismissable amber banner is rendered above the toolbar with a clear button that resets the status filter and strips the nudge param from the URL

Translation keys `gabinet.calendar.nudgeFilter.unconfirmedToday` were added to both PL and EN bundles, matching the structure used by the recent CRM calendar nudge fix in #646.

Note: typecheck/tests were not run — `node_modules` is not installed in this worktree. The changes follow exactly the pattern from the recently merged sibling fixes (#637, #646), so the risk is low.