### PR TITLE
Podgląd wizyty

### DIFF
--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -170,7 +170,7 @@ export function DraggableAppointment({
     <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
       <PopoverAnchor asChild>{card}</PopoverAnchor>
       <PopoverContent
-        className="w-[650px] p-4"
+        className="w-[553px] p-4"
         align="start"
         side="right"
         sideOffset={8}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #830.

Closes #830

---

## Claude summary

Reduced the appointment preview popover width from 650px to 553px (15% horizontal reduction) in `src/components/gabinet/calendar/draggable-appointment.tsx:173`. Vertical sizing (textarea min-height) left unchanged since the issue is specifically about horizontal width. Committed as d1f5f70 referencing #830.