### PR TITLE
sprzedaj

### DIFF
--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2928,7 +2928,7 @@
       "splitMismatchError": "Suma rozdzielonych płatności musi być równa cenie pakietu",
       "splitMissingAmount": "Podaj kwotę co najmniej jednej metody płatności",
       "splitSameMethodError": "Wybierz dwie różne metody płatności",
-      "purchaseButton": "Sprzedaj",
+      "purchaseButton": "Dodaj sprzedaż",
       "usePackage": "Użyj pakietu",
       "remaining": "pozostało",
       "coveredByPackage": "Pokryte pakietem",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1036.

Closes #1036

---

## Claude summary

Renamed the Polish translation for `gabinet.packages.purchaseButton` from "Sprzedaj" to "Dodaj sprzedaż" in `public/locales/pl/translation.json:2931`. This is the action button at the bottom of the package purchase drawer (`src/components/gabinet/package-purchase-drawer.tsx:522`), opened from the patient page's Packages card. Committed as `652dc94`.