### PR TITLE
zmiana słowa

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -721,7 +721,9 @@ export function AppointmentPreviewContent({
                 ? t("gabinet.appointmentDetail.addFirstTagHint", {
                     defaultValue: 'Dodaj pierwszy tag w "Zarządzaj"',
                   })
-                : t("tags.assign", { defaultValue: "Tagi" })
+                : t("gabinet.appointmentDetail.addTagsPlaceholder", {
+                    defaultValue: "Etykiety",
+                  })
             }
           />
         </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #791.

Closes #791

---

## Claude summary

Done. In the gabinet calendar's appointment preview popup, the tags picker placeholder was reading "Tagi" while the section label above it reads "Etykiety". I swapped the placeholder to "Etykiety" by using a new local i18n key (`gabinet.appointmentDetail.addTagsPlaceholder`) so the change is scoped to this dialog and doesn't affect other TagsPicker usages elsewhere in the app (calls, leads, contacts, etc.).

File changed: `src/components/gabinet/calendar/appointment-preview-content.tsx:724` — committed as `05392d3`.