### PR TITLE
Block mousewheel on remaining gabinet number inputs in treatment-form

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -245,6 +245,7 @@ export function TreatmentForm({
             min="1"
             value={duration}
             onChange={(e) => setDuration(e.target.value)}
+            onWheel={(e) => (e.currentTarget as HTMLInputElement).blur()}
             placeholder="30"
             required
           />
@@ -320,6 +321,7 @@ export function TreatmentForm({
               min="2"
               value={treatmentCount}
               onChange={(e) => setTreatmentCount(e.target.value)}
+              onWheel={(e) => (e.currentTarget as HTMLInputElement).blur()}
               placeholder="2"
             />
             <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #974.

Closes #974

---

## Claude summary

Applied the `onWheel={(e) => (e.currentTarget as HTMLInputElement).blur()}` handler to both the duration input (line 244) and the treatment count input (line 318) in `src/components/gabinet/treatment-form.tsx`, mirroring the existing fix on the price input from #972. Committed as `8789866`.