### PR TITLE
godzina wizyty 

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -150,6 +150,25 @@ export function AppointmentPreviewContent({
   const [date, setDate] = useState("");
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
+
+  const handleStartTimeChange = (newStart: string) => {
+    setStartTime(newStart);
+    if (!newStart || !startTime || !endTime) return;
+    const toMin = (s: string) => {
+      const [h, m] = s.split(":").map(Number);
+      return Number.isFinite(h) && Number.isFinite(m) ? h * 60 + m : null;
+    };
+    const oldStart = toMin(startTime);
+    const oldEnd = toMin(endTime);
+    const next = toMin(newStart);
+    if (oldStart === null || oldEnd === null || next === null) return;
+    const duration = oldEnd - oldStart;
+    if (duration <= 0) return;
+    const newEnd = Math.min(next + duration, 24 * 60 - 1);
+    const eh = Math.floor(newEnd / 60);
+    const em = newEnd % 60;
+    setEndTime(`${String(eh).padStart(2, "0")}:${String(em).padStart(2, "0")}`);
+  };
   const [internalNotes, setInternalNotes] = useState("");
   const [treatmentId, setTreatmentId] = useState("");
   const [treatmentOpen, setTreatmentOpen] = useState(false);
@@ -721,7 +740,7 @@ export function AppointmentPreviewContent({
               type="time"
               step={900}
               value={startTime}
-              onChange={(e) => setStartTime(e.target.value)}
+              onChange={(e) => handleStartTimeChange(e.target.value)}
               className="h-8 w-[88px] text-sm"
             />
           </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #669.

Closes #669

---

## Claude summary

Committed. Summary of the fix:

In `src/components/gabinet/calendar/appointment-preview-content.tsx` (the side-panel preview that opens when you click an appointment on the calendar), the start-time `<input type="time">` previously had `onChange={(e) => setStartTime(e.target.value)}`, so changing 11:15 → 13:30 left the end time at 12:15 — silently shrinking the visit to a negative duration.

The new `handleStartTimeChange` helper computes the existing duration from the current state (`endTime - startTime` in minutes) and then shifts the end time by that same delta when start time changes, so 11:15–12:15 becomes 13:30–14:30 automatically. It safely no-ops on empty/invalid inputs and clamps to within a single day. End time remains independently editable afterward.