### PR TITLE
"Kolejność" zabiegi

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2048,7 +2048,6 @@
       "taxRate": "Vat",
       "category": "Category",
       "color": "Color",
-      "sortOrder": "Sort Order",
       "requiredEquipment": "Required Equipment",
       "contraindications": "Contraindications",
       "preparationInstructions": "Preparation Instructions",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2056,7 +2056,6 @@
       "taxRate": "Vat",
       "category": "Kategoria",
       "color": "Kolor",
-      "sortOrder": "Kolejność",
       "requiredEquipment": "Wymagany sprzęt",
       "contraindications": "Przeciwwskazania",
       "preparationInstructions": "Instrukcje przygotowania",

--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -43,7 +43,6 @@ export interface TreatmentFormData {
   aftercareInstructions?: string;
   requiresApproval?: boolean;
   color?: string;
-  sortOrder?: number;
   treatmentCount?: number;
 }
 
@@ -120,7 +119,6 @@ export function TreatmentForm({
   );
   const [requiresApproval, setRequiresApproval] = useState(initialData?.requiresApproval ?? false);
   const [color, setColor] = useState(initialData?.color ?? "");
-  const [sortOrder, setSortOrder] = useState(String(initialData?.sortOrder ?? "0"));
   const [treatmentCount, setTreatmentCount] = useState(String(initialData?.treatmentCount ?? ""));
 
   const listEquipmentAction = useAction(api.gabinet.equipment.listEquipment);
@@ -160,7 +158,6 @@ export function TreatmentForm({
       aftercareInstructions: aftercareInstructions || undefined,
       requiresApproval: requiresApproval || undefined,
       color: color || undefined,
-      sortOrder: parseInt(sortOrder) || undefined,
       treatmentCount: parseInt(treatmentCount) > 1 ? parseInt(treatmentCount) : undefined,
     });
   };
@@ -231,15 +228,6 @@ export function TreatmentForm({
         <div className="space-y-1.5">
           <Label>{t("gabinet.treatments.category")}</Label>
           {categorySelector}
-        </div>
-        <div className="space-y-1.5">
-          <Label>{t("gabinet.treatments.sortOrder")}</Label>
-          <Input
-            type="number"
-            min="0"
-            value={sortOrder}
-            onChange={(e) => setSortOrder(e.target.value)}
-          />
         </div>
         <div className="space-y-1.5">
           <Label>{t("gabinet.treatments.treatmentCount", "Liczba zabiegów")}</Label>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -1217,7 +1217,6 @@ function TreatmentDetail() {
               aftercareInstructions: treatment.aftercareInstructions ?? undefined,
               requiresApproval: treatment.requiresApproval ?? undefined,
               color: treatment.color ?? undefined,
-              sortOrder: treatment.sortOrder ?? undefined,
               treatmentCount: treatment.treatmentCount ?? undefined,
             }}
             onSubmit={handleEditSubmit}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -557,7 +557,6 @@ function TreatmentsIndex() {
                   requiresApproval:
                     editingTreatment.requiresApproval ?? undefined,
                   color: editingTreatment.color ?? undefined,
-                  sortOrder: editingTreatment.sortOrder ?? undefined,
                   treatmentCount: editingTreatment.treatmentCount ?? undefined,
                 }
               : undefined


### PR DESCRIPTION
Auto-generated by Claude in response to issue #854.

Closes #854

---

## Claude summary

Removed the "Kolejność" (sort order) input from the gabinet treatment form. Changes: dropped the `<Label>/<Input>` block, the `sortOrder` state, the field from `TreatmentFormData`, the value from the submit payload, the two callers' `initialData` (`_layout.gabinet.treatments.$treatmentId.tsx` and `_layout.gabinet.treatments.index.tsx`), and the orphaned `gabinet.treatments.sortOrder` i18n keys in PL and EN. The DB column is left in place — only the user-facing option is removed. Committed as `9ca3679`.