### PR TITLE
Add catch with toast.error to full-page create routes

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.companies.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.new.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useAction } from "convex/react";
 import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseCustomFieldDefinitions } from "@/hooks/use-supabase-custom-fields";
@@ -61,6 +62,8 @@ function NewCompany() {
                 });
                 navigate({ to: `/dashboard/companies/${id}` });
                 void queryClient.invalidateQueries({ queryKey: supabaseKeys.companies.list(organizationId) });
+              } catch (e) {
+                toast.error(e instanceof Error ? e.message : String(e));
               } finally {
                 setIsSubmitting(false);
               }

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.new.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useAction } from "convex/react";
 import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseCustomFieldDefinitions } from "@/hooks/use-supabase-custom-fields";
@@ -62,6 +63,8 @@ function NewContact() {
                 // Invalidate Supabase contacts cache after create
                 void queryClient.invalidateQueries({ queryKey: supabaseKeys.contacts.list(organizationId) });
                 navigate({ to: `/dashboard/contacts/${id}` });
+              } catch (e) {
+                toast.error(e instanceof Error ? e.message : String(e));
               } finally {
                 setIsSubmitting(false);
               }

--- a/src/routes/_app/_auth/dashboard/_layout.leads.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.new.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useAction } from "convex/react";
 import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useSupabasePipelinesList, useSupabasePipelineStages } from "@/hooks/use-supabase-pipelines";
@@ -72,6 +73,8 @@ function NewLead() {
                 });
                 queryClient.invalidateQueries({ queryKey: supabaseKeys.leads.all });
                 navigate({ to: `/dashboard/leads/${id}` });
+              } catch (e) {
+                toast.error(e instanceof Error ? e.message : String(e));
               } finally {
                 setIsSubmitting(false);
               }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #897.

Closes #897

---

## Claude summary

Added `catch (e) { toast.error(...) }` to the three full-page create routes (`companies.new.tsx`, `contacts.new.tsx`, `leads.new.tsx`), mirroring the side-panel fix from #893. Errors from `createCompany` / `createContact` / `createLead` now surface via sonner instead of being silently swallowed by the bare `try/finally`. Committed on `claude/issue-897`.