### PR TITLE
nazwa

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1982,7 +1982,7 @@
         "female": "Female",
         "other": "Other"
       },
-      "medicalNotes": "Medical Notes",
+      "medicalNotes": "Client Note",
       "allergies": "Allergies",
       "bloodType": "Blood Type",
       "emergencyContact": "Emergency Contact",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1990,7 +1990,7 @@
         "female": "Kobieta",
         "other": "Inna"
       },
-      "medicalNotes": "Notatki medyczne",
+      "medicalNotes": "Notatka o kliencie",
       "allergies": "Alergie",
       "bloodType": "Grupa krwi",
       "emergencyContact": "Kontakt awaryjny",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #802.

Closes #802

---

## Claude summary

Renamed the patient sidebar section header from "Notatki medyczne" to "Notatka o kliencie" by updating the `gabinet.patients.medicalNotes` translation key. Since the key is also used by the patient form and the patients list, the new label propagates consistently across all three surfaces. English copy updated to "Client Note" to match the new semantic meaning. Committed as cb1d458.