### PR TITLE
rozlicz wizytę

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2642,7 +2642,7 @@
       "phoneAdded": "Phone number added",
       "edit": "Edit",
       "close": "Close",
-      "closeAndSettle": "Close and settle",
+      "closeAndSettle": "Settle visit",
       "history": {
         "unifiedDescription": "Unified operational history for this appointment, including messages and workflow events.",
         "metadata": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2654,7 +2654,7 @@
       "phoneAdded": "Numer telefonu dodany",
       "edit": "Edytuj",
       "close": "Zamknij",
-      "closeAndSettle": "Zamknij i rozlicz",
+      "closeAndSettle": "Rozlicz wizytę",
       "history": {
         "unifiedDescription": "Ujednolicona historia operacyjna tej wizyty, w tym wiadomości i zdarzenia workflow.",
         "metadata": {

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -902,7 +902,7 @@ export function AppointmentPreviewContent({
         >
           {saving
             ? t("common.saving")
-            : t("gabinet.appointmentDetail.closeAndSettle", "Zamknij i rozlicz")}
+            : t("gabinet.appointmentDetail.closeAndSettle", "Rozlicz wizytę")}
         </Button>
       </div>
     </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #992.

Closes #992

---

## Claude summary

Renamed the appointment preview action button from "Zamknij i rozlicz" to "Rozlicz wizytę" (EN: "Settle visit"). Changes in `src/components/gabinet/calendar/appointment-preview-content.tsx:905` plus both PL and EN translation files. Commit `9d5cee1` pushed to branch `claude/issue-992`.