### PR TITLE
widok wizyt

### DIFF
--- a/src/components/gabinet/calendar/appointment-card.tsx
+++ b/src/components/gabinet/calendar/appointment-card.tsx
@@ -35,7 +35,7 @@ export function AppointmentCard({
       className={`w-full h-full overflow-hidden rounded border-l-4 text-left text-xs transition-opacity hover:opacity-80 ${cls}${strike}`}
       style={color ? { borderLeftColor: color } : undefined}
     >
-      <div className="flex items-center justify-between gap-1 bg-black/10 px-2 py-0.5 font-semibold dark:bg-black/30">
+      <div className="flex items-center justify-between gap-1 bg-black/30 px-2 py-0.5 font-semibold dark:bg-black/50">
         <span className="truncate">{startTime}–{endTime}</span>
         {tags && tags.length > 0 && (
           <div className="flex shrink-0 items-center gap-0.5">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #675.

Closes #675

---

## Claude summary

Committed as `ae13f57`. The single change is in `src/components/gabinet/calendar/appointment-card.tsx:38` — the existing time header strip on each appointment tile is now noticeably darker (`bg-black/30` light, `bg-black/50` dark) so the start–end time reads as a distinct header band, matching the Versum reference in the Jam recording. The bar was already positioned at the top of the card, so no layout changes were needed.