### PR TITLE
nie można zapisać zmian po zrobieniu zmiany statusu

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { useTranslation } from "react-i18next";
@@ -188,8 +188,14 @@ export function AppointmentPreviewContent({
 
   const docCounts = useAppointmentDocumentCounts(appointmentId, organizationId);
 
+  // Only seed local form state from `detail` once per appointment. Refetches
+  // triggered by status changes must not clobber the user's other unsaved edits
+  // (notes, date/time, tags, treatment). Issue #620.
+  const initializedRef = useRef<string | null>(null);
   useEffect(() => {
     if (!detail) return;
+    if (initializedRef.current === appointmentId) return;
+    initializedRef.current = appointmentId;
     const appt = detail.appointment;
     setStatus(appt.status as AppointmentStatus);
     setDate(appt.date);
@@ -200,7 +206,7 @@ export function AppointmentPreviewContent({
     setTagIds(
       (appt.tagIds ?? []).map((id) => id as Id<"tagDefinitions">),
     );
-  }, [detail]);
+  }, [detail, appointmentId]);
 
   if (isLoading || !detail) {
     return (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #620.

Closes #620

---

## Claude summary

Committed.

Summary: In the calendar appointment preview popover (`src/components/gabinet/calendar/appointment-preview-content.tsx`), the `useEffect` re-seeded all local form fields from `detail` on every refetch. Because changing the status auto-saves and then calls `refetch()`, the user's other in-progress edits (notes, date/time, tags, treatment) were silently overwritten and the Save button went disabled. The fix gates the seeding effect with a ref keyed by `appointmentId` so it runs once on initial load (or when switching to a different appointment) and not on subsequent refetches; status changes still propagate because `performStatusChange` and the cancel path already update local `status` explicitly.