### PR TITLE
Numer telefonu

### DIFF
--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -129,7 +129,7 @@ export function PhoneInput({
   return (
     <div className={`flex gap-2 ${className ?? ""}`}>
       <Select value={isKnown ? dialCode : DEFAULT_DIAL_CODE} onValueChange={handleDialChange}>
-        <SelectTrigger className="w-[110px] shrink-0" size="sm">
+        <SelectTrigger className="w-[90px] shrink-0" size="sm">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #828.

Closes #828

---

## Claude summary

Committed. Summary:

Reduced the country-code `SelectTrigger` width from `w-[110px]` to `w-[90px]` in `src/components/ui/phone-input.tsx:132`. The longest dial code in the list is 4 digits (e.g. `+420`), so 90px still fits flag + code + chevron, while giving the phone-number input ~20px more room — enough to display the full Polish 9-digit number that was being clipped in the patient edit form's side panel.

The same `PhoneInput` is used in `src/components/forms/patient-form.tsx` for both the patient phone and the emergency-contact phone, so both fields benefit from the change.