### PR TITLE
Normalize remaining `catch (e

### DIFF
--- a/src/components/csv/csv-import-dialog.tsx
+++ b/src/components/csv/csv-import-dialog.tsx
@@ -196,8 +196,8 @@ export function CsvImportDialog({
         allErrors.push(
           ...result.errors.map((e) => ({ ...e, row: e.row + i }))
         );
-      } catch (e: any) {
-        allErrors.push({ row: i, error: e.message ?? "Batch failed" });
+      } catch (e) {
+        allErrors.push({ row: i, error: e instanceof Error ? e.message : "Batch failed" });
       }
       setProgress(Math.min(i + BATCH_SIZE, records.length));
     }

--- a/src/components/data-table/editable-cell.tsx
+++ b/src/components/data-table/editable-cell.tsx
@@ -95,8 +95,8 @@ export function EditableCell({
       await onChange(v);
       setErrorMessage(null);
       setActive(false);
-    } catch (e: any) {
-      setErrorMessage(e.message || "Save failed");
+    } catch (e) {
+      setErrorMessage(e instanceof Error ? e.message : "Save failed");
     } finally {
       setSaving(false);
     }

--- a/src/routes/sign.$token.tsx
+++ b/src/routes/sign.$token.tsx
@@ -148,8 +148,8 @@ function SigningFlow({
     try {
       await requestOtp({ token });
       setOtpSent(true);
-    } catch (err: any) {
-      setError(err.message ?? "Nie udało się wysłać kodu");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Nie udało się wysłać kodu");
     } finally {
       setLoading(false);
     }
@@ -162,8 +162,8 @@ function SigningFlow({
       await verifyOtp({ token, code: otpCode });
       setOtpVerified(true);
       setStep("sign");
-    } catch (err: any) {
-      setError(err.message ?? "Nieprawidłowy kod");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Nieprawidłowy kod");
     } finally {
       setLoading(false);
     }
@@ -176,8 +176,8 @@ function SigningFlow({
       try {
         await signExternal({ token, signatureData });
         setStep("done");
-      } catch (err: any) {
-        setError(err.message ?? "Nie udało się podpisać dokumentu");
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Nie udało się podpisać dokumentu");
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #904.

Closes #904

---

## Claude summary

Committed as `776b415`. Normalized the five remaining `catch (err: any)` blocks in `sign.$token.tsx` (3), `csv-import-dialog.tsx` (1), and `editable-cell.tsx` (1) to use the canonical `catch (err) { ... err instanceof Error ? err.message : "fallback" ... }` pattern. Verified `npm run typecheck` passes; `grep` confirms no `catch (X: any)` blocks remain anywhere in `src/`.