### PR TITLE
fix(invite): add missing translations + widen dialog

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -89,19 +89,7 @@
     "insights": "Insights",
     "products": "Products",
     "calls": "Calls",
-    "gabinet": {
-      "dashboard": "Dashboard",
-      "calendar": "Calendar",
-      "patients": "Patients",
-      "treatments": "Treatments",
-      "packages": "Packages",
-      "employees": "Employees",
-      "documents": "Documents",
-      "reports": "Reports",
-      "scheduling": "Working Hours",
-      "leaves": "Leaves",
-      "documentTemplates": "Document Templates"
-    },
+    "gabinet": "Cabinet",
     "sections": {
       "main": "Main",
       "database": "Database",
@@ -185,7 +173,6 @@
       "gabinet": "Gabinet",
       "gabinetDesc": "Clinic & clients"
     },
-    "gabinet": "Cabinet",
     "settings": "Settings",
     "home": "Home"
   },
@@ -786,7 +773,16 @@
       "role": "Role",
       "roleHint": "Admins can manage settings and team",
       "sendInvite": "Send Invitation",
-      "invitationInfo": "We'll send an invitation email. Recipient will have 7 days to accept."
+      "invitationInfo": "We'll send an invitation email. Recipient will have 7 days to accept.",
+      "roles": {
+        "admin": "Administrator",
+        "member": "Member"
+      },
+      "module": "Module",
+      "moduleNone": "None (invitation only)",
+      "moduleGabinet": "Gabinet — create employee profile",
+      "moduleHint": "Pick a module to pre-fill the fields needed to provision a profile once the invitation is accepted.",
+      "gabinetSectionTitle": "Gabinet employee details"
     },
     "pipelines": {
       "title": "Pipelines",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -787,7 +787,16 @@
       "role": "Rola",
       "roleHint": "Administratorzy mogą zarządzać ustawieniami i zespołem",
       "sendInvite": "Wyślij zaproszenie",
-      "invitationInfo": "Zaproszenie wyślemy e-mailem. Odbiorca będzie miał 7 dni na jego przyjęcie."
+      "invitationInfo": "Zaproszenie wyślemy e-mailem. Odbiorca będzie miał 7 dni na jego przyjęcie.",
+      "roles": {
+        "admin": "Administrator",
+        "member": "Członek"
+      },
+      "module": "Moduł",
+      "moduleNone": "Brak (tylko zaproszenie)",
+      "moduleGabinet": "Gabinet — utwórz profil pracownika",
+      "moduleHint": "Wybierz moduł, aby od razu wypełnić dane potrzebne do utworzenia profilu po akceptacji zaproszenia.",
+      "gabinetSectionTitle": "Dane pracownika Gabinetu"
     },
     "pipelines": {
       "title": "Pipeline",

--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -266,82 +266,73 @@ export function UserInvitationForm({
         </div>
       )}
 
-      <div className="space-y-1.5">
-        <Label>
-          {t("settings.team.email")} <span className="text-destructive">*</span>
-        </Label>
-        <Input
-          type="email"
-          value={email}
-          onChange={(e) => {
-            setEmail(e.target.value);
-            if (emailError) validateEmail(e.target.value);
-          }}
-          placeholder={t("settings.team.emailPlaceholder")}
-          disabled={isAtLimit}
-          required
-        />
-        {emailError && <p className="text-xs text-destructive">{emailError}</p>}
-      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5 sm:col-span-2">
+          <Label>
+            {t("settings.team.email")} <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            type="email"
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              if (emailError) validateEmail(e.target.value);
+            }}
+            placeholder={t("settings.team.emailPlaceholder")}
+            disabled={isAtLimit}
+            required
+          />
+          {emailError && <p className="text-xs text-destructive">{emailError}</p>}
+        </div>
 
