### PR TITLE
Podgląd

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -787,7 +787,7 @@ export function AppointmentPreviewContent({
             value={internalNotes}
             onChange={(e) => setInternalNotes(e.target.value)}
             placeholder={t("gabinet.appointments.internalNotesPlaceholder")}
-            className="min-h-[80px] text-sm"
+            className="min-h-[104px] text-sm"
           />
         </div>
       </div>

--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -170,7 +170,7 @@ export function DraggableAppointment({
     <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
       <PopoverAnchor asChild>{card}</PopoverAnchor>
       <PopoverContent
-        className="w-[500px] p-4"
+        className="w-[650px] p-4"
         align="start"
         side="right"
         sideOffset={8}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #825.

Closes #825

---

## Claude summary

Enlarged the calendar appointment preview popover by ~30%: width 500→650px in `src/components/gabinet/calendar/draggable-appointment.tsx:173`, and the internal-notes textarea min-height 80→104px in `src/components/gabinet/calendar/appointment-preview-content.tsx:790` so the preview also grows vertically (the rest of the popover sizes to content). Committed on branch `claude/issue-825`.