### PR TITLE
Localize automation-action description in convex/automation.ts

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1699,6 +1699,12 @@
       "daysAgo_one": "{{count}}d ago",
       "daysAgo_other": "{{count}}d ago"
     },
+    "entityLabels": {
+      "patient": "patient",
+      "appointment": "appointment",
+      "employee": "employee",
+      "lead": "lead"
+    },
     "descriptions": {
       "updatedAppointment": "Updated appointment",
       "createdAppointment": "Created appointment for {{date}} at {{time}}",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1721,6 +1721,12 @@
       "daysAgo_many": "{{count}} d temu",
       "daysAgo_other": "{{count}} d temu"
     },
+    "entityLabels": {
+      "patient": "Pacjent",
+      "appointment": "Wizyta",
+      "employee": "Pracownik",
+      "lead": "Lead"
+    },
     "descriptions": {
       "updatedAppointment": "Zaktualizowano wizytę",
       "createdAppointment": "Utworzono wizytę na {{date}} o {{time}}",

--- a/src/components/activity-timeline/translate-description.ts
+++ b/src/components/activity-timeline/translate-description.ts
@@ -23,6 +23,17 @@ interface Rule {
   build: (match: RegExpMatchArray, t: Translator) => string;
 }
 
+// Maps the raw English entity tokens written by `convex/automation.ts`
+// (`patient`, `appointment`, `employee`, `lead`) to a localized label so the
+// rendered "Updated <entity> field … via automation" line does not leak
+// English nouns into Polish UI. Falls back to the original token for
+// unknown entity types.
+function translateAutomationEntityToken(token: string, t: Translator): string {
+  const key = `activityTimeline.entityLabels.${token}`;
+  const translated = t(key, { defaultValue: token });
+  return typeof translated === "string" ? translated : token;
+}
+
 const rules: Rule[] = [
   // ----- Appointments (existing) -----
   {
@@ -456,7 +467,7 @@ const rules: Rule[] = [
     build: (m, t) =>
       t("activityTimeline.descriptions.updatedFieldViaAutomation", {
         defaultValue: "Updated {{entity}} field {{field}} via automation",
-        entity: m[1],
+        entity: translateAutomationEntityToken(m[1], t),
         field: m[2],
       }),
   },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1035.

Closes #1035

---

## Claude summary

Committed. Here's what changed:

`convex/automation.ts:809` writes activity descriptions like `Updated lead field status via automation`, using raw English tokens (`lead`, `patient`, `appointment`, `employee`) from the `activityLabelByEntity` map. The frontend translator at `src/components/activity-timeline/translate-description.ts:455` already matched the template but passed the captured token straight through as `{{entity}}`, so Polish output read `Zaktualizowano pole status elementu lead przez automatyzację` — entity stayed English.

Fix: added a `translateAutomationEntityToken` helper that routes the token through a new `activityTimeline.entityLabels.*` i18n namespace, with `lead→Lead`, `patient→Pacjent`, `appointment→Wizyta`, `employee→Pracownik` in PL (lowercase originals in EN). Unknown tokens fall back to the raw value.

The fix lives in the frontend (where rendering happens) rather than in `convex/automation.ts`, because the Convex code persists a stable English template string that the translator pattern-matches at render time — same convention every other entry in `translate-description.ts` follows.