### PR TITLE
Translate other appointment status-change strings

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -186,6 +186,16 @@
       "minutesAgo": "{{count}}m ago",
       "hoursAgo": "{{count}}h ago",
       "daysAgo": "{{count}}d ago"
+    },
+    "descriptions": {
+      "appointmentStatusChangedTitle": "Appointment status changed",
+      "appointmentStatusChangedMessage": "Appointment status changed to \"{{status}}\"",
+      "appointmentConfirmedViaSmsTitle": "Appointment confirmed via SMS",
+      "appointmentCancelledViaSmsTitle": "Appointment cancelled via SMS",
+      "appointmentStatusChangedViaSmsMessage": "Appointment status changed to \"{{status}}\" from patient SMS reply",
+      "appointmentCancelledTitle": "Appointment cancelled",
+      "appointmentCancelledMessage": "An appointment has been cancelled",
+      "appointmentCancelledMessageWithReason": "An appointment has been cancelled: {{reason}}"
     }
   },
   "sidebar": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -199,6 +199,16 @@
       "minutesAgo": "{{count}} min temu",
       "hoursAgo": "{{count}} godz. temu",
       "daysAgo": "{{count}} dni temu"
+    },
+    "descriptions": {
+      "appointmentStatusChangedTitle": "Zmiana statusu wizyty",
+      "appointmentStatusChangedMessage": "Status wizyty zmieniony na „{{status}}”",
+      "appointmentConfirmedViaSmsTitle": "Wizyta potwierdzona przez SMS",
+      "appointmentCancelledViaSmsTitle": "Wizyta odwołana przez SMS",
+      "appointmentStatusChangedViaSmsMessage": "Status wizyty zmieniony na „{{status}}” po odpowiedzi SMS pacjenta",
+      "appointmentCancelledTitle": "Wizyta odwołana",
+      "appointmentCancelledMessage": "Wizyta została odwołana",
+      "appointmentCancelledMessageWithReason": "Wizyta została odwołana: {{reason}}"
     }
   },
   "sidebar": {

--- a/src/components/notifications/notification-bell.tsx
+++ b/src/components/notifications/notification-bell.tsx
@@ -12,6 +12,10 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  translateNotificationMessage,
+  translateNotificationTitle,
+} from "@/components/notifications/translate-notification";
 import type { Id } from "@cvx/_generated/dataModel";
 
 function useFormatRelativeTime() {
@@ -150,11 +154,11 @@ export function NotificationBell() {
                         : "truncate text-sm font-medium text-foreground"
                     }
                   >
-                    {notification.title}
+                    {translateNotificationTitle(notification.title, t)}
                   </p>
                   {notification.message && (
                     <p className="truncate text-xs text-muted-foreground">
-                      {notification.message}
+                      {translateNotificationMessage(notification.message, t)}
                     </p>
                   )}
                   <p className="mt-0.5 text-xs text-muted-foreground">

--- a/src/components/notifications/translate-notification.test.ts
+++ b/src/components/notifications/translate-notification.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  translateNotificationMessage,
+  translateNotificationTitle,
+} from "./translate-notification";
+
+// Minimal i18next-like translator that echoes the default value with
+// `{{param}}` placeholders interpolated. Status keys
+// (`gabinet.appointments.statuses.<status>`) fall through the i18next
+// fallback (no defaultValue) so we map them inline below.
+const STATUS_LABELS: Record<string, string> = {
+  scheduled: "Scheduled",
+  pending_confirmation: "Pending confirmation",
+  confirmed: "Confirmed",
+  in_progress: "In progress",
+  completed: "Completed",
+  cancelled: "Cancelled",
+  no_show: "No-show",
+};
+
+const t = (
+  key: string,
+  arg?: string | { defaultValue?: string; [k: string]: unknown },
+): string => {
+  if (key.startsWith("gabinet.appointments.statuses.")) {
+    const status = key.split(".").pop() ?? "";
+    return STATUS_LABELS[status] ?? (typeof arg === "string" ? arg : status);
+  }
+  if (typeof arg === "string") return arg;
+  const tpl = (arg?.defaultValue as string) ?? "";
+  return tpl.replace(/\{\{(\w+)\}\}/g, (_, name) => String(arg?.[name] ?? ""));
+};
+
+describe("translateNotificationTitle", () => {
+  it("translates known title templates", () => {
+    expect(translateNotificationTitle("Appointment status changed", t)).toBe(
+      "Appointment status changed",
+    );
+    expect(translateNotificationTitle("Appointment confirmed via SMS", t)).toBe(
+      "Appointment confirmed via SMS",
+    );
+    expect(translateNotificationTitle("Appointment cancelled via SMS", t)).toBe(
+      "Appointment cancelled via SMS",
+    );
+    expect(translateNotificationTitle("Appointment cancelled", t)).toBe(
+      "Appointment cancelled",
+    );
+  });
+
+  it("returns unrecognised titles unchanged", () => {
+    expect(translateNotificationTitle("Some other title", t)).toBe(
+      "Some other title",
+    );
+  });
+
+  it("returns input when no translator provided", () => {
+    expect(
+      translateNotificationTitle("Appointment status changed", undefined),
+    ).toBe("Appointment status changed");
+  });
+});
+
+describe("translateNotificationMessage", () => {
+  it("translates the SMS-reply message and the status name within it", () => {
+    expect(
+      translateNotificationMessage(
+        'Appointment status changed to "confirmed" from patient SMS reply',
+        t,
+      ),
+    ).toBe('Appointment status changed to "Confirmed" from patient SMS reply');
+
+    expect(
+      translateNotificationMessage(
+        'Appointment status changed to "cancelled" from patient SMS reply',
+        t,
+      ),
+    ).toBe('Appointment status changed to "Cancelled" from patient SMS reply');
+  });
+
+  it("translates the generic status-change message and the status name within it", () => {
+    expect(
+      translateNotificationMessage(
+        'Appointment status changed to "completed"',
+        t,
+      ),
+    ).toBe('Appointment status changed to "Completed"');
+
+    expect(
+      translateNotificationMessage(
+        'Appointment status changed to "no_show"',
+        t,
+      ),
+    ).toBe('Appointment status changed to "No-show"');
+  });
+
+  it("translates the cancelled message with and without reason", () => {
+    expect(
+      translateNotificationMessage("An appointment has been cancelled", t),
+    ).toBe("An appointment has been cancelled");
+    expect(
+      translateNotificationMessage(
+        "An appointment has been cancelled: patient sick",
+        t,
+      ),
+    ).toBe("An appointment has been cancelled: patient sick");
+  });
+
+  it("returns unrecognised messages unchanged", () => {
+    expect(translateNotificationMessage("Something else", t)).toBe(
+      "Something else",
+    );
+  });
+});

