### PR TITLE
Audit `gabinet/employees.ts

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -1,9 +1,7 @@
-import { query, action, internalMutation } from "../_generated/server";
+import { action, internalMutation } from "../_generated/server";
 import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { internal } from "../_generated/api";
-import { verifyOrgAccess } from "../_helpers/auth";
-import { checkPermission } from "../_helpers/permissions";
 import { logActivity } from "../_helpers/activities";
 import { gabinetEmployeeRoleValidator } from "../schema";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
@@ -467,25 +465,32 @@ export const _removeSideEffects = internalMutation({
 });
 
 /** Get employees qualified for a specific treatment */
-export const getQualifiedForTreatment = query({
+export const getQualifiedForTreatment = action({
   args: {
     organizationId: v.id("organizations"),
-    treatmentId: v.id("gabinetTreatments"),
+    treatmentId: v.string(),
   },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    const perm = await checkPermission(ctx, args.organizationId, "gabinet_employees", "view");
+  handler: async (ctx, args): Promise<GabinetEmployeeRow[]> => {
+    await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
+      organizationId: args.organizationId,
+      feature: "gabinet_employees",
+      action: "view",
+    }) as { allowed: boolean; scope: string };
     if (!perm.allowed) throw new Error("Permission denied");
 
-    const employees = await ctx.db
+    const db = createSupabaseDb();
+    const employees = (await db
       .query("gabinetEmployees")
-      .withIndex("by_orgAndActive", (q) =>
-        q.eq("organizationId", args.organizationId).eq("isActive", true)
-      )
-      .collect();
+      .eq("organizationId", String(args.organizationId))
+      .eq("isActive", true)
+      .collect()) as GabinetEmployeeRow[];
 
     return employees.filter((e) =>
-      e.qualifiedTreatmentIds.includes(args.treatmentId)
+      (e.qualifiedTreatmentIds ?? []).includes(args.treatmentId as Id<"gabinetTreatments">)
     );
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #772.

Closes #772

---

## Claude summary

Triage confirmed: `getQualifiedForTreatment` at `convex/gabinet/employees.ts:470` was a Convex `query` reading from the empty Convex `gabinetEmployees` table (writes now go to Supabase), so it silently returned `[]` — exactly the anti-pattern called out in the issue.

The fix converts it to an `action` that reads from Supabase via `createSupabaseDb()`, mirroring the #757 / #754 pattern: `treatmentId` validator relaxed from `v.id("gabinetTreatments")` to `v.string()`, auth routed through `internal._helpers.authAction.*`, return-type annotated as `GabinetEmployeeRow[]`. The `.includes(...)` keeps the `as Id<"gabinetTreatments">` cast that `gabinet/treatments.ts:getTreatmentEmployees` already uses for the same field. Dropped the now-unused `query`, `verifyOrgAccess`, and `checkPermission` imports (this was the only in-file consumer). No frontend callsites — verified by grepping the repo.

Convex typecheck passes; app typecheck passes; all 114 convex unit tests pass. Committed as `4d306c9`.