### PR TITLE
Run `npm run test

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,27 @@
+name: Audit
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  manifests:
+    name: Module Manifest Dispatches
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run manifest dispatches audit
+        run: npm run test:manifests


### PR DESCRIPTION
Auto-generated by Claude in response to issue #117.

Closes #117

---

## Claude summary

Added `.github/workflows/audit.yml` which runs `npm run test:manifests` on PRs and pushes to `main`. The workflow is intentionally lightweight (no Playwright, no build, no preview server) — checkout, setup-node, `npm ci --legacy-peer-deps`, then the audit. Verified locally that the test passes (4 tests / ~3ms). Committed as c519384.

Note: the branch in this worktree is `claude/issue-429`, not `claude/issue-117` as the task prompt indicated — the commit references #117 in the message regardless.