### PR TITLE
Add % suffix to product tax rate input

### DIFF
--- a/src/components/forms/product-form.tsx
+++ b/src/components/forms/product-form.tsx
@@ -115,14 +115,20 @@ export function ProductForm({
         </div>
         <div className="space-y-1.5">
           <Label>{t("products.form.taxRate")}</Label>
-          <Input
-            type="number"
-            min={0}
-            max={100}
-            step={1}
-            value={taxRate}
-            onChange={(e) => setTaxRate(parseFloat(e.target.value) || 0)}
-          />
+          <div className="relative">
+            <Input
+              type="number"
+              min={0}
+              max={100}
+              step={1}
+              value={taxRate}
+              onChange={(e) => setTaxRate(parseFloat(e.target.value) || 0)}
+              className="pr-8"
+            />
+            <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-sm text-muted-foreground">
+              %
+            </span>
+          </div>
         </div>
         <div className="flex items-center gap-2 self-end">
           <Switch checked={isActive} onCheckedChange={setIsActive} />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #856.

Closes #856

---

## Claude summary

Applied the same `%` suffix overlay pattern from the merged treatment-form fix (#850, commit 1a9f042) to the product tax rate input at `src/components/forms/product-form.tsx:118`. Wrapped the `Input` in a `relative` div with `pr-8` padding and an absolutely-positioned `%` span. Committed as `eac2949`.