### PR TITLE
Dark-mode contrast for employee-tinted tiles

### DIFF
--- a/src/components/gabinet/calendar/appointment-card.tsx
+++ b/src/components/gabinet/calendar/appointment-card.tsx
@@ -59,7 +59,7 @@ export function AppointmentCard({
   return (
     <button
       onClick={onClick}
-      className={`flex w-full h-full flex-col overflow-hidden rounded border-l-4 text-left text-xs transition-opacity hover:opacity-80 ${fallbackCls}${strike}`}
+      className={`flex w-full h-full flex-col overflow-hidden rounded border-l-4 text-left text-xs transition-opacity hover:opacity-80 ${employeeStyle ? "gabinet-tile-tint" : ""} ${fallbackCls}${strike}`}
       style={
         employeeStyle
           ? employeeStyle.containerStyle

--- a/src/index.css
+++ b/src/index.css
@@ -454,3 +454,16 @@ img {
   --invert-foreground: var(--color-zinc-50);
   --highlight: oklch(0.852 0.199 91.936);
 }
+
+/*
+ * Gabinet calendar tile text color — picks between the darkened (light mode)
+ * and lightened (dark mode) shade of the employee color. Both shades are
+ * provided as inline CSS custom properties by `appointmentEmployeeStyle()` in
+ * `src/lib/gabinet-appointment-status.ts`. Issue #1022.
+ */
+.gabinet-tile-tint {
+  color: var(--gabinet-tile-text);
+}
+.dark .gabinet-tile-tint {
+  color: var(--gabinet-tile-text-dark);
+}

--- a/src/lib/gabinet-appointment-status.ts
+++ b/src/lib/gabinet-appointment-status.ts
@@ -103,6 +103,13 @@ export interface AppointmentEmployeeStyle {
  * Build inline styles that tint a calendar tile in shades of the employee's
  * chosen color, varying by status. Returns null if the color can't be parsed,
  * letting the caller fall back to the status-only Tailwind classes.
+ *
+ * Text color is exposed via two CSS custom properties — `--gabinet-tile-text`
+ * for light mode (darkened base) and `--gabinet-tile-text-dark` for dark mode
+ * (lightened base). The actual `color` is picked by the `.gabinet-tile-tint`
+ * rule in `src/index.css`, which switches on the `.dark` class. This fixes
+ * issue #1022: a darkened hex reads fine on a light-mode tint but disappears
+ * once the page background flips dark.
  */
 export function appointmentEmployeeStyle(
   status: string,
@@ -114,13 +121,22 @@ export function appointmentEmployeeStyle(
   const cfg = STATUS_ALPHA[status] ?? STATUS_ALPHA.scheduled;
   const { r, g, b } = rgb;
 
-  // Darken the base for text so it stays legible on the light tint. For very
-  // dark base colors we already have enough contrast — skip the extra darken.
+  // Light mode: darken the base for text so it stays legible on the light
+  // tint. For very dark base colors we already have enough contrast — skip the
+  // extra darken.
   const lum = rgbRelativeLuminance(rgb);
-  const textShift = lum > 0.35 ? 70 : 25;
-  const textR = Math.max(0, r - textShift);
-  const textG = Math.max(0, g - textShift);
-  const textB = Math.max(0, b - textShift);
+  const lightShift = lum > 0.35 ? 70 : 25;
+  const lightR = Math.max(0, r - lightShift);
+  const lightG = Math.max(0, g - lightShift);
+  const lightB = Math.max(0, b - lightShift);
+
+  // Dark mode: mix the base color toward white so it stands out against the
+  // dark page bleeding through the low-alpha tint. Very light bases (yellow,
+  // mint) only need a small lift; saturated mid-tones (blue, red) get more.
+  const darkMix = lum > 0.6 ? 0.25 : 0.6;
+  const darkR = Math.round(r + (255 - r) * darkMix);
+  const darkG = Math.round(g + (255 - g) * darkMix);
+  const darkB = Math.round(b + (255 - b) * darkMix);
 
   // The "in_progress" tile uses a near-solid background, so text needs to be
   // either white (for dark bases) or kept dark (for light bases).
@@ -130,9 +146,10 @@ export function appointmentEmployeeStyle(
     containerStyle: {
       backgroundColor: `rgba(${r}, ${g}, ${b}, ${cfg.bg})`,
       borderLeftColor: `rgba(${r}, ${g}, ${b}, ${cfg.border})`,
-      color: `rgb(${textR}, ${textG}, ${textB})`,
       opacity: cfg.opacity,
-    },
+      "--gabinet-tile-text": `rgb(${lightR}, ${lightG}, ${lightB})`,
+      "--gabinet-tile-text-dark": `rgb(${darkR}, ${darkG}, ${darkB})`,
+    } as CSSProperties,
     headerStyle: {
       backgroundColor: `rgba(${r}, ${g}, ${b}, ${Math.min(1, cfg.border + 0.05)})`,
       color: status === "in_progress" ? headerOnSolid : "#ffffff",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1022.

Closes #1022

---

## Claude summary

Committed. The fix addresses the dark-mode contrast issue by computing two text colors instead of one: a darkened shade for light mode and a lightened shade for dark mode (mixed toward white, with the mix amount scaled by base luminance so light bases like yellow get a smaller lift than saturated mid-tones like blue/red). Both are emitted as inline CSS custom properties (`--gabinet-tile-text` and `--gabinet-tile-text-dark`) on each tile, and a single rule in `src/index.css` keyed on the `.dark` class picks between them. Typecheck (`tsc -p tsconfig.app.json`) passes with no errors.

I used the codebase's `.dark`-class scheme rather than a raw `prefers-color-scheme` media query — the user's manual light/dark/system toggle wouldn't work with a media query alone, since the toggle adds/removes the `.dark` class on `<html>` (see `src/ui/theme-switcher.tsx:34`).