### PR TITLE
feat(team): change role of a pending invitation in place (no cancel + reinvite)

### DIFF
--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -392,13 +392,33 @@ export const _acceptInternal = internalMutation({
       );
     }
 
-    await ctx.db.insert("teamMemberships", {
+    const joinedAt = Date.now();
+    const membershipId = await ctx.db.insert("teamMemberships", {
       userId: user._id,
       organizationId: invitation.organizationId,
       role: invitation.role,
       invitedBy: invitation.invitedBy,
-      joinedAt: Date.now(),
+      joinedAt,
     });
+
+    // Mirror to Supabase so the team-settings page (which reads members
+    // via useSupabaseOrganizationMembers) and the RBAC bridge (which
+    // also reads team_memberships from Supabase) both see the new
+    // membership. Without this, an invited admin/member has a row in
+    // Convex teamMemberships but is invisible to the UI's permission
+    // checks — UI shows empty / 403 on protected actions.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.supabase.organizations.writeTeamMembershipToSupabase,
+      {
+        membershipId: String(membershipId),
+        userId: String(user._id),
+        organizationId: String(invitation.organizationId),
+        role: invitation.role,
+        invitedBy: String(invitation.invitedBy),
+        joinedAt,
+      },
+    );
 
     // If the invitee just signed up via OTP and has no username yet, derive
     // one from the email local-part so they skip the /onboarding/username

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -668,6 +668,70 @@ export const _resendInternal = internalMutation({
   },
 });
 
+// Update the role of a PENDING invitation in place. Org-admin only. Useful
+// when the inviter picked the wrong role and doesn't want to cancel +
+// re-send (which would invalidate the link the invitee already received).
+export const updatePendingRole = action({
+  args: {
+    organizationId: v.id("organizations"),
+    invitationId: v.string(),
+    role: orgRoleValidator,
+  },
+  handler: async (ctx, args): Promise<string> => {
+    const updated: {
+      invitationId: string;
+      role: "admin" | "member" | "viewer" | "owner";
+      updatedAt: number;
+    } = await ctx.runMutation(internal.invitations._updatePendingRoleInternal, {
+      organizationId: args.organizationId,
+      invitationId: args.invitationId as Id<"invitations">,
+      role: args.role,
+    });
+
+    // Mirror to Supabase so the team-settings page reflects the new role.
+    try {
+      const db = createSupabaseDb();
+      await db.patch("invitations", updated.invitationId, {
+        role: updated.role,
+        updatedAt: updated.updatedAt,
+      });
+    } catch (e) {
+      console.error("[invitations.updatePendingRole] Supabase mirror failed:", e);
+    }
+
+    return updated.invitationId;
+  },
+});
+
+export const _updatePendingRoleInternal = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    invitationId: v.id("invitations"),
+    role: orgRoleValidator,
+  },
+  handler: async (ctx, args) => {
+    await requireOrgAdmin(ctx, args.organizationId);
+    const inv = await ctx.db.get(args.invitationId);
+    if (!inv || inv.organizationId !== args.organizationId) {
+      throw new Error("Invitation not found");
+    }
+    if (inv.status !== "pending") {
+      throw new Error("Only pending invitations can have their role changed");
+    }
+    if (args.role === "owner") {
+      // Ownership transfer is a separate flow — never grant via plain invite.
+      throw new Error("Cannot assign owner role via invitation");
+    }
+    const updatedAt = Date.now();
+    await ctx.db.patch(args.invitationId, { role: args.role, updatedAt });
+    return {
+      invitationId: String(args.invitationId),
+      role: args.role,
+      updatedAt,
+    };
+  },
+});
+
 // Admin tool — bumps expiry on a pending invitation and re-sends the email,
 // bypassing the org-admin auth guard so it can be invoked from `npx convex run`.
 // Useful when an env-level fix (e.g. broken SITE_URL) made an earlier email

--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -75,12 +75,28 @@ export const _createOrgInternal = internalMutation({
       updatedAt: now,
     });
 
