### PR TITLE
numer telefonu 

### DIFF
--- a/src/components/crm/company-overview-tab.tsx
+++ b/src/components/crm/company-overview-tab.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react";
 import type { MappedCompany } from "@/lib/supabase/mappers/companies";
 import { PlateText } from "@/components/plate-text";
+import { formatPhoneNumber } from "@/lib/phone";
 
 // Studio statistics cards
 import StatisticsOrderCard from "@/components/shadcn-studio/blocks/statistics-order-card";
@@ -194,7 +195,7 @@ export function CompanyOverviewTab({
           <div className="grid gap-x-8 gap-y-4 sm:grid-cols-2 lg:grid-cols-3">
             <InfoField label={t("detail.fields.industry", "Branża")} value={company.industry} icon={<Building2 className="h-3.5 w-3.5" />} />
             <InfoField label={t("detail.fields.size", "Wielkość")} value={company.size} icon={<UsersIcon className="h-3.5 w-3.5" />} />
-            <InfoField label={t("detail.fields.phone", "Telefon")} value={company.phone} icon={<Phone className="h-3.5 w-3.5" />} />
+            <InfoField label={t("detail.fields.phone", "Telefon")} value={company.phone ? formatPhoneNumber(company.phone) : undefined} icon={<Phone className="h-3.5 w-3.5" />} />
             <InfoField
               label={t("detail.fields.website", "Strona WWW")}
               value={company.website}

--- a/src/components/gabinet/appointment-form.tsx
+++ b/src/components/gabinet/appointment-form.tsx
@@ -44,6 +44,7 @@ import { AlertTriangle, CalendarSearch } from "lucide-react";
 import { format } from "date-fns";
 import { pl } from "date-fns/locale";
 import { cn } from "@/lib/utils";
+import { formatPhoneNumber } from "@/lib/phone";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
@@ -576,7 +577,7 @@ export function AppointmentForm({
                         </span>
                         {p.phone && (
                           <span className="text-muted-foreground ml-auto text-xs">
-                            {p.phone}
+                            {formatPhoneNumber(p.phone)}
                           </span>
                         )}
                       </CommandItem>
@@ -615,7 +616,7 @@ export function AppointmentForm({
                             </Badge>
                             {(c.phone || c.email) && (
                               <span className="text-muted-foreground ml-auto text-xs">
-                                {c.phone || c.email}
+                                {c.phone ? formatPhoneNumber(c.phone) : c.email}
                               </span>
                             )}
                           </CommandItem>

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -8,6 +8,7 @@ import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
+import { formatPhoneNumber } from "@/lib/phone";
 import {
   extractActionErrorMessage,
   formatAppointmentError,
@@ -575,7 +576,7 @@ export function AppointmentPreviewContent({
                 className="inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
               >
                 <Phone className="size-3" />
-                {patient.phone}
+                {formatPhoneNumber(patient.phone)}
               </a>
             ) : isEditingPhone ? (
               <div className="inline-flex items-center gap-1 rounded-md border px-1 py-0.5">

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -8,68 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-
-type Country = {
-  code: string;
-  iso: string;
-  flag: string;
-  name: string;
-};
-
-const COUNTRIES: Country[] = [
-  { code: "+48", iso: "PL", flag: "🇵🇱", name: "Polska" },
-  { code: "+49", iso: "DE", flag: "🇩🇪", name: "Niemcy" },
-  { code: "+44", iso: "GB", flag: "🇬🇧", name: "Wielka Brytania" },
-  { code: "+1", iso: "US", flag: "🇺🇸", name: "USA / Kanada" },
-  { code: "+33", iso: "FR", flag: "🇫🇷", name: "Francja" },
-  { code: "+39", iso: "IT", flag: "🇮🇹", name: "Włochy" },
-  { code: "+34", iso: "ES", flag: "🇪🇸", name: "Hiszpania" },
-  { code: "+31", iso: "NL", flag: "🇳🇱", name: "Holandia" },
-  { code: "+32", iso: "BE", flag: "🇧🇪", name: "Belgia" },
-  { code: "+43", iso: "AT", flag: "🇦🇹", name: "Austria" },
-  { code: "+41", iso: "CH", flag: "🇨🇭", name: "Szwajcaria" },
-  { code: "+420", iso: "CZ", flag: "🇨🇿", name: "Czechy" },
-  { code: "+421", iso: "SK", flag: "🇸🇰", name: "Słowacja" },
-  { code: "+380", iso: "UA", flag: "🇺🇦", name: "Ukraina" },
-  { code: "+375", iso: "BY", flag: "🇧🇾", name: "Białoruś" },
-  { code: "+370", iso: "LT", flag: "🇱🇹", name: "Litwa" },
-  { code: "+371", iso: "LV", flag: "🇱🇻", name: "Łotwa" },
-  { code: "+372", iso: "EE", flag: "🇪🇪", name: "Estonia" },
-  { code: "+353", iso: "IE", flag: "🇮🇪", name: "Irlandia" },
-  { code: "+46", iso: "SE", flag: "🇸🇪", name: "Szwecja" },
-  { code: "+47", iso: "NO", flag: "🇳🇴", name: "Norwegia" },
-  { code: "+45", iso: "DK", flag: "🇩🇰", name: "Dania" },
-  { code: "+358", iso: "FI", flag: "🇫🇮", name: "Finlandia" },
-  { code: "+351", iso: "PT", flag: "🇵🇹", name: "Portugalia" },
-  { code: "+30", iso: "GR", flag: "🇬🇷", name: "Grecja" },
-  { code: "+40", iso: "RO", flag: "🇷🇴", name: "Rumunia" },
-  { code: "+36", iso: "HU", flag: "🇭🇺", name: "Węgry" },
-  { code: "+359", iso: "BG", flag: "🇧🇬", name: "Bułgaria" },
-  { code: "+385", iso: "HR", flag: "🇭🇷", name: "Chorwacja" },
-  { code: "+386", iso: "SI", flag: "🇸🇮", name: "Słowenia" },
-  { code: "+7", iso: "RU", flag: "🇷🇺", name: "Rosja / Kazachstan" },
-  { code: "+90", iso: "TR", flag: "🇹🇷", name: "Turcja" },
-];
-
-const DEFAULT_DIAL_CODE = "+48";
-
-const SORTED_CODES = [...COUNTRIES].sort(
-  (a, b) => b.code.length - a.code.length,
-);
-
-function detectDialCode(
-  raw: string,
-): { dialCode: string; rest: string } | null {
-  let v = raw.trim();
-  if (v.startsWith("00")) v = "+" + v.slice(2);
-  if (!v.startsWith("+")) return null;
-  for (const c of SORTED_CODES) {
-    if (v.startsWith(c.code)) {
-      return { dialCode: c.code, rest: v.slice(c.code.length).trimStart() };
-    }
-  }
-  return null;
-}
+import { COUNTRIES, DEFAULT_DIAL_CODE, detectDialCode } from "@/lib/phone";
 
 function parseInitialValue(value: string): { dialCode: string; number: string } {
   if (!value) return { dialCode: DEFAULT_DIAL_CODE, number: "" };

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -1,0 +1,89 @@
+export type Country = {
+  code: string;
+  iso: string;
+  flag: string;
+  name: string;
+};
+
+export const COUNTRIES: Country[] = [
+  { code: "+48", iso: "PL", flag: "🇵🇱", name: "Polska" },
+  { code: "+49", iso: "DE", flag: "🇩🇪", name: "Niemcy" },
+  { code: "+44", iso: "GB", flag: "🇬🇧", name: "Wielka Brytania" },
+  { code: "+1", iso: "US", flag: "🇺🇸", name: "USA / Kanada" },
+  { code: "+33", iso: "FR", flag: "🇫🇷", name: "Francja" },
+  { code: "+39", iso: "IT", flag: "🇮🇹", name: "Włochy" },
+  { code: "+34", iso: "ES", flag: "🇪🇸", name: "Hiszpania" },
+  { code: "+31", iso: "NL", flag: "🇳🇱", name: "Holandia" },
+  { code: "+32", iso: "BE", flag: "🇧🇪", name: "Belgia" },
+  { code: "+43", iso: "AT", flag: "🇦🇹", name: "Austria" },
+  { code: "+41", iso: "CH", flag: "🇨🇭", name: "Szwajcaria" },
+  { code: "+420", iso: "CZ", flag: "🇨🇿", name: "Czechy" },
+  { code: "+421", iso: "SK", flag: "🇸🇰", name: "Słowacja" },
+  { code: "+380", iso: "UA", flag: "🇺🇦", name: "Ukraina" },
+  { code: "+375", iso: "BY", flag: "🇧🇾", name: "Białoruś" },
+  { code: "+370", iso: "LT", flag: "🇱🇹", name: "Litwa" },
+  { code: "+371", iso: "LV", flag: "🇱🇻", name: "Łotwa" },
+  { code: "+372", iso: "EE", flag: "🇪🇪", name: "Estonia" },
+  { code: "+353", iso: "IE", flag: "🇮🇪", name: "Irlandia" },
+  { code: "+46", iso: "SE", flag: "🇸🇪", name: "Szwecja" },
+  { code: "+47", iso: "NO", flag: "🇳🇴", name: "Norwegia" },
+  { code: "+45", iso: "DK", flag: "🇩🇰", name: "Dania" },
+  { code: "+358", iso: "FI", flag: "🇫🇮", name: "Finlandia" },
+  { code: "+351", iso: "PT", flag: "🇵🇹", name: "Portugalia" },
+  { code: "+30", iso: "GR", flag: "🇬🇷", name: "Grecja" },
+  { code: "+40", iso: "RO", flag: "🇷🇴", name: "Rumunia" },
+  { code: "+36", iso: "HU", flag: "🇭🇺", name: "Węgry" },
+  { code: "+359", iso: "BG", flag: "🇧🇬", name: "Bułgaria" },
+  { code: "+385", iso: "HR", flag: "🇭🇷", name: "Chorwacja" },
+  { code: "+386", iso: "SI", flag: "🇸🇮", name: "Słowenia" },
+  { code: "+7", iso: "RU", flag: "🇷🇺", name: "Rosja / Kazachstan" },
+  { code: "+90", iso: "TR", flag: "🇹🇷", name: "Turcja" },
+];
+
+export const DEFAULT_DIAL_CODE = "+48";
+
+export const SORTED_CODES = [...COUNTRIES].sort(
+  (a, b) => b.code.length - a.code.length,
+);
+
+export function detectDialCode(
+  raw: string,
+): { dialCode: string; rest: string } | null {
+  let v = raw.trim();
+  if (v.startsWith("00")) v = "+" + v.slice(2);
+  if (!v.startsWith("+")) return null;
+  for (const c of SORTED_CODES) {
+    if (v.startsWith(c.code)) {
+      return { dialCode: c.code, rest: v.slice(c.code.length).trimStart() };
+    }
+  }
+  return null;
+}
+
+function groupDigitsByThree(digits: string): string {
+  if (!digits) return "";
+  const parts: string[] = [];
+  for (let i = 0; i < digits.length; i += 3) {
+    parts.push(digits.slice(i, i + 3));
+  }
+  return parts.join(" ");
+}
+
+// Formats a phone number for display: inserts a space every 3 digits after
+// the international dial code, e.g. "+48793904950" → "+48 793 904 950".
+// Falls back to the original input when no dial code is detected and no
+// digits are present.
+export function formatPhoneNumber(value: string | null | undefined): string {
+  if (!value) return "";
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  const detected = detectDialCode(trimmed);
+  if (detected) {
+    const digits = detected.rest.replace(/\D/g, "");
+    const grouped = groupDigitsByThree(digits);
+    return grouped ? `${detected.dialCode} ${grouped}` : detected.dialCode;
+  }
+  const digits = trimmed.replace(/\D/g, "");
+  if (!digits) return trimmed;
+  return groupDigitsByThree(digits);
+}

--- a/src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx
@@ -18,6 +18,7 @@ import { useSupabaseScheduledActivitiesByEntity } from "@/hooks/use-supabase-sch
 import { useSupabaseLeadsList } from "@/hooks/use-supabase-leads";
 import { useSupabaseContactsList } from "@/hooks/use-supabase-contacts";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
+import { formatPhoneNumber } from "@/lib/phone";
 import { SidePanel } from "@/components/crm/side-panel";
 import { CompanyForm } from "@/components/forms/company-form";
 import { ContactForm } from "@/components/forms/contact-form";
@@ -658,7 +659,7 @@ function CompanyDetail() {
       ) : "—",
       fieldKey: "domain",
     },
-    { label: t('detail.fields.phone'), value: company.phone ?? "—", fieldKey: "phone" },
+    { label: t('detail.fields.phone'), value: company.phone ? formatPhoneNumber(company.phone) : "—", fieldKey: "phone" },
     { label: t('detail.fields.industry'), value: company.industry ?? "—", fieldKey: "industry" },
     { label: t('detail.fields.size'), value: company.size ?? "—", fieldKey: "size" },
     {

--- a/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
@@ -14,6 +14,7 @@ import { PlateText } from "@/components/plate-text";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { companySizeOptions } from "@/lib/options";
+import { formatPhoneNumber } from "@/lib/phone";
 import { Plus, Trash2, Upload, Download, X } from "@/lib/ez-icons";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { CsvImportDialog } from "@/components/csv/csv-import-dialog";
@@ -221,7 +222,7 @@ function CompaniesIndex() {
     {
       id: "phone",
       label: t('common.phone'),
-      render: (item) => item.phone ?? "—",
+      render: (item) => item.phone ? formatPhoneNumber(item.phone) : "—",
     },
     {
       id: "industry",

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
@@ -18,6 +18,7 @@ import { useSupabaseLeadsList } from "@/hooks/use-supabase-leads";
 import { useSupabaseCompaniesList } from "@/hooks/use-supabase-companies";
 import { useSupabaseCustomFieldDefinitions, useSupabaseCustomFieldValues } from "@/hooks/use-supabase-custom-fields";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
+import { formatPhoneNumber } from "@/lib/phone";
 import { SidePanel } from "@/components/crm/side-panel";
 import { ContactForm } from "@/components/forms/contact-form";
 import { CompanyForm } from "@/components/forms/company-form";
@@ -684,7 +685,7 @@ function ContactDetail() {
   const allFields = contact
     ? [
         { label: t('detail.fields.email'), value: contact.email, fieldKey: "email" },
-        { label: t('detail.fields.phone'), value: contact.phone, fieldKey: "phone" },
+        { label: t('detail.fields.phone'), value: contact.phone ? formatPhoneNumber(contact.phone) : undefined, fieldKey: "phone" },
         { label: t('detail.fields.source'), value: contactAny?.source, fieldKey: "source" },
         { label: t('detail.fields.jobTitle'), value: contact.title, fieldKey: "title" },
         { label: t('detail.fields.tags'), value: contactAny?.tags?.join(", "), fieldKey: "tags" },

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
@@ -27,6 +27,7 @@ import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
 import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
+import { formatPhoneNumber } from "@/lib/phone";
 
 type ContactNudgeFilter = "unlinked-company";
 
@@ -254,7 +255,7 @@ function ContactsIndex() {
     {
       id: "phone",
       label: t('common.phone'),
-      render: (item) => item.phone ?? "—",
+      render: (item) => item.phone ? formatPhoneNumber(item.phone) : "—",
     },
     {
       id: "title",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -6,6 +6,7 @@ import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
+import { formatPhoneNumber } from "@/lib/phone";
 import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
 import { Button } from "@/components/ui/button";
 import {
@@ -526,7 +527,7 @@ function AppointmentDetail() {
           <ItemContent>
             <ItemTitle>{pat?.firstName} {pat?.lastName}</ItemTitle>
             <ItemDescription className="text-xs">
-              {[pat?.phone, pat?.email].filter(Boolean).join(" · ")}
+              {[pat?.phone ? formatPhoneNumber(pat.phone) : undefined, pat?.email].filter(Boolean).join(" · ")}
             </ItemDescription>
             {loyBal > 0 && (
               <Badge variant="outline" className="mt-0.5 w-fit text-[10px]">

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -20,6 +20,7 @@ import {
   groupSchedulesIntoPeriods,
 } from "@/components/gabinet/flexible-schedule-editor";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
+import { formatPhoneNumber } from "@/lib/phone";
 import {
   EntityDetailLayout,
   type DetailField,
@@ -1109,7 +1110,7 @@ function PatientsTabContent({
                 </p>
                 <p className="text-xs text-muted-foreground">
                   {pat.email}
-                  {pat.phone && ` · ${pat.phone}`}
+                  {pat.phone && ` · ${formatPhoneNumber(pat.phone)}`}
                 </p>
               </div>
               <div className="flex items-center gap-2 shrink-0">
@@ -1894,7 +1895,7 @@ function DetailedDataTab({
               {readOnlyField(t("gabinet.employees.lastName"), employee.lastName)}
               {readOnlyField(
                 t("gabinet.employees.detailedData.phone"),
-                employee.phone,
+                employee.phone ? formatPhoneNumber(employee.phone) : undefined,
                 <Phone className="h-3.5 w-3.5" />,
               )}
               {readOnlyField(

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -39,6 +39,7 @@ import { PatientPackagesCard } from "@/components/gabinet/patient-packages-card"
 import { plateJsonToText } from "@/components/gabinet/rich-text-editor";
 import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
 import { displayReferralSource } from "@/lib/options";
+import { formatPhoneNumber } from "@/lib/phone";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/patients/$patientId",
@@ -108,7 +109,7 @@ function PatientDetail() {
     if (!patient) return [];
     const fields: DetailField[] = [];
     if (patient.email) fields.push({ label: t("common.email"), value: patient.email, fieldKey: "email" });
-    if (patient.phone) fields.push({ label: t("common.phone"), value: patient.phone, fieldKey: "phone" });
+    if (patient.phone) fields.push({ label: t("common.phone"), value: formatPhoneNumber(patient.phone), fieldKey: "phone" });
     if (patient.dateOfBirth) fields.push({ label: t("gabinet.patients.dateOfBirth"), value: patient.dateOfBirth, fieldKey: "dob" });
     if (patient.gender) fields.push({ label: t("gabinet.patients.gender"), value: t(`gabinet.patients.genderOptions.${patient.gender}`), fieldKey: "gender" });
     if (patient.pesel) fields.push({ label: t("gabinet.patients.pesel"), value: patient.pesel, fieldKey: "pesel" });

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -27,6 +27,7 @@ import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
 import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
+import { formatPhoneNumber } from "@/lib/phone";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { Label } from "@/components/ui/label";
@@ -256,7 +257,7 @@ function PatientsIndex() {
                 src={["/images/avatars/blue.jpg", "/images/avatars/purple.jpg", "/images/avatars/red.jpg"][item._id.charCodeAt(item._id.length - 1) % 3]}
                 initials={item.firstName[0] + item.lastName[0]}
                 title={`${item.firstName} ${item.lastName}`}
-                subtitle={item.email ?? item.phone ?? "—"}
+                subtitle={item.email ?? (item.phone ? formatPhoneNumber(item.phone) : "—")}
               />
             </Link>
             {!item.isActive && (
@@ -278,7 +279,7 @@ function PatientsIndex() {
       {
         id: "phone",
         label: t("common.phone"),
-        render: (item) => item.phone ?? "—",
+        render: (item) => item.phone ? formatPhoneNumber(item.phone) : "—",
       },
       {
         id: "pesel",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #832.

Closes #832

---

## Claude summary

Committed `51ac9b3`. Phone numbers now render with spaces every 3 digits after the dial code (e.g. `+48 793 904 950`).

Summary of changes:
- New shared helper `src/lib/phone.ts` exposes `COUNTRIES`, `detectDialCode`, and `formatPhoneNumber`. `phone-input.tsx` now imports from it (single source of truth for dial codes).
- `formatPhoneNumber` detects the leading `+XX`/`+XXX` dial code, then groups remaining digits in chunks of 3 from the left. Tolerates input with or without existing spaces.
- Applied at display sites only (detail pages, list tables, appointment preview, appointment-form patient picker). Form `<Input>` values and `tel:` hrefs intentionally keep raw stored values so editing/dialing isn't disturbed.
- Typecheck (`tsc -p tsconfig.app.json`) and `npm run test:unit` both pass.

## Follow-ups
- Country-specific grouping for phone numbers: current helper groups in 3-3-3-... for every dial code; e.g. US convention is 3-3-4 ("+1 555 123 4567" vs current "+1 555 123 456 7"). Add per-country grouping rules if desired.
- detectDialCode does not handle "00 " (with space) → "+": `00 48 793904950` falls through to digit-only formatting. Pre-existing behavior in phone-input.tsx; fix in src/lib/phone.ts detectDialCode if normalization is desired.