### PR TITLE
Normalize toast.error catch style across codebase

### DIFF
--- a/src/components/documents/after-completion-documents-dialog.tsx
+++ b/src/components/documents/after-completion-documents-dialog.tsx
@@ -215,7 +215,7 @@ export function AfterCompletionDocumentsDialog({
         setActiveDocId(next?._id ?? null);
 
         refetch();
-      } catch (err: unknown) {
+      } catch (err) {
         const message =
           err instanceof Error ? err.message : t("common.error");
         toast.error(message);
@@ -271,7 +271,7 @@ export function AfterCompletionDocumentsDialog({
       setActiveDocId(next?._id ?? null);
 
       refetch();
-    } catch (err: unknown) {
+    } catch (err) {
       const message = err instanceof Error ? err.message : t("common.error");
       toast.error(message);
     } finally {

--- a/src/components/documents/generate-document-dialog.tsx
+++ b/src/components/documents/generate-document-dialog.tsx
@@ -772,7 +772,7 @@ export function GenerateDocumentDialog({
         });
         setMissingDataHandled(true);
         setStep("fill_form");
-      } catch (e: unknown) {
+      } catch (e) {
         const message = e instanceof Error ? e.message : "Error saving data";
         toast.error(message);
       } finally {
@@ -802,7 +802,7 @@ export function GenerateDocumentDialog({
         );
         handleOpenChange(false);
         onDocumentCreated?.(docId.documentId as Id<"formDocuments">);
-      } catch (e: unknown) {
+      } catch (e) {
         const message =
           e instanceof Error ? e.message : "Wystapil blad";
         toast.error(message);

--- a/src/components/documents/treatment-required-documents.tsx
+++ b/src/components/documents/treatment-required-documents.tsx
@@ -138,7 +138,7 @@ export function TreatmentRequiredDocuments({
       setAddDialogOpen(false);
       setSelectedTemplateId(null);
       setSearch("");
-    } catch (error: unknown) {
+    } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
     }
@@ -167,7 +167,7 @@ export function TreatmentRequiredDocuments({
         toast.success(
           t("documents.requiredDocs.removed", "Usunieto wymagany dokument"),
         );
-      } catch (error: unknown) {
+      } catch (error) {
         const msg =
           error instanceof Error ? error.message : t("common.error");
         toast.error(msg);
@@ -191,7 +191,7 @@ export function TreatmentRequiredDocuments({
           treatmentId,
           requiredFormTemplates: updated,
         });
-      } catch (error: unknown) {
+      } catch (error) {
         const msg =
           error instanceof Error ? error.message : t("common.error");
         toast.error(msg);

--- a/src/components/gabinet/appointment-form.tsx
+++ b/src/components/gabinet/appointment-form.tsx
@@ -442,7 +442,7 @@ export function AppointmentForm({
         toast.success(
           t("gabinet.patients.created", { defaultValue: "Klient utworzony" }),
         );
-      } catch (e: unknown) {
+      } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         toast.error(msg);
         setPatientLabel("");

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -553,7 +553,7 @@ export function AppointmentDialog({
         });
         setAddPatientOpen(false);
         toast.success(t("gabinet.patients.created", { defaultValue: "Klient utworzony" }));
-      } catch (e: unknown) {
+      } catch (e) {
         const inner = extractActionErrorMessage(e);
         toast.error(
           inner ||
@@ -682,7 +682,7 @@ export function AppointmentDialog({
       ]);
       toast.success(t("gabinet.appointments.created"));
       onOpenChange(false);
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(
         formatAppointmentError(e, t, {
           key: "gabinet.appointments.createFailed",

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -289,7 +289,7 @@ export function AppointmentPreviewContent({
       setIsEditingPhone(false);
       setPhoneInput("");
       toast.success(t("gabinet.appointmentDetail.phoneAdded"));
-    } catch (error: unknown) {
+    } catch (error) {
       console.error("[appointment-preview] phone save failed", error);
       toast.error(extractActionErrorMessage(error) || t("common.error"));
     } finally {
@@ -318,7 +318,7 @@ export function AppointmentPreviewContent({
       ]);
       await refetch();
       toast.success(t("gabinet.appointments.statusUpdated"));
-    } catch (error: unknown) {
+    } catch (error) {
       setStatus(previous);
       console.error("[appointment-preview] status update failed", error);
       toast.error(
@@ -376,7 +376,7 @@ export function AppointmentPreviewContent({
       setCancelDialogOpen(false);
       setCancelReason("");
       toast.success(t("gabinet.appointments.cancelled"));
-    } catch (error: unknown) {
+    } catch (error) {
       setStatus(previous);
       console.error("[appointment-preview] cancel failed", error);
       toast.error(
@@ -444,7 +444,7 @@ export function AppointmentPreviewContent({
       await refetch();
       toast.success(t("gabinet.appointments.updated"));
       onClose();
-    } catch (error: unknown) {
+    } catch (error) {
       console.error("[appointment-preview] save failed", error);
       toast.error(
         formatAppointmentError(error, t, {

--- a/src/components/gabinet/change-employee-modal.tsx
+++ b/src/components/gabinet/change-employee-modal.tsx
@@ -266,8 +266,8 @@ export function ChangeEmployeeModal({
       onOpenChange(false);
       setSelectedId(null);
       setUseNewSlot(false);
-    } catch (err: any) {
-      toast.error(err.message ?? t("common.error"));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t("common.error"));
     } finally {
       setIsSubmitting(false);
     }

--- a/src/components/gabinet/documentation-tab.tsx
+++ b/src/components/gabinet/documentation-tab.tsx
@@ -155,8 +155,8 @@ export function DocumentationTab({
       });
       toast.success(t("common.saved"));
       await onChanged?.();
-    } catch (err: any) {
-      toast.error(err.message ?? t("common.error"));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t("common.error"));
     } finally {
       setIsSavingParams(false);
     }
@@ -178,8 +178,8 @@ export function DocumentationTab({
       });
       toast.success(t("common.saved"));
       await onChanged?.();
-    } catch (err: any) {
-      toast.error(err.message ?? t("common.error"));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t("common.error"));
     } finally {
       setIsSavingInterview(false);
     }
@@ -201,8 +201,8 @@ export function DocumentationTab({
       });
       toast.success(t("common.saved"));
       await onChanged?.();
-    } catch (err: any) {
-      toast.error(err.message ?? t("common.error"));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t("common.error"));
     } finally {
       setIsSavingRemarks(false);
     }
@@ -273,8 +273,8 @@ export function DocumentationTab({
                 toast.success(t("common.saved"));
                 await onChanged?.();
                 resolve();
-              } catch (err: any) {
-                toast.error(err.message ?? t("common.error"));
+              } catch (err) {
+                toast.error(err instanceof Error ? err.message : t("common.error"));
                 reject(err);
               }
             } else {
@@ -312,8 +312,8 @@ export function DocumentationTab({
       });
       toast.success(t("common.saved"));
       await onChanged?.();
-    } catch (err: any) {
-      toast.error(err.message ?? t("common.error"));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t("common.error"));
     }
   };
 

--- a/src/components/gabinet/employee-schedule-manager.tsx
+++ b/src/components/gabinet/employee-schedule-manager.tsx
@@ -93,8 +93,8 @@ export function EmployeeScheduleManager({ employeeId }: EmployeeScheduleManagerP
       toast.success(t("common.saved"));
       setEditingId(null);
       setFormData({});
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     }
   };
 
@@ -115,8 +115,8 @@ export function EmployeeScheduleManager({ employeeId }: EmployeeScheduleManagerP
       toast.success(t("common.saved"));
       setEditingId(null);
       setFormData({});
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     }
   };
 
@@ -127,8 +127,8 @@ export function EmployeeScheduleManager({ employeeId }: EmployeeScheduleManagerP
         scheduleId: scheduleId as Id<"gabinetEmployeeSchedules">,
       });
       toast.success(t("common.delete"));
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     }
   };
 

--- a/src/components/gabinet/flexible-schedule-editor.tsx
+++ b/src/components/gabinet/flexible-schedule-editor.tsx
@@ -269,8 +269,8 @@ export function FlexibleScheduleEditor({
       }
       toast.success(t("common.saved"));
       cancelEdit();
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setSaving(false);
     }
@@ -286,8 +286,8 @@ export function FlexibleScheduleEditor({
         effectiveFrom: effectiveFrom || undefined,
       });
       toast.success(t("common.deleted"));
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     }
   };
 

--- a/src/components/gabinet/package-purchase-drawer.tsx
+++ b/src/components/gabinet/package-purchase-drawer.tsx
@@ -230,8 +230,8 @@ export function PackagePurchaseDrawer({
       toast.success(t("gabinet.packages.purchased", "Package purchased successfully"));
       resetForm();
       onOpenChange(false);
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setSubmitting(false);
     }

--- a/src/components/gabinet/patient-packages-card.tsx
+++ b/src/components/gabinet/patient-packages-card.tsx
@@ -401,7 +401,7 @@ function InstallmentPayButton({
       await queryClient.invalidateQueries({ queryKey });
       setOpen(false);
       resetForm();
-    } catch (error: unknown) {
+    } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
     } finally {

--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -179,7 +179,7 @@ export function TreatmentForm({
         prev.includes(newId) ? prev : [...prev, newId]
       );
       resetAddEquipmentForm();
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : "Unknown error");
     } finally {
       setCreatingEquipment(false);

--- a/src/components/settings/google-calendar-sync-settings.tsx
+++ b/src/components/settings/google-calendar-sync-settings.tsx
@@ -126,7 +126,7 @@ export function GoogleCalendarSyncSettings({
         connectionId: myConnection._id,
       });
       setAvailableCalendars(calendars as GoogleCalendarInfo[]);
-    } catch (e: unknown) {
+    } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(t("googleCalendar.settings.fetchCalendarsError") + ": " + message);
       setShowPicker(false);
@@ -153,7 +153,7 @@ export function GoogleCalendarSyncSettings({
           count: results.length,
         })
       );
-    } catch (e: unknown) {
+    } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(
         t("googleCalendar.settings.syncError", { error: message })
@@ -176,7 +176,7 @@ export function GoogleCalendarSyncSettings({
         visibility: "full",
       });
       toast.success(t("googleCalendar.settings.calendarAdded"));
-    } catch (e: unknown) {
+    } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(message);
     } finally {
@@ -196,7 +196,7 @@ export function GoogleCalendarSyncSettings({
   ) => {
     try {
       await updateConfig({ configId, ...patch });
-    } catch (e: unknown) {
+    } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(message);
     }
@@ -207,7 +207,7 @@ export function GoogleCalendarSyncSettings({
   ) => {
     try {
       await removeConfig({ configId });
-    } catch (e: unknown) {
+    } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(message);
     }

--- a/src/components/settings/sms-config-card.tsx
+++ b/src/components/settings/sms-config-card.tsx
@@ -65,8 +65,8 @@ export function SmsConfigCard({ organizationId }: SmsConfigCardProps) {
       toast.success("Konfiguracja SMS zapisana");
       setApiToken("");
       setApiSecret("");
-    } catch (err: any) {
-      toast.error(err.message ?? "Nie udało się zapisać konfiguracji");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Nie udało się zapisać konfiguracji");
     } finally {
       setSaving(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.calendar.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calendar.tsx
@@ -244,8 +244,8 @@ function UnifiedCalendarPage() {
           updated: result.updated,
         })
       );
-    } catch (e: any) {
-      toast.error(e.message ?? t("calendar.googleImportFailed", "Import failed"));
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : t("calendar.googleImportFailed", "Import failed"));
     } finally {
       setIsImporting(false);
     }
@@ -399,8 +399,8 @@ function UnifiedCalendarPage() {
         ]);
 
         toast.success(t("calendar.eventMoved", "Event moved"));
-      } catch (err: any) {
-        toast.error(err.message ?? t("calendar.moveFailed", "Failed to move event"));
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : t("calendar.moveFailed", "Failed to move event"));
       }
     },
     [editPerm.allowed, events, organizationId, updateActivity, updateAppointment, queryClient, t]

--- a/src/routes/_app/_auth/dashboard/_layout.document-editor.$id.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.document-editor.$id.tsx
@@ -145,7 +145,7 @@ function EditDocumentEditorPage() {
       });
 
       toast.success(t("settings.formTemplates.saved"));
-    } catch (e: unknown) {
+    } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(message);
     } finally {
@@ -175,7 +175,7 @@ function EditDocumentEditorPage() {
         to: "/dashboard/document-editor/$id",
         params: { id: newId },
       });
