### PR TITLE
Fix `npm run test

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "status:dashboard": "npm --prefix status-dashboard run dev",
     "test:e2e": "playwright test",
     "test:unit": "cd convex && vitest run",
-    "test:manifests": "vitest run src/modules/manifest-dispatches.test.ts",
+    "test:manifests": "vitest run --dir . src/modules/manifest-dispatches.test.ts",
     "check:convex-codegen": "node scripts/check-convex-codegen.mjs",
     "test": "npm run test:unit && npm run test:e2e",
     "verify:jwt": "npx tsx scripts/verify-jwt-bridge.ts",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #933.

Closes #933

---

## Claude summary

Fixed and committed. The bug was confirmed: `npm run test:manifests` exited with code 1 ("No test files found") because the root `vitest.config.ts` pins `test.root` to `./convex` and the CLI's positional file filter was being resolved against `convex/` rather than the repo root. Adding `--dir .` makes vitest scan from the repo root so the filter `src/modules/manifest-dispatches.test.ts` resolves correctly. The test now runs and all 4 cases pass.