### PR TITLE
ukryj

### DIFF
--- a/src/components/layout/app-footer.tsx
+++ b/src/components/layout/app-footer.tsx
@@ -15,6 +15,7 @@ import {
   UserPlus,
 } from "@/lib/ez-icons";
 import { useSidebarActions } from "@/components/layout/sidebar-context";
+import { GabinetQuickActionsDropdown } from "@/components/sidebar-widgets/gabinet/quick-actions-dropdown";
 
 interface FooterAction {
   labelKey: string;
@@ -108,6 +109,8 @@ export function AppFooter() {
   const { openQuickCreate, navigateTo, dispatch } = useSidebarActions();
 
   const isGabinetRoute = !!matchRoute({ to: "/dashboard/gabinet", fuzzy: true });
+  const isGabinetSettingsRoute = !!matchRoute({ to: "/dashboard/gabinet/settings", fuzzy: true });
+  const showGabinetQuickActions = isGabinetRoute && !isGabinetSettingsRoute;
 
   let actions: FooterAction[] = [];
 
@@ -155,6 +158,7 @@ export function AppFooter() {
               {t(action.labelKey)}
             </Button>
           ))}
+          {showGabinetQuickActions && <GabinetQuickActionsDropdown />}
         </div>
       </div>
     </footer>

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -23,7 +23,6 @@ import { CalendarMiniMonth } from "@untitled/app/calendar/base-components/calend
 import { WorkspaceSwitcher } from "@/components/layout/workspace-switcher";
 import { cn } from "@/utils/misc";
 import Logo from "@/assets/svg/logo";
-import { GabinetQuickActionsDropdown } from "@/components/sidebar-widgets/gabinet/quick-actions-dropdown";
 import { DayTimeline } from "@/components/sidebar-widgets/day-timeline";
 import { getModuleById, getVisibleModules, moduleRegistry } from "@/modules/registry";
 
@@ -234,8 +233,6 @@ export function AppSidebar() {
               )}
             </>
           )}
