### PR TITLE
Remove unused `CONVEX_DEPLOY_KEY` env from `.github/workflows/e2e.yml`

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,9 +6,6 @@ on:
   push:
     branches: [main]
 
-env:
-  CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
-
 jobs:
   e2e:
     name: Playwright E2E Tests


### PR DESCRIPTION
Auto-generated by Claude in response to issue #484.

Closes #484

---

## Claude summary

Removed the unused top-level `env` block (`CONVEX_DEPLOY_KEY`) from `.github/workflows/e2e.yml`. Verified via grep that the secret has no other references in the repo and no workflow step invokes `convex deploy`. Committed as `899c970` on branch `claude/issue-144`.