### PR TITLE
feat(automation): land Supabase-primary applyUpdateFieldAction (reconciles claude/issue-574)

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -537,13 +537,14 @@ async function applyUpdateFieldAction(
     throw new Error(permission.reason ?? "Permission denied");
   }
 
-  const entityId = targetId as Id<
-    "gabinetPatients" | "gabinetAppointments" | "gabinetEmployees" | "leads"
-  >;
-  const entity = (await ctx.db.get(entityId as never)) as
-    | ({ organizationId: Id<"organizations">; customFields?: unknown } & Record<string, unknown>)
+  // Read entity from Supabase — leads/patients/appointments/employees are all
+  // Supabase-primary, so ctx.db.get against Convex returns null in prod for
+  // entities written by the new action handlers.
+  const db = createSupabaseDb();
+  const entity = (await db.get(descriptor.table, targetId)) as
+    | ({ organizationId?: string; customFields?: unknown } & Record<string, unknown>)
     | null;
-  if (!entity || entity.organizationId !== args.organizationId) {
+  if (!entity || String(entity.organizationId) !== String(args.organizationId)) {
     throw new Error(descriptor.notFoundMessage);
   }
   if (permission.scope === "own" && !descriptor.canEditOwn(entity, args.actorUserId)) {
@@ -554,6 +555,7 @@ async function applyUpdateFieldAction(
   const coercedValue = coerceAutomationFieldValue(renderedValue, args.action.valueType);
   const now = Date.now();
 
+  let updates: Record<string, unknown>;
   if (args.action.fieldKind === "custom") {
     if (!descriptor.supportsCustom) {
       throw new Error(descriptor.unsupportedCustomFieldMessage);
@@ -563,21 +565,36 @@ async function applyUpdateFieldAction(
       entity.customFields && typeof entity.customFields === "object"
         ? (entity.customFields as Record<string, unknown>)
         : {};
-    await ctx.db.patch(entityId as never, {
+    updates = {
       customFields: {
         ...existingCustomFields,
         [args.action.fieldKey]: coercedValue,
       },
       updatedAt: now,
-    } as never);
+    };
   } else {
     if (!STANDARD_FIELD_ALLOWLIST[descriptor.linkedEntityType].has(args.action.fieldKey)) {
       throw new Error(descriptor.unsupportedStandardFieldMessage);
     }
-    await ctx.db.patch(entityId as never, {
+    updates = {
       [args.action.fieldKey]: coercedValue,
       updatedAt: now,
-    } as never);
+    };
+  }
+
+  // Write to Supabase (primary).
+  await db.patch(descriptor.table, targetId, updates);
+
+  // Mirror to Convex if a doc with this id still exists there (gabinet
+  // entities seeded by tests, or legacy data not yet migrated). For
+  // Supabase-only ids (e.g. UUIDs returned by leads.create), normalizeId
+  // returns null and we silently skip the Convex write.
+  const convexId = ctx.db.normalizeId(descriptor.table, targetId);
+  if (convexId) {
+    const convexDoc = await ctx.db.get(convexId);
+    if (convexDoc) {
+      await ctx.db.patch(convexId, updates as never);
+    }
   }
 
   if (args.actorUserId) {
@@ -591,7 +608,7 @@ async function applyUpdateFieldAction(
     await logActivity(ctx, {
       organizationId: args.organizationId,
       entityType: descriptor.linkedEntityType,
-      entityId,
+      entityId: targetId,
       action: "updated",
       description: `Updated ${activityLabelByEntity[descriptor.linkedEntityType]} field ${args.action.fieldKey} via automation`,
       performedBy: args.actorUserId,
@@ -600,7 +617,7 @@ async function applyUpdateFieldAction(
 
   return {
     linkedEntityType: descriptor.linkedEntityType,
-    linkedEntityId: String(entityId),
+    linkedEntityId: targetId,
     renderedBody: `${args.action.fieldKind}:${args.action.fieldKey}=${String(coercedValue)}`,
   };
 }

--- a/convex/documentDataSources.ts
+++ b/convex/documentDataSources.ts
@@ -113,6 +113,7 @@ export const PLATFORM_DATA_SOURCES: DataSourceDefinition[] = [
 // ---------------------------------------------------------------------------
 
 import { CRM_DATA_SOURCES } from "./crm/documentDataSources";
+import { GABINET_DATA_SOURCES } from "./gabinet/documentDataSources";
 
 // ---------------------------------------------------------------------------
 // Aggregate registry
@@ -121,6 +122,7 @@ import { CRM_DATA_SOURCES } from "./crm/documentDataSources";
 export const ALL_DATA_SOURCES: DataSourceDefinition[] = [
   ...PLATFORM_DATA_SOURCES,
   ...CRM_DATA_SOURCES,
+  ...GABINET_DATA_SOURCES,
 ];
 
 // ---------------------------------------------------------------------------

--- a/convex/gabinet/documentDataSources.ts
+++ b/convex/gabinet/documentDataSources.ts
@@ -1,0 +1,51 @@
+import type { DataSourceDefinition } from "../documentDataSources";
+
+const patientSource: DataSourceDefinition = {
+  key: "patient",
+  label: "Klient",
+  module: "gabinet",
+  fields: [
+    { key: "firstName", label: "Imię", type: "text" },
+    { key: "lastName", label: "Nazwisko", type: "text" },
+    { key: "fullName", label: "Imię i nazwisko", type: "text" },
+    { key: "pesel", label: "PESEL", type: "pesel" },
+    { key: "dateOfBirth", label: "Data urodzenia", type: "date" },
+    { key: "phone", label: "Telefon", type: "phone" },
+    { key: "email", label: "E-mail", type: "email" },
+    { key: "address", label: "Adres", type: "text" },
+    { key: "allergies", label: "Alergie", type: "textarea" },
+    { key: "bloodType", label: "Grupa krwi", type: "text" },
+    { key: "emergencyContact", label: "Kontakt awaryjny", type: "text" },
+  ],
+  resolve: async (ctx, patientId): Promise<Record<string, string>> => {
+    if (!patientId) return {};
+    const patient = (await ctx.db.get(patientId as any)) as any;
+    if (!patient) return {};
+    return {
+      firstName: patient.firstName ?? "",
+      lastName: patient.lastName ?? "",
+      fullName: [patient.firstName, patient.lastName].filter(Boolean).join(" "),
+      pesel: patient.pesel ?? "",
+      dateOfBirth: patient.dateOfBirth ?? "",
+      phone: patient.phone ?? "",
+      email: patient.email ?? "",
+      address: [
+        patient.address?.street,
+        patient.address?.postalCode,
+        patient.address?.city,
+      ]
+        .filter(Boolean)
+        .join(", "),
+      allergies: patient.allergies ?? "",
+      bloodType: patient.bloodType ?? "",
+      emergencyContact: [
+        patient.emergencyContactName,
+        patient.emergencyContactPhone,
+      ]
+        .filter(Boolean)
+        .join(" — "),
+    };
+  },
+};
+
+export const GABINET_DATA_SOURCES: DataSourceDefinition[] = [patientSource];

--- a/tests/convex/automation.test.ts
+++ b/tests/convex/automation.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { api, internal } from "../../convex/_generated/api";
 import { DEFAULT_PERMISSIONS } from "../../convex/_helpers/permissions";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
 import {
   createTestCtx,
   seedGabinetPrereqs,
@@ -51,11 +52,19 @@ async function setPatientPhone(
   patientId: any,
   phone: string,
 ) {
+  const now = Date.now();
   await t.run(async (ctx) => {
     await ctx.db.patch(patientId, {
       phone,
-      updatedAt: Date.now(),
+      updatedAt: now,
     });
+  });
+  // Gabinet appointment + SMS actions read patient via createSupabaseDb
+  // (Supabase-primary), so mirror the update there too.
+  const db = createSupabaseDb();
+  await db.patch("gabinetPatients", String(patientId), {
+    phone,
+    updatedAt: now,
   });
 }
 
@@ -64,11 +73,17 @@ async function setPatientEmail(
   patientId: any,
   email: string,
 ) {
+  const now = Date.now();
   await t.run(async (ctx) => {
     await ctx.db.patch(patientId, {
       email,
-      updatedAt: Date.now(),
+      updatedAt: now,
     });
+  });
+  const db = createSupabaseDb();
+  await db.patch("gabinetPatients", String(patientId), {
+    email,
+    updatedAt: now,
   });
 }
 

--- a/tests/convex/automation.test.ts
+++ b/tests/convex/automation.test.ts
@@ -1071,7 +1071,7 @@ describe("automation lifecycle", () => {
           runId: run._id,
         })
       : [];
-    const lead = await t.run(async (ctx) => ctx.db.get(leadId));
+    const lead = await createSupabaseDb().get<{ notes?: string }>("leads", String(leadId));
 
     expect(run?.status).toBe("processed");
     expect(steps).toHaveLength(1);
@@ -1340,7 +1340,7 @@ describe("automation lifecycle", () => {
           runId: run._id,
         })
       : [];
-    const lead = await t.run(async (ctx) => ctx.db.get(leadId));
+    const lead = await createSupabaseDb().get<{ notes?: string }>("leads", String(leadId));
 
     expect(run?.status).toBe("processed");
     expect(steps).toHaveLength(1);


### PR DESCRIPTION
Reconciles the long-lived `claude/issue-574` branch with current `main`, lands the Supabase-primary automation work that's been sitting orphaned since #574.

## Architecture call

Per platform owner: **Supabase is primary** (where data lives); Convex is for orchestration. So `applyUpdateFieldAction` reads/writes go to Supabase, with a mirror to Convex when a doc still exists there (gabinet test seeds, legacy rows).

## Resolution

Merged `origin/main` into `claude/issue-574` (renamed locally to `reconcile/issue-574` for cleanliness). 67 of 69 files auto-resolved. Two conflicts both resolved by taking the **HEAD (Supabase-primary)** side:

- `convex/automation.ts` — 4 conflict hunks in `applyUpdateFieldAction`. HEAD does `createSupabaseDb().get(...)` unconditionally and writes with a `normalizeId`-gated Convex mirror. Main had a `descriptor.storage === "supabase" ? supabaseDb : ctx.db` ternary — that's the half-migrated shape; superseded.
- `tests/convex/automation.test.ts` — 2 hunks, both cosmetic (`get<{notes?: string}>` generic vs `as Record<string, unknown>` cast). HEAD form is cleaner since the generic IS supported.

Also amended a small type fix to `convex/invitations.ts:_adminResendAndSend` — `runMutation` was hitting a circular-type-inference TS7022 after the merge brought in more api.d.ts surface; added an explicit return type for `r`.

## Verification

- `npx convex dev --once` runs clean (codegen + push to dev deployment OK)
- `npx tsc -p convex/tsconfig.json --noEmit` passes (the `convex/supabase/backfill.ts` TS7006 noise predates this PR — it's pre-existing on main)
- Unit tests not run here — vitest had an env-level startup error on my local pnpm setup; CI is the right place to run them