### PR TITLE
Investigate TS2589 in convex/nudges.ts

### DIFF
--- a/convex/nudges.ts
+++ b/convex/nudges.ts
@@ -15,6 +15,7 @@ export interface NudgeData {
 }
 
 async function verify(ctx: any, organizationId: string) {
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
   await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
     organizationId,
   });

--- a/src/contexts/nudges-context.tsx
+++ b/src/contexts/nudges-context.tsx
@@ -36,6 +36,7 @@ export function NudgesProvider({ children }: { children: React.ReactNode }) {
   const [isLoading, setIsLoading] = useState(false);
 
   // CRM nudges (Supabase-primary action)
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
   const getCrmNudges = useAction(api.nudges.getAll);
   const { data: crmNudges, isLoading: crmLoading } = useQuery({
     queryKey: ["nudges.getAll", organizationId],
@@ -44,6 +45,7 @@ export function NudgesProvider({ children }: { children: React.ReactNode }) {
   });
 
   // Gabinet nudges (Supabase-primary action)
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
   const getGabinetNudges = useAction(api.gabinet.nudges.getAll);
   const { data: gabinetNudges, isLoading: gabinetLoading } = useQuery({
     queryKey: ["gabinet.nudges.getAll", organizationId],


### PR DESCRIPTION
Auto-generated by Claude in response to issue #651.

Closes #651

---

## Claude summary

Investigation summary: `npm run typecheck` (all three tsconfigs) currently passes cleanly on the freshly-checked-out branch, so the TS2589 error reported in #625 is non-reproducible right now. This matches the "known, non-deterministic" label the repo applies to this pattern in 25+ other Convex codegen call sites. Rather than mark NOT_A_BUG, I applied the same `@ts-ignore` suppression used by precedent #326 to the three call sites named in the issue (`convex/nudges.ts:18`, `src/contexts/nudges-context.tsx:39` for CRM, and the sibling line for the Gabinet `useAction`) so future builds are insulated from the same flake. Typecheck still passes after the change; committed as `bf5f41b`.