### PR TITLE
Podatek

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -76,7 +76,7 @@ export function TreatmentForm({
   const [duration, setDuration] = useState(String(initialData?.duration ?? ""));
   const [price, setPrice] = useState(String(initialData?.price ?? ""));
   const [currency, setCurrency] = useState(initialData?.currency ?? "PLN");
-  const [taxRate, setTaxRate] = useState(String(initialData?.taxRate ?? "23"));
+  const [taxRate, setTaxRate] = useState(String(initialData?.taxRate ?? "8"));
   const [selectedEquipmentIds, setSelectedEquipmentIds] = useState<Id<"gabinetEquipment">[]>(
     initialData?.requiredEquipmentIds ?? []
   );
@@ -192,7 +192,7 @@ export function TreatmentForm({
             max="100"
             value={taxRate}
             onChange={(e) => setTaxRate(e.target.value)}
-            placeholder="23"
+            placeholder="8"
           />
         </div>
         <div className="space-y-1.5">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #846.

Closes #846

---

## Claude summary

Changed the default tax rate for new Gabinet treatments from 23% to 8% in `src/components/gabinet/treatment-form.tsx` (state initializer + input placeholder). Existing treatments keep whatever value they already have (`initialData?.taxRate` takes precedence). Committed as c947762.