### PR TITLE
Audit remaining raw toast.error(e.message) sites in CRM routes

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -473,6 +473,9 @@
       "tags": "Tags",
       "tagsPlaceholder": "Type and press Enter",
       "notes": "Notes"
+    },
+    "errors": {
+      "createFailed": "Could not create the contact."
     }
   },
   "companies": {
@@ -518,6 +521,9 @@
       "zip": "Zip",
       "country": "Country",
       "notes": "Notes"
+    },
+    "errors": {
+      "createFailed": "Could not create the company."
     }
   },
   "activities": {
@@ -756,6 +762,10 @@
   "calendar": {
     "nudgeFilter": {
       "yesterdayOverdue": "Showing yesterday's overdue activities (due yesterday and not completed)."
+    },
+    "errors": {
+      "googleImportFailed": "Could not import Google Calendar events.",
+      "moveFailed": "Could not move the event."
     }
   },
   "settings": {
@@ -3421,7 +3431,12 @@
     "all": "All",
     "crm": "CRM",
     "gabinet": "Gabinet",
-    "platform": "Platform"
+    "platform": "Platform",
+    "errors": {
+      "bindFailed": "Could not bind the template to the event.",
+      "toggleFailed": "Could not change the binding state.",
+      "unbindFailed": "Could not remove the binding."
+    }
   },
   "sms": {
     "title": "SMS Settings",
@@ -3443,7 +3458,11 @@
     "deactivatedSuccess": "SMS notifications deactivated.",
     "apiTokenRequired": "API token is required.",
     "apiTokenPlaceholder": "Enter API token",
-    "apiSecretPlaceholder": "Enter Auth Token (Twilio)"
+    "apiSecretPlaceholder": "Enter Auth Token (Twilio)",
+    "errors": {
+      "saveFailed": "Could not save the SMS configuration.",
+      "toggleFailed": "Could not change the SMS notifications state."
+    }
   },
   "emailSequences": {
     "title": "Email Sequences",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -472,6 +472,9 @@
       "tags": "Tagi",
       "tagsPlaceholder": "Wpisz i naciśnij Enter",
       "notes": "Notatki"
+    },
+    "errors": {
+      "createFailed": "Nie udało się utworzyć kontaktu."
     }
   },
   "companies": {
@@ -517,6 +520,9 @@
       "zip": "Kod pocztowy",
       "country": "Kraj",
       "notes": "Notatki"
+    },
+    "errors": {
+      "createFailed": "Nie udało się utworzyć firmy."
     }
   },
   "activities": {
@@ -756,6 +762,10 @@
   "calendar": {
     "nudgeFilter": {
       "yesterdayOverdue": "Pokazywane są zaległe aktywności z wczoraj (z wczorajszą datą i nieukończone)."
+    },
+    "errors": {
+      "googleImportFailed": "Nie udało się zaimportować kalendarza Google.",
+      "moveFailed": "Nie udało się przenieść wydarzenia."
     }
   },
   "settings": {
@@ -3436,7 +3446,12 @@
     "all": "Wszystkie",
     "crm": "CRM",
     "gabinet": "Gabinet",
-    "platform": "Platforma"
+    "platform": "Platforma",
+    "errors": {
+      "bindFailed": "Nie udało się przypisać szablonu do zdarzenia.",
+      "toggleFailed": "Nie udało się zmienić stanu powiązania.",
+      "unbindFailed": "Nie udało się usunąć powiązania."
+    }
   },
   "sms": {
     "title": "Ustawienia SMS",
@@ -3458,7 +3473,11 @@
     "deactivatedSuccess": "Powiadomienia SMS dezaktywowane.",
     "apiTokenRequired": "Token API jest wymagany.",
     "apiTokenPlaceholder": "Wprowadź token API",
-    "apiSecretPlaceholder": "Wprowadź Auth Token (Twilio)"
+    "apiSecretPlaceholder": "Wprowadź Auth Token (Twilio)",
+    "errors": {
+      "saveFailed": "Nie udało się zapisać konfiguracji SMS.",
+      "toggleFailed": "Nie udało się zmienić stanu powiadomień SMS."
+    }
   },
   "emailSequences": {
     "title": "Sekwencje email",

--- a/src/routes/_app/_auth/dashboard/_layout.calendar.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calendar.tsx
@@ -30,6 +30,7 @@ import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { useState, useMemo, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 import { Id } from "@cvx/_generated/dataModel";
 import { Loader2 } from "lucide-react";
 
@@ -245,7 +246,12 @@ function UnifiedCalendarPage() {
         })
       );
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : t("calendar.googleImportFailed", "Import failed"));
+      toast.error(
+        formatActionError(e, t, {
+          key: "calendar.errors.googleImportFailed",
+          defaultValue: "Nie udało się zaimportować kalendarza Google.",
+        }),
+      );
     } finally {
       setIsImporting(false);
     }
@@ -400,7 +406,12 @@ function UnifiedCalendarPage() {
 
         toast.success(t("calendar.eventMoved", "Event moved"));
       } catch (err) {
-        toast.error(err instanceof Error ? err.message : t("calendar.moveFailed", "Failed to move event"));
+        toast.error(
+          formatActionError(err, t, {
+            key: "calendar.errors.moveFailed",
+            defaultValue: "Nie udało się przenieść wydarzenia.",
+          }),
+        );
       }
     },
     [editPerm.allowed, events, organizationId, updateActivity, updateAppointment, queryClient, t]