-    } catch (e: unknown) {
+    } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(message);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.document-editor.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.document-editor.new.tsx
@@ -111,7 +111,7 @@ function NewDocumentEditorPage() {
         to: "/dashboard/document-editor/$id",
         params: { id: templateId },
       });
-    } catch (e: unknown) {
+    } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(message);
     } finally {

--- a/src/routes/_app/_auth/dashboard/_layout.email-templates.$templateId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.email-templates.$templateId.tsx
@@ -167,7 +167,7 @@ function EditEmailTemplatePage() {
         isActive,
       });
       toast.success("Szablon został zapisany");
-    } catch (e: unknown) {
+    } catch (e) {
       const msg = e instanceof Error ? e.message : "Błąd podczas zapisywania";
       toast.error(msg);
     } finally {
@@ -180,7 +180,7 @@ function EditEmailTemplatePage() {
       await removeTemplate({ organizationId, templateId });
       toast.success("Szablon został usunięty");
       navigate({ to: "/dashboard/email-templates" });
-    } catch (e: unknown) {
+    } catch (e) {
       const msg = e instanceof Error ? e.message : "Błąd podczas usuwania";
       toast.error(msg);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.email-templates.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.email-templates.new.tsx
@@ -118,7 +118,7 @@ function NewEmailTemplatePage() {
         to: "/dashboard/email-templates/$templateId",
         params: { templateId: templateId as string },
       });
-    } catch (e: unknown) {
+    } catch (e) {
       const msg = e instanceof Error ? e.message : "Błąd podczas zapisywania";
       toast.error(msg);
     } finally {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -473,7 +473,7 @@ function AppointmentDetail() {
       });
       await invalidateAppointmentCaches();
       refetch();
