### PR TITLE
godzina

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -1347,8 +1347,32 @@ export function AppointmentDialog({
           {/* ============================================================= */}
           <div className="w-full md:w-[280px] flex flex-col">
             {!slotsEnabled ? (
-              <div className="flex flex-col items-center justify-center flex-1 px-5 py-8">
-                <UntitledAlert>{t("gabinet.appointments.calendarDialog.selectDateForSlots")}</UntitledAlert>
+              <div className="flex flex-col items-center justify-center flex-1 px-5 py-8 gap-3">
+                {selectedSlot?.start && (
+                  <div className="w-full rounded-md border bg-muted/30 px-3 py-2.5 text-center">
+                    <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+                      {t("gabinet.appointments.calendarDialog.time")}
+                    </p>
+                    <p className="text-base font-semibold tabular-nums">
+                      {selectedSlot.start}
+                      {selectedSlot.end ? ` – ${selectedSlot.end}` : ""}
+                    </p>
+                    {selectedDate && (
+                      <p className="text-xs text-muted-foreground capitalize mt-0.5">
+                        {format(selectedDate, "EEEE, d MMMM", {
+                          locale: dateFnsLocale,
+                        })}
+                      </p>
+                    )}
+                  </div>
+                )}
+                <UntitledAlert>
+                  {t(
+                    calendarEnabled
+                      ? "gabinet.appointments.calendarDialog.selectDateForSlots"
+                      : "gabinet.appointments.calendarDialog.selectTreatmentAndEmployee",
+                  )}
+                </UntitledAlert>
               </div>
             ) : (
               <>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #815.

Closes #815

---

## Claude summary

Committed `c0b8ec9`. 

Summary: In `src/components/gabinet/calendar/appointment-dialog.tsx`, when a user clicked a calendar slot the dialog stored the time in state but the right panel rendered a generic "pick a date" alert until treatment + employee + date were all set — completely hiding the clicked time. The fix renders a small card with the preselected time (and date when known) above the alert, and switches the alert message to `selectTreatmentAndEmployee` when those are the actual blockers (the i18n key already existed but was unused).