### PR TITLE
Audit `gabinet/employees.ts

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -137,22 +137,31 @@ export const getById = action({
   },
 });
 
-export const getByUserId = query({
+export const getByUserId = action({
   args: {
     organizationId: v.id("organizations"),
-    userId: v.id("users"),
+    userId: v.string(),
   },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    const perm = await checkPermission(ctx, args.organizationId, "gabinet_employees", "view");
+  handler: async (ctx, args): Promise<GabinetEmployeeRow | null> => {
+    await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
+      organizationId: args.organizationId,
+      feature: "gabinet_employees",
+      action: "view",
+    }) as { allowed: boolean; scope: string };
     if (!perm.allowed) throw new Error("Permission denied");
 
-    return await ctx.db
+    const db = createSupabaseDb();
+    const results = (await db
       .query("gabinetEmployees")
-      .withIndex("by_orgAndUser", (q) =>
-        q.eq("organizationId", args.organizationId).eq("userId", args.userId)
-      )
-      .first();
+      .eq("organizationId", String(args.organizationId))
+      .eq("userId", String(args.userId))
+      .collect()) as GabinetEmployeeRow[];
+
+    return results[0] ?? null;
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #757.

Closes #757

---

## Claude summary

Committed. Summary of the change:

`convex/gabinet/employees.ts:140` — `getByUserId` was a Convex `query` reading from the now-empty `gabinetEmployees` table via `withIndex("by_orgAndUser")`. Converted it to an `action` that reads from Supabase via `createSupabaseDb()`, matching the pattern landed in #754 for `patients.getByContact`:

- `userId` validator relaxed from `v.id("users")` to `v.string()` (users live in Supabase, so callers may pass UUIDs).
- Auth routed through `internal._helpers.authAction.{verifyOrgAccess,checkPermission}` like the surrounding actions in this file.
- Original `.first()` semantics preserved by returning `results[0] ?? null`.

No frontend callsites reference this endpoint — employees reads go through `useSupabaseGabinetEmployee*` hooks in `src/hooks/use-supabase-gabinet-employees.ts`. The `query` import stays because `getQualifiedForTreatment` at line 470 still uses it (separate concern, see follow-up).

Convex typecheck passes; all 114 convex unit tests pass.

## Follow-ups
- Audit `gabinet/employees.ts:getQualifiedForTreatment` for Supabase migration: still a `query` against the empty Convex `gabinetEmployees` table, same anti-pattern as #757