### PR TITLE
Stawka podatku VAT

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2045,7 +2045,7 @@
       "durationMinutes": "Duration (minutes)",
       "price": "Price",
       "currency": "Currency",
-      "taxRate": "Vat",
+      "taxRate": "VAT Rate",
       "category": "Category",
       "color": "Color",
       "requiredEquipment": "Required Equipment",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2053,7 +2053,7 @@
       "durationMinutes": "Czas trwania (minuty)",
       "price": "Cena",
       "currency": "Waluta",
-      "taxRate": "Vat",
+      "taxRate": "Stawka podatku VAT",
       "category": "Kategoria",
       "color": "Kolor",
       "requiredEquipment": "Wymagany sprzęt",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #864.

Closes #864

---

## Claude summary

Updated the `gabinet.treatments.taxRate` label from "Vat" to "Stawka podatku VAT" (PL) and "VAT Rate" (EN). This key is used as the VAT column header in the treatments table (`src/components/gabinet/treatment-form.tsx:319` references this label, but the visible column header in the treatments index uses the same `gabinet.treatments.taxRate` key). Committed as `df4b902`.