### PR TITLE
Okienka klient

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2025,7 +2025,10 @@
       "patient": "Client",
       "lastAppointments": "Client's recent appointments",
       "totalAppointments": "Total Appointments",
-      "added": "Added"
+      "added": "Added",
+      "upcomingAppointments": "Upcoming appointments",
+      "noUpcomingAppointments": "No upcoming appointments",
+      "noMedicalInfo": "No medical information"
     },
     "treatments": {
       "title": "Treatments",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2033,7 +2033,10 @@
       "patient": "Klient",
       "lastAppointments": "Ostatnie wizyty klienta",
       "totalAppointments": "Łącznie wizyt",
-      "added": "Dodano"
+      "added": "Dodano",
+      "upcomingAppointments": "Nadchodzące wizyty",
+      "noUpcomingAppointments": "Brak nadchodzących wizyt",
+      "noMedicalInfo": "Brak informacji medycznych"
     },
     "treatments": {
       "title": "Zabiegi",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -7,6 +7,7 @@ import { useOrganization } from "@/components/org-context";
 import { useSupabaseGabinetPatient } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
 import { useSupabaseGabinetAppointmentsByPatient } from "@/hooks/use-supabase-gabinet-appointments";
+import type { MappedGabinetAppointment } from "@/lib/supabase/mappers/gabinet/appointments";
 import { useSupabaseGabinetLoyaltyBalance, useSupabaseGabinetLoyaltyTransactions } from "@/hooks/use-supabase-gabinet-loyalty";
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
@@ -218,6 +219,63 @@ function PatientDetail() {
   };
 
   // --- Tabs ---
+  const today = new Date().toISOString().split("T")[0];
+  const upcomingAppointments = (patientAppointments ?? [])
+    .filter(
+      (apt) =>
+        apt.date >= today &&
+        apt.status !== "cancelled" &&
+        apt.status !== "no_show",
+    )
+    .sort((a, b) => (a.date + a.startTime).localeCompare(b.date + b.startTime))
+    .slice(0, 3);
+  const pastAppointments = (patientAppointments ?? [])
+    .filter((apt) => apt.date < today)
+    .sort((a, b) => (b.date + b.startTime).localeCompare(a.date + a.startTime))
+    .slice(0, 3);
+  const hasMedicalInfo = Boolean(
+    patient?.allergies ||
+      patient?.bloodType ||
+      patient?.emergencyContactName ||
+      patient?.emergencyContactPhone,
+  );
+
+  const renderAppointmentRow = (apt: MappedGabinetAppointment) => {
+    const treatmentName = treatmentsData?.find(
+      (tr) => tr._id === apt.treatmentId,
+    )?.name;
+    return (
+      <div
+        key={apt._id}
+        className="flex items-center gap-4 rounded-lg border p-3 cursor-pointer hover:bg-muted/50 transition-colors"
+        onClick={() =>
+          navigate({
+            to: "/dashboard/gabinet/appointments/$appointmentId",
+            params: { appointmentId: apt._id },
+          })
+        }
+      >
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+          <Calendar className="h-4 w-4 text-primary" variant="stroke" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium truncate">
+            {treatmentName ?? t("common.unknown")}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {apt.date} &middot; {apt.startTime}–{apt.endTime}
+          </p>
+        </div>
+        <Badge
+          variant="outline"
+          className={appointmentStatusBadgeClass(apt.status)}
+        >
+          {t(`gabinet.appointments.statuses.${apt.status}`)}
+        </Badge>
+      </div>
+    );
+  };
+
   const tabs = [
     {
       label: t("gabinet.patients.tabs.overview"),
@@ -283,6 +341,106 @@ function PatientDetail() {
               </CardContent>
             </Card>
           </div>
+
+          <Card>
+            <CardContent className="pt-6 space-y-4">
+              <h3 className="text-sm font-semibold flex items-center gap-2">
+                <Calendar
+                  className="h-4 w-4 text-muted-foreground"
+                  variant="stroke"
+                />
+                {t("gabinet.patients.upcomingAppointments")}
+              </h3>
+              {upcomingAppointments.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  {t("gabinet.patients.noUpcomingAppointments")}
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {upcomingAppointments.map(renderAppointmentRow)}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="pt-6 space-y-4">
+              <h3 className="text-sm font-semibold flex items-center gap-2">
+                <Calendar
+                  className="h-4 w-4 text-muted-foreground"
+                  variant="stroke"
+                />
+                {t("gabinet.patients.lastAppointments")}
+              </h3>
+              {pastAppointments.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  {t("gabinet.patients.noHistoryDesc")}
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {pastAppointments.map(renderAppointmentRow)}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="pt-6 space-y-4">
+              <h3 className="text-sm font-semibold flex items-center gap-2">
+                <Heart
+                  className="h-4 w-4 text-muted-foreground"
+                  variant="stroke"
+                />
+                {t("gabinet.patients.medicalInfo")}
+              </h3>
+              {!hasMedicalInfo ? (
+                <p className="text-sm text-muted-foreground">
+                  {t("gabinet.patients.noMedicalInfo")}
+                </p>
+              ) : (
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {patient?.allergies && (
+                    <div>
+                      <p className="text-xs text-muted-foreground">
+                        {t("gabinet.patients.allergies")}
+                      </p>
+                      <p className="text-sm font-medium">{patient.allergies}</p>
+                    </div>
+                  )}
+                  {patient?.bloodType && (
+                    <div>
+                      <p className="text-xs text-muted-foreground">
+                        {t("gabinet.patients.bloodType")}
+                      </p>
+                      <p className="text-sm font-medium">
+                        <Badge variant="outline" className="text-[10px]">
+                          {patient.bloodType}
+                        </Badge>
+                      </p>
+                    </div>
+                  )}
+                  {(patient?.emergencyContactName ||
+                    patient?.emergencyContactPhone) && (
+                    <div className="sm:col-span-2">
+                      <p className="text-xs text-muted-foreground">
+                        {t("gabinet.patients.emergencyContact")}
+                      </p>
+                      <p className="text-sm font-medium">
+                        {[
+                          patient.emergencyContactName,
+                          patient.emergencyContactPhone
+                            ? formatPhoneNumber(patient.emergencyContactPhone)
+                            : null,
+                        ]
+                          .filter(Boolean)
+                          .join(" · ")}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
         </div>
       ),
     },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #845.

Closes #845

---

## Claude summary

Committed. Note on the interpretation: the issue text was just "dodaj 3 okienka" (add 3 boxes) with rectangles drawn over empty space on the patient Overview tab. Without specification of content, I chose three useful at-a-glance summaries that complement the existing tabs/sidebar without duplicating their full contents:

- Upcoming appointments (next 3, sorted asc, excludes cancelled/no-show)
- Recent appointments (last 3 past, sorted desc)
- Medical info (allergies, blood type, emergency contact)

Each box handles the empty state with a localized fallback message, and appointment rows are clickable to the appointment detail view. PL/EN translations added for the three new strings. Typecheck passes.

If the issue author had different content in mind for the 3 boxes (e.g. payment summary, notes preview, related contacts), it should be straightforward to swap any of the three sections.