### PR TITLE
widok wszystkich

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -84,6 +84,9 @@ interface AppointmentDialogProps {
   defaultDate?: string;
   defaultTime?: string;
   defaultEndTime?: string;
+  /** Pre-select an employee when opening — used by the day-by-employee
+   *  calendar view so clicking inside a column carries the column owner. */
+  defaultEmployeeId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -162,6 +165,7 @@ export function AppointmentDialog({
   defaultDate,
   defaultTime,
   defaultEndTime,
+  defaultEmployeeId,
 }: AppointmentDialogProps) {
   const { t, i18n } = useTranslation();
   const dateFnsLocale = i18n.resolvedLanguage === "pl" ? pl : undefined;
@@ -216,7 +220,7 @@ export function AppointmentDialog({
   // -------------------------------------------------------------------------
 
   const [treatmentId, setTreatmentId] = useState("");
-  const [employeeId, setEmployeeId] = useState("");
+  const [employeeId, setEmployeeId] = useState(defaultEmployeeId ?? "");
   const [patientId, setPatientId] = useState("");
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(
     defaultDate ? new Date(defaultDate + "T00:00:00") : undefined,
@@ -775,9 +779,15 @@ export function AppointmentDialog({
       setSelectedSlot(
         defaultTime ? { start: defaultTime, end: defaultEndTime ?? "" } : null,
       );
+      // Seed employee from prop when opening so the day-by-employee view's
+      // column selection survives even though the auto-select effect below
+      // would otherwise overwrite it once treatments load.
+      if (defaultEmployeeId) {
+        setEmployeeId(defaultEmployeeId);
+      }
     } else {
       setTreatmentId("");
-      setEmployeeId("");
+      setEmployeeId(defaultEmployeeId ?? "");
       setPatientId("");
       setSelectedDate(
         defaultDate ? new Date(defaultDate + "T00:00:00") : undefined,
@@ -798,7 +808,7 @@ export function AppointmentDialog({
       setPendingPatientLabel(null);
       setPastConfirmOpen(false);
     }
-  }, [open, defaultDate, defaultTime, defaultEndTime]);
+  }, [open, defaultDate, defaultTime, defaultEndTime, defaultEmployeeId]);
 
   // -------------------------------------------------------------------------
   // Determine which panels are active

--- a/src/components/gabinet/calendar/calendar-day-by-employee-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-by-employee-view.tsx
@@ -1,0 +1,497 @@
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { DraggableAppointment } from "./draggable-appointment";
+import { DroppableSlot } from "./droppable-slot";
+import { useDragToCreate } from "./use-drag-to-create";
+import { useCurrentTime } from "@/hooks/use-current-time";
+import type { AppointmentIndicator } from "./appointment-card";
+
+interface Appointment {
+  _id: string;
+  startTime: string;
+  endTime: string;
+  patientName: string;
+  treatmentName: string;
+  status: string;
+  color?: string;
+  employeeId?: string;
+  tags?: Array<{ name: string; color: string }>;
+  indicators?: AppointmentIndicator[];
+}
+
+export interface DayByEmployeeColumn {
+  userId: string;
+  name: string;
+  initials: string;
+  schedule?: {
+    startTime: string;
+    endTime: string;
+    breakStart?: string;
+    breakEnd?: string;
+  } | null;
+  leave?: { startTime?: string; endTime?: string } | null;
+}
+
+interface CalendarDayByEmployeeViewProps {
+  date: string;
+  appointments: Appointment[];
+  employees: DayByEmployeeColumn[];
+  onSlotClick?: (date: string, time: string, employeeId: string) => void;
+  onSlotDragSelect?: (
+    date: string,
+    startTime: string,
+    endTime: string,
+    employeeId: string,
+  ) => void;
+  onAppointmentResize?: (id: string, newEndTime: string) => void;
+  slotMinutes?: 5 | 10 | 15 | 30 | 60;
+}
+
+const LEAVE_STRIPE_BG =
+  "repeating-linear-gradient(135deg, rgba(245, 158, 11, 0.18) 0px, rgba(245, 158, 11, 0.18) 6px, rgba(245, 158, 11, 0.06) 6px, rgba(245, 158, 11, 0.06) 12px)";
+
+const HOURS = Array.from({ length: 14 }, (_, i) => i + 7); // 07:00 – 20:00
+const HOUR_HEIGHT = 90;
+
+function timeToTop(time: string): number {
+  const [h, m] = time.split(":").map(Number);
+  return (((h - 7) * 60 + m) * HOUR_HEIGHT) / 60;
+}
+
+function buildSlots(slotMinutes: number) {
+  const slotsPerHour = 60 / slotMinutes;
+  const slotHeight = HOUR_HEIGHT / slotsPerHour;
+  const totalSlots = HOURS.length * slotsPerHour;
+  return Array.from({ length: totalSlots }, (_, i) => {
+    const minutesFromStart = i * slotMinutes;
+    const h = 7 + Math.floor(minutesFromStart / 60);
+    const m = minutesFromStart % 60;
+    const time = `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+    return { time, h, m, slotHeight, isHourMark: m === 0 };
+  });
+}
+
+interface LayoutedAppointment {
+  appointment: Appointment;
+  column: number;
+  totalColumns: number;
+}
+
+function layoutAppointments(appts: Appointment[]): LayoutedAppointment[] {
+  if (appts.length === 0) return [];
+
+  const sorted = [...appts].sort(
+    (a, b) =>
+      a.startTime.localeCompare(b.startTime) ||
+      a.endTime.localeCompare(b.endTime),
+  );
+
+  const clusters: Appointment[][] = [];
+  let clusterEnd = "";
+  let currentCluster: Appointment[] = [];
+
+  for (const appt of sorted) {
+    if (currentCluster.length === 0 || appt.startTime < clusterEnd) {
+      currentCluster.push(appt);
+      if (appt.endTime > clusterEnd) clusterEnd = appt.endTime;
+    } else {
+      clusters.push(currentCluster);
+      currentCluster = [appt];
+      clusterEnd = appt.endTime;
+    }
+  }
+  if (currentCluster.length > 0) clusters.push(currentCluster);
+
+  const result: LayoutedAppointment[] = [];
+
+  for (const cluster of clusters) {
+    const columns: string[] = [];
+    const assignments: { appointment: Appointment; column: number }[] = [];
+
+    for (const appt of cluster) {
+      let col = -1;
+      for (let i = 0; i < columns.length; i++) {
+        if (appt.startTime >= columns[i]) {
+          col = i;
+          break;
+        }
+      }
+      if (col === -1) {
+        col = columns.length;
+        columns.push(appt.endTime);
+      } else {
+        columns[col] = appt.endTime;
+      }
+      assignments.push({ appointment: appt, column: col });
+    }
+
+    const totalColumns = columns.length;
+    for (const a of assignments) {
+      result.push({ ...a, totalColumns });
+    }
+  }
+
+  return result;
+}
+
+interface EmployeeColumnProps {
+  date: string;
+  employee: DayByEmployeeColumn;
+  appointments: Appointment[];
+  slots: ReturnType<typeof buildSlots>;
+  slotMinutes: 5 | 10 | 15 | 30 | 60;
+  isToday: boolean;
+  currentTimeTop: number | null;
+  onSlotClick?: (date: string, time: string, employeeId: string) => void;
+  onSlotDragSelect?: (
+    date: string,
+    startTime: string,
+    endTime: string,
+    employeeId: string,
+  ) => void;
+  onAppointmentResize?: (id: string, newEndTime: string) => void;
+}
+
+function EmployeeColumn({
+  date,
+  employee,
+  appointments,
+  slots,
+  slotMinutes,
+  isToday,
+  currentTimeTop,
+  onSlotClick,
+  onSlotDragSelect,
+  onAppointmentResize,
+}: EmployeeColumnProps) {
+  const { t } = useTranslation();
+  const showSubdivisions = slotMinutes === 60;
+  const layouts = useMemo(() => layoutAppointments(appointments), [appointments]);
+
+  const schedule = employee.schedule ?? null;
+  const leave = employee.leave ?? null;
+
+  const workStartTop = schedule ? timeToTop(schedule.startTime) : null;
+  const workEndTop = schedule ? timeToTop(schedule.endTime) : null;
+  const breakStartTop = schedule?.breakStart
+    ? timeToTop(schedule.breakStart)
+    : null;
+  const breakEndTop = schedule?.breakEnd ? timeToTop(schedule.breakEnd) : null;
+
+  const leaveTop = leave ? (leave.startTime ? timeToTop(leave.startTime) : 0) : null;
+  const leaveBottom = leave
+    ? leave.endTime
+      ? timeToTop(leave.endTime)
+      : HOURS.length * HOUR_HEIGHT
+    : null;
+  const leaveHeight =
+    leaveTop !== null && leaveBottom !== null ? leaveBottom - leaveTop : 0;
+  const leaveLabel = leave
+    ? leave.startTime && leave.endTime
+      ? t("gabinet.calendar.leaveBadgePartial", {
+          start: leave.startTime,
+          end: leave.endTime,
+          defaultValue: "Urlop {{start}}–{{end}}",
+        })
+      : t("gabinet.calendar.leaveBadge", { defaultValue: "Urlop" })
+    : "";
+
+  const handleClick = useCallback(
+    (time: string) => onSlotClick?.(date, time, employee.userId),
+    [onSlotClick, date, employee.userId],
+  );
+  const handleDragSelect = useCallback(
+    (startTime: string, endTime: string) =>
+      onSlotDragSelect?.(date, startTime, endTime, employee.userId),
+    [onSlotDragSelect, date, employee.userId],
+  );
+
+  const dragHandler = useDragToCreate({
+    hoursStart: 7,
+    hoursCount: HOURS.length,
+    hourHeight: HOUR_HEIGHT,
+    snapMinutes: Math.min(15, slotMinutes),
+    minDragDistance: 8,
+    onClick: handleClick,
+    onDragSelect: handleDragSelect,
+  });
+
+  const dragTop = dragHandler.dragRange
+    ? Math.min(dragHandler.dragRange.start, dragHandler.dragRange.end)
+    : 0;
+  const dragHeight = dragHandler.dragRange
+    ? Math.abs(dragHandler.dragRange.end - dragHandler.dragRange.start)
+    : 0;
+
+  return (
+    <div className="flex-1 min-w-[140px] border-r last:border-r-0">
+      {/* Header with avatar + name */}
+      <div className="sticky top-0 z-30 bg-background">
+        <div className="flex items-center gap-2 border-b bg-muted/40 px-2 py-2 text-xs font-medium">
+          <Avatar className="h-6 w-6">
+            <AvatarFallback className="bg-muted text-[10px] font-medium text-muted-foreground">
+              {employee.initials || "?"}
+            </AvatarFallback>
+          </Avatar>
+          <span className="truncate" title={employee.name}>
+            {employee.name}
+          </span>
+        </div>
+      </div>
+
+      <div
+        ref={dragHandler.containerRef}
+        className="relative select-none"
+        onMouseDown={dragHandler.handleMouseDown}
+      >
+        {/* Closed entire day */}
+        {workStartTop === null && (
+          <div
+            className="pointer-events-none absolute inset-0 z-0 bg-primary/5"
+            style={{ height: `${HOURS.length * HOUR_HEIGHT}px` }}
+          />
+        )}
+
+        {/* Closed: before working hours */}
+        {workStartTop !== null && workStartTop > 0 && (
+          <div
+            className="pointer-events-none absolute left-0 right-0 z-0 border-b border-primary/10 bg-primary/5"
+            style={{ top: 0, height: `${workStartTop}px` }}
+          />
+        )}
+
+        {/* Closed: after working hours */}
+        {workEndTop !== null && workEndTop < HOURS.length * HOUR_HEIGHT && (
+          <div
+            className="pointer-events-none absolute left-0 right-0 z-0 border-t border-primary/10 bg-primary/5"
+            style={{
+              top: `${workEndTop}px`,
+              height: `${HOURS.length * HOUR_HEIGHT - workEndTop}px`,
+            }}
+          />
+        )}
+
+        {/* Break */}
+        {breakStartTop !== null && breakEndTop !== null && (
+          <div
+            className="pointer-events-none absolute left-0 right-0 z-0 border-y border-orange-200/50 bg-orange-100/50"
+            style={{
+              top: `${breakStartTop}px`,
+              height: `${breakEndTop - breakStartTop}px`,
+            }}
+          />
+        )}
+
+        {/* Leave overlay */}
+        {leave && leaveTop !== null && leaveHeight > 0 && (
+          <div
+            className="pointer-events-none absolute left-0 right-0 z-[5] border-y border-amber-400/70 dark:border-amber-500/60"
+            style={{
+              top: `${leaveTop}px`,
+              height: `${leaveHeight}px`,
+              backgroundImage: LEAVE_STRIPE_BG,
+            }}
+            title={t("gabinet.calendar.leaveOverlayTitle", {
+              defaultValue: "Pracownik ma zatwierdzony urlop",
+            })}
+            aria-label={leaveLabel}
+          >
+            <span className="absolute left-0.5 top-0.5 rounded bg-amber-500/90 px-1 py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide text-white shadow-sm">
+              {leaveLabel}
+            </span>
+          </div>
+        )}
+
+        {/* Slot rows */}
+        {slots.map((s) => (
+          <DroppableSlot
+            key={s.time}
+            id={`${date}-${employee.userId}-${s.time}`}
+            date={date}
+            time={s.time}
+            employeeId={employee.userId}
+            className={`border-b border-dashed ${s.isHourMark ? "border-muted" : "border-muted/40"}`}
+            style={{ height: `${s.slotHeight}px` }}
+          >
+            <div className="relative h-full w-full cursor-pointer hover:bg-muted/20">
+              {showSubdivisions && (
+                <>
+                  <div
+                    className="pointer-events-none absolute left-0 right-0 border-t border-dashed border-muted/40"
+                    style={{ top: `${HOUR_HEIGHT / 4}px` }}
+                  />
+                  <div
+                    className="pointer-events-none absolute left-0 right-0 border-t border-dashed border-muted/60"
+                    style={{ top: `${HOUR_HEIGHT / 2}px` }}
+                  />
+                  <div
+                    className="pointer-events-none absolute left-0 right-0 border-t border-dashed border-muted/40"
+                    style={{ top: `${(HOUR_HEIGHT * 3) / 4}px` }}
+                  />
+                </>
+              )}
+            </div>
+          </DroppableSlot>
+        ))}
+
+        {/* Drag-to-create ghost */}
+        {dragHandler.dragRange && dragHeight > 0 && (
+          <div
+            className="pointer-events-none absolute left-0.5 right-0.5 z-30 rounded-sm bg-primary/30 ring-2 ring-primary/60"
+            style={{
+              top: `${dragTop}px`,
+              height: `${Math.max(dragHeight, 4)}px`,
+            }}
+          />
+        )}
+
+        {/* Current time line */}
+        {isToday &&
+          currentTimeTop !== null &&
+          currentTimeTop > 0 &&
+          currentTimeTop < HOURS.length * HOUR_HEIGHT && (
+            <div
+              className="pointer-events-none absolute left-0 right-0 z-20 border-t-2 border-red-500"
+              style={{ top: `${currentTimeTop}px` }}
+            >
+              <div className="absolute -left-1 -top-1.5 h-3 w-3 rounded-full bg-red-500" />
+            </div>
+          )}
+
+        {/* Appointments */}
+        {layouts.map((laid) => {
+          const appt = laid.appointment;
+          const top = timeToTop(appt.startTime);
+          const height = timeToTop(appt.endTime) - top;
+          if (top < 0 || height <= 0) return null;
+
+          const step = Math.min(24, Math.floor(75 / laid.totalColumns));
+          const leftPct = laid.column * step;
+
+          return (
+            <div
+              key={appt._id}
+              className={`absolute ${laid.column > 0 ? "shadow-md" : ""}`}
+              style={{
+                top: `${top}px`,
+                height: `${Math.max(height, 18)}px`,
+                left: `${leftPct}%`,
+                right: "2px",
+                zIndex: 10 + laid.column,
+              }}
+            >
+              <DraggableAppointment
+                {...appt}
+                date={date}
+                onResize={onAppointmentResize}
+                hourHeight={HOUR_HEIGHT}
+                snapMinutes={Math.min(15, slotMinutes)}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function CalendarDayByEmployeeView({
+  date,
+  appointments,
+  employees,
+  onSlotClick,
+  onSlotDragSelect,
+  onAppointmentResize,
+  slotMinutes = 60,
+}: CalendarDayByEmployeeViewProps) {
+  const { t } = useTranslation();
+  const now = useCurrentTime();
+  const isToday =
+    date ===
+    `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+  const currentMinutes = now.getHours() * 60 + now.getMinutes();
+  const currentTimeTop = ((currentMinutes - 7 * 60) / 60) * HOUR_HEIGHT;
+  const currentTimeLabel = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+  const showCurrentTime =
+    isToday && currentTimeTop > 0 && currentTimeTop < HOURS.length * HOUR_HEIGHT;
+
+  const slots = useMemo(() => buildSlots(slotMinutes), [slotMinutes]);
+
+  const appointmentsByEmployee = useMemo(() => {
+    const map = new Map<string, Appointment[]>();
+    for (const emp of employees) {
+      map.set(emp.userId, []);
+    }
+    for (const a of appointments) {
+      if (!a.employeeId) continue;
+      const list = map.get(a.employeeId);
+      if (list) list.push(a);
+    }
+    return map;
+  }, [appointments, employees]);
+
+  if (employees.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
+        {t("gabinet.calendar.noEmployees", {
+          defaultValue: "Brak aktywnych pracowników.",
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full overflow-auto">
+      {/* Time labels */}
+      <div className="sticky left-0 z-40 w-14 shrink-0 border-r bg-background pt-[42px] relative">
+        {slots.map((s) => {
+          const showLabel = s.isHourMark || s.slotHeight >= 15;
+          return (
+            <div
+              key={s.time}
+              className="flex items-start justify-end pr-2"
+              style={{ height: `${s.slotHeight}px` }}
+            >
+              {showLabel && (
+                <span
+                  className={`${s.isHourMark ? "text-xs font-medium text-muted-foreground" : "text-[10px] text-muted-foreground/60"} leading-none`}
+                >
+                  {s.time}
+                </span>
+              )}
+            </div>
+          );
+        })}
+        {showCurrentTime && (
+          <div
+            className="pointer-events-none absolute right-1 z-30 rounded bg-red-500 px-1 py-0.5 text-[10px] font-semibold leading-none text-white shadow"
+            style={{
+              top: `${42 + currentTimeTop}px`,
+              transform: "translateY(-50%)",
+            }}
+          >
+            {currentTimeLabel}
+          </div>
+        )}
+      </div>
+
+      {/* Employee columns */}
+      {employees.map((emp) => (
+        <EmployeeColumn
+          key={emp.userId}
+          date={date}
+          employee={emp}
+          appointments={appointmentsByEmployee.get(emp.userId) ?? []}
+          slots={slots}
+          slotMinutes={slotMinutes}
+          isToday={isToday}
+          currentTimeTop={isToday ? currentTimeTop : null}
+          onSlotClick={onSlotClick}
+          onSlotDragSelect={onSlotDragSelect}
+          onAppointmentResize={onAppointmentResize}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/gabinet/calendar/droppable-slot.tsx
+++ b/src/components/gabinet/calendar/droppable-slot.tsx
@@ -5,18 +5,23 @@ interface DroppableSlotProps {
   id: string;
   date: string;
   time: string;
+  /** Optional employee id used by the per-employee day view so a drop carries
+   *  the target column's owner, allowing the parent to reassign as well as
+   *  reschedule the appointment. */
+  employeeId?: string;
   children?: ReactNode;
   className?: string;
   style?: CSSProperties;
 }
 
-export function DroppableSlot({ id, date, time, children, className, style }: DroppableSlotProps) {
+export function DroppableSlot({ id, date, time, employeeId, children, className, style }: DroppableSlotProps) {
   const { isOver, setNodeRef } = useDroppable({
     id,
     data: {
       type: "time-slot",
       date,
       time,
+      employeeId,
     },
   });
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -37,6 +37,10 @@ import {
   useSensors,
 } from "@dnd-kit/core";
 import { CalendarDayView } from "@/components/gabinet/calendar/calendar-day-view";
+import {
+  CalendarDayByEmployeeView,
+  type DayByEmployeeColumn,
+} from "@/components/gabinet/calendar/calendar-day-by-employee-view";
 import { CalendarWeekView } from "@/components/gabinet/calendar/calendar-week-view";
 import { CalendarMonthView } from "@/components/gabinet/calendar/calendar-month-view";
 import { AppointmentDialog } from "@/components/gabinet/calendar/appointment-dialog";
@@ -140,6 +144,9 @@ function GabinetCalendarPage() {
     string | undefined
   >();
   const [createDefaultEndTime, setCreateDefaultEndTime] = useState<
+    string | undefined
+  >();
+  const [createDefaultEmployeeId, setCreateDefaultEmployeeId] = useState<
     string | undefined
   >();
 
@@ -374,6 +381,15 @@ function GabinetCalendarPage() {
     },
   );
 
+  // The "day by employee" view (day view + Wszyscy pracownicy) shows a column
+  // per employee, so we need leaves for every employee on the visible day.
+  // Issue #1013.
+  const isDayByEmployeeView = viewMode === "day" && employeeFilter === "all";
+  const { data: allLeavesRaw } = useSupabaseGabinetLeavesList(organizationId, {
+    status: "approved",
+    enabled: isDayByEmployeeView,
+  });
+
   // Build date -> leave info map for the visible range. A multi-day leave is
   // expanded so each covered date carries the same per-day time window.
   const leavesByDate = useMemo(() => {
@@ -402,6 +418,25 @@ function GabinetCalendarPage() {
     () => new Set(leavesByDate.keys()),
     [leavesByDate],
   );
+
+  // For the day-by-employee view: map userId -> leave window covering the
+  // selected day (or null if none). Computed only when this view is active.
+  const dayLeaveByEmployee = useMemo(() => {
+    const map = new Map<string, { startTime?: string; endTime?: string }>();
+    if (!isDayByEmployeeView || !allLeavesRaw) return map;
+    const target = formatDateStr(currentDate);
+    for (const leave of allLeavesRaw) {
+      if (leave.endDate < target || leave.startDate > target) continue;
+      // First write wins to preserve a partial-day window over a full-day one.
+      if (!map.has(leave.userId)) {
+        map.set(leave.userId, {
+          startTime: leave.startTime,
+          endTime: leave.endTime,
+        });
+      }
+    }
+    return map;
+  }, [isDayByEmployeeView, allLeavesRaw, currentDate]);
 
   // Dates with at least one non-cancelled appointment requiring (but not yet
   // confirmed) prepayment — surfaces the "$" indicator on the month view so
@@ -461,6 +496,7 @@ function GabinetCalendarPage() {
       treatmentName: string;
       status: string;
       color?: string;
+      employeeId?: string;
       tags?: Array<{ name: string; color: string }>;
       indicators?: Indicator[];
     }> = [];
@@ -550,6 +586,7 @@ function GabinetCalendarPage() {
           treatmentName: treatment?.name ?? "",
           status: a.status,
           color: a.color ?? treatment?.color,
+          employeeId: a.employeeId,
           tags: tags && tags.length > 0 ? tags : undefined,
           indicators: indicators.length > 0 ? indicators : undefined,
         });
@@ -647,6 +684,7 @@ function GabinetCalendarPage() {
         setCreateDefaultTime(dateOrTime);
       }
       setCreateDefaultEndTime(undefined);
+      setCreateDefaultEmployeeId(undefined);
       setCreateDialogOpen(true);
     },
     [currentDate],
@@ -658,6 +696,31 @@ function GabinetCalendarPage() {
       setCreateDefaultDate(date);
       setCreateDefaultTime(startTime);
       setCreateDefaultEndTime(endTime);
+      setCreateDefaultEmployeeId(undefined);
+      setCreateDialogOpen(true);
+    },
+    [],
+  );
+
+  // Click-to-create for the day-by-employee view — pre-selects the employee
+  // whose column was clicked so the user doesn't have to choose again.
+  const handleEmployeeSlotClick = useCallback(
+    (date: string, time: string, employeeId: string) => {
+      setCreateDefaultDate(date);
+      setCreateDefaultTime(time);
+      setCreateDefaultEndTime(undefined);
+      setCreateDefaultEmployeeId(employeeId);
+      setCreateDialogOpen(true);
+    },
+    [],
+  );
+
+  const handleEmployeeSlotDragSelect = useCallback(
+    (date: string, startTime: string, endTime: string, employeeId: string) => {
+      setCreateDefaultDate(date);
+      setCreateDefaultTime(startTime);
+      setCreateDefaultEndTime(endTime);
+      setCreateDefaultEmployeeId(employeeId);
       setCreateDialogOpen(true);
     },
     [],
@@ -750,6 +813,16 @@ function GabinetCalendarPage() {
         const newEndM = newEndMinutes % 60;
         const newEndTime = `${String(newEndH).padStart(2, "0")}:${String(newEndM).padStart(2, "0")}`;
 
+        // The day-by-employee view tags each slot with the column owner so
+        // dropping into a different employee's column reassigns the visit.
+        const targetEmployeeId =
+          typeof dropData.employeeId === "string" && dropData.employeeId
+            ? (dropData.employeeId as string)
+            : undefined;
+        const reassign =
+          targetEmployeeId !== undefined &&
+          targetEmployeeId !== originalAppt.employeeId;
+
         try {
           await updateAppointment({
             organizationId,
@@ -757,6 +830,7 @@ function GabinetCalendarPage() {
             date: newDate,
             startTime: newStartTime,
             endTime: newEndTime,
+            ...(reassign ? { employeeId: targetEmployeeId } : {}),
           });
           toast.success(
             t("gabinet.appointments.rescheduled", "Appointment rescheduled"),
@@ -848,6 +922,47 @@ function GabinetCalendarPage() {
       .slice(0, 2)
       .toUpperCase();
   }
+
+  // Columns for the day-by-employee view. Each column carries the employee's
+  // working schedule for the visible day and any approved leave overlapping it
+  // so the grid can paint closed-hours and leave overlays per column.
+  const dayByEmployeeColumns: DayByEmployeeColumn[] = useMemo(() => {
+    if (!isDayByEmployeeView) return [];
+    const dayOfWeek = new Date(currentDate).getDay();
+    const dow = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+    const list = employees ?? [];
+    return list.map((emp) => {
+      const name = getEmployeeName(emp);
+      const initials = getEmployeeInitials(name);
+      const sched = (employeeSchedulesRaw ?? []).find(
+        (s) => s.userId === emp.userId && s.dayOfWeek === dow && s.isWorking,
+      );
+      return {
+        userId: emp.userId,
+        name,
+        initials,
+        schedule: sched
+          ? {
+              startTime: sched.startTime,
+              endTime: sched.endTime,
+              breakStart: sched.breakStart,
+              breakEnd: sched.breakEnd,
+            }
+          : null,
+        leave: dayLeaveByEmployee.get(emp.userId) ?? null,
+      };
+    });
+    // userMap is captured by getEmployeeName via closure; depend on it so
+    // names refresh once members load.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    isDayByEmployeeView,
+    currentDate,
+    employees,
+    employeeSchedulesRaw,
+    dayLeaveByEmployee,
+    userMap,
+  ]);
 
   return (
     <DndContext
@@ -957,6 +1072,7 @@ function GabinetCalendarPage() {
                   setCreateDefaultDate(formatDateStr(currentDate));
                   setCreateDefaultTime(undefined);
                   setCreateDefaultEndTime(undefined);
+                  setCreateDefaultEmployeeId(undefined);
                   setCreateDialogOpen(true);
                 }}
               >
@@ -1171,7 +1287,18 @@ function GabinetCalendarPage() {
 
         {/* Calendar content */}
         <div className="flex-1 overflow-hidden">
-          {viewMode === "day" && (
+          {viewMode === "day" && isDayByEmployeeView && (
+            <CalendarDayByEmployeeView
+              date={formatDateStr(currentDate)}
+              appointments={viewAppointments}
+              employees={dayByEmployeeColumns}
+              onSlotClick={handleEmployeeSlotClick}
+              onSlotDragSelect={handleEmployeeSlotDragSelect}
+              onAppointmentResize={handleAppointmentResize}
+              slotMinutes={slotMinutes}
+            />
+          )}
+          {viewMode === "day" && !isDayByEmployeeView && (
             <CalendarDayView
               date={formatDateStr(currentDate)}
               appointments={viewAppointments}
@@ -1220,6 +1347,7 @@ function GabinetCalendarPage() {
           defaultDate={createDefaultDate}
           defaultTime={createDefaultTime}
           defaultEndTime={createDefaultEndTime}
+          defaultEmployeeId={createDefaultEmployeeId}
         />
       </div>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1013.

Closes #1013

---

## Claude summary

Implemented and committed.

The gabinet calendar now has a per-employee resource view: when the user picks day mode with the "Wszyscy pracownicy" pill, the grid switches from a single-column day view to one column per active employee. Each column shows the employee's avatar/name in a sticky header, their per-day working schedule (closed-hours and break overlays), any approved leave block for the day, and their appointments. Clicking or drag-selecting a slot opens the appointment dialog with that employee pre-filled; dragging an existing appointment into a different column reassigns it via the existing `update` action.

Files: `src/components/gabinet/calendar/calendar-day-by-employee-view.tsx` (new), `src/components/gabinet/calendar/droppable-slot.tsx` (added optional `employeeId` to drop data), `src/components/gabinet/calendar/appointment-dialog.tsx` (added `defaultEmployeeId` prop), `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx` (wiring, all-leaves fetch, per-day column build, mode-aware view switch). Typecheck on touched files is clean (pre-existing errors remain in unrelated files).

Picking a specific employee from the pill row falls back to the original single-column day view, so the old behavior is preserved when a single resource is selected.