### PR TITLE
detectDialCode does not handle "00 " (with space) → "+"

### DIFF
--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -55,7 +55,7 @@ export function detectDialCode(
   raw: string,
 ): { dialCode: string; rest: string } | null {
   let v = raw.trim();
-  if (v.startsWith("00")) v = "+" + v.slice(2);
+  if (v.startsWith("00")) v = "+" + v.slice(2).trimStart();
   if (!v.startsWith("+")) return null;
   for (const c of SORTED_CODES) {
     if (v.startsWith(c.code)) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #837.

Closes #837

---

## Claude summary

Fixed `detectDialCode` in `src/lib/phone.ts:58` to trim whitespace after stripping the `"00"` prefix. Now `"00 48 793904950"` correctly normalizes to `"+48 793904950"` and matches the `+48` dial code instead of falling through to digit-only formatting. Committed as `67b8a7c`.