### PR TITLE
przykład

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2736,7 +2736,8 @@
       },
       "leaveBadge": "On leave",
       "leaveBadgePartial": "On leave {{start}}–{{end}}",
-      "leaveOverlayTitle": "Employee is on approved leave"
+      "leaveOverlayTitle": "Employee is on approved leave",
+      "dayOff": "day off"
     },
     "packages": {
       "title": "Treatment Packages",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2761,7 +2761,8 @@
       },
       "leaveBadge": "Urlop",
       "leaveBadgePartial": "Urlop {{start}}–{{end}}",
-      "leaveOverlayTitle": "Pracownik ma zatwierdzony urlop"
+      "leaveOverlayTitle": "Pracownik ma zatwierdzony urlop",
+      "dayOff": "dzień wolny"
     },
     "packages": {
       "title": "Pakiety zabiegów",

--- a/src/components/gabinet/calendar/calendar-day-by-employee-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-by-employee-view.tsx
@@ -226,17 +226,30 @@ function EmployeeColumn({
 
   return (
     <div className="flex-1 min-w-[140px] border-r last:border-r-0">
-      {/* Header with avatar + name */}
+      {/* Header with avatar + name + working hours / day-off */}
       <div className="sticky top-0 z-30 bg-background">
-        <div className="flex items-center gap-2 border-b bg-muted/40 px-2 py-2 text-xs font-medium">
-          <Avatar className="h-6 w-6">
+        <div
+          className="flex h-[52px] items-start gap-2 border-b bg-muted/40 px-2 py-2 text-xs font-medium"
+        >
+          <Avatar className="mt-0.5 h-6 w-6">
             <AvatarFallback className="bg-muted text-[10px] font-medium text-muted-foreground">
               {employee.initials || "?"}
             </AvatarFallback>
           </Avatar>
-          <span className="truncate" title={employee.name}>
-            {employee.name}
-          </span>
+          <div className="flex min-w-0 flex-col leading-tight">
+            <span className="truncate" title={employee.name}>
+              {employee.name}
+            </span>
+            {schedule ? (
+              <span className="truncate text-[10px] font-normal text-muted-foreground">
+                {schedule.startTime} – {schedule.endTime}
+              </span>
+            ) : (
+              <span className="truncate text-[10px] font-normal text-muted-foreground">
+                {t("gabinet.calendar.dayOff", { defaultValue: "dzień wolny" })}
+              </span>
+            )}
+          </div>
         </div>
       </div>
 
@@ -444,7 +457,7 @@ export function CalendarDayByEmployeeView({
   return (
     <div className="flex h-full overflow-auto">
       {/* Time labels */}
-      <div className="sticky left-0 z-40 w-14 shrink-0 border-r bg-background pt-[42px] relative">
+      <div className="sticky left-0 z-40 w-14 shrink-0 border-r bg-background pt-[52px] relative">
         {slots.map((s) => {
           const showLabel = s.isHourMark || s.slotHeight >= 15;
           return (
@@ -467,7 +480,7 @@ export function CalendarDayByEmployeeView({
           <div
             className="pointer-events-none absolute right-1 z-30 rounded bg-red-500 px-1 py-0.5 text-[10px] font-semibold leading-none text-white shadow"
             style={{
-              top: `${42 + currentTimeTop}px`,
+              top: `${52 + currentTimeTop}px`,
               transform: "translateY(-50%)",
             }}
           >


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1014.

Closes #1014

---

## Claude summary

Committed. The user attached a versum.com screenshot as a reference for the day-by-employee calendar view shipped in #1013. Comparing against the reference, the existing column header was missing the working-hours line (e.g. "12:00 – 20:00") and the "dzień wolny" label for employees not scheduled that day — both visible under each employee name in versum.

I updated `src/components/gabinet/calendar/calendar-day-by-employee-view.tsx:227-254` to render the schedule range under the name, falling back to a translated "dzień wolny" label when there's no schedule. The header was given a fixed 52px height and the time-labels column padding bumped from 42px → 52px (in the `pt-[…]` class and the current-time pill offset) so slot rows stay aligned. Added `gabinet.calendar.dayOff` to PL ("dzień wolny") and EN ("day off") translation files.