### PR TITLE
zamknij i rozlicz

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -467,6 +467,7 @@ export function AppointmentPreviewContent({
     void navigate({
       to: "/dashboard/gabinet/appointments/$appointmentId",
       params: { appointmentId: appointment._id },
+      search: { tab: "payments" },
     });
   };
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { createLazyFileRoute, useNavigate } from "@tanstack/react-router";
+import { createLazyFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
@@ -301,6 +301,9 @@ function NoteItem({
 
 function AppointmentDetail() {
   const { appointmentId } = Route.useParams();
+  const { tab: tabSearch } = useSearch({
+    from: "/_app/_auth/dashboard/_layout/gabinet/appointments/$appointmentId",
+  });
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
   const { t, i18n } = useTranslation();
@@ -2284,6 +2287,9 @@ function AppointmentDetail() {
         expandedFieldCount={5}
         sidebarExtra={sidebarExtra}
         tabs={tabs}
+        defaultTab={
+          tabSearch === "payments" ? t("gabinet.payments.payments") : undefined
+        }
       />
 
       {/* Change Employee Modal */}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.tsx
@@ -1,5 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+type AppointmentSearch = {
+  tab?: "payments";
+};
+
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/appointments/$appointmentId"
-)({});
+)({
+  validateSearch: (search: Record<string, unknown>): AppointmentSearch => ({
+    tab: search.tab === "payments" ? "payments" : undefined,
+  }),
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #968.

Closes #968

---

## Claude summary

NOT_A_BUG: The original "zamknij i rozlicz" → payments tab routing was already fixed and merged in PR #970 (commit `b38f1d7` on `main`). The follow-up comment is just asking for a pointer to the `TreatmentPurchaseDrawer` component, so there is nothing to commit here.

The component lives at:

- `src/components/gabinet/treatment-purchase-drawer.tsx:42` — `export function TreatmentPurchaseDrawer(...)`
- GitHub: https://github.com/aleksanderem/crm_new/blob/main/src/components/gabinet/treatment-purchase-drawer.tsx

It is consumed in three places (always as a Radix `Sheet`-based drawer that handles patient + treatment selection, one-time / installment payment, and split payments):

- `src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx:33,603` — "Sprzedaj zabieg" button on the treatments list
- `src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx:52,805` — equivalent flow on the packages list
- `src/components/gabinet/patient-treatment-sales-card.tsx:29,143` — opened from the patient detail page (no patient picker)

If `aslocka` actually wants the drawer wired into the appointment detail page (e.g. from the new Payments tab opened by PR #970), that would be a separate feature, not part of #968. Let me know and I can scope it as its own issue/PR.