### PR TITLE
tylko tekst

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -13,7 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
+import { RichTextEditor, plateJsonToText } from "@/components/gabinet/rich-text-editor";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -500,7 +500,12 @@ function PackagesIndex() {
                 <div className="flex items-start justify-between">
                   <div>
                     <h3 className="font-medium">{pkg.name}</h3>
-                    {pkg.description && <p className="text-sm text-muted-foreground">{pkg.description}</p>}
+                    {pkg.description && (() => {
+                      const descText = plateJsonToText(pkg.description);
+                      return descText ? (
+                        <p className="text-sm text-muted-foreground whitespace-pre-line">{descText}</p>
+                      ) : null;
+                    })()}
                   </div>
                   <Badge variant={pkg.isActive ? "default" : "secondary"}>
                     {pkg.isActive ? t("gabinet.packages.active") : t("gabinet.packages.inactive")}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #657.

Closes #657

---

## Claude summary

Fixed. The package descriptions on `/dashboard/gabinet/packages` were being rendered as the raw Plate-JSON serialization (e.g. `[{"type":"p","children":[{"text":"Trzy krotne skoki..."}],"id":"..."}]`) instead of just the text the user typed. The `RichTextEditor` module already exports a `plateJsonToText` helper that walks the Plate tree and extracts the text — I imported it and used it for the card description at `src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx:503-507`, with `whitespace-pre-line` so multi-line descriptions still render with line breaks.

## Follow-ups
- Audit other places that render rich-text fields as plain strings: contact/company/lead/call/activity notes, treatments, appointments, products — any list view that displays `*.description` or `*.notes` likely has the same JSON-leak bug. Centralize with a shared `<PlateText>` component instead of ad-hoc calls to `plateJsonToText`.