### PR TITLE
numer telefonu podgląd

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -71,6 +71,7 @@ import { toast } from "sonner";
 import { SidePanel } from "@/components/crm/side-panel";
 import { PatientForm } from "@/components/forms/patient-form";
 import { useSupabaseGabinetLeavesList } from "@/hooks/use-supabase-gabinet-leaves";
+import { formatPhoneNumber } from "@/lib/phone";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -889,7 +890,7 @@ export function AppointmentDialog({
                                   </span>
                                   {p.phone && (
                                     <span className="text-xs text-muted-foreground">
-                                      {p.phone}
+                                      {formatPhoneNumber(p.phone)}
                                     </span>
                                   )}
                                 </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #833.

Closes #833

---

## Claude summary

Fixed and committed.

The phone formatting helper (`formatPhoneNumber` in `src/lib/phone.ts`) was already added in #832/#835 and applied to most display sites — but the calendar's appointment dialog (`src/components/gabinet/calendar/appointment-dialog.tsx`, the dialog opened when creating/editing an appointment on `/dashboard/gabinet/calendar`) was missed. The patient picker inside that dialog was rendering `p.phone` raw at line 892, so a number like `+48793904950` showed unbroken instead of `+48 793 904 950`.

Change: import `formatPhoneNumber` and wrap the raw value (one-line render fix). Filter logic still matches on the raw value, and the rest of the calendar (appointment preview popover, appointment-form picker, list/detail pages) was already formatted.