### PR TITLE
Audit remaining raw toast.error(e.message) sites in gabinet routes

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2058,7 +2058,11 @@
       "added": "Added",
       "upcomingAppointments": "Upcoming appointments",
       "noUpcomingAppointments": "No upcoming appointments",
-      "noMedicalInfo": "No medical information"
+      "noMedicalInfo": "No medical information",
+      "errors": {
+        "createFailed": "Could not add the client.",
+        "saveFailed": "Could not save client changes."
+      }
     },
     "treatments": {
       "title": "Treatments",
@@ -2253,7 +2257,10 @@
       "addBreak": "Add break",
       "removeBreak": "Remove break",
       "validationEndAfterStart": "End time must be after start time: {{days}}",
-      "validationBreakEndAfterStart": "Break end must be after break start: {{days}}"
+      "validationBreakEndAfterStart": "Break end must be after break start: {{days}}",
+      "errors": {
+        "saveFailed": "Could not save working hours."
+      }
     },
     "reminders": {
       "title": "Appointment Reminders",
@@ -2298,7 +2305,11 @@
       "confirmApproveTitle": "Approve Leave Request",
       "confirmApproveDesc": "Are you sure you want to approve this leave request? The employee will be notified.",
       "confirmRejectTitle": "Reject Leave Request",
-      "confirmRejectDesc": "Are you sure you want to reject this leave request? The employee will be notified."
+      "confirmRejectDesc": "Are you sure you want to reject this leave request? The employee will be notified.",
+      "errors": {
+        "createFailed": "Could not create the leave request.",
+        "statusChangeFailed": "Could not update the leave request status."
+      }
     },
     "employees": {
       "title": "Employees",
@@ -2436,7 +2447,12 @@
       "employee": "Employee",
       "active": "Active",
       "confirmDelete": "Are you sure you want to delete this employee?",
-      "searchPlaceholder": "Search employees..."
+      "searchPlaceholder": "Search employees...",
+      "errors": {
+        "createFailed": "Could not add the employee.",
+        "saveFailed": "Could not save employee changes.",
+        "noteFailed": "Could not add the note."
+      }
     },
     "leaveTypes": {
       "title": "Leave Types",
@@ -2453,7 +2469,11 @@
       "unlimited": "Unlimited",
       "confirmDelete": "Are you sure you want to deactivate this leave type?",
       "initBalances": "Initialize Balances {{year}}",
-      "balancesInitialized": "Initialized {{count}} balance(s)"
+      "balancesInitialized": "Initialized {{count}} balance(s)",
+      "errors": {
+        "saveFailed": "Could not save the leave type.",
+        "initBalancesFailed": "Could not initialize leave balances."
+      }
     },
     "leaveBalances": {
       "title": "Leave Balances",
@@ -2799,6 +2819,11 @@
       "nudgeFilter": {
         "expiring": "Showing packages with usages expiring within 30 days.",
         "noUsage": "Showing active packages with no active usage."
+      },
+      "errors": {
+        "saveFailed": "Could not save the package.",
+        "deleteFailed": "Could not delete the package.",
+        "purchaseFailed": "Could not sell the package."
       }
     },
     "documents": {
@@ -3072,7 +3097,15 @@
       "postalCode": "Postal code",
       "country": "Country",
       "room": "Room",
-      "selectRoom": "Select room..."
+      "selectRoom": "Select room...",
+      "errors": {
+        "createFailed": "Could not add the location.",
+        "saveFailed": "Could not save the location.",
+        "deleteFailed": "Could not delete the location.",
+        "roomCreateFailed": "Could not add the room.",
+        "roomDeleteFailed": "Could not delete the room.",
+        "roomUpdateFailed": "Could not update the room."
+      }
     },
     "equipment": {
       "title": "Equipment",
@@ -3092,6 +3125,11 @@
         "in_use": "In use",
         "maintenance": "Maintenance",
         "retired": "Retired"
+      },
+      "errors": {
+        "createFailed": "Could not add the equipment.",
+        "saveFailed": "Could not save the equipment.",
+        "transferFailed": "Could not transfer the equipment."
       }
     }
   },

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2066,7 +2066,11 @@
       "added": "Dodano",
       "upcomingAppointments": "Nadchodzące wizyty",
       "noUpcomingAppointments": "Brak nadchodzących wizyt",
