### PR TITLE
Deduplicate inline `AppointmentIndicator` interfaces in `calendar-day-view.tsx` 

### DIFF
--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -4,12 +4,7 @@ import { DraggableAppointment } from "./draggable-appointment";
 import { DroppableSlot } from "./droppable-slot";
 import { useDragToCreate } from "./use-drag-to-create";
 import { useCurrentTime } from "@/hooks/use-current-time";
-
-interface AppointmentIndicator {
-  kind: "firstVisit" | "payment" | "count";
-  label: string;
-  title?: string;
-}
+import type { AppointmentIndicator } from "./appointment-card";
 
 interface Appointment {
   _id: string;

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -5,12 +5,7 @@ import { DraggableAppointment } from "./draggable-appointment";
 import { DroppableSlot } from "./droppable-slot";
 import { useDragToCreate } from "./use-drag-to-create";
 import { useCurrentTime } from "@/hooks/use-current-time";
-
-interface AppointmentIndicator {
-  kind: "firstVisit" | "payment" | "count";
-  label: string;
-  title?: string;
-}
+import type { AppointmentIndicator } from "./appointment-card";
 
 interface Appointment {
   _id: string;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #741.

Closes #741

---

## Claude summary

Done. The two inline `AppointmentIndicator` interface declarations in `calendar-day-view.tsx` and `calendar-week-view.tsx` are now replaced with a type import from `./appointment-card`, which already exports the canonical `AppointmentIndicator` interface (and is the same source `draggable-appointment.tsx` was already using). The issue body mentioned `appointment-indicators.tsx`, but that file does not exist — `appointment-card.tsx` is the actual canonical location. Typecheck passes.