-    } catch (error: unknown) {
+    } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
       setTagIds((detail.appointment.tagIds as Id<"tagDefinitions">[] | undefined) ?? []);
@@ -769,7 +769,7 @@ function AppointmentDetail() {
         // Small delay so Convex reactive query picks up the new documents
         setTimeout(() => setAfterCompletionDialogOpen(true), 500);
       }
-    } catch (error: unknown) {
+    } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
     } finally {
@@ -815,7 +815,7 @@ function AppointmentDetail() {
       setCancelReason("");
       await invalidateAppointmentCaches();
       refetch();
-    } catch (error: unknown) {
+    } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
     } finally {
@@ -833,7 +833,7 @@ function AppointmentDetail() {
       });
       toast.success(t("common.saved"));
       refetch();
-    } catch (error: unknown) {
+    } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
     } finally {
@@ -865,7 +865,7 @@ function AppointmentDetail() {
       setPaymentAmount("");
       setPaymentNote("");
       refetch();
-    } catch (error: unknown) {
+    } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
     } finally {
@@ -881,7 +881,7 @@ function AppointmentDetail() {
       });
       toast.success(t("gabinet.payments.markedPaid"));
       refetch();
-    } catch (error: unknown) {
+    } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
     }
@@ -895,7 +895,7 @@ function AppointmentDetail() {
       });
       toast.success(t("gabinet.payments.refunded"));
       refetch();
