### PR TITLE
Replace misleading `as Id<"gabinetAppointments">` casts in convex/automation.ts

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -1476,7 +1476,7 @@ export const processRun = internalMutation({
                 organizationId: run.organizationId,
                 appointmentId:
                   run.entityType === "gabinetAppointment"
-                    ? (run.entityId as Id<"gabinetAppointments">)
+                    ? run.entityId
                     : undefined,
                 actionType: action.type,
                 recipient: recipientEmail,
@@ -1525,7 +1525,7 @@ export const processRun = internalMutation({
                 organizationId: run.organizationId,
                 appointmentId:
                   run.entityType === "gabinetAppointment"
-                    ? (run.entityId as Id<"gabinetAppointments">)
+                    ? run.entityId
                     : undefined,
                 actionType: action.type,
                 recipient: recipientEmail,
@@ -1610,7 +1610,7 @@ export const processRun = internalMutation({
               organizationId: run.organizationId,
               appointmentId:
                 run.entityType === "gabinetAppointment"
-                  ? (run.entityId as Id<"gabinetAppointments">)
+                  ? run.entityId
                   : undefined,
               actionType: action.type,
               recipient: recipientEmail,
@@ -1647,7 +1647,7 @@ export const processRun = internalMutation({
                 organizationId: run.organizationId,
                 appointmentId:
                   run.entityType === "gabinetAppointment"
-                    ? (run.entityId as Id<"gabinetAppointments">)
+                    ? run.entityId
                     : undefined,
                 actionType: action.type,
                 recipient: phone,
@@ -1664,7 +1664,7 @@ export const processRun = internalMutation({
               run.entityType === "gabinetAppointment"
                 ? await ctx.runMutation(internal.gabinet.appointmentSms.queueAutomationSms, {
                     organizationId: run.organizationId,
-                    appointmentId: run.entityId as Id<"gabinetAppointments">,
+                    appointmentId: run.entityId as string,
                     phone,
                     message: renderedBody,
                     eventType: run.eventType,
@@ -1704,7 +1704,7 @@ export const processRun = internalMutation({
               organizationId: run.organizationId,
               appointmentId:
                 run.entityType === "gabinetAppointment"
-                  ? (run.entityId as Id<"gabinetAppointments">)
+                  ? run.entityId
                   : undefined,
               actionType: action.type,
               recipient: phone,
@@ -1882,7 +1882,7 @@ export const processRun = internalMutation({
             organizationId: run.organizationId,
             appointmentId:
               run.entityType === "gabinetAppointment"
-                ? (run.entityId as Id<"gabinetAppointments">)
+                ? run.entityId
                 : undefined,
             actionType: action.type,
             status: "failed",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #736.

Closes #736

---

## Claude summary

Done. Removed all 7 misleading `as Id<"gabinetAppointments">` casts in `convex/automation.ts`:

- Lines 1479/1528/1613/1650/1707/1885 (passed to `patchLegacyAppointmentWorkflowHistory`, which takes `appointmentId?: string`) — cast dropped entirely.
- Line 1667 (passed to `queueAutomationSms`, which takes `v.string()`) — changed to `as string` to preserve the non-null narrowing without lying about the brand.

Committed as `f799f27` on `claude/issue-736`.