### PR TITLE
Visually mark leave days on the calendar grid

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2618,7 +2618,10 @@
         "day": "Day",
         "week": "Week",
         "month": "Month"
-      }
+      },
+      "leaveBadge": "On leave",
+      "leaveBadgePartial": "On leave {{start}}–{{end}}",
+      "leaveOverlayTitle": "Employee is on approved leave"
     },
     "packages": {
       "title": "Treatment Packages",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2629,7 +2629,10 @@
         "day": "Dzień",
         "week": "Tydzień",
         "month": "Miesiąc"
-      }
+      },
+      "leaveBadge": "Urlop",
+      "leaveBadgePartial": "Urlop {{start}}–{{end}}",
+      "leaveOverlayTitle": "Pracownik ma zatwierdzony urlop"
     },
     "packages": {
       "title": "Pakiety zabiegów",

--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { DraggableAppointment } from "./draggable-appointment";
 import { DroppableSlot } from "./droppable-slot";
 import { useDragToCreate } from "./use-drag-to-create";
@@ -22,8 +23,13 @@ interface CalendarDayViewProps {
   onSlotDragSelect?: (date: string, startTime: string, endTime: string) => void;
   onAppointmentResize?: (id: string, newEndTime: string) => void;
   workingHours?: { startTime: string; endTime: string; breakStart?: string; breakEnd?: string } | null;
+  /** Approved leave overlapping this date for the filtered employee. */
+  leave?: { startTime?: string; endTime?: string } | null;
   slotMinutes?: 5 | 10 | 15 | 30 | 60;
 }
+
+const LEAVE_STRIPE_BG =
+  "repeating-linear-gradient(135deg, rgba(245, 158, 11, 0.18) 0px, rgba(245, 158, 11, 0.18) 6px, rgba(245, 158, 11, 0.06) 6px, rgba(245, 158, 11, 0.06) 12px)";
 
 const HOURS = Array.from({ length: 14 }, (_, i) => i + 7); // 07:00 – 20:00
 const HOUR_HEIGHT = 60; // 1 minute = 1px
@@ -109,7 +115,8 @@ function layoutAppointments(appts: Appointment[]): LayoutedAppointment[] {
   return result;
 }
 
-export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSelect, onAppointmentResize, workingHours, slotMinutes = 60 }: CalendarDayViewProps) {
+export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSelect, onAppointmentResize, workingHours, leave, slotMinutes = 60 }: CalendarDayViewProps) {
+  const { t } = useTranslation();
   const now = useCurrentTime();
   const isToday = date === `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
   const currentMinutes = now.getHours() * 60 + now.getMinutes();
@@ -127,6 +134,24 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
   const workEndTop = workingHours ? timeToTop(workingHours.endTime) : null;
   const breakStartTop = workingHours?.breakStart ? timeToTop(workingHours.breakStart) : null;
   const breakEndTop = workingHours?.breakEnd ? timeToTop(workingHours.breakEnd) : null;
+
+  // Leave block — full day if no times set, otherwise the specified range.
+  const leaveTop = leave ? (leave.startTime ? timeToTop(leave.startTime) : 0) : null;
+  const leaveBottom = leave
+    ? leave.endTime
+      ? timeToTop(leave.endTime)
+      : HOURS.length * 60
+    : null;
+  const leaveHeight = leaveTop !== null && leaveBottom !== null ? leaveBottom - leaveTop : 0;
+  const leaveLabel = leave
+    ? leave.startTime && leave.endTime
+      ? t("gabinet.calendar.leaveBadgePartial", {
+          start: leave.startTime,
+          end: leave.endTime,
+          defaultValue: "Urlop {{start}}–{{end}}",
+        })
+      : t("gabinet.calendar.leaveBadge", { defaultValue: "Urlop" })
+    : "";
 
   const handleClick = useCallback(
     (time: string) => onSlotClick?.(time),
@@ -233,6 +258,26 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
               height: `${breakEndTop - breakStartTop}px`,
             }}
           />
+        )}
+
+        {/* Approved leave overlay */}
+        {leave && leaveTop !== null && leaveHeight > 0 && (
+          <div
+            className="pointer-events-none absolute left-0 right-0 z-[5] border-y border-amber-400/70 dark:border-amber-500/60"
+            style={{
+              top: `${leaveTop}px`,
+              height: `${leaveHeight}px`,
+              backgroundImage: LEAVE_STRIPE_BG,
+            }}
+            title={t("gabinet.calendar.leaveOverlayTitle", {
+              defaultValue: "Pracownik ma zatwierdzony urlop",
+            })}
+            aria-label={leaveLabel}
+          >
+            <span className="absolute left-1 top-1 rounded bg-amber-500/90 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white shadow-sm">
+              {leaveLabel}
+            </span>
+          </div>
         )}
 
         {/* Slot rows — solid border at hour marks, faded at sub-slot marks */}

--- a/src/components/gabinet/calendar/calendar-month-view.tsx
+++ b/src/components/gabinet/calendar/calendar-month-view.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
 
 interface Appointment {
   _id: string;
@@ -15,6 +16,8 @@ interface CalendarMonthViewProps {
   appointments: Appointment[];
   onDayClick?: (date: string) => void;
   selectedDate?: string;
+  /** Dates covered by approved leave for the filtered employee. */
+  leaveDates?: Set<string>;
 }
 
 function getMonthGrid(year: number, month: number): (string | null)[][] {
@@ -45,7 +48,8 @@ function getMonthGrid(year: number, month: number): (string | null)[][] {
 
 const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
-export function CalendarMonthView({ year, month, appointments, onDayClick, selectedDate }: CalendarMonthViewProps) {
+export function CalendarMonthView({ year, month, appointments, onDayClick, selectedDate, leaveDates }: CalendarMonthViewProps) {
+  const { t } = useTranslation();
   const grid = useMemo(() => getMonthGrid(year, month), [year, month]);
   const now = new Date();
   const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
@@ -80,16 +84,32 @@ export function CalendarMonthView({ year, month, appointments, onDayClick, selec
 
           const count = countByDate.get(date) ?? 0;
           const isToday = date === today;
+          const isLeave = leaveDates?.has(date) ?? false;
 
           return (
             <div
               key={date}
-              className={`border-b border-r p-1 cursor-pointer hover:bg-muted/30 transition-colors ${date === selectedDate ? "bg-primary/15 ring-1 ring-inset ring-primary/30" : isToday ? "bg-primary/5" : ""}`}
+              className={`relative border-b border-r p-1 cursor-pointer hover:bg-muted/30 transition-colors ${date === selectedDate ? "bg-primary/15 ring-1 ring-inset ring-primary/30" : isToday ? "bg-primary/5" : ""}`}
+              style={
+                isLeave
+                  ? {
+                      backgroundImage:
+                        "repeating-linear-gradient(135deg, rgba(245, 158, 11, 0.15) 0px, rgba(245, 158, 11, 0.15) 6px, rgba(245, 158, 11, 0.04) 6px, rgba(245, 158, 11, 0.04) 12px)",
+                    }
+                  : undefined
+              }
               onClick={() => onDayClick?.(date)}
             >
               <div className={`text-xs ${isToday ? "font-bold text-primary" : "text-muted-foreground"}`}>
                 {parseInt(date.split("-")[2])}
               </div>
+              {isLeave && (
+                <div className="mt-0.5">
+                  <span className="inline-flex items-center rounded-full bg-amber-500/90 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white shadow-sm">
+                    {t("gabinet.calendar.leaveBadge", { defaultValue: "Urlop" })}
+                  </span>
+                </div>
+              )}
               {count > 0 && (
                 <div className="mt-0.5">
                   <span className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary">

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { DraggableAppointment } from "./draggable-appointment";
 import { DroppableSlot } from "./droppable-slot";
 import { useDragToCreate } from "./use-drag-to-create";
@@ -26,8 +27,13 @@ interface CalendarWeekViewProps {
   onDayHeaderClick?: (date: string) => void;
   selectedDate?: string;
   employeeSchedules?: Map<string, { startTime: string; endTime: string; breakStart?: string; breakEnd?: string }>;
+  /** Approved leaves by date string (YYYY-MM-DD) for the filtered employee. */
+  leavesByDate?: Map<string, { startTime?: string; endTime?: string }>;
   slotMinutes?: 5 | 10 | 15 | 30 | 60;
 }
+
+const LEAVE_STRIPE_BG =
+  "repeating-linear-gradient(135deg, rgba(245, 158, 11, 0.18) 0px, rgba(245, 158, 11, 0.18) 6px, rgba(245, 158, 11, 0.06) 6px, rgba(245, 158, 11, 0.06) 12px)";
 
 const HOURS = Array.from({ length: 14 }, (_, i) => i + 7);
 const HOUR_HEIGHT = 60; // 1 minute = 1px
@@ -136,6 +142,7 @@ interface WeekDayColumnProps {
   isSelected: boolean;
   layouts: LayoutedAppointment[];
   schedule?: { startTime: string; endTime: string; breakStart?: string; breakEnd?: string };
+  leave?: { startTime?: string; endTime?: string } | null;
   currentTimeTop: number | null;
   onSlotClick?: (date: string, time: string) => void;
   onSlotDragSelect?: (date: string, startTime: string, endTime: string) => void;
@@ -152,6 +159,7 @@ function WeekDayColumn({
   isSelected,
   layouts,
   schedule,
+  leave,
   currentTimeTop,
   onSlotClick,
   onSlotDragSelect,
@@ -160,7 +168,25 @@ function WeekDayColumn({
   slotMinutes,
   slots,
 }: WeekDayColumnProps) {
+  const { t } = useTranslation();
   const showSubdivisions = slotMinutes === 60;
+
+  const leaveTop = leave ? (leave.startTime ? timeToTop(leave.startTime) : 0) : null;
+  const leaveBottom = leave
+    ? leave.endTime
+      ? timeToTop(leave.endTime)
+      : HOURS.length * 60
+    : null;
+  const leaveHeight = leaveTop !== null && leaveBottom !== null ? leaveBottom - leaveTop : 0;
+  const leaveLabel = leave
+    ? leave.startTime && leave.endTime
+      ? t("gabinet.calendar.leaveBadgePartial", {
+          start: leave.startTime,
+          end: leave.endTime,
+          defaultValue: "Urlop {{start}}–{{end}}",
+        })
+      : t("gabinet.calendar.leaveBadge", { defaultValue: "Urlop" })
+    : "";
   const handleClick = useCallback(
     (time: string) => onSlotClick?.(date, time),
     [onSlotClick, date],
@@ -252,6 +278,26 @@ function WeekDayColumn({
           </>
         )}
 
+        {/* Approved leave overlay */}
+        {leave && leaveTop !== null && leaveHeight > 0 && (
+          <div
+            className="pointer-events-none absolute left-0 right-0 z-[5] border-y border-amber-400/70 dark:border-amber-500/60"
+            style={{
+              top: `${leaveTop}px`,
+              height: `${leaveHeight}px`,
+              backgroundImage: LEAVE_STRIPE_BG,
+            }}
+            title={t("gabinet.calendar.leaveOverlayTitle", {
+              defaultValue: "Pracownik ma zatwierdzony urlop",
+            })}
+            aria-label={leaveLabel}
+          >
+            <span className="absolute left-0.5 top-0.5 rounded bg-amber-500/90 px-1 py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide text-white shadow-sm">
+              {leaveLabel}
+            </span>
+          </div>
+        )}
+
         {slots.map((s) => (
           <DroppableSlot
             key={s.time}
@@ -330,7 +376,7 @@ function WeekDayColumn({
   );
 }
 
-export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotDragSelect, onAppointmentResize, onDayHeaderClick, selectedDate, employeeSchedules, slotMinutes = 60 }: CalendarWeekViewProps) {
+export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotDragSelect, onAppointmentResize, onDayHeaderClick, selectedDate, employeeSchedules, leavesByDate, slotMinutes = 60 }: CalendarWeekViewProps) {
   const dates = useMemo(() => getWeekDates(weekStart), [weekStart]);
   const now = useCurrentTime();
   const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
@@ -399,6 +445,7 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotD
             isSelected={isSelected}
             layouts={layouts}
             schedule={schedule}
+            leave={leavesByDate?.get(date) ?? null}
             currentTimeTop={isToday ? currentTimeTop : null}
             onSlotClick={onSlotClick}
             onSlotDragSelect={onSlotDragSelect}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -49,6 +49,7 @@ import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-pat
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
 import { useSupabaseGabinetEmployeeSchedulesList } from "@/hooks/use-supabase-gabinet-employee-schedules";
 import { useSupabaseGabinetWorkingHoursList } from "@/hooks/use-supabase-gabinet-working-hours";
+import { useSupabaseGabinetLeavesList } from "@/hooks/use-supabase-gabinet-leaves";
 import { useSupabaseScheduledActivitiesByDateRange } from "@/hooks/use-supabase-scheduled-activities";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
@@ -346,6 +347,50 @@ function GabinetCalendarPage() {
     const dow = dayOfWeek === 0 ? 6 : dayOfWeek - 1; // Monday = 0
     return employeeSchedules.get(`${dow}`) ?? null;
   }, [viewMode, currentDate, employeeSchedules]);
+
+  // Approved leaves for the filtered employee — used to overlay leave blocks
+  // on the calendar grid so admins can spot conflicts without opening the
+  // appointment dialog. Skipped when "all" employees is selected because the
+  // grid then shows everyone's appointments and a single overlay would be
+  // ambiguous. Issue #693.
+  const employeeLeaveFilter = employeeFilter !== "all" ? employeeFilter : undefined;
+  const { data: employeeLeavesRaw } = useSupabaseGabinetLeavesList(
+    organizationId,
+    {
+      userId: employeeLeaveFilter,
+      status: "approved",
+      enabled: !!employeeLeaveFilter,
+    },
+  );
+
+  // Build date -> leave info map for the visible range. A multi-day leave is
+  // expanded so each covered date carries the same per-day time window.
+  const leavesByDate = useMemo(() => {
+    const map = new Map<string, { startTime?: string; endTime?: string }>();
+    if (!employeeLeaveFilter || !employeeLeavesRaw) return map;
+    for (const leave of employeeLeavesRaw) {
+      if (leave.endDate < startDate || leave.startDate > endDate) continue;
+      const from = leave.startDate < startDate ? startDate : leave.startDate;
+      const to = leave.endDate > endDate ? endDate : leave.endDate;
+      const d = new Date(from + "T00:00:00");
+      const e = new Date(to + "T00:00:00");
+      while (d.getTime() <= e.getTime()) {
+        const ds = formatDateStr(d);
+        // First write wins so an existing partial-day leave isn't overwritten by
+        // a later full-day one.
+        if (!map.has(ds)) {
+          map.set(ds, { startTime: leave.startTime, endTime: leave.endTime });
+        }
+        d.setDate(d.getDate() + 1);
+      }
+    }
+    return map;
+  }, [employeeLeaveFilter, employeeLeavesRaw, startDate, endDate]);
+
+  const leaveDates = useMemo(
+    () => new Set(leavesByDate.keys()),
+    [leavesByDate],
+  );
 
   // Transform and filter appointments for view components
   const viewAppointments = useMemo(() => {
@@ -945,6 +990,7 @@ function GabinetCalendarPage() {
               onSlotDragSelect={handleSlotDragSelect}
               onAppointmentResize={handleAppointmentResize}
               workingHours={dayWorkingHours}
+              leave={leavesByDate.get(formatDateStr(currentDate)) ?? null}
               slotMinutes={slotMinutes}
             />
           )}
@@ -958,6 +1004,7 @@ function GabinetCalendarPage() {
               onDayHeaderClick={handleDayClick}
               selectedDate={formatDateStr(currentDate)}
               employeeSchedules={employeeSchedules}
+              leavesByDate={leavesByDate}
               slotMinutes={slotMinutes}
             />
           )}
@@ -968,6 +1015,7 @@ function GabinetCalendarPage() {
               appointments={viewAppointments}
               onDayClick={handleDayClick}
               selectedDate={formatDateStr(currentDate)}
+              leaveDates={leaveDates}
             />
           )}
         </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #693.

Closes #693

---

## Claude summary

Committed. Summary of what changed:

When the calendar is filtered to a specific employee, the gabinet calendar grid now visually marks any approved leave days so admins can see conflicts without opening the create dialog:

- `calendar-day-view.tsx` and `calendar-week-view.tsx` render an amber striped overlay (135° diagonal stripes), full-height for whole-day leaves or constrained to the leave window for partial-day leaves, with an inline "Urlop" / "On leave" badge in the top-left.
- `calendar-month-view.tsx` renders the same striped background on covered dates plus an "Urlop" pill next to the existing appointment count.
- The calendar route fetches approved leaves (status="approved") for the filtered employee and expands multi-day leaves into a `date → leave window` map for the visible range.
- Overlay is intentionally skipped when "all employees" is selected (the grid would aggregate everyone's bookings, making a single overlay ambiguous). This matches the existing per-employee semantics already used by `employeeSchedules` and `dayWorkingHours`.

Typecheck and ESLint pass on the changed files. The implementation reuses the same Supabase hook that the appointment dialog already uses for its leave warning (issue #652), so the data source and "approved" filter are consistent.