### PR TITLE
aktywuj

### DIFF
--- a/convex/gabinet/_e2eTest.ts
+++ b/convex/gabinet/_e2eTest.ts
@@ -224,14 +224,21 @@ export const runAll = internalMutation({
     // ============================================================
     // TEST 7: Appointment STATUS WORKFLOW (scheduled → confirmed → in_progress → completed)
     // ============================================================
-    const VALID_TRANSITIONS: Record<string, string[]> = {
-      scheduled: ["confirmed", "cancelled", "no_show"],
-      confirmed: ["in_progress", "completed", "cancelled", "no_show"],
-      in_progress: ["completed", "cancelled"],
-      completed: [],
-      cancelled: [],
-      no_show: [],
-    };
+    // Manual transitions are unrestricted (issue #1027) — every status maps to
+    // every OTHER status so staff can correct mistakes. Only same→same is
+    // rejected.
+    const ALL_STATUSES = [
+      "pending_confirmation",
+      "scheduled",
+      "confirmed",
+      "in_progress",
+      "completed",
+      "cancelled",
+      "no_show",
+    ] as const;
+    const VALID_TRANSITIONS: Record<string, string[]> = Object.fromEntries(
+      ALL_STATUSES.map((s) => [s, ALL_STATUSES.filter((t) => t !== s)]),
+    );
 
     try {
       if (!testAppointmentId) throw new Error("No appointment for status test");
@@ -266,21 +273,23 @@ export const runAll = internalMutation({
     // ============================================================
     try {
       if (!testAppointmentId) throw new Error("No appointment for invalid transition test");
-      // completed → scheduled should be invalid per VALID_TRANSITIONS
+      // Same-state transition (completed → completed) should be invalid per
+      // VALID_TRANSITIONS — the permissive map allows any status → any OTHER
+      // status (issue #1027), so the only remaining guard is the self-loop.
       const appt = await ctx.db.get(testAppointmentId);
       if (!appt) throw new Error("Appointment not found");
       const allowed = VALID_TRANSITIONS[appt.status] ?? [];
-      if (allowed.includes("scheduled")) {
+      if (allowed.includes(appt.status)) {
         results.push({
           test: "appointment_invalid_transition_guard",
           pass: false,
-          detail: "completed→scheduled should be invalid but was found in VALID_TRANSITIONS",
+          detail: `${appt.status}→${appt.status} should be invalid but was found in VALID_TRANSITIONS`,
         });
       } else {
         results.push({
           test: "appointment_invalid_transition_guard",
           pass: true,
-          detail: `Guard OK: completed has allowed transitions=[${allowed.join(",")}], does not include scheduled`,
+          detail: `Guard OK: ${appt.status} has allowed transitions=[${allowed.join(",")}], does not include itself`,
           ids: { appointmentId: testAppointmentId },
         });
       }

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -43,7 +43,9 @@ import { checkDocumentGate } from "./_helpers/documentGate";
 
 // Dual-write refs removed — Supabase is now primary for appointment writes
 
-const VALID_TRANSITIONS: Record<string, string[]> = {
+// Restrictive map used for automated SMS-driven transitions only — a late
+// patient reply must not overwrite a status that staff already set manually.
+const AUTOMATED_TRANSITIONS: Record<string, string[]> = {
   pending_confirmation: ["scheduled", "confirmed", "cancelled"],
   scheduled: ["confirmed", "in_progress", "completed", "cancelled", "no_show"],
   confirmed: ["in_progress", "completed", "cancelled", "no_show"],
@@ -52,6 +54,26 @@ const VALID_TRANSITIONS: Record<string, string[]> = {
   cancelled: [],
   no_show: [],
 };
+
+// Manual transitions are unrestricted (any → any other) so staff can correct
+// mistakes after a visit was already marked completed/cancelled/no_show.
+// Issue #1027.
+const ALL_APPOINTMENT_STATUSES = [
+  "pending_confirmation",
+  "scheduled",
+  "confirmed",
+  "in_progress",
+  "completed",
+  "cancelled",
+  "no_show",
+] as const;
+
+const MANUAL_TRANSITIONS: Record<string, string[]> = Object.fromEntries(
+  ALL_APPOINTMENT_STATUSES.map((s) => [
+    s,
+    ALL_APPOINTMENT_STATUSES.filter((t) => t !== s),
+  ]),
+);
 
 function getSmsTargetStatus(intent: "confirm" | "cancel") {
   return intent === "confirm" ? "confirmed" : "cancelled";
@@ -1338,7 +1360,7 @@ export const update = action({
 
     // Handle status change with cancellation support
     if (status) {
-      const allowed = VALID_TRANSITIONS[appt.status as string];
+      const allowed = MANUAL_TRANSITIONS[appt.status as string];
       if (!allowed?.includes(status)) {
         throw new Error(`Cannot transition from ${appt.status} to ${status}`);
       }
@@ -1518,7 +1540,7 @@ export const updateStatus = action({
       throw new Error("Permission denied: you can only edit your own records");
     }
 
-    const allowed = VALID_TRANSITIONS[appt.status as string];
+    const allowed = MANUAL_TRANSITIONS[appt.status as string];
     if (!allowed?.includes(args.status)) {
       throw new Error(
         `Cannot transition from ${appt.status} to ${args.status}`,
@@ -1722,7 +1744,7 @@ export const applySmsReplyTransition = internalMutation({
     }
 
     const targetStatus = getSmsTargetStatus(args.intent);
-    const allowed = VALID_TRANSITIONS[appointment.status as string];
+    const allowed = AUTOMATED_TRANSITIONS[appointment.status as string];
     if (!allowed?.includes(targetStatus)) {
       return {
         processingStatus: "ignored" as const,

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -85,15 +85,21 @@ import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useSidebarActions } from "@/components/layout/sidebar-context";
 
-const VALID_TRANSITIONS: Record<string, string[]> = {
-  pending_confirmation: ["scheduled", "confirmed", "cancelled"],
-  scheduled: ["confirmed", "in_progress", "completed", "cancelled", "no_show"],
-  confirmed: ["in_progress", "completed", "cancelled", "no_show"],
-  in_progress: ["completed", "cancelled"],
-  completed: [],
-  cancelled: [],
-  no_show: [],
-};
+// All statuses can transition to any other status. Lets staff correct mistakes
+// after a visit was already marked completed/cancelled/no_show (issue #1027).
+const ALL_STATUSES = [
+  "pending_confirmation",
+  "scheduled",
+  "confirmed",
+  "in_progress",
+  "completed",
+  "cancelled",
+  "no_show",
+] as const;
+
+const VALID_TRANSITIONS: Record<string, string[]> = Object.fromEntries(
+  ALL_STATUSES.map((s) => [s, ALL_STATUSES.filter((t) => t !== s)]),
+);
 
 const STATUS_DOT_COLORS: Record<string, string> = {
   pending_confirmation: "bg-amber-400",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -127,15 +127,21 @@ export const Route = createLazyFileRoute(
   component: AppointmentDetail,
 });
 
-const VALID_TRANSITIONS: Record<string, string[]> = {
-  pending_confirmation: ["scheduled", "confirmed", "cancelled"],
-  scheduled: ["confirmed", "in_progress", "completed", "cancelled", "no_show"],
-  confirmed: ["in_progress", "completed", "cancelled", "no_show"],
-  in_progress: ["completed", "cancelled"],
-  completed: [],
-  cancelled: [],
-  no_show: [],
-};
+// All statuses can transition to any other status. Lets staff correct mistakes
+// after a visit was already marked completed/cancelled/no_show (issue #1027).
+const ALL_STATUSES = [
+  "pending_confirmation",
+  "scheduled",
+  "confirmed",
+  "in_progress",
+  "completed",
+  "cancelled",
+  "no_show",
+] as const;
+
+const VALID_TRANSITIONS: Record<string, string[]> = Object.fromEntries(
+  ALL_STATUSES.map((s) => [s, ALL_STATUSES.filter((t) => t !== s)]),
+);
 
 function getSmsSummary(events: Array<Record<string, unknown>>, appointmentStatus: string) {
   const latestOutbound = events.find(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1027.

Closes #1027

---

## Claude summary

Commit landed (the post-commit bash error was a harmless cwd-permission warning, not a commit failure).

Summary: the previous status-transition map left `completed`, `cancelled`, and `no_show` with an empty allow-list, so all status buttons in the appointment preview/detail views went inert once a visit was closed. I replaced the manual-transition map (used by the UI, `update`, and `updateStatus`) with a permissive any→any-other rule so staff can correct mistakes — while keeping the strict map for the SMS reply handler so a late patient text can't silently overwrite a manually set status. Updated four files: backend `convex/gabinet/appointments.ts`, the in-place runtime test in `convex/gabinet/_e2eTest.ts` (its negative assertion now checks the only remaining invalid case: same→same), the appointment preview component, and the standalone appointment detail page.