-    } catch (error: unknown) {
+    } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
     }
@@ -920,7 +920,7 @@ function AppointmentDetail() {
       setNewNoteContent("");
       setReplyToNoteId(null);
       refetch();
-    } catch (error: unknown) {
+    } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
     } finally {
@@ -942,7 +942,7 @@ function AppointmentDetail() {
       setEditingNoteId(null);
       setEditNoteContent("");
       refetch();
-    } catch (error: unknown) {
+    } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
     } finally {
@@ -957,7 +957,7 @@ function AppointmentDetail() {
       await deleteNote({ organizationId, noteId });
       toast.success(t("common.deleted"));
       refetch();
-    } catch (error: unknown) {
+    } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
     }
@@ -967,7 +967,7 @@ function AppointmentDetail() {
     try {
       await togglePinNote({ organizationId, noteId });
       refetch();
-    } catch (error: unknown) {
+    } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
     }
@@ -994,7 +994,7 @@ function AppointmentDetail() {
       });
       toast.success(t("common.saved"));
       refetch();
-    } catch (error: unknown) {
+    } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
     } finally {
@@ -2512,7 +2512,7 @@ function AppointmentDetail() {
                   toast.success(t("gabinet.packages.usageRecorded"));
                   setUsageDialogOpen(false);
                   refetch();
-                } catch (e: unknown) {
+                } catch (e) {
                   const msg = e instanceof Error ? e.message : String(e);
                   toast.error(msg);
                 } finally {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -681,7 +681,7 @@ function GabinetCalendarPage() {
         void queryClient.invalidateQueries({
           queryKey: supabaseKeys.gabinetAppointments.all,
         });
-      } catch (e: unknown) {
+      } catch (e) {
         toast.error(
           formatAppointmentError(e, t, {
             key: "gabinet.appointments.resizeFailed",
@@ -761,7 +761,7 @@ function GabinetCalendarPage() {
           );
           // Invalidate Supabase appointments cache after Convex mutation
           void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetAppointments.all });
-        } catch (e: unknown) {
+        } catch (e) {
           toast.error(
             formatAppointmentError(e, t, {
               key: "gabinet.appointments.rescheduleFailed",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -1295,8 +1295,8 @@ function EditEmployeeDrawer({
       });
       toast.success(t("common.saved"));
       onOpenChange(false);
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setIsSubmitting(false);
     }
@@ -1722,8 +1722,8 @@ function DetailedDataTab({
       await onUpdate(updatePayload);
       toast.success(t("common.saved"));
       setEditing(null);
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setSaving(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -469,8 +469,8 @@ function CreateEmployeeSheet({
       setTagIds([]);
       setCategoryId(undefined);
       setTreatmentSearch("");
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setSaving(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -292,8 +292,8 @@ function PackagesIndex() {
       invalidatePackages();
       setPanelOpen(false);
       resetForm();
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setSubmitting(false);
     }
@@ -310,8 +310,8 @@ function PackagesIndex() {
       await removePkg({ organizationId, packageId: deletingId });
       toast.success(t("common.deleted"));
       invalidatePackages();
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setDeleteDialogOpen(false);
       setDeletingId(null);
@@ -350,8 +350,8 @@ function PackagesIndex() {
       invalidatePackages();
       setAssignPanelOpen(false);
       resetAssignForm();
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setAssignSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
@@ -207,7 +207,7 @@ function EquipmentCard({
       });
       toast.success(t("common.saved"));
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetEquipment.list(organizationId) });
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : "Unknown error");
     } finally {
       setSaving(false);
@@ -230,7 +230,7 @@ function EquipmentCard({
       setTransferLocationId("");
       setTransferRoomId("");
       setTransferNotes("");
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : "Unknown error");
     } finally {
       setTransferring(false);
@@ -535,7 +535,7 @@ function EquipmentSettingsPage() {
       setNewSerial("");
       setNewStatus("available");
       setNewLocationId("");
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : "Unknown error");
     } finally {
       setCreating(false);

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
@@ -50,8 +50,8 @@ function LeaveTypesSettings() {
     try {
       const result = await initAllBalances({ organizationId, year: currentYear });
       toast.success(t("gabinet.leaveTypes.balancesInitialized", { count: result.created }));
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     }
   };
 
@@ -235,8 +235,8 @@ function LeaveTypeDialog({
         requiresApproval,
         ...(initial ? { isActive } : {}),
       });
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setSaving(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
@@ -163,8 +163,8 @@ function LeavesPage() {
       setStartDate("");
       setEndDate("");
       setReason("");
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setSubmitting(false);
     }
@@ -192,7 +192,7 @@ function LeavesPage() {
       }
       // Invalidate Supabase leaves cache after status change
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetLeaves.all });
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : "Unknown error");
     } finally {
       setConfirmLeaveId(null);

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
@@ -159,7 +159,7 @@ function LocationCard({
       });
       toast.success(t("common.saved"));
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetLocations.list(organizationId) });
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : "Unknown error");
     } finally {
       setSaving(false);
@@ -172,7 +172,7 @@ function LocationCard({
       toast.success(t("common.deleted"));
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetLocations.list(organizationId) });
       onDeleted();
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : "Unknown error");
     }
   };
@@ -191,7 +191,7 @@ function LocationCard({
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetRooms.list(organizationId) });
       setNewRoomFloor("");
       setAddRoomOpen(false);
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : "Unknown error");
     } finally {
       setAddingRoom(false);
@@ -201,7 +201,7 @@ function LocationCard({
   const handleDeleteRoom = async (roomId: Id<"gabinetRooms">) => {
     try {
       await deleteRoom({ organizationId, roomId });
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : "Unknown error");
     }
   };
@@ -209,7 +209,7 @@ function LocationCard({
   const handleToggleRoom = async (roomId: Id<"gabinetRooms">, isActive: boolean) => {
     try {
       await updateRoom({ organizationId, roomId, isActive: !isActive });
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : "Unknown error");
     }
   };
@@ -512,7 +512,7 @@ function LocationsSettingsPage() {
       setNewPhone("");
       setNewEmail("");
       setNewCity("");
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : "Unknown error");
     } finally {
       setCreating(false);

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.reminders.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.reminders.tsx
@@ -50,7 +50,7 @@ function ReminderSettings() {
         reminderHoursBefore: hoursBefore,
       });
       toast.success(t("gabinet.reminders.saved"));
-    } catch (e: unknown) {
+    } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(message);
     } finally {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
@@ -121,8 +121,8 @@ function SchedulingSettings() {
         })),
       });
       toast.success(t("common.saved"));
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setSaving(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.inbox.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.inbox.index.tsx
@@ -65,8 +65,8 @@ function InboxPage() {
     try {
       const result = await syncGmail({ organizationId });
       toast.success(`${t("integrations.syncing")} — ${result.synced} emails`);
-    } catch (e: any) {
-      toast.error(e.message ?? "Sync failed");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Sync failed");
     } finally {
       setIsSyncing(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.settings.document-components.$id.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.document-components.$id.tsx
@@ -91,8 +91,8 @@ function EditDocumentComponentPage() {
       });
       toast.success("Komponent zaktualizowany");
       navigate({ to: "/dashboard/settings/document-components" });
-    } catch (err: any) {
-      toast.error(err.message ?? "Błąd podczas zapisu");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Błąd podczas zapisu");
     } finally {
       setSaving(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.settings.document-components.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.document-components.index.tsx
@@ -90,8 +90,8 @@ function DocumentComponentsListPage() {
     try {
       await removeMutation({ organizationId, componentId: deleteTarget });
       toast.success("Komponent usunięty");
-    } catch (err: any) {
-      toast.error(err.message ?? "Błąd");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Błąd");
     }
     setDeleteTarget(null);
   };
@@ -100,8 +100,8 @@ function DocumentComponentsListPage() {
     try {
       await duplicateMutation({ organizationId, componentId: id });
       toast.success("Komponent skopiowany");
-    } catch (err: any) {
-      toast.error(err.message ?? "Błąd");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Błąd");
     }
   };
 

--- a/src/routes/_app/_auth/dashboard/_layout.settings.document-components.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.document-components.new.tsx
@@ -70,8 +70,8 @@ function NewDocumentComponentPage() {
       });
       toast.success("Komponent utworzony");
       navigate({ to: "/dashboard/settings/document-components" });
-    } catch (err: any) {
-      toast.error(err.message ?? "Błąd podczas tworzenia");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Błąd podczas tworzenia");
     } finally {
       setSaving(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.settings.email-events.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.email-events.tsx
@@ -108,7 +108,7 @@ function EmailEventsSettings() {
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.emailEventBindings.list(organizationId) });
       toast.success(t("emailEvents.bindingSaved"));
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setBindingInProgress(null);
@@ -125,7 +125,7 @@ function EmailEventsSettings() {
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.emailEventBindings.list(organizationId) });
       toast.success(t("emailEvents.bindingSaved"));
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setBindingInProgress(null);
@@ -146,7 +146,7 @@ function EmailEventsSettings() {
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.emailEventBindings.list(organizationId) });
       toast.success(t("emailEvents.bindingDeleted"));
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setBindingInProgress(null);

--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.$id.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.$id.tsx
@@ -203,7 +203,7 @@ function EditFormTemplatePage() {
       });
 
       toast.success(t("settings.formTemplates.saved"));
