### PR TITLE
Audit deployment pipeline for unapplied Supabase migrations

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -1,0 +1,66 @@
+name: Supabase Migrations
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "supabase/migrations/**"
+      - "scripts/supabase-migrations.mjs"
+      - ".github/workflows/supabase-migrations.yml"
+  push:
+    branches: [main]
+    paths:
+      - "supabase/migrations/**"
+      - "scripts/supabase-migrations.mjs"
+      - ".github/workflows/supabase-migrations.yml"
+
+jobs:
+  # On PR: verify that the migrations already on main are applied to the
+  # deployed database. This is a soft check — it surfaces drift without
+  # blocking the PR, because the PR may be the one introducing the migration.
+  check:
+    name: Check deployed migrations
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Verify base-branch migrations are applied
+        run: node scripts/supabase-migrations.mjs check
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+
+  # On push to main: apply any pending migrations to the deployed database
+  # before the rest of the deploy (Netlify build + convex deploy) runs.
+  # Fails the workflow if migrations can't be applied, so the deploy is not
+  # silently left in a broken state.
+  apply:
+    name: Apply pending migrations
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Apply pending migrations
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          if [ -z "${SUPABASE_DB_URL:-}" ]; then
+            echo "::error::SUPABASE_DB_URL repository secret is not set."
+            echo "::error::Configure it in Settings -> Secrets and variables -> Actions"
+            echo "::error::so this workflow can apply migrations to the deployed database."
+            exit 1
+          fi
+          node scripts/supabase-migrations.mjs apply

