### PR TITLE
procent VAT zabieg

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -185,15 +185,21 @@ export function TreatmentForm({
         </div>
         <div className="space-y-1.5">
           <Label>{t("gabinet.treatments.taxRate")}</Label>
-          <Input
-            type="number"
-            step="0.01"
-            min="0"
-            max="100"
-            value={taxRate}
-            onChange={(e) => setTaxRate(e.target.value)}
-            placeholder="8"
-          />
+          <div className="relative">
+            <Input
+              type="number"
+              step="0.01"
+              min="0"
+              max="100"
+              value={taxRate}
+              onChange={(e) => setTaxRate(e.target.value)}
+              placeholder="8"
+              className="pr-8"
+            />
+            <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-sm text-muted-foreground">
+              %
+            </span>
+          </div>
         </div>
         <div className="space-y-1.5">
           <Label>{t("gabinet.treatments.category")}</Label>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #850.

Closes #850

---

## Claude summary

Committed the fix. Summary of the change:

The screenshot in issue #850 shows the treatment "Edytuj" dialog where the "Stawka podatku" input shows just `23` with no unit indicator. The detail page and list already render the value with `%` (treatments.$treatmentId.tsx:279, treatments.index.tsx:284), but the edit form input had no suffix.

I wrapped the `Input` in a `relative` container and added a `pointer-events-none` `%` overlay on the right side, with `pr-8` on the input so the value doesn't collide with the suffix. The same UX appears in the create-new-treatment form because both flows use `treatment-form.tsx`.

## Follow-ups
- Add % suffix to product tax rate input: src/components/forms/product-form.tsx:118 has the same bare-number issue for product VAT