### PR TITLE
kolumny

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2055,6 +2055,9 @@
       "requiresApproval": "Requires Approval",
       "treatmentCount": "Sessions per course",
       "treatmentCountHint": "Number of sessions in a course (e.g. 20). Auto-creates a package on first booking.",
+      "package": "Package",
+      "isPackageTooltip": "Package — {{count}} sessions in a course",
+      "isRegularTooltip": "Regular treatment",
       "views": {
         "all": "All Treatments",
         "active": "Active",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2063,6 +2063,9 @@
       "requiresApproval": "Wymaga zatwierdzenia",
       "treatmentCount": "Liczba zabiegów",
       "treatmentCountHint": "Ilość zabiegów w cyklu (np. 20). Automatycznie tworzy pakiet przy pierwszej wizycie.",
+      "package": "Pakiet",
+      "isPackageTooltip": "Pakiet — {{count}} zabiegów w cyklu",
+      "isRegularTooltip": "Zwykły zabieg",
       "views": {
         "all": "Wszystkie zabiegi",
         "active": "Aktywne",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -15,6 +15,12 @@ import type { TreatmentFormData } from "@/components/gabinet/treatment-form";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Plus, Pencil, Trash2, Power, X } from "@/lib/ez-icons";
 import type { SavedView, FieldDef, FilterCondition } from "@/components/crm/types";
 import { Id } from "@cvx/_generated/dataModel";
@@ -256,6 +262,36 @@ function TreatmentsIndex() {
           </div>
         ),
         getSortValue: (item) => item.name,
+      },
+      {
+        id: "isPackage",
+        label: t("gabinet.treatments.package", "Pakiet"),
+        sortable: true,
+        render: (item) => {
+          const isPackage = (item.treatmentCount ?? 1) > 1;
+          const tooltipLabel = isPackage
+            ? t("gabinet.treatments.isPackageTooltip", {
+                count: item.treatmentCount ?? 0,
+                defaultValue: "Pakiet — {{count}} zabiegów w cyklu",
+              })
+            : t("gabinet.treatments.isRegularTooltip", "Zwykły zabieg");
+          return (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className={`inline-block h-2.5 w-2.5 rounded-full ${
+                      isPackage ? "bg-violet-500" : "bg-slate-300"
+                    }`}
+                    aria-label={tooltipLabel}
+                  />
+                </TooltipTrigger>
+                <TooltipContent>{tooltipLabel}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          );
+        },
+        getSortValue: (item) => ((item.treatmentCount ?? 1) > 1 ? 1 : 0),
       },
       {
         id: "category",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #863.

Closes #863

---

## Claude summary

Added a "Pakiet" column to the treatments table at `src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx:266` that shows a colored dot — violet when the treatment is a multi-session package (`treatmentCount > 1`, which per the existing `treatmentCountHint` auto-creates a package on first booking), slate when it is a regular single-session treatment. Hovering the dot reveals a tooltip with the session count. PL/EN translations added under `gabinet.treatments.package`, `isPackageTooltip`, `isRegularTooltip`. The column is sortable and integrates with the existing column-visibility toggles.

Note: this interprets "pakiet" as the treatment's own `treatmentCount` flag (the only "package" property a row in `gabinetTreatments` carries). If the user actually meant "this treatment is included in some `gabinetTreatmentPackages` bundle," that would need an extra cross-table lookup — let me know and I'll swap the logic.