### PR TITLE
Nazwa wizyta tygodniowo

### DIFF
--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2455,7 +2455,7 @@
       "create": "Utwórz wizytę",
       "frequencies": {
         "daily": "Codziennie",
-        "weekly": "Tygodniowo",
+        "weekly": "Co tydzień",
         "biweekly": "Co dwa tygodnie",
         "monthly": "Miesięcznie",
         "custom": "Dowolnie"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #842.

Closes #842

---

## Claude summary

Renamed the Polish appointment frequency label `"weekly"` from "Tygodniowo" to "Co tydzień" in `public/locales/pl/translation.json:2458`. This matches the phrasing of sibling options like "Co dwa tygodnie" and is the only instance of the string in the codebase.