### PR TITLE
Migrate convex/gabinet/onboarding.ts getSetupStatus to Supabase

### DIFF
--- a/convex/gabinet/onboarding.ts
+++ b/convex/gabinet/onboarding.ts
@@ -2,49 +2,82 @@
  * Gabinet onboarding: setup status and completion tracking.
  */
 
-import { query, action, internalMutation } from "../_generated/server";
+import { action, internalMutation, internalQuery } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { v } from "convex/values";
-import { verifyOrgAccess } from "../_helpers/auth";
+import { createSupabaseDb } from "../_helpers/supabaseDb";
+
+/**
+ * Internal: read the organization's `onboardingCompleted` flag from Convex.
+ * Organizations stay in Convex (auth table); `_completeSetupSideEffects`
+ * patches the flag here only, so this is the canonical source.
+ */
+export const _getOnboardingFlag = internalQuery({
+  args: {
+    organizationId: v.id("organizations"),
+  },
+  handler: async (ctx, args): Promise<boolean> => {
+    const org = await ctx.db.get(args.organizationId);
+    return org?.onboardingCompleted ?? false;
+  },
+});
 
 /**
  * Get onboarding setup status for an organization.
  * Returns which setup steps have been completed.
+ *
+ * Reads `gabinetEmployees` / `gabinetTreatments` / `gabinetWorkingHours`
+ * from Supabase (those tables are Supabase-primary; the Convex copies are
+ * empty). The org's `onboardingCompleted` flag is still patched in Convex
+ * by `_completeSetupSideEffects`, so it's read back via an internal query.
  */
-export const getSetupStatus = query({
+export const getSetupStatus = action({
   args: {
     organizationId: v.id("organizations"),
   },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{
+    needsSetup: boolean;
+    hasEmployees: boolean;
+    hasTreatments: boolean;
+    hasSchedule: boolean;
+    onboardingCompleted: boolean;
+  }> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
 
-    // Check employees exist (gabinetEmployees table uses by_org index)
-    const employees = await ctx.db
+    const db = createSupabaseDb();
+    const orgIdStr = String(args.organizationId);
+
+    const employees = await db
       .query("gabinetEmployees")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+      .eq("organizationId", orgIdStr)
       .collect();
 
-    // Check treatments exist
-    const treatments = await ctx.db
+    const treatments = await db
       .query("gabinetTreatments")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+      .eq("organizationId", orgIdStr)
       .collect();
 
-    // Check working hours exist
-    const workingHours = await ctx.db
+    const workingHours = await db
       .query("gabinetWorkingHours")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+      .eq("organizationId", orgIdStr)
       .first();
 
-    // Get organization onboarding status
-    const org = await ctx.db.get(args.organizationId);
+    const onboardingCompleted: boolean = await ctx.runQuery(
+      internal.gabinet.onboarding._getOnboardingFlag,
+      { organizationId: args.organizationId },
+    );
 
     return {
       needsSetup: employees.length === 0 && treatments.length === 0,
       hasEmployees: employees.length > 0,
       hasTreatments: treatments.length > 0,
       hasSchedule: !!workingHours,
-      onboardingCompleted: org?.onboardingCompleted ?? false,
+      onboardingCompleted,
     };
   },
 });

--- a/src/routes/_app/_auth/dashboard/_layout.setup.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.setup.tsx
@@ -2,7 +2,8 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { convexQuery, useConvexAction } from "@convex-dev/react-query";
+import { useConvexAction } from "@convex-dev/react-query";
+import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { Logo } from "@/ui/logo";
@@ -51,10 +52,15 @@ function SetupWizard() {
   ]);
   const [schedule, setSchedule] = useState<Record<string, { start: string; end: string; enabled: boolean }>>({});
 
-  // Fix #2 & #3: Wire up backend mutations and query
-  const { data: setupStatus } = useQuery(
-    convexQuery(api.gabinet.onboarding.getSetupStatus, { organizationId })
-  );
+  // Fix #2 & #3: Wire up backend mutations and query.
+  // `getSetupStatus` is a Supabase-backed action (#770), not a Convex query,
+  // so it's called via `useAction` + react-query rather than `convexQuery`.
+  const getSetupStatus = useAction(api.gabinet.onboarding.getSetupStatus);
+  const { data: setupStatus } = useQuery({
+    queryKey: ["gabinet.onboarding.getSetupStatus", organizationId],
+    queryFn: () => getSetupStatus({ organizationId }),
+    enabled: !!organizationId,
+  });
 
   const { mutateAsync: completeSetup } = useMutation({
     mutationFn: useConvexAction(api.gabinet.onboarding.completeSetup),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #770.

Closes #770

---

## Claude summary

Migration committed. Summary of changes:

`convex/gabinet/onboarding.ts`: Converted `getSetupStatus` from `query` to `action`. It now reads `gabinetEmployees`, `gabinetTreatments`, and `gabinetWorkingHours` from Supabase via `createSupabaseDb()`. Added `_getOnboardingFlag` internal query so the action can still read the organization's `onboardingCompleted` flag from Convex (where `_completeSetupSideEffects` patches it).

`src/routes/_app/_auth/dashboard/_layout.setup.tsx`: Updated the only caller — replaced `convexQuery(api.gabinet.onboarding.getSetupStatus, ...)` (which only works on queries) with `useAction` + react-query's `useQuery`, matching the `nudges-context.tsx` pattern.

Verified: `npx tsc -p convex/tsconfig.json --noEmit` and `npx tsc -p tsconfig.app.json --noEmit` pass; `npm run test:unit` runs all 114 convex unit tests green.