### PR TITLE
Translate raw backend errors before showing in toast on gabinet treatments page

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2079,6 +2079,15 @@
       "treatment": "Treatment",
       "nudgeFilter": {
         "noPrice": "Showing active treatments with no price or price 0."
+      },
+      "errors": {
+        "createFailed": "Could not create the treatment.",
+        "updateFailed": "Could not update the treatment.",
+        "notFound": "Treatment not found. Refresh the list and try again.",
+        "variantNotFound": "Treatment variant not found.",
+        "permissionDenied": "You don't have permission for this treatment action.",
+        "invalidArguments": "Could not save the treatment — invalid data.",
+        "storage": "Could not save the treatment — storage error. Please try again."
       }
     },
     "treatmentDetail": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2087,6 +2087,15 @@
       "treatment": "Zabieg",
       "nudgeFilter": {
         "noPrice": "Pokazywane są aktywne zabiegi bez ceny lub z ceną 0."
+      },
+      "errors": {
+        "createFailed": "Nie udało się utworzyć zabiegu.",
+        "updateFailed": "Nie udało się zaktualizować zabiegu.",
+        "notFound": "Nie znaleziono zabiegu. Odśwież listę i spróbuj ponownie.",
+        "variantNotFound": "Nie znaleziono wariantu zabiegu.",
+        "permissionDenied": "Brak uprawnień do tej operacji na zabiegu.",
+        "invalidArguments": "Nie udało się zapisać zabiegu — nieprawidłowe dane.",
+        "storage": "Nie udało się zapisać zabiegu — błąd magazynu danych. Spróbuj ponownie."
       }
     },
     "treatmentDetail": {

--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -126,3 +126,56 @@ export function formatAppointmentError(
   }
   return t(fallback.key, { defaultValue: fallback.defaultValue });
 }
+
+const TREATMENT_ERROR_MAP: Array<{
+  test: (msg: string) => boolean;
+  key: string;
+  fallback: string;
+}> = [
+  {
+    test: (m) => /treatment not found/i.test(m),
+    key: "gabinet.treatments.errors.notFound",
+    fallback: "Nie znaleziono zabiegu. Odśwież listę i spróbuj ponownie.",
+  },
+  {
+    test: (m) => /variant not found|parent treatment not found/i.test(m),
+    key: "gabinet.treatments.errors.variantNotFound",
+    fallback: "Nie znaleziono wariantu zabiegu.",
+  },
+  {
+    test: (m) => /permission denied/i.test(m),
+    key: "gabinet.treatments.errors.permissionDenied",
+    fallback: "Brak uprawnień do tej operacji na zabiegu.",
+  },
+  {
+    test: (m) =>
+      /argumentvalidationerror|value does not match validator|invalid input syntax|violates .* constraint|column .* does not exist|null value in column/i.test(
+        m,
+      ),
+    key: "gabinet.treatments.errors.invalidArguments",
+    fallback: "Nie udało się zapisać zabiegu — nieprawidłowe dane.",
+  },
+  {
+    test: (m) => /supabasedb\.(get|getmany|patch|delete|insert|query)/i.test(m),
+    key: "gabinet.treatments.errors.storage",
+    fallback: "Nie udało się zapisać zabiegu — błąd magazynu danych. Spróbuj ponownie.",
+  },
+];
+
+// Convert a Convex action error from the treatments domain into a
+// user-friendly toast message. Falls back to a provided generic message when
+// nothing matches so raw English Supabase/validator output never reaches end
+// users.
+export function formatTreatmentError(
+  err: unknown,
+  t: TFunction,
+  fallback: { key: string; defaultValue: string },
+): string {
+  const inner = extractActionErrorMessage(err);
+  for (const entry of TREATMENT_ERROR_MAP) {
+    if (entry.test(inner)) {
+      return t(entry.key, { defaultValue: entry.fallback });
+    }
+  }
+  return t(fallback.key, { defaultValue: fallback.defaultValue });
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -37,6 +37,7 @@ import { CategoriesManagerSlideout } from "@/components/categories-tags/categori
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
+import { formatTreatmentError } from "@/lib/format-action-error";
 
 // shadcn/studio statistics blocks
 import StatisticsOrderCard from "@/components/shadcn-studio/blocks/statistics-order-card";
@@ -389,12 +390,21 @@ function TreatmentsIndex() {
         setTagIds([]);
         setCategoryId(undefined);
       } catch (e) {
-        toast.error(e instanceof Error ? e.message : String(e));
+        toast.error(
+          formatTreatmentError(e, t, {
+            key: editingTreatment
+              ? "gabinet.treatments.errors.updateFailed"
+              : "gabinet.treatments.errors.createFailed",
+            defaultValue: editingTreatment
+              ? "Nie udało się zaktualizować zabiegu."
+              : "Nie udało się utworzyć zabiegu.",
+          }),
+        );
       } finally {
         setIsSubmitting(false);
       }
     },
-    [editingTreatment, createTreatment, updateTreatment, organizationId, tagIds, categoryId],
+    [editingTreatment, createTreatment, updateTreatment, organizationId, tagIds, categoryId, t],
   );
 
   const handleBulkAction = useCallback(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #934.

Closes #934

---

## Claude summary

Fix committed. Summary of changes:

The fix follows the existing `formatAppointmentError` pattern in `src/lib/format-action-error.ts`. I added a sibling `formatTreatmentError` that runs the raw error message through `extractActionErrorMessage` (peels off the `[CONVEX A(...)] ... Uncaught Error:` wrapper) and then matches the inner text against known treatment-domain patterns: `Treatment not found`, `Variant not found` / `Parent treatment not found`, `Permission denied`, validator errors (`ArgumentValidationError`, `value does not match validator`, Postgres `column ... does not exist` / `null value in column` / `violates ... constraint`), and bare `supabaseDb.*` storage failures. Each matched pattern maps to an i18n key under `gabinet.treatments.errors.*`; non-matches fall through to a clean operation-failed message (`createFailed` / `updateFailed`) so raw English Supabase output never reaches end users. Added the corresponding keys to `public/locales/pl/translation.json` and `public/locales/en/translation.json`, and updated the `catch` block at `_layout.gabinet.treatments.index.tsx:392` to call the helper instead of `toast.error(e.message)`. Typecheck passes.

## Follow-ups
- Translate raw backend errors on gabinet treatment detail page: `_layout.gabinet.treatments.$treatmentId.tsx:391` still does `toast.error(e instanceof Error ? e.message : String(e))` for the parameter-edit submit — should use the new `formatTreatmentError` helper.
- Audit other raw toast.error(e.message) sites: leads.new, products.index, settings.document-components, inbox.index, and patient portal pages all do the same and likely leak technical errors to end users.