-    } catch (e: unknown) {
+    } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(message);
     } finally {

--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -749,7 +749,7 @@ function FormTemplatesListPage() {
                     try {
                       const result = await seedTemplates({ organizationId });
                       toast.success(t("settings.formTemplates.seedSuccess", { count: result.count }));
-                    } catch (e: unknown) {
+                    } catch (e) {
                       toast.error(
                         e instanceof Error ? e.message : t("common.error"),
                       );
@@ -765,7 +765,7 @@ function FormTemplatesListPage() {
                       toast.success(
                         t("settings.formTemplates.migrateSuccess", { count: result.patched }),
                       );
-                    } catch (e: unknown) {
+                    } catch (e) {
                       toast.error(
                         e instanceof Error ? e.message : t("common.error"),
                       );

--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.new.tsx
@@ -168,7 +168,7 @@ function NewFormTemplatePage() {
         to: "/dashboard/settings/form-templates/$id",
         params: { id: templateId },
       });
-    } catch (e: unknown) {
+    } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(message);
     } finally {

--- a/src/routes/_app/_auth/dashboard/_layout.settings.sms.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.sms.tsx
@@ -77,7 +77,7 @@ function SmsSettings() {
       setApiToken("");
       setApiSecret("");
       toast.success(t("sms.saved"));
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setSaving(false);
@@ -91,7 +91,7 @@ function SmsSettings() {
       toast.success(
         isActive ? t("sms.activatedSuccess") : t("sms.deactivatedSuccess")
       );
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setToggling(false);

--- a/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
@@ -126,7 +126,7 @@ function TeamSettings() {
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(organizationId) });
       toast.success(t("team.invitationRoleUpdated", { defaultValue: "Rola zaproszenia została zmieniona" }));
-    } catch (e: unknown) {
+    } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(message);
     }
@@ -150,7 +150,7 @@ function TeamSettings() {
       await cancelInvitation({ organizationId, invitationId });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(organizationId) });
       toast.success(t("team.invitationCancelled"));