-      "noMedicalInfo": "Brak informacji medycznych"
+      "noMedicalInfo": "Brak informacji medycznych",
+      "errors": {
+        "createFailed": "Nie udało się dodać klienta.",
+        "saveFailed": "Nie udało się zapisać zmian klienta."
+      }
     },
     "treatments": {
       "title": "Zabiegi",
@@ -2263,7 +2267,10 @@
       "addBreak": "Dodaj przerwę",
       "removeBreak": "Usuń przerwę",
       "validationEndAfterStart": "Godzina końca musi być po godzinie początku: {{days}}",
-      "validationBreakEndAfterStart": "Koniec przerwy musi być po początku przerwy: {{days}}"
+      "validationBreakEndAfterStart": "Koniec przerwy musi być po początku przerwy: {{days}}",
+      "errors": {
+        "saveFailed": "Nie udało się zapisać godzin pracy."
+      }
     },
     "reminders": {
       "title": "Przypomnienia o wizytach",
@@ -2308,7 +2315,11 @@
       "confirmApproveTitle": "Zatwierdź wniosek urlopowy",
       "confirmApproveDesc": "Czy na pewno chcesz zatwierdzić ten wniosek urlopowy? Pracownik zostanie powiadomiony.",
       "confirmRejectTitle": "Odrzuć wniosek urlopowy",
-      "confirmRejectDesc": "Czy na pewno chcesz odrzucić ten wniosek urlopowy? Pracownik zostanie powiadomiony."
+      "confirmRejectDesc": "Czy na pewno chcesz odrzucić ten wniosek urlopowy? Pracownik zostanie powiadomiony.",
+      "errors": {
+        "createFailed": "Nie udało się utworzyć wniosku urlopowego.",
+        "statusChangeFailed": "Nie udało się zaktualizować statusu wniosku urlopowego."
+      }
     },
     "employees": {
       "title": "Pracownicy",
@@ -2446,7 +2457,12 @@
       "employee": "Pracownik",
       "active": "Aktywny",
       "confirmDelete": "Czy na pewno chcesz usunąć tego pracownika?",
-      "searchPlaceholder": "Szukaj pracowników..."
+      "searchPlaceholder": "Szukaj pracowników...",
+      "errors": {
+        "createFailed": "Nie udało się dodać pracownika.",
+        "saveFailed": "Nie udało się zapisać zmian pracownika.",
+        "noteFailed": "Nie udało się dodać notatki."
+      }
     },
     "leaveTypes": {
       "title": "Typy urlopów",
@@ -2463,7 +2479,11 @@
       "unlimited": "Bez limitu",
       "confirmDelete": "Czy na pewno chcesz dezaktywować ten typ urlopu?",
       "initBalances": "Inicjalizuj salda {{year}}",
-      "balancesInitialized": "Zainicjalizowano {{count}} saldo(a)"
+      "balancesInitialized": "Zainicjalizowano {{count}} saldo(a)",
+      "errors": {
+        "saveFailed": "Nie udało się zapisać typu urlopu.",
+        "initBalancesFailed": "Nie udało się zainicjalizować sald urlopowych."
+      }
     },
     "leaveBalances": {
       "title": "Salda urlopów",
@@ -2810,6 +2830,11 @@
       "nudgeFilter": {
         "expiring": "Pokazywane są pakiety z użyciami wygasającymi w ciągu 30 dni.",
         "noUsage": "Pokazywane są aktywne pakiety bez aktywnych użyć."
+      },
+      "errors": {
+        "saveFailed": "Nie udało się zapisać pakietu.",
+        "deleteFailed": "Nie udało się usunąć pakietu.",
+        "purchaseFailed": "Nie udało się sprzedać pakietu."
       }
     },
     "documents": {
@@ -3083,7 +3108,15 @@
       "postalCode": "Kod pocztowy",
       "country": "Kraj",
       "room": "Gabinet",
-      "selectRoom": "Wybierz gabinet..."
+      "selectRoom": "Wybierz gabinet...",
+      "errors": {
+        "createFailed": "Nie udało się dodać lokalizacji.",
+        "saveFailed": "Nie udało się zapisać lokalizacji.",
+        "deleteFailed": "Nie udało się usunąć lokalizacji.",
+        "roomCreateFailed": "Nie udało się dodać gabinetu.",
+        "roomDeleteFailed": "Nie udało się usunąć gabinetu.",
+        "roomUpdateFailed": "Nie udało się zaktualizować gabinetu."
+      }
     },
     "equipment": {
       "title": "Sprzęt",
@@ -3103,6 +3136,11 @@
         "in_use": "W użyciu",
         "maintenance": "Serwis",
         "retired": "Wycofany"
+      },
+      "errors": {
+        "createFailed": "Nie udało się dodać sprzętu.",
+        "saveFailed": "Nie udało się zapisać sprzętu.",
+        "transferFailed": "Nie udało się przenieść sprzętu."
       }
     }
   },

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -77,7 +77,9 @@ import type { GabinetEmployeeRole } from "@cvx/schema";
 import type { MappedGabinetAppointment } from "@/lib/supabase/mappers/gabinet/appointments";
 import type { MappedGabinetEmployee } from "@/lib/supabase/mappers/gabinet/employees";
 import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 import { useSidebarSlot } from "@/components/layout/sidebar-slot-context";
 import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
 
