### PR TITLE
Fix `npm ci` in `.github/workflows/e2e.yml`

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium


### PR DESCRIPTION
Auto-generated by Claude in response to issue #136.

Closes #136

---

## Claude summary

Fixed and committed. The change adds `--legacy-peer-deps` to `npm ci` in `.github/workflows/e2e.yml:27`, matching what `audit.yml:24` already does. This bypasses the `@heroui/react` peer dep conflict (it requires React 19 but the project pins React 18.3.1) so the E2E workflow can install dependencies again.

Note: I'm on branch `claude/issue-429` rather than `claude/issue-136` as the task description suggested — the worktree appears to have been reused. The commit references #136 in both the subject and body, so it will be tracked correctly.