### PR TITLE
Fix pre-existing `any` casts in EmployeeForm useAction results

### DIFF
--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -94,14 +94,14 @@ export function EmployeeForm({
     queryKey: ["gabinet.employees.listAll", organizationId],
     queryFn: () => listEmployees({ organizationId }),
     enabled: !!organizationId,
-  }) as { data: any[] | undefined };
+  });
 
   const listActiveTreatments = useAction(api.gabinet.treatments.listActive);
   const { data: treatments } = useQuery({
     queryKey: ["gabinet.treatments.listActive", organizationId],
     queryFn: () => listActiveTreatments({ organizationId }),
     enabled: !!organizationId,
-  }) as { data: any[] | undefined };
+  });
 
   // Users not yet registered as employees (for create mode)
   const availableUsers = useMemo(() => {
@@ -313,7 +313,7 @@ export function EmployeeForm({
                         : false
                   }
                   onCheckedChange={(checked) => {
-                    const visibleIds = filteredTreatments.map((tr) => tr._id);
+                    const visibleIds = filteredTreatments.map((tr) => tr._id as string);
                     if (checked === true) {
                       setSelectedTreatments(
                         Array.from(new Set([...selectedTreatments, ...visibleIds])),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #965.

Closes #965

---

## Claude summary

Removed the `any[]` casts on the `useQuery` results for `listAll` (employees) and `listActive` (treatments) in `src/components/forms/employee-form.tsx`. `useQuery` now infers `data` from each action's existing typed return (`GabinetEmployeeRow[]` / `GabinetTreatmentRow[]`), eliminating the ESLint warnings. One downstream `tr._id as string` cast was added in the select-all handler to keep the existing `string[]` state shape intact. Typecheck shows only the three pre-existing TS2589 errors (unchanged before/after), and ESLint passes clean on the file.