--- a/src/components/notifications/translate-notification.ts
+++ b/src/components/notifications/translate-notification.ts
@@ -1,0 +1,135 @@
+/**
+ * Translates known English notification title/message templates that are
+ * stored in the database (written by Convex mutations such as the
+ * appointment status-change handlers in `convex/gabinet/appointments.ts`)
+ * into the user's current language at render time.
+ *
+ * Mirrors the approach used for activity descriptions in
+ * `src/components/activity-timeline/translate-description.ts`: we keep the
+ * stored payload in English so existing rows render correctly after a
+ * language switch, and pattern-match here on a small set of known templates.
+ * Unrecognised strings are returned unchanged.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Translator = (...args: any[]) => any;
+
+interface Rule {
+  pattern: RegExp;
+  build: (match: RegExpMatchArray, t: Translator) => string;
+}
+
+const APPOINTMENT_STATUS_KEYS = new Set([
+  "scheduled",
+  "pending_confirmation",
+  "confirmed",
+  "in_progress",
+  "completed",
+  "cancelled",
+  "no_show",
+]);
+
+function translateAppointmentStatus(status: string, t: Translator): string {
+  if (APPOINTMENT_STATUS_KEYS.has(status)) {
+    return t(`gabinet.appointments.statuses.${status}`, status);
+  }
+  return status;
+}
+
+const titleRules: Rule[] = [
+  {
+    pattern: /^Appointment status changed$/,
+    build: (_m, t) =>
+      t(
+        "notifications.descriptions.appointmentStatusChangedTitle",
+        "Appointment status changed",
+      ),
+  },
+  {
+    pattern: /^Appointment confirmed via SMS$/,
+    build: (_m, t) =>
+      t(
+        "notifications.descriptions.appointmentConfirmedViaSmsTitle",
+        "Appointment confirmed via SMS",
+      ),
+  },
+  {
+    pattern: /^Appointment cancelled via SMS$/,
+    build: (_m, t) =>
+      t(
+        "notifications.descriptions.appointmentCancelledViaSmsTitle",
+        "Appointment cancelled via SMS",
+      ),
+  },
+  {
+    pattern: /^Appointment cancelled$/,
+    build: (_m, t) =>
+      t(
+        "notifications.descriptions.appointmentCancelledTitle",
+        "Appointment cancelled",
+      ),
+  },
+];
+
+const messageRules: Rule[] = [
+  {
+    pattern: /^Appointment status changed to "(.+)" from patient SMS reply$/,
+    build: (m, t) =>
+      t("notifications.descriptions.appointmentStatusChangedViaSmsMessage", {
+        defaultValue:
+          'Appointment status changed to "{{status}}" from patient SMS reply',
+        status: translateAppointmentStatus(m[1], t),
+      }),
+  },
+  {
+    pattern: /^Appointment status changed to "(.+)"$/,
+    build: (m, t) =>
+      t("notifications.descriptions.appointmentStatusChangedMessage", {
+        defaultValue: 'Appointment status changed to "{{status}}"',
+        status: translateAppointmentStatus(m[1], t),
+      }),
+  },
+  {
+    pattern: /^An appointment has been cancelled: (.+)$/,
+    build: (m, t) =>
+      t("notifications.descriptions.appointmentCancelledMessageWithReason", {
+        defaultValue: "An appointment has been cancelled: {{reason}}",
+        reason: m[1],
+      }),
+  },
+  {
+    pattern: /^An appointment has been cancelled$/,
+    build: (_m, t) =>
+      t(
+        "notifications.descriptions.appointmentCancelledMessage",
+        "An appointment has been cancelled",
+      ),
+  },
+];
+
+function applyRules(
+  input: string | undefined,
+  rules: Rule[],
+  t: Translator | undefined,
+): string | undefined {
+  if (!input || !t) return input;
+  for (const rule of rules) {
+    const match = input.match(rule.pattern);
+    if (match) return rule.build(match, t);
+  }
+  return input;
+}
+
+export function translateNotificationTitle(
+  title: string | undefined,
+  t: Translator | undefined,
+): string | undefined {
+  return applyRules(title, titleRules, t);
+}
+
+export function translateNotificationMessage(
+  message: string | undefined,
+  t: Translator | undefined,
+): string | undefined {
+  return applyRules(message, messageRules, t);
+}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1030.

Closes #1030

---

## Claude summary

Committed `a8f2832`.

Summary: appointment status-change notifications (titles like "Appointment status changed", "Appointment cancelled via SMS" and messages like `Appointment status changed to "confirmed"`) were stored in English in the `notifications` table and rendered as-is by the bell. Following the render-time pattern from #1028/#1033, I added `translateNotificationTitle` / `translateNotificationMessage` (mapping the eight known title+message templates emitted by `convex/gabinet/appointments.ts`, with the embedded raw status token resolved against the existing `gabinet.appointments.statuses.*` labels), wired them through `notification-bell.tsx`, added EN + PL strings, and a vitest spec (7 passing tests). Typecheck clean for changed files; pre-existing repo-wide TS errors in `convex/gabinetRoles.ts` and the team settings page are unrelated.