### PR TITLE
@claude nie można utworzyć zabiegu

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -491,7 +491,7 @@ export function TreatmentForm({
         <Button type="button" variant="outline" onClick={onCancel}>
           {t("common.cancel")}
         </Button>
-        <Button type="submit" disabled={!name.trim() || !duration || !price || isSubmitting}>
+        <Button type="submit" disabled={isSubmitting}>
           {isSubmitting
             ? t("common.saving")
             : initialData


### PR DESCRIPTION
Auto-generated by Claude in response to issue #861.

Closes #861

---

## Claude summary

The fix is committed. Here's a summary of what I found and what changed.

What happened: The user opened the create-treatment side panel, typed a name ("a10") and a duration ("1000"), picked a category, set treatmentCount to 10, but never filled the price field. The submit button was gated by `disabled={!name.trim() || !duration || !price || isSubmitting}`, so an empty price kept it disabled. Combined with shadcn's `disabled:pointer-events-none`, clicks on the button never registered — the Jam user-event log shows the click bubbling up to the parent `flex justify-end gap-2` div twice at the end, and the network log confirms `gabinet/treatments:create` was never called.

What changed: `src/components/gabinet/treatment-form.tsx:494` now uses `disabled={isSubmitting}` only. The name/duration/price inputs already carry HTML5 `required`, so a submit click on an incomplete form now triggers the browser's native "Please fill in this field" tooltip pointing at the empty input. This matches `src/components/forms/product-form.tsx:209`.

## Follow-ups
- Treatment form layout/scroll position needs verification: the user's screenshot shows the TagsPicker trigger button appearing visually below the Anuluj/Utwórz buttons in the side panel, but the JSX order puts `{children}` (tags) before the action-button row. Worth eyeballing in the live UI to confirm it's not a real ordering bug masked by the scroll position.