-
-          {activeWorkspace === "gabinet" && !isSettingsRoute && <GabinetQuickActionsDropdown />}
 
           {miniCalState.visible &&
             miniCalState.selectedDate &&

--- a/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
+++ b/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
@@ -27,83 +27,79 @@ export function GabinetQuickActionsDropdown() {
   const { openQuickCreate } = useSidebarActions();
 
   return (
-    <div className="border-t px-3 py-2">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="outline" className="w-full gap-2">
-            <Plus className="size-4" />
-            {t("sidebar.gabinet.quickActions", "Szybkie akcje")}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          className="w-60 p-2"
-          side="top"
-          align="center"
-          sideOffset={8}
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="h-7 gap-1 text-xs">
+          <Plus className="mr-1 h-3.5 w-3.5" />
+          {t("sidebar.gabinet.quickActions", "Szybkie akcje")}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="w-60 p-2"
+        side="top"
+        align="end"
+        sideOffset={8}
+      >
+        <DropdownMenuItem
+          className="px-3 py-2.5 text-sm"
+          onSelect={() => openQuickCreate("appointment")}
         >
-          {/* Create actions — open modals */}
-          <DropdownMenuItem
-            className="px-3 py-2.5 text-sm"
-            onSelect={() => openQuickCreate("appointment")}
-          >
-            <CalendarCheck className="text-foreground size-5" />
-            {t("sidebar.gabinet.bookAppointment", "Umów wizytę")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="px-3 py-2.5 text-sm"
-            onSelect={() => openQuickCreate("patient")}
-          >
-            <UserPlus className="text-foreground size-5" />
-            {t("sidebar.gabinet.addPatient", "Dodaj klienta")}
-          </DropdownMenuItem>
+          <CalendarCheck className="text-foreground size-5" />
+          {t("sidebar.gabinet.bookAppointment", "Umów wizytę")}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="px-3 py-2.5 text-sm"
+          onSelect={() => openQuickCreate("patient")}
+        >
+          <UserPlus className="text-foreground size-5" />
+          {t("sidebar.gabinet.addPatient", "Dodaj klienta")}
+        </DropdownMenuItem>
 
-          <DropdownMenuSeparator />
+        <DropdownMenuSeparator />
 
-          {/* Navigation actions */}
-          <DropdownMenuItem
-            className="px-3 py-2.5 text-sm"
-            onSelect={() => navigate({ to: "/dashboard/gabinet/calendar" })}
-          >
-            <Calendar className="text-foreground size-5" />
-            {t("sidebar.gabinet.goToCalendar", "Kalendarz")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="px-3 py-2.5 text-sm"
-            onSelect={() => navigate({ to: "/dashboard/gabinet/patients" })}
-          >
-            <Users className="text-foreground size-5" />
-            {t("sidebar.gabinet.goToPatients", "Klienci")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="px-3 py-2.5 text-sm"
-            onSelect={() => navigate({ to: "/dashboard/gabinet/treatments" })}
-          >
-            <Stethoscope className="text-foreground size-5" />
-            {t("sidebar.gabinet.goToTreatments", "Zabiegi")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="px-3 py-2.5 text-sm"
-            onSelect={() => navigate({ to: "/dashboard/gabinet/packages" })}
-          >
-            <Package className="text-foreground size-5" />
-            {t("sidebar.gabinet.goToPackages", "Pakiety")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="px-3 py-2.5 text-sm"
-            onSelect={() => navigate({ to: "/dashboard/gabinet/documents" })}
-          >
-            <FileText className="text-foreground size-5" />
-            {t("sidebar.gabinet.goToDocuments", "Dokumenty")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="px-3 py-2.5 text-sm"
-            onSelect={() => navigate({ to: "/dashboard/gabinet/settings/scheduling" })}
-          >
-            <Settings className="text-foreground size-5" />
-            {t("sidebar.gabinet.goToSettings", "Ustawienia")}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+        <DropdownMenuItem
+          className="px-3 py-2.5 text-sm"
+          onSelect={() => navigate({ to: "/dashboard/gabinet/calendar" })}
+        >
+          <Calendar className="text-foreground size-5" />
+          {t("sidebar.gabinet.goToCalendar", "Kalendarz")}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="px-3 py-2.5 text-sm"
+          onSelect={() => navigate({ to: "/dashboard/gabinet/patients" })}
+        >
+          <Users className="text-foreground size-5" />
+          {t("sidebar.gabinet.goToPatients", "Klienci")}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="px-3 py-2.5 text-sm"
+          onSelect={() => navigate({ to: "/dashboard/gabinet/treatments" })}
+        >
+          <Stethoscope className="text-foreground size-5" />
+          {t("sidebar.gabinet.goToTreatments", "Zabiegi")}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="px-3 py-2.5 text-sm"
+          onSelect={() => navigate({ to: "/dashboard/gabinet/packages" })}
+        >
+          <Package className="text-foreground size-5" />
+          {t("sidebar.gabinet.goToPackages", "Pakiety")}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="px-3 py-2.5 text-sm"
+          onSelect={() => navigate({ to: "/dashboard/gabinet/documents" })}
+        >
+          <FileText className="text-foreground size-5" />
+          {t("sidebar.gabinet.goToDocuments", "Dokumenty")}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="px-3 py-2.5 text-sm"
+          onSelect={() => navigate({ to: "/dashboard/gabinet/settings/scheduling" })}
+        >
+          <Settings className="text-foreground size-5" />
+          {t("sidebar.gabinet.goToSettings", "Ustawienia")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #909.

Closes #909

---

## Claude summary

Committed. Summary of changes for issue #909:

The "+ Szybkie akcje" dropdown was previously pinned to the bottom of the contextual sidebar on every Gabinet page (`src/components/layout/app-sidebar.tsx:238`). I moved the trigger button into the sticky `AppFooter` (the "dolne menu") so it sits alongside the route-specific action buttons there.

Changes:
- `src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx` — removed the sidebar-specific wrapper (`border-t px-3 py-2` + `w-full` button) and restyled the trigger to match footer buttons (`size="sm"`, `h-7 text-xs`, `align="end"`).
- `src/components/layout/app-sidebar.tsx` — removed import and render of `GabinetQuickActionsDropdown`.
- `src/components/layout/app-footer.tsx` — render `GabinetQuickActionsDropdown` after the contextual buttons when on a Gabinet route (but not on Gabinet settings, matching prior behavior).