### PR TITLE
tło

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -574,7 +574,7 @@ function CreateEmployeeSheet({
             )}
             <div className="max-h-48 overflow-y-auto rounded-md border p-2 space-y-1">
               {filteredTreatments.length > 0 && (
-                <label className="flex items-center gap-2 text-sm font-medium cursor-pointer border-b pb-1 mb-1">
+                <label className="-mx-2 -mt-2 mb-1 flex items-center gap-2 rounded-t bg-muted/60 px-3 py-2 text-sm font-medium cursor-pointer border-b">
                   <Checkbox
                     checked={
                       filteredTreatments.every((tr) => selectedTreatments.includes(tr._id))


### PR DESCRIPTION
Auto-generated by Claude in response to issue #923.

Closes #923

---

## Claude summary

Committed. The "Zaznacz wszystkie" row in the qualified treatments picker (inside the Add Employee sheet at `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx:577`) now has a `bg-muted/60` background extending to the container edges, so it visually reads as a header row separated from the treatment list below it.