### PR TITLE
vat

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2045,7 +2045,7 @@
       "durationMinutes": "Duration (minutes)",
       "price": "Price",
       "currency": "Currency",
-      "taxRate": "VAT Rate",
+      "taxRate": "Vat",
       "category": "Category",
       "color": "Color",
       "sortOrder": "Sort Order",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2053,7 +2053,7 @@
       "durationMinutes": "Czas trwania (minuty)",
       "price": "Cena",
       "currency": "Waluta",
-      "taxRate": "Stawka podatku VAT",
+      "taxRate": "Vat",
       "category": "Kategoria",
       "color": "Kolor",
       "sortOrder": "Kolejność",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #848.

Closes #848

---

## Claude summary

Done. Changed the treatment tax rate label from "Stawka podatku VAT" (PL) / "VAT Rate" (EN) to "Vat" in both locale files at `public/locales/pl/translation.json:2056` and `public/locales/en/translation.json:2048`. Committed as `042306e`.