### PR TITLE
zmiana

### DIFF
--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -11,7 +11,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "grid place-content-center peer h-4 w-4 shrink-0 rounded-[3px] border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
       className
     )}
     {...props}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #921.

Closes #921

---

## Claude summary

Fixed and committed.

Root cause: the project sets `--radius: 0.775rem` in src/index.css:231, and Tailwind's `rounded-sm` is defined as `calc(var(--radius) - 4px)` ≈ 8.4px. Applied to the 16px Checkbox in src/components/ui/checkbox.tsx, the radius exceeds half the side length, so the checkbox renders as a perfect circle — exactly what the user pointed at in the screenshot (the "Zaznacz wszystkie" / treatment list circles in the Add Employee sheet).

Fix: replaced `rounded-sm` with `rounded-[3px]` in the Checkbox primitive. Since the same component is used in 34 places across CRM and Gabinet, this corrects the appearance globally without per-page changes.