### PR TITLE
Have Netlify build wait for migrations to apply

### DIFF
--- a/DEPLOYMENT-CHECKLIST.md
+++ b/DEPLOYMENT-CHECKLIST.md
@@ -107,14 +107,27 @@ npm run build
 ```
 
 ### 2a. Apply Supabase Migrations
-On every push to `main`, the `Supabase Migrations` GitHub Actions workflow
-(`.github/workflows/supabase-migrations.yml`) applies any pending SQL files
-from `supabase/migrations/` against the deployed database and notifies
-PostgREST to reload its schema cache.
+Migrations are applied in two places so the frontend never goes live
+against a DB that's missing the columns it expects (issue #942):
 
-Requires the `SUPABASE_DB_URL` repository secret to be set. If the workflow
-fails or the secret is missing, run the migrations manually before the
-frontend deploy completes:
+1. The Netlify production build command (`netlify.toml`) runs
+   `npm run migrations:apply` before `convex deploy` + `npm run build`,
+   so a failed migration aborts the frontend deploy.
+2. The `Supabase Migrations` GitHub Actions workflow
+   (`.github/workflows/supabase-migrations.yml`) applies pending SQL on
+   every push to `main` as a secondary signal (surfaces failures in PR
+   checks even if Netlify is misconfigured).
+
+Both paths require the `SUPABASE_DB_URL` secret:
+- Netlify: set it under Site settings → Environment variables.
+- GitHub Actions: set it under Settings → Secrets and variables → Actions.
+
+If the secret is missing in Netlify, `npm run migrations:apply` exits 0
+(fail-open) and the Netlify gating becomes a no-op — set the env var to
+get the gating behavior.
+
+If both fail, run the migrations manually before the frontend deploy
+completes:
 ```bash
 export SUPABASE_DB_URL='postgresql://...'
 npm run migrations:apply

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,4 +4,9 @@
   status = 200
 
 [context.production]
-  command = "npx convex deploy --cmd 'npm run build'"
+  # Apply pending Supabase migrations before the frontend goes live so the
+  # newly-deployed UI never hits a DB that's missing columns it expects.
+  # Requires SUPABASE_DB_URL to be configured in Netlify env; without it the
+  # script exits 0 (fail-open) and the parallel GitHub Actions workflow
+  # (.github/workflows/supabase-migrations.yml) remains the only gate.
+  command = "npm run migrations:apply && npx convex deploy --cmd 'npm run build'"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #942.

Closes #942

---

## Claude summary

Committed `d827765`. The change is a two-line edit to `netlify.toml`: the production build command now runs `npm run migrations:apply` before `convex deploy --cmd 'npm run build'`, so any pending Supabase migration is applied (and verified) before the frontend bundle is built and goes live.

Key design points:
- The script's existing fail-open behavior (exits 0 if `SUPABASE_DB_URL` is unset) means this commit is safe to land without any Netlify config change — the gating activates the moment the secret is set in Netlify's site settings.
- The existing `supabase-migrations.yml` workflow stays in place as a secondary signal (it still gates PR checks and runs on main).
- `psql` is preinstalled on Netlify's Ubuntu (focal) build image, so no extra install step is needed.

`DEPLOYMENT-CHECKLIST.md` updated to document the two gating paths and the Netlify env var that needs to be set.

## Follow-ups
- Gate Netlify deploy on GHA workflow success: even with this fix, the GHA workflow's failure does not block Netlify's deploy. The cleanest long-term fix is option 1 from the issue — disable Netlify auto-deploy and trigger it from a single GHA job after migrations succeed. Tracked separately because it requires Netlify build-hook setup and disabling auto-deploy in Netlify UI.
- Document required Netlify env vars in `.env.example` or a Netlify-specific doc: the file lists local-dev vars but doesn't call out which must be configured in Netlify's UI for production builds (`SUPABASE_DB_URL`, Convex deploy key, etc.).