### PR TITLE
bardziej widoczne

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -494,15 +494,15 @@ export function AppointmentPreviewContent({
               <PopoverTrigger asChild>
                 <button
                   type="button"
-                  className="mt-0.5 inline-flex max-w-full items-center gap-1 rounded text-xs text-muted-foreground hover:text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                  className="mt-1 inline-flex max-w-full items-center gap-1.5 rounded text-sm font-medium text-foreground hover:text-primary focus:outline-none focus:ring-1 focus:ring-ring"
                   aria-label={t("gabinet.appointments.selectTreatment")}
                 >
-                  <Stethoscope className="size-3 shrink-0" />
+                  <Stethoscope className="size-3.5 shrink-0 text-primary" />
                   <span className="truncate">
                     {treatmentDisplayName ||
                       t("gabinet.appointments.selectTreatment")}
                   </span>
-                  <ChevronsUpDown className="size-3 shrink-0 opacity-60" />
+                  <ChevronsUpDown className="size-3.5 shrink-0 opacity-60" />
                 </button>
               </PopoverTrigger>
               <PopoverContent className="w-72 p-0" align="start">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #781.

Closes #781

---

## Claude summary

Committed. Summary of the fix:

In the calendar appointment preview side panel, the treatment name shown under the patient name (e.g. "EKG" in the screenshot) was rendered with `text-xs` and `text-muted-foreground`, which made it small and low-contrast. The user marked it up asking for it to be more prominent.

Changed `src/components/gabinet/calendar/appointment-preview-content.tsx:497-505` to use `text-sm font-medium text-foreground` with a `text-primary` stethoscope icon and slightly larger chevron, so the treatment label now reads as a proper secondary header beneath the patient name rather than a faint muted line.