### PR TITLE
Consider extending indicators to the month view

### DIFF
--- a/src/components/gabinet/calendar/calendar-month-view.tsx
+++ b/src/components/gabinet/calendar/calendar-month-view.tsx
@@ -18,6 +18,8 @@ interface CalendarMonthViewProps {
   selectedDate?: string;
   /** Dates covered by approved leave for the filtered employee. */
   leaveDates?: Set<string>;
+  /** Dates with at least one non-cancelled appointment whose prepayment is required but unpaid. */
+  paymentDueDates?: Set<string>;
 }
 
 function getMonthGrid(year: number, month: number): (string | null)[][] {
@@ -48,7 +50,7 @@ function getMonthGrid(year: number, month: number): (string | null)[][] {
 
 const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
-export function CalendarMonthView({ year, month, appointments, onDayClick, selectedDate, leaveDates }: CalendarMonthViewProps) {
+export function CalendarMonthView({ year, month, appointments, onDayClick, selectedDate, leaveDates, paymentDueDates }: CalendarMonthViewProps) {
   const { t } = useTranslation();
   const grid = useMemo(() => getMonthGrid(year, month), [year, month]);
   const now = new Date();
@@ -85,6 +87,7 @@ export function CalendarMonthView({ year, month, appointments, onDayClick, selec
           const count = countByDate.get(date) ?? 0;
           const isToday = date === today;
           const isLeave = leaveDates?.has(date) ?? false;
+          const hasPaymentDue = paymentDueDates?.has(date) ?? false;
 
           return (
             <div
@@ -110,11 +113,26 @@ export function CalendarMonthView({ year, month, appointments, onDayClick, selec
                   </span>
                 </div>
               )}
-              {count > 0 && (
-                <div className="mt-0.5">
-                  <span className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary">
-                    {count}
-                  </span>
+              {(count > 0 || hasPaymentDue) && (
+                <div className="mt-0.5 flex flex-wrap items-center gap-1">
+                  {count > 0 && (
+                    <span className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary">
+                      {count}
+                    </span>
+                  )}
+                  {hasPaymentDue && (
+                    <span
+                      title={t("gabinet.calendar.indicators.paymentDue", {
+                        defaultValue: "Wymagana przedpłata",
+                      })}
+                      aria-label={t("gabinet.calendar.indicators.paymentDue", {
+                        defaultValue: "Wymagana przedpłata",
+                      })}
+                      className="inline-flex h-4 min-w-4 items-center justify-center rounded-sm bg-amber-500 px-0.5 text-[10px] font-bold leading-none text-white"
+                    >
+                      $
+                    </span>
+                  )}
                 </div>
               )}
             </div>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -392,6 +392,21 @@ function GabinetCalendarPage() {
     [leavesByDate],
   );
 
+  // Dates with at least one non-cancelled appointment requiring (but not yet
+  // confirmed) prepayment — surfaces the "$" indicator on the month view so
+  // users can spot unpaid bookings at a glance.
+  const paymentDueDates = useMemo(() => {
+    const set = new Set<string>();
+    if (!rawAppointments) return set;
+    for (const a of rawAppointments) {
+      if (a.status === "cancelled") continue;
+      if (a.prepaymentRequired && a.prepaymentStatus !== "paid") {
+        set.add(a.date);
+      }
+    }
+    return set;
+  }, [rawAppointments]);
+
   // Transform and filter appointments for view components
   const viewAppointments = useMemo(() => {
     const items: Array<{
@@ -1016,6 +1031,7 @@ function GabinetCalendarPage() {
               onDayClick={handleDayClick}
               selectedDate={formatDateStr(currentDate)}
               leaveDates={leaveDates}
+              paymentDueDates={paymentDueDates}
             />
           )}
         </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #731.

Closes #731

---

## Claude summary

Committed `113ab0b`.

Summary: extended the gabinet calendar month view with a "$" prepayment indicator. The route at `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx` now derives a `paymentDueDates` Set from the already-fetched `rawAppointments` (no extra query: filters out cancelled ones, keeps those where `prepaymentRequired && prepaymentStatus !== "paid"`) and passes it to `CalendarMonthView`. `src/components/gabinet/calendar/calendar-month-view.tsx` renders a small amber "$" pill next to the existing per-day count badge when the date is in that set. The tooltip uses the `gabinet.calendar.indicators.paymentDue` i18n key with a Polish fallback (the same key mentioned in follow-up #729). Typecheck passes (`tsc -p tsconfig.app.json`).

Note: the underlying day/week indicator feature from #712 has not yet landed on `origin/main` (`dce06d9` lives only on `claude/issue-719`). This change is self-contained and does not depend on it — it derives the prepayment state directly from the raw appointment rows.