### PR TITLE
pakiet

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2056,6 +2056,9 @@
       "treatmentCount": "Sessions per course",
       "treatmentCountHint": "Number of sessions in a course (e.g. 20). Auto-creates a package on first booking.",
       "package": "Package",
+      "type": "Type",
+      "packageBadge": "Package · {{count}}x",
+      "singleBadge": "Single",
       "isPackageTooltip": "Package — {{count}} sessions in a course",
       "isRegularTooltip": "Regular treatment",
       "views": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2064,6 +2064,9 @@
       "treatmentCount": "Liczba zabiegów",
       "treatmentCountHint": "Ilość zabiegów w cyklu (np. 20). Automatycznie tworzy pakiet przy pierwszej wizycie.",
       "package": "Pakiet",
+      "type": "Typ",
+      "packageBadge": "Pakiet · {{count}}x",
+      "singleBadge": "Pojedynczy",
       "isPackageTooltip": "Pakiet — {{count}} zabiegów w cyklu",
       "isRegularTooltip": "Zwykły zabieg",
       "views": {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -265,30 +265,38 @@ function TreatmentsIndex() {
       },
       {
         id: "isPackage",
-        label: t("gabinet.treatments.package", "Pakiet"),
+        label: t("gabinet.treatments.type", "Typ"),
         sortable: true,
         render: (item) => {
           const isPackage = (item.treatmentCount ?? 1) > 1;
-          const tooltipLabel = isPackage
-            ? t("gabinet.treatments.isPackageTooltip", {
-                count: item.treatmentCount ?? 0,
-                defaultValue: "Pakiet — {{count}} zabiegów w cyklu",
-              })
-            : t("gabinet.treatments.isRegularTooltip", "Zwykły zabieg");
+          if (isPackage) {
+            const tooltipLabel = t("gabinet.treatments.isPackageTooltip", {
+              count: item.treatmentCount ?? 0,
+              defaultValue: "Pakiet — {{count}} zabiegów w cyklu",
+            });
+            return (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge
+                      variant="secondary"
+                      className="border-violet-200 bg-violet-100 text-violet-800 dark:border-violet-900 dark:bg-violet-950/60 dark:text-violet-200"
+                    >
+                      {t("gabinet.treatments.packageBadge", {
+                        count: item.treatmentCount ?? 0,
+                        defaultValue: "Pakiet · {{count}}x",
+                      })}
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent>{tooltipLabel}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            );
+          }
           return (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    className={`inline-block h-2.5 w-2.5 rounded-full ${
-                      isPackage ? "bg-violet-500" : "bg-slate-300"
-                    }`}
-                    aria-label={tooltipLabel}
-                  />
-                </TooltipTrigger>
-                <TooltipContent>{tooltipLabel}</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Badge variant="outline" className="text-fg-quaternary">
+              {t("gabinet.treatments.singleBadge", "Pojedynczy")}
+            </Badge>
           );
         },
         getSortValue: (item) => ((item.treatmentCount ?? 1) > 1 ? 1 : 0),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #881.

Closes #881

---

## Claude summary

Done. The treatments list now shows a clear text badge in the type column so users can immediately tell packages from single treatments:

- Packages: violet `Pakiet · Nx` badge (with session count, hover still shows the longer tooltip)
- Single treatments: outlined `Pojedynczy` badge

Renamed the column header from "Pakiet" to "Typ" so it covers both cases. Translation keys (`type`, `packageBadge`, `singleBadge`) added to both `pl` and `en` locale files. Commit `341a039` references #881.