-    await ctx.db.insert("teamMemberships", {
+    const ownerMembershipId = await ctx.db.insert("teamMemberships", {
       userId: user._id,
       organizationId: orgId,
       role: "owner",
       joinedAt: now,
     });
+
+    // Mirror owner membership to Supabase — same reason as in
+    // invitations._acceptInternal: the UI reads team_memberships from
+    // Supabase, not Convex, so without this the org creator has zero
+    // permissions in their own org.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.supabase.organizations.writeTeamMembershipToSupabase,
+      {
+        membershipId: String(ownerMembershipId),
+        userId: String(user._id),
+        organizationId: String(orgId),
+        role: "owner",
+        joinedAt: now,
+      },
+    );
 
     await logActivity(ctx, {
       organizationId: orgId,
@@ -273,13 +289,28 @@ export const _inviteMemberInternal = internalMutation({
       .unique();
     if (existing) throw new Error("User is already a member");
 
+    const joinedAt = Date.now();
     const membershipId = await ctx.db.insert("teamMemberships", {
       userId: args.userId,
       organizationId: args.organizationId,
       role: args.role,
       invitedBy: user._id,
-      joinedAt: Date.now(),
+      joinedAt,
     });
+
+    // Mirror to Supabase — UI reads team_memberships from there.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.supabase.organizations.writeTeamMembershipToSupabase,
+      {
+        membershipId: String(membershipId),
+        userId: String(args.userId),
+        organizationId: String(args.organizationId),
+        role: args.role,
+        invitedBy: String(user._id),
+        joinedAt,
+      },
+    );
 
     await logActivity(ctx, {
       organizationId: args.organizationId,

--- a/convex/supabase/organizations.ts
+++ b/convex/supabase/organizations.ts
@@ -3,7 +3,8 @@
  */
 
 import { v } from "convex/values";
-import { internalAction } from "@cvx/_generated/server";
+import { internalAction, internalQuery } from "@cvx/_generated/server";
+import { internal } from "@cvx/_generated/api";
 import { createServiceRoleClient, upsertWithFkRetry } from "./client";
 
 // ── Organization ──────────────────────────────────────────────────────────────
@@ -43,6 +44,79 @@ export const writeOrganizationToSupabase = internalAction({
 });
 
 // ── Team Membership ───────────────────────────────────────────────────────────
+
+// One-shot backfill: mirrors EVERY Convex teamMemberships row into Supabase.
+// Safe to re-run — upsert semantics in writeTeamMembershipToSupabase. Used to
+// recover from the historical gap when org.create / invitations._acceptInternal
+// / organizations.addMember wrote to Convex only.
+export const _backfillAllTeamMembershipsToSupabase = internalAction({
+  args: {},
+  returns: v.object({
+    scanned: v.number(),
+    mirrored: v.number(),
+    errors: v.number(),
+  }),
+  handler: async (ctx): Promise<{ scanned: number; mirrored: number; errors: number }> => {
+    const rows: Array<{
+      _id: string;
+      userId: string;
+      organizationId: string;
+      role: string;
+      invitedBy?: string;
+      joinedAt: number;
+    }> = await ctx.runQuery(
+      internal.supabase.organizations._listAllTeamMemberships,
+      {},
+    );
+    let mirrored = 0;
+    let errors = 0;
+    for (const r of rows) {
+      try {
+        await ctx.runAction(
+          internal.supabase.organizations.writeTeamMembershipToSupabase,
+          {
+            membershipId: r._id,
+            userId: r.userId,
+            organizationId: r.organizationId,
+            role: r.role,
+            invitedBy: r.invitedBy,
+            joinedAt: r.joinedAt,
+          },
+        );
+        mirrored += 1;
+      } catch (e) {
+        console.error(`[backfill teamMemberships] ${r._id} failed:`, e);
+        errors += 1;
+      }
+    }
+    return { scanned: rows.length, mirrored, errors };
+  },
+});
+
+export const _listAllTeamMemberships = internalQuery({
+  args: {},
+  returns: v.array(
+    v.object({
+      _id: v.string(),
+      userId: v.string(),
+      organizationId: v.string(),
+      role: v.string(),
+      invitedBy: v.optional(v.string()),
+      joinedAt: v.number(),
+    }),
+  ),
+  handler: async (ctx) => {
+    const all = await ctx.db.query("teamMemberships").collect();
+    return all.map((r) => ({
+      _id: String(r._id),
+      userId: String(r.userId),
+      organizationId: String(r.organizationId),
+      role: r.role,
+      invitedBy: r.invitedBy ? String(r.invitedBy) : undefined,
+      joinedAt: r.joinedAt,
+    }));
+  },
+});
 
 export const writeTeamMembershipToSupabase = internalAction({
   args: {

--- a/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
@@ -81,6 +81,7 @@ function TeamSettings() {
   const isAtLimit = seatUsage ? !seatUsage.canAddMore : false;
 
   const updateRole = useAction(api.organizations.updateMemberRole);
+  const updatePendingRole = useAction(api.invitations.updatePendingRole);
   const removeMember = useAction(api.organizations.removeMember);
   const cancelInvitation = useAction(api.invitations.cancel);
   const resendInvitation = useAction(api.invitations.resend);
@@ -111,6 +112,24 @@ function TeamSettings() {
       role: role as "admin" | "member" | "viewer" | "owner",
     });
     void queryClient.invalidateQueries({ queryKey: supabaseKeys.teamMemberships.list(organizationId) });
+  };
+
+  const handleChangePendingRole = async (
+    invitationId: Id<"invitations">,
+    role: string,
+  ) => {
+    try {
+      await updatePendingRole({
+        organizationId,
+        invitationId,
+        role: role as "admin" | "member" | "viewer",
+      });
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(organizationId) });
+      toast.success(t("team.invitationRoleUpdated", { defaultValue: "Rola zaproszenia została zmieniona" }));
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      toast.error(message);
+    }
   };
 
   const handleRemoveMember = (membershipId: Id<"teamMemberships">, memberName: string) => {
@@ -460,9 +479,27 @@ function TeamSettings() {
                 </div>
 
                 <div className="flex items-center gap-2">
-                  <Badge variant="outline" className="capitalize">
-                    {t(`team.roles.${invitation.role}`)}
-                  </Badge>
+                  <Select
+                    value={invitation.role}
+                    onValueChange={(role) =>
+                      handleChangePendingRole(
+                        invitation._id as Id<"invitations">,
+                        role,
+                      )
+                    }
+                    disabled={resendingId === invitation._id || cancellingId === invitation._id}
+                  >
+                    <SelectTrigger className="h-8 w-32 capitalize">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {ROLES.map((role) => (
+                        <SelectItem key={role} value={role} className="capitalize">
+                          {t(`team.roles.${role}`)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                   <Button
                     variant="ghost"
                     size="sm"


### PR DESCRIPTION
Wraps a Select dropdown around the pending-invitation role badge so the inviter can fix a wrong role without invalidating the link the invitee already received.

New mutation: `invitations.updatePendingRole` (org-admin guarded, refuses non-pending invitations and `owner` role). Mirrors to Supabase like the rest of the invitations write paths.