### PR TITLE
dodaj zmień

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -9,6 +9,7 @@
     "moveUp": "Move up",
     "moveDown": "Move down",
     "edit": "Edit",
+    "change": "Change",
     "add": "Add",
     "search": "Search",
     "reset": "Reset",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -9,6 +9,7 @@
     "moveUp": "Przesuń w górę",
     "moveDown": "Przesuń w dół",
     "edit": "Edytuj",
+    "change": "Zmień",
     "add": "Dodaj",
     "search": "Szukaj",
     "reset": "Resetuj",

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -69,7 +69,6 @@ import {
   OctagonX,
   Phone,
   PlayCircle,
-  RefreshCcw,
   Stethoscope,
   User,
   XCircle,
@@ -834,19 +833,21 @@ export function AppointmentPreviewContent({
       {/* Employee + Date summary */}
       <div className="grid grid-cols-2 gap-2 text-xs">
         {appointment.treatmentId ? (
-          <button
-            type="button"
-            onClick={() => setChangeEmployeeOpen(true)}
-            className="group inline-flex min-w-0 items-center gap-1.5 rounded text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            aria-label={t(
-              "gabinet.appointments.changeEmployee",
-              "Zmień pracownika",
-            )}
-          >
+          <div className="flex min-w-0 items-center gap-1.5 text-muted-foreground">
             <User className="size-3 shrink-0" />
             <span className="truncate">{employeeName}</span>
-            <RefreshCcw className="size-3 shrink-0 opacity-0 transition-opacity group-hover:opacity-60 group-focus-visible:opacity-60" />
-          </button>
+            <button
+              type="button"
+              onClick={() => setChangeEmployeeOpen(true)}
+              className="shrink-0 rounded text-[10px] font-medium text-primary hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label={t(
+                "gabinet.appointments.changeEmployee",
+                "Zmień pracownika",
+              )}
+            >
+              {t("common.change", "Zmień")}
+            </button>
+          </div>
         ) : (
           <div className="flex items-center gap-1.5 text-muted-foreground">
             <User className="size-3" />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1010.

Closes #1010

---

## Claude summary

Committed as `324256b`.

Summary of the change: in the calendar appointment preview, the employee row was clickable (added in #1009) but only showed a faded `RefreshCcw` icon on hover — easy to miss. I replaced it with an always-visible "Zmień" text link styled like the existing "Zarządzaj" link next to tags, so the change action is now obvious. Also added the `common.change` translation key in PL/EN (`Zmień` / `Change`) and removed the now-unused `RefreshCcw` import.

Files changed:
- `src/components/gabinet/calendar/appointment-preview-content.tsx:833-861` — replaced hover-only icon with visible "Zmień" button
- `public/locales/pl/translation.json` — added `common.change: "Zmień"`
- `public/locales/en/translation.json` — added `common.change: "Change"`