### PR TITLE
dowolnie

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2446,7 +2446,8 @@
         "daily": "Daily",
         "weekly": "Weekly",
         "biweekly": "Biweekly",
-        "monthly": "Monthly"
+        "monthly": "Monthly",
+        "custom": "Custom"
       },
       "created": "Appointment created",
       "updated": "Appointment updated",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2457,7 +2457,8 @@
         "daily": "Codziennie",
         "weekly": "Tygodniowo",
         "biweekly": "Co dwa tygodnie",
-        "monthly": "Miesięcznie"
+        "monthly": "Miesięcznie",
+        "custom": "Dowolnie"
       },
       "created": "Wizyta utworzona",
       "updated": "Wizyta zaktualizowana",

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -112,12 +112,17 @@ function computeEndTime(start: string, durationMinutes: number): string {
 /**
  * Mirror of backend `generateRecurringDates` (convex/gabinet/appointments.ts).
  * Keep in sync — both compute the list of recurrence dates following the base.
+ * For "custom" frequency there is no cycle: every occurrence defaults to the
+ * base date so the user has a starting row to edit. Issue #817.
  */
 function generateRecurringDates(
   startDate: string,
   frequency: string,
   count: number,
 ): string[] {
+  if (frequency === "custom") {
+    return Array.from({ length: Math.max(0, count - 1) }, () => startDate);
+  }
   const dates: string[] = [];
   const d = new Date(startDate + "T00:00:00");
   for (let i = 1; i < count; i++) {
@@ -642,10 +647,15 @@ export function AppointmentDialog({
               endTime: computeEndTime(occ.startTime, treatmentDuration),
             }))
           : undefined;
-      const hasCustomizations = recurringOverridesPayload?.some(
-        (o, i) =>
-          o.startTime !== selectedSlot.start || o.date !== cycleDates[i],
-      );
+      // For "custom" frequency every occurrence is by definition user-chosen,
+      // so always send overrides — otherwise the backend's rule-based
+      // generator returns nothing for the unknown "custom" cycle. Issue #817.
+      const hasCustomizations =
+        frequency === "custom" ||
+        recurringOverridesPayload?.some(
+          (o, i) =>
+            o.startTime !== selectedSlot.start || o.date !== cycleDates[i],
+        );
       await createAppointment({
         organizationId,
         patientId: patientId as Id<"gabinetPatients">,
@@ -1202,6 +1212,11 @@ export function AppointmentDialog({
                           <SelectItem value="monthly">
                             {t(
                               "gabinet.appointments.frequencies.monthly",
+                            )}
+                          </SelectItem>
+                          <SelectItem value="custom">
+                            {t(
+                              "gabinet.appointments.frequencies.custom",
                             )}
                           </SelectItem>
                         </SelectContent>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #817.

Closes #817

---

## Claude summary

Committed `c9a19f0`. Summary of the change:

The new-appointment dialog under Wizyty pakietowe now offers a "Dowolnie" frequency (alongside Codziennie / Tygodniowo / Co dwa tygodnie / Miesięcznie). When picked, no cycle is applied — every occurrence after the base defaults to the base date and is freely editable via the per-row date+time inputs that were already added in #790. The frontend always emits the `recurringOverrides` payload for `custom` so the backend (which doesn't know that frequency) uses the explicit override path instead of its empty rule-based fallback. No Convex/schema changes needed.

Files touched: `src/components/gabinet/calendar/appointment-dialog.tsx`, `public/locales/pl/translation.json`, `public/locales/en/translation.json`.

Verification limited: ran JSON-validation on translation files; full TypeScript typecheck couldn't run because `node_modules` isn't installed in this worktree, but the changes are isolated and additive — new switch branch, one extra condition in an existing OR, one extra `<SelectItem>`, one new translation key.