### PR TITLE
Audit other raw toast.error(e.message) sites

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -69,7 +69,12 @@
     "optional": "optional",
     "continue": "Continue",
     "selectAll": "Select all",
-    "deselectAll": "Deselect all"
+    "deselectAll": "Deselect all",
+    "errors": {
+      "permissionDenied": "You don't have permission to perform this action.",
+      "invalidArguments": "Invalid data. Please check the form and try again.",
+      "storage": "Storage error. Please try again."
+    }
   },
   "nav": {
     "deals": "Deals",
@@ -427,6 +432,9 @@
       "won": "Won",
       "lost": "Lost",
       "archived": "Archived"
+    },
+    "errors": {
+      "createFailed": "Could not create the deal."
     }
   },
   "contacts": {
@@ -700,6 +708,9 @@
       "isActive": "Active",
       "description": "Description",
       "descriptionPlaceholder": "Product description..."
+    },
+    "errors": {
+      "saveFailed": "Could not save the product."
     }
   },
   "calls": {
@@ -1307,6 +1318,14 @@
       "seedSuccess": "Loaded {{count}} templates",
       "migrateFolders": "Migrate folders",
       "migrateSuccess": "Assigned folders to {{count}} templates"
+    },
+    "documentComponents": {
+      "errors": {
+        "createFailed": "Could not create the component.",
+        "updateFailed": "Could not save the component.",
+        "deleteFailed": "Could not delete the component.",
+        "duplicateFailed": "Could not duplicate the component."
+      }
     }
   },
   "leadForm": {
@@ -1847,7 +1866,10 @@
     "unreadCount": "{{count}} unread",
     "allMailboxes": "All mailboxes",
     "sendFrom": "Send from",
-    "mailbox": "Mailbox"
+    "mailbox": "Mailbox",
+    "errors": {
+      "syncFailed": "Could not sync the inbox."
+    }
   },
   "team": {
     "title": "Team",
@@ -3121,7 +3143,8 @@
       "changeEmail": "Use a different email",
       "invalidPortalLink": "Invalid Portal Link",
       "invalidPortalLinkDescription": "This link is invalid or expired. Please contact your clinic for a new portal link.",
-      "errorGeneric": "Something went wrong. Please try again."
+      "errorGeneric": "Something went wrong. Please try again.",
+      "sendOtpFailed": "Could not send the code. Please try again."
     },
     "dashboard": {
       "welcome": "Welcome, {{name}}",
@@ -3147,13 +3170,15 @@
       "rescheduleReasonPlaceholder": "Optional — let us know why you need to reschedule",
       "rescheduleSubmit": "Send Request",
       "rescheduleSuccess": "Reschedule request sent. The clinic will contact you to confirm.",
-      "reschedulePendingNote": "This is a request only. Your appointment will remain unchanged until the clinic confirms the new time."
+      "reschedulePendingNote": "This is a request only. Your appointment will remain unchanged until the clinic confirms the new time.",
+      "rescheduleFailed": "Could not send the reschedule request."
     },
     "documents": {
       "title": "My Documents",
       "empty": "No documents available",
       "signDocument": "Sign Document",
       "signed": "Document signed successfully",
+      "signFailed": "Could not sign the document.",
       "formDocuments": "Form Documents",
       "legacyDocuments": "Other Documents",
       "signPrompt": "Please review the document and provide your signature below.",
@@ -3162,7 +3187,8 @@
     "profile": {
       "title": "My Profile",
       "name": "Name",
-      "editableFields": "Editable Information"
+      "editableFields": "Editable Information",
+      "updateFailed": "Could not update your profile."
     },
     "packages": {
       "title": "My Packages",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -69,7 +69,12 @@
     "optional": "opcjonalnie",
     "continue": "Dalej",
     "selectAll": "Zaznacz wszystkie",
-    "deselectAll": "Odznacz wszystkie"
+    "deselectAll": "Odznacz wszystkie",
+    "errors": {
+      "permissionDenied": "Brak uprawnień do tej operacji.",
+      "invalidArguments": "Nieprawidłowe dane. Sprawdź formularz i spróbuj ponownie.",
+      "storage": "Błąd magazynu danych. Spróbuj ponownie."
+    }
   },
   "nav": {
     "deals": "Transakcje",
@@ -426,6 +431,9 @@
       "won": "Wygrana",
       "lost": "Przegrana",
       "archived": "Zarchiwizowana"
+    },
+    "errors": {
+      "createFailed": "Nie udało się utworzyć transakcji."
     }
   },
   "contacts": {
@@ -700,6 +708,9 @@
       "isActive": "Aktywny",
       "description": "Opis",
       "descriptionPlaceholder": "Opis produktu..."
+    },
+    "errors": {
+      "saveFailed": "Nie udało się zapisać produktu."
     }
   },
   "calls": {
@@ -1309,6 +1320,14 @@
       "seedSuccess": "Załadowano {{count}} szablonów",
       "migrateFolders": "Migruj foldery",
       "migrateSuccess": "Przypisano foldery do {{count}} szablonów"
+    },
+    "documentComponents": {
+      "errors": {
+        "createFailed": "Nie udało się utworzyć komponentu.",
+        "updateFailed": "Nie udało się zapisać komponentu.",
+        "deleteFailed": "Nie udało się usunąć komponentu.",
+        "duplicateFailed": "Nie udało się zduplikować komponentu."
+      }
     }
   },
   "leadForm": {
@@ -1855,7 +1874,10 @@
     "unreadCount": "{{count}} nieprzeczytanych",
     "allMailboxes": "Wszystkie skrzynki",
     "sendFrom": "Wyślij z",
-    "mailbox": "Skrzynka"
+    "mailbox": "Skrzynka",
+    "errors": {
+      "syncFailed": "Nie udało się zsynchronizować skrzynki."
+    }
   },
   "team": {
     "title": "Zespół",
@@ -3132,7 +3154,8 @@
       "changeEmail": "Użyj innego e-maila",
       "invalidPortalLink": "Nieprawidłowy link do portalu",
       "invalidPortalLinkDescription": "Ten link jest nieprawidłowy lub wygasł. Skontaktuj się z gabinetem, aby otrzymać nowy link.",
-      "errorGeneric": "Coś poszło nie tak. Spróbuj ponownie."
+      "errorGeneric": "Coś poszło nie tak. Spróbuj ponownie.",
+      "sendOtpFailed": "Nie udało się wysłać kodu. Spróbuj ponownie."
     },
     "dashboard": {
       "welcome": "Witaj, {{name}}",
@@ -3158,13 +3181,15 @@
       "rescheduleReasonPlaceholder": "Opcjonalnie — daj nam znać, dlaczego musisz przełożyć wizytę",
       "rescheduleSubmit": "Wyślij prośbę",
       "rescheduleSuccess": "Prośba o zmianę terminu wysłana. Klinika skontaktuje się z Tobą w celu potwierdzenia.",
-      "reschedulePendingNote": "To jest tylko prośba. Twoja wizyta pozostanie bez zmian do momentu potwierdzenia przez klinikę."
+      "reschedulePendingNote": "To jest tylko prośba. Twoja wizyta pozostanie bez zmian do momentu potwierdzenia przez klinikę.",
+      "rescheduleFailed": "Nie udało się wysłać prośby o zmianę terminu."
     },
     "documents": {
       "title": "Moje dokumenty",
       "empty": "Brak dostępnych dokumentów",
       "signDocument": "Podpisz dokument",
       "signed": "Dokument podpisany pomyślnie",
+      "signFailed": "Nie udało się podpisać dokumentu.",
       "formDocuments": "Dokumenty formularzy",
       "legacyDocuments": "Inne dokumenty",
       "signPrompt": "Zapoznaj się z dokumentem i złóż podpis poniżej.",
@@ -3173,7 +3198,8 @@
     "profile": {
       "title": "Mój profil",
       "name": "Imię i nazwisko",
-      "editableFields": "Edytowalne informacje"
+      "editableFields": "Edytowalne informacje",
+      "updateFailed": "Nie udało się zaktualizować profilu."
     },
     "packages": {
       "title": "Moje pakiety",

--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -179,3 +179,46 @@ export function formatTreatmentError(
   }
   return t(fallback.key, { defaultValue: fallback.defaultValue });
 }
+
+const GENERIC_ERROR_MAP: Array<{
+  test: (msg: string) => boolean;
+  key: string;
+  fallback: string;
+}> = [
+  {
+    test: (m) => /permission denied/i.test(m),
+    key: "common.errors.permissionDenied",
+    fallback: "Brak uprawnień do tej operacji.",
+  },
+  {
+    test: (m) =>
+      /argumentvalidationerror|value does not match validator|invalid input syntax|violates .* constraint|column .* does not exist|null value in column/i.test(
+        m,
+      ),
+    key: "common.errors.invalidArguments",
+    fallback: "Nieprawidłowe dane. Sprawdź formularz i spróbuj ponownie.",
+  },
+  {
+    test: (m) => /supabasedb\.(get|getmany|patch|delete|insert|query)/i.test(m),
+    key: "common.errors.storage",
+    fallback: "Błąd magazynu danych. Spróbuj ponownie.",
+  },
+];
+
+// Generic translator for raw Convex action errors. Recognises universal
+// patterns (permission denied, validator errors, raw Supabase storage errors)
+// and otherwise returns a caller-provided fallback message, so raw English
+// backend output never leaks to end users.
+export function formatActionError(
+  err: unknown,
+  t: TFunction,
+  fallback: { key: string; defaultValue: string },
+): string {
+  const inner = extractActionErrorMessage(err);
+  for (const entry of GENERIC_ERROR_MAP) {
+    if (entry.test(inner)) {
+      return t(entry.key, { defaultValue: entry.fallback });
+    }
+  }
+  return t(fallback.key, { defaultValue: fallback.defaultValue });
+}

--- a/src/routes/_app/_auth/dashboard/_layout.inbox.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.inbox.index.tsx
@@ -25,6 +25,7 @@ import { Pencil, Mail, RefreshCw, X } from "@/lib/ez-icons";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { useSidebarSlot } from "@/components/layout/sidebar-slot-context";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 type InboxNudgeFilter = "unanswered";
 
@@ -66,7 +67,12 @@ function InboxPage() {
       const result = await syncGmail({ organizationId });
       toast.success(`${t("integrations.syncing")} — ${result.synced} emails`);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Sync failed");
+      toast.error(
+        formatActionError(e, t, {
+          key: "inbox.errors.syncFailed",
+          defaultValue: "Nie udało się zsynchronizować skrzynki.",
+        }),
+      );
     } finally {
       setIsSyncing(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.leads.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.new.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useAction } from "convex/react";
 import { useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
@@ -10,6 +11,7 @@ import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { PageHeader } from "@/components/layout/page-header";
 import { LeadForm } from "@/components/forms/lead-form";
 import { Card, CardContent } from "@/components/ui/card";
+import { formatActionError } from "@/lib/format-action-error";
 import { useState } from "react";
 import { Id } from "@cvx/_generated/dataModel";
 
@@ -20,6 +22,7 @@ export const Route = createFileRoute(
 });
 
 function NewLead() {
+  const { t } = useTranslation();
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
   const createLead = useAction(api.leads.create);
@@ -74,7 +77,12 @@ function NewLead() {
                 queryClient.invalidateQueries({ queryKey: supabaseKeys.leads.all });
                 navigate({ to: `/dashboard/leads/${id}` });
               } catch (e) {
-                toast.error(e instanceof Error ? e.message : String(e));
+                toast.error(
+                  formatActionError(e, t, {
+                    key: "deals.errors.createFailed",
+                    defaultValue: "Nie udało się utworzyć transakcji.",
+                  }),
+                );
               } finally {
                 setIsSubmitting(false);
               }

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -39,6 +39,7 @@ import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-s
 import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
+import { formatActionError } from "@/lib/format-action-error";
 
 type ProductsNudgeFilter = "unused";
 
@@ -258,7 +259,12 @@ function ProductsPage() {
       setPanelOpen(false);
       resetForm();
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "products.errors.saveFailed",
+          defaultValue: "Nie udało się zapisać produktu.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.settings.document-components.$id.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.document-components.$id.tsx
@@ -16,8 +16,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ArrowLeft, Lock } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { DocumentTemplateEditor } from "@/components/documents/document-template-editor";
+import { formatActionError } from "@/lib/format-action-error";
 import type { Id } from "@cvx/_generated/dataModel";
 
 export const Route = createFileRoute(
@@ -40,6 +42,7 @@ const CATEGORY_OPTIONS: { value: ComponentCategory; label: string }[] = [
 ];
 
 function EditDocumentComponentPage() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const { id } = Route.useParams();
   const { organizationId } = useOrganization();
@@ -92,7 +95,12 @@ function EditDocumentComponentPage() {
       toast.success("Komponent zaktualizowany");
       navigate({ to: "/dashboard/settings/document-components" });
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Błąd podczas zapisu");
+      toast.error(
+        formatActionError(err, t, {
+          key: "settings.documentComponents.errors.updateFailed",
+          defaultValue: "Nie udało się zapisać komponentu.",
+        }),
+      );
     } finally {
       setSaving(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.settings.document-components.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.document-components.index.tsx
@@ -36,6 +36,7 @@ import {
   Globe,
 } from "lucide-react";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 import type { Id } from "@cvx/_generated/dataModel";
 
 export const Route = createFileRoute(
@@ -91,7 +92,12 @@ function DocumentComponentsListPage() {
       await removeMutation({ organizationId, componentId: deleteTarget });
       toast.success("Komponent usunięty");
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Błąd");
+      toast.error(
+        formatActionError(err, t, {
+          key: "settings.documentComponents.errors.deleteFailed",
+          defaultValue: "Nie udało się usunąć komponentu.",
+        }),
+      );
     }
     setDeleteTarget(null);
   };
@@ -101,7 +107,12 @@ function DocumentComponentsListPage() {
       await duplicateMutation({ organizationId, componentId: id });
       toast.success("Komponent skopiowany");
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Błąd");
+      toast.error(
+        formatActionError(err, t, {
+          key: "settings.documentComponents.errors.duplicateFailed",
+          defaultValue: "Nie udało się zduplikować komponentu.",
+        }),
+      );
     }
   };
 

--- a/src/routes/_app/_auth/dashboard/_layout.settings.document-components.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.document-components.new.tsx
@@ -18,6 +18,7 @@ import {
 import { ArrowLeft } from "lucide-react";
 import { toast } from "sonner";
 import { DocumentTemplateEditor } from "@/components/documents/document-template-editor";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/settings/document-components/new",
@@ -71,7 +72,12 @@ function NewDocumentComponentPage() {
       toast.success("Komponent utworzony");
       navigate({ to: "/dashboard/settings/document-components" });
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Błąd podczas tworzenia");
+      toast.error(
+        formatActionError(err, t, {
+          key: "settings.documentComponents.errors.createFailed",
+          defaultValue: "Nie udało się utworzyć komponentu.",
+        }),
+      );
     } finally {
       setSaving(false);
     }

--- a/src/routes/_app/patient/_layout.appointments.tsx
+++ b/src/routes/_app/patient/_layout.appointments.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Id } from "@cvx/_generated/dataModel";
 import { PlateText } from "@/components/plate-text";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute("/_app/patient/_layout/appointments")({
   component: PatientAppointments,
@@ -115,7 +116,12 @@ function PatientAppointments() {
       toast.success(t("patientPortal.appointments.rescheduleSuccess"));
       closeReschedule();
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "patientPortal.appointments.rescheduleFailed",
+          defaultValue: "Nie udało się wysłać prośby o zmianę terminu.",
+        }),
+      );
     } finally {
       setSubmitting(false);
     }

--- a/src/routes/_app/patient/_layout.documents.tsx
+++ b/src/routes/_app/patient/_layout.documents.tsx
@@ -16,6 +16,7 @@ import { Eye, PenTool, FileText } from "@/lib/ez-icons";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute("/_app/patient/_layout/documents")({
   component: PatientDocuments,
@@ -59,7 +60,12 @@ function PatientDocuments() {
       toast.success(t("patientPortal.documents.signed"));
       setSignDocId(null);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "patientPortal.documents.signFailed",
+          defaultValue: "Nie udało się podpisać dokumentu.",
+        }),
+      );
     }
   };
 

--- a/src/routes/_app/patient/_layout.profile.tsx
+++ b/src/routes/_app/patient/_layout.profile.tsx
@@ -8,6 +8,7 @@ import { Label } from "@/components/ui/label";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute("/_app/patient/_layout/profile")({
   component: PatientProfile,
@@ -57,7 +58,12 @@ function PatientProfile() {
       });
       toast.success(t("common.saved"));
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "patientPortal.profile.updateFailed",
+          defaultValue: "Nie udało się zaktualizować profilu.",
+        }),
+      );
     } finally {
       setSaving(false);
     }

