### PR TITLE
Migrate convex/gabinet/scheduling.ts stale ctx.db handlers

### DIFF
--- a/convex/_helpers/supabaseRows.ts
+++ b/convex/_helpers/supabaseRows.ts
@@ -13,6 +13,7 @@ export type GabinetPatientRow = SupabaseRow<"gabinetPatients">;
 export type GabinetAppointmentRow = SupabaseRow<"gabinetAppointments">;
 export type GabinetEmployeeRow = SupabaseRow<"gabinetEmployees">;
 export type GabinetEmployeeScheduleRow = SupabaseRow<"gabinetEmployeeSchedules">;
+export type GabinetWorkingHoursRow = SupabaseRow<"gabinetWorkingHours">;
 export type GabinetLeaveRow = SupabaseRow<"gabinetLeaves">;
 export type GabinetLeaveTypeRow = SupabaseRow<"gabinetLeaveTypes">;
 export type GabinetLocationRow = SupabaseRow<"gabinetLocations">;

--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -1,27 +1,30 @@
-import { query, action } from "../_generated/server";
+import { action } from "../_generated/server";
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
-import { verifyOrgAccess } from "../_helpers/auth";
 import { gabinetLeaveTypeValidator, gabinetLeaveStatusValidator } from "../schema";
 import { getAvailableSlotsSupabase } from "./_availability_supabase";
 import type {
   GabinetEmployeeScheduleRow,
   GabinetLeaveRow,
+  GabinetWorkingHoursRow,
 } from "../_helpers/supabaseRows";
 
 // Dual-write refs removed — Supabase is now primary for scheduling writes
 
 // --- Working Hours (clinic-level defaults) ---
 
-export const getWorkingHours = query({
+export const getWorkingHours = action({
   args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    return await ctx.db
+  handler: async (ctx, args): Promise<GabinetWorkingHoursRow[]> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const db = createSupabaseDb();
+    return (await db
       .query("gabinetWorkingHours")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .collect();
+      .eq("organizationId", String(args.organizationId))
+      .collect()) as GabinetWorkingHoursRow[];
   },
 });
 
@@ -408,14 +411,17 @@ export const removeSchedulePeriod = action({
   },
 });
 
-export const listEmployeeSchedules = query({
+export const listEmployeeSchedules = action({
   args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    return await ctx.db
+  handler: async (ctx, args): Promise<GabinetEmployeeScheduleRow[]> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const db = createSupabaseDb();
+    return (await db
       .query("gabinetEmployeeSchedules")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .collect();
+      .eq("organizationId", String(args.organizationId))
+      .collect()) as GabinetEmployeeScheduleRow[];
   },
 });
 
@@ -569,23 +575,23 @@ export const rejectLeave = action({
   },
 });
 
-export const getLeavesByDateRange = query({
+export const getLeavesByDateRange = action({
   args: {
     organizationId: v.id("organizations"),
     startDate: v.string(),
     endDate: v.string(),
   },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-
-    const leaves = await ctx.db
+  handler: async (ctx, args): Promise<GabinetLeaveRow[]> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const db = createSupabaseDb();
+    const leaves = (await db
       .query("gabinetLeaves")
-      .withIndex("by_orgAndDate", (q) =>
-        q.eq("organizationId", args.organizationId)
-          .gte("startDate", args.startDate)
-          .lte("startDate", args.endDate)
-      )
-      .collect();
+      .eq("organizationId", String(args.organizationId))
+      .gte("startDate", args.startDate)
+      .lte("startDate", args.endDate)
+      .collect()) as GabinetLeaveRow[];
 
     return leaves.filter((l) => l.status === "approved");
   },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #768.

Closes #768

---

## Claude summary

Migrated the three stale `ctx.db` handlers in `convex/gabinet/scheduling.ts` to Supabase, matching the action-based pattern used in #754/#755/#757/#769/#770.

What changed:
- `getWorkingHours` (`query` → `action`): reads `gabinetWorkingHours` via `createSupabaseDb()`.
- `listEmployeeSchedules` (`query` → `action`): reads `gabinetEmployeeSchedules` via `createSupabaseDb()`.
- `getLeavesByDateRange` (`query` → `action`): reads `gabinetLeaves` with `.gte()` / `.lte()` on `startDate`, then filters to approved.
- Auth now routes through `internal._helpers.authAction.verifyOrgAccess`; the unused `verifyOrgAccess` import from `_helpers/auth` is dropped.
- Added `GabinetWorkingHoursRow` alias to `_helpers/supabaseRows.ts` so the working-hours handler returns a typed row array.

Verification:
- Convex typecheck (`tsc -p convex/tsconfig.json`) passes.
- App typecheck (`tsc -p tsconfig.app.json`) passes.
- `npm run test:unit` — 114 / 114 convex unit tests pass.
- No frontend or backend callers reference these three endpoints (grep confirms only docs mention them), so the `query → action` conversion is transparent.

Committed as `b901b51` on branch `claude/issue-768`.