### PR TITLE
przesuwanie

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2496,6 +2496,7 @@
     },
     "appointments": {
       "createAppointment": "New Appointment",
+      "dragToMove": "Drag to move",
       "patient": "Client",
       "treatment": "Treatment",
       "employee": "Employee",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2506,6 +2506,7 @@
     },
     "appointments": {
       "createAppointment": "Nowa wizyta",
+      "dragToMove": "Przeciągnij, aby przesunąć",
       "patient": "Klient",
       "treatment": "Zabieg",
       "package": "Pakiet",

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -65,7 +65,7 @@ import {
   MapPin,
   Building2,
 } from "@/lib/ez-icons";
-import { AlertTriangle, CalendarSearch, X } from "lucide-react";
+import { AlertTriangle, CalendarSearch, GripHorizontal, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { SidePanel } from "@/components/crm/side-panel";
@@ -259,6 +259,46 @@ export function AppointmentDialog({
 
   // Past-slot confirmation popup
   const [pastConfirmOpen, setPastConfirmOpen] = useState(false);
+
+  // Drag-to-reposition state — users want to peek at the calendar underneath
+  // without closing the dialog (issue #977). Offset resets when the dialog
+  // closes so the next open starts centered.
+  const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  useEffect(() => {
+    if (!open) {
+      setDragOffset({ x: 0, y: 0 });
+      setIsDragging(false);
+    }
+  }, [open]);
+
+  const handleDragStart = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const startOffset = dragOffset;
+      setIsDragging(true);
+
+      const handleMove = (ev: PointerEvent) => {
+        setDragOffset({
+          x: startOffset.x + (ev.clientX - startX),
+          y: startOffset.y + (ev.clientY - startY),
+        });
+      };
+
+      const handleUp = () => {
+        window.removeEventListener("pointermove", handleMove);
+        window.removeEventListener("pointerup", handleUp);
+        setIsDragging(false);
+      };
+
+      window.addEventListener("pointermove", handleMove);
+      window.addEventListener("pointerup", handleUp);
+    },
+    [dragOffset],
+  );
 
   // Auto-scroll the currently-selected slot button into view so the user
   // doesn't have to scroll through the full day's slot list to find a time
@@ -774,13 +814,38 @@ export function AppointmentDialog({
   return (
     <>
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-5xl p-0 gap-0 overflow-hidden max-h-[90vh] md:max-h-[640px]">
+      <DialogContent
+        className="max-w-5xl p-0 gap-0 overflow-hidden max-h-[90vh] md:max-h-[640px]"
+        overlayClassName="bg-black/40"
+        style={
+          dragOffset.x !== 0 || dragOffset.y !== 0
+            ? {
+                transform: `translate(calc(-50% + ${dragOffset.x}px), calc(-50% + ${dragOffset.y}px))`,
+              }
+            : undefined
+        }
+      >
         <DialogTitle className="sr-only">
           {t("gabinet.appointments.createAppointment")}
         </DialogTitle>
         <DialogDescription className="sr-only">
           {t("gabinet.appointments.createAppointment")}
         </DialogDescription>
+
+        {/* Drag handle bar — lets the user move the dialog aside to peek at the
+            calendar underneath (issue #977). */}
+        <div
+          onPointerDown={handleDragStart}
+          className={cn(
+            "flex items-center justify-center gap-1.5 border-b bg-muted/40 px-3 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground select-none touch-none",
+            isDragging ? "cursor-grabbing" : "cursor-grab",
+          )}
+          title={t("gabinet.appointments.dragToMove", "Przeciągnij, aby przesunąć")}
+          aria-label={t("gabinet.appointments.dragToMove", "Przeciągnij, aby przesunąć")}
+        >
+          <GripHorizontal className="size-3 opacity-60" />
+          <span>{t("gabinet.appointments.dragToMove", "Przeciągnij, aby przesunąć")}</span>
+        </div>
 
         {/* 3-panel layout: stacks vertically on mobile */}
         <div className="relative flex flex-col md:flex-row md:h-[600px]">

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -27,12 +27,18 @@ const DialogOverlay = React.forwardRef<
 ))
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
+type DialogContentProps = React.ComponentPropsWithoutRef<
+  typeof DialogPrimitive.Content
+> & {
+  overlayClassName?: string
+}
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  DialogContentProps
+>(({ className, children, overlayClassName, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay />
+    <DialogOverlay className={overlayClassName} />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #977.

Closes #977

---

## Claude summary

Committed. Summary of what changed:

The "Nowa wizyta" (new appointment) dialog on `/dashboard/gabinet/calendar` covered most of the calendar grid, making it hard to verify timing against neighboring slots. I added a drag handle bar at the top of the dialog so users can move it aside while it stays open, and softened the modal backdrop (`bg-black/80` → `bg-black/40` for this dialog only) so the calendar remains partially visible underneath.

Implementation:
- `src/components/ui/dialog.tsx:30-39` — added `overlayClassName` prop to `DialogContent` so a single caller can override the backdrop without breaking other dialogs.
- `src/components/gabinet/calendar/appointment-dialog.tsx:263-301` — drag state + pointer handlers (window-level `pointermove`/`pointerup`, resets on close).
- `src/components/gabinet/calendar/appointment-dialog.tsx:817-848` — applied inline `transform: translate(calc(-50% + Xpx), calc(-50% + Ypx))` only when offset is non-zero (preserves opening animation) and added a small "Przeciągnij, aby przesunąć" grip bar above the existing 3-panel layout.
- Translations added in `public/locales/{pl,en}/translation.json`.

Typecheck passes cleanly on the changed files (the lone preexisting TS2589 in `treatment-form.tsx` is unrelated).