@@ -404,7 +406,12 @@ function EmployeeDetail() {
       });
       setNewNote("");
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.employees.errors.noteFailed",
+          defaultValue: "Nie udało się dodać notatki.",
+        }),
+      );
     } finally {
       setIsAddingNote(false);
     }
@@ -1253,7 +1260,7 @@ function EditEmployeeDrawer({
   onUpdate: (args: FunctionArgs<typeof api.gabinet.employees.update>) => Promise<void>;
   isSubmitting: boolean;
   setIsSubmitting: (v: boolean) => void;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: TFunction;
 }) {
   const [firstName, setFirstName] = useState(employee.firstName ?? "");
   const [lastName, setLastName] = useState(employee.lastName ?? "");
@@ -1296,7 +1303,12 @@ function EditEmployeeDrawer({
       toast.success(t("common.saved"));
       onOpenChange(false);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.employees.errors.saveFailed",
+          defaultValue: "Nie udało się zapisać zmian pracownika.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -1558,7 +1570,7 @@ function DetailedDataTab({
   organizationId: Id<"organizations">;
   onUpdate: (args: FunctionArgs<typeof api.gabinet.employees.update>) => Promise<void>;
   onSetTreatments: (args: FunctionArgs<typeof api.gabinet.employees.setQualifiedTreatments>) => Promise<void>;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: TFunction;
   i18nLanguage: string;
 }) {
   const [editing, setEditing] = useState<string | null>(null);
@@ -1723,7 +1735,12 @@ function DetailedDataTab({
       toast.success(t("common.saved"));
       setEditing(null);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.employees.errors.saveFailed",
+          defaultValue: "Nie udało się zapisać zmian pracownika.",
+        }),
+      );
     } finally {
       setSaving(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from "react-i18next";
 import { DataListFilterBar } from "@/components/crm/data-list-filter-bar";
 import type { FieldDef, FilterCondition } from "@/components/crm/types";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 import { Id } from "@cvx/_generated/dataModel";
 import type { MappedGabinetEmployee } from "@/lib/supabase/mappers/gabinet/employees";
 import type { MappedGabinetTreatment } from "@/lib/supabase/mappers/gabinet/treatments";
@@ -470,7 +471,12 @@ function CreateEmployeeSheet({
       setCategoryId(undefined);
       setTreatmentSearch("");
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.employees.errors.createFailed",
+          defaultValue: "Nie udało się dodać pracownika.",
+        }),
+      );
     } finally {
       setSaving(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -43,6 +43,7 @@ import { Plus, Trash2, Package, Pencil, Loader2, X } from "@/lib/ez-icons";
 import { useState, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 import { EmptyState } from "@/components/layout/empty-state";
 import { QuickActionBar } from "@/components/crm/quick-action-bar";
@@ -293,7 +294,12 @@ function PackagesIndex() {
       setPanelOpen(false);
       resetForm();
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.packages.errors.saveFailed",
+          defaultValue: "Nie udało się zapisać pakietu.",
+        }),
+      );
     } finally {
       setSubmitting(false);
     }
