### PR TITLE
Gate Netlify deploy on GHA workflow success

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -9,10 +9,10 @@ on:
       - ".github/workflows/supabase-migrations.yml"
   push:
     branches: [main]
-    paths:
-      - "supabase/migrations/**"
-      - "scripts/supabase-migrations.mjs"
-      - ".github/workflows/supabase-migrations.yml"
+    # No path filter on purpose: every push to main must apply pending
+    # migrations AND trigger the Netlify deploy. Path-filtering would let
+    # pushes that touch only the frontend skip the deploy gate, defeating
+    # the ordering this workflow exists to enforce (#951).
 
 jobs:
   # On PR: verify that the migrations already on main are applied to the
@@ -38,9 +38,8 @@ jobs:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
 
   # On push to main: apply any pending migrations to the deployed database
-  # before the rest of the deploy (Netlify build + convex deploy) runs.
-  # Fails the workflow if migrations can't be applied, so the deploy is not
-  # silently left in a broken state.
+  # before the deploy job triggers Netlify. Fails the workflow if migrations
+  # can't be applied, so a broken schema does not get a frontend in front of it.
   apply:
     name: Apply pending migrations
     if: github.event_name == 'push'
@@ -64,3 +63,41 @@ jobs:
             exit 1
           fi
           node scripts/supabase-migrations.mjs apply
+
+  # On push to main: trigger Netlify production build via build hook, but
+  # only after `apply` has succeeded. This is the gating fix from #951:
+  # Netlify auto-deploy must be turned OFF in the UI and the build hook URL
+  # stored as a repo secret so this workflow is the single entrypoint into
+  # a production deploy. If the secret is missing, we exit 0 with a warning
+  # so existing setups (Netlify auto-deploy still on) keep working — the
+  # gating only activates once the Netlify-side migration is done.
+  deploy:
+    name: Trigger Netlify deploy
+    if: github.event_name == 'push'
+    needs: apply
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger Netlify build hook
+        env:
+          NETLIFY_BUILD_HOOK_URL: ${{ secrets.NETLIFY_BUILD_HOOK_URL }}
+        run: |
+          if [ -z "${NETLIFY_BUILD_HOOK_URL:-}" ]; then
+            echo "::warning::NETLIFY_BUILD_HOOK_URL is not set — skipping deploy trigger."
+            echo "::warning::Netlify auto-deploy (if still enabled in the Netlify UI) handles"
+            echo "::warning::the deploy in parallel, but the migrations -> deploy ordering is"
+            echo "::warning::NOT enforced. To activate gating (issue #951):"
+            echo "::warning::  1. Create a build hook in Netlify"
+            echo "::warning::     (Site settings -> Build & deploy -> Build hooks)."
+            echo "::warning::  2. Disable auto-publishing / continuous deployment in Netlify"
+            echo "::warning::     (Site settings -> Build & deploy -> Continuous deployment)."
+            echo "::warning::  3. Add the hook URL as NETLIFY_BUILD_HOOK_URL repo secret."
+            exit 0
+          fi
+          curl -fsSL --retry 3 --retry-delay 5 \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d '{}' \
+            "${NETLIFY_BUILD_HOOK_URL}"
+          echo
+          echo "Triggered Netlify production build."

