### PR TITLE
Add unit tests to CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-name: E2E Tests
+name: Tests
 
 on:
   pull_request:
@@ -7,6 +7,25 @@ on:
     branches: [main]
 
 jobs:
+  unit-tests:
+    name: Vitest Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run unit tests
+        run: npm run test:unit
+
   e2e:
     name: Playwright E2E Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Auto-generated by Claude in response to issue #487.

Closes #487

---

## Claude summary

Committed on `claude/issue-487`. Summary: added a parallel `unit-tests` job to `.github/workflows/e2e.yml` that runs `npm run test:unit` on every PR/push to main, and renamed the workflow from "E2E Tests" to "Tests" since it now covers both. I verified locally that the convex suite is currently green (16 files / 114 tests), so the job is added as a blocking check — no `continue-on-error`. The original rot called out in #487's comments has since been resolved by follow-ups #506, #509, #510, #511, #512, #513, #514, #516.