### PR TITLE
nazwa

### DIFF
--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -97,7 +97,8 @@
       "treatments": "Zabiegi",
       "packages": "Pakiety",
       "documents": "Dokumenty",
-      "employees": "Pracownicy"
+      "employees": "Pracownicy",
+      "reports": "Raporty"
     },
     "sections": {
       "main": "Główne",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #980.

Closes #980

---

## Claude summary

Added the missing Polish translation `nav.gabinet.reports` → `"Raporty"` in `public/locales/pl/translation.json:100`. The sidebar button on `/dashboard/gabinet/reports` was rendering the raw i18n key because the Polish file only had `dashboard`, `calendar`, `patients`, `treatments`, `packages`, `documents`, `employees` under `nav.gabinet` while the English file already had `reports`. Committed as `b2b9c1e`.

## Follow-ups
- Add missing PL/EN translations for nav.gabinet.scheduling/leaves/documentTemplates: sidebar.tsx:71-73 references three more `nav.gabinet.*` keys that are not defined in either locale file, so those sidebar items also render raw keys