### PR TITLE
Add missing PL/EN translations for nav.gabinet.scheduling/leaves/documentTemplat

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -97,7 +97,10 @@
       "packages": "Packages",
       "employees": "Employees",
       "documents": "Documents",
-      "reports": "Reports"
+      "reports": "Reports",
+      "scheduling": "Working Hours",
+      "leaves": "Leaves",
+      "documentTemplates": "Document Templates"
     },
     "sections": {
       "main": "Main",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -98,7 +98,10 @@
       "packages": "Pakiety",
       "documents": "Dokumenty",
       "employees": "Pracownicy",
-      "reports": "Raporty"
+      "reports": "Raporty",
+      "scheduling": "Godziny pracy",
+      "leaves": "Urlopy",
+      "documentTemplates": "Szablony dokumentów"
     },
     "sections": {
       "main": "Główne",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #985.

Closes #985

---

## Claude summary

Confirmed the bug and fixed it: `src/components/layout/sidebar.tsx:71-73` references `nav.gabinet.scheduling`, `nav.gabinet.leaves`, and `nav.gabinet.documentTemplates`, but the `nav.gabinet` block in both `public/locales/en/translation.json` and `public/locales/pl/translation.json` only had keys up through `reports`. Added the three missing entries to each locale (EN: "Working Hours" / "Leaves" / "Document Templates"; PL: "Godziny pracy" / "Urlopy" / "Szablony dokumentów"). For EN `scheduling` I used "Working Hours" to match the page title at `gabinet.scheduling.title`. Both JSON files validated and committed as `065f6bf`.