### PR TITLE
przenieś wyżej 

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -697,35 +697,6 @@ export function AppointmentPreviewContent({
           </Select>
         </div>
 
-        <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0 flex-1">
-            <TagsPicker
-              tags={tagDefinitions}
-              selectedIds={tagIds}
-              onChange={setTagIds}
-              selectedTagsBelow
-              placeholder={
-                tagDefinitions.length === 0
-                  ? t("gabinet.appointmentDetail.addFirstTagHint", {
-                      defaultValue: 'Dodaj pierwszy tag w "Zarządzaj"',
-                    })
-                  : t("gabinet.appointmentDetail.addTagsPlaceholder", {
-                      defaultValue: "Etykiety",
-                    })
-              }
-            />
-          </div>
-          <button
-            type="button"
-            onClick={() => dispatch("manageTags")}
-            className="shrink-0 self-center text-[11px] font-medium text-primary hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring rounded"
-          >
-            {t("gabinet.appointmentDetail.manageTags", {
-              defaultValue: "Zarządzaj",
-            })}
-          </button>
-        </div>
-
         <div className="grid grid-cols-[1fr_auto_auto] items-end gap-1.5">
           <div className="space-y-1">
             <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
@@ -762,6 +733,35 @@ export function AppointmentPreviewContent({
               className="h-8 w-[88px] text-sm"
             />
           </div>
+        </div>
+
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <TagsPicker
+              tags={tagDefinitions}
+              selectedIds={tagIds}
+              onChange={setTagIds}
+              selectedTagsBelow
+              placeholder={
+                tagDefinitions.length === 0
+                  ? t("gabinet.appointmentDetail.addFirstTagHint", {
+                      defaultValue: 'Dodaj pierwszy tag w "Zarządzaj"',
+                    })
+                  : t("gabinet.appointmentDetail.addTagsPlaceholder", {
+                      defaultValue: "Etykiety",
+                    })
+              }
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => dispatch("manageTags")}
+            className="shrink-0 self-center text-[11px] font-medium text-primary hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring rounded"
+          >
+            {t("gabinet.appointmentDetail.manageTags", {
+              defaultValue: "Zarządzaj",
+            })}
+          </button>
         </div>
 
         <div className="space-y-1">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #798.

Closes #798

---

## Claude summary

Moved the date/from/to time inputs above the Etykiety (tags) row in the appointment preview popover (`src/components/gabinet/calendar/appointment-preview-content.tsx:700`). The tags picker uses `selectedTagsBelow`, so each selected tag wraps below the picker button and pushes content down — keeping the time fields above the tags ensures they stay visible without scrolling, regardless of how many tags are assigned. Committed as `2dc5089`.