### PR TITLE
Nazwa Podatek/zabieg

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2045,7 +2045,7 @@
       "durationMinutes": "Duration (minutes)",
       "price": "Price",
       "currency": "Currency",
-      "taxRate": "Tax Rate",
+      "taxRate": "VAT Rate",
       "category": "Category",
       "color": "Color",
       "sortOrder": "Sort Order",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2053,7 +2053,7 @@
       "durationMinutes": "Czas trwania (minuty)",
       "price": "Cena",
       "currency": "Waluta",
-      "taxRate": "Stawka podatku",
+      "taxRate": "Stawka podatku VAT",
       "category": "Kategoria",
       "color": "Kolor",
       "sortOrder": "Kolejność",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #847.

Closes #847

---

## Claude summary

Renamed the treatment field label from "Stawka podatku" to "Stawka podatku VAT" in `public/locales/pl/translation.json:2056`, and updated the English counterpart to "VAT Rate" in `public/locales/en/translation.json:2048` for consistency. The key `gabinet.treatments.taxRate` is consumed by the treatments index, detail page, and form, so all three surfaces will now display the new label.