### PR TITLE
kolory

### DIFF
--- a/src/components/gabinet/calendar/appointment-card.tsx
+++ b/src/components/gabinet/calendar/appointment-card.tsx
@@ -1,4 +1,7 @@
-import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
+import {
+  appointmentEmployeeStyle,
+  appointmentStatusBadgeClass,
+} from "@/lib/gabinet-appointment-status";
 
 export interface AppointmentTag {
   name: string;
@@ -42,16 +45,37 @@ export function AppointmentCard({
   indicators,
   onClick,
 }: AppointmentCardProps) {
-  const cls = appointmentStatusBadgeClass(status);
+  // When a base color is provided (employee color, treatment color, or an
+  // explicit appointment override), tint the whole tile in shades of that
+  // color so each employee's appointments form a visually coherent group on
+  // the calendar (issue #1019). When parsing the color fails we fall back to
+  // the existing status-only Tailwind palette.
+  const employeeStyle = color ? appointmentEmployeeStyle(status, color) : null;
+  const fallbackCls = employeeStyle
+    ? ""
+    : appointmentStatusBadgeClass(status);
   const strike = status === "cancelled" ? " line-through" : "";
 
   return (
     <button
       onClick={onClick}
-      className={`flex w-full h-full flex-col overflow-hidden rounded border-l-4 text-left text-xs transition-opacity hover:opacity-80 ${cls}${strike}`}
-      style={color ? { borderLeftColor: color } : undefined}
+      className={`flex w-full h-full flex-col overflow-hidden rounded border-l-4 text-left text-xs transition-opacity hover:opacity-80 ${fallbackCls}${strike}`}
+      style={
+        employeeStyle
+          ? employeeStyle.containerStyle
+          : color
+            ? { borderLeftColor: color }
+            : undefined
+      }
     >
-      <div className="flex items-center justify-between gap-1 bg-black/30 px-2 py-0.5 font-semibold dark:bg-black/50">
+      <div
+        className={
+          employeeStyle
+            ? "flex items-center justify-between gap-1 px-2 py-0.5 font-semibold"
+            : "flex items-center justify-between gap-1 bg-black/30 px-2 py-0.5 font-semibold dark:bg-black/50"
+        }
+        style={employeeStyle ? employeeStyle.headerStyle : undefined}
+      >
         <span className="truncate">{startTime}–{endTime}</span>
         {((tags && tags.length > 0) || (indicators && indicators.length > 0)) && (
           <div className="flex shrink-0 items-center gap-0.5">

--- a/src/lib/gabinet-appointment-status.ts
+++ b/src/lib/gabinet-appointment-status.ts
@@ -7,6 +7,8 @@
  * reads consistently wherever a status is shown.
  */
 
+import type { CSSProperties } from "react";
+
 export const APPOINTMENT_STATUS_BADGE_CLASSES: Record<string, string> = {
   pending_confirmation:
     "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-400",
@@ -29,4 +31,112 @@ export function appointmentStatusBadgeClass(status: string): string {
     APPOINTMENT_STATUS_BADGE_CLASSES[status] ??
     APPOINTMENT_STATUS_BADGE_CLASSES.scheduled
   );
+}
+
+// ---------------------------------------------------------------------------
+// Per-employee color shading for calendar tiles
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-status alpha values used to tint an employee's base color on calendar
+ * tiles. Earlier statuses (pending/scheduled) are lighter so confirmed and
+ * in-progress visits visually dominate the day. Completed/cancelled are faded
+ * because they no longer need attention. Tuned by eye against blue/red/green
+ * employee colors so all three read clearly on a white grid.
+ */
+const STATUS_ALPHA: Record<
+  string,
+  { bg: number; border: number; opacity: number }
+> = {
+  pending_confirmation: { bg: 0.1, border: 0.45, opacity: 1 },
+  scheduled: { bg: 0.15, border: 0.55, opacity: 1 },
+  confirmed: { bg: 0.28, border: 0.75, opacity: 1 },
+  in_progress: { bg: 0.5, border: 1, opacity: 1 },
+  completed: { bg: 0.08, border: 0.35, opacity: 0.7 },
+  cancelled: { bg: 0.1, border: 0.4, opacity: 0.65 },
+  no_show: { bg: 0.1, border: 0.55, opacity: 0.8 },
+  blocked: { bg: 0.18, border: 0.55, opacity: 0.85 },
+};
+
+function hexToRgb(
+  hex: string,
+): { r: number; g: number; b: number } | null {
+  const clean = hex.trim().replace("#", "");
+  const expanded =
+    clean.length === 3
+      ? clean
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : clean;
+  if (expanded.length !== 6 || /[^0-9a-f]/i.test(expanded)) return null;
+  const r = parseInt(expanded.slice(0, 2), 16);
+  const g = parseInt(expanded.slice(2, 4), 16);
+  const b = parseInt(expanded.slice(4, 6), 16);
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+  return { r, g, b };
+}
+
+function rgbRelativeLuminance({
+  r,
+  g,
+  b,
+}: {
+  r: number;
+  g: number;
+  b: number;
+}): number {
+  const [R, G, B] = [r, g, b].map((v) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+}
+
+export interface AppointmentEmployeeStyle {
+  containerStyle: CSSProperties;
+  headerStyle: CSSProperties;
+  strike: boolean;
+}
+
+/**
+ * Build inline styles that tint a calendar tile in shades of the employee's
+ * chosen color, varying by status. Returns null if the color can't be parsed,
+ * letting the caller fall back to the status-only Tailwind classes.
+ */
+export function appointmentEmployeeStyle(
+  status: string,
+  baseColor: string,
+): AppointmentEmployeeStyle | null {
+  const rgb = hexToRgb(baseColor);
+  if (!rgb) return null;
+
+  const cfg = STATUS_ALPHA[status] ?? STATUS_ALPHA.scheduled;
+  const { r, g, b } = rgb;
+
+  // Darken the base for text so it stays legible on the light tint. For very
+  // dark base colors we already have enough contrast — skip the extra darken.
+  const lum = rgbRelativeLuminance(rgb);
+  const textShift = lum > 0.35 ? 70 : 25;
+  const textR = Math.max(0, r - textShift);
+  const textG = Math.max(0, g - textShift);
+  const textB = Math.max(0, b - textShift);
+
+  // The "in_progress" tile uses a near-solid background, so text needs to be
+  // either white (for dark bases) or kept dark (for light bases).
+  const headerOnSolid = lum > 0.6 ? "#1f2937" : "#ffffff";
+
+  return {
+    containerStyle: {
+      backgroundColor: `rgba(${r}, ${g}, ${b}, ${cfg.bg})`,
+      borderLeftColor: `rgba(${r}, ${g}, ${b}, ${cfg.border})`,
+      color: `rgb(${textR}, ${textG}, ${textB})`,
+      opacity: cfg.opacity,
+    },
+    headerStyle: {
+      backgroundColor: `rgba(${r}, ${g}, ${b}, ${Math.min(1, cfg.border + 0.05)})`,
+      color: status === "in_progress" ? headerOnSolid : "#ffffff",
+    },
+    strike: status === "cancelled",
+  };
 }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -314,6 +314,19 @@ function GabinetCalendarPage() {
     return map;
   }, [members]);
 
+  // userId -> per-employee color (hex). Drives the calendar's per-employee
+  // shading so every appointment for the same employee reads as a variation
+  // of one hue (issue #1019). Employees without an assigned color are simply
+  // omitted; the appointment then falls back to its treatment color or the
+  // status-only palette.
+  const employeeColorMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const emp of employees ?? []) {
+      if (emp.color) map.set(emp.userId, emp.color);
+    }
+    return map;
+  }, [employees]);
+
   // Build schedule map for the filtered employee (or all employees)
   const employeeSchedules = useMemo(() => {
     const map = new Map<
@@ -585,7 +598,12 @@ function GabinetCalendarPage() {
           patientName: patientMap.get(a.patientId) ?? "",
           treatmentName: treatment?.name ?? "",
           status: a.status,
-          color: a.color ?? treatment?.color,
+          // Per-appointment override wins, then the employee's assigned color
+          // (issue #1019), then treatment color as a final fallback.
+          color:
+            a.color ??
+            employeeColorMap.get(a.employeeId) ??
+            treatment?.color,
           employeeId: a.employeeId,
           tags: tags && tags.length > 0 ? tags : undefined,
           indicators: indicators.length > 0 ? indicators : undefined,
@@ -624,7 +642,7 @@ function GabinetCalendarPage() {
     }
 
     return items;
-  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, tagMap, firstAppointmentIds, packagePositions, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
+  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, tagMap, employeeColorMap, firstAppointmentIds, packagePositions, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
 
   // Build print-friendly appointment data for the current day
   const printDate = formatDateStr(currentDate);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1019.

Closes #1019

---

## Claude summary

Committed.

Summary of the change: the calendar now uses each employee's assigned color (`gabinetEmployees.color`, set per employee in their profile) as the base hue for every appointment tile. Appointment status determines the intensity — `pending_confirmation` / `scheduled` are the lightest tints, `confirmed` is darker, `in_progress` is near-solid, and `completed` / `cancelled` / `no_show` fade out (with `cancelled` keeping the existing strikethrough). So if an employee has blue, all their appointments read as shades of blue, exactly as requested.

The priority chain in `viewAppointments` is per-appointment color override → employee color → treatment color, so an explicit override still wins and employees without a color fall back to the previous behavior. Files touched: `src/lib/gabinet-appointment-status.ts` (new `appointmentEmployeeStyle` helper), `src/components/gabinet/calendar/appointment-card.tsx` (consume helper), and `src/routes/.../gabinet.calendar.index.lazy.tsx` (build employee→color map, pass employee color).

## Follow-ups
- Dark-mode contrast for employee-tinted tiles: text color is a darkened hex of the employee color, which is fine on light tints but low-contrast on the darker tint produced over a dark background; consider switching to a CSS variable + media query.