### PR TITLE
Audit other places that render rich-text fields as plain strings

### DIFF
--- a/src/components/crm/activity-detail-drawer.tsx
+++ b/src/components/crm/activity-detail-drawer.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
+import { PlateText } from "@/components/plate-text";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { CustomFieldFormSection } from "@/components/custom-fields/custom-field-form-section";
@@ -384,7 +385,7 @@ export function ActivityDetailDrawer({
                 <div className="space-y-1.5">
                   <Label className="text-muted-foreground text-xs">{t('activityDetail.description')}</Label>
                   <p className="text-sm whitespace-pre-wrap rounded-lg border p-3">
-                    {activity.description}
+                    <PlateText value={activity.description} />
                   </p>
                 </div>
               )}

--- a/src/components/crm/company-overview-tab.tsx
+++ b/src/components/crm/company-overview-tab.tsx
@@ -20,6 +20,7 @@ import {
   ExternalLink,
 } from "lucide-react";
 import type { MappedCompany } from "@/lib/supabase/mappers/companies";
+import { PlateText } from "@/components/plate-text";
 
 // Studio statistics cards
 import StatisticsOrderCard from "@/components/shadcn-studio/blocks/statistics-order-card";
@@ -275,7 +276,9 @@ export function CompanyOverviewTab({
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-sm text-muted-foreground whitespace-pre-wrap line-clamp-4">{company.notes}</p>
+            <p className="text-sm text-muted-foreground whitespace-pre-wrap line-clamp-4">
+              <PlateText value={company.notes} />
+            </p>
           </CardContent>
         </Card>
       )}

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -44,6 +44,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
+import { PlateText } from "@/components/plate-text";
 import { ScrollShadow } from "@/components/ui/scroll-shadow";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -959,7 +960,7 @@ export function AppointmentDialog({
                         </p>
                         {selectedTreatment.description && (
                           <p className="text-xs text-muted-foreground mt-1 line-clamp-3">
-                            {selectedTreatment.description}
+                            <PlateText value={selectedTreatment.description} />
                           </p>
                         )}
                       </div>

--- a/src/components/gabinet/package-purchase-drawer.tsx
+++ b/src/components/gabinet/package-purchase-drawer.tsx
@@ -24,6 +24,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Loader2 } from "@/lib/ez-icons";
+import { PlateText } from "@/components/plate-text";
 
 interface PackagePurchaseDrawerProps {
   patientId: string;
@@ -271,7 +272,9 @@ export function PackagePurchaseDrawer({
             <div className="rounded-lg border p-3 space-y-2">
               <p className="text-sm font-medium">{selectedPkg.name}</p>
               {selectedPkg.description && (
-                <p className="text-xs text-muted-foreground">{selectedPkg.description}</p>
+                <p className="text-xs text-muted-foreground">
+                  <PlateText value={selectedPkg.description} />
+                </p>
               )}
               <div className="space-y-1">
                 {selectedPkg.treatments.map((tr) => (

--- a/src/components/gabinet/patient-packages-card.tsx
+++ b/src/components/gabinet/patient-packages-card.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/components/ui/select";
 import { Package, Plus, Loader2 } from "@/lib/ez-icons";
 import { PackagePurchaseDrawer } from "./package-purchase-drawer";
+import { PlateText } from "@/components/plate-text";
 
 type PaymentMethod = "cash" | "card" | "transfer" | "other";
 
@@ -643,7 +644,9 @@ function PackageDetailDialog({
               <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
                 {t("gabinet.packages.description", "Description")}
               </p>
-              <p className="text-sm whitespace-pre-wrap">{pkg.description}</p>
+              <p className="text-sm whitespace-pre-wrap">
+                <PlateText value={pkg.description} />
+              </p>
             </div>
           )}
 

--- a/src/components/gabinet/rich-text-editor.tsx
+++ b/src/components/gabinet/rich-text-editor.tsx
@@ -22,6 +22,7 @@ import {
   NumberedListToolbarButton,
 } from "@/components/ui/list-toolbar-button";
 import { ToolbarGroup } from "@/components/ui/toolbar";
+import { plateJsonToText } from "@/components/plate-text";
 
 // ---------------------------------------------------------------------------
 // Helpers: convert between Plate Value and plain-text string
@@ -136,25 +137,6 @@ export function RichTextEditor({
       </Plate>
     </div>
   );
-}
-
-/** Extract plain text from a stored string (Plate JSON or plain text). */
-function plateJsonToText(raw: string | undefined): string {
-  if (!raw) return "";
-  try {
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) {
-      const extractText = (node: any): string => {
-        if (typeof node.text === "string") return node.text;
-        if (Array.isArray(node.children)) return node.children.map(extractText).join("");
-        return "";
-      };
-      return parsed.map((block: any) => extractText(block)).join("\n");
-    }
-  } catch {
-    // Not JSON — return as-is
-  }
-  return raw;
 }
 
 export { parseValue, serializeValue, isValueEmpty, plateJsonToText };

--- a/src/components/plate-text.tsx
+++ b/src/components/plate-text.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+
+/** Extract plain text from a stored string (Plate JSON or plain text). */
+export function plateJsonToText(raw: string | null | undefined): string {
+  if (!raw) return "";
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      const extractText = (node: any): string => {
+        if (typeof node.text === "string") return node.text;
+        if (Array.isArray(node.children)) return node.children.map(extractText).join("");
+        return "";
+      };
+      return parsed.map((block: any) => extractText(block)).join("\n");
+    }
+  } catch {
+    // Not JSON — return as-is
+  }
+  return raw;
+}
+
+interface PlateTextProps {
+  /** Raw stored string (Plate JSON or plain text). */
+  value: string | null | undefined;
+  /** Rendered when the extracted text is empty. */
+  fallback?: ReactNode;
+}
+
+/**
+ * Renders a Plate-JSON or plain-text value as plain text. Use this anywhere a
+ * rich-text field (e.g. notes, description, contraindications) is displayed
+ * inside JSX so the raw JSON string never leaks into the DOM.
+ */
+export function PlateText({ value, fallback = null }: PlateTextProps) {
+  const text = plateJsonToText(value).trim();
+  if (!text) return <>{fallback}</>;
+  return <>{text}</>;
+}

--- a/src/routes/_app/_auth/dashboard/_layout.calls.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calls.index.tsx
@@ -15,6 +15,7 @@ import { SidePanel } from "@/components/crm/side-panel";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
+import { plateJsonToText } from "@/components/plate-text";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -308,10 +309,11 @@ function CallsPage() {
       id: "note",
       label: t('calls.note'),
       render: (item) => {
-        if (!item.note) return <span className="text-fg-quaternary">—</span>;
+        const text = plateJsonToText(item.note).trim();
+        if (!text) return <span className="text-fg-quaternary">—</span>;
         return (
-          <span className="text-fg-tertiary" title={item.note}>
-            {item.note.length > 60 ? item.note.slice(0, 60) + "..." : item.note}
+          <span className="text-fg-tertiary" title={text}>
+            {text.length > 60 ? text.slice(0, 60) + "..." : text}
           </span>
         );
       },

--- a/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
@@ -10,6 +10,7 @@ import { DataListFilterBar } from "@/components/crm/data-list-filter-bar";
 import { MiniChartsRow } from "@/components/crm/mini-charts";
 import { SidePanel } from "@/components/crm/side-panel";
 import { CompanyForm } from "@/components/forms/company-form";
+import { PlateText } from "@/components/plate-text";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { companySizeOptions } from "@/lib/options";
@@ -267,7 +268,7 @@ function CompaniesIndex() {
     {
       id: "notes",
       label: t('common.notes'),
-      render: (item) => item.notes ?? "—",
+      render: (item) => <PlateText value={item.notes} fallback="—" />,
     },
     {
       id: "createdAt",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -36,7 +36,8 @@ import { Input } from "@/components/ui/input";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
-import { RichTextEditor, plateJsonToText } from "@/components/gabinet/rich-text-editor";
+import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
+import { PlateText, plateJsonToText } from "@/components/plate-text";
 import {
   Select,
   SelectContent,
@@ -479,7 +480,7 @@ function EmployeeDetail() {
           </CardHeader>
           <CardContent>
             <p className="text-sm text-muted-foreground whitespace-pre-wrap">
-              {employee.notes}
+              <PlateText value={employee.notes} />
             </p>
           </CardContent>
         </Card>
@@ -2040,7 +2041,7 @@ function DetailedDataTab({
                   : t("common.inactive"),
               )}
               {employee.notes &&
-                readOnlyField(t("gabinet.employees.detailedData.notesComments"), employee.notes)}
+                readOnlyField(t("gabinet.employees.detailedData.notesComments"), plateJsonToText(employee.notes))}
             </div>
           )}
         </CardContent>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -33,6 +33,7 @@ import { CategoriesManagerSlideout } from "@/components/categories-tags/categori
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { applyFilterConditions } from "@/hooks/use-saved-views";
+import { PlateText } from "@/components/plate-text";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 
 // shadcn/studio statistics blocks
@@ -230,7 +231,7 @@ function EmployeesIndex() {
     {
       id: "notes",
       label: t("gabinet.employees.notes"),
-      render: (item) => item.notes ?? "\u2014",
+      render: (item) => <PlateText value={item.notes} fallback="\u2014" />,
     },
     {
       id: "isActive",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
@@ -39,6 +39,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
+import { PlateText } from "@/components/plate-text";
 import { Id } from "@cvx/_generated/dataModel";
 import { Plus, Check, X } from "@/lib/ez-icons";
 import { AlertTriangle } from "lucide-react";
@@ -370,7 +371,9 @@ function LeavesPage() {
                   <td className="px-4 py-2 text-sm">{t(`gabinet.leaves.types.${leave.type}`)}</td>
                   <td className="px-4 py-2 text-sm">{leave.startDate}</td>
                   <td className="px-4 py-2 text-sm">{leave.endDate}</td>
-                  <td className="px-4 py-2 text-sm text-muted-foreground">{leave.reason ?? "—"}</td>
+                  <td className="px-4 py-2 text-sm text-muted-foreground">
+                    <PlateText value={leave.reason} fallback="—" />
+                  </td>
                   <td className="px-4 py-2">
                     <Badge variant={statusColor(leave.status)}>
                       {leave.status === "pending" ? t("gabinet.leaves.pending") :

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -12,6 +12,7 @@ import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { SidePanel } from "@/components/crm/side-panel";
 import { TreatmentForm } from "@/components/gabinet/treatment-form";
 import type { TreatmentFormData } from "@/components/gabinet/treatment-form";
+import { plateJsonToText } from "@/components/plate-text";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import {
@@ -1433,7 +1434,7 @@ function TreatmentDetail() {
                 <p className="text-sm text-muted-foreground/60 italic line-clamp-2">
                   {treatment?.description
                     ? t("gabinet.treatmentDetail.variants.parentValue", {
-                        value: treatment.description,
+                        value: plateJsonToText(treatment.description),
                       })
                     : "—"}
                 </p>

--- a/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
@@ -18,6 +18,7 @@ import { DataListFilterBar } from "@/components/crm/data-list-filter-bar";
 import { MiniChartsRow } from "@/components/crm/mini-charts";
 import { SidePanel } from "@/components/crm/side-panel";
 import { LeadForm } from "@/components/forms/lead-form";
+import { PlateText } from "@/components/plate-text";
 import { leadStatusOptions, leadPriorityOptions } from "@/lib/options";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -440,7 +441,7 @@ function LeadsIndex() {
     {
       id: "notes",
       label: t("common.notes"),
-      render: (item) => item.notes ?? "—",
+      render: (item) => <PlateText value={item.notes} fallback="—" />,
     },
     {
       id: "wonAt",

--- a/src/routes/_app/patient/_layout.appointments.tsx
+++ b/src/routes/_app/patient/_layout.appointments.tsx
@@ -20,6 +20,7 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Id } from "@cvx/_generated/dataModel";
+import { PlateText } from "@/components/plate-text";
 
 export const Route = createFileRoute("/_app/patient/_layout/appointments")({
   component: PatientAppointments,
@@ -160,7 +161,7 @@ function PatientAppointments() {
               </p>
               {a.notes && (
                 <p className="mt-0.5 text-xs text-muted-foreground">
-                  {a.notes}
+                  <PlateText value={a.notes} />
                 </p>
               )}
             </div>

--- a/src/routes/_app/patient/_layout.book.tsx
+++ b/src/routes/_app/patient/_layout.book.tsx
@@ -9,6 +9,7 @@ import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import type { Id } from "@cvx/_generated/dataModel";
+import { PlateText } from "@/components/plate-text";
 
 export const Route = createFileRoute("/_app/patient/_layout/book")({
   component: PatientBooking,
@@ -295,7 +296,7 @@ function PatientBooking() {
                           </p>
                           {treatment.description && (
                             <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                              {treatment.description}
+                              <PlateText value={treatment.description} />
                             </p>
                           )}
                           <p className="mt-1 text-xs text-muted-foreground">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #699.

Closes #699

---

## Claude summary

Committed as `f254888`.

Summary: Added `src/components/plate-text.tsx` exporting `plateJsonToText()` and a `<PlateText value={...} fallback={...} />` wrapper. Moved the helper out of `rich-text-editor.tsx` (re-exported for backward compat) and converted 14 render sites across CRM, Gabinet, and patient-portal routes/components where Plate-JSON `notes`/`description`/`reason` fields were being rendered as raw strings. An audit confirmed no remaining leak sites (loyalty/payment reasons, equipment descriptions, audit-log activity strings are plain text, not Plate JSON).

Typecheck was not runnable in this worktree (no `node_modules`); changes are mechanical wrapper substitutions with consistent prop shapes (`value: string | null | undefined`, `fallback: ReactNode`).