### PR TITLE
dodaj

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -67,7 +67,9 @@
     "actionCannotBeUndone": "This action cannot be undone",
     "module": "Module",
     "optional": "optional",
-    "continue": "Continue"
+    "continue": "Continue",
+    "selectAll": "Select all",
+    "deselectAll": "Deselect all"
   },
   "nav": {
     "deals": "Deals",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -67,7 +67,9 @@
     "actionCannotBeUndone": "Tej operacji nie można cofnąć",
     "module": "Moduł",
     "optional": "opcjonalnie",
-    "continue": "Dalej"
+    "continue": "Dalej",
+    "selectAll": "Zaznacz wszystkie",
+    "deselectAll": "Odznacz wszystkie"
   },
   "nav": {
     "deals": "Transakcje",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -573,6 +573,33 @@ function CreateEmployeeSheet({
               </div>
             )}
             <div className="max-h-48 overflow-y-auto rounded-md border p-2 space-y-1">
+              {filteredTreatments.length > 0 && (
+                <label className="flex items-center gap-2 text-sm font-medium cursor-pointer border-b pb-1 mb-1">
+                  <Checkbox
+                    checked={
+                      filteredTreatments.every((tr) => selectedTreatments.includes(tr._id))
+                        ? true
+                        : filteredTreatments.some((tr) => selectedTreatments.includes(tr._id))
+                          ? "indeterminate"
+                          : false
+                    }
+                    onCheckedChange={(checked) => {
+                      const visibleIds = filteredTreatments.map((tr) => tr._id);
+                      if (checked === true) {
+                        setSelectedTreatments(
+                          Array.from(new Set([...selectedTreatments, ...visibleIds])),
+                        );
+                      } else {
+                        const visibleSet = new Set(visibleIds);
+                        setSelectedTreatments(
+                          selectedTreatments.filter((id) => !visibleSet.has(id)),
+                        );
+                      }
+                    }}
+                  />
+                  {t("common.selectAll")}
+                </label>
+              )}
               {filteredTreatments.map((tr) => (
                 <label key={tr._id} className="flex items-center gap-2 text-sm cursor-pointer">
                   <Checkbox


### PR DESCRIPTION
Auto-generated by Claude in response to issue #916.

Closes #916

---

## Claude summary

Added a "Zaznacz wszystkie" (Select all) checkbox at the top of the Kwalifikacje zabiegowe (Qualified treatments) list in the Create Employee sheet at `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx:576`. 

Behavior: it shows checked/unchecked/indeterminate based on how many of the currently visible (search-filtered) treatments are selected, and toggling it selects or deselects only the visible items, leaving any selections outside the search untouched. Added `common.selectAll` and `common.deselectAll` to both PL and EN translation files. Committed as `87fa661`.