### PR TITLE
wygląd wizyty w kalendarzu

### DIFF
--- a/src/components/gabinet/calendar/appointment-card.tsx
+++ b/src/components/gabinet/calendar/appointment-card.tsx
@@ -32,13 +32,13 @@ export function AppointmentCard({
   return (
     <button
       onClick={onClick}
-      className={`w-full h-full overflow-hidden rounded border-l-4 px-2 py-1 text-left text-xs transition-opacity hover:opacity-80 ${cls}${strike}`}
+      className={`w-full h-full overflow-hidden rounded border-l-4 text-left text-xs transition-opacity hover:opacity-80 ${cls}${strike}`}
       style={color ? { borderLeftColor: color } : undefined}
     >
-      <div className="flex items-start justify-between gap-1">
-        <div className="font-medium truncate flex-1">{patientName}</div>
+      <div className="flex items-center justify-between gap-1 bg-black/10 px-2 py-0.5 font-semibold dark:bg-black/30">
+        <span className="truncate">{startTime}–{endTime}</span>
         {tags && tags.length > 0 && (
-          <div className="flex shrink-0 items-center gap-0.5 pt-0.5">
+          <div className="flex shrink-0 items-center gap-0.5">
             {tags.map((tag, i) => (
               <span
                 key={`${tag.name}-${i}`}
@@ -50,8 +50,10 @@ export function AppointmentCard({
           </div>
         )}
       </div>
-      <div className="truncate opacity-75">{treatmentName}</div>
-      <div className="opacity-60">{startTime}–{endTime}</div>
+      <div className="px-2 py-1">
+        <div className="truncate font-medium">{patientName}</div>
+        <div className="truncate opacity-75">{treatmentName}</div>
+      </div>
     </button>
   );
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #653.

Closes #653

---

## Claude summary

Done. Restructured `src/components/gabinet/calendar/appointment-card.tsx` so the time now appears as a darker top banner (`bg-black/10` light / `bg-black/30` dark) on every calendar tile, with patient name and treatment below. Tags moved into the time banner so they stay visible on short tiles. The status color (per `appointmentStatusBadgeClass`) and the left color stripe (treatment color) are unchanged, and the dark-mode contrast is preserved by the per-status text/border classes.

Verification: dependencies aren't installed in this worktree (no `node_modules`), so I couldn't run `npm run typecheck` or e2e here, but the diff is JSX + Tailwind-class only — no type or import changes — and the existing e2e selectors (`[data-appointment-id]`, `[class*="appointment-card"]`) are unaffected.