### PR TITLE
suwak nowy zabieg cena

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -240,10 +240,12 @@ export function TreatmentForm({
             type="number"
             step="0.01"
             min="0"
+            inputMode="decimal"
             value={price}
             onChange={(e) => setPrice(e.target.value)}
             placeholder="0.00"
             required
+            className="[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           />
         </div>
         <div className="space-y-1.5">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #867.

Closes #867

---

## Claude summary

Committed. Summary: the price input on the treatment form (`src/components/gabinet/treatment-form.tsx:239`) was an `<input type="number" step="0.01">` whose native up/down spin buttons each changed the value by 1 grosz — that's the "suwak" the user wanted gone. The fix adds Tailwind classes to hide the inner/outer webkit spin buttons and sets `appearance: textfield` (Firefox), plus `inputMode="decimal"` for a numeric keyboard on mobile. The field still validates as a number and only accepts typed input.

## Follow-ups
- Import or delete src/styles/globals.css: the file defines global spinner-hiding and other input resets but is not imported anywhere (only src/index.css is loaded from src/main.tsx), so any number input across the app still shows native spinner arrows.