### PR TITLE
Investigate automation.test.ts pre-existing failures

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -440,7 +440,8 @@ export const _sendAutomationEmail = internalAction({
     bodyHtml: v.string(),
     bodyText: v.string(),
     sentBy: v.optional(v.id("users")),
-    appointmentId: v.optional(v.id("gabinetAppointments")),
+    // Supabase UUID; gabinet appointments moved off Convex ids in #353.
+    appointmentId: v.optional(v.string()),
     actionType: v.string(),
     idempotencyKey: v.string(),
   },
@@ -513,7 +514,8 @@ export const _recordAutomationEmailResult = internalMutation({
     bodyHtml: v.string(),
     bodyText: v.string(),
     sentBy: v.optional(v.id("users")),
-    appointmentId: v.optional(v.id("gabinetAppointments")),
+    // Supabase UUID; gabinet appointments moved off Convex ids in #353.
+    appointmentId: v.optional(v.string()),
     actionType: v.string(),
     idempotencyKey: v.string(),
   },
@@ -786,7 +788,8 @@ async function patchLegacyAppointmentWorkflowHistory(
   ctx: MutationCtx,
   args: {
     organizationId: Id<"organizations">;
-    appointmentId?: Id<"gabinetAppointments">;
+    // Supabase UUID; gabinet appointments moved off Convex ids in #353.
+    appointmentId?: string;
     actionType: string;
     recipient?: string;
     recipientName?: string;

--- a/tests/convex/automation.test.ts
+++ b/tests/convex/automation.test.ts
@@ -18,7 +18,12 @@ function createManagedTestCtx() {
 }
 
 beforeEach(() => {
-  vi.useFakeTimers();
+  // Restrict the fake-timer surface: vitest's default toFake (setImmediate /
+  // Date / performance / …) breaks convex-test — `finishAllScheduledFunctions`
+  // never sees jobs transition out of "pending" and afterEach times out (#721).
+  vi.useFakeTimers({
+    toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"],
+  });
   vi.stubGlobal(
     "fetch",
     vi.fn(async () => ({


### PR DESCRIPTION
Auto-generated by Claude in response to issue #721.

Closes #721

---

## Claude summary

Fix committed. Two independent regressions in `automation.test.ts`:

1. **afterEach timeouts (6 tests)**: vitest@4's `vi.useFakeTimers()` defaults to faking `setImmediate`, which breaks convex-test's scheduled-function poller — jobs never transition to "inProgress" so `finishAllScheduledFunctions` returns immediately with no work observed. Restricted `toFake` to just `setTimeout`/`setInterval` (+ clear variants).

2. **`send_email` steps stuck at "pending" (2 tests)**: after #353 made gabinet appointments Supabase-primary, `run.entityId` is a UUID string but `_sendAutomationEmail` / `_recordAutomationEmailResult` validators still declared `v.id("gabinetAppointments")`, so scheduling threw `Validator error: Expected ID for table "gabinetAppointments"` before any email work ran. Relaxed both to `v.string()` (matches `appointmentWorkflowHistory.appointmentId` in the schema).

The remaining 11 failures were a cascading consequence of issue 1 — same `pending` symptom, same root cause. Result: 19/19 automation tests pass; full convex suite stays green (115/115 across 16 files).

## Follow-ups
- Audit other automation.ts validators for stale `v.id("gabinetAppointments")` / `v.id("gabinetPatients")`: anywhere a Supabase-primary entity flows through an internalAction / internalMutation arg validator is a latent crash. Grep convex/ for `v.id("gabinet` outside the schema and verify each call site sources its id from Convex, not Supabase.
- Document fake-timer + convex-test pitfall in TESTING.md: vitest@4 broadened the default `toFake` list; record the `toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"]` recipe so future tests don't rediscover it.