### PR TITLE
Move `gabinet/patients.ts

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -1,10 +1,8 @@
-import { query, action, internalMutation } from "../_generated/server";
+import { action, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
-import { verifyOrgAccess } from "../_helpers/auth";
-import { checkPermission } from "../_helpers/permissions";
 import { logActivity } from "../_helpers/activities";
 import type { GabinetPatientRow, SupabasePaginationResult } from "../_helpers/supabaseRows";
 import { Id } from "../_generated/dataModel";
@@ -480,24 +478,32 @@ export const _removeSideEffects = internalMutation({
   },
 });
 
-export const getByContact = query({
+export const getByContact = action({
   args: {
     organizationId: v.id("organizations"),
-    contactId: v.id("contacts"),
+    contactId: v.string(),
   },
-  handler: async (ctx, args) => {
-    const { user } = await verifyOrgAccess(ctx, args.organizationId);
-    const perm = await checkPermission(ctx, args.organizationId, "gabinet_patients", "view");
+  handler: async (ctx, args): Promise<GabinetPatientRow[]> => {
+    const authResult = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
+      organizationId: args.organizationId,
+      feature: "gabinet_patients",
+      action: "view",
+    }) as { allowed: boolean; scope: string };
     if (!perm.allowed) throw new Error("Permission denied");
 
-    const results = await ctx.db
+    const db = createSupabaseDb();
+    let results = (await db
       .query("gabinetPatients")
-      .withIndex("by_orgAndContact", (q) =>
-        q.eq("organizationId", args.organizationId).eq("contactId", args.contactId)
-      )
-      .collect();
+      .eq("organizationId", String(args.organizationId))
+      .eq("contactId", String(args.contactId))
+      .collect()) as GabinetPatientRow[];
+
     if (perm.scope === "own") {
-      return results.filter((r) => r.createdBy === user._id);
+      results = results.filter((r) => String(r.createdBy) === String(authResult.userId));
     }
     return results;
   },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #754.

Closes #754

---

## Claude summary

Triage confirmed the issue: `gabinet/patients.ts:getByContact` was a Convex `query` reading from `ctx.db.query("gabinetPatients").withIndex("by_orgAndContact")`. Since patient writes go to Supabase, that Convex table is empty, so the query silently returned `[]`.

Converted `getByContact` from a `query` to an `action` that reads from Supabase via `createSupabaseDb()`, matching the patterns already used by `list` and `getById` (both migrated in #735). `contactId` relaxes from `v.id("contacts")` → `v.string()` since contacts also live in Supabase. Auth now uses the action-style `internal._helpers.authAction.*` internal queries.

The function had no callers in the codebase, so the migration is low-risk. Typecheck shows only the pre-existing TS2589 on `list` (unrelated, same error existed on `main`).

Committed as `f8e03d4` on `claude/issue-754`.