### PR TITLE
Translate raw backend errors on gabinet treatment detail page

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -63,6 +63,7 @@ import {
 import { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { formatTreatmentError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/treatments/$treatmentId",
@@ -388,7 +389,12 @@ function TreatmentDetail() {
       setEditPanelOpen(false);
       toast.success(t("common.saved"));
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatTreatmentError(e, t, {
+          key: "gabinet.treatments.errors.updateFailed",
+          defaultValue: "Nie udało się zaktualizować zabiegu.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #939.

Closes #939

---

## Claude summary

Fixed. The treatment detail page's edit submit now uses `formatTreatmentError` instead of dumping the raw `e.message` to the toast, so users see translated friendly messages (matching the pattern already used on the treatments list page).

Triage note: the issue description says "parameter-edit submit" but line 391 is actually the main treatment edit form's catch handler (`handleEditSubmit`, which calls `updateTreatment`). The `formatTreatmentError` helper is the right fit either way since both code paths touch the treatments domain. Typecheck passes.