### PR TITLE
fix(perms): mirror teamMemberships to Supabase on every write path (admin can't see anything)

### DIFF
--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -392,13 +392,33 @@ export const _acceptInternal = internalMutation({
       );
     }
 
-    await ctx.db.insert("teamMemberships", {
+    const joinedAt = Date.now();
+    const membershipId = await ctx.db.insert("teamMemberships", {
       userId: user._id,
       organizationId: invitation.organizationId,
       role: invitation.role,
       invitedBy: invitation.invitedBy,
-      joinedAt: Date.now(),
+      joinedAt,
     });
+
+    // Mirror to Supabase so the team-settings page (which reads members
+    // via useSupabaseOrganizationMembers) and the RBAC bridge (which
+    // also reads team_memberships from Supabase) both see the new
+    // membership. Without this, an invited admin/member has a row in
+    // Convex teamMemberships but is invisible to the UI's permission
+    // checks — UI shows empty / 403 on protected actions.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.supabase.organizations.writeTeamMembershipToSupabase,
+      {
+        membershipId: String(membershipId),
+        userId: String(user._id),
+        organizationId: String(invitation.organizationId),
+        role: invitation.role,
+        invitedBy: String(invitation.invitedBy),
+        joinedAt,
+      },
+    );
 
     // If the invitee just signed up via OTP and has no username yet, derive
     // one from the email local-part so they skip the /onboarding/username

--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -75,12 +75,28 @@ export const _createOrgInternal = internalMutation({
       updatedAt: now,
     });
 
-    await ctx.db.insert("teamMemberships", {
+    const ownerMembershipId = await ctx.db.insert("teamMemberships", {
       userId: user._id,
       organizationId: orgId,
       role: "owner",
       joinedAt: now,
     });
+
+    // Mirror owner membership to Supabase — same reason as in
+    // invitations._acceptInternal: the UI reads team_memberships from
+    // Supabase, not Convex, so without this the org creator has zero
+    // permissions in their own org.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.supabase.organizations.writeTeamMembershipToSupabase,
+      {
+        membershipId: String(ownerMembershipId),
+        userId: String(user._id),
+        organizationId: String(orgId),
+        role: "owner",
+        joinedAt: now,
+      },
+    );
 
     await logActivity(ctx, {
       organizationId: orgId,
@@ -273,13 +289,28 @@ export const _inviteMemberInternal = internalMutation({
       .unique();
     if (existing) throw new Error("User is already a member");
 
+    const joinedAt = Date.now();
     const membershipId = await ctx.db.insert("teamMemberships", {
       userId: args.userId,
       organizationId: args.organizationId,
       role: args.role,
       invitedBy: user._id,
-      joinedAt: Date.now(),
+      joinedAt,
     });
+
+    // Mirror to Supabase — UI reads team_memberships from there.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.supabase.organizations.writeTeamMembershipToSupabase,
+      {
+        membershipId: String(membershipId),
+        userId: String(args.userId),
+        organizationId: String(args.organizationId),
+        role: args.role,
+        invitedBy: String(user._id),
+        joinedAt,
+      },
+    );
 
     await logActivity(ctx, {
       organizationId: args.organizationId,

--- a/convex/supabase/organizations.ts
+++ b/convex/supabase/organizations.ts
@@ -3,7 +3,8 @@
  */
 
 import { v } from "convex/values";
-import { internalAction } from "@cvx/_generated/server";
+import { internalAction, internalQuery } from "@cvx/_generated/server";
+import { internal } from "@cvx/_generated/api";
 import { createServiceRoleClient, upsertWithFkRetry } from "./client";
 
 // ── Organization ──────────────────────────────────────────────────────────────
@@ -43,6 +44,79 @@ export const writeOrganizationToSupabase = internalAction({
 });
 
 // ── Team Membership ───────────────────────────────────────────────────────────
+
+// One-shot backfill: mirrors EVERY Convex teamMemberships row into Supabase.
+// Safe to re-run — upsert semantics in writeTeamMembershipToSupabase. Used to
+// recover from the historical gap when org.create / invitations._acceptInternal
+// / organizations.addMember wrote to Convex only.
+export const _backfillAllTeamMembershipsToSupabase = internalAction({
+  args: {},
+  returns: v.object({
+    scanned: v.number(),
+    mirrored: v.number(),
+    errors: v.number(),
+  }),
+  handler: async (ctx): Promise<{ scanned: number; mirrored: number; errors: number }> => {
+    const rows: Array<{
+      _id: string;
+      userId: string;
+      organizationId: string;
+      role: string;
+      invitedBy?: string;
+      joinedAt: number;
+    }> = await ctx.runQuery(
+      internal.supabase.organizations._listAllTeamMemberships,
+      {},
+    );
+    let mirrored = 0;
+    let errors = 0;
+    for (const r of rows) {
+      try {
+        await ctx.runAction(
+          internal.supabase.organizations.writeTeamMembershipToSupabase,
+          {
+            membershipId: r._id,
+            userId: r.userId,
+            organizationId: r.organizationId,
+            role: r.role,
+            invitedBy: r.invitedBy,
+            joinedAt: r.joinedAt,
+          },
+        );
+        mirrored += 1;
+      } catch (e) {
+        console.error(`[backfill teamMemberships] ${r._id} failed:`, e);
+        errors += 1;
+      }
+    }
+    return { scanned: rows.length, mirrored, errors };
+  },
+});
+
+export const _listAllTeamMemberships = internalQuery({
+  args: {},
+  returns: v.array(
+    v.object({
+      _id: v.string(),
+      userId: v.string(),
+      organizationId: v.string(),
+      role: v.string(),
+      invitedBy: v.optional(v.string()),
+      joinedAt: v.number(),
+    }),
+  ),
+  handler: async (ctx) => {
+    const all = await ctx.db.query("teamMemberships").collect();
+    return all.map((r) => ({
+      _id: String(r._id),
+      userId: String(r.userId),
+      organizationId: String(r.organizationId),
+      role: r.role,
+      invitedBy: r.invitedBy ? String(r.invitedBy) : undefined,
+      joinedAt: r.joinedAt,
+    }));
+  },
+});
 
 export const writeTeamMembershipToSupabase = internalAction({
   args: {


### PR DESCRIPTION
Root cause of "administrator nagle nie widzi elementów":

Three Convex code paths inserted into `teamMemberships` without mirroring to Supabase `team_memberships`:
- `invitations._acceptInternal` (invitee accepts)
- `organizations.create` (owner row on org create)
- `organizations.addMember` (manual add)

Frontend reads members via `useSupabaseOrganizationMembers` (queries Supabase), RBAC bridge also reads `team_memberships` from Supabase — so a Convex-only membership was invisible to permission checks. Invited admin = 0 perms in UI.

All three paths now `scheduler.runAfter(0, writeTeamMembershipToSupabase, ...)` after the Convex insert.

Plus `_backfillAllTeamMembershipsToSupabase` helper for one-shot recovery (already ran on dev: 1 mirrored / 35 FK-errors which are unrelated QA test accounts missing parent rows in Supabase).