--- a/src/routes/_app/_auth/dashboard/_layout.companies.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.new.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useAction } from "convex/react";
 import { useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
@@ -9,6 +10,7 @@ import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { PageHeader } from "@/components/layout/page-header";
 import { CompanyForm } from "@/components/forms/company-form";
 import { Card, CardContent } from "@/components/ui/card";
+import { formatActionError } from "@/lib/format-action-error";
 import { useState, type ComponentProps } from "react";
 import { Id } from "@cvx/_generated/dataModel";
 
@@ -19,6 +21,7 @@ export const Route = createFileRoute(
 });
 
 function NewCompany() {
+  const { t } = useTranslation();
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -63,7 +66,12 @@ function NewCompany() {
                 navigate({ to: `/dashboard/companies/${id}` });
                 void queryClient.invalidateQueries({ queryKey: supabaseKeys.companies.list(organizationId) });
               } catch (e) {
-                toast.error(e instanceof Error ? e.message : String(e));
+                toast.error(
+                  formatActionError(e, t, {
+                    key: "companies.errors.createFailed",
+                    defaultValue: "Nie udało się utworzyć firmy.",
+                  }),
+                );
               } finally {
                 setIsSubmitting(false);
               }

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.new.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useAction } from "convex/react";
 import { useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
@@ -8,6 +9,7 @@ import { useSupabaseCustomFieldDefinitions } from "@/hooks/use-supabase-custom-f
 import { PageHeader } from "@/components/layout/page-header";
 import { ContactForm } from "@/components/forms/contact-form";
 import { Card, CardContent } from "@/components/ui/card";
+import { formatActionError } from "@/lib/format-action-error";
 import { useState, type ComponentProps } from "react";
 import { Id } from "@cvx/_generated/dataModel";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
@@ -19,6 +21,7 @@ export const Route = createFileRoute(
 });
 
 function NewContact() {
+  const { t } = useTranslation();
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -64,7 +67,12 @@ function NewContact() {
                 void queryClient.invalidateQueries({ queryKey: supabaseKeys.contacts.list(organizationId) });
                 navigate({ to: `/dashboard/contacts/${id}` });
               } catch (e) {
-                toast.error(e instanceof Error ? e.message : String(e));
+                toast.error(
+                  formatActionError(e, t, {
+                    key: "contacts.errors.createFailed",
+                    defaultValue: "Nie udało się utworzyć kontaktu.",
+                  }),
+                );
               } finally {
                 setIsSubmitting(false);
               }

--- a/src/routes/_app/_auth/dashboard/_layout.settings.email-events.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.email-events.tsx
@@ -25,6 +25,7 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { Badge } from "@/components/ui/badge";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 import { Id } from "@cvx/_generated/dataModel";
 
 export const Route = createFileRoute(
@@ -109,7 +110,12 @@ function EmailEventsSettings() {
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.emailEventBindings.list(organizationId) });
       toast.success(t("emailEvents.bindingSaved"));
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "emailEvents.errors.bindFailed",
+          defaultValue: "Nie udało się przypisać szablonu do zdarzenia.",
+        }),
+      );
     } finally {
       setBindingInProgress(null);
     }
@@ -126,7 +132,12 @@ function EmailEventsSettings() {
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.emailEventBindings.list(organizationId) });
       toast.success(t("emailEvents.bindingSaved"));
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "emailEvents.errors.toggleFailed",
+          defaultValue: "Nie udało się zmienić stanu powiązania.",
+        }),
+      );
     } finally {
       setBindingInProgress(null);
     }
@@ -147,7 +158,12 @@ function EmailEventsSettings() {
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.emailEventBindings.list(organizationId) });
       toast.success(t("emailEvents.bindingDeleted"));
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "emailEvents.errors.unbindFailed",
+          defaultValue: "Nie udało się usunąć powiązania.",
+        }),
+      );
     } finally {
       setBindingInProgress(null);
       setUnbindTarget(null);

--- a/src/routes/_app/_auth/dashboard/_layout.settings.sms.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.sms.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/settings/sms"
@@ -78,7 +79,12 @@ function SmsSettings() {
       setApiSecret("");
       toast.success(t("sms.saved"));
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "sms.errors.saveFailed",
+          defaultValue: "Nie udało się zapisać konfiguracji SMS.",
+        }),
+      );
     } finally {
       setSaving(false);
     }
@@ -92,7 +98,12 @@ function SmsSettings() {
         isActive ? t("sms.activatedSuccess") : t("sms.deactivatedSuccess")
       );
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e));
+      toast.error(
+        formatActionError(e, t, {
+          key: "sms.errors.toggleFailed",
+          defaultValue: "Nie udało się zmienić stanu powiadomień SMS.",
+        }),
+      );
     } finally {
       setToggling(false);
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #948.

Closes #948

---

## Claude summary

All five flagged sites now use `formatActionError` from `src/lib/format-action-error.ts` with a Polish fallback message, instead of leaking raw `e.message` (which carries English Convex/Supabase output) to users. Specifically:

- `_layout.companies.new.tsx` — `createCompany` catch → `companies.errors.createFailed`
- `_layout.contacts.new.tsx` — `createContact` catch → `contacts.errors.createFailed`
- `_layout.calendar.tsx` — `handleGoogleImport` → `calendar.errors.googleImportFailed`; `handleDrop` → `calendar.errors.moveFailed`
- `_layout.settings.sms.tsx` — `handleSave` → `sms.errors.saveFailed`; `handleToggleActive` → `sms.errors.toggleFailed`
- `_layout.settings.email-events.tsx` — `handleBindTemplate` / `handleToggleBinding` / `confirmUnbind` → `emailEvents.errors.{bindFailed,toggleFailed,unbindFailed}`

EN + PL translations added for every new key. `npm run typecheck` passes clean. Committed as `b743053`.