### PR TITLE
Surface indicators in the appointment detail/preview popover

### DIFF
--- a/src/components/gabinet/calendar/appointment-card.tsx
+++ b/src/components/gabinet/calendar/appointment-card.tsx
@@ -1,4 +1,11 @@
 import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
+import {
+  AppointmentIndicatorBadge,
+  type AppointmentIndicator,
+  type AppointmentIndicatorKind,
+} from "./appointment-indicators";
+
+export type { AppointmentIndicator, AppointmentIndicatorKind };
 
 export interface AppointmentTag {
   name: string;
@@ -13,6 +20,7 @@ interface AppointmentCardProps {
   status: string;
   color?: string;
   tags?: AppointmentTag[];
+  indicators?: AppointmentIndicator[];
   onClick?: () => void;
 }
 
@@ -24,6 +32,7 @@ export function AppointmentCard({
   status,
   color,
   tags,
+  indicators,
   onClick,
 }: AppointmentCardProps) {
   const cls = appointmentStatusBadgeClass(status);
@@ -37,14 +46,21 @@ export function AppointmentCard({
     >
       <div className="flex items-center justify-between gap-1 bg-black/30 px-2 py-0.5 font-semibold dark:bg-black/50">
         <span className="truncate">{startTime}–{endTime}</span>
-        {tags && tags.length > 0 && (
+        {((tags && tags.length > 0) || (indicators && indicators.length > 0)) && (
           <div className="flex shrink-0 items-center gap-0.5">
-            {tags.map((tag, i) => (
+            {tags?.map((tag, i) => (
               <span
-                key={`${tag.name}-${i}`}
+                key={`tag-${tag.name}-${i}`}
                 title={tag.name}
                 className="inline-block h-1.5 w-1.5 rounded-full ring-1 ring-white/60"
                 style={{ backgroundColor: tag.color }}
+              />
+            ))}
+            {indicators?.map((ind, i) => (
+              <AppointmentIndicatorBadge
+                key={`ind-${ind.kind}-${i}`}
+                indicator={ind}
+                className="ring-white/60"
               />
             ))}
           </div>

--- a/src/components/gabinet/calendar/appointment-indicators.tsx
+++ b/src/components/gabinet/calendar/appointment-indicators.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@/lib/utils";
+
+export type AppointmentIndicatorKind = "firstVisit" | "payment" | "count";
+
+export interface AppointmentIndicator {
+  kind: AppointmentIndicatorKind;
+  label: string;
+  title?: string;
+}
+
+const INDICATOR_CLASS: Record<AppointmentIndicatorKind, string> = {
+  firstVisit: "bg-emerald-500 text-white",
+  payment: "bg-amber-500 text-white",
+  count: "bg-sky-500 text-white",
+};
+
+interface AppointmentIndicatorBadgeProps {
+  indicator: AppointmentIndicator;
+  /** Extra classes — typically used to switch the ring color between the dark
+   * calendar card header (ring-white/60) and lighter surfaces like the preview
+   * popover (ring-black/10). */
+  className?: string;
+}
+
+export function AppointmentIndicatorBadge({
+  indicator,
+  className,
+}: AppointmentIndicatorBadgeProps) {
+  return (
+    <span
+      title={indicator.title ?? indicator.label}
+      className={cn(
+        "inline-flex h-3.5 min-w-3.5 items-center justify-center rounded-sm px-0.5 text-[9px] font-bold leading-none ring-1",
+        INDICATOR_CLASS[indicator.kind],
+        className,
+      )}
+    >
+      {indicator.label}
+    </span>
+  );
+}

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -69,6 +69,14 @@ import {
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useSidebarActions } from "@/components/layout/sidebar-context";
+import {
+  useSupabaseGabinetFirstAppointmentIdsByPatient,
+  useSupabaseGabinetAppointmentPackagePositions,
+} from "@/hooks/use-supabase-gabinet-appointments";
+import {
+  AppointmentIndicatorBadge,
+  type AppointmentIndicator,
+} from "./appointment-indicators";
 
 const VALID_TRANSITIONS: Record<string, string[]> = {
   pending_confirmation: ["scheduled", "confirmed", "cancelled"],
@@ -145,6 +153,29 @@ export function AppointmentPreviewContent({
     queryFn: () => listActiveTreatments({ organizationId }),
     enabled: !!organizationId,
   }) as { data: Array<{ _id: string; name: string; duration: number }> | undefined };
+
+  // Mirror the indicator logic from the calendar card so the popover surfaces
+  // the same "first visit", "payment due" and "X/Y" badges. Hook calls happen
+  // unconditionally; the hooks themselves no-op when the input arrays are
+  // empty. Inputs are derived from the loaded `detail` payload below.
+  const indicatorPatientIds = detail?.patient?._id
+    ? [String(detail.patient._id)]
+    : [];
+  const indicatorPackageIds = detail?.appointment?.packageUsageId
+    ? [String(detail.appointment.packageUsageId)]
+    : [];
+
+  const { data: firstAppointmentIds } =
+    useSupabaseGabinetFirstAppointmentIdsByPatient(
+      organizationId,
+      indicatorPatientIds,
+    );
+
+  const { data: packagePositions } =
+    useSupabaseGabinetAppointmentPackagePositions(
+      organizationId,
+      indicatorPackageIds,
+    );
 
   const [status, setStatus] = useState<AppointmentStatus | "">("");
   const [date, setDate] = useState("");
@@ -240,6 +271,51 @@ export function AppointmentPreviewContent({
     if (!q) return all;
     return all.filter((tr) => (tr.name ?? "").toLowerCase().includes(q));
   })();
+
+  const indicators: AppointmentIndicator[] = [];
+  // First-visit badge — only for non-cancelled/no-show appointments and only
+  // when this is the patient's earliest known appointment.
+  if (
+    appointment.status !== "cancelled" &&
+    appointment.status !== "no_show" &&
+    firstAppointmentIds?.has(String(appointment._id))
+  ) {
+    indicators.push({
+      kind: "firstVisit",
+      label: "1",
+      title: t("gabinet.calendar.indicators.firstVisit", "Pierwsza wizyta"),
+    });
+  }
+  if (appointment.prepaymentRequired && appointment.prepaymentStatus !== "paid") {
+    indicators.push({
+      kind: "payment",
+      label: "$",
+      title: t("gabinet.calendar.indicators.paymentDue", "Do zapłacenia"),
+    });
+  }
+  const pkgPos = appointment.packageUsageId
+    ? packagePositions?.get(String(appointment._id))
+    : undefined;
+  if (pkgPos) {
+    indicators.push({
+      kind: "count",
+      label: `${pkgPos.position}/${pkgPos.total}`,
+      title: t("gabinet.calendar.indicators.packageVisit", "Wizyta pakietowa"),
+    });
+  } else if (appointment.isRecurring && appointment.recurringRule) {
+    const rule = appointment.recurringRule as { count?: number };
+    if (typeof rule.count === "number" && rule.count > 0) {
+      const pos = (appointment.recurringIndex ?? 0) + 1;
+      indicators.push({
+        kind: "count",
+        label: `${pos}/${rule.count}`,
+        title: t(
+          "gabinet.calendar.indicators.recurringVisit",
+          "Wizyta cykliczna",
+        ),
+      });
+    }
+  }
 
   const phoneDirty =
     isEditingPhone &&
@@ -544,12 +620,21 @@ export function AppointmentPreviewContent({
               </PopoverContent>
             </Popover>
           </div>
-          <Badge variant="outline" className="shrink-0 text-[10px]">
-            <span
-              className={`mr-1 inline-block h-1.5 w-1.5 rounded-full ${STATUS_DOT_COLORS[initialStatus] ?? "bg-muted-foreground"}`}
-            />
-            {t(`gabinet.appointments.statuses.${initialStatus}`)}
-          </Badge>
+          <div className="flex shrink-0 items-center gap-1">
+            {indicators.map((ind, i) => (
+              <AppointmentIndicatorBadge
+                key={`ind-${ind.kind}-${i}`}
+                indicator={ind}
+                className="ring-black/10"
+              />
+            ))}
+            <Badge variant="outline" className="shrink-0 text-[10px]">
+              <span
+                className={`mr-1 inline-block h-1.5 w-1.5 rounded-full ${STATUS_DOT_COLORS[initialStatus] ?? "bg-muted-foreground"}`}
+              />
+              {t(`gabinet.appointments.statuses.${initialStatus}`)}
+            </Badge>
+          </div>
         </div>
 
         {/* Quick contact links */}

--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -5,6 +5,12 @@ import { DroppableSlot } from "./droppable-slot";
 import { useDragToCreate } from "./use-drag-to-create";
 import { useCurrentTime } from "@/hooks/use-current-time";
 
+interface AppointmentIndicator {
+  kind: "firstVisit" | "payment" | "count";
+  label: string;
+  title?: string;
+}
+
 interface Appointment {
   _id: string;
   startTime: string;
@@ -14,6 +20,7 @@ interface Appointment {
   status: string;
   color?: string;
   tags?: Array<{ name: string; color: string }>;
+  indicators?: AppointmentIndicator[];
 }
 
 interface CalendarDayViewProps {

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -6,6 +6,12 @@ import { DroppableSlot } from "./droppable-slot";
 import { useDragToCreate } from "./use-drag-to-create";
 import { useCurrentTime } from "@/hooks/use-current-time";
 
+interface AppointmentIndicator {
+  kind: "firstVisit" | "payment" | "count";
+  label: string;
+  title?: string;
+}
+
 interface Appointment {
   _id: string;
   date: string;
@@ -16,6 +22,7 @@ interface Appointment {
   status: string;
   color?: string;
   tags?: Array<{ name: string; color: string }>;
+  indicators?: AppointmentIndicator[];
 }
 
 interface CalendarWeekViewProps {

--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -5,7 +5,11 @@ import {
   PopoverAnchor,
   PopoverContent,
 } from "@/components/ui/popover";
-import { AppointmentCard, type AppointmentTag } from "./appointment-card";
+import {
+  AppointmentCard,
+  type AppointmentTag,
+  type AppointmentIndicator,
+} from "./appointment-card";
 import { AppointmentPreviewContent } from "./appointment-preview-content";
 
 interface Appointment {
@@ -18,6 +22,7 @@ interface Appointment {
   status: string;
   color?: string;
   tags?: AppointmentTag[];
+  indicators?: AppointmentIndicator[];
 }
 
 interface DraggableAppointmentProps extends Appointment {
@@ -47,6 +52,7 @@ export function DraggableAppointment({
   status,
   color,
   tags,
+  indicators,
   onResize,
   hourHeight = 60,
   snapMinutes = 15,
@@ -140,6 +146,7 @@ export function DraggableAppointment({
         status={status}
         color={color}
         tags={tags}
+        indicators={indicators}
         onClick={handleCardClick}
       />
       {onResize && status !== "blocked" && (

--- a/src/hooks/use-supabase-gabinet-appointments.ts
+++ b/src/hooks/use-supabase-gabinet-appointments.ts
@@ -200,6 +200,168 @@ export function useSupabaseGabinetRecentVisitPatientIds(
 }
 
 // ---------------------------------------------------------------------------
+// Earliest Appointment IDs per Patient (for first-visit indicator)
+// ---------------------------------------------------------------------------
+
+/**
+ * For a given set of patient IDs, returns the IDs of the chronologically first
+ * non-cancelled, non-no-show appointment for each patient. Used by the gabinet
+ * calendar to render a "first visit" indicator on the appointment card.
+ *
+ * Disabled when `patientIds` is empty.
+ */
+export function useSupabaseGabinetFirstAppointmentIdsByPatient(
+  organizationId: string,
+  patientIds: string[],
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  const stableIds = [...patientIds].sort();
+
+  return useQuery<Set<string>, Error>({
+    queryKey: [
+      ...supabaseKeys.gabinetAppointments.list(organizationId),
+      "firstAppointmentIdsByPatient",
+      stableIds.join(","),
+    ],
+    queryFn: async (): Promise<Set<string>> => {
+      if (!client) throw new Error("Supabase client not ready");
+      if (stableIds.length === 0) return new Set();
+
+      const { data, error } = await client
+        .from("gabinet_appointments")
+        .select("id, patient_id, date, start_time")
+        .eq("organization_id", organizationId)
+        .in("patient_id", stableIds)
+        .not("status", "in", '("cancelled","no_show")')
+        .order("date", { ascending: true })
+        .order("start_time", { ascending: true });
+
+      if (error) throw error;
+
+      const firstIds = new Set<string>();
+      const seen = new Set<string>();
+      for (const row of (data ?? []) as {
+        id: string;
+        patient_id: string;
+      }[]) {
+        if (seen.has(row.patient_id)) continue;
+        seen.add(row.patient_id);
+        firstIds.add(row.id);
+      }
+      return firstIds;
+    },
+    enabled:
+      enabled &&
+      isReady &&
+      !!organizationId &&
+      stableIds.length > 0,
+  } satisfies UseQueryOptions<Set<string>, Error>);
+}
+
+// ---------------------------------------------------------------------------
+// Appointment Positions Within Package Usages
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns, for each appointment that belongs to one of the given package usage
+ * records, its 1-based position among non-cancelled appointments sharing the
+ * same package usage. Used by the gabinet calendar to render a "visit X / Y"
+ * indicator for package-bound appointments.
+ *
+ * The total Y is computed by summing all `totalCount`/`totalAllowed` values
+ * across the matching `gabinet_package_usage` row's `treatments_used` array.
+ */
+export interface AppointmentPackagePosition {
+  position: number;
+  total: number;
+}
+
+export function useSupabaseGabinetAppointmentPackagePositions(
+  organizationId: string,
+  packageUsageIds: string[],
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  const stableIds = [...packageUsageIds].sort();
+
+  return useQuery<Map<string, AppointmentPackagePosition>, Error>({
+    queryKey: [
+      ...supabaseKeys.gabinetAppointments.list(organizationId),
+      "packagePositions",
+      stableIds.join(","),
+    ],
+    queryFn: async (): Promise<Map<string, AppointmentPackagePosition>> => {
+      const result = new Map<string, AppointmentPackagePosition>();
+      if (!client) throw new Error("Supabase client not ready");
+      if (stableIds.length === 0) return result;
+
+      const [usageRes, apptRes] = await Promise.all([
+        client
+          .from("gabinet_package_usage")
+          .select("id, treatments_used")
+          .eq("organization_id", organizationId)
+          .in("id", stableIds),
+        client
+          .from("gabinet_appointments")
+          .select("id, package_usage_id, date, start_time")
+          .eq("organization_id", organizationId)
+          .in("package_usage_id", stableIds)
+          .not("status", "in", '("cancelled","no_show")')
+          .order("date", { ascending: true })
+          .order("start_time", { ascending: true }),
+      ]);
+
+      if (usageRes.error) throw usageRes.error;
+      if (apptRes.error) throw apptRes.error;
+
+      // Sum totals per package usage from the treatments_used JSONB.
+      const totalsByUsage = new Map<string, number>();
+      for (const u of (usageRes.data ?? []) as {
+        id: string;
+        treatments_used: unknown;
+      }[]) {
+        const entries = Array.isArray(u.treatments_used)
+          ? (u.treatments_used as Array<{
+              totalCount?: number;
+              totalAllowed?: number;
+            }>)
+          : [];
+        const total = entries.reduce(
+          (s, e) => s + (Number(e.totalCount ?? e.totalAllowed ?? 0) || 0),
+          0,
+        );
+        if (total > 0) totalsByUsage.set(u.id, total);
+      }
+
+      // Walk appointments in chronological order and assign positions.
+      const counter = new Map<string, number>();
+      for (const a of (apptRes.data ?? []) as {
+        id: string;
+        package_usage_id: string;
+      }[]) {
+        const total = totalsByUsage.get(a.package_usage_id);
+        if (!total) continue;
+        const next = (counter.get(a.package_usage_id) ?? 0) + 1;
+        counter.set(a.package_usage_id, next);
+        result.set(a.id, { position: next, total });
+      }
+
+      return result;
+    },
+    enabled:
+      enabled &&
+      isReady &&
+      !!organizationId &&
+      stableIds.length > 0,
+  } satisfies UseQueryOptions<Map<string, AppointmentPackagePosition>, Error>);
+}
+
+// ---------------------------------------------------------------------------
 // Single Appointment
 // ---------------------------------------------------------------------------
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -42,7 +42,11 @@ import { AppointmentCard } from "@/components/gabinet/calendar/appointment-card"
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { toast } from "sonner";
 import type { Id } from "@cvx/_generated/dataModel";
-import { useSupabaseGabinetAppointmentsByDateRange } from "@/hooks/use-supabase-gabinet-appointments";
+import {
+  useSupabaseGabinetAppointmentsByDateRange,
+  useSupabaseGabinetFirstAppointmentIdsByPatient,
+  useSupabaseGabinetAppointmentPackagePositions,
+} from "@/hooks/use-supabase-gabinet-appointments";
 import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
@@ -147,6 +151,11 @@ function GabinetCalendarPage() {
     status: string;
     color?: string;
     tags?: Array<{ name: string; color: string }>;
+    indicators?: Array<{
+      kind: "firstVisit" | "payment" | "count";
+      label: string;
+      title?: string;
+    }>;
   } | null>(null);
 
   // Mutations
@@ -392,8 +401,40 @@ function GabinetCalendarPage() {
     [leavesByDate],
   );
 
+  // Distinct patient + package usage IDs from the rendered range — used to
+  // compute the "first visit" and "visit X/Y" indicators on appointment cards.
+  const indicatorLookupIds = useMemo(() => {
+    const patientIds = new Set<string>();
+    const packageUsageIds = new Set<string>();
+    for (const a of rawAppointments ?? []) {
+      if (a.patientId) patientIds.add(a.patientId);
+      if (a.packageUsageId) packageUsageIds.add(a.packageUsageId);
+    }
+    return {
+      patientIds: Array.from(patientIds),
+      packageUsageIds: Array.from(packageUsageIds),
+    };
+  }, [rawAppointments]);
+
+  const { data: firstAppointmentIds } =
+    useSupabaseGabinetFirstAppointmentIdsByPatient(
+      organizationId,
+      indicatorLookupIds.patientIds,
+    );
+
+  const { data: packagePositions } =
+    useSupabaseGabinetAppointmentPackagePositions(
+      organizationId,
+      indicatorLookupIds.packageUsageIds,
+    );
+
   // Transform and filter appointments for view components
   const viewAppointments = useMemo(() => {
+    type Indicator = {
+      kind: "firstVisit" | "payment" | "count";
+      label: string;
+      title?: string;
+    };
     const items: Array<{
       _id: string;
       date: string;
@@ -404,6 +445,7 @@ function GabinetCalendarPage() {
       status: string;
       color?: string;
       tags?: Array<{ name: string; color: string }>;
+      indicators?: Indicator[];
     }> = [];
 
     if (rawAppointments) {
@@ -420,6 +462,68 @@ function GabinetCalendarPage() {
         const tags = a.tagIds
           ?.map((id) => tagMap.get(String(id)))
           .filter((t): t is { name: string; color: string } => !!t);
+
+        const indicators: Indicator[] = [];
+
+        // First-visit badge — only for non-cancelled appointments, and only if
+        // this is the patient's earliest known appointment.
+        if (
+          a.status !== "cancelled" &&
+          a.status !== "no_show" &&
+          firstAppointmentIds?.has(a._id)
+        ) {
+          indicators.push({
+            kind: "firstVisit",
+            label: "1",
+            title: t(
+              "gabinet.calendar.indicators.firstVisit",
+              "Pierwsza wizyta",
+            ),
+          });
+        }
+
+        // Payment-due badge — prepayment required but not yet paid.
+        if (a.prepaymentRequired && a.prepaymentStatus !== "paid") {
+          indicators.push({
+            kind: "payment",
+            label: "$",
+            title: t(
+              "gabinet.calendar.indicators.paymentDue",
+              "Do zapłacenia",
+            ),
+          });
+        }
+
+        // Visit-number badge — package position takes precedence over the
+        // recurring index. Falls back to the recurring rule's count when the
+        // appointment is part of a recurring series.
+        const pkgPos = a.packageUsageId
+          ? packagePositions?.get(a._id)
+          : undefined;
+        if (pkgPos) {
+          indicators.push({
+            kind: "count",
+            label: `${pkgPos.position}/${pkgPos.total}`,
+            title: t(
+              "gabinet.calendar.indicators.packageVisit",
+              "Wizyta pakietowa",
+            ),
+          });
+        } else if (a.isRecurring && a.recurringRule) {
+          const rule = a.recurringRule as { count?: number };
+          if (typeof rule.count === "number" && rule.count > 0) {
+            const pos = (a.recurringIndex ?? 0) + 1;
+            indicators.push({
+              kind: "count",
+              label: `${pos}/${rule.count}`,
+              title: t(
+                "gabinet.calendar.indicators.recurringVisit",
+                "Wizyta cykliczna",
+              ),
+            });
+          }
+        }
+
         items.push({
           _id: a._id,
           date: a.date,
@@ -430,6 +534,7 @@ function GabinetCalendarPage() {
           status: a.status,
           color: a.color ?? treatment?.color,
           tags: tags && tags.length > 0 ? tags : undefined,
+          indicators: indicators.length > 0 ? indicators : undefined,
         });
       }
     }
@@ -465,7 +570,7 @@ function GabinetCalendarPage() {
     }
 
     return items;
-  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, tagMap, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
+  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, tagMap, firstAppointmentIds, packagePositions, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
 
   // Build print-friendly appointment data for the current day
   const printDate = formatDateStr(currentDate);
@@ -1053,6 +1158,7 @@ function GabinetCalendarPage() {
               status={activeAppointment.status}
               color={activeAppointment.color}
               tags={activeAppointment.tags}
+              indicators={activeAppointment.indicators}
             />
           </div>
         ) : null}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #730.

Closes #730

---

## Claude summary

Committed `725dddf` on branch `claude/issue-730-v2`. The popover now renders the same first-visit, payment-due and visit-count badges as the calendar card, placed next to the status pill. Indicator computation reuses the same Supabase hooks the calendar route uses (`useSupabaseGabinetFirstAppointmentIdsByPatient`, `useSupabaseGabinetAppointmentPackagePositions`), so the rules stay in lockstep. The badge JSX is extracted to a shared `appointment-indicators.tsx` module — only the ring color differs between surfaces (white on dark card header, black/10 on lighter popover).

Lint passes on all touched files. The one TS2589 warning in `appointment-preview-content.tsx` is pre-existing (only the line number shifted because of the import additions); it's a TanStack/Convex type-inference complexity issue unrelated to this change.