### PR TITLE
zapłacona

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2731,6 +2731,11 @@
       "settleMarkCompleted": "Mark appointment as completed",
       "settleNothingToDo": "Enter an amount or check the close option.",
       "settleSuccess": "Appointment settled",
+      "paymentBadge": {
+        "paid": "Paid",
+        "partial": "Partially paid",
+        "unpaid": "Unpaid"
+      },
       "history": {
         "unifiedDescription": "Unified operational history for this appointment, including messages and workflow events.",
         "metadata": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2760,6 +2760,11 @@
       "settleMarkCompleted": "Oznacz wizytę jako zakończoną",
       "settleNothingToDo": "Wpisz kwotę lub zaznacz zamknięcie wizyty.",
       "settleSuccess": "Wizyta rozliczona",
+      "paymentBadge": {
+        "paid": "Zapłacona",
+        "partial": "Częściowo opłacona",
+        "unpaid": "Niezapłacona"
+      },
       "history": {
         "unifiedDescription": "Ujednolicona historia operacyjna tej wizyty, w tym wiadomości i zdarzenia workflow.",
         "metadata": {

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -541,6 +541,39 @@ export function AppointmentPreviewContent({
   const outstanding = Math.max(0, treatmentPrice - totalPaid);
   const canMarkCompleted = availableTransitions.includes("completed");
 
+  // Completed-only total drives the visible "Paid / Partial / Unpaid" badge —
+  // pending payments are auto-created when an appointment is booked, so they
+  // mustn't count as actually paid. Issue #1031.
+  const completedPaid = (detail.payments ?? [])
+    .filter((p) => p.status === "completed")
+    .reduce((sum, p) => sum + (p.amount ?? 0), 0);
+  const paymentBadge: { kind: "paid" | "partial" | "unpaid"; label: string } | null =
+    treatmentPrice > 0
+      ? completedPaid >= treatmentPrice
+        ? {
+            kind: "paid",
+            label: t("gabinet.appointmentDetail.paymentBadge.paid", {
+              defaultValue: "Zapłacona",
+            }),
+          }
+        : completedPaid > 0
+          ? {
+              kind: "partial",
+              label: t("gabinet.appointmentDetail.paymentBadge.partial", {
+                defaultValue: "Częściowo opłacona",
+              }),
+            }
+          : {
+              kind: "unpaid",
+              label: t("gabinet.appointmentDetail.paymentBadge.unpaid", {
+                defaultValue: "Niezapłacona",
+              }),
+            }
+      : null;
+  const paymentBadgeTooltip = paymentBadge
+    ? `${t("gabinet.payments.totalPaid")}: ${completedPaid.toFixed(2)} PLN / ${treatmentPrice.toFixed(2)} PLN`
+    : null;
+
   const handleOpenSettleDialog = () => {
     if (saving || settleSubmitting) return;
     setSettleAmount(outstanding > 0 ? outstanding.toFixed(2) : "");
@@ -717,7 +750,24 @@ export function AppointmentPreviewContent({
               </PopoverContent>
             </Popover>
           </div>
-          <div className="flex shrink-0 items-center gap-1.5">
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
+            {paymentBadge && (
+              <Badge
+                variant="outline"
+                title={paymentBadgeTooltip ?? undefined}
+                className={cn(
+                  "text-xs",
+                  paymentBadge.kind === "paid" &&
+                    "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300",
+                  paymentBadge.kind === "partial" &&
+                    "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300",
+                  paymentBadge.kind === "unpaid" &&
+                    "border-red-300 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300",
+                )}
+              >
+                {paymentBadge.label}
+              </Badge>
+            )}
             <Badge variant="outline" className="text-xs">
               <span
                 className={`mr-1.5 inline-block h-2 w-2 rounded-full ${STATUS_DOT_COLORS[initialStatus] ?? "bg-muted-foreground"}`}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1031.

Closes #1031

---

## Claude summary

Committed. The appointment preview panel on the calendar now shows a color-coded payment badge next to the existing status badge (`src/components/gabinet/calendar/appointment-preview-content.tsx:753`):

- Green "Zapłacona" when completed payments cover the treatment price
- Amber "Częściowo opłacona" when there's a partial payment
- Red "Niezapłacona" when there's a price but no completed payment
- Hidden entirely when the treatment has no price (free visits)

Hovering shows the exact amount paid vs. owed. I count only `completed` payments because the backend auto-creates a `pending` payment at booking (`convex/gabinet/appointments.ts:2172`), so pending != actually paid — this matches the semantics already used on the full appointment detail page (`_layout.gabinet.appointments.$appointmentId.lazy.tsx:1127`).

I deliberately scoped this to the preview panel rather than the calendar tiles themselves — surfacing paid status on every calendar tile would require fetching payment totals across the entire visible date range (a much heavier backend change), and the preview is where the user clicks to inspect a specific visit.

## Follow-ups
- Show paid indicator on calendar tiles directly: would let users spot unpaid completed visits without opening each one, but needs a new aggregated payments query for the date range