### PR TITLE
Add SUPABASE_DB_URL presence smoke test to repo health check

### DIFF
--- a/.github/workflows/secrets-health.yml
+++ b/.github/workflows/secrets-health.yml
@@ -1,0 +1,37 @@
+name: Secrets Health Check
+
+# Periodic smoke test that the deployment-critical repository secrets are
+# present. Catches the "silent fail after secret rotation" class of bug where
+# someone rotates/removes a secret in GitHub settings and we only find out
+# when the next push to main can't apply migrations (#983).
+#
+# This workflow does NOT connect to the database — it only checks that the
+# secret has a non-empty value in the GitHub Actions environment. A reachability
+# check would either require a long-lived test connection (security risk) or
+# duplicate the work the migrations workflow already does on every push.
+
+on:
+  schedule:
+    # Daily at 07:00 UTC (~09:00 Europe/Warsaw). Picked so any failure shows
+    # up in the team's morning before deploys typically happen.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  check-secrets:
+    name: Verify required secrets are set
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Check SUPABASE_DB_URL is present
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          if [ -z "${SUPABASE_DB_URL:-}" ]; then
+            echo "::error::SUPABASE_DB_URL repository secret is unset or empty."
+            echo "::error::Without it, the Supabase Migrations workflow will fail on"
+            echo "::error::the next push to main and migrations will not be applied."
+            echo "::error::Restore it in Settings -> Secrets and variables -> Actions."
+            exit 1
+          fi
+          echo "SUPABASE_DB_URL is present."


### PR DESCRIPTION
Auto-generated by Claude in response to issue #983.

Closes #983

---

## Claude summary

Added `.github/workflows/secrets-health.yml`: a daily scheduled workflow (07:00 UTC) plus manual dispatch that fails loudly if the `SUPABASE_DB_URL` secret is missing. It's a presence check only — no DB connection — so it can't leak credentials or duplicate the work `supabase-migrations.yml` already does on every push. Committed as `9051e35`.