### PR TITLE
edycja pracownika

### DIFF
--- a/convex/supabase/client.ts
+++ b/convex/supabase/client.ts
@@ -1,6 +1,25 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from "@cvx/env";
 
+// Stub WebSocket transport for the Convex action runtime, which doesn't
+// expose a global `WebSocket`. supabase-js 2.105+ eagerly constructs a
+// RealtimeClient inside `createClient`, and that constructor throws
+// "Unknown JavaScript runtime without WebSocket support" if no transport
+// is supplied. We never use realtime server-side, so we hand it a no-op
+// constructor; if anything ever calls `connect()` it will fail loudly
+// instead of silently subscribing.
+class NoopWebSocketTransport {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  constructor() {
+    throw new Error(
+      "Realtime is not supported in the Convex action runtime",
+    );
+  }
+}
+
 export function createServiceRoleClient() {
   if (!SUPABASE_URL) {
     throw new Error("SUPABASE_URL not configured");
@@ -11,6 +30,9 @@ export function createServiceRoleClient() {
 
   return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
     auth: { persistSession: false, autoRefreshToken: false },
+    realtime: {
+      transport: NoopWebSocketTransport as unknown as typeof WebSocket,
+    },
   });
 }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #999.

Closes #999

---

## Claude summary

Fixed and committed.

Root cause: the user's report ("napraw możliwość edycji pracownika") is a Convex action failure. The Jam console logs show:

```
[CONVEX A(gabinet/employees:update)] Server Error
Uncaught Error: Unknown JavaScript runtime without WebSocket support.
  at getWebSocketConstructor (.../realtime-js/src/lib/websocket-factory.ts:178:2)
  at _initializeOptions (.../realtime-js/src/RealtimeClient.ts:775:32)
  at new RealtimeClient (.../realtime-js/src/RealtimeClient.ts:243:9)
  at _initRealtimeClient (.../supabase-js/src/SupabaseClient.ts:596:61)
  at new SupabaseClient (.../supabase-js/src/SupabaseClient.ts:329:20)
  at createServiceRoleClient (.../convex/supabase/client.ts:12:10)
  at createSupabaseDb (.../convex/_helpers/supabaseDb.ts:216:2)
  at handler (.../convex/gabinet/employees.ts:345:9)
```

`@supabase/supabase-js@2.105.3` (pinned in `package-lock.json:53`) now eagerly constructs a `RealtimeClient` inside `createClient()`, and that constructor calls `getWebSocketConstructor()` immediately rather than lazily on `.connect()`. The Convex action runtime has no global `WebSocket`, so the call throws — meaning every action that goes through `createSupabaseDb()` (employees.update, and broadly anything writing through Supabase server-side) fails before it ever hits Postgres. The user happened to notice it on employee edit; the same regression affects every Supabase-backed mutation.

Fix in `convex/supabase/client.ts`: pass `realtime: { transport: NoopWebSocketTransport }` so `RealtimeClient._initializeOptions` uses the supplied transport (verified at `realtime-js/dist/main/RealtimeClient.js:564`) and never calls `getWebSocketConstructor()`. The stub's constructor throws if anything ever tries to actually open a socket, but nothing in `convex/` uses realtime (grep confirmed: no `.channel(`, `.subscribe(`, `realtime.`, or `.connect()` calls).

Typecheck passes (only pre-existing unrelated error in `appointment-preview-content.tsx`). Existing test setup at `tests/convex/_setup.ts:64` fully mocks `createServiceRoleClient`, so unit tests are unaffected.