--- a/DEPLOYMENT-CHECKLIST.md
+++ b/DEPLOYMENT-CHECKLIST.md
@@ -107,24 +107,41 @@ npm run build
 ```
 
 ### 2a. Apply Supabase Migrations
-Migrations are applied in two places so the frontend never goes live
-against a DB that's missing the columns it expects (issue #942):
+Production deploys are gated through the `Supabase Migrations` GitHub
+Actions workflow (`.github/workflows/supabase-migrations.yml`). On push
+to `main` it runs two jobs in order (#951):
 
-1. The Netlify production build command (`netlify.toml`) runs
-   `npm run migrations:apply` before `convex deploy` + `npm run build`,
-   so a failed migration aborts the frontend deploy.
-2. The `Supabase Migrations` GitHub Actions workflow
-   (`.github/workflows/supabase-migrations.yml`) applies pending SQL on
-   every push to `main` as a secondary signal (surfaces failures in PR
-   checks even if Netlify is misconfigured).
+1. `apply` — runs `node scripts/supabase-migrations.mjs apply` against
+   the deployed Postgres, failing the workflow if any migration can't
+   be applied.
+2. `deploy` — `needs: apply`, POSTs to the Netlify build hook so the
+   frontend deploy only starts after migrations succeed.
 
-Both paths require the `SUPABASE_DB_URL` secret:
-- Netlify: set it under Site settings → Environment variables.
-- GitHub Actions: set it under Settings → Secrets and variables → Actions.
+The Netlify production build command (`netlify.toml`) also runs
+`npm run migrations:apply` before `convex deploy` + `npm run build`,
+as defense-in-depth — if a deploy is triggered some other way (manual
+re-deploy in Netlify UI, build hook fired by hand), the build will
+still abort on a failed migration.
 
-If the secret is missing in Netlify, `npm run migrations:apply` exits 0
-(fail-open) and the Netlify gating becomes a no-op — set the env var to
-get the gating behavior.
+Required secrets:
+- `SUPABASE_DB_URL` — set in BOTH GitHub Actions
+  (Settings → Secrets and variables → Actions) and Netlify
+  (Site settings → Environment variables).
+- `NETLIFY_BUILD_HOOK_URL` — set as a GitHub Actions secret; the URL
+  comes from Netlify (Site settings → Build & deploy → Build hooks →
+  Add build hook, branch = `main`).
+
+Required Netlify UI setup (one-time, do this when adding the hook):
+- Disable continuous deployment / auto-publish in Netlify
+  (Site settings → Build & deploy → Continuous deployment). Otherwise
+  Netlify keeps deploying in parallel on every push and the gating in
+  GitHub Actions becomes advisory only.
+
+If `NETLIFY_BUILD_HOOK_URL` is missing the `deploy` job exits 0 with a
+warning, so the workflow is safe to run before the Netlify-side setup
+is complete. If `SUPABASE_DB_URL` is missing in Netlify, the in-build
+migration step exits 0 (fail-open) and only the GHA workflow gates
+schema drift.
 
 If both fail, run the migrations manually before the frontend deploy
 completes:
@@ -197,6 +214,15 @@ Backend runtime secrets — NOT set in Netlify:
 `SUPABASE_URL` is the one var that must be set in BOTH Netlify (so the
 migration script can find the DB host) and Convex (so functions can read
 from it at runtime).
+
+### GitHub Actions (Settings → Secrets and variables → Actions)
+
+- `SUPABASE_DB_URL` — same Postgres connection string as in Netlify;
+  used by the `apply` job in `supabase-migrations.yml` to run pending
+  migrations against the deployed DB on every push to `main`.
+- `NETLIFY_BUILD_HOOK_URL` — Netlify build hook URL (`main` branch);
+  the workflow POSTs to this after migrations succeed, gating the
+  Netlify deploy on the migration step. See #951.
 
 ---
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #951.

Closes #951

---

## Claude summary

Committed `139b680`.

Summary: `.github/workflows/supabase-migrations.yml` now drops the path filter on the push trigger and adds a `deploy` job (`needs: apply`) that POSTs to the Netlify build hook only after migrations succeed. If `NETLIFY_BUILD_HOOK_URL` isn't set, the deploy step exits 0 with a warning explaining the Netlify-side setup, so this is safe to land before the manual Netlify steps (create build hook, disable continuous deployment) are done. `DEPLOYMENT-CHECKLIST.md` documents the new flow and the new GHA secret. The in-build migration step in `netlify.toml` stays as defense-in-depth.

The user still needs to do the one-time Netlify setup to fully activate gating:
1. Create a Netlify build hook for `main`
2. Disable continuous deployment in Netlify UI
3. Add `NETLIFY_BUILD_HOOK_URL` as a GitHub Actions secret

Until then the deploy job is advisory (warns, returns 0) and Netlify auto-deploy keeps running in parallel as today — no regression.