### PR TITLE
polski

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1688,6 +1688,17 @@
       "hoursAgo_other": "{{count}}h ago",
       "daysAgo_one": "{{count}}d ago",
       "daysAgo_other": "{{count}}d ago"
+    },
+    "descriptions": {
+      "updatedAppointment": "Updated appointment",
+      "createdAppointment": "Created appointment for {{date}} at {{time}}",
+      "cancelledAppointment": "Cancelled appointment",
+      "cancelledAppointmentWithReason": "Cancelled appointment: {{reason}}",
+      "statusChanged": "Status changed from {{from}} to {{to}}",
+      "appointmentConfirmedViaSms": "Appointment confirmed via SMS reply",
+      "appointmentCancelledViaSms": "Appointment cancelled via SMS reply",
+      "automationRun": "Automation run",
+      "automationNamed": "Automation: {{name}}"
     }
   },
   "lostReasons": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1710,6 +1710,17 @@
       "daysAgo_few": "{{count}} d temu",
       "daysAgo_many": "{{count}} d temu",
       "daysAgo_other": "{{count}} d temu"
+    },
+    "descriptions": {
+      "updatedAppointment": "Zaktualizowano wizytę",
+      "createdAppointment": "Utworzono wizytę na {{date}} o {{time}}",
+      "cancelledAppointment": "Anulowano wizytę",
+      "cancelledAppointmentWithReason": "Anulowano wizytę: {{reason}}",
+      "statusChanged": "Status zmieniony z „{{from}}” na „{{to}}”",
+      "appointmentConfirmedViaSms": "Wizyta potwierdzona przez SMS",
+      "appointmentCancelledViaSms": "Wizyta anulowana przez SMS",
+      "automationRun": "Uruchomienie automatyzacji",
+      "automationNamed": "Automatyzacja: {{name}}"
     }
   },
   "lostReasons": {

--- a/src/components/activity-timeline/merge-timeline-sources.ts
+++ b/src/components/activity-timeline/merge-timeline-sources.ts
@@ -1,4 +1,5 @@
 import type { ActivityWithMetadata } from "./presenter/activity-presenter";
+import type { Translator } from "./translate-description";
 
 export interface TimelineSourceEntry {
   _id: string;
@@ -39,8 +40,9 @@ export function mergeTimelineSources(opts: {
   activities?: TimelineSourceEntry[];
   smsEvents?: SmsEventEntry[];
   automationRuns?: AutomationRunEntry[];
+  t?: Translator;
 }): ActivityWithMetadata[] {
-  const { activities = [], smsEvents = [], automationRuns = [] } = opts;
+  const { activities = [], smsEvents = [], automationRuns = [], t } = opts;
 
   const seen = new Set<string>();
 
@@ -69,18 +71,28 @@ export function mergeTimelineSources(opts: {
   });
 
   const automationEntries: ActivityWithMetadata[] = automationRuns.map(
-    (run) => ({
-      _id: `automation-${run._id}`,
-      action: "updated" as const,
-      description: run.ruleName
-        ? `Automation: ${run.ruleName}`
-        : "Automation run",
-      createdAt: run.createdAt,
-      metadata: {
-        automationStatus: run.status,
-        actionsSummary: run.actionsSummary,
-      },
-    }),
+    (run) => {
+      const description = run.ruleName
+        ? t
+          ? t("activityTimeline.descriptions.automationNamed", {
+              defaultValue: "Automation: {{name}}",
+              name: run.ruleName,
+            })
+          : `Automation: ${run.ruleName}`
+        : t
+          ? t("activityTimeline.descriptions.automationRun", "Automation run")
+          : "Automation run";
+      return {
+        _id: `automation-${run._id}`,
+        action: "updated" as const,
+        description,
+        createdAt: run.createdAt,
+        metadata: {
+          automationStatus: run.status,
+          actionsSummary: run.actionsSummary,
+        },
+      };
+    },
   );
 
   const merged = [

--- a/src/components/activity-timeline/translate-description.ts
+++ b/src/components/activity-timeline/translate-description.ts
@@ -1,0 +1,101 @@
+/**
+ * Translates known English activity-description templates that are stored
+ * in the database (e.g. `Updated appointment`, `Cancelled appointment: <reason>`)
+ * into the user's current language.
+ *
+ * Descriptions are written by Convex mutations at the time of the action and
+ * persisted as plain English. The timeline renders them as-is, which leaks
+ * English copy into otherwise Polish UI. Rather than back-fill the DB, we
+ * pattern-match known templates here and return the translated equivalent.
+ *
+ * If the input does not match any known template, it is returned unchanged so
+ * free-text and not-yet-covered descriptions still render.
+ */
+
+// Loose translator shape compatible with i18next's TFunction.
+// Returning `any` avoids depending on i18next's generic types while still
+// letting callers pass `useTranslation().t` directly.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Translator = (...args: any[]) => any;
+
+interface Rule {
+  pattern: RegExp;
+  build: (match: RegExpMatchArray, t: Translator) => string;
+}
+
+const rules: Rule[] = [
+  {
+    pattern: /^Updated appointment$/,
+    build: (_m, t) => t("activityTimeline.descriptions.updatedAppointment", "Updated appointment"),
+  },
+  {
+    pattern: /^Created appointment for (.+) at (.+)$/,
+    build: (m, t) =>
+      t("activityTimeline.descriptions.createdAppointment", {
+        defaultValue: "Created appointment for {{date}} at {{time}}",
+        date: m[1],
+        time: m[2],
+      }),
+  },
+  {
+    pattern: /^Cancelled appointment: (.+)$/,
+    build: (m, t) =>
+      t("activityTimeline.descriptions.cancelledAppointmentWithReason", {
+        defaultValue: "Cancelled appointment: {{reason}}",
+        reason: m[1],
+      }),
+  },
+  {
+    pattern: /^Cancelled appointment$/,
+    build: (_m, t) => t("activityTimeline.descriptions.cancelledAppointment", "Cancelled appointment"),
+  },
+  {
+    pattern: /^Status changed from (.+) to (.+)$/,
+    build: (m, t) =>
+      t("activityTimeline.descriptions.statusChanged", {
+        defaultValue: "Status changed from {{from}} to {{to}}",
+        from: m[1],
+        to: m[2],
+      }),
+  },
+  {
+    pattern: /^Appointment confirmed via SMS reply$/,
+    build: (_m, t) =>
+      t(
+        "activityTimeline.descriptions.appointmentConfirmedViaSms",
+        "Appointment confirmed via SMS reply",
+      ),
+  },
+  {
+    pattern: /^Appointment cancelled via SMS reply$/,
+    build: (_m, t) =>
+      t(
+        "activityTimeline.descriptions.appointmentCancelledViaSms",
+        "Appointment cancelled via SMS reply",
+      ),
+  },
+  {
+    pattern: /^Automation run$/,
+    build: (_m, t) => t("activityTimeline.descriptions.automationRun", "Automation run"),
+  },
+  {
+    pattern: /^Automation: (.+)$/,
+    build: (m, t) =>
+      t("activityTimeline.descriptions.automationNamed", {
+        defaultValue: "Automation: {{name}}",
+        name: m[1],
+      }),
+  },
+];
+
+export function translateActivityDescription(
+  description: string | undefined,
+  t: Translator | undefined,
+): string | undefined {
+  if (!description || !t) return description;
+  for (const rule of rules) {
+    const match = description.match(rule.pattern);
+    if (match) return rule.build(match, t);
+  }
+  return description;
+}

--- a/src/components/crm/activity-feed-adapter.ts
+++ b/src/components/crm/activity-feed-adapter.ts
@@ -8,6 +8,10 @@
 
 import type { FeedEntry } from "@/components/crm/activity-feed";
 import type { ActivityAction } from "@cvx/schema";
+import {
+  translateActivityDescription,
+  type Translator,
+} from "@/components/activity-timeline/translate-description";
 
 function readEnvelopeActorLabel(metadata: unknown): string | undefined {
   if (!metadata || typeof metadata !== "object") return undefined;
@@ -64,9 +68,13 @@ function extractMetadata(meta: unknown): Record<string, unknown> {
 
 /**
  * Convert an array of MappedActivity-like objects to FeedEntry[] for ActivityFeed.
+ *
+ * Pass `t` to translate known stored English description templates (e.g.
+ * `Updated appointment`, `Automation: <name>`) into the current language.
  */
 export function activitiesToFeedEntries(
   activities: MappedActivityLike[],
+  t?: Translator,
 ): FeedEntry[] {
   return activities.map((a): FeedEntry => {
     const meta = extractMetadata(a.metadata);
@@ -75,12 +83,17 @@ export function activitiesToFeedEntries(
     const actorLabel = a.performedByName ?? readEnvelopeActorLabel(a.metadata);
     const safeLegacyActor = looksLikeOpaqueId(a.performedBy) ? undefined : a.performedBy;
 
+    const translatedDescription = translateActivityDescription(a.description, t) ?? a.description;
+    const translatedBody = a.contentSnapshot
+      ? a.contentSnapshot
+      : translatedDescription;
+
     const entry: FeedEntry = {
       _id: a._id,
       type: feedType,
       action: a.action as ActivityAction,
-      title: a.description,
-      body: a.contentSnapshot ?? a.description,
+      title: translatedDescription,
+      body: translatedBody,
       createdAt: a.createdAt,
       performedBy: actorLabel ?? safeLegacyActor
         ? { name: actorLabel ?? safeLegacyActor! }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1166,6 +1166,7 @@ function AppointmentDetail() {
       createdAt: r.createdAt as number,
       actionsSummary: r.actionsSummary as string | undefined,
     })) as AutomationRunEntry[],
+    t,
   });
 
   // Header title and subtitle
@@ -1923,7 +1924,7 @@ function AppointmentDetail() {
             </CardHeader>
             <CardContent className="px-6 py-4">
               <ActivityFeed
-                entries={activitiesToFeedEntries(mergedTimeline as any[])}
+                entries={activitiesToFeedEntries(mergedTimeline as any[], t)}
                 maxHeight="400px"
               />
             </CardContent>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1026.

Closes #1026

---

## Claude summary

Committed the fix on `claude/issue-1026` as `c4367ba`.

The appointment-history tab leaked English strings ("Updated appointment", "Automation run") because activity descriptions are written as plain English by Convex mutations and persisted that way. Rather than rewrite history in the DB, I added a render-time translator:

- `src/components/activity-timeline/translate-description.ts` — pattern-matches known stored English templates and emits i18n keys (e.g. `activityTimeline.descriptions.updatedAppointment`). Unknown descriptions pass through untouched.
- `merge-timeline-sources.ts` — now accepts an optional `t` and uses it for the client-side "Automation: …" / "Automation run" entries.
- `activity-feed-adapter.ts` — `activitiesToFeedEntries(activities, t?)` translates each `description` via the helper before building the feed entry.
- Appointment detail route passes `t` into both functions.
- PL/EN translations added under `activityTimeline.descriptions.*` for: `updatedAppointment`, `createdAppointment`, `cancelledAppointment`(+with reason), `statusChanged`, `appointmentConfirmedViaSms`, `appointmentCancelledViaSms`, `automationRun`, `automationNamed`.

Typecheck: my changes are clean (pre-existing errors in `convex/gabinetRoles.ts` and `_layout.settings.team.tsx` were verified on `main` before my edits).

## Follow-ups
- Localize remaining gabinet activity descriptions at write time: many backend mutations across `convex/gabinet/*` and `convex/*` still write English descriptions to the DB (e.g. "Created contact", "Updated lead", "Uploaded document"). Either move all known templates into the render-time translator's rule table, or change the storage format to `{ key, params }` so localization happens centrally.
- Translate other appointment status-change strings: `notificationTitle`/`notificationMessage` in `convex/gabinet/appointments.ts` (~line 1668, 1781) are still English and surface in notifications.