### PR TITLE
utwórz zabieg

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useNavigate, useSearch } from "@tanstack/react-router"
 import { Link } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
+import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
 import { useOrganization } from "@/components/org-context";
@@ -387,6 +388,8 @@ function TreatmentsIndex() {
         setEditingTreatment(null);
         setTagIds([]);
         setCategoryId(undefined);
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : String(e));
       } finally {
         setIsSubmitting(false);
       }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #890.

Closes #890

---

## Claude summary

Investigation summary:

The issue reports that the "Utwórz zabieg" (Create treatment) button on `/dashboard/gabinet/treatments` does nothing. The Jam screenshot shows the side panel scrolled to the bottom with the user circling the submit button — classic "I clicked it and nothing happened" symptom.

A closely related PR (#882, merged ~1h37m before this issue was filed) already fixed one cause: the submit button was previously `disabled` whenever name/duration/price were empty, so clicks did nothing and Chrome never surfaced the HTML5 "Please fill in this field" message. That fix is now in `main`.

What was still missing: `handleSubmit` in `src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx` wrapped `createTreatment` / `updateTreatment` in `try { } finally { }` with no `catch`. So if the server rejected the call (permission denied, Supabase column issue, etc.), the panel stayed open, the button became clickable again, and the user got zero feedback — visually identical to "the button doesn't work."

Fix: added a `catch` that pipes the error to `toast.error`, matching the pattern already used elsewhere in this codebase (e.g. `treatment-form.tsx:183`, `tags-manager-slideout.tsx`).

Commit `a23435a` on `claude/issue-890`.

## Follow-ups
- Apply same toast.error pattern to other gabinet/CRM side-panel forms: patients, products, employees etc. all use the same silent try/finally pattern and will look broken on any server error
- Verify form validation focus inside SidePanel scrolls properly: HTML5 required-field focus may not auto-scroll the Sheet's internal overflow container, leaving invalid required fields off-screen when user clicks submit from the bottom of the form