@@ -311,7 +317,12 @@ function PackagesIndex() {
       toast.success(t("common.deleted"));
       invalidatePackages();
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.packages.errors.deleteFailed",
+          defaultValue: "Nie udało się usunąć pakietu.",
+        }),
+      );
     } finally {
       setDeleteDialogOpen(false);
       setDeletingId(null);
@@ -351,7 +362,12 @@ function PackagesIndex() {
       setAssignPanelOpen(false);
       resetAssignForm();
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.packages.errors.purchaseFailed",
+          defaultValue: "Nie udało się sprzedać pakietu.",
+        }),
+      );
     } finally {
       setAssignSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseGabinetPatient } from "@/hooks/use-supabase-gabinet-patients";
@@ -204,7 +205,12 @@ function PatientDetail() {
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetPatients.list(organizationId) });
       setEditDrawerOpen(false);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.patients.errors.saveFailed",
+          defaultValue: "Nie udało się zapisać zmian klienta.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate, useSearch, Link } from "@tanstack/react-router";
 import { useAction } from "convex/react";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 import { api } from "@cvx/_generated/api";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseGabinetRecentVisitPatientIds } from "@/hooks/use-supabase-gabinet-appointments";
@@ -360,12 +361,17 @@ function PatientsIndex() {
         setTagIds([]);
         setCategoryId(undefined);
       } catch (e) {
-        toast.error(e instanceof Error ? e.message : String(e));
+        toast.error(
+          formatActionError(e, t, {
+            key: "gabinet.patients.errors.createFailed",
+            defaultValue: "Nie udało się dodać klienta.",
+          }),
+        );
       } finally {
         setIsCreating(false);
       }
     },
-    [createPatient, organizationId, tagIds, categoryId],
+    [createPatient, organizationId, tagIds, categoryId, t],
   );
 
   const handleBulkAction = useCallback(

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
@@ -39,6 +39,7 @@ import {
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/equipment"
@@ -208,7 +209,12 @@ function EquipmentCard({
       toast.success(t("common.saved"));
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetEquipment.list(organizationId) });
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Unknown error");
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.equipment.errors.saveFailed",
+          defaultValue: "Nie udało się zapisać sprzętu.",
+        }),
+      );
     } finally {
       setSaving(false);
     }
@@ -231,7 +237,12 @@ function EquipmentCard({
       setTransferRoomId("");
       setTransferNotes("");
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Unknown error");
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.equipment.errors.transferFailed",
+          defaultValue: "Nie udało się przenieść sprzętu.",
+        }),
+      );
     } finally {
       setTransferring(false);
     }
@@ -536,7 +547,12 @@ function EquipmentSettingsPage() {
       setNewStatus("available");
       setNewLocationId("");
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Unknown error");
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.equipment.errors.createFailed",
+          defaultValue: "Nie udało się dodać sprzętu.",
+        }),
+      );
     } finally {
       setCreating(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
@@ -20,6 +20,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Id } from "@cvx/_generated/dataModel";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/leave-types"
@@ -51,7 +52,12 @@ function LeaveTypesSettings() {
       const result = await initAllBalances({ organizationId, year: currentYear });
       toast.success(t("gabinet.leaveTypes.balancesInitialized", { count: result.created }));
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.leaveTypes.errors.initBalancesFailed",
+          defaultValue: "Nie udało się zainicjalizować sald urlopowych.",
+        }),
+      );
     }
   };
 
@@ -236,7 +242,12 @@ function LeaveTypeDialog({
         ...(initial ? { isActive } : {}),
       });
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.leaveTypes.errors.saveFailed",
+          defaultValue: "Nie udało się zapisać typu urlopu.",
+        }),
+      );
     } finally {
       setSaving(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
@@ -46,6 +46,7 @@ import { AlertTriangle } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 type LeavesNudgeFilter = "pending";
 
@@ -164,7 +165,12 @@ function LeavesPage() {
       setEndDate("");
       setReason("");
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.leaves.errors.createFailed",
+          defaultValue: "Nie udało się utworzyć wniosku urlopowego.",
+        }),
+      );
     } finally {
       setSubmitting(false);
     }
