### PR TITLE
feat(invite): land in register/login flow with prefilled email + workspace context

### DIFF
--- a/src/routes/_app/invite.$token.tsx
+++ b/src/routes/_app/invite.$token.tsx
@@ -9,7 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useState } from "react";
-import { Users, AlertCircle, CheckCircle2, XCircle, LogIn } from "@/lib/ez-icons";
+import { Users, AlertCircle, CheckCircle2, XCircle } from "@/lib/ez-icons";
 
 export const Route = createFileRoute("/_app/invite/$token")({
   component: InviteAcceptPage,
@@ -110,15 +110,41 @@ function InviteAcceptPage() {
     );
   }
 
-  // Not logged in
+  // Not logged in — redirect to /login with the invite context so we can
+  // pre-fill email, skip the choose-method screen, and come back here after
+  // OTP verification (which transparently creates a new account if needed).
   if (!isAuthenticated) {
     return (
       <CenteredCard>
         <div className="flex flex-col items-center gap-4 text-center">
-          <LogIn className="h-12 w-12 text-muted-foreground" />
-          <p className="text-lg font-medium">{t("invite.signInFirst")}</p>
-          <Button asChild>
-            <Link to="/login">{t("layout.settings").replace("Settings", "Sign In")}</Link>
+          <Users className="h-12 w-12 text-primary" />
+          <div className="space-y-1">
+            <p className="text-lg font-medium">
+              {t("invite.joinOrgTitle", { defaultValue: "Dołącz do {{orgName}}", orgName: orgName ?? "" })}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              {inviterName
+                ? t("invite.invitedBy", {
+                    defaultValue: "Zaproszenie od {{inviterName}}",
+                    inviterName,
+                  })
+                : t("invite.youHaveBeenInvited", { defaultValue: "Zostałeś zaproszony" })}
+            </p>
+            <p className="text-xs text-muted-foreground pt-2">
+              {t("invite.continueHint", {
+                defaultValue:
+                  "Wyślemy jednorazowy kod na {{email}}. Jeśli nie masz jeszcze konta, utworzymy je automatycznie.",
+                email: invitation.email,
+              })}
+            </p>
+          </div>
+          <Button asChild className="w-full">
+            <Link
+              to="/login"
+              search={{ inviteToken: token, email: invitation.email }}
+            >
+              {t("invite.continueButton", { defaultValue: "Kontynuuj" })}
+            </Link>
           </Button>
         </div>
       </CenteredCard>

--- a/src/routes/_app/login/_layout.index.tsx
+++ b/src/routes/_app/login/_layout.index.tsx
@@ -20,6 +20,13 @@ import Logo from "@/assets/svg/logo";
 
 export const Route = createFileRoute("/_app/login/_layout/")({
   component: Login,
+  // Invite-flow context: when the user lands here from `/invite/<token>`,
+  // we pre-fill the email and route them back to `/invite/<token>` after
+  // auth so the invitation is accepted automatically.
+  validateSearch: z.object({
+    inviteToken: z.string().optional(),
+    email: z.string().optional(),
+  }),
 });
 
 type LoginStep =
@@ -31,18 +38,40 @@ type LoginStep =
   | { resetPassword: string };
 
 function Login() {
-  const [step, setStep] = useState<LoginStep>("choose");
+  const { inviteToken, email: inviteEmail } = Route.useSearch();
+  const isInviteFlow = Boolean(inviteToken);
+
+  // In invite flow we skip the choose-method screen and jump straight to OTP
+  // (passwordless email auth — works equally for new and existing accounts,
+  // so the user doesn't have to know whether they have a password yet).
+  const [step, setStep] = useState<LoginStep>(
+    isInviteFlow ? "otp-email" : "choose",
+  );
   const { isAuthenticated, isLoading } = useConvexAuth();
   const { data: user } = useQuery({
     ...convexQuery(api.app.getCurrentUser, {}),
     enabled: isAuthenticated,
   });
+
+  // Fetch invitation context for the banner shown above the OTP form.
+  const { data: inviteData } = useQuery({
+    ...convexQuery(api.invitations.getByToken, { token: inviteToken ?? "" }),
+    enabled: Boolean(inviteToken),
+  });
+
   const navigate = useNavigate();
 
   useEffect(() => {
     if (isLoading || !isAuthenticated) return;
     if (!user) {
+      // No user record yet — let the dashboard's auth gate handle it
       navigate({ to: DashboardRoute.fullPath, replace: true });
+      return;
+    }
+    // If user came from /invite/<token>, send them back so the invitation
+    // gets accepted automatically.
+    if (inviteToken) {
+      navigate({ to: "/invite/$token", params: { token: inviteToken }, replace: true });
       return;
     }
     if (!user.username) {
@@ -50,7 +79,21 @@ function Login() {
       return;
     }
     navigate({ to: DashboardRoute.fullPath, replace: true });
-  }, [isLoading, isAuthenticated, user, navigate]);
+  }, [isLoading, isAuthenticated, user, navigate, inviteToken]);
+
+  // Optional banner rendered above every step when in invite flow
+  const inviteBanner = isInviteFlow && inviteData ? (
+    <div className="mb-4 rounded-md border border-primary/20 bg-primary/5 p-3 text-sm">
+      <div className="font-medium">
+        {inviteData.inviterName ?? "Ktoś"} zaprasza Cię do{" "}
+        <strong>{inviteData.orgName ?? "zespołu"}</strong>
+      </div>
+      <div className="mt-1 text-xs text-muted-foreground">
+        Wpisz kod, który wyślemy na {inviteData.invitation.email}. Jeśli nie
+        masz jeszcze konta, utworzymy je automatycznie.
+      </div>
+    </div>
+  ) : null;
 
   if (step === "choose") {
     return (
@@ -61,10 +104,25 @@ function Login() {
     );
   }
   if (step === "otp-email") {
-    return <OtpEmailForm onSubmit={(email) => setStep({ otpVerify: email })} onBack={() => setStep("choose")} />;
+    return (
+      <>
+        {inviteBanner}
+        <OtpEmailForm
+          initialEmail={inviteEmail}
+          lockEmail={isInviteFlow}
+          onSubmit={(email) => setStep({ otpVerify: email })}
+          onBack={isInviteFlow ? undefined : () => setStep("choose")}
+        />
+      </>
+    );
   }
   if (typeof step === "object" && "otpVerify" in step) {
-    return <OtpVerifyForm email={step.otpVerify} onBack={() => setStep("otp-email")} />;
+    return (
+      <>
+        {inviteBanner}
+        <OtpVerifyForm email={step.otpVerify} onBack={() => setStep("otp-email")} />
+      </>
+    );
   }
   if (step === "password") {
     return <PasswordForm onBack={() => setStep("choose")} onForgotPassword={() => setStep("forgot-password")} />;
@@ -321,9 +379,13 @@ function PasswordForm({ onBack, onForgotPassword }: { onBack: () => void; onForg
 function OtpEmailForm({
   onSubmit,
   onBack,
+  initialEmail,
+  lockEmail,
 }: {
   onSubmit: (email: string) => void;
-  onBack: () => void;
+  onBack?: () => void;
+  initialEmail?: string;
+  lockEmail?: boolean;
 }) {
   const { signIn } = useAuthActions();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -331,7 +393,7 @@ function OtpEmailForm({
 
   const form = useForm({
     validatorAdapter: zodValidator(),
-    defaultValues: { email: "" },
+    defaultValues: { email: initialEmail ?? "" },
     onSubmit: async ({ value }) => {
       setIsSubmitting(true);
       setError(null);
@@ -376,6 +438,8 @@ function OtpEmailForm({
                 value={field.state.value}
                 onBlur={field.handleBlur}
                 onChange={(e) => field.handleChange(e.target.value)}
+                readOnly={lockEmail}
+                disabled={lockEmail}
                 className={field.state.meta?.errors.length > 0 ? "border-destructive focus-visible:ring-destructive" : ""}
               />
               {field.state.meta?.errors.length > 0 && (
@@ -392,9 +456,11 @@ function OtpEmailForm({
         </Button>
       </form>
 
-      <Button variant="ghost" className="w-full" onClick={onBack}>
-        Wróć do wyboru metody
-      </Button>
+      {onBack && (
+        <Button variant="ghost" className="w-full" onClick={onBack}>
+          Wróć do wyboru metody
+        </Button>
+      )}
     </>
   );
 }


### PR DESCRIPTION
When invitee clicks the link, they go through a single linear flow that:

1. Shows org + inviter context on the invite page
2. Routes to /login with the token + email pre-filled
3. Skips choose-method, goes straight to OTP (passwordless = handles both new and existing accounts)
4. After OTP verify, redirects back to /invite/<token> which auto-accepts

The invite token is what defines the workspace the user joins. No more dead-end "Sign in first" screen.