### PR TITLE
Surface Supabase schema-cache errors more visibly in treatment-create toast

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -73,6 +73,7 @@
     "errors": {
       "permissionDenied": "You don't have permission to perform this action.",
       "invalidArguments": "Invalid data. Please check the form and try again.",
+      "schemaCache": "Database schema is missing a column — a migration likely wasn't applied. Run `npm run migrations:apply` and refresh.",
       "storage": "Storage error. Please try again."
     }
   },
@@ -2127,6 +2128,7 @@
         "variantNotFound": "Treatment variant not found.",
         "permissionDenied": "You don't have permission for this treatment action.",
         "invalidArguments": "Could not save the treatment — invalid data.",
+        "schemaCache": "Database schema is missing a column — a migration likely wasn't applied. Run `npm run migrations:apply` and refresh.",
         "storage": "Could not save the treatment — storage error. Please try again."
       }
     },

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -73,6 +73,7 @@
     "errors": {
       "permissionDenied": "Brak uprawnień do tej operacji.",
       "invalidArguments": "Nieprawidłowe dane. Sprawdź formularz i spróbuj ponownie.",
+      "schemaCache": "Brak kolumny w schemacie bazy — najpewniej nie zastosowano migracji. Uruchom `npm run migrations:apply` i odśwież stronę.",
       "storage": "Błąd magazynu danych. Spróbuj ponownie."
     }
   },
@@ -2135,6 +2136,7 @@
         "variantNotFound": "Nie znaleziono wariantu zabiegu.",
         "permissionDenied": "Brak uprawnień do tej operacji na zabiegu.",
         "invalidArguments": "Nie udało się zapisać zabiegu — nieprawidłowe dane.",
+        "schemaCache": "Brak kolumny w schemacie bazy — najpewniej nie zastosowano migracji. Uruchom `npm run migrations:apply` i odśwież stronę.",
         "storage": "Nie udało się zapisać zabiegu — błąd magazynu danych. Spróbuj ponownie."
       }
     },

--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -148,6 +148,12 @@ const TREATMENT_ERROR_MAP: Array<{
     fallback: "Brak uprawnień do tej operacji na zabiegu.",
   },
   {
+    test: (m) => /pgrst204|schema cache/i.test(m),
+    key: "gabinet.treatments.errors.schemaCache",
+    fallback:
+      "Brak kolumny w schemacie bazy — najpewniej nie zastosowano migracji. Uruchom `npm run migrations:apply` i odśwież stronę.",
+  },
+  {
     test: (m) =>
       /argumentvalidationerror|value does not match validator|invalid input syntax|violates .* constraint|column .* does not exist|null value in column/i.test(
         m,
@@ -189,6 +195,12 @@ const GENERIC_ERROR_MAP: Array<{
     test: (m) => /permission denied/i.test(m),
     key: "common.errors.permissionDenied",
     fallback: "Brak uprawnień do tej operacji.",
+  },
+  {
+    test: (m) => /pgrst204|schema cache/i.test(m),
+    key: "common.errors.schemaCache",
+    fallback:
+      "Brak kolumny w schemacie bazy — najpewniej nie zastosowano migracji. Uruchom `npm run migrations:apply` i odśwież stronę.",
   },
   {
     test: (m) =>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #978.

Closes #978

---

## Claude summary

Committed as `81f50fc`.

Summary: PGRST204 schema-cache errors (e.g. when a treatments-table migration hasn't been applied) used to fall through to the generic "Nie udało się utworzyć zabiegu" toast. Added a dedicated match in `TREATMENT_ERROR_MAP` and `GENERIC_ERROR_MAP` (`src/lib/format-action-error.ts`) keyed off `pgrst204|schema cache`, plus matching PL/EN translations under `gabinet.treatments.errors.schemaCache` and `common.errors.schemaCache`. The new toast tells the operator to run `npm run migrations:apply` and refresh, so deployment drift is self-diagnosing. The new match is ordered before the storage catch-all so it takes precedence.