-      <div className="space-y-1.5">
-        <Label>
-          {t("settings.team.role")} <span className="text-destructive">*</span>
-        </Label>
-        <Select
-          value={role}
-          onValueChange={(v) => setRole(v as OrgRole)}
-          disabled={isAtLimit}
-        >
-          <SelectTrigger>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {ROLES.map((r) => (
-              <SelectItem key={r.value} value={r.value}>
-                {t(r.labelKey)}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <p className="text-xs text-muted-foreground">{t("settings.team.roleHint")}</p>
-      </div>
+        <div className="space-y-1.5">
+          <Label>
+            {t("settings.team.role")} <span className="text-destructive">*</span>
+          </Label>
+          <Select
+            value={role}
+            onValueChange={(v) => setRole(v as OrgRole)}
+            disabled={isAtLimit}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {ROLES.map((r) => (
+                <SelectItem key={r.value} value={r.value}>
+                  {t(r.labelKey)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">{t("settings.team.roleHint")}</p>
+        </div>
 
-      {/* Module picker — when Gabinet is chosen, pre-fill module fields so a
-          gabinet_employees row is auto-provisioned on invite-accept. */}
-      <div className="space-y-1.5">
-        <Label>
-          {t("settings.team.module", { defaultValue: "Moduł" })}
-        </Label>
-        <Select
-          value={module}
-          onValueChange={(v) => setModule(v as InviteModule)}
-          disabled={isAtLimit}
-        >
-          <SelectTrigger>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="none">
-              {t("settings.team.moduleNone", { defaultValue: "Brak (tylko zaproszenie)" })}
-            </SelectItem>
-            <SelectItem value="gabinet">
-              {t("settings.team.moduleGabinet", { defaultValue: "Gabinet — utwórz profil pracownika" })}
-            </SelectItem>
-          </SelectContent>
-        </Select>
-        <p className="text-xs text-muted-foreground">
-          {t("settings.team.moduleHint", {
-            defaultValue:
-              "Wybierz moduł, aby od razu wypełnić dane potrzebne do utworzenia profilu po akceptacji zaproszenia.",
-          })}
-        </p>
+        {/* Module picker — when Gabinet is chosen, pre-fill module fields so a
+            gabinet_employees row is auto-provisioned on invite-accept. */}
+        <div className="space-y-1.5">
+          <Label>{t("settings.team.module")}</Label>
+          <Select
+            value={module}
+            onValueChange={(v) => setModule(v as InviteModule)}
+            disabled={isAtLimit}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none">{t("settings.team.moduleNone")}</SelectItem>
+              <SelectItem value="gabinet">{t("settings.team.moduleGabinet")}</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">{t("settings.team.moduleHint")}</p>
+        </div>
       </div>
 
       {module === "gabinet" && (
         <div className="rounded-lg border bg-muted/20 p-4 space-y-4">
           <h3 className="text-sm font-medium">
-            {t("settings.team.gabinetSectionTitle", { defaultValue: "Dane pracownika Gabinetu" })}
+            {t("settings.team.gabinetSectionTitle")}
           </h3>
 
           <div className="grid gap-4 sm:grid-cols-2">
@@ -353,48 +344,48 @@ export function UserInvitationForm({
               <Label>{t("gabinet.employees.lastName")}</Label>
               <Input value={lastName} onChange={(e) => setLastName(e.target.value)} />
             </div>
-          </div>
 
-          <div className="space-y-1.5">
-            <Label>
-              {t("gabinet.employees.role")} <span className="text-destructive">*</span>
-            </Label>
-            <Select value={gabinetRole} onValueChange={(v) => setGabinetRole(v as GabinetRole)}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {GABINET_ROLES.map((r) => (
-                  <SelectItem key={r} value={r}>
-                    {t(`gabinet.employees.roles.${r}`)}
-                  </SelectItem>
+            <div className="space-y-1.5">
+              <Label>
+                {t("gabinet.employees.role")} <span className="text-destructive">*</span>
+              </Label>
+              <Select value={gabinetRole} onValueChange={(v) => setGabinetRole(v as GabinetRole)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {GABINET_ROLES.map((r) => (
+                    <SelectItem key={r} value={r}>
+                      {t(`gabinet.employees.roles.${r}`)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label>{t("gabinet.employees.specialization")}</Label>
+              <Input value={specialization} onChange={(e) => setSpecialization(e.target.value)} />
+            </div>
+
+            <div className="space-y-2 sm:col-span-2">
+              <Label>{t("gabinet.employees.color")}</Label>
+              <div className="flex gap-2">
+                {COLOR_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    className={`h-7 w-7 rounded-full border-2 transition-all ${
+                      color === opt.value
+                        ? "border-foreground scale-110"
+                        : "border-transparent hover:border-muted-foreground/40"
+                    }`}
+                    style={{ backgroundColor: opt.value }}
+                    onClick={() => setColor(color === opt.value ? "" : opt.value)}
+                    title={opt.label}
+                  />
                 ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="space-y-1.5">
-            <Label>{t("gabinet.employees.specialization")}</Label>
-            <Input value={specialization} onChange={(e) => setSpecialization(e.target.value)} />
-          </div>
-
-          <div className="space-y-2">
-            <Label>{t("gabinet.employees.color")}</Label>
-            <div className="flex gap-2">
-              {COLOR_OPTIONS.map((opt) => (
-                <button
-                  key={opt.value}
-                  type="button"
-                  className={`h-7 w-7 rounded-full border-2 transition-all ${
-                    color === opt.value
-                      ? "border-foreground scale-110"
-                      : "border-transparent hover:border-muted-foreground/40"
-                  }`}
-                  style={{ backgroundColor: opt.value }}
-                  onClick={() => setColor(color === opt.value ? "" : opt.value)}
-                  title={opt.label}
-                />
-              ))}
+              </div>
             </div>
           </div>
 
@@ -449,25 +440,27 @@ export function UserInvitationForm({
             </div>
           )}
 
-          {tagDefinitions && tagDefinitions.length > 0 && (
-            <div className="space-y-1.5">
-              <Label>{t("common.tags", { defaultValue: "Tagi" })}</Label>
-              <TagsPicker tags={tagDefinitions} selectedIds={tagIds} onChange={setTagIds} />
-            </div>
-          )}
+          <div className="grid gap-4 sm:grid-cols-2">
+            {tagDefinitions && tagDefinitions.length > 0 && (
+              <div className="space-y-1.5">
+                <Label>{t("common.tags", { defaultValue: "Tagi" })}</Label>
+                <TagsPicker tags={tagDefinitions} selectedIds={tagIds} onChange={setTagIds} />
+              </div>
+            )}
 
-          {organizationId && (
-            <div className="space-y-1.5">
-              <Label>{t("common.category", { defaultValue: "Kategoria" })}</Label>
-              <CategoryPicker
-                categories={categoryDefinitions ?? []}
-                selectedId={categoryId}
-                onChange={setCategoryId}
-                organizationId={organizationId}
-                entityType="gabinetEmployee"
-              />
-            </div>
-          )}
+            {organizationId && (
+              <div className="space-y-1.5">
+                <Label>{t("common.category", { defaultValue: "Kategoria" })}</Label>
+                <CategoryPicker
+                  categories={categoryDefinitions ?? []}
+                  selectedId={categoryId}
+                  onChange={setCategoryId}
+                  organizationId={organizationId}
+                  entityType="gabinetEmployee"
+                />
+              </div>
+            )}
+          </div>
 
           {customFieldDefs && customFieldDefs.length > 0 && (
             <div className="space-y-2 pt-2 border-t">

--- a/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
@@ -392,7 +392,7 @@ function TeamSettings() {
                 {t("team.inviteMember")}
               </Button>
             </DialogTrigger>
-            <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
+            <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
               <DialogHeader>
                 <DialogTitle>{t("team.inviteDialog.title")}</DialogTitle>
                 <DialogDescription>


### PR DESCRIPTION
Two follow-ups to PR #1002 / #1005:

- **Missing PL/EN translations** for the org-role dropdown (`settings.team.roles.admin/member`) and all my new module-related labels. They were falling through to raw key strings.
- **Dialog widened** from `sm:max-w-lg` (512px) → `sm:max-w-3xl` (768px) and the form laid out in a 2-column grid (email full-width, role+module side by side, Gabinet name/role/specialization paired). Same content, much less scroll.