### PR TITLE
scroll

### DIFF
--- a/src/components/crm/side-panel.tsx
+++ b/src/components/crm/side-panel.tsx
@@ -49,7 +49,7 @@ export function SidePanel({
           {description && <SheetDescription>{description}</SheetDescription>}
         </SheetHeader>
 
-        <div className="flex-1 overflow-y-auto py-4">{children}</div>
+        <div className="flex-1 overflow-y-auto overscroll-contain py-4">{children}</div>
 
         {onSubmit && (
           <SheetFooter className="border-t pt-4">

--- a/src/index.css
+++ b/src/index.css
@@ -334,6 +334,15 @@ body {
   height: 100dvh;
 }
 
+/* The dashboard layout's <main> is the actual scroll container (body itself has
+   overflow:hidden). Radix's body-scroll-lock therefore has no effect, and wheel
+   events over non-scrollable parts of a modal (overlay, header, footer) leak
+   through and scroll <main> behind the dialog. Lock <main> while any modal
+   dialog/sheet is open. */
+body:has([role="dialog"][aria-modal="true"][data-state="open"]) main {
+  overflow: hidden;
+}
+
 body {
   font-size: 14px;
   font-weight: 400;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #887.

Closes #887

---

## Claude summary

Committed. Summary of what was done and why:

The previous fix (commit c23a821) added `overscroll-contain` on SidePanel's inner scroll area at `src/components/crm/side-panel.tsx:52`. That only prevents wheel-scroll propagation when the inner area actually reaches its scroll boundary. Wheel events over non-scrollable parts of the modal (the overlay region to the left, the SheetHeader, the SheetFooter, or any case where the form content fits without overflow) still bubbled up past the inner div.

Why Radix's built-in body-scroll-lock didn't catch them: `<body>` already has `overflow:hidden` (set in `src/index.css:331-335`), so locking body scroll is a no-op. The actual scroll container in this app is the dashboard layout's `<main className="overflow-y-auto">` (`src/routes/_app/_auth/dashboard/_layout.tsx:804`) — Radix doesn't know about that element, so it kept scrolling.

The new fix in `src/index.css:342-344` uses a CSS `:has()` selector to set `overflow: hidden` on `<main>` whenever any modal dialog or sheet is open (`[role="dialog"][aria-modal="true"][data-state="open"]`). This covers Sheet/Dialog/AlertDialog uniformly and is scoped to modal dialogs only, so non-modal popovers, tooltips, and dropdowns are unaffected. Typecheck passes.