### PR TITLE
wyrównaj

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -574,7 +574,7 @@ function CreateEmployeeSheet({
             )}
             <div className="max-h-48 overflow-y-auto rounded-md border p-2 space-y-1">
               {filteredTreatments.length > 0 && (
-                <label className="-mx-2 -mt-2 mb-1 flex items-center gap-2 rounded-t bg-muted/60 px-3 py-2 text-sm font-medium cursor-pointer border-b">
+                <label className="-mx-2 -mt-2 mb-1 flex items-center gap-2 rounded-t bg-muted/60 px-2 py-2 text-sm font-medium cursor-pointer border-b">
                   <Checkbox
                     checked={
                       filteredTreatments.every((tr) => selectedTreatments.includes(tr._id))


### PR DESCRIPTION
Auto-generated by Claude in response to issue #926.

Closes #926

---

## Claude summary

Committed the fix.

In the "Add employee" sheet, the qualified-treatments list parent uses `p-2` (8px) padding. The "Zaznacz wszystkie" header label has `-mx-2 ... px-3`, which puts its checkbox at 12px from the container edge, while the treatment item labels (no padding) sit at 8px — a 4px horizontal offset. Changed `px-3` to `px-2` so the select-all checkbox lines up vertically with the item checkboxes below it. The bg/border-b/font-medium styling for the header row is preserved.