### PR TITLE
fix(data-table): keep at least one isRowHeader column visible

### DIFF
--- a/src/components/crm/enhanced-data-table.tsx
+++ b/src/components/crm/enhanced-data-table.tsx
@@ -128,10 +128,20 @@ export function CrmDataTable<TData>({
   const { t } = useTranslation();
 
   // --- Visible columns ---
-  const visibleColumns = useMemo(
-    () => (hiddenColumnIds?.size ? columns.filter((c) => !hiddenColumnIds.has(c.id)) : columns),
-    [columns, hiddenColumnIds],
-  );
+  const visibleColumns = useMemo(() => {
+    const filtered = hiddenColumnIds?.size
+      ? columns.filter((c) => !hiddenColumnIds.has(c.id))
+      : columns;
+    if (filtered.length === 0) return filtered;
+    // React Aria's Table throws "A table must have at least one Column with
+    // isRowHeader" if the user hides the column originally marked as
+    // row-header (typically "name"). Promote the first remaining column so
+    // the table keeps working with any visibility subset.
+    if (!filtered.some((c) => c.isRowHeader)) {
+      return filtered.map((c, i) => (i === 0 ? { ...c, isRowHeader: true } : c));
+    }
+    return filtered;
+  }, [columns, hiddenColumnIds]);
 
   // --- Sorting ---
   const [internalSort, setInternalSort] = useState<SortDescriptor | undefined>(undefined);


### PR DESCRIPTION
Fixes "A table must have at least one Column with the isRowHeader prop set to true" — React Aria error thrown when the user hides the column originally marked as row-header (typically "name"). After the hide, no remaining column had `isRowHeader=true` and the entire table fails to render.

Affected every CrmDataTable page (contacts/leads/companies/patients/treatments/employees/products/documents/activities). User report: "przy tworzeniu zabiegu nowego wywala convex" — wasn't actually a Convex error but a Table render failure on the list page; the create form sits behind it.