### PR TITLE
Wizyta cykliczna

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -812,11 +812,14 @@ export const _createSideEffects = internalMutation({
     // Patient contact info for automation event
     patientEmail: v.optional(v.string()),
     patientPhone: v.optional(v.string()),
-    // Recurring series: list of {appointmentId, date, recurringIndex} for each item
+    // Recurring series: per-occurrence appointment ID, date, index and times
+    // (times may differ from the base when the user customizes them — #665).
     recurringAppointments: v.optional(v.array(v.object({
       appointmentId: v.string(),
       date: v.string(),
       recurringIndex: v.number(),
+      startTime: v.optional(v.string()),
+      endTime: v.optional(v.string()),
     }))),
     // Package usage (already resolved by action)
     packageUsageId: v.optional(v.string()),
@@ -896,8 +899,12 @@ export const _createSideEffects = internalMutation({
           .unique();
         const reminderHours = (orgSettings as any)?.reminderHoursBefore ?? 24;
 
-        const scheduleReminderFor = async (apptId: string, apptDate: string) => {
-          const appointmentMs = new Date(`${apptDate}T${args.startTime}:00`).getTime();
+        const scheduleReminderFor = async (
+          apptId: string,
+          apptDate: string,
+          apptStartTime: string,
+        ) => {
+          const appointmentMs = new Date(`${apptDate}T${apptStartTime}:00`).getTime();
           const reminderMs = appointmentMs - reminderHours * 60 * 60 * 1000;
           if (reminderMs <= Date.now()) return;
           const reminderId = await ctx.db.insert("appointmentReminders", {
@@ -915,9 +922,13 @@ export const _createSideEffects = internalMutation({
           );
         };
 
-        await scheduleReminderFor(args.appointmentId, args.date);
+        await scheduleReminderFor(args.appointmentId, args.date, args.startTime);
         for (const recur of recurringAppointments) {
-          await scheduleReminderFor(recur.appointmentId, recur.date);
+          await scheduleReminderFor(
+            recur.appointmentId,
+            recur.date,
+            recur.startTime ?? args.startTime,
+          );
         }
       } catch (e) {
         console.warn("Reminder scheduling failed (non-fatal):", e);
@@ -951,6 +962,19 @@ export const create = action({
         count: v.optional(v.number()),
         until: v.optional(v.string()),
       }),
+    ),
+    // Per-occurrence overrides for the recurring series (excludes the base
+    // appointment at index 0). When present, used instead of generating from
+    // `recurringRule` — lets the user pick a different time for each date.
+    // Issue #665.
+    recurringOverrides: v.optional(
+      v.array(
+        v.object({
+          date: v.string(),
+          startTime: v.string(),
+          endTime: v.string(),
+        }),
+      ),
     ),
     prepaymentRequired: v.optional(v.boolean()),
     prepaymentAmount: v.optional(v.number()),
@@ -1087,19 +1111,40 @@ export const create = action({
     console.info("[create] appointment inserted:", firstId);
 
     // --- INSERT recurring appointments to Supabase ---
-    const recurringAppointments: Array<{ appointmentId: string; date: string; recurringIndex: number }> = [];
+    // If recurringOverrides are provided (issue #665), use them as the source
+    // of truth — they let the user pick a different time per occurrence.
+    // Otherwise fall back to generating dates from the rule with the base time.
+    const recurringAppointments: Array<{
+      appointmentId: string;
+      date: string;
+      recurringIndex: number;
+      startTime: string;
+      endTime: string;
+    }> = [];
     if (isRecurring && args.recurringRule) {
-      const dates = generateRecurringDates(args.date, args.recurringRule);
-      for (let i = 0; i < dates.length; i++) {
+      const occurrences: Array<{ date: string; startTime: string; endTime: string }> =
+        args.recurringOverrides && args.recurringOverrides.length > 0
+          ? args.recurringOverrides
+          : generateRecurringDates(args.date, args.recurringRule).map((d) => ({
+              date: d,
+              startTime: args.startTime,
+              endTime: args.endTime,
+            }));
+      for (let i = 0; i < occurrences.length; i++) {
+        const occ = occurrences[i];
         const recurId = await db.insert("gabinetAppointments", {
           ...baseRow,
-          date: dates[i],
+          date: occ.date,
+          startTime: occ.startTime,
+          endTime: occ.endTime,
           recurringIndex: i + 1,
         });
         recurringAppointments.push({
           appointmentId: recurId,
-          date: dates[i],
+          date: occ.date,
           recurringIndex: i + 1,
+          startTime: occ.startTime,
+          endTime: occ.endTime,
         });
       }
     }
@@ -1133,8 +1178,8 @@ export const create = action({
 
     const recurActivityIds: Array<{ appointmentId: string; activityId: string }> = [];
     for (const recur of recurringAppointments) {
-      const recurDueMs = new Date(`${recur.date}T${args.startTime}:00`).getTime();
-      const recurEndMs = new Date(`${recur.date}T${args.endTime}:00`).getTime();
+      const recurDueMs = new Date(`${recur.date}T${recur.startTime}:00`).getTime();
+      const recurEndMs = new Date(`${recur.date}T${recur.endTime}:00`).getTime();
       const recurActivityId = await db.insert("scheduledActivities", {
         organizationId: String(args.organizationId),
         title: calendarTitle,

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2400,6 +2400,8 @@
       "notes": "Notes",
       "notesPlaceholder": "Additional notes for the appointment...",
       "recurring": "Recurring appointment",
+      "recurringPreview": "Recurring appointment dates",
+      "recurringPreviewSelectSlot": "Pick the date and time of the first appointment to see the preview.",
       "frequency": "Frequency",
       "count": "Occurrences",
       "selectPatient": "Select client",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2411,6 +2411,8 @@
       "notes": "Notatki",
       "notesPlaceholder": "Dodatkowe uwagi do wizyty...",
       "recurring": "Wizyta cykliczna",
+      "recurringPreview": "Daty wizyt cyklicznych",
+      "recurringPreviewSelectSlot": "Wybierz datę i godzinę pierwszej wizyty, aby zobaczyć podgląd.",
       "frequency": "Częstotliwość",
       "count": "Powtórzenia",
       "selectPatient": "Wybierz klienta",

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -108,6 +108,42 @@ function computeEndTime(start: string, durationMinutes: number): string {
   return `${String(eh).padStart(2, "0")}:${String(em).padStart(2, "0")}`;
 }
 
+/**
+ * Mirror of backend `generateRecurringDates` (convex/gabinet/appointments.ts).
+ * Keep in sync — both compute the list of recurrence dates following the base.
+ */
+function generateRecurringDates(
+  startDate: string,
+  frequency: string,
+  count: number,
+): string[] {
+  const dates: string[] = [];
+  const d = new Date(startDate + "T00:00:00");
+  for (let i = 1; i < count; i++) {
+    switch (frequency) {
+      case "daily":
+        d.setDate(d.getDate() + 1);
+        break;
+      case "weekly":
+        d.setDate(d.getDate() + 7);
+        break;
+      case "biweekly":
+        d.setDate(d.getDate() + 14);
+        break;
+      case "monthly":
+        d.setMonth(d.getMonth() + 1);
+        break;
+      default:
+        return dates;
+    }
+    const yyyy = d.getFullYear();
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const dd = String(d.getDate()).padStart(2, "0");
+    dates.push(`${yyyy}-${mm}-${dd}`);
+  }
+  return dates;
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -188,6 +224,12 @@ export function AppointmentDialog({
   const [isRecurring, setIsRecurring] = useState(false);
   const [frequency, setFrequency] = useState("weekly");
   const [recurringCount, setRecurringCount] = useState(4);
+  // Per-occurrence start-time overrides, keyed by date (YYYY-MM-DD). Only
+  // includes entries the user actually edited; missing entries fall back to
+  // the base slot's start time. Issue #665.
+  const [recurringStartTimes, setRecurringStartTimes] = useState<
+    Record<string, string>
+  >({});
   const [submitting, setSubmitting] = useState(false);
   const [searchingSlot, setSearchingSlot] = useState(false);
   const [locationId, setLocationId] = useState("");
@@ -537,6 +579,20 @@ export function AppointmentDialog({
     return slotStart.getTime() < Date.now();
   }, [dateStr, selectedSlot]);
 
+  // Recurring occurrences (date + effective start time). The first entry is
+  // the base appointment; the rest are generated. Per-date overrides come
+  // from `recurringStartTimes`. Issue #665.
+  const recurringOccurrences = useMemo(() => {
+    if (!isRecurring || !dateStr || !selectedSlot?.start) return [];
+    const baseStart = selectedSlot.start;
+    const dates = [dateStr, ...generateRecurringDates(dateStr, frequency, recurringCount)];
+    return dates.map((date, index) => ({
+      date,
+      startTime: recurringStartTimes[date] ?? baseStart,
+      index,
+    }));
+  }, [isRecurring, dateStr, selectedSlot, frequency, recurringCount, recurringStartTimes]);
+
   const canSubmit =
     !!patientId &&
     !!treatmentId &&
@@ -549,6 +605,21 @@ export function AppointmentDialog({
     if (!canSubmit || !selectedSlot) return;
     setSubmitting(true);
     try {
+      const treatmentDuration = selectedTreatment?.duration ?? 30;
+      // Build per-occurrence overrides for the recurrences (excluding the base
+      // appointment at index 0). Only send if at least one entry has a custom
+      // start time so the backend keeps using the simple rule path otherwise.
+      const recurringOverrides =
+        isRecurring && recurringOccurrences.length > 1
+          ? recurringOccurrences.slice(1).map((occ) => ({
+              date: occ.date,
+              startTime: occ.startTime,
+              endTime: computeEndTime(occ.startTime, treatmentDuration),
+            }))
+          : undefined;
+      const hasCustomTimes = recurringOverrides?.some(
+        (o) => o.startTime !== selectedSlot.start,
+      );
       await createAppointment({
         organizationId,
         patientId: patientId as Id<"gabinetPatients">,
@@ -562,6 +633,7 @@ export function AppointmentDialog({
         recurringRule: isRecurring
           ? { frequency, count: recurringCount }
           : undefined,
+        recurringOverrides: hasCustomTimes ? recurringOverrides : undefined,
         locationId: locationId ? (locationId as Id<"gabinetLocations">) : undefined,
         roomId: roomId ? (roomId as Id<"gabinetRooms">) : undefined,
       });
@@ -597,6 +669,8 @@ export function AppointmentDialog({
     isRecurring,
     frequency,
     recurringCount,
+    recurringOccurrences,
+    selectedTreatment,
     locationId,
     roomId,
     onOpenChange,
@@ -629,6 +703,7 @@ export function AppointmentDialog({
       setIsRecurring(false);
       setFrequency("weekly");
       setRecurringCount(4);
+      setRecurringStartTimes({});
       setPatientSearch("");
       setTreatmentSearch("");
       setLocationId("");
@@ -1118,6 +1193,52 @@ export function AppointmentDialog({
                           )}
                         </SelectContent>
                       </Select>
+
+                      <div className="rounded-md border bg-muted/20 p-2">
+                        <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide mb-1.5">
+                          {t("gabinet.appointments.recurringPreview")}
+                        </p>
+                        {recurringOccurrences.length === 0 ? (
+                          <p className="text-xs text-muted-foreground">
+                            {t(
+                              "gabinet.appointments.recurringPreviewSelectSlot",
+                            )}
+                          </p>
+                        ) : (
+                          <ScrollShadow className="max-h-44 overflow-y-auto">
+                            <ul className="space-y-1">
+                              {recurringOccurrences.map((occ) => (
+                                <li
+                                  key={occ.date}
+                                  className="flex items-center justify-between gap-2"
+                                >
+                                  <span className="text-xs capitalize tabular-nums">
+                                    {format(
+                                      new Date(occ.date + "T00:00:00"),
+                                      "EEE d MMM yyyy",
+                                      { locale: dateFnsLocale },
+                                    )}
+                                  </span>
+                                  <input
+                                    type="time"
+                                    value={occ.startTime}
+                                    onChange={(e) =>
+                                      setRecurringStartTimes((prev) => ({
+                                        ...prev,
+                                        [occ.date]: e.target.value,
+                                      }))
+                                    }
+                                    className="h-7 w-[88px] rounded-md border border-input bg-background px-2 text-xs tabular-nums focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                                    aria-label={t(
+                                      "gabinet.appointments.calendarDialog.time",
+                                    )}
+                                  />
+                                </li>
+                              ))}
+                            </ul>
+                          </ScrollShadow>
+                        )}
+                      </div>
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #665.

Closes #665

---

## Claude summary

Done. Summary:

When the user checks "Wizyta cykliczna" in the appointment dialog and has picked a base date+slot, a preview panel now appears under the recurrence controls showing every generated date in the series with a `<input type="time">` next to it. Each row's start time defaults to the base slot's start; editing it stores a per-date override. End times are auto-derived from the treatment duration.

On submit, if any time was customized the dialog sends `recurringOverrides: [{date, startTime, endTime}]` to `api.gabinet.appointments.create`. The backend uses these overrides verbatim when present (creating each `gabinetAppointments` row and its `scheduledActivities` calendar event with the per-occurrence times) and also schedules per-occurrence reminders. When no overrides are sent, the existing rule-based path is unchanged.

Files changed:
- `src/components/gabinet/calendar/appointment-dialog.tsx:111` — added `generateRecurringDates` helper, `recurringStartTimes` state, `recurringOccurrences` memo, preview UI, and override-aware submit
- `convex/gabinet/appointments.ts:954` — added `recurringOverrides` arg, per-occurrence inserts with custom times, per-occurrence reminder scheduling
- `public/locales/pl/translation.json:2414` and `public/locales/en/translation.json:2403` — new strings `recurringPreview` and `recurringPreviewSelectSlot`

Verified via `npm run typecheck` (clean) and `npx eslint` on the changed files (zero errors, only pre-existing `any` warnings). I did not test in a browser — only static checks.