### PR TITLE
Relax stale `v.id("gabinet*")` validators on public gabinet read endpoints

### DIFF
--- a/convex/emailTemplates.ts
+++ b/convex/emailTemplates.ts
@@ -146,10 +146,10 @@ export const renderTemplate = query({
     contactId: v.optional(v.id("contacts")),
     companyId: v.optional(v.id("companies")),
     leadId: v.optional(v.id("leads")),
-    // Gabinet entities
-    patientId: v.optional(v.id("gabinetPatients")),
-    employeeId: v.optional(v.id("gabinetEmployees")),
-    appointmentId: v.optional(v.id("gabinetAppointments")),
+    // Gabinet entities (Supabase-primary — strings, not Convex Ids)
+    patientId: v.optional(v.string()),
+    employeeId: v.optional(v.string()),
+    appointmentId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const { user } = await verifyOrgAccess(ctx, args.organizationId);

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -391,48 +391,63 @@ export const toggleStar = action({
   },
 });
 
-export const listByPatient = query({
+export const listByPatient = action({
   args: {
     organizationId: v.id("organizations"),
-    patientId: v.id("gabinetPatients"),
+    patientId: v.string(),
   },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    return await ctx.db
+  handler: async (ctx, args): Promise<EmailRow[]> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const db = createSupabaseDb();
+    return (await db
       .query("emails")
-      .withIndex("by_patient", (q) => q.eq("patientId", args.patientId))
-      .order("desc")
-      .take(50);
+      .eq("organizationId", String(args.organizationId))
+      .eq("patientId", args.patientId)
+      .order("sentAt", false)
+      .take(50)
+      .collect()) as EmailRow[];
   },
 });
 
-export const listByAppointment = query({
+export const listByAppointment = action({
   args: {
     organizationId: v.id("organizations"),
-    appointmentId: v.id("gabinetAppointments"),
+    appointmentId: v.string(),
   },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    return await ctx.db
+  handler: async (ctx, args): Promise<EmailRow[]> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const db = createSupabaseDb();
+    return (await db
       .query("emails")
-      .withIndex("by_appointment", (q) => q.eq("appointmentId", args.appointmentId))
-      .order("desc")
-      .take(50);
+      .eq("organizationId", String(args.organizationId))
+      .eq("appointmentId", args.appointmentId)
+      .order("sentAt", false)
+      .take(50)
+      .collect()) as EmailRow[];
   },
 });
 
-export const listByEmployee = query({
+export const listByEmployee = action({
   args: {
     organizationId: v.id("organizations"),
-    employeeId: v.id("gabinetEmployees"),
+    employeeId: v.string(),
   },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    return await ctx.db
+  handler: async (ctx, args): Promise<EmailRow[]> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const db = createSupabaseDb();
+    return (await db
       .query("emails")
-      .withIndex("by_employee", (q) => q.eq("employeeId", args.employeeId))
-      .order("desc")
-      .take(50);
+      .eq("organizationId", String(args.organizationId))
+      .eq("employeeId", args.employeeId)
+      .order("sentAt", false)
+      .take(50)
+      .collect()) as EmailRow[];
   },
 });
 

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -444,31 +444,31 @@ export const listByDateRange = query({
   },
 });
 
-export const listByPatient = query({
+export const listByPatient = action({
   args: {
     organizationId: v.id("organizations"),
-    patientId: v.id("gabinetPatients"),
+    patientId: v.string(),
   },
-  handler: async (ctx, args) => {
-    const { user } = await verifyOrgAccess(ctx, args.organizationId);
-    const perm = await checkPermission(
-      ctx,
-      args.organizationId,
-      "gabinet_appointments",
-      "view",
+  handler: async (ctx, args): Promise<GabinetAppointmentRow[]> => {
+    const authResult = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
     );
+    const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
+      organizationId: args.organizationId,
+      feature: "gabinet_appointments",
+      action: "view",
+    }) as { allowed: boolean; scope: string };
     if (!perm.allowed) throw new Error("Permission denied");
 
-    const results = await ctx.db
+    const db = createSupabaseDb();
+    let results = (await db
       .query("gabinetAppointments")
-      .withIndex("by_orgAndPatient", (q) =>
-        q
-          .eq("organizationId", args.organizationId)
-          .eq("patientId", args.patientId),
-      )
-      .collect();
+      .eq("organizationId", String(args.organizationId))
+      .eq("patientId", args.patientId)
+      .collect()) as GabinetAppointmentRow[];
     if (perm.scope === "own") {
-      return results.filter((r) => r.createdBy === user._id);
+      results = results.filter((r) => String(r.createdBy) === String(authResult.userId));
     }
     return results;
   },

--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -108,21 +108,29 @@ export const listAll = action({
   },
 });
 
-export const getById = query({
+export const getById = action({
   args: {
     organizationId: v.id("organizations"),
-    employeeId: v.id("gabinetEmployees"),
+    employeeId: v.string(),
   },
-  handler: async (ctx, args) => {
-    const { user } = await verifyOrgAccess(ctx, args.organizationId);
-    const perm = await checkPermission(ctx, args.organizationId, "gabinet_employees", "view");
+  handler: async (ctx, args): Promise<GabinetEmployeeRow> => {
+    const authResult = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
+      organizationId: args.organizationId,
+      feature: "gabinet_employees",
+      action: "view",
+    }) as { allowed: boolean; scope: string };
     if (!perm.allowed) throw new Error("Permission denied");
 
-    const emp = await ctx.db.get(args.employeeId);
-    if (!emp || emp.organizationId !== args.organizationId) {
+    const db = createSupabaseDb();
+    const emp = (await db.get("gabinetEmployees", args.employeeId)) as GabinetEmployeeRow | null;
+    if (!emp || String(emp.organizationId) !== String(args.organizationId)) {
       throw new Error("Employee not found");
     }
-    if (perm.scope === "own" && emp.createdBy !== user._id) {
+    if (perm.scope === "own" && String(emp.createdBy) !== String(authResult.userId)) {
       throw new Error("Permission denied: you can only view your own records");
     }
     return emp;

--- a/convex/gabinet/leaveTypes.ts
+++ b/convex/gabinet/leaveTypes.ts
@@ -151,22 +151,24 @@ export const remove = action({
 
 // --- Leave Balances ---
 
-export const getBalances = query({
+export const getBalances = action({
   args: {
     organizationId: v.id("organizations"),
-    employeeId: v.id("gabinetEmployees"),
+    employeeId: v.string(),
     year: v.number(),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
 
-    return await ctx.db
+    const db = createSupabaseDb();
+    const all = await db
       .query("gabinetLeaveBalances")
-      .withIndex("by_orgAndEmployee", (q) =>
-        q.eq("organizationId", args.organizationId).eq("employeeId", args.employeeId)
-      )
-      .collect()
-      .then((all) => all.filter((b) => b.year === args.year));
+      .eq("organizationId", String(args.organizationId))
+      .eq("employeeId", args.employeeId)
+      .collect();
+    return all.filter((b) => (b as { year?: number }).year === args.year);
   },
 });
 

--- a/convex/gabinet/locations.ts
+++ b/convex/gabinet/locations.ts
@@ -1,8 +1,7 @@
-import { query, action } from "../_generated/server";
+import { action } from "../_generated/server";
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
-import { verifyOrgAccess } from "../_helpers/auth";
 import type {
   GabinetLocationRow,
   GabinetRoomRow,
@@ -182,19 +181,22 @@ export const deleteLocation = action({
   },
 });
 
-export const listRooms = query({
+export const listRooms = action({
   args: {
     organizationId: v.id("organizations"),
-    locationId: v.id("gabinetLocations"),
+    locationId: v.string(),
   },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    const location = await ctx.db.get(args.locationId);
-    if (!location || location.organizationId !== args.organizationId) return [];
-    return await ctx.db
+  handler: async (ctx, args): Promise<GabinetRoomRow[]> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const db = createSupabaseDb();
+    const location = await db.get("gabinetLocations", args.locationId);
+    if (!location || String(location.organizationId) !== String(args.organizationId)) return [];
+    return (await db
       .query("gabinetRooms")
-      .withIndex("by_location", (q) => q.eq("locationId", args.locationId))
-      .collect();
+      .eq("locationId", args.locationId)
+      .collect()) as GabinetRoomRow[];
   },
 });
 

--- a/convex/gabinet/loyalty.ts
+++ b/convex/gabinet/loyalty.ts
@@ -1,39 +1,42 @@
-import { query, action } from "../_generated/server";
+import { action } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
-import { verifyOrgAccess } from "../_helpers/auth";
 
 // Dual-write refs removed — Supabase is now primary for loyalty writes
 
-export const getBalance = query({
+export const getBalance = action({
   args: {
     organizationId: v.id("organizations"),
-    patientId: v.id("gabinetPatients"),
+    patientId: v.string(),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    return await ctx.db
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const db = createSupabaseDb();
+    return await db
       .query("gabinetLoyaltyPoints")
-      .withIndex("by_orgAndPatient", (q) =>
-        q.eq("organizationId", args.organizationId).eq("patientId", args.patientId)
-      )
+      .eq("organizationId", String(args.organizationId))
+      .eq("patientId", args.patientId)
       .first();
   },
 });
 
-export const getTransactions = query({
+export const getTransactions = action({
   args: {
     organizationId: v.id("organizations"),
-    patientId: v.id("gabinetPatients"),
+    patientId: v.string(),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    return await ctx.db
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const db = createSupabaseDb();
+    return await db
       .query("gabinetLoyaltyTransactions")
-      .withIndex("by_orgAndPatient", (q) =>
-        q.eq("organizationId", args.organizationId).eq("patientId", args.patientId)
-      )
+      .eq("organizationId", String(args.organizationId))
+      .eq("patientId", args.patientId)
       .collect();
   },
 });

--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -609,41 +609,50 @@ export const getPatientPackages = action({
 
 // --- Enriched package usage details (with treatment names, package name, progress) ---
 
-export const getPatientPackagesEnriched = query({
+export const getPatientPackagesEnriched = action({
   args: {
     organizationId: v.id("organizations"),
-    patientId: v.id("gabinetPatients"),
+    patientId: v.string(),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    const perm = await checkPermission(ctx, args.organizationId, "gabinet_packages", "view");
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
+      organizationId: args.organizationId,
+      feature: "gabinet_packages",
+      action: "view",
+    }) as { allowed: boolean; scope: string };
     if (!perm.allowed) throw new Error("Permission denied");
 
-    const usages = await ctx.db
+    const db = createSupabaseDb();
+    const usages = (await db
       .query("gabinetPackageUsage")
-      .withIndex("by_orgAndPatient", (q) =>
-        q.eq("organizationId", args.organizationId).eq("patientId", args.patientId),
-      )
-      .collect();
+      .eq("organizationId", String(args.organizationId))
+      .eq("patientId", args.patientId)
+      .collect()) as GabinetPackageUsageRow[];
 
-    // Collect unique package and treatment IDs
-    const packageIds = [...new Set(usages.map((u) => u.packageId))];
+    const packageIds = [...new Set(usages.map((u) => String(u.packageId)))];
     const treatmentIds = [
-      ...new Set(usages.flatMap((u) => u.treatmentsUsed.map((t) => t.treatmentId))),
+      ...new Set(
+        usages.flatMap((u) =>
+          (u.treatmentsUsed ?? []).map((t) => String(t.treatmentId)),
+        ),
+      ),
     ];
 
     const [packages, treatments] = await Promise.all([
-      Promise.all(packageIds.map((id) => ctx.db.get(id))),
-      Promise.all(treatmentIds.map((id) => ctx.db.get(id))),
+      db.getMany("gabinetTreatmentPackages", packageIds),
+      db.getMany("gabinetTreatments", treatmentIds),
     ]);
 
-    const pkgMap = new Map(packages.filter(Boolean).map((p) => [p!._id, p!]));
-    const treatmentMap = new Map(treatments.filter(Boolean).map((t) => [t!._id, t!]));
+    const pkgMap = new Map(packages.map((p) => [String(p._id), p]));
+    const treatmentMap = new Map(treatments.map((t) => [String(t._id), t]));
 
     return usages.map((u) => {
-      const pkg = pkgMap.get(u.packageId);
-      const enrichedTreatments = u.treatmentsUsed.map((t) => {
-        const tr = treatmentMap.get(t.treatmentId);
+      const pkg = pkgMap.get(String(u.packageId));
+      const enrichedTreatments = (u.treatmentsUsed ?? []).map((t) => {
+        const tr = treatmentMap.get(String(t.treatmentId));
         return {
           ...t,
           treatmentName: tr?.name ?? null,

--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -64,21 +64,29 @@ export const list = action({
   },
 });
 
-export const getById = query({
+export const getById = action({
   args: {
     organizationId: v.id("organizations"),
-    patientId: v.id("gabinetPatients"),
+    patientId: v.string(),
   },
-  handler: async (ctx, args) => {
-    const { user } = await verifyOrgAccess(ctx, args.organizationId);
-    const perm = await checkPermission(ctx, args.organizationId, "gabinet_patients", "view");
+  handler: async (ctx, args): Promise<GabinetPatientRow> => {
+    const authResult = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
+      organizationId: args.organizationId,
+      feature: "gabinet_patients",
+      action: "view",
+    }) as { allowed: boolean; scope: string };
     if (!perm.allowed) throw new Error("Permission denied");
 
-    const patient = await ctx.db.get(args.patientId);
-    if (!patient || patient.organizationId !== args.organizationId) {
+    const db = createSupabaseDb();
+    const patient = (await db.get("gabinetPatients", args.patientId)) as GabinetPatientRow | null;
+    if (!patient || String(patient.organizationId) !== String(args.organizationId)) {
       throw new Error("Patient not found");
     }
-    if (perm.scope === "own" && patient.createdBy !== user._id) {
+    if (perm.scope === "own" && String(patient.createdBy) !== String(authResult.userId)) {
       throw new Error("Permission denied: you can only view your own records");
     }
 

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -63,7 +63,7 @@ export const list = action({
 export const getByAppointment = action({
   args: {
     organizationId: v.id("organizations"),
-    appointmentId: v.id("gabinetAppointments"),
+    appointmentId: v.string(),
   },
   handler: async (ctx, args) => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
@@ -74,7 +74,7 @@ export const getByAppointment = action({
     return await db
       .query("payments")
       .eq("organizationId", String(args.organizationId))
-      .eq("appointmentId", String(args.appointmentId))
+      .eq("appointmentId", args.appointmentId)
       .first();
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #735.

Closes #735

---

## Claude summary

Committed as `6c526b0`. All 15 sites listed in #735 are addressed: validators relaxed to `v.string()`, handlers switched to `createSupabaseDb()`, and `query`s converted to `action`s where they now need to invoke internal queries for auth/permissions. Convex tsc, app tsc, and the 114 convex unit tests all pass. No frontend callers used these endpoints directly — reads go through the Supabase hooks — so the `query → action` change is transparent.

## Follow-ups
- Migrate remaining gabinet `v.id("gabinet*")` validators on write endpoints: convex/gabinet/appointments.ts still has `listByEmployee` (line ~477) and other handlers using `v.id("users")`/`v.id("gabinet*")` against `ctx.db`; audit the rest of `gabinet/*.ts` for parity.
- Move `gabinet/patients.ts:getByContact` to Supabase: still a `query` reading `ctx.db.query("gabinetPatients").withIndex("by_orgAndContact")` against an empty Convex table; will silently return [].
- Move `gabinet/leaveTypes.ts:getAllBalances` + `getById` to Supabase: still `query`s against empty Convex tables (`gabinetLeaveBalances`, `gabinetLeaveTypes`).
- Move `gabinet/appointments.ts:listByDateRange` + `listByEmployee` to Supabase: same stale `ctx.db.query("gabinetAppointments")` pattern; calendar reads may silently return [].
- Audit `gabinet/employees.ts:getByUserId` for Supabase migration: still a `query` against the empty Convex `gabinetEmployees` table.