### PR TITLE
Add typecheck error gate for `convex/recentlyViewed.ts` and `convex/supabase/bac

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Typecheck
         run: npx tsc -p tsconfig.app.json
 
+      - name: Typecheck Convex
+        run: npx tsc -p convex/tsconfig.json
+
       - name: Build
         run: npx vite build
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #576.

Closes #576

---

## Claude summary

Triage outcome: the issue's `recentlyViewed.ts` fix already landed on main (`convex/recentlyViewed.ts:66-101`), but the `Typecheck Convex` CI step was never wired up because the bot's token can't push to `.github/workflows/*`. Verified `npx tsc -p convex/tsconfig.json` now exits 0, then added the missing step to `.github/workflows/e2e.yml:51-52` so future drift gets caught. Committed as `32f4628` on `claude/issue-576`.

Note: pushing this commit to origin will need to be done manually (or by a token with workflow write scope), same constraint that lost the original attempt.