### PR TITLE
Lista VAT zabiegi

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -11,6 +11,13 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Command,
   CommandEmpty,
   CommandGroup,
@@ -61,6 +68,29 @@ const COLOR_OPTIONS = [
   { value: "#6b7280", label: "Gray" },
 ];
 
+// VAT-exempt ("zwolniony") is stored as -1 since the DB column is numeric.
+export const TAX_RATE_ZW_SENTINEL = -1;
+
+const TAX_RATE_OPTIONS = [
+  { value: "zw", label: "ZW" },
+  { value: "0", label: "0%" },
+  { value: "5", label: "5%" },
+  { value: "8", label: "8%" },
+  { value: "23", label: "23%" },
+];
+
+function taxRateToFormValue(value: number | undefined): string {
+  if (value === TAX_RATE_ZW_SENTINEL) return "zw";
+  if (value == null) return "8";
+  return String(value);
+}
+
+function formValueToTaxRate(value: string): number | undefined {
+  if (value === "zw") return TAX_RATE_ZW_SENTINEL;
+  const num = parseFloat(value);
+  return Number.isFinite(num) ? num : undefined;
+}
+
 export function TreatmentForm({
   organizationId,
   initialData,
@@ -76,7 +106,7 @@ export function TreatmentForm({
   const [duration, setDuration] = useState(String(initialData?.duration ?? ""));
   const [price, setPrice] = useState(String(initialData?.price ?? ""));
   const [currency, setCurrency] = useState(initialData?.currency ?? "PLN");
-  const [taxRate, setTaxRate] = useState(String(initialData?.taxRate ?? "8"));
+  const [taxRate, setTaxRate] = useState(taxRateToFormValue(initialData?.taxRate));
   const [selectedEquipmentIds, setSelectedEquipmentIds] = useState<Id<"gabinetEquipment">[]>(
     initialData?.requiredEquipmentIds ?? []
   );
@@ -123,7 +153,7 @@ export function TreatmentForm({
       duration: parseInt(duration) || 30,
       price: parseFloat(price) || 0,
       currency: currency || undefined,
-      taxRate: parseFloat(taxRate) || undefined,
+      taxRate: formValueToTaxRate(taxRate),
       requiredEquipmentIds: selectedEquipmentIds.length > 0 ? selectedEquipmentIds : undefined,
       contraindications: contraindications || undefined,
       preparationInstructions: preparationInstructions || undefined,
@@ -185,21 +215,18 @@ export function TreatmentForm({
         </div>
         <div className="space-y-1.5">
           <Label>{t("gabinet.treatments.taxRate")}</Label>
-          <div className="relative">
-            <Input
-              type="number"
-              step="0.01"
-              min="0"
-              max="100"
-              value={taxRate}
-              onChange={(e) => setTaxRate(e.target.value)}
-              placeholder="8"
-              className="pr-8"
-            />
-            <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-sm text-muted-foreground">
-              %
-            </span>
-          </div>
+          <Select value={taxRate} onValueChange={setTaxRate}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TAX_RATE_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
         <div className="space-y-1.5">
           <Label>{t("gabinet.treatments.category")}</Label>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -10,7 +10,7 @@ import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-em
 import { useSupabaseGabinetEquipmentList } from "@/hooks/use-supabase-gabinet-equipment";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { SidePanel } from "@/components/crm/side-panel";
-import { TreatmentForm } from "@/components/gabinet/treatment-form";
+import { TreatmentForm, TAX_RATE_ZW_SENTINEL } from "@/components/gabinet/treatment-form";
 import type { TreatmentFormData } from "@/components/gabinet/treatment-form";
 import { plateJsonToText } from "@/components/plate-text";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
@@ -276,7 +276,8 @@ function TreatmentDetail() {
       { label: t("gabinet.treatments.category"), value: categoryName ?? "—", fieldKey: "category" },
     ];
     if (treatment.taxRate != null) {
-      fields.push({ label: t("gabinet.treatments.taxRate"), value: `${treatment.taxRate}%`, fieldKey: "taxRate" });
+      const taxLabel = treatment.taxRate === TAX_RATE_ZW_SENTINEL ? "ZW" : `${treatment.taxRate}%`;
+      fields.push({ label: t("gabinet.treatments.taxRate"), value: taxLabel, fieldKey: "taxRate" });
     }
     if (treatment.requiredEquipmentIds?.length || treatment.requiredEquipment?.length) {
       const equipmentNames = treatment.requiredEquipmentIds?.length

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -10,7 +10,7 @@ import { CrmDataTable, useColumnVisibility, useAllColumns } from "@/components/c
 import type { CrmColumn } from "@/components/crm/enhanced-data-table";
 import { DataListFilterBar } from "@/components/crm/data-list-filter-bar";
 import { SidePanel } from "@/components/crm/side-panel";
-import { TreatmentForm } from "@/components/gabinet/treatment-form";
+import { TreatmentForm, TAX_RATE_ZW_SENTINEL } from "@/components/gabinet/treatment-form";
 import type { TreatmentFormData } from "@/components/gabinet/treatment-form";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -281,7 +281,12 @@ function TreatmentsIndex() {
       {
         id: "taxRate",
         label: t("gabinet.treatments.taxRate"),
-        render: (item) => (item.taxRate != null ? `${item.taxRate}%` : "—"),
+        render: (item) =>
+          item.taxRate == null
+            ? "—"
+            : item.taxRate === TAX_RATE_ZW_SENTINEL
+              ? "ZW"
+              : `${item.taxRate}%`,
       },
       {
         id: "isActive",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #853.

Closes #853

---

## Claude summary

Replaced the "Stawka podatku" numeric input in the gabinet treatment form (`src/components/gabinet/treatment-form.tsx`) with a Select dropdown offering ZW / 0% / 5% / 8% / 23%. Since the Supabase `tax_rate` column is numeric and a DB migration was out of scope, "ZW" is persisted as the sentinel `-1` and rendered back as "ZW" in both display sites — the treatment detail sidebar and the treatments list "taxRate" column. The previous `parseFloat(taxRate) || undefined` also silently dropped 0% values; the new `formValueToTaxRate` helper uses `Number.isFinite` so 0% is now preserved. Typecheck passes. Committed as `2a97b43`.

## Follow-ups
- Migrate gabinet treatment tax_rate to native ZW support: replace the -1 sentinel with a proper schema (e.g. union of number and "zw" literal) and a Supabase migration so the value is self-describing rather than a magic number.
- Apply the same tax rate dropdown to the CRM products form: `src/components/forms/product-form.tsx` and `src/routes/_app/_auth/dashboard/_layout.products.index.tsx` still use a free numeric input for `taxRate`.