--- a/DEPLOYMENT-CHECKLIST.md
+++ b/DEPLOYMENT-CHECKLIST.md
@@ -106,6 +106,30 @@ npm run build
 # - Custom: rsync -avz dist/ user@server:/path
 ```
 
+### 2a. Apply Supabase Migrations
+On every push to `main`, the `Supabase Migrations` GitHub Actions workflow
+(`.github/workflows/supabase-migrations.yml`) applies any pending SQL files
+from `supabase/migrations/` against the deployed database and notifies
+PostgREST to reload its schema cache.
+
+Requires the `SUPABASE_DB_URL` repository secret to be set. If the workflow
+fails or the secret is missing, run the migrations manually before the
+frontend deploy completes:
+```bash
+export SUPABASE_DB_URL='postgresql://...'
+npm run migrations:apply
+```
+
+First-time bootstrap (one-off): the deployed database already has some
+migrations applied manually but no tracking table yet. Record those as
+applied before the first automated run so they aren't re-executed:
+```bash
+export SUPABASE_DB_URL='postgresql://...'
+node scripts/supabase-migrations.mjs mark 00001 00002 00003 00004
+# then apply whatever is actually pending:
+npm run migrations:apply
+```
+
 ### 3. Post-Deploy Verification
 - [ ] Login works on production
 - [ ] All pages load

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "test:unit": "cd convex && vitest run",
     "test:manifests": "vitest run --dir . src/modules/manifest-dispatches.test.ts",
     "check:convex-codegen": "node scripts/check-convex-codegen.mjs",
+    "migrations:check": "node scripts/supabase-migrations.mjs check",
+    "migrations:apply": "node scripts/supabase-migrations.mjs apply",
     "test": "npm run test:unit && npm run test:e2e",
     "verify:jwt": "npx tsx scripts/verify-jwt-bridge.ts",
     "verify:s03": "npx tsx scripts/verify-s03-integration.ts",

--- a/scripts/supabase-migrations.mjs
+++ b/scripts/supabase-migrations.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+// Check / apply Supabase SQL migrations against the database in $SUPABASE_DB_URL.
+//
+// Tracks applied migrations in `supabase_migrations.schema_migrations` (the same
+// schema the Supabase CLI uses), keyed by the filename version prefix
+// (e.g. `00005` for `00005_gabinet_treatment_tax_exempt.sql`).
+//
+// Modes:
+//   check               — print pending migrations, exit non-zero if any (default)
+//   apply               — apply pending migrations in order, each wrapped in
+//                         BEGIN/COMMIT, recording success in schema_migrations
+//   mark <ver> [<ver>…] — record the given versions as applied without running
+//                         them. One-time bootstrap when the deployed database
+//                         already has migrations that were applied manually
+//                         (e.g. 00001-00004 in this repo).
+//
+// Requires `psql` on PATH (preinstalled on ubuntu-latest GitHub runners).
+//
+// Why this exists: issue #935 — migration 00005 was merged 2 days before being
+// flagged as missing from quera-dev because nothing in CI/CD applies migrations.
+
+import { readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const MIGRATIONS_DIR = "supabase/migrations";
+const MODE = (process.argv[2] ?? "check").toLowerCase();
+
+if (!["check", "apply", "mark"].includes(MODE)) {
+  console.error(`Unknown mode "${MODE}". Use "check", "apply", or "mark".`);
+  process.exit(2);
+}
+
+const dbUrl = process.env.SUPABASE_DB_URL;
+if (!dbUrl) {
+  console.error("SUPABASE_DB_URL is not set. Skipping migration check.");
+  // Exit 0 so callers that haven't configured the secret aren't blocked.
+  // The CI workflow gates the job on the secret separately for stricter enforcement.
+  process.exit(0);
+}
+
+if (!existsSync(MIGRATIONS_DIR)) {
+  console.error(`No ${MIGRATIONS_DIR} directory found.`);
+  process.exit(0);
+}
+
+function ensurePsql(result) {
+  if (result.error && result.error.code === "ENOENT") {
+    throw new Error(
+      "psql is not installed or not on PATH. Install postgresql-client " +
+        "(it is preinstalled on GitHub ubuntu-latest runners).",
+    );
+  }
+}
+
+function runPsql(sql, { captureStdout = false } = {}) {
+  const result = spawnSync(
+    "psql",
+    [
+      dbUrl,
+      "-v",
+      "ON_ERROR_STOP=1",
+      "--no-psqlrc",
+      "--quiet",
+      ...(captureStdout ? ["-tA"] : []),
+      "-c",
+      sql,
+    ],
+    { encoding: "utf8" },
+  );
+  ensurePsql(result);
+  if (result.status !== 0) {
+    const stderr = result.stderr ?? "";
+    throw new Error(`psql failed (exit ${result.status}): ${stderr.trim()}`);
+  }
+  return result.stdout ?? "";
+}
+
+function runPsqlFile(path) {
+  const result = spawnSync(
+    "psql",
+    [
+      dbUrl,
+      "-v",
+      "ON_ERROR_STOP=1",
+      "--no-psqlrc",
+      "--quiet",
+      "--single-transaction",
+      "-f",
+      path,
+    ],
+    { encoding: "utf8" },
+  );
+  ensurePsql(result);
+  if (result.status !== 0) {
+    const stderr = result.stderr ?? "";
+    throw new Error(`psql failed applying ${path} (exit ${result.status}): ${stderr.trim()}`);
+  }
+}
+
+function parseFile(name) {
+  const match = /^(\d+)_(.+)\.sql$/u.exec(name);
+  if (!match) return null;
+  return { version: match[1], name: match[2], file: name };
+}
+
+const localMigrations = readdirSync(MIGRATIONS_DIR)
+  .map(parseFile)
+  .filter((m) => m !== null)
+  .sort((a, b) => a.version.localeCompare(b.version));
+
+if (localMigrations.length === 0) {
+  console.log("No migration files found.");
+  process.exit(0);
+}
+
+// Ensure tracking table exists
+runPsql(`
+  CREATE SCHEMA IF NOT EXISTS supabase_migrations;
+  CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (
+    version TEXT PRIMARY KEY,
+    name TEXT,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  );
+`);
+
+const appliedRaw = runPsql(
+  "SELECT version FROM supabase_migrations.schema_migrations ORDER BY version;",
+  { captureStdout: true },
+);
+const applied = new Set(
+  appliedRaw
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean),
+);
+
+if (MODE === "mark") {
+  const versions = process.argv.slice(3);
+  if (versions.length === 0) {
+    console.error("mark mode requires one or more version arguments.");
+    console.error("Example: node scripts/supabase-migrations.mjs mark 00001 00002");
+    process.exit(2);
+  }
+  const localVersions = new Set(localMigrations.map((m) => m.version));
+  for (const v of versions) {
+    if (!localVersions.has(v)) {
+      console.error(`Version "${v}" has no matching file in ${MIGRATIONS_DIR}.`);
+      process.exit(2);
+    }
+  }
+  for (const v of versions) {
+    const m = localMigrations.find((x) => x.version === v);
+    const sanitizedName = m.name.replace(/'/gu, "''");
+    runPsql(
+      `INSERT INTO supabase_migrations.schema_migrations (version, name) ` +
+        `VALUES ('${m.version}', '${sanitizedName}') ` +
+        `ON CONFLICT (version) DO NOTHING;`,
+    );
+    console.log(`marked ${m.version} as applied`);
+  }
+  process.exit(0);
+}
+
+const pending = localMigrations.filter((m) => !applied.has(m.version));
+
+if (pending.length === 0) {
+  console.log(
+    `All ${localMigrations.length} migrations applied (latest: ${localMigrations.at(-1).version}).`,
+  );
+  process.exit(0);
+}
+
+console.log(`Pending migrations (${pending.length}):`);
+for (const m of pending) console.log(`  - ${m.file}`);
+
+if (MODE === "check") {
+  console.error(
+    "\nThe deployed database is missing the migrations above. Run\n" +
+      "`npm run migrations:apply` (with SUPABASE_DB_URL set) to apply them, or wait\n" +
+      "for the CI workflow on main to do it.",
+  );
+  process.exit(1);
+}
+
+// apply
+for (const m of pending) {
+  const path = join(MIGRATIONS_DIR, m.file);
+  console.log(`Applying ${m.file}...`);
+  runPsqlFile(path);
+  // Record after success. We do this in a separate statement because some
+  // migrations contain statements that cannot run inside a transaction
+  // (e.g. CREATE INDEX CONCURRENTLY). psql --single-transaction will already
+  // have committed if all statements ran successfully.
+  const sanitizedName = m.name.replace(/'/gu, "''");
+  runPsql(
+    `INSERT INTO supabase_migrations.schema_migrations (version, name) ` +
+      `VALUES ('${m.version}', '${sanitizedName}') ` +
+      `ON CONFLICT (version) DO NOTHING;`,
+  );
+  console.log(`  applied ${m.version}`);
+}
+
+console.log(`\nApplied ${pending.length} migration(s).`);
+
+// Reload PostgREST schema cache so newly-added columns/tables are visible
+// without waiting for the periodic refresh. Safe no-op if pgrst isn't listening.
+try {
+  runPsql("NOTIFY pgrst, 'reload schema';");
+  console.log("Notified PostgREST to reload schema cache.");
+} catch (err) {
+  console.warn(`Could not notify PostgREST: ${err.message}`);
+}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #935.

Closes #935

---

## Claude summary

Closed the deployment-pipeline gap that let migration 00005 sit unapplied on quera-dev for two days. Added a `psql`-driven `scripts/supabase-migrations.mjs` (modes: `check`, `apply`, `mark`) plus a `.github/workflows/supabase-migrations.yml` that applies pending migrations on push to main and surfaces drift on PRs. `npm run migrations:check`/`migrations:apply` and a bootstrap note in the deployment checklist round it out.

Operator follow-up needed (out of repo): set the `SUPABASE_DB_URL` repository secret and, on first run, mark the already-applied versions so they aren't re-executed:

```bash
SUPABASE_DB_URL=... node scripts/supabase-migrations.mjs mark 00001 00002 00003 00004 00005
SUPABASE_DB_URL=... npm run migrations:apply   # applies 00006 + future ones
```

## Follow-ups
- Have Netlify build wait for migrations to apply: GitHub Actions and Netlify deploy in parallel on push to main, so the frontend can briefly hit a DB without the new column; gate the Netlify build on the migrations workflow (e.g. promote deploy command into a single GitHub Actions job, or have Netlify call `npm run migrations:apply` in its build command).
- Track when migration 00006 (`products_tax_exempt`) actually lands on quera-dev: same drift risk as 00005 until the workflow is enabled with the secret.