### PR TITLE
puste pole

### DIFF
--- a/src/components/gabinet/calendar/appointment-card.tsx
+++ b/src/components/gabinet/calendar/appointment-card.tsx
@@ -32,7 +32,7 @@ export function AppointmentCard({
   return (
     <button
       onClick={onClick}
-      className={`w-full h-full overflow-hidden rounded border-l-4 text-left text-xs transition-opacity hover:opacity-80 ${cls}${strike}`}
+      className={`flex w-full h-full flex-col overflow-hidden rounded border-l-4 text-left text-xs transition-opacity hover:opacity-80 ${cls}${strike}`}
       style={color ? { borderLeftColor: color } : undefined}
     >
       <div className="flex items-center justify-between gap-1 bg-black/30 px-2 py-0.5 font-semibold dark:bg-black/50">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #719.

Closes #719

---

## Claude summary

Typecheck passes. The fix from the previous session (commit `ff129c0`) is already on branch `claude/issue-719` and correctly addresses the issue — the empty colored band above the time bar in appointment cards on `/dashboard/gabinet/calendar`. 

The fix adds `flex flex-col` to the button shell at `src/components/gabinet/calendar/appointment-card.tsx:35`, which overrides the user-agent vertical-centering behavior of native `<button>` elements with explicit height. With `flex flex-col`, the dark time bar (first child) sits flush against the top edge of the card, and the patient/treatment block sits directly beneath it, eliminating the empty pastel band that the user marked with purple arrows in the Jam screenshot. The same component is reused in the day-view grid and the drag-overlay, so all three render correctly with the change.

No further code changes are needed — the issue is already addressed in this branch. The reason the user's auto-merge comment fired is that the previous session pushed the commit to the branch but no PR was open against `main`. To actually ship the fix, a PR `claude/issue-719 → main` needs to be opened (or the commit needs to be cherry-picked onto main), but that's a delivery step rather than additional engineering work on the issue itself.