### PR TITLE
Podgląd wizyty "zaplanowana"

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -559,9 +559,9 @@ export function AppointmentPreviewContent({
               </PopoverContent>
             </Popover>
           </div>
-          <Badge variant="outline" className="shrink-0 text-[10px]">
+          <Badge variant="outline" className="shrink-0 text-xs">
             <span
-              className={`mr-1 inline-block h-1.5 w-1.5 rounded-full ${STATUS_DOT_COLORS[initialStatus] ?? "bg-muted-foreground"}`}
+              className={`mr-1.5 inline-block h-2 w-2 rounded-full ${STATUS_DOT_COLORS[initialStatus] ?? "bg-muted-foreground"}`}
             />
             {t(`gabinet.appointments.statuses.${initialStatus}`)}
           </Badge>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #834.

Closes #834

---

## Claude summary

Enlarged the "Zaplanowana" status badge in the appointment preview popover at `src/components/gabinet/calendar/appointment-preview-content.tsx:562-567`: font bumped from `text-[10px]` to `text-xs` (the Badge default, ~20% larger) and the status dot grew from `h-1.5 w-1.5` to `h-2 w-2` with a touch more spacing. Committed as `f606086`.