@@ -193,7 +199,12 @@ function LeavesPage() {
       // Invalidate Supabase leaves cache after status change
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetLeaves.all });
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Unknown error");
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.leaves.errors.statusChangeFailed",
+          defaultValue: "Nie udało się zaktualizować statusu wniosku urlopowego.",
+        }),
+      );
     } finally {
       setConfirmLeaveId(null);
       setConfirmAction(null);

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
@@ -33,6 +33,7 @@ import { Plus, Trash2, ChevronDown, ChevronRight, MapPin, Phone } from "@/lib/ez
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/locations"
@@ -160,7 +161,12 @@ function LocationCard({
       toast.success(t("common.saved"));
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetLocations.list(organizationId) });
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Unknown error");
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.locations.errors.saveFailed",
+          defaultValue: "Nie udało się zapisać lokalizacji.",
+        }),
+      );
     } finally {
       setSaving(false);
     }
@@ -173,7 +179,12 @@ function LocationCard({
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetLocations.list(organizationId) });
       onDeleted();
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Unknown error");
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.locations.errors.deleteFailed",
+          defaultValue: "Nie udało się usunąć lokalizacji.",
+        }),
+      );
     }
   };
 
@@ -192,7 +203,12 @@ function LocationCard({
       setNewRoomFloor("");
       setAddRoomOpen(false);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Unknown error");
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.locations.errors.roomCreateFailed",
+          defaultValue: "Nie udało się dodać gabinetu.",
+        }),
+      );
     } finally {
       setAddingRoom(false);
     }
@@ -202,7 +218,12 @@ function LocationCard({
     try {
       await deleteRoom({ organizationId, roomId });
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Unknown error");
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.locations.errors.roomDeleteFailed",
+          defaultValue: "Nie udało się usunąć gabinetu.",
+        }),
+      );
     }
   };
 
@@ -210,7 +231,12 @@ function LocationCard({
     try {
       await updateRoom({ organizationId, roomId, isActive: !isActive });
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Unknown error");
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.locations.errors.roomUpdateFailed",
+          defaultValue: "Nie udało się zaktualizować gabinetu.",
+        }),
+      );
     }
   };
 
@@ -513,7 +539,12 @@ function LocationsSettingsPage() {
       setNewEmail("");
       setNewCity("");
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Unknown error");
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.locations.errors.createFailed",
+          defaultValue: "Nie udało się dodać lokalizacji.",
+        }),
+      );
     } finally {
       setCreating(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
@@ -12,6 +12,7 @@ import { Plus, Trash2 } from "@/lib/ez-icons";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/scheduling"
@@ -122,7 +123,12 @@ function SchedulingSettings() {
       });
       toast.success(t("common.saved"));
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.scheduling.errors.saveFailed",
+          defaultValue: "Nie udało się zapisać godzin pracy.",
+        }),
+      );
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #947.

Closes #947

---

## Claude summary

Done. Replaced raw `toast.error(e instanceof Error ? e.message : ...)` calls in all 10 gabinet route files listed in #947 with `formatActionError` so users see translated PL/EN messages instead of raw Convex/Supabase output. The worktree already had partial coverage (settings.locations/scheduling/leaves/leave-types/equipment plus packages.index partially), and I added:

- `packages.index` — purchase-package error (was still raw)
- `employees.index` — handleCreate error
- `employees.$employeeId` — handleAddNote, EditEmployeeDrawer save, DetailedDataTab section save (3 sites)
- `patients.index` — handleCreate (with `t` added to useCallback deps)
- `patients.$patientId` — handleUpdate

Also added matching `errors.*` keys under each domain in both PL and EN translation files, and widened two `t` prop signatures in `employees.$employeeId.tsx` from a narrow `(key, opts) => string` to `TFunction` (importing `type { TFunction } from "i18next"`) so `formatActionError` accepts them. `tsc -p tsconfig.app.json --noEmit` passes clean. Committed as `8bed592`.