### PR TITLE
cena

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -260,6 +260,7 @@ export function TreatmentForm({
             inputMode="decimal"
             value={price}
             onChange={(e) => setPrice(e.target.value)}
+            onWheel={(e) => (e.currentTarget as HTMLInputElement).blur()}
             placeholder="0.00"
             required
             className="[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #972.

Closes #972

---

## Claude summary

Fixed by adding `onWheel={(e) => (e.currentTarget as HTMLInputElement).blur()}` to the price `Input` in `src/components/gabinet/treatment-form.tsx:263`. Now mouse-wheel scrolling over a focused price field blurs it and scrolls the page instead of changing the value. Typecheck clean, committed as `0f7e14f`.

## Follow-ups
- Block mousewheel on remaining gabinet number inputs in treatment-form: duration (line 244) and treatment count (line 318) have the same scroll-changes-value issue