### PR TITLE
pokazuj wybraną godzinę

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -252,6 +252,15 @@ export function AppointmentDialog({
   // Past-slot confirmation popup
   const [pastConfirmOpen, setPastConfirmOpen] = useState(false);
 
+  // Auto-scroll the currently-selected slot button into view so the user
+  // doesn't have to scroll through the full day's slot list to find a time
+  // pre-filled from a calendar click or "Find nearest slot". Issue #786.
+  const selectedSlotButtonRef = useCallback((node: HTMLButtonElement | null) => {
+    if (node) {
+      node.scrollIntoView({ block: "nearest" });
+    }
+  }, []);
+
   // -------------------------------------------------------------------------
   // Derived data
   // -------------------------------------------------------------------------
@@ -1347,6 +1356,11 @@ export function AppointmentDialog({
                       availableSlots.map((slot) => (
                         <button
                           key={slot.start}
+                          ref={
+                            selectedSlot?.start === slot.start
+                              ? selectedSlotButtonRef
+                              : undefined
+                          }
                           type="button"
                           onClick={() => handleSlotSelect(slot)}
                           className={cn(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #786.

Closes #786

---

## Claude summary

Committed.

Summary: In `src/components/gabinet/calendar/appointment-dialog.tsx`, when the appointment dialog opened with a pre-filled time (e.g., from clicking a 14:00 slot on the calendar, or after "Find nearest slot"), the matching slot button in the right-panel list was highlighted but rendered below the visible area — the list always starts at the day's first slot (e.g., 08:00). The user had to scroll to see/verify the selection before clicking save.

Fix: a callback ref on the currently-selected slot button calls `scrollIntoView({ block: "nearest" })`. With `block: "nearest"` it's a no-op when the slot is already visible (e.g., when the user just clicked it manually), so it only kicks in when the slot is off-screen.