### PR TITLE
Add appointment context to automation-created notifications by default

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -1646,7 +1646,9 @@ export const processRun = internalMutation({
             const message = applyTemplate(action.messageTemplate, payload);
             const link = action.linkTemplate
               ? applyTemplate(action.linkTemplate, payload)
-              : undefined;
+              : run.entityType === "gabinetAppointment" && run.entityId
+                ? `/dashboard/gabinet/appointments/${run.entityId}`
+                : undefined;
 
             if (!userId) {
               await ctx.db.patch(stepId, {

--- a/tests/convex/automation.test.ts
+++ b/tests/convex/automation.test.ts
@@ -383,6 +383,57 @@ describe("automation lifecycle", () => {
     ).toBe(true);
   });
 
+  test("appointment notification without linkTemplate defaults to the appointment detail URL", async () => {
+    const t = createManagedTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    await t.withIdentity(identity).action(api.automation.createRule, {
+      organizationId,
+      name: "Notify employee without link",
+      module: "gabinet",
+      eventType: "gabinet.appointment.created",
+      entityType: "gabinetAppointment",
+      conditions: [],
+      actions: [
+        {
+          type: "create_notification",
+          userIdPath: "employeeId",
+          titleTemplate: "Nowa wizyta: {{patientName}}",
+          messageTemplate: "{{patientName}} ma wizytę {{date}} o {{startTime}}.",
+        },
+      ],
+      enabled: true,
+    });
+
+    const appointmentId = await createAppointment(t, identity, {
+      organizationId,
+      patientId,
+      treatmentId,
+      employeeId: userId,
+    });
+
+    await flushScheduled(t);
+
+    const notifications = await t.run(async (ctx) =>
+      ctx.db
+        .query("notifications")
+        .withIndex("by_org", (q) => q.eq("organizationId", organizationId))
+        .collect(),
+    );
+
+    const automationNotification = notifications.find(
+      (notification) => notification.type === "automation_rule",
+    );
+    expect(automationNotification?.link).toBe(
+      `/dashboard/gabinet/appointments/${appointmentId}`,
+    );
+  });
+
   test("patient created event processes notification preset and records a processed run", async () => {
     const t = createManagedTestCtx();
     const { organizationId, userId, identity } = await seedTestUser(t);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #715.

Closes #715

---

## Claude summary

Committed. Summary:

In `convex/automation.ts:1647-1651`, the `create_notification` action now falls back to `/dashboard/gabinet/appointments/<run.entityId>` when `action.linkTemplate` is not set and the run targets a `gabinetAppointment`. This uses `run.entityId` directly (rather than relying on the payload containing `appointmentId`) so it works regardless of how the event was emitted.

Added a regression test in `tests/convex/automation.test.ts` that creates a rule with no `linkTemplate` and asserts the resulting notification's `link` points at the appointment detail page.

Typecheck (`tsc -p convex/tsconfig.json` and `tsc -p tsconfig.app.json`) passes. The full `npm run test:unit -- automation.test.ts` suite cannot be validated in this worktree because all 18 pre-existing tests fail on `main` (before my changes) with the same "Hook timed out" / `pending` symptoms — an unrelated environment/setup issue in the test harness, not a regression from this fix.

## Follow-ups
- Fix duplicate `createSupabaseDb` import in tests/convex/automation.test.ts: lines 4 and 11 both import the same symbol; likely related to the 18 pre-existing failures in this suite on main
- Investigate automation.test.ts pre-existing failures: all 18 tests fail on main with `Hook timed out` in afterEach and step status stuck at `pending`, suggesting a regression in convex-test setup or scheduled-function flushing