### PR TITLE
jedna linia

### DIFF
--- a/src/components/categories-tags/tags-picker.tsx
+++ b/src/components/categories-tags/tags-picker.tsx
@@ -25,6 +25,8 @@ interface TagsPickerProps {
   onChange: (tagIds: Id<"tagDefinitions">[]) => void;
   placeholder?: string;
   selectedTagsBelow?: boolean;
+  direction?: "vertical" | "horizontal";
+  size?: "sm" | "md";
 }
 
 export function TagsPicker({
@@ -33,6 +35,8 @@ export function TagsPicker({
   onChange,
   placeholder,
   selectedTagsBelow = false,
+  direction = "vertical",
+  size = "sm",
 }: TagsPickerProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -74,7 +78,7 @@ export function TagsPicker({
       {selectedTags.map((tag) => (
         <Badge
           key={tag._id}
-          size="sm"
+          size={size}
           type="pill-color"
           color="gray"
         >
@@ -98,7 +102,14 @@ export function TagsPicker({
   );
 
   return (
-    <div className="flex flex-col gap-1.5">
+    <div
+      className={cx(
+        "gap-1.5",
+        direction === "horizontal"
+          ? "flex flex-wrap items-center"
+          : "flex flex-col",
+      )}
+    >
       {!selectedTagsBelow && selectedBadges}
 
       <Popover open={open} onOpenChange={setOpen}>
@@ -107,7 +118,7 @@ export function TagsPicker({
             type="button"
             className={cx(
               buttonStyles.common.root,
-              buttonStyles.sizes.sm.root,
+              buttonStyles.sizes[size].root,
               buttonStyles.colors.secondary.root,
             )}
           >

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -735,13 +735,14 @@ export function AppointmentPreviewContent({
           </div>
         </div>
 
-        <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
           <div className="min-w-0 flex-1">
             <TagsPicker
               tags={tagDefinitions}
               selectedIds={tagIds}
               onChange={setTagIds}
-              selectedTagsBelow
+              direction="horizontal"
+              size="md"
               placeholder={
                 tagDefinitions.length === 0
                   ? t("gabinet.appointmentDetail.addFirstTagHint", {
@@ -756,7 +757,7 @@ export function AppointmentPreviewContent({
           <button
             type="button"
             onClick={() => dispatch("manageTags")}
-            className="shrink-0 self-center text-[11px] font-medium text-primary hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring rounded"
+            className="shrink-0 self-center text-[10px] font-medium text-primary hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring rounded"
           >
             {t("gabinet.appointmentDetail.manageTags", {
               defaultValue: "Zarządzaj",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #808.

Closes #808

---

## Claude summary

Committed. Summary of changes:

In the appointment preview Etykiety row, the layout was split across two lines: the picker button + Zarządzaj on top, then selected tag badges wrapped below. Now all three elements sit on one line.

Changes in `src/components/categories-tags/tags-picker.tsx:22-40,76-122`: added optional `direction` (`vertical` | `horizontal`, default `vertical`) and `size` (`sm` | `md`, default `sm`) props. Horizontal mode switches the container from `flex flex-col` to `flex flex-wrap items-center`, so selected tag badges render inline with the picker button. Both Badge and the picker button now use the `size` prop. All existing call sites are unaffected (defaults preserve current behavior).

Changes in `src/components/gabinet/calendar/appointment-preview-content.tsx:738-766`: the Etykiety row now uses `direction="horizontal"` and `size="md"` on TagsPicker (bigger field and tag badges), and Zarządzaj drops to `text-[10px]` so it stays inline as the smaller third element.