### PR TITLE
Apply same toast.error pattern to other gabinet/CRM side-panel forms

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
+import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseGabinetPatient } from "@/hooks/use-supabase-gabinet-patients";
@@ -202,6 +203,8 @@ function PatientDetail() {
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetPatients.detail(organizationId, patientId) });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetPatients.list(organizationId) });
       setEditDrawerOpen(false);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setIsSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, useNavigate, useSearch, Link } from "@tanstack/react-router";
 import { useAction } from "convex/react";
+import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseGabinetRecentVisitPatientIds } from "@/hooks/use-supabase-gabinet-appointments";
@@ -358,6 +359,8 @@ function PatientsIndex() {
         setPanelOpen(false);
         setTagIds([]);
         setCategoryId(undefined);
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : String(e));
       } finally {
         setIsCreating(false);
       }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -387,6 +387,8 @@ function TreatmentDetail() {
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatments.list(organizationId) });
       setEditPanelOpen(false);
       toast.success(t("common.saved"));
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setIsSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react";
 import { createFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { useAction } from "convex/react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
 import {
   useSupabaseProductsList,
@@ -256,6 +257,8 @@ function ProductsPage() {
       }
       setPanelOpen(false);
       resetForm();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #893.

Closes #893

---

## Claude summary

Committed. Applied the toast.error catch pattern from #890 to four more side-panel forms that had identical silent try/finally submit handlers:

- `_layout.gabinet.patients.index.tsx` — patient create
- `_layout.gabinet.patients.$patientId.tsx` — patient edit drawer
- `_layout.products.index.tsx` — product create/edit
- `_layout.gabinet.treatments.$treatmentId.tsx` — treatment edit panel

Each one already wrapped its mutation in `try { ... } finally { setIsSubmitting(false); }` with no catch, so any server-side failure (RBAC denial, validation error, Supabase failure) left the panel open with no visible feedback. Added `catch (e) { toast.error(e instanceof Error ? e.message : String(e)); }` and imported `toast` where missing — mirroring #890 verbatim.

Files I intentionally skipped:
- `_layout.companies.new.tsx`, `_layout.contacts.new.tsx`, `_layout.leads.new.tsx` — these are full-page routes, not side panels (issue scope was "side-panel forms")
- `handleAddNote` in `_layout.gabinet.employees.$employeeId.tsx` — silent try/finally, but it's the inline notes textarea, not a side-panel form; the actual side-panel forms on that page already have proper catch blocks
- Employee create side panel in `_layout.gabinet.employees.index.tsx` — already has `catch (e: any) { toast.error(e.message); }`

## Follow-ups
- Add catch with toast.error to full-page create routes: companies.new.tsx, contacts.new.tsx, leads.new.tsx have the same silent try/finally pattern as the fixed side panels — same UX bug, just on a different surface
- Add catch with toast.error to handleAddNote in gabinet.employees.$employeeId.tsx: inline note submit silently swallows server errors
- Normalize toast.error catch style across codebase: some files use `catch (e: any) { toast.error(e.message); }` while #890/#893 introduced `catch (e) { toast.error(e instanceof Error ? e.message : String(e)); }` — pick one and apply consistently