### PR TITLE
Document fake-timer + convex-test pitfall in TESTING.md

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -38,3 +38,25 @@ Error: SUPABASE_URL not configured
 ```
 
 …it almost always means vitest was invoked from the wrong cwd or with the wrong config, so `tests/convex/_setup.ts` never ran and the real `createServiceRoleClient` is being called instead of the in-memory stub. Re-run via `npm run test:unit` (or one of the alternatives above). It is not an environment problem — the test suite never needs a real `SUPABASE_URL`.
+
+## Fake timers + convex-test: restrict `toFake`
+
+If your test uses `vi.useFakeTimers()` alongside convex-test scheduled functions (e.g. `t.finishAllScheduledFunctions(() => vi.runAllTimers())`), you MUST pass an explicit `toFake` list:
+
+```ts
+beforeEach(() => {
+  vi.useFakeTimers({
+    toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"],
+  });
+});
+```
+
+Why: vitest@4 broadened the default `toFake` list to also include `setImmediate`, `queueMicrotask`, `Date`, `performance`, and the rest of the timer surface. Convex-test fires each scheduled function from a captured `setTimeout(0, …)` whose internal continuations rely on the un-faked surface — when those APIs are also faked, jobs never transition out of `"pending"`, `finishAllScheduledFunctions` returns immediately with no work observed, and `afterEach` (or the call itself) times out with `Hook timed out in 10000ms`.
+
+Symptoms:
+
+- `Hook timed out in 10000ms` in `afterEach`.
+- Scheduled jobs / workflow steps stuck on `"pending"` instead of advancing to `"inProgress"` / `"processed"`.
+- The bare `vi.useFakeTimers()` form worked under vitest@3 and stopped working after the bump.
+
+Fix: stick to the four-entry `toFake` list above. That preserves the timer surface convex-test needs while still letting `vi.runAllTimers()` drive the poller. See `tests/convex/automation.test.ts` for the canonical setup (#721).


### PR DESCRIPTION
Auto-generated by Claude in response to issue #727.

Closes #727

---

## Claude summary

Done. Added a "Fake timers + convex-test: restrict `toFake`" section to TESTING.md documenting the recipe, root cause (vitest@4 broadened the default), and symptoms (`Hook timed out in 10000ms`, jobs stuck on `"pending"`). Pointer to `tests/convex/automation.test.ts` as the canonical example. Committed as `8c4ae9e` on `claude/issue-727`.