### PR TITLE
feat(invitations): module-aware invites — auto-create Gabinet employee on accept

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -1,4 +1,4 @@
-import { action, internalMutation } from "../_generated/server";
+import { action, internalAction, internalMutation } from "../_generated/server";
 import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { internal } from "../_generated/api";
@@ -242,6 +242,115 @@ export const create = action({
     }
 
     return employeeId;
+  },
+});
+
+/**
+ * System-internal: create a gabinet_employees row from an invitation's
+ * `moduleData` payload. Called by `invitations._acceptInternal` after the
+ * invitee's user row is mirrored. Bypasses the role-based permission check
+ * the public `create` action enforces — the inviting admin already vetted
+ * this assignment when they created the invitation.
+ *
+ * `data` is the free-form payload the invite UI persisted; treated as
+ * untrusted JSON and field-by-field validated here before insert.
+ */
+export const _createFromInvitation = internalAction({
+  args: {
+    organizationId: v.id("organizations"),
+    userId: v.string(),
+    invitedBy: v.string(),
+    data: v.any(),
+  },
+  handler: async (ctx, args) => {
+    const db = createSupabaseDb();
+
+    // Idempotency: bail if an employee row already exists for this user/org.
+    const existing = await db
+      .query("gabinetEmployees")
+      .eq("organizationId", String(args.organizationId))
+      .eq("userId", args.userId)
+      .collect();
+    if (existing.length > 0) {
+      console.log(
+        `[gabinet.employees._createFromInvitation] skip — employee already exists for user=${args.userId}`,
+      );
+      return { skipped: true, employeeId: String(existing[0]._id) };
+    }
+
+    const d = (args.data ?? {}) as Record<string, unknown>;
+
+    const asString = (v: unknown) =>
+      typeof v === "string" && v.length > 0 ? v : null;
+    const asStringArray = (v: unknown) =>
+      Array.isArray(v) ? (v.filter((x) => typeof x === "string") as string[]) : null;
+
+    const role = asString(d.role) ?? "doctor";
+    const allowedRoles = ["doctor", "nurse", "therapist", "receptionist", "admin", "other"];
+    const safeRole = allowedRoles.includes(role) ? role : "doctor";
+
+    const now = Date.now();
+    const employeeId = await db.insert("gabinetEmployees", {
+      organizationId: String(args.organizationId),
+      userId: args.userId,
+      firstName: asString(d.firstName),
+      lastName: asString(d.lastName),
+      role: safeRole,
+      specialization: asString(d.specialization),
+      qualifiedTreatmentIds: asStringArray(d.qualifiedTreatmentIds) ?? [],
+      licenseNumber: null,
+      hireDate: null,
+      isActive: true,
+      color: asString(d.color),
+      notes: null,
+      tagIds: asStringArray(d.tagIds),
+      categoryId: asString(d.categoryId),
+      createdBy: args.invitedBy,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Custom fields (free-form per-org definitions) — moduleData.customFields
+    // is expected to be an array of { fieldDefinitionId, value }. Matches the
+    // shape `customFields.setValues` produces and what the renderer emits.
+    const cfs = Array.isArray(d.customFields) ? d.customFields : null;
+    if (cfs) {
+      for (const f of cfs) {
+        if (!f || typeof f !== "object") continue;
+        const defId = (f as Record<string, unknown>).fieldDefinitionId;
+        const val = (f as Record<string, unknown>).value;
+        if (typeof defId !== "string" || defId.length === 0) continue;
+        try {
+          await db.insert("customFieldValues", {
+            organizationId: String(args.organizationId),
+            fieldDefinitionId: defId,
+            entityType: "gabinetEmployee",
+            entityId: String(employeeId),
+            value: val ?? null,
+            createdAt: now,
+            updatedAt: now,
+          });
+        } catch (e) {
+          console.error(
+            `[gabinet.employees._createFromInvitation] custom field ${defId} insert failed:`,
+            e,
+          );
+        }
+      }
+    }
+
+    // Activity log + audit, fire-and-forget.
+    try {
+      await ctx.runMutation(internal.gabinet.employees._createSideEffects, {
+        employeeId: String(employeeId),
+        organizationId: args.organizationId,
+        createdBy: args.invitedBy,
+      });
+    } catch (e) {
+      console.error("[gabinet.employees._createFromInvitation] side effects failed:", e);
+    }
+
+    return { skipped: false, employeeId: String(employeeId) };
   },
 });
 

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -74,6 +74,10 @@ export const create = action({
     organizationId: v.id("organizations"),
     email: v.string(),
     role: orgRoleValidator,
+    // Optional module provisioning. module="gabinet" + moduleData triggers
+    // auto-create of gabinet_employees row when the invitee accepts.
+    module: v.optional(v.string()),
+    moduleData: v.optional(v.any()),
   },
   handler: async (ctx, args): Promise<string> => {
     const created: {
@@ -86,10 +90,14 @@ export const create = action({
       expiresAt: number;
       createdAt: number;
       updatedAt: number;
+      module?: string;
+      moduleData?: unknown;
     } = await ctx.runMutation(internal.invitations._createInternal, {
       organizationId: args.organizationId,
       email: args.email,
       role: args.role,
+      module: args.module,
+      moduleData: args.moduleData,
     });
 
     // Mirror to Supabase so the team-settings page (which reads from
@@ -108,6 +116,8 @@ export const create = action({
         expiresAt: created.expiresAt,
         createdAt: created.createdAt,
         updatedAt: created.updatedAt,
+        module: created.module ?? null,
+        moduleData: created.moduleData ?? null,
       });
     } catch (e) {
       console.error("[invitations.create] Supabase mirror failed:", e);
@@ -243,6 +253,8 @@ export const _createInternal = internalMutation({
     organizationId: v.id("organizations"),
     email: v.string(),
     role: orgRoleValidator,
+    module: v.optional(v.string()),
+    moduleData: v.optional(v.any()),
   },
   handler: async (ctx, args) => {
     const { user } = await requireOrgAdmin(ctx, args.organizationId);
@@ -300,6 +312,8 @@ export const _createInternal = internalMutation({
       expiresAt,
       createdAt: now,
       updatedAt: now,
+      module: args.module,
+      moduleData: args.moduleData,
     });
 
     await logActivity(ctx, {
@@ -330,6 +344,8 @@ export const _createInternal = internalMutation({
       expiresAt,
       createdAt: now,
       updatedAt: now,
+      module: args.module,
+      moduleData: args.moduleData,
     };
   },
 });
@@ -470,6 +486,25 @@ export const _acceptInternal = internalMutation({
       createdAt: Math.floor(user._creationTime),
       updatedAt: Date.now(),
     });
+
+    // Module provisioning: if the invite carried a module="gabinet" payload,
+    // auto-create the gabinet_employees row using the data captured at invite
+    // time. Runs AFTER the user mirror so the FK on gabinet_employees.user_id
+    // resolves. Scheduled (not awaited) so any failure here doesn't roll back
+    // the membership — the inviter can re-create the employee manually if
+    // needed.
+    if (invitation.module === "gabinet" && invitation.moduleData) {
+      await ctx.scheduler.runAfter(
+        500, // small delay so the user mirror lands first
+        internal.gabinet.employees._createFromInvitation,
+        {
+          organizationId: invitation.organizationId,
+          userId: String(user._id),
+          invitedBy: String(invitation.invitedBy),
+          data: invitation.moduleData,
+        },
+      );
+    }
 
     const acceptedAt = Date.now();
     const updatedAt = acceptedAt;

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -771,6 +771,14 @@ export function createCrmTables({
     invitedBy: v.id("users"),
     expiresAt: v.number(),
     acceptedAt: v.optional(v.number()),
+    // Optional module to provision on accept. "gabinet" auto-creates a
+    // gabinet_employees row using `moduleData`. Free-form so future modules
+    // (crm, billing, …) can be added without a schema migration.
+    module: v.optional(v.string()),
+    // Module-specific payload captured at invite time and applied on accept.
+    // For module="gabinet": { firstName, lastName, role, specialization,
+    //   color, qualifiedTreatmentIds[], tagIds[], categoryId, customFields }.
+    moduleData: v.optional(v.any()),
     createdAt: v.number(),
     updatedAt: v.number(),
   })

--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -1,12 +1,15 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
 import { convexQuery } from "@convex-dev/react-query";
+import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
+import type { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -14,18 +17,65 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { AlertCircle, Users } from "@/lib/ez-icons";
+import { TagsPicker } from "@/components/categories-tags/tags-picker";
+import { CategoryPicker } from "@/components/categories-tags/category-picker";
+import { CustomFieldFormSection } from "@/components/custom-fields/custom-field-form-section";
+import { useTagDefinitions } from "@/hooks/use-tag-definitions";
+import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
+import { AlertCircle, Search, Users } from "@/lib/ez-icons";
 
 type OrgRole = "owner" | "admin" | "member";
+type InviteModule = "none" | "gabinet";
+type GabinetRole =
+  | "doctor"
+  | "nurse"
+  | "therapist"
+  | "receptionist"
+  | "admin"
+  | "other";
 
 const ROLES: { value: OrgRole; labelKey: string }[] = [
   { value: "admin", labelKey: "settings.team.roles.admin" },
   { value: "member", labelKey: "settings.team.roles.member" },
 ];
 
+const GABINET_ROLES: GabinetRole[] = [
+  "doctor",
+  "nurse",
+  "therapist",
+  "receptionist",
+  "admin",
+  "other",
+];
+
+const COLOR_OPTIONS = [
+  { value: "#3b82f6", label: "Blue" },
+  { value: "#22c55e", label: "Green" },
+  { value: "#ef4444", label: "Red" },
+  { value: "#f59e0b", label: "Yellow" },
+  { value: "#8b5cf6", label: "Purple" },
+  { value: "#ec4899", label: "Pink" },
+  { value: "#f97316", label: "Orange" },
+  { value: "#6b7280", label: "Gray" },
+];
+
 export interface UserInvitationFormData {
   email: string;
   role: OrgRole;
+  module?: "gabinet";
+  moduleData?: GabinetModuleData;
+}
+
+export interface GabinetModuleData {
+  firstName?: string;
+  lastName?: string;
+  role: GabinetRole;
+  specialization?: string;
+  color?: string;
+  qualifiedTreatmentIds?: string[];
+  tagIds?: string[];
+  categoryId?: string;
+  customFields?: Array<{ fieldDefinitionId: string; value: unknown }>;
 }
 
 interface UserInvitationFormProps {
@@ -45,27 +95,91 @@ export function UserInvitationForm({
   const { data: members } = useQuery(
     convexQuery(api.organizations.getMembers, { organizationId })
   );
-
   const { data: pendingInvitations } = useQuery(
     convexQuery(api.invitations.listPending, { organizationId })
   );
-
   const { data: subscription } = useQuery(
     convexQuery(api.productSubscriptions.getSubscription, { organizationId })
   );
+
+  // Gabinet-specific data sources — only fetched lazily once Gabinet is picked.
+  const [module, setModule] = useState<InviteModule>("none");
+
+  const listActiveTreatments = useAction(api.gabinet.treatments.listActive);
+  const { data: treatments } = useQuery({
+    queryKey: ["gabinet.treatments.listActive", organizationId],
+    queryFn: () => listActiveTreatments({ organizationId }),
+    enabled: !!organizationId && module === "gabinet",
+  }) as { data: Array<{ _id: string; name: string; duration?: number }> | undefined };
+
+  const { tags: tagDefinitions } = useTagDefinitions(organizationId) as {
+    tags: Array<{ _id: Id<"tagDefinitions">; name: string; color: string }>;
+  };
+
+  const { categories: categoryDefinitions } = useCategoryDefinitions(
+    organizationId,
+    "gabinetEmployee" as any,
+  ) as {
+    categories: Array<{
+      _id: Id<"categoryDefinitions">;
+      name: string;
+      parentId?: Id<"categoryDefinitions">;
+      color?: string;
+    }>;
+  };
+
+  const { data: customFieldDefs } = useQuery(
+    convexQuery(
+      api.customFields.getDefinitions,
+      module === "gabinet"
+        ? { organizationId, entityType: "gabinetEmployee" }
+        : ("skip" as any),
+    ),
+  ) as {
+    data:
+      | Array<{
+          _id: string;
+          name: string;
+          fieldKey: string;
+          fieldType: any;
+          options?: string[];
+          isRequired?: boolean;
+          group?: string;
+        }>
+      | undefined;
+  };
 
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<OrgRole>("member");
   const [emailError, setEmailError] = useState<string | null>(null);
 
+  // Gabinet module form state
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [gabinetRole, setGabinetRole] = useState<GabinetRole>("doctor");
+  const [specialization, setSpecialization] = useState("");
+  const [color, setColor] = useState("#3b82f6");
+  const [selectedTreatments, setSelectedTreatments] = useState<string[]>([]);
+  const [tagIds, setTagIds] = useState<Id<"tagDefinitions">[]>([]);
+  const [categoryId, setCategoryId] = useState<Id<"categoryDefinitions"> | undefined>(undefined);
+  const [customFieldValues, setCustomFieldValues] = useState<Record<string, unknown>>({});
+  const [treatmentSearch, setTreatmentSearch] = useState("");
+
   const memberCount = members?.length ?? 0;
   const pendingCount = pendingInvitations?.length ?? 0;
   const totalUsers = memberCount + pendingCount;
-
-  // Get seat limit from subscription or default to 10
   const seatLimit = subscription?.seatLimit ?? 10;
   const isNearLimit = totalUsers >= seatLimit - 2;
   const isAtLimit = totalUsers >= seatLimit;
+
+  const filteredTreatments = useMemo(() => {
+    if (!treatments) return [];
+    const q = treatmentSearch.trim().toLowerCase();
+    if (!q) return treatments;
+    return treatments.filter((tr) => tr.name?.toLowerCase().includes(q));
+  }, [treatments, treatmentSearch]);
+
+  const isClinicalRole = gabinetRole !== "receptionist" && gabinetRole !== "admin";
 
   const validateEmail = (value: string): boolean => {
     if (!value.trim()) {
@@ -86,9 +200,35 @@ export function UserInvitationForm({
     if (!validateEmail(email)) return;
     if (isAtLimit) return;
 
+    let moduleData: GabinetModuleData | undefined;
+    if (module === "gabinet") {
+      const customFields = (customFieldDefs ?? [])
+        .map((def) => ({
+          fieldDefinitionId: def._id,
+          value: customFieldValues[def.fieldKey],
+        }))
+        .filter((f) => f.value !== undefined && f.value !== "");
+
+      moduleData = {
+        firstName: firstName || undefined,
+        lastName: lastName || undefined,
+        role: gabinetRole,
+        specialization: specialization || undefined,
+        color: color || undefined,
+        qualifiedTreatmentIds: isClinicalRole && selectedTreatments.length > 0
+          ? selectedTreatments
+          : undefined,
+        tagIds: tagIds.length > 0 ? tagIds : undefined,
+        categoryId: categoryId || undefined,
+        customFields: customFields.length > 0 ? customFields : undefined,
+      };
+    }
+
     onSubmit({
       email: email.trim().toLowerCase(),
       role,
+      module: module === "gabinet" ? "gabinet" : undefined,
+      moduleData,
     });
   };
 
@@ -98,9 +238,7 @@ export function UserInvitationForm({
       <div className="flex items-center gap-3 rounded-lg border bg-muted/30 p-3">
         <Users className="h-5 w-5 text-muted-foreground" />
         <div className="flex-1">
-          <p className="text-sm font-medium">
-            {t("settings.team.currentUsage")}
-          </p>
+          <p className="text-sm font-medium">{t("settings.team.currentUsage")}</p>
           <p className="text-xs text-muted-foreground">
             {t("settings.team.usageCount", { current: totalUsers, limit: seatLimit })}
             {pendingCount > 0 && (
@@ -112,7 +250,6 @@ export function UserInvitationForm({
         </div>
       </div>
 
-      {/* Near limit warning */}
       {isNearLimit && !isAtLimit && (
         <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-900/50 dark:bg-amber-950/30">
           <AlertCircle className="mt-0.5 h-4 w-4 text-amber-600 dark:text-amber-400" />
@@ -122,13 +259,10 @@ export function UserInvitationForm({
         </div>
       )}
 
-      {/* At limit error */}
       {isAtLimit && (
         <div className="flex items-start gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3">
           <AlertCircle className="mt-0.5 h-4 w-4 text-destructive" />
-          <p className="text-sm text-destructive">
-            {t("settings.team.limitReached")}
-          </p>
+          <p className="text-sm text-destructive">{t("settings.team.limitReached")}</p>
         </div>
       )}
 
@@ -147,9 +281,7 @@ export function UserInvitationForm({
           disabled={isAtLimit}
           required
         />
-        {emailError && (
-          <p className="text-xs text-destructive">{emailError}</p>
-        )}
+        {emailError && <p className="text-xs text-destructive">{emailError}</p>}
       </div>
 
       <div className="space-y-1.5">
@@ -172,25 +304,194 @@ export function UserInvitationForm({
             ))}
           </SelectContent>
         </Select>
+        <p className="text-xs text-muted-foreground">{t("settings.team.roleHint")}</p>
+      </div>
+
+      {/* Module picker — when Gabinet is chosen, pre-fill module fields so a
+          gabinet_employees row is auto-provisioned on invite-accept. */}
+      <div className="space-y-1.5">
+        <Label>
+          {t("settings.team.module", { defaultValue: "Moduł" })}
+        </Label>
+        <Select
+          value={module}
+          onValueChange={(v) => setModule(v as InviteModule)}
+          disabled={isAtLimit}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">
+              {t("settings.team.moduleNone", { defaultValue: "Brak (tylko zaproszenie)" })}
+            </SelectItem>
+            <SelectItem value="gabinet">
+              {t("settings.team.moduleGabinet", { defaultValue: "Gabinet — utwórz profil pracownika" })}
+            </SelectItem>
+          </SelectContent>
+        </Select>
         <p className="text-xs text-muted-foreground">
-          {t("settings.team.roleHint")}
+          {t("settings.team.moduleHint", {
+            defaultValue:
+              "Wybierz moduł, aby od razu wypełnić dane potrzebne do utworzenia profilu po akceptacji zaproszenia.",
+          })}
         </p>
       </div>
 
+      {module === "gabinet" && (
+        <div className="rounded-lg border bg-muted/20 p-4 space-y-4">
+          <h3 className="text-sm font-medium">
+            {t("settings.team.gabinetSectionTitle", { defaultValue: "Dane pracownika Gabinetu" })}
+          </h3>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label>{t("gabinet.employees.firstName")}</Label>
+              <Input value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+            </div>
+            <div className="space-y-1.5">
+              <Label>{t("gabinet.employees.lastName")}</Label>
+              <Input value={lastName} onChange={(e) => setLastName(e.target.value)} />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>
+              {t("gabinet.employees.role")} <span className="text-destructive">*</span>
+            </Label>
+            <Select value={gabinetRole} onValueChange={(v) => setGabinetRole(v as GabinetRole)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {GABINET_ROLES.map((r) => (
+                  <SelectItem key={r} value={r}>
+                    {t(`gabinet.employees.roles.${r}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>{t("gabinet.employees.specialization")}</Label>
+            <Input value={specialization} onChange={(e) => setSpecialization(e.target.value)} />
+          </div>
+
+          <div className="space-y-2">
+            <Label>{t("gabinet.employees.color")}</Label>
+            <div className="flex gap-2">
+              {COLOR_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  className={`h-7 w-7 rounded-full border-2 transition-all ${
+                    color === opt.value
+                      ? "border-foreground scale-110"
+                      : "border-transparent hover:border-muted-foreground/40"
+                  }`}
+                  style={{ backgroundColor: opt.value }}
+                  onClick={() => setColor(color === opt.value ? "" : opt.value)}
+                  title={opt.label}
+                />
+              ))}
+            </div>
+          </div>
+
+          {isClinicalRole && (
+            <div className="space-y-2">
+              <Label>{t("gabinet.employees.qualifiedTreatments")}</Label>
+              {treatments && treatments.length > 0 && (
+                <div className="relative">
+                  <Search
+                    className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
+                    variant="stroke"
+                  />
+                  <Input
+                    type="search"
+                    value={treatmentSearch}
+                    onChange={(e) => setTreatmentSearch(e.target.value)}
+                    placeholder={t("gabinet.treatments.searchPlaceholder")}
+                    className="pl-8"
+                  />
+                </div>
+              )}
+              <div className="max-h-48 overflow-y-auto rounded-md border p-2 space-y-1">
+                {filteredTreatments.map((tr) => (
+                  <label key={tr._id} className="flex items-center gap-2 text-sm cursor-pointer">
+                    <Checkbox
+                      checked={selectedTreatments.includes(tr._id)}
+                      onCheckedChange={(checked) => {
+                        if (checked) {
+                          setSelectedTreatments([...selectedTreatments, tr._id]);
+                        } else {
+                          setSelectedTreatments(selectedTreatments.filter((id) => id !== tr._id));
+                        }
+                      }}
+                    />
+                    <span className="flex-1">{tr.name}</span>
+                    {tr.duration != null && (
+                      <span className="text-xs text-muted-foreground">{tr.duration} min</span>
+                    )}
+                  </label>
+                ))}
+                {(!treatments || treatments.length === 0) && (
+                  <p className="text-xs text-muted-foreground py-2">
+                    {t("gabinet.employees.noTreatments")}
+                  </p>
+                )}
+                {treatments && treatments.length > 0 && filteredTreatments.length === 0 && (
+                  <p className="text-xs text-muted-foreground py-2">
+                    {t("detail.relationships.noResults")}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
+          {tagDefinitions && tagDefinitions.length > 0 && (
+            <div className="space-y-1.5">
+              <Label>{t("common.tags", { defaultValue: "Tagi" })}</Label>
+              <TagsPicker tags={tagDefinitions} selectedIds={tagIds} onChange={setTagIds} />
+            </div>
+          )}
+
+          {organizationId && (
+            <div className="space-y-1.5">
+              <Label>{t("common.category", { defaultValue: "Kategoria" })}</Label>
+              <CategoryPicker
+                categories={categoryDefinitions ?? []}
+                selectedId={categoryId}
+                onChange={setCategoryId}
+                organizationId={organizationId}
+                entityType="gabinetEmployee"
+              />
+            </div>
+          )}
+
+          {customFieldDefs && customFieldDefs.length > 0 && (
+            <div className="space-y-2 pt-2 border-t">
+              <CustomFieldFormSection
+                definitions={customFieldDefs as any}
+                values={customFieldValues}
+                onChange={(fieldKey, value) =>
+                  setCustomFieldValues((prev) => ({ ...prev, [fieldKey]: value }))
+                }
+              />
+            </div>
+          )}
+        </div>
+      )}
+
       <div className="rounded-lg border bg-muted/30 p-3">
-        <p className="text-sm text-muted-foreground">
-          {t("settings.team.invitationInfo")}
-        </p>
+        <p className="text-sm text-muted-foreground">{t("settings.team.invitationInfo")}</p>
       </div>
 
       <div className="flex justify-end gap-2 pt-2">
         <Button type="button" variant="outline" onClick={onCancel}>
           {t("common.cancel")}
         </Button>
-        <Button
-          type="submit"
-          disabled={!email.trim() || isAtLimit || isSubmitting}
-        >
+        <Button type="submit" disabled={!email.trim() || isAtLimit || isSubmitting}>
           {isSubmitting ? t("common.saving") : t("settings.team.sendInvite")}
         </Button>
       </div>

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -618,6 +618,8 @@ function DashboardLayout() {
                     organizationId: orgId,
                     email: data.email,
                     role: data.role,
+                    module: data.module,
+                    moduleData: data.moduleData,
                   });
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(orgId) });
                   opts.onSuccess();


### PR DESCRIPTION
Adds a Module selector to the team invitation dialog. Picking **Gabinet** reveals an inline section with all the Gabinet employee fields (minus license) plus any per-org custom field definitions. On invite-accept, a `gabinet_employees` row is auto-provisioned from the captured payload.

## What the user sees
1. Open team-settings → "Invite user".
2. Same email + role as before, plus a new **Moduł** dropdown:
   - **Brak (tylko zaproszenie)** — current behavior.
   - **Gabinet — utwórz profil pracownika** — reveals the pre-fill section.
3. Pre-fill section: firstName, lastName, role (doctor/nurse/…), specialization, color picker, qualified treatments, tags, category, and any per-org custom fields configured for `entityType="gabinetEmployee"`.
4. Submit sends the invite. On accept, `gabinet_employees` + `customFieldValues` rows are created automatically.

## Why
"Potrzebuje, żeby w miejscu gdzie dodaje się członka zespołu była możliwość od razu wybrania modułu np Gabinet i uzupełnienia pozostałych typowych dla gabinetu pól."

## Implementation
- `invitations` table grows `module text` + `module_data jsonb` (Convex schema + Supabase ALTER). Nullable, additive-only.
- `invitations.create` accepts `{module, moduleData}` and persists / mirrors them.
- `_acceptInternal` schedules `gabinet.employees._createFromInvitation` 500ms after the user mirror so the FK on `user_id` resolves.
- `_createFromInvitation` is system-internal (bypasses role-perm check — admin already vetted), idempotent, validates every field, and writes `customFieldValues` for each provided custom-field entry.
- License field intentionally excluded from invite path per spec.

Supabase migration already applied to prod via /pg/query.