### PR TITLE
Translate raw e.message in admin pages

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3714,5 +3714,17 @@
       "sourceSystem": "System",
       "incompleteSidebarKpi": "To complete"
     }
+  },
+  "admin": {
+    "email": {
+      "errors": {
+        "saveFailed": "Could not save the email settings."
+      }
+    },
+    "users": {
+      "errors": {
+        "roleUpdateFailed": "Could not update the user's role."
+      }
+    }
   }
 }

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3729,5 +3729,17 @@
       "sourceSystem": "System",
       "incompleteSidebarKpi": "Do uzupełnienia"
     }
+  },
+  "admin": {
+    "email": {
+      "errors": {
+        "saveFailed": "Nie udało się zapisać ustawień e-mail."
+      }
+    },
+    "users": {
+      "errors": {
+        "roleUpdateFailed": "Nie udało się zmienić roli użytkownika."
+      }
+    }
   }
 }

--- a/src/routes/_app/_auth/admin.email-config.tsx
+++ b/src/routes/_app/_auth/admin.email-config.tsx
@@ -5,6 +5,7 @@ import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
 import { useMutation } from "@tanstack/react-query";
 import { api } from "@cvx/_generated/api";
 import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -16,6 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute("/_app/_auth/admin/email-config")({
   component: AdminEmailConfig,
@@ -24,6 +26,7 @@ export const Route = createFileRoute("/_app/_auth/admin/email-config")({
 type ProviderChoice = "env" | "resend" | "mailgun";
 
 function AdminEmailConfig() {
+  const { t } = useTranslation();
   const { data: user, isLoading: userLoading } = useQuery(
     convexQuery(api.app.getCurrentUser, {}),
   );
@@ -61,7 +64,12 @@ function AdminEmailConfig() {
       toast.success("Platform email settings saved");
     },
     onError: (e: Error) => {
-      toast.error(e.message || "Failed to save settings");
+      toast.error(
+        formatActionError(e, t, {
+          key: "admin.email.errors.saveFailed",
+          defaultValue: "Nie udało się zapisać ustawień e-mail.",
+        }),
+      );
     },
   });
 

--- a/src/routes/_app/_auth/admin.users.tsx
+++ b/src/routes/_app/_auth/admin.users.tsx
@@ -4,15 +4,18 @@ import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { Id } from "@cvx/_generated/dataModel";
 import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute("/_app/_auth/admin/users")({
   component: AdminUsers,
 });
 
 function AdminUsers() {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
 
   const { data: viewer, isLoading: viewerLoading } = useQuery(
@@ -31,7 +34,12 @@ function AdminUsers() {
       queryClient.invalidateQueries({ queryKey: ["convexQuery"] });
     },
     onError: (e: Error) => {
-      toast.error(e.message || "Failed to update role");
+      toast.error(
+        formatActionError(e, t, {
+          key: "admin.users.errors.roleUpdateFailed",
+          defaultValue: "Nie udało się zmienić roli użytkownika.",
+        }),
+      );
     },
   });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #956.

Closes #956

---

## Claude summary

Both flagged sites (`admin.email-config.tsx:64` and `admin.users.tsx:34`) now use `formatActionError` from `@/lib/format-action-error`, mirroring the prior #948/#949 fixes. Universal Convex error patterns (permission denied, validator failures, raw `supabaseDb.*` storage errors) get translated via the existing `common.errors.*` keys; otherwise we fall back to two new domain-specific keys, added in both EN and PL: `admin.email.errors.saveFailed` and `admin.users.errors.roleUpdateFailed`. JSON validates clean; typecheck couldn't run locally (no node_modules in this worktree), but the edits are minimal and follow the proven pattern verbatim.