### PR TITLE
scroll

### DIFF
--- a/src/components/crm/side-panel.tsx
+++ b/src/components/crm/side-panel.tsx
@@ -49,7 +49,7 @@ export function SidePanel({
           {description && <SheetDescription>{description}</SheetDescription>}
         </SheetHeader>
 
-        <div className="flex-1 overflow-y-auto py-4">{children}</div>
+        <div className="flex-1 overflow-y-auto overscroll-contain py-4">{children}</div>
 
         {onSubmit && (
           <SheetFooter className="border-t pt-4">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #887.

Closes #887

---

## Claude summary

Committed the fix.

Summary: In the treatment dialog (and every other dialog that uses `SidePanel`), scrolling inside the panel could leak to the `<main>` element behind it because the actual scroll container in this app is `<main className="overflow-y-auto">`, not `<body>`. Radix's body-scroll-lock didn't help. Adding `overscroll-contain` to the side panel's inner scroll area at `src/components/crm/side-panel.tsx:52` keeps scroll contained inside the dialog when reaching the boundary.

Note: I couldn't see the Jam video (it's a "replay" type without video, and screenshots returned empty), so I inferred the most likely intent from "zablokuj scroll w tym okienku" + the page's nested-scroll layout. If you actually meant something different (e.g. number inputs changing value on mouse wheel, or making the form fit without any internal scroll), please clarify and I'll adjust.