### PR TITLE
scroll

### DIFF
--- a/src/components/crm/side-panel.tsx
+++ b/src/components/crm/side-panel.tsx
@@ -49,7 +49,7 @@ export function SidePanel({
           {description && <SheetDescription>{description}</SheetDescription>}
         </SheetHeader>
 
-        <div className="flex-1 overflow-y-auto py-4">{children}</div>
+        <div className="flex-1 overflow-y-auto overscroll-contain py-4">{children}</div>
 
         {onSubmit && (
           <SheetFooter className="border-t pt-4">

--- a/src/index.css
+++ b/src/index.css
@@ -334,6 +334,15 @@ body {
   height: 100dvh;
 }
 
+/* The dashboard layout's <main> is the actual scroll container (body itself has
+   overflow:hidden). Radix's body-scroll-lock therefore has no effect, and wheel
+   events over non-scrollable parts of a modal (overlay, header, footer) leak
+   through and scroll <main> behind the dialog. Lock <main> while any modal
+   dialog/sheet is open. */
+body:has([role="dialog"][aria-modal="true"][data-state="open"]) main {
+  overflow: hidden;
+}
+
 body {
   font-size: 14px;
   font-weight: 400;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #887.

Closes #887

---

## Claude summary

NOT_A_BUG: This issue is already closed and both fixes are present on the current branch (and on `main`). The user's last complaint (`znowu się scroluje` at 12:33Z) was addressed by PR #907 at 12:58Z, and aslocka has not posted again to indicate the second fix didn't take.

Current state I verified on `claude/issue-887`:

1. `src/components/crm/side-panel.tsx:52` — the inner scroll area has `overflow-y-auto overscroll-contain py-4`, which prevents wheel events from leaking once the panel's scroll area hits its boundary (commit c23a821, PR #889).

2. `src/index.css:342-344` — a `:has()` rule locks the dashboard's actual scroll container (`<main>`) whenever any modal dialog/sheet is open:
   ```css
   body:has([role="dialog"][aria-modal="true"][data-state="open"]) main {
     overflow: hidden;
   }
   ```
   (commit 52ef69f, also rolled up into PR #907.) This is the fix that catches the cases the first one couldn't: wheel events over the overlay, the header, the footer, or a fitting-without-overflow form.

The targeted dialog — the treatment form on `/dashboard/gabinet/treatments` — uses `SidePanel` (`src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx:557`), which is the Radix Sheet that both fixes cover. The Sheet uses `@radix-ui/react-dialog` (`src/components/ui/sheet.tsx:4`), which sets `role="dialog"`, `aria-modal="true"`, and `data-state` automatically, so the selector matches.

Chrome 148 (the user's browser) supports `:has()`, so the rule will apply. If aslocka tests again after the merge and still sees `<main>` scrolling behind the open treatment dialog, that would be a fresh report worth investigating — for example, a non-modal popover/menu that doesn't carry `aria-modal="true"`, or a different "okienko" on the page that isn't a Radix dialog at all (e.g. a `Popover`, `DropdownMenu`, or HoverCard). Without a follow-up message from the user, there is nothing left to fix here.

Nothing committed.