### PR TITLE
Fix duplicate `createSupabaseDb` import in tests/convex/automation.test.ts

### DIFF
--- a/tests/convex/automation.test.ts
+++ b/tests/convex/automation.test.ts
@@ -8,7 +8,6 @@ import {
   seedSecondUser,
   seedTestUser,
 } from "../../convex/_test_helpers";
-import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
 
 const activeContexts = new Set<ReturnType<typeof createTestCtx>>();
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #720.

Closes #720

---

## Claude summary

Removed the duplicate `import { createSupabaseDb } from "../../convex/_helpers/supabaseDb"` on line 11 of `tests/convex/automation.test.ts` (the same symbol was already imported on line 4). Verified exactly one import statement remains. Committed as `3bacf90`.

Note: the issue body speculates this duplicate may be related to "18 pre-existing failures in this suite on main." That's unlikely — a duplicate-identifier import is a parse-time error that would prevent the file from loading at all (0 tests, not 18 failures). The real cause of those failures lives elsewhere and is out of scope for this surgical fix.