-    } catch (e: unknown) {
+    } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(message);
     } finally {
@@ -165,7 +165,7 @@ function TeamSettings() {
       await resendInvitation({ organizationId, invitationId });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(organizationId) });
       toast.success(t("team.invitationResent"));
-    } catch (e: unknown) {
+    } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(message);
     } finally {
@@ -189,7 +189,7 @@ function TeamSettings() {
       setInviteOpen(false);
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(organizationId) });
       setInvitationSentPopup(t("team.invitationSent"));
-    } catch (e: unknown) {
+    } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       if (message.includes("Seat limit reached")) {
         toast.error(t("settings.team.limitReached"), {

--- a/src/routes/_app/patient/_layout.appointments.tsx
+++ b/src/routes/_app/patient/_layout.appointments.tsx
@@ -114,7 +114,7 @@ function PatientAppointments() {
       });
       toast.success(t("patientPortal.appointments.rescheduleSuccess"));
       closeReschedule();
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setSubmitting(false);

--- a/src/routes/_app/patient/_layout.book.tsx
+++ b/src/routes/_app/patient/_layout.book.tsx
@@ -199,7 +199,7 @@ function PatientBooking() {
       });
       toast.success(t("patientPortal.booking.success"));
       navigate({ to: "/patient/appointments" });
-    } catch (err: unknown) {
+    } catch (err) {
       const message = err instanceof Error ? err.message : "Booking failed";
       toast.error(message);
     } finally {

--- a/src/routes/_app/patient/_layout.documents.tsx
+++ b/src/routes/_app/patient/_layout.documents.tsx
@@ -58,8 +58,8 @@ function PatientDocuments() {
       });
       toast.success(t("patientPortal.documents.signed"));
       setSignDocId(null);
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     }
   };
 

