### PR TITLE
Apply the same tax rate dropdown to the CRM products form

### DIFF
--- a/convex/csvExport.ts
+++ b/convex/csvExport.ts
@@ -123,7 +123,7 @@ export const exportProducts = query({
       name: p.name,
       sku: p.sku,
       unitPrice: p.unitPrice.toString(),
-      taxRate: p.taxRate.toString(),
+      taxRate: p.taxExempt ? "ZW" : p.taxRate != null ? p.taxRate.toString() : "",
       isActive: p.isActive ? "Yes" : "No",
       description: p.description ?? "",
       createdAt: new Date(p.createdAt).toISOString(),

--- a/convex/products.ts
+++ b/convex/products.ts
@@ -82,7 +82,8 @@ export const create = action({
     name: v.string(),
     sku: v.string(),
     unitPrice: v.number(),
-    taxRate: v.number(),
+    taxRate: v.optional(v.number()),
+    taxExempt: v.optional(v.boolean()),
     isActive: v.boolean(),
     description: v.optional(v.string()),
     tagIds: v.optional(v.array(v.string())),
@@ -107,7 +108,8 @@ export const create = action({
       name: args.name,
       sku: args.sku,
       unitPrice: args.unitPrice,
-      taxRate: args.taxRate,
+      taxRate: args.taxExempt ? null : args.taxRate ?? null,
+      taxExempt: args.taxExempt ?? null,
       isActive: args.isActive,
       description: args.description ?? null,
       tagIds: args.tagIds ?? null,
@@ -159,6 +161,7 @@ export const update = action({
     sku: v.optional(v.string()),
     unitPrice: v.optional(v.number()),
     taxRate: v.optional(v.number()),
+    taxExempt: v.optional(v.boolean()),
     description: v.optional(v.string()),
     tagIds: v.optional(v.array(v.string())),
     categoryId: v.optional(v.string()),
@@ -185,7 +188,11 @@ export const update = action({
     }
 
     const { organizationId, productId, ...updates } = args;
-    await db.patch("products", productId, { ...updates, updatedAt: Date.now() });
+    const patchPayload: Record<string, unknown> = { ...updates, updatedAt: Date.now() };
+    if (updates.taxExempt === true) {
+      patchPayload.taxRate = null;
+    }
+    await db.patch("products", productId, patchPayload);
 
     try {
       await ctx.runMutation(internal.products._updateSideEffects, {

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -313,7 +313,10 @@ export function createCrmTables({
     name: v.string(),
     sku: v.string(),
     unitPrice: v.number(),
-    taxRate: v.number(),
+    taxRate: v.optional(v.number()),
+    // True when the product is VAT-exempt ("zwolniony" / ZW). When set, the
+    // numeric taxRate is ignored. Mirrors gabinetTreatments.taxExempt.
+    taxExempt: v.optional(v.boolean()),
     isActive: v.boolean(),
     description: v.optional(v.string()),
     tagIds: v.optional(v.array(v.id("tagDefinitions"))),

--- a/scripts/gen-db-types.mjs
+++ b/scripts/gen-db-types.mjs
@@ -15,6 +15,7 @@
  *   • CREATE TYPE ... AS ENUM (...)
  *   • CREATE TABLE [IF NOT EXISTS] <name> ( ... )
  *   • ALTER TABLE [IF EXISTS] <name> ADD COLUMN [IF NOT EXISTS] <col> <type> ...
+ *   • ALTER TABLE [IF EXISTS] <name> ALTER COLUMN <col> DROP NOT NULL
  *
  * SQL column → TypeScript mapping rules:
  *   TEXT                → string
@@ -164,6 +165,13 @@ function applyMigration(sql) {
       if (col && !table.columns.some((c) => c.name === col.name)) {
         table.columns.push(col);
       }
+    }
+
+    const dropNotNullRe = /ALTER\s+COLUMN\s+"?(\w+)"?\s+DROP\s+NOT\s+NULL/gi;
+    for (const a of actions.matchAll(dropNotNullRe)) {
+      const colName = a[1];
+      const col = table.columns.find((c) => c.name === colName);
+      if (col) col.nullable = true;
     }
   }
 }

--- a/src/components/forms/product-form.tsx
+++ b/src/components/forms/product-form.tsx
@@ -5,9 +5,36 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
 import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import type { Id } from "@cvx/_generated/dataModel";
+
+// VAT-exempt ("zwolniony") is tracked as a separate boolean (taxExempt) on the
+// product. The "zw" option is selected when the boolean is true; otherwise the
+// numeric percentage is used. Mirrors the gabinet treatment form.
+const TAX_RATE_OPTIONS = [
+  { value: "zw", label: "ZW" },
+  { value: "0", label: "0%" },
+  { value: "5", label: "5%" },
+  { value: "8", label: "8%" },
+  { value: "23", label: "23%" },
+];
+
+function initialTaxRateFormValue(
+  taxRate: number | undefined,
+  taxExempt: boolean | undefined,
+): string {
+  if (taxExempt) return "zw";
+  if (taxRate == null) return "23";
+  return String(taxRate);
+}
 
 interface TagDef {
   _id: Id<"tagDefinitions">;
@@ -27,7 +54,8 @@ export interface ProductFormData {
   description?: string;
   sku: string;
   unitPrice: number;
-  taxRate: number;
+  taxRate?: number;
+  taxExempt?: boolean;
   isActive: boolean;
   tagIds?: Id<"tagDefinitions">[];
   categoryId?: Id<"categoryDefinitions">;
@@ -57,19 +85,28 @@ export function ProductForm({
   const [description, setDescription] = useState(initialData?.description ?? "");
   const [sku, setSku] = useState(initialData?.sku ?? "");
   const [unitPrice, setUnitPrice] = useState(initialData?.unitPrice ?? 0);
-  const [taxRate, setTaxRate] = useState(initialData?.taxRate ?? 23);
+  const [taxRate, setTaxRate] = useState(
+    initialTaxRateFormValue(initialData?.taxRate, initialData?.taxExempt),
+  );
   const [isActive, setIsActive] = useState(initialData?.isActive ?? true);
   const [tagIds, setTagIds] = useState<Id<"tagDefinitions">[]>(initialData?.tagIds ?? []);
   const [categoryId, setCategoryId] = useState<Id<"categoryDefinitions"> | undefined>(initialData?.categoryId);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    const isExempt = taxRate === "zw";
+    const numericTaxRate = !isExempt
+      ? Number.isFinite(parseFloat(taxRate))
+        ? parseFloat(taxRate)
+        : undefined
+      : undefined;
     onSubmit({
       name,
       description: description || undefined,
       sku,
       unitPrice,
-      taxRate,
+      taxRate: numericTaxRate,
+      taxExempt: isExempt,
       isActive,
       tagIds: tagIds.length > 0 ? tagIds : undefined,
       categoryId: categoryId || undefined,
@@ -115,20 +152,18 @@ export function ProductForm({
         </div>
         <div className="space-y-1.5">
           <Label>{t("products.form.taxRate")}</Label>
-          <div className="relative">
-            <Input
-              type="number"
-              min={0}
-              max={100}
-              step={1}
-              value={taxRate}
-              onChange={(e) => setTaxRate(parseFloat(e.target.value) || 0)}
-              className="pr-8"
-            />
-            <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-sm text-muted-foreground">
-              %
-            </span>
-          </div>
+          <Select value={taxRate} onValueChange={setTaxRate}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TAX_RATE_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
         <div className="flex items-center gap-2 self-end">
           <Switch checked={isActive} onCheckedChange={setIsActive} />

--- a/src/lib/supabase/database.columns.ts
+++ b/src/lib/supabase/database.columns.ts
@@ -10,6 +10,7 @@
  *   • 00003_add_selected_id_to_saved_views.sql
  *   • 00004_document_components.sql
  *   • 00005_gabinet_treatment_tax_exempt.sql
+ *   • 00006_products_tax_exempt.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  */
@@ -146,7 +147,7 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   object_relationships: new Set(["id", "organization_id", "source_type", "source_id", "target_type", "target_id", "relationship_type", "created_by", "created_at"]),
   activities: new Set(["id", "organization_id", "entity_type", "entity_id", "action", "description", "metadata", "performed_by", "created_at"]),
   notes: new Set(["id", "organization_id", "entity_type", "entity_id", "content", "created_by", "is_pinned", "parent_note_id", "created_at", "updated_at"]),
-  products: new Set(["id", "organization_id", "name", "sku", "unit_price", "tax_rate", "is_active", "description", "tag_ids", "category_id", "created_by", "created_at", "updated_at"]),
+  products: new Set(["id", "organization_id", "name", "sku", "unit_price", "tax_rate", "is_active", "description", "tag_ids", "category_id", "created_by", "created_at", "updated_at", "tax_exempt"]),
   deal_products: new Set(["id", "organization_id", "deal_id", "product_id", "quantity", "unit_price", "discount", "created_at"]),
   calls: new Set(["id", "organization_id", "outcome", "call_date", "note", "duration", "tag_ids", "category_id", "created_by", "created_at", "updated_at"]),
   lost_reasons: new Set(["id", "organization_id", "label", "order", "is_active", "created_by", "created_at", "updated_at"]),

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -10,6 +10,7 @@
  *   • 00003_add_selected_id_to_saved_views.sql
  *   • 00004_document_components.sql
  *   • 00005_gabinet_treatment_tax_exempt.sql
+ *   • 00006_products_tax_exempt.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -1330,7 +1331,7 @@ export interface Database {
           name: string;
           sku: string;
           unit_price: number;
-          tax_rate: number;
+          tax_rate: number | null;
           is_active: boolean;
           description: string | null;
           tag_ids: string[] | null;
@@ -1338,6 +1339,7 @@ export interface Database {
           created_by: string;
           created_at: number;
           updated_at: number;
+          tax_exempt: boolean | null;
         };
         Insert: {
           id?: string;
@@ -1345,7 +1347,7 @@ export interface Database {
           name: string;
           sku: string;
           unit_price: number;
-          tax_rate: number;
+          tax_rate?: number | null;
           is_active: boolean;
           description?: string | null;
           tag_ids?: string[] | null;
@@ -1353,6 +1355,7 @@ export interface Database {
           created_by: string;
           created_at: number;
           updated_at: number;
+          tax_exempt?: boolean | null;
         };
         Update: {
           id?: string;
@@ -1360,7 +1363,7 @@ export interface Database {
           name?: string;
           sku?: string;
           unit_price?: number;
-          tax_rate?: number;
+          tax_rate?: number | null;
           is_active?: boolean;
           description?: string | null;
           tag_ids?: string[] | null;
@@ -1368,6 +1371,7 @@ export interface Database {
           created_by?: string;
           created_at?: number;
           updated_at?: number;
+          tax_exempt?: boolean | null;
         };
       };
       deal_products: {

--- a/src/lib/supabase/mappers/products.ts
+++ b/src/lib/supabase/mappers/products.ts
@@ -12,7 +12,8 @@ export interface MappedProduct {
   name: string;
   sku: string;
   unitPrice: number;
-  taxRate: number;
+  taxRate?: number;
+  taxExempt?: boolean;
   isActive: boolean;
   description?: string;
   tagIds?: string[];

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -17,6 +17,13 @@ import { Label } from "@/components/ui/label";
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Plus, Pencil, Trash2, Power, Upload, Download, X } from "@/lib/ez-icons";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { CsvImportDialog } from "@/components/csv/csv-import-dialog";
@@ -50,6 +57,26 @@ export const Route = createFileRoute(
 });
 
 type Product = MappedProduct;
+
+// VAT-exempt ("zwolniony") is tracked as a separate boolean (taxExempt) on the
+// product. The "zw" option is selected when the boolean is true; otherwise the
+// numeric percentage is used.
+const TAX_RATE_OPTIONS = [
+  { value: "zw", label: "ZW" },
+  { value: "0", label: "0%" },
+  { value: "5", label: "5%" },
+  { value: "8", label: "8%" },
+  { value: "23", label: "23%" },
+];
+
+function initialTaxRateFormValue(
+  taxRate: number | undefined | null,
+  taxExempt: boolean | undefined | null,
+): string {
+  if (taxExempt) return "zw";
+  if (taxRate == null) return "23";
+  return String(taxRate);
+}
 
 function generateSku(): string {
   const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -122,7 +149,7 @@ function ProductsPage() {
   const [name, setName] = useState("");
   const [sku, setSku] = useState("");
   const [unitPrice, setUnitPrice] = useState("");
-  const [taxRate, setTaxRate] = useState("0");
+  const [taxRate, setTaxRate] = useState("23");
   const [isActive, setIsActive] = useState(true);
   const [description, setDescription] = useState("");
   const [tagIds, setTagIds] = useState<Id<"tagDefinitions">[]>([]);
@@ -162,7 +189,7 @@ function ProductsPage() {
     setName("");
     setSku(generateSku());
     setUnitPrice("");
-    setTaxRate("0");
+    setTaxRate("23");
     setIsActive(true);
     setDescription("");
     setTagIds([]);
@@ -180,7 +207,7 @@ function ProductsPage() {
     setName(product.name);
     setSku(product.sku);
     setUnitPrice(String(product.unitPrice));
-    setTaxRate(String(product.taxRate));
+    setTaxRate(initialTaxRateFormValue(product.taxRate, product.taxExempt));
     setIsActive(product.isActive);
     setDescription(product.description ?? "");
     setTagIds((product.tagIds as Id<"tagDefinitions">[]) ?? []);
@@ -193,6 +220,12 @@ function ProductsPage() {
   const handleSubmit = async () => {
     if (!name.trim() || !sku.trim() || !unitPrice) return;
     setIsSubmitting(true);
+    const isExempt = taxRate === "zw";
+    const numericTaxRate = !isExempt
+      ? Number.isFinite(parseFloat(taxRate))
+        ? parseFloat(taxRate)
+        : undefined
+      : undefined;
     try {
       if (editingProduct) {
         await updateProduct({
@@ -201,7 +234,8 @@ function ProductsPage() {
           name: name.trim(),
           sku: sku.trim(),
           unitPrice: parseFloat(unitPrice),
-          taxRate: parseFloat(taxRate) || 0,
+          taxRate: numericTaxRate,
+          taxExempt: isExempt,
           description: description.trim() || undefined,
           tagIds,
           categoryId,
@@ -212,7 +246,8 @@ function ProductsPage() {
           name: name.trim(),
           sku: sku.trim(),
           unitPrice: parseFloat(unitPrice),
-          taxRate: parseFloat(taxRate) || 0,
+          taxRate: numericTaxRate,
+          taxExempt: isExempt,
           isActive,
           description: description.trim() || undefined,
           tagIds,
@@ -250,7 +285,11 @@ function ProductsPage() {
     {
       id: "taxRate",
       label: t('products.taxRate'),
-      render: (item) => item.taxRate != null ? `${item.taxRate}%` : "\u2014",
+      render: (item) => {
+        if (item.taxExempt) return "ZW";
+        if (item.taxRate == null) return "\u2014";
+        return `${item.taxRate}%`;
+      },
     },
     {
       id: "isActive",
@@ -412,15 +451,18 @@ function ProductsPage() {
 
             <div className="space-y-1.5">
               <Label>{t('products.taxRate')}</Label>
-              <Input
-                type="number"
-                step="0.01"
-                min="0"
-                max="100"
-                value={taxRate}
-                onChange={(e) => setTaxRate(e.target.value)}
-                placeholder="0"
-              />
+              <Select value={taxRate} onValueChange={setTaxRate}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TAX_RATE_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           </div>
 

--- a/supabase/migrations/00006_products_tax_exempt.sql
+++ b/supabase/migrations/00006_products_tax_exempt.sql
@@ -1,0 +1,12 @@
+-- Add native ZW (VAT-exempt) support to products.tax_rate.
+--
+-- The CRM products form is being switched to the same VAT dropdown used by
+-- gabinet treatments (ZW, 0%, 5%, 8%, 23%). Introduce a self-describing
+-- tax_exempt boolean and make tax_rate nullable so VAT-exempt products do
+-- not have to carry a numeric value. Mirrors 00005_gabinet_treatment_tax_exempt.
+
+ALTER TABLE products
+  ADD COLUMN IF NOT EXISTS tax_exempt BOOLEAN;
+
+ALTER TABLE products
+  ALTER COLUMN tax_rate DROP NOT NULL;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #860.

Closes #860

---

## Claude summary

Done. Both CRM product form locations now use the same VAT dropdown as the gabinet treatment form (ZW, 0%, 5%, 8%, 23%), with ZW persisted via a dedicated `taxExempt` boolean instead of a sentinel — mirroring the schema pattern landed in #859. Supporting changes: nullable `tax_rate` migration (00006), updated Convex schema/action/mapper, CSV export handling for ZW, and a small enhancement to `gen-db-types.mjs` so it understands `ALTER COLUMN ... DROP NOT NULL`. Typecheck shows only the pre-existing TS2589 in `convex/products.ts` (present before this change on the same `ctx.runQuery` call).

## Follow-ups
- Fix TS2589 in convex/products.ts: `ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, ...)` hits "Type instantiation is excessively deep" — present on `main` too; likely needs an `as` cast or breaking up the action arg validators.
- Add ZW import support to convex/csvImport.ts batchCreateProducts: import currently coerces missing taxRate to 0, so ZW rows round-trip lossily through CSV.