### PR TITLE
zablokuj kolumny

### DIFF
--- a/src/components/gabinet/calendar/calendar-day-by-employee-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-by-employee-view.tsx
@@ -457,7 +457,11 @@ export function CalendarDayByEmployeeView({
   return (
     <div className="flex h-full overflow-auto">
       {/* Time labels */}
-      <div className="sticky left-0 z-40 w-14 shrink-0 border-r bg-background pt-[52px] relative">
+      <div className="sticky left-0 z-40 w-14 shrink-0 border-r bg-background relative">
+        {/* Sticky spacer matching the employee column headers so the time
+            labels below scroll behind it instead of disappearing under the
+            sticky column headers — keeps row alignment when scrolling. */}
+        <div className="sticky top-0 z-30 h-[52px] border-b bg-background" />
         {slots.map((s) => {
           const showLabel = s.isHourMark || s.slotHeight >= 15;
           return (

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -415,7 +415,11 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotD
   return (
     <div className="flex h-full overflow-auto">
       {/* Time labels */}
-      <div className="sticky left-0 z-40 w-14 shrink-0 border-r bg-background pt-8 relative">
+      <div className="sticky left-0 z-40 w-14 shrink-0 border-r bg-background relative">
+        {/* Sticky spacer matching the day-header height so the time labels
+            below scroll behind it instead of disappearing under the sticky
+            day headers — keeps row alignment when scrolling. */}
+        <div className="sticky top-0 z-30 h-8 border-b bg-background" />
         {slots.map((s) => {
           // For small slot heights, only render the hour label so text doesn't overlap.
           const showLabel = s.isHourMark || s.slotHeight >= 15;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1018.

Closes #1018

---

## Claude summary

Fixed and committed. Summary of the change:

In the gabinet calendar's day-by-employee view and week view, the column headers (employee names / day labels) were `sticky top-0`, but the time-labels column on the left used static `pt-[52px]` / `pt-8` padding. When the user scrolled down, the column headers stayed pinned at the top while the time labels scrolled up — so the visible hour labels no longer lined up with the visible rows in the employee/day columns. I replaced the static padding with a matching `sticky top-0` spacer in the time-labels column so the labels tuck behind it the same way appointment slots tuck behind the sticky column headers, keeping row alignment intact at every scroll position. The day view doesn't have a column header and the month view doesn't scroll, so they need no change.

Commit `6d98420` on branch `claude/issue-1018`.