### PR TITLE
Align documents nudge backend with /dashboard/documents data source

### DIFF
--- a/convex/nudges.ts
+++ b/convex/nudges.ts
@@ -217,11 +217,11 @@ export const getDocumentsNudges = action({
     const db = createSupabaseDb();
 
     const docs = (await db
-      .query("documents")
+      .query("formDocuments")
       .eq("organizationId", String(args.organizationId))
       .collect()) as any[];
 
-    const pending = docs.filter((d) => d.status === "sent");
+    const pending = docs.filter((d) => d.status === "pending_signature");
     if (pending.length > 0) {
       return [
         {
@@ -431,7 +431,7 @@ export const getAll = action({
       db.query("contacts").eq("organizationId", orgId).collect(),
       db.query("objectRelationships").eq("organizationId", orgId).collect(),
       db.query("emails").eq("organizationId", orgId).collect(),
-      db.query("documents").eq("organizationId", orgId).collect(),
+      db.query("formDocuments").eq("organizationId", orgId).collect(),
       db.query("companies").eq("organizationId", orgId).collect(),
       db.query("calls").eq("organizationId", orgId).collect(),
       db.query("products").eq("organizationId", orgId).collect(),
@@ -517,7 +517,9 @@ export const getAll = action({
     }
 
     // Documents pending
-    const pendingDocs = (documentsList as any[]).filter((d) => d.status === "sent");
+    const pendingDocs = (documentsList as any[]).filter(
+      (d) => d.status === "pending_signature",
+    );
     if (pendingDocs.length > 0) {
       nudges.push({
         message: "sidebar.nudges.documents.pendingApproval",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #683.

Closes #683

---

## Claude summary

Committed. Summary:

Two call sites in `convex/nudges.ts` queried the legacy `documents` table with `status === "sent"`, but `/dashboard/documents` (src/routes/_app/_auth/dashboard/_layout.documents.index.tsx:147,310) reads from `form_documents` via `useSupabaseFormDocumentsList` and filters the `nudge=pending-approval` view by `status === "pending_signature"`.

I switched both `getDocumentsNudges` (line 219) and the batched read in `getAll` (line 434) to `db.query("formDocuments")` and updated the filter from `"sent"` to `"pending_signature"`. The `formDocuments` table is already mapped to `form_documents` in `convex/_helpers/supabaseDb.ts:43` and `pending_signature` is a valid value in `formDocumentStatusValidator` (convex/schema/documents.ts:16). The nudge count will now match the documents shown when the user clicks through.