### PR TITLE
#804

### DIFF
--- a/src/components/gabinet/appointment-form.tsx
+++ b/src/components/gabinet/appointment-form.tsx
@@ -984,6 +984,7 @@ export function AppointmentForm({
         onSubmit={handleCreatePatient}
         onCancel={() => setAddPatientOpen(false)}
         isSubmitting={isCreatingPatient}
+        organizationId={organizationId}
       />
     </SidePanel>
     </>

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -1492,6 +1492,7 @@ export function AppointmentDialog({
         onSubmit={handleCreatePatient}
         onCancel={() => setAddPatientOpen(false)}
         isSubmitting={creatingPatient}
+        organizationId={organizationId}
       />
     </SidePanel>
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -601,6 +601,7 @@ function PatientDetail() {
             onSubmit={handleEditSubmit}
             onCancel={() => setEditDrawerOpen(false)}
             isSubmitting={isSubmitting}
+            organizationId={organizationId}
           />
         </SidePanel>
       )}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -518,6 +518,7 @@ function PatientsIndex() {
           onSubmit={handleCreate}
           onCancel={() => setPanelOpen(false)}
           isSubmitting={isCreating}
+          organizationId={organizationId}
         />
         {tags.length > 0 && (
           <div className="space-y-1.5">

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -443,6 +443,7 @@ function DashboardLayout() {
               }}
               onCancel={opts.onCancel}
               isSubmitting={isCreating}
+              organizationId={orgId}
             />
           );
         case "appointment":


### PR DESCRIPTION
Auto-generated by Claude in response to issue #806.

Closes #806

---

## Claude summary

Fixed. The root cause was that #804 added an optional `organizationId` prop to `PatientForm` to fetch the org's historical custom referral sources, but none of the five `PatientForm` call sites were updated to pass it. The fetch `useEffect` bails at `if (!organizationId) return;` (patient-form.tsx:113), so users only ever saw the predefined options plus the bare "+ Add new source..." item — visually identical to before #804. Wiring `organizationId` through at all five call sites activates the fetch and surfaces previously-used custom sources in the dropdown.