### PR TITLE
urlop pracownika

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2489,6 +2489,7 @@
         "past": "Appointment has passed",
         "qualification": "Employee is not qualified for this treatment",
         "leave": "Employee is on leave at this time",
+        "leavePartial": "Employee is on leave on this day between {{start}}–{{end}}.",
         "outsideHours": "Outside clinic working hours",
         "conflict": "Conflicts with another appointment",
         "pastConfirm": {
@@ -3177,6 +3178,10 @@
       "vacation": "Vacation",
       "sick": "Sick Leave",
       "personal": "Personal Leave"
+    },
+    "warnings": {
+      "existingAppointments_one": "Employee has {{count}} scheduled appointment during this period. Remember to cancel or reschedule it.",
+      "existingAppointments_other": "Employee has {{count}} scheduled appointments during this period. Remember to cancel or reschedule them."
     }
   },
   "permissions": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2500,6 +2500,7 @@
         "past": "Termin minął",
         "qualification": "Pracownik nie ma kwalifikacji do tego zabiegu",
         "leave": "Pracownik jest na urlopie w tym terminie",
+        "leavePartial": "Pracownik jest na urlopie w tym dniu w godzinach {{start}}–{{end}}.",
         "outsideHours": "Termin poza godzinami pracy gabinetu",
         "conflict": "Kolizja terminów z inną wizytą",
         "pastConfirm": {
@@ -3188,6 +3189,12 @@
       "vacation": "Urlop wypoczynkowy",
       "sick": "Zwolnienie lekarskie",
       "personal": "Sprawy prywatne"
+    },
+    "warnings": {
+      "existingAppointments_one": "Pracownik ma {{count}} zaplanowaną wizytę w tym okresie. Pamiętaj o jej anulowaniu lub przeniesieniu.",
+      "existingAppointments_few": "Pracownik ma {{count}} zaplanowane wizyty w tym okresie. Pamiętaj o ich anulowaniu lub przeniesieniu.",
+      "existingAppointments_many": "Pracownik ma {{count}} zaplanowanych wizyt w tym okresie. Pamiętaj o ich anulowaniu lub przeniesieniu.",
+      "existingAppointments_other": "Pracownik ma {{count}} zaplanowanych wizyt w tym okresie. Pamiętaj o ich anulowaniu lub przeniesieniu."
     }
   },
   "permissions": {

--- a/src/components/forms/leave-form.tsx
+++ b/src/components/forms/leave-form.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
@@ -16,6 +16,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { AlertTriangle } from "lucide-react";
+import { useSupabaseGabinetAppointmentsByDateRange } from "@/hooks/use-supabase-gabinet-appointments";
 
 type LeaveType = "vacation" | "sick" | "personal";
 
@@ -97,6 +99,21 @@ export function LeaveForm({
       setEndDate(value);
     }
   };
+
+  // Existing scheduled appointments overlapping the requested leave range —
+  // surface a warning so staff know they need to cancel / reschedule. Issue #652.
+  const { data: rangeAppointments } = useSupabaseGabinetAppointmentsByDateRange(
+    organizationId ?? "",
+    startDate,
+    endDate,
+    { employeeId: userId || undefined, enabled: !!userId && !!startDate && !!endDate },
+  );
+  const overlappingAppointments = useMemo(() => {
+    if (!rangeAppointments) return [];
+    return rangeAppointments.filter(
+      (a) => a.status !== "cancelled" && a.status !== "no_show",
+    );
+  }, [rangeAppointments]);
 
   return (
     <form onSubmit={handleSubmit} className="space-y-5">
@@ -235,6 +252,22 @@ export function LeaveForm({
           minHeight="80px"
         />
       </div>
+
+      {overlappingAppointments.length > 0 && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
+        >
+          <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+          <span>
+            {t("schedule.warnings.existingAppointments", {
+              count: overlappingAppointments.length,
+              defaultValue:
+                "Pracownik ma {{count}} zaplanowane wizyty w tym okresie. Pamiętaj o ich anulowaniu lub przeniesieniu.",
+            })}
+          </span>
+        </div>
+      )}
 
       <div className="rounded-lg border bg-muted/30 p-3">
         <p className="text-sm text-muted-foreground">

--- a/src/components/gabinet/appointment-form.tsx
+++ b/src/components/gabinet/appointment-form.tsx
@@ -49,6 +49,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
 import { SidePanel } from "@/components/crm/side-panel";
 import { PatientForm } from "@/components/forms/patient-form";
+import { useSupabaseGabinetLeavesList } from "@/hooks/use-supabase-gabinet-leaves";
 
 function getEmployeeName(emp: {
   firstName?: string;
@@ -254,6 +255,22 @@ export function AppointmentForm({
       (id) => !atLocationIds.has(id),
     );
   }, [locationId, selectedTreatment, equipmentAtLocation]);
+
+  // Approved leaves for selected employee — used to surface a warning when
+  // the chosen date overlaps with an approved leave. The available-slots
+  // backend already excludes leave time, but the user otherwise sees an
+  // empty/short slot list with no explanation. Issue #652.
+  const { data: employeeLeaves } = useSupabaseGabinetLeavesList(
+    organizationId ?? "",
+    { userId: employeeId || undefined, status: "approved", enabled: !!organizationId && !!employeeId },
+  );
+
+  const employeeLeaveOnSelectedDate = useMemo(() => {
+    if (!dateStr || !employeeLeaves || employeeLeaves.length === 0) return null;
+    return employeeLeaves.find(
+      (l) => l.startDate <= dateStr && l.endDate >= dateStr,
+    ) ?? null;
+  }, [employeeLeaves, dateStr]);
 
   // Filter employees by treatment qualification
   const qualifiedEmployees = useMemo(() => {
@@ -758,6 +775,28 @@ export function AppointmentForm({
               />
             </PopoverContent>
           </Popover>
+        </div>
+      )}
+
+      {/* Leave warning — employee is on approved leave overlapping selected date */}
+      {employeeId && date && employeeLeaveOnSelectedDate && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
+        >
+          <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+          <span>
+            {employeeLeaveOnSelectedDate.startTime && employeeLeaveOnSelectedDate.endTime
+              ? t("gabinet.appointments.warnings.leavePartial", {
+                  start: employeeLeaveOnSelectedDate.startTime,
+                  end: employeeLeaveOnSelectedDate.endTime,
+                  defaultValue:
+                    "Pracownik jest na urlopie w tym dniu w godzinach {{start}}–{{end}}.",
+                })
+              : t("gabinet.appointments.warnings.leave", {
+                  defaultValue: "Pracownik jest na urlopie w tym terminie",
+                })}
+          </span>
         </div>
       )}
 

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -69,6 +69,7 @@ import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { SidePanel } from "@/components/crm/side-panel";
 import { PatientForm } from "@/components/forms/patient-form";
+import { useSupabaseGabinetLeavesList } from "@/hooks/use-supabase-gabinet-leaves";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -339,6 +340,23 @@ export function AppointmentDialog({
   });
 
   const activeLocations = locations?.filter((l) => l.isActive) ?? [];
+
+  // Approved leaves for the selected employee — flag overlaps with the chosen
+  // date so the user sees an explicit warning. The available-slots backend
+  // already filters leave time but does not tell the user why. Issue #652.
+  const { data: employeeLeaves } = useSupabaseGabinetLeavesList(
+    organizationId,
+    { userId: employeeId || undefined, status: "approved", enabled: !!employeeId },
+  );
+
+  const employeeLeaveOnSelectedDate = useMemo(() => {
+    if (!dateStr || !employeeLeaves || employeeLeaves.length === 0) return null;
+    return (
+      employeeLeaves.find(
+        (l) => l.startDate <= dateStr && l.endDate >= dateStr,
+      ) ?? null
+    );
+  }, [employeeLeaves, dateStr]);
 
   // Equipment warning — advisory only
   const missingEquipmentIds = useMemo(() => {
@@ -1157,6 +1175,29 @@ export function AppointmentDialog({
                     {t("gabinet.appointments.availableSlots")}
                   </p>
                 </div>
+
+                {employeeLeaveOnSelectedDate && (
+                  <div
+                    role="alert"
+                    className="mx-3 mb-2 flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-2.5 py-2 text-xs text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
+                  >
+                    <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                    <span>
+                      {employeeLeaveOnSelectedDate.startTime &&
+                      employeeLeaveOnSelectedDate.endTime
+                        ? t("gabinet.appointments.warnings.leavePartial", {
+                            start: employeeLeaveOnSelectedDate.startTime,
+                            end: employeeLeaveOnSelectedDate.endTime,
+                            defaultValue:
+                              "Pracownik jest na urlopie w tym dniu w godzinach {{start}}–{{end}}.",
+                          })
+                        : t("gabinet.appointments.warnings.leave", {
+                            defaultValue:
+                              "Pracownik jest na urlopie w tym terminie",
+                          })}
+                    </span>
+                  </div>
+                )}
 
                 <Separator />
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
+import { useSupabaseGabinetAppointmentsByDateRange } from "@/hooks/use-supabase-gabinet-appointments";
 import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
 import { useSupabaseGabinetLeavesList } from "@/hooks/use-supabase-gabinet-leaves";
 import { useSupabaseOrganizationMembers } from "@/hooks/use-supabase-organizations";
@@ -40,7 +41,8 @@ import {
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
 import { Id } from "@cvx/_generated/dataModel";
 import { Plus, Check, X } from "@/lib/ez-icons";
-import { useState } from "react";
+import { AlertTriangle } from "lucide-react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -98,6 +100,21 @@ function LeavesPage() {
 
   const [confirmLeaveId, setConfirmLeaveId] = useState<Id<"gabinetLeaves"> | null>(null);
   const [confirmAction, setConfirmAction] = useState<"approve" | "reject" | null>(null);
+
+  // Existing appointments overlapping the requested leave range — warn the
+  // user there are bookings they need to deal with before approving. Issue #652.
+  const { data: rangeAppointments } = useSupabaseGabinetAppointmentsByDateRange(
+    organizationId,
+    startDate,
+    endDate,
+    { employeeId: selectedUserId || undefined, enabled: !!selectedUserId && !!startDate && !!endDate },
+  );
+  const overlappingAppointments = useMemo(() => {
+    if (!rangeAppointments) return [];
+    return rangeAppointments.filter(
+      (a) => a.status !== "cancelled" && a.status !== "no_show",
+    );
+  }, [rangeAppointments]);
 
   const handleCreate = async () => {
     if (!startDate || !endDate || !selectedUserId) return;
@@ -238,6 +255,21 @@ function LeavesPage() {
                       <Label>{t("gabinet.leaves.reason")}</Label>
                       <RichTextEditor value={reason} onChange={(val) => setReason(val ?? "")} minHeight="80px" />
                     </div>
+                    {overlappingAppointments.length > 0 && (
+                      <div
+                        role="alert"
+                        className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
+                      >
+                        <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+                        <span>
+                          {t("schedule.warnings.existingAppointments", {
+                            count: overlappingAppointments.length,
+                            defaultValue:
+                              "Pracownik ma {{count}} zaplanowane wizyty w tym okresie. Pamiętaj o ich anulowaniu lub przeniesieniu.",
+                          })}
+                        </span>
+                      </div>
+                    )}
                     <div className="flex justify-end gap-2">
                       <Button variant="outline" onClick={() => setDialogOpen(false)}>{t("common.cancel")}</Button>
                       <Button onClick={handleCreate} disabled={submitting || !startDate || !endDate || !selectedUserId}>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #652.

Closes #652

---

## Claude summary

Triage outcome: the user is right that the UI was silent about leaves. Backend `checkConflictSupabase` in `convex/gabinet/_availability_supabase.ts:314-335` already refuses overlapping creates and `getAvailableSlotsSupabase` already drops leave time, but neither the appointment-create dialog/form nor the leave-create form surfaced any explanatory warning, so users saw empty slot lists or got cryptic errors only on submit.

Changes (committed as `da92057`):

- `src/components/gabinet/appointment-form.tsx` and `src/components/gabinet/calendar/appointment-dialog.tsx`: query approved leaves for the picked employee via `useSupabaseGabinetLeavesList`, and render an amber alert when an approved leave overlaps the chosen date (with hours for partial-day leaves).
- `src/components/forms/leave-form.tsx` and `src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx`: query existing appointments for the chosen employee + date range via `useSupabaseGabinetAppointmentsByDateRange`, filter out `cancelled`/`no_show`, and render an amber alert listing the count.
- `public/locales/{pl,en}/translation.json`: added `gabinet.appointments.warnings.leavePartial` and `schedule.warnings.existingAppointments` (with PL plural variants).

Typecheck passes (`tsc -p tsconfig.app.json` and `tsc -p tsconfig.node.json`, both no errors).

## Follow-ups
- Visually mark leave days on the calendar grid: the warnings now fire on the create flow, but the calendar itself still doesn't show leave blocks for employees, so the admin needs to open the create dialog to discover the conflict.
- Block leave approval when it overlaps existing appointments: this PR only warns at create-time; if a pending leave is approved later via the table action, no check warns about appointments inside the period.