### PR TITLE
Add catch with toast.error to handleAddNote in gabinet.employees.$employeeId.tsx

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -403,6 +403,8 @@ function EmployeeDetail() {
         content: newNote.trim(),
       });
       setNewNote("");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setIsAddingNote(false);
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #898.

Closes #898

---

## Claude summary

Fixed and committed. `handleAddNote` in `_layout.gabinet.employees.$employeeId.tsx:395` now catches errors from `createNote` and routes them through `toast.error`, matching the pattern established in #890/#893/#897. `toast` was already imported on line 80, so no extra imports were needed.