### PR TITLE
powiadomienia górne

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -180,7 +180,14 @@
   },
   "notifications": {
     "title": "Notifications",
-    "empty": "No notifications"
+    "empty": "No notifications",
+    "markAllRead": "Mark all read",
+    "relativeTime": {
+      "justNow": "just now",
+      "minutesAgo": "{{count}}m ago",
+      "hoursAgo": "{{count}}h ago",
+      "daysAgo": "{{count}}d ago"
+    }
   },
   "sidebar": {
     "todayActivities": "Today's Activities ({{count}})",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -179,7 +179,14 @@
   },
   "notifications": {
     "title": "Powiadomienia",
-    "empty": "Brak powiadomień"
+    "empty": "Brak powiadomień",
+    "markAllRead": "Oznacz wszystkie jako przeczytane",
+    "relativeTime": {
+      "justNow": "przed chwilą",
+      "minutesAgo": "{{count}} min temu",
+      "hoursAgo": "{{count}} godz. temu",
+      "daysAgo": "{{count}} dni temu"
+    }
   },
   "sidebar": {
     "todayActivities": "Dzisiejsze aktywności ({{count}})",

--- a/src/components/notifications/notification-bell.tsx
+++ b/src/components/notifications/notification-bell.tsx
@@ -14,19 +14,25 @@ import {
 } from "@/components/ui/popover";
 import type { Id } from "@cvx/_generated/dataModel";
 
-function formatRelativeTime(timestamp: number): string {
-  const now = Date.now();
-  const diff = now - timestamp;
-  const seconds = Math.floor(diff / 1000);
-  const minutes = Math.floor(seconds / 60);
-  const hours = Math.floor(minutes / 60);
-  const days = Math.floor(hours / 24);
+function useFormatRelativeTime() {
+  const { t, i18n } = useTranslation();
+  return (timestamp: number): string => {
+    const now = Date.now();
+    const diff = now - timestamp;
+    const seconds = Math.floor(diff / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
 
-  if (seconds < 60) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  if (hours < 24) return `${hours}h ago`;
-  if (days < 7) return `${days}d ago`;
-  return new Date(timestamp).toLocaleDateString();
+    if (seconds < 60) return t("notifications.relativeTime.justNow");
+    if (minutes < 60)
+      return t("notifications.relativeTime.minutesAgo", { count: minutes });
+    if (hours < 24)
+      return t("notifications.relativeTime.hoursAgo", { count: hours });
+    if (days < 7)
+      return t("notifications.relativeTime.daysAgo", { count: days });
+    return new Date(timestamp).toLocaleDateString(i18n.language);
+  };
 }
 
 const notificationTypeIcons: Record<string, React.ReactNode> = {
@@ -46,6 +52,7 @@ function getNotificationIcon(type?: string) {
 
 export function NotificationBell() {
   const { t } = useTranslation();
+  const formatRelativeTime = useFormatRelativeTime();
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #627.

Closes #627

---

## Claude summary

Fixed and committed in `17caac6`. The notification bell popover (`src/components/notifications/notification-bell.tsx`) was rendering "Mark all read" and relative timestamps like "17m ago" / "just now" as hardcoded English literals. The new `useFormatRelativeTime` hook routes them through i18next with new PL/EN keys under `notifications.relativeTime.*` and `notifications.markAllRead`, and the >=7-day fallback now passes the active language to `toLocaleDateString`. Project typecheck passes.

About the second half of the issue ("which appointment is it"): the notification titles/messages in the screenshot ("Appointment update from test", "Automation lifecycle test notification.") are literal strings the user typed when configuring the automation rule (see `convex/automation.ts:1645-1646` — they're rendered via `applyTemplate(action.titleTemplate, payload)`). The engine already supports `{{variable}}` interpolation, so to include the appointment identity, the rule's title/message templates need to reference variables like `{{date}}`, `{{startTime}}`, or `{{patientName}}` (which the existing UI exposes — see the SMS message default in `e2e/gabinet/appointments.spec.ts:273`). That's an authoring fix in the rule itself, not a code bug. If you want me to also enrich automation-generated notifications with a default appointment link/context even when the rule author leaves the template generic, let me know — that's a separate change.

## Follow-ups
- Add appointment context to automation-created notifications by default: when a `create_notification` action runs against a `gabinetAppointment` entity and no `linkTemplate` is set, default `link` to `/dashboard/gabinet/appointments/{{appointmentId}}` so users can identify which visit triggered the notification.