--- a/src/routes/_app/patient/_layout.profile.tsx
+++ b/src/routes/_app/patient/_layout.profile.tsx
@@ -56,8 +56,8 @@ function PatientProfile() {
         emergencyContactPhone: emergencyContactPhone || undefined,
       });
       toast.success(t("common.saved"));
-    } catch (e: any) {
-      toast.error(e.message);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setSaving(false);
     }

--- a/src/routes/_app/patient/login.tsx
+++ b/src/routes/_app/patient/login.tsx
@@ -79,7 +79,7 @@ function PatientLogin() {
       await sendOtp({ email, organizationId });
       setStep("otp");
       toast.success(t("patientPortal.login.otpSent"));
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
@@ -98,7 +98,7 @@ function PatientLogin() {
       localStorage.setItem("patientPortalToken", result.sessionToken);
       localStorage.setItem("patientPortalPatientId", result.patientId);
       navigate({ to: "/patient" });
-    } catch (e: unknown) {
+    } catch (e) {
       toast.error(e instanceof Error ? e.message : t("patientPortal.login.errorGeneric"));
     } finally {
       setLoading(false);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #899.

Closes #899

---

## Claude summary

Committed. Summary of work:

Normalized 46 files (134 insertions, 134 deletions) so every `toast.error` catch block uses the canonical pattern from #890/#893/#897/#898:

```ts
} catch (e) {
  toast.error(e instanceof Error ? e.message : String(e));
}
```

Two prior variants were converted: unsafe `catch (e: any) { toast.error(e.message); }` (which renders `undefined` when the thrown value isn't an Error) and the safe-but-stylistically-different `catch (e: unknown) { ... }` (annotation is redundant under strict mode's `useUnknownInCatchVariables`). Where a catch had a meaningful fallback string like `?? "Sync failed"` or `?? t("common.error")`, the fallback is preserved on the right side of the ternary. Existing variable names (`e`/`err`/`error`) are kept to minimize churn.

Three `catch (e: any)` blocks in `sign.$token.tsx`, `csv-import-dialog.tsx`, and `editable-cell.tsx` route to `setError`/`allErrors.push`/`setErrorMessage` rather than `toast.error` — left untouched as out of scope.

Verified with `npm run typecheck`.

## Follow-ups
- Normalize remaining `catch (e: any)` blocks that route to non-toast handlers: 3 occurrences in `src/routes/sign.$token.tsx` (uses `setError`), 1 in `src/components/csv/csv-import-dialog.tsx` (pushes to error list), and 1 in `src/components/data-table/editable-cell.tsx` (uses `setErrorMessage`) still rely on unsafe `err.message` access on `any`-typed errors