### PR TITLE
nr wizyty

### DIFF
--- a/src/hooks/use-supabase-gabinet-appointments.ts
+++ b/src/hooks/use-supabase-gabinet-appointments.ts
@@ -362,6 +362,70 @@ export function useSupabaseGabinetAppointmentPackagePositions(
 }
 
 // ---------------------------------------------------------------------------
+// Appointment Positions Within Recurring Series
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns, for each appointment that belongs to one of the given recurring
+ * groups, its 1-based position in chronological order among non-cancelled
+ * siblings sharing the same `recurringGroupId`. Used by the gabinet calendar
+ * so that the "visit X / Y" indicator reflects the actual order after a
+ * recurring occurrence has been rescheduled — the stored `recurringIndex`
+ * does not update on move (issue #1032).
+ */
+export function useSupabaseGabinetAppointmentRecurringPositions(
+  organizationId: string,
+  recurringGroupIds: string[],
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  const stableIds = [...recurringGroupIds].sort();
+
+  return useQuery<Map<string, number>, Error>({
+    queryKey: [
+      ...supabaseKeys.gabinetAppointments.list(organizationId),
+      "recurringPositions",
+      stableIds.join(","),
+    ],
+    queryFn: async (): Promise<Map<string, number>> => {
+      const result = new Map<string, number>();
+      if (!client) throw new Error("Supabase client not ready");
+      if (stableIds.length === 0) return result;
+
+      const { data, error } = await client
+        .from("gabinet_appointments")
+        .select("id, recurring_group_id, date, start_time")
+        .eq("organization_id", organizationId)
+        .in("recurring_group_id", stableIds)
+        .not("status", "in", '("cancelled","no_show")')
+        .order("date", { ascending: true })
+        .order("start_time", { ascending: true });
+
+      if (error) throw error;
+
+      const counter = new Map<string, number>();
+      for (const a of (data ?? []) as {
+        id: string;
+        recurring_group_id: string;
+      }[]) {
+        const next = (counter.get(a.recurring_group_id) ?? 0) + 1;
+        counter.set(a.recurring_group_id, next);
+        result.set(a.id, next);
+      }
+
+      return result;
+    },
+    enabled:
+      enabled &&
+      isReady &&
+      !!organizationId &&
+      stableIds.length > 0,
+  } satisfies UseQueryOptions<Map<string, number>, Error>);
+}
+
+// ---------------------------------------------------------------------------
 // Single Appointment
 // ---------------------------------------------------------------------------
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -52,6 +52,7 @@ import {
   useSupabaseGabinetAppointmentsByDateRange,
   useSupabaseGabinetFirstAppointmentIdsByPatient,
   useSupabaseGabinetAppointmentPackagePositions,
+  useSupabaseGabinetAppointmentRecurringPositions,
 } from "@/hooks/use-supabase-gabinet-appointments";
 import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
@@ -466,18 +467,22 @@ function GabinetCalendarPage() {
     return set;
   }, [rawAppointments]);
 
-  // Distinct patient + package usage IDs from the rendered range — used to
-  // compute the "first visit" and "visit X/Y" indicators on appointment cards.
+  // Distinct patient + package usage + recurring group IDs from the rendered
+  // range — used to compute the "first visit" and "visit X/Y" indicators on
+  // appointment cards.
   const indicatorLookupIds = useMemo(() => {
     const patientIds = new Set<string>();
     const packageUsageIds = new Set<string>();
+    const recurringGroupIds = new Set<string>();
     for (const a of rawAppointments ?? []) {
       if (a.patientId) patientIds.add(a.patientId);
       if (a.packageUsageId) packageUsageIds.add(a.packageUsageId);
+      if (a.recurringGroupId) recurringGroupIds.add(a.recurringGroupId);
     }
     return {
       patientIds: Array.from(patientIds),
       packageUsageIds: Array.from(packageUsageIds),
+      recurringGroupIds: Array.from(recurringGroupIds),
     };
   }, [rawAppointments]);
 
@@ -491,6 +496,12 @@ function GabinetCalendarPage() {
     useSupabaseGabinetAppointmentPackagePositions(
       organizationId,
       indicatorLookupIds.packageUsageIds,
+    );
+
+  const { data: recurringPositions } =
+    useSupabaseGabinetAppointmentRecurringPositions(
+      organizationId,
+      indicatorLookupIds.recurringGroupIds,
     );
 
   // Transform and filter appointments for view components
@@ -578,7 +589,15 @@ function GabinetCalendarPage() {
         } else if (a.isRecurring && a.recurringRule) {
           const rule = a.recurringRule as { count?: number };
           if (typeof rule.count === "number" && rule.count > 0) {
-            const pos = (a.recurringIndex ?? 0) + 1;
+            // Prefer the dynamically-computed chronological position so the
+            // "X/Y" indicator reflects the current order after a recurring
+            // occurrence is rescheduled (issue #1032). Fall back to the
+            // stored `recurringIndex` when the group has no live position
+            // (e.g. cancelled, no recurringGroupId, or hook not loaded).
+            const dynamicPos = a.recurringGroupId
+              ? recurringPositions?.get(a._id)
+              : undefined;
+            const pos = dynamicPos ?? (a.recurringIndex ?? 0) + 1;
             indicators.push({
               kind: "count",
               label: `${pos}/${rule.count}`,
@@ -642,7 +661,7 @@ function GabinetCalendarPage() {
     }
 
     return items;
-  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, tagMap, employeeColorMap, firstAppointmentIds, packagePositions, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
+  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, tagMap, employeeColorMap, firstAppointmentIds, packagePositions, recurringPositions, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
 
   // Build print-friendly appointment data for the current day
   const printDate = formatDateStr(currentDate);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1032.

Closes #1032

---

## Claude summary

Fix committed. Summary of what I did:

The "X/Y" visit-number badge on recurring appointments in the gabinet calendar was using the stored `recurringIndex` (set at series creation and never updated on reschedule). That's why the screenshot shows `1/6, 5/6, 4/6, 3/6, 6/6, 2/6` instead of chronological order after the visits were dragged around the week.

I mirrored the existing package-position pattern:

- Added `useSupabaseGabinetAppointmentRecurringPositions` in `src/hooks/use-supabase-gabinet-appointments.ts:376` that queries all non-cancelled siblings for the visible `recurring_group_id`s and assigns 1-based positions ordered by `(date, start_time)`.
- Wired it into `_layout.gabinet.calendar.index.lazy.tsx`: collected distinct `recurringGroupId`s alongside the existing patient/package lookups (line 473), called the new hook (line 501), and used the dynamic position with a fallback to `recurringIndex + 1` for safety (line 589).

The query is backed by the existing `gabinet_appointments_org_recurring_group_idx` index, so it stays efficient.