--- a/src/routes/_app/patient/login.tsx
+++ b/src/routes/_app/patient/login.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { z } from "zod";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute("/_app/patient/login")({
   validateSearch: z.object({
@@ -80,7 +81,12 @@ function PatientLogin() {
       setStep("otp");
       toast.success(t("patientPortal.login.otpSent"));
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "patientPortal.login.sendOtpFailed",
+          defaultValue: "Nie udało się wysłać kodu. Spróbuj ponownie.",
+        }),
+      );
     } finally {
       setLoading(false);
     }
@@ -99,7 +105,12 @@ function PatientLogin() {
       localStorage.setItem("patientPortalPatientId", result.patientId);
       navigate({ to: "/patient" });
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : t("patientPortal.login.errorGeneric"));
+      toast.error(
+        formatActionError(e, t, {
+          key: "patientPortal.login.errorGeneric",
+          defaultValue: "Coś poszło nie tak. Spróbuj ponownie.",
+        }),
+      );
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #940.

Closes #940

---

## Claude summary

Committed as `27216e9`. The fix follows the same pattern used in #934/#939: a new generic `formatActionError` helper in `src/lib/format-action-error.ts:212` maps universal Convex/Supabase error patterns (permission denied, ArgumentValidationError, supabaseDb storage) to `common.errors.*` i18n keys, with a caller-provided domain fallback when nothing matches. Every page listed in the issue was updated, plus PL/EN translations for all new keys. `tsc -p tsconfig.app.json` and `vitest` manifest tests both pass.

## Follow-ups
- Audit remaining raw toast.error(e.message) sites in gabinet routes: gabinet.settings.locations, gabinet.settings.scheduling, gabinet.settings.leaves, gabinet.settings.equipment, gabinet.settings.leave-types, gabinet.packages.index, gabinet.employees.index, gabinet.employees.$employeeId, gabinet.patients.index, gabinet.patients.$patientId still pass raw e.message to toast.
- Audit remaining raw toast.error(e.message) sites in CRM routes: companies.new, contacts.new, calendar, settings.sms, settings.email-events still pass raw e.message to toast.
- Audit remaining raw toast.error(e.message) sites in shared components: treatment-form, change-employee-modal, tags-manager-slideout, categories-manager-slideout, flexible-schedule-editor, package-purchase-drawer, employee-schedule-manager, sms-config-card, documentation-tab all leak raw e.message.