### PR TITLE
ukryj pasek

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -638,6 +638,7 @@ function DashboardLayout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const showDatePicker = /^\/(dashboard)\/?$/.test(pathname)
     || /^\/dashboard\/(activities|calls|leads|pipelines)/.test(pathname);
+  const showAgendaStrip = !pathname.startsWith("/dashboard/gabinet");
 
   const [lastDispatch, setLastDispatch] = useState<{ id: string; seq: number } | null>(null);
   const dispatchSeqRef = useRef(0);
@@ -794,7 +795,7 @@ function DashboardLayout() {
                 </div>
               </header>
 
-              {firstOrg && user && (
+              {showAgendaStrip && firstOrg && user && (
                 <AgendaStrip organizationId={firstOrg._id} userId={user._id} />
               )}
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #785.

Closes #785

---

## Claude summary

Fix committed. The bar in the screenshot was the global `AgendaStrip` (upcoming events ticker) rendered in `_layout.tsx` for all dashboard pages. I made it skip rendering under `/dashboard/gabinet/*` so CRM keeps it but the gabinet workspace (including the calendar page from the screenshot) no longer shows it.

Change summary:
- `src/routes/_app/_auth/dashboard/_layout.tsx:641` — derive `showAgendaStrip` from pathname
- `src/routes/_app/_auth/dashboard/_layout.tsx:798` — gate `<AgendaStrip>` on it