### PR TITLE
Document required Netlify env vars in `.env.example` or a Netlify-specific doc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,37 +1,69 @@
+# =============================================================================
+# Local development uses this whole file via `.env.local`.
+#
+# Production deploys split env vars across TWO different surfaces:
+#
+#   1. Netlify  - vars needed by the Netlify build command itself
+#                 (`npm run migrations:apply && npx convex deploy --cmd
+#                 'npm run build'`) and any `VITE_*` vars that Vite bakes
+#                 into the static bundle. Set these under:
+#                   Site settings → Environment variables.
+#                 They are marked with `# [netlify]` below.
+#
+#   2. Convex   - vars consumed by Convex functions at runtime (auth,
+#                 Resend, Stripe webhooks, Google OAuth, Supabase service
+#                 role, etc.). Set these with `npx convex env set NAME value`
+#                 against the production deployment, NOT in Netlify.
+#                 They are marked with `# [convex]` below.
+#
+# Vars marked `# [netlify+convex]` must be set in BOTH places (e.g.
+# SUPABASE_URL — the build script reads it via Node, and Convex functions
+# read it at runtime).
+# =============================================================================
+
 # Convex (required - cloud deployment)
-CONVEX_DEPLOYMENT=dev:your-project-name
-VITE_CONVEX_URL=https://your-project.convex.cloud
-CONVEX_SITE_URL=https://your-project.convex.site
+# CONVEX_DEPLOYMENT and VITE_CONVEX_URL are written by `npx convex dev` for
+# local development; in Netlify, set CONVEX_DEPLOY_KEY instead (a production
+# deploy key generated in the Convex dashboard) and Convex's deploy CLI
+# will populate VITE_CONVEX_URL during the build automatically.
+CONVEX_DEPLOYMENT=dev:your-project-name              # [local dev only]
+VITE_CONVEX_URL=https://your-project.convex.cloud    # [netlify] (or let `convex deploy` inject it)
+CONVEX_SITE_URL=https://your-project.convex.site     # [convex]
+CONVEX_DEPLOY_KEY=                                   # [netlify] required for `convex deploy` in CI
 
 # Auth
-AUTH_RESEND_KEY=
-AUTH_EMAIL=
-HOST_URL=
-SITE_URL=
+AUTH_RESEND_KEY=     # [convex]
+AUTH_EMAIL=          # [convex]
+HOST_URL=            # [convex]
+SITE_URL=            # [convex]
 
 # Email (Resend)
-RESEND_API_KEY=
-RESEND_FROM=
+RESEND_API_KEY=      # [convex]
+RESEND_FROM=         # [convex]
 
 # Stripe (optional for billing)
-STRIPE_SECRET_KEY=
-STRIPE_WEBHOOK_SECRET=
+STRIPE_SECRET_KEY=       # [convex]
+STRIPE_WEBHOOK_SECRET=   # [convex]
 
 # Google OAuth (optional for Gmail integration)
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
-GOOGLE_REDIRECT_URI=
+GOOGLE_CLIENT_ID=      # [convex]
+GOOGLE_CLIENT_SECRET=  # [convex]
+GOOGLE_REDIRECT_URI=   # [convex]
 
 # Supabase (remote self-hosted - main database storage)
-SUPABASE_URL=https://supabase.your-domain.com
-SUPABASE_DB_URL=postgresql://postgres:password@supabase.your-domain.com:5433/postgres
-SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-SUPABASE_JWT_SECRET=your-jwt-secret-here
+# SUPABASE_DB_URL is required by the Netlify build to apply pending SQL
+# migrations before `convex deploy` (see netlify.toml and #942). Without it
+# the migration step exits 0 (fail-open) and the GitHub Actions workflow
+# becomes the only gate.
+SUPABASE_URL=https://supabase.your-domain.com                                            # [netlify+convex]
+SUPABASE_DB_URL=postgresql://postgres:password@supabase.your-domain.com:5433/postgres    # [netlify] required to gate the build on migrations
+SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...                                # [convex]
+SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...                        # [convex]
+SUPABASE_JWT_SECRET=your-jwt-secret-here                                                 # [convex]
 
 # Supabase (frontend - exposed to Vite, used by supabase-js client)
-VITE_SUPABASE_URL=https://supabase.your-domain.com
-VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+VITE_SUPABASE_URL=https://supabase.your-domain.com                # [netlify] baked into bundle
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...    # [netlify] baked into bundle
 
 # App URL
-APP_URL=
+APP_URL=             # [convex]

--- a/DEPLOYMENT-CHECKLIST.md
+++ b/DEPLOYMENT-CHECKLIST.md
@@ -160,16 +160,43 @@ npm run migrations:apply
 
 ## Environment Variables Required
 
-**Check for:**
-- Database connection strings
-- API keys
-- Authentication secrets
-- Feature flags
+Production env vars are split across two surfaces — Netlify (build-time +
+frontend bundle) and Convex (runtime backend). See `.env.example` for the
+full list with per-var `# [netlify]` / `# [convex]` annotations.
 
-**Verify:**
-- All env vars documented
-- Production values set
-- Secrets secured
+### Netlify (Site settings → Environment variables)
+
+Required for the production build command in `netlify.toml`
+(`npm run migrations:apply && npx convex deploy --cmd 'npm run build'`):
+
+- `CONVEX_DEPLOY_KEY` — production deploy key from the Convex dashboard;
+  without it `convex deploy` fails.
+- `SUPABASE_DB_URL` — Postgres connection string used by
+  `scripts/supabase-migrations.mjs` to apply pending SQL before the
+  frontend goes live. Without it the migration step exits 0 (fail-open)
+  and only the GitHub Actions workflow gates schema drift — see #942.
+- `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` — baked into the
+  static bundle by Vite; the runtime supabase-js client cannot start
+  without them.
+- `VITE_CONVEX_URL` — only set manually if you are not running
+  `convex deploy` in the build command. With the current `netlify.toml`
+  the Convex CLI injects this for you.
+
+### Convex (`npx convex env set NAME value` against the prod deployment)
+
+Backend runtime secrets — NOT set in Netlify:
+
+- Auth: `AUTH_RESEND_KEY`, `AUTH_EMAIL`, `HOST_URL`, `SITE_URL`, `CONVEX_SITE_URL`
+- Email: `RESEND_API_KEY`, `RESEND_FROM`
+- Stripe: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`
+- Google OAuth: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`
+- Supabase server-side: `SUPABASE_URL`, `SUPABASE_ANON_KEY`,
+  `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_JWT_SECRET`
+- `APP_URL`
+
+`SUPABASE_URL` is the one var that must be set in BOTH Netlify (so the
+migration script can find the DB host) and Convex (so functions can read
+from it at runtime).
 
 ---
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #952.

Closes #952

---

## Claude summary

Committed. Summary of changes:

`.env.example` — added a header explaining the two-surface split (Netlify vs Convex), and tagged every var with `# [netlify]`, `# [convex]`, or `# [netlify+convex]`. Called out the previously-missing `CONVEX_DEPLOY_KEY` (required for `convex deploy` in the build command) and noted that `SUPABASE_DB_URL` is what activates the migration gating from #942.

`DEPLOYMENT-CHECKLIST.md` — replaced the generic "check for database strings, API keys, secrets" Environment Variables section with explicit Netlify vs Convex lists matching `.env.example`.