### PR TITLE
zablokuj kolumny

### DIFF
--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -218,16 +218,21 @@ function WeekDayColumn({
 
   return (
     <div className="flex-1 min-w-[120px] border-r last:border-r-0">
-      {/* Day header */}
+      {/* Day header — wrapped in opaque sticky shell so appointments scrolling
+          past don't bleed through the semi-transparent tint. */}
       <div
-        className={`sticky top-0 z-10 border-b px-2 py-1 text-center text-xs font-medium ${
-          isSelected ? "bg-primary/20 ring-1 ring-inset ring-primary/30" : isToday ? "bg-primary/10" : "bg-muted/50"
-        } ${onDayHeaderClick ? "cursor-pointer hover:bg-primary/15" : ""}`}
+        className={`sticky top-0 z-30 bg-background ${onDayHeaderClick ? "cursor-pointer" : ""}`}
         onClick={() => onDayHeaderClick?.(date)}
       >
-        <div>{DAY_LABELS[dayIndex]}</div>
-        <div className={isToday ? "font-bold text-primary" : isSelected ? "font-semibold text-primary" : "text-muted-foreground"}>
-          {date.split("-")[2]}
+        <div
+          className={`border-b px-2 py-1 text-center text-xs font-medium ${
+            isSelected ? "bg-primary/20 ring-1 ring-inset ring-primary/30" : isToday ? "bg-primary/10" : "bg-muted/50"
+          } ${onDayHeaderClick ? "hover:bg-primary/15" : ""}`}
+        >
+          <div>{DAY_LABELS[dayIndex]}</div>
+          <div className={isToday ? "font-bold text-primary" : isSelected ? "font-semibold text-primary" : "text-muted-foreground"}>
+            {date.split("-")[2]}
+          </div>
         </div>
       </div>
 
@@ -410,7 +415,7 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotD
   return (
     <div className="flex h-full overflow-auto">
       {/* Time labels */}
-      <div className="sticky left-0 z-10 w-14 shrink-0 border-r bg-background pt-8 relative">
+      <div className="sticky left-0 z-40 w-14 shrink-0 border-r bg-background pt-8 relative">
         {slots.map((s) => {
           // For small slot heights, only render the hour label so text doesn't overlap.
           const showLabel = s.isHourMark || s.slotHeight >= 15;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #810.

Closes #810

---

## Claude summary

Fixed and committed. 

Summary: In the gabinet week-view calendar (`src/components/gabinet/calendar/calendar-week-view.tsx`), the sticky day headers used `z-10` — the same z-index as the appointment cards (which set `zIndex: 10 + column` inline). Since appointments come after the header in the DOM, they rendered on top of the sticky header when scrolled into its band, making the date columns appear to disappear. The semi-transparent `bg-muted/50` also let content bleed through.

The fix wraps each day header in an opaque sticky shell (`sticky top-0 z-30 bg-background`) so it stays above appointments, and bumps the sticky time-labels column to `z-40` so it remains above the headers during horizontal scroll.