### PR TITLE
przenieś

### DIFF
--- a/src/components/categories-tags/tags-picker.tsx
+++ b/src/components/categories-tags/tags-picker.tsx
@@ -24,9 +24,16 @@ interface TagsPickerProps {
   selectedIds: Id<"tagDefinitions">[];
   onChange: (tagIds: Id<"tagDefinitions">[]) => void;
   placeholder?: string;
+  selectedTagsBelow?: boolean;
 }
 
-export function TagsPicker({ tags, selectedIds, onChange, placeholder }: TagsPickerProps) {
+export function TagsPicker({
+  tags,
+  selectedIds,
+  onChange,
+  placeholder,
+  selectedTagsBelow = false,
+}: TagsPickerProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -62,35 +69,37 @@ export function TagsPicker({ tags, selectedIds, onChange, placeholder }: TagsPic
     [tags, selectedSet],
   );
 
+  const selectedBadges = selectedTags.length > 0 && (
+    <div className="flex flex-wrap gap-1">
+      {selectedTags.map((tag) => (
+        <Badge
+          key={tag._id}
+          size="sm"
+          type="pill-color"
+          color="gray"
+        >
+          <span className="flex items-center gap-1">
+            <span
+              className="inline-block h-1.5 w-1.5 rounded-full"
+              style={{ backgroundColor: tag.color }}
+            />
+            {tag.name}
+            <button
+              type="button"
+              onClick={() => removeTag(tag._id)}
+              className="ml-0.5 text-fg-quaternary hover:text-fg-secondary"
+            >
+              <XClose className="h-3 w-3" />
+            </button>
+          </span>
+        </Badge>
+      ))}
+    </div>
+  );
+
   return (
     <div className="flex flex-col gap-1.5">
-      {selectedTags.length > 0 && (
-        <div className="flex flex-wrap gap-1">
-          {selectedTags.map((tag) => (
-            <Badge
-              key={tag._id}
-              size="sm"
-              type="pill-color"
-              color="gray"
-            >
-              <span className="flex items-center gap-1">
-                <span
-                  className="inline-block h-1.5 w-1.5 rounded-full"
-                  style={{ backgroundColor: tag.color }}
-                />
-                {tag.name}
-                <button
-                  type="button"
-                  onClick={() => removeTag(tag._id)}
-                  className="ml-0.5 text-fg-quaternary hover:text-fg-secondary"
-                >
-                  <XClose className="h-3 w-3" />
-                </button>
-              </span>
-            </Badge>
-          ))}
-        </div>
-      )}
+      {!selectedTagsBelow && selectedBadges}
 
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
@@ -142,6 +151,8 @@ export function TagsPicker({ tags, selectedIds, onChange, placeholder }: TagsPic
           </div>
         </PopoverContent>
       </Popover>
+
+      {selectedTagsBelow && selectedBadges}
     </div>
   );
 }

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -703,6 +703,7 @@ export function AppointmentPreviewContent({
               tags={tagDefinitions}
               selectedIds={tagIds}
               onChange={setTagIds}
+              selectedTagsBelow
               placeholder={
                 tagDefinitions.length === 0
                   ? t("gabinet.appointmentDetail.addFirstTagHint", {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #795.

Closes #795

---

## Claude summary

Done. The fix addresses the user's request:

The screenshot shows the picker button (`[icon] Etykiety`) being pushed down below the selected tag badge, away from where the "ETYKIETY" label used to be. PR #794 had already removed that label, but the `TagsPicker` component still renders selected tag badges ABOVE the picker button, so once a tag is selected the button drifts down out of the row where "Zarządzaj" sits.

Fix: added an opt-in `selectedTagsBelow` prop to `TagsPicker` (`src/components/categories-tags/tags-picker.tsx:27`). When set, selected tag badges render below the picker button instead of above it. Enabled in the appointment preview (`src/components/gabinet/calendar/appointment-preview-content.tsx:706`). Other consumers (forms in CRM/Gabinet listings) keep the original above-button layout via the default `false` value.

Result: the picker button stays at the top of the row (where the old "ETYKIETY" label was), with "Zarządzaj" aligned on its right and any selected badges below — matching the layout the user marked up.

Typecheck (`tsc -p tsconfig.app.json`) passes.