### PR TITLE
sugerowana godzina zabiegu

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -687,9 +687,18 @@ export function AppointmentDialog({
     void performCreate();
   }, [canSubmit, selectedSlot, isPastSlot, performCreate]);
 
-  // Reset state when dialog closes
+  // Sync date/time from props when dialog opens, reset everything when it closes.
+  // Without the open-branch, clicking a calendar slot would not pre-fill the
+  // dialog because useState initializers only run on first mount (issue #670).
   useEffect(() => {
-    if (!open) {
+    if (open) {
+      setSelectedDate(
+        defaultDate ? new Date(defaultDate + "T00:00:00") : undefined,
+      );
+      setSelectedSlot(
+        defaultTime ? { start: defaultTime, end: defaultEndTime ?? "" } : null,
+      );
+    } else {
       setTreatmentId("");
       setEmployeeId("");
       setPatientId("");


### PR DESCRIPTION
Auto-generated by Claude in response to issue #670.

Closes #670

---

## Claude summary

Fixed and committed.

The bug was in `src/components/gabinet/calendar/appointment-dialog.tsx`: the dialog's `selectedDate`/`selectedSlot` state was initialised by `useState` (runs once at mount, when the defaults were `undefined`) and only re-synced when `open` became `false`. So clicking a slot updated the parent's `createDefaultDate`/`createDefaultTime` and called `setCreateDialogOpen(true)`, but the dialog's local state never picked up the new props until after the first close — which is what the user saw as "I have to type everything manually."

The fix adds an open-branch to the same `useEffect`: whenever `open` flips to `true` (or the defaults change while opening), `selectedDate` and `selectedSlot` are synced from `defaultDate`/`defaultTime`/`defaultEndTime`. The close-branch behaviour is unchanged.