### PR TITLE
zamknij i rozlicz

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -467,6 +467,7 @@ export function AppointmentPreviewContent({
     void navigate({
       to: "/dashboard/gabinet/appointments/$appointmentId",
       params: { appointmentId: appointment._id },
+      search: { tab: "payments" },
     });
   };
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { createLazyFileRoute, useNavigate } from "@tanstack/react-router";
+import { createLazyFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
@@ -301,6 +301,9 @@ function NoteItem({
 
 function AppointmentDetail() {
   const { appointmentId } = Route.useParams();
+  const { tab: tabSearch } = useSearch({
+    from: "/_app/_auth/dashboard/_layout/gabinet/appointments/$appointmentId",
+  });
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
   const { t, i18n } = useTranslation();
@@ -2284,6 +2287,9 @@ function AppointmentDetail() {
         expandedFieldCount={5}
         sidebarExtra={sidebarExtra}
         tabs={tabs}
+        defaultTab={
+          tabSearch === "payments" ? t("gabinet.payments.payments") : undefined
+        }
       />
 
       {/* Change Employee Modal */}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.tsx
@@ -1,5 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+type AppointmentSearch = {
+  tab?: "payments";
+};
+
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/appointments/$appointmentId"
-)({});
+)({
+  validateSearch: (search: Record<string, unknown>): AppointmentSearch => ({
+    tab: search.tab === "payments" ? "payments" : undefined,
+  }),
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #968.

Closes #968

---

## Claude summary

Committed.

Summary of the fix for #968:

The "Zamknij i rozlicz" button in the calendar appointment preview already navigated to the appointment detail page, but it landed on the default "Szczegóły" tab instead of "Płatności". I wired the navigation through to the payments tab.

Changes:
- `src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.tsx:3-13` — added `validateSearch` accepting `tab: "payments"`.
- `src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx:304-306, 2290-2292` — read `tab` from search and pass to `EntityDetailLayout` as `defaultTab` resolved to the payments tab label.
- `src/components/gabinet/calendar/appointment-preview-content.tsx:470` — `handleCloseAndSettle` now navigates with `search: { tab: "payments" }`.

Typecheck passes (`tsc -p tsconfig.app.json`).