### PR TITLE
pole etykiety

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -697,35 +697,32 @@ export function AppointmentPreviewContent({
           </Select>
         </div>
 
-        <div className="space-y-1">
-          <div className="flex items-center justify-between gap-2">
-            <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
-              {t("gabinet.appointmentDetail.tags", { defaultValue: "Etykiety" })}
-            </Label>
-            <button
-              type="button"
-              onClick={() => dispatch("manageTags")}
-              className="text-[11px] font-medium text-primary hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring rounded"
-            >
-              {t("gabinet.appointmentDetail.manageTags", {
-                defaultValue: "Zarządzaj",
-              })}
-            </button>
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <TagsPicker
+              tags={tagDefinitions}
+              selectedIds={tagIds}
+              onChange={setTagIds}
+              placeholder={
+                tagDefinitions.length === 0
+                  ? t("gabinet.appointmentDetail.addFirstTagHint", {
+                      defaultValue: 'Dodaj pierwszy tag w "Zarządzaj"',
+                    })
+                  : t("gabinet.appointmentDetail.addTagsPlaceholder", {
+                      defaultValue: "Etykiety",
+                    })
+              }
+            />
           </div>
-          <TagsPicker
-            tags={tagDefinitions}
-            selectedIds={tagIds}
-            onChange={setTagIds}
-            placeholder={
-              tagDefinitions.length === 0
-                ? t("gabinet.appointmentDetail.addFirstTagHint", {
-                    defaultValue: 'Dodaj pierwszy tag w "Zarządzaj"',
-                  })
-                : t("gabinet.appointmentDetail.addTagsPlaceholder", {
-                    defaultValue: "Etykiety",
-                  })
-            }
-          />
+          <button
+            type="button"
+            onClick={() => dispatch("manageTags")}
+            className="shrink-0 self-center text-[11px] font-medium text-primary hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring rounded"
+          >
+            {t("gabinet.appointmentDetail.manageTags", {
+              defaultValue: "Zarządzaj",
+            })}
+          </button>
         </div>
 
         <div className="grid grid-cols-[1fr_auto_auto] items-end gap-1.5">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #792.

Closes #792

---

## Claude summary

Committed. Summary of the change:

In `src/components/gabinet/calendar/appointment-preview-content.tsx:700-726`, the tags section previously had two rows — `Etykiety` label + `Zarządzaj` button on row 1, and the `TagsPicker` on row 2. After the fix, the picker and `Zarządzaj` share a single row (picker on the left, action on the right). The picker's own button already shows "Etykiety" as placeholder text (set in the prior PR #791), so the standalone label became redundant and was removed.