### PR TITLE
umów wizyte zmiana

### DIFF
--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -97,7 +97,7 @@ export const gabinetManifest: ModuleManifest = {
       matches: [{ to: "/dashboard/gabinet/calendar", fuzzy: true }],
       actions: [
         {
-          labelKey: "nav.actions.bookAppointment",
+          labelKey: "nav.actions.addActivity",
           icon: CalendarCheck,
           quickCreate: "appointment",
           permissionFeature: "gabinet_appointments",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #654.

Closes #654

---

## Claude summary

Changed `src/modules/gabinet/manifest.ts:100` — the calendar page-context sidebar action now uses `nav.actions.addActivity` (existing key: "Dodaj aktywność" PL / "Add Activity" EN) instead of `nav.actions.bookAppointment`. The button's behavior (opens the appointment quick-create modal) is unchanged. Other places using `nav.actions.bookAppointment` (dashboard page-context, footer, manifest dashboard entry) are untouched. Committed as f75fef8.