### PR TITLE
Add ZW import support to convex/csvImport.ts batchCreateProducts

### DIFF
--- a/convex/csvImport.ts
+++ b/convex/csvImport.ts
@@ -224,6 +224,7 @@ export const batchCreateProducts = action({
         sku: v.string(),
         unitPrice: v.number(),
         taxRate: v.optional(v.number()),
+        taxExempt: v.optional(v.boolean()),
         isActive: v.optional(v.boolean()),
         description: v.optional(v.string()),
       })
@@ -255,7 +256,8 @@ export const batchCreateProducts = action({
           name: record.name.trim(),
           sku: record.sku.trim(),
           unitPrice: record.unitPrice,
-          taxRate: record.taxRate ?? 0,
+          taxRate: record.taxExempt ? null : record.taxRate ?? null,
+          taxExempt: record.taxExempt ?? null,
           isActive: record.isActive ?? true,
           description: record.description?.trim() ?? null,
           createdBy: String(authResult.userId),

--- a/src/components/csv/csv-import-dialog.tsx
+++ b/src/components/csv/csv-import-dialog.tsx
@@ -136,6 +136,8 @@ export function CsvImportDialog({
 
       if (crmField === "tags") {
         mapped[crmField] = value.split(";").map((t: string) => t.trim()).filter(Boolean);
+      } else if (crmField === "taxRate" && value.trim().toUpperCase() === "ZW") {
+        mapped.taxExempt = true;
       } else if (crmField === "value" || crmField === "unitPrice" || crmField === "taxRate") {
         const num = parseFloat(value);
         if (!isNaN(num)) mapped[crmField] = num;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #872.

Closes #872

---

## Claude summary

Committed `abb52ba`. The fix has two parts:

1. `convex/csvImport.ts` — `batchCreateProducts` now accepts an optional `taxExempt` flag and persists it the same way `products.create` does: when `taxExempt` is true the numeric `taxRate` is stored as `null`; otherwise `taxRate` falls back to `null` instead of the previous `0` coercion.

2. `src/components/csv/csv-import-dialog.tsx` — when the mapped `taxRate` column value is `"ZW"` (case-insensitive), set `taxExempt: true` on the record instead of attempting `parseFloat` (which produced `NaN` and silently dropped the field).

This closes the round-trip: `csvExport.ts:126` emits `"ZW"` for VAT-exempt products, and importing the same CSV now reconstructs a `taxExempt=true, taxRate=null` row rather than a `taxRate=0` one. `npx tsc -p convex/tsconfig.json` and `npx tsc -p tsconfig.app.json` both pass clean.