### PR TITLE
Kolor kalendarza

### DIFF
--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -197,7 +197,7 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
         {/* Closed hours background — entire day when clinic is closed */}
         {workStartTop === null && (
           <div
-            className="pointer-events-none absolute inset-0 bg-muted/60"
+            className="pointer-events-none absolute inset-0 bg-primary/5"
             style={{ height: `${HOURS.length * 60}px` }}
           />
         )}
@@ -205,7 +205,7 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
         {/* Closed: before clinic opens */}
         {workStartTop !== null && workStartTop > 0 && (
           <div
-            className="pointer-events-none absolute left-0 right-0 bg-muted/60"
+            className="pointer-events-none absolute left-0 right-0 bg-primary/5 border-b border-primary/10"
             style={{
               top: 0,
               height: `${workStartTop}px`,
@@ -216,21 +216,10 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
         {/* Closed: after clinic closes */}
         {workEndTop !== null && workEndTop < HOURS.length * 60 && (
           <div
-            className="pointer-events-none absolute left-0 right-0 bg-muted/60"
+            className="pointer-events-none absolute left-0 right-0 bg-primary/5 border-t border-primary/10"
             style={{
               top: `${workEndTop}px`,
               height: `${HOURS.length * 60 - workEndTop}px`,
-            }}
-          />
-        )}
-
-        {/* Working hours background */}
-        {workStartTop !== null && workEndTop !== null && (
-          <div
-            className="pointer-events-none absolute left-0 right-0 bg-primary/5 border-y border-primary/10"
-            style={{
-              top: `${workStartTop}px`,
-              height: `${workEndTop - workStartTop}px`,
             }}
           />
         )}

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -212,7 +212,7 @@ function WeekDayColumn({
         {/* Closed hours background — entire day when clinic is closed */}
         {!schedule && (
           <div
-            className="pointer-events-none absolute inset-0 bg-muted/60 z-0"
+            className="pointer-events-none absolute inset-0 bg-primary/5 z-0"
             style={{ height: `${HOURS.length * 60}px` }}
           />
         )}
@@ -223,7 +223,7 @@ function WeekDayColumn({
             {/* Closed: before clinic opens */}
             {timeToTop(schedule.startTime) > 0 && (
               <div
-                className="pointer-events-none absolute left-0 right-0 bg-muted/60 z-0"
+                className="pointer-events-none absolute left-0 right-0 bg-primary/5 border-b border-primary/10 z-0"
                 style={{
                   top: 0,
                   height: `${timeToTop(schedule.startTime)}px`,
@@ -233,20 +233,13 @@ function WeekDayColumn({
             {/* Closed: after clinic closes */}
             {timeToTop(schedule.endTime) < HOURS.length * 60 && (
               <div
-                className="pointer-events-none absolute left-0 right-0 bg-muted/60 z-0"
+                className="pointer-events-none absolute left-0 right-0 bg-primary/5 border-t border-primary/10 z-0"
                 style={{
                   top: `${timeToTop(schedule.endTime)}px`,
                   height: `${HOURS.length * 60 - timeToTop(schedule.endTime)}px`,
                 }}
               />
             )}
-            <div
-              className="pointer-events-none absolute left-0 right-0 bg-primary/5 border-y border-primary/10 z-0"
-              style={{
-                top: `${timeToTop(schedule.startTime)}px`,
-                height: `${timeToTop(schedule.endTime) - timeToTop(schedule.startTime)}px`,
-              }}
-            />
             {schedule.breakStart && schedule.breakEnd && (
               <div
                 className="pointer-events-none absolute left-0 right-0 bg-orange-100/50 border-y border-orange-200/50 z-0"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #656.

Closes #656

---

## Claude summary

Swapped the calendar background highlight in both day and week views (`src/components/gabinet/calendar/calendar-day-view.tsx` and `calendar-week-view.tsx`). Closed hours — before opening, after closing, and full-day closures — now use the blue `bg-primary/5` tint, with a thin `border-primary/10` line marking the transition to working hours. The working-hours range is left with the default background, matching the user's request to flip which range is highlighted.