### PR TITLE
dodaj 

### DIFF
--- a/src/components/gabinet/sell-package-panel.tsx
+++ b/src/components/gabinet/sell-package-panel.tsx
@@ -1,0 +1,181 @@
+import { useCallback, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAction } from "convex/react";
+import { api } from "@cvx/_generated/api";
+import type { Id } from "@cvx/_generated/dataModel";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { SidePanel } from "@/components/crm/side-panel";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Loader2 } from "@/lib/ez-icons";
+import { useSupabaseGabinetTreatmentPackagesList } from "@/hooks/use-supabase-gabinet-packages";
+import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
+import { formatActionError } from "@/lib/format-action-error";
+
+interface SellPackagePanelProps {
+  organizationId: Id<"organizations">;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function SellPackagePanel({
+  organizationId,
+  open,
+  onOpenChange,
+}: SellPackagePanelProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const purchasePackage = useAction(api.gabinet.packages.purchasePackage);
+  const createPayment = useAction(api.payments.create);
+
+  const { data: packagesData } = useSupabaseGabinetTreatmentPackagesList(organizationId);
+  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId);
+
+  const [patientId, setPatientId] = useState<string>("");
+  const [packageId, setPackageId] = useState<string>("");
+  const [paymentMethod, setPaymentMethod] = useState<string>("cash");
+  const [submitting, setSubmitting] = useState(false);
+
+  const reset = useCallback(() => {
+    setPatientId("");
+    setPackageId("");
+    setPaymentMethod("cash");
+  }, []);
+
+  const handleSubmit = async () => {
+    if (!patientId || !packageId) return;
+    const pkg = (packagesData ?? []).find((p) => p._id === packageId);
+    if (!pkg) return;
+    setSubmitting(true);
+    try {
+      const usageId = await purchasePackage({
+        organizationId,
+        patientId,
+        packageId,
+        paidAmount: pkg.totalPrice,
+        paymentMethod,
+      });
+      await createPayment({
+        organizationId,
+        patientId,
+        packageUsageId: usageId,
+        amount: pkg.totalPrice,
+        currency: pkg.currency ?? "PLN",
+        paymentMethod: paymentMethod as "cash" | "card" | "transfer",
+        notes: `Package: ${pkg.name}`,
+      });
+      toast.success(t("gabinet.packages.purchased"));
+      void queryClient.invalidateQueries({
+        queryKey: supabaseKeys.gabinetTreatmentPackages.list(organizationId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: supabaseKeys.gabinetPackageUsage.list(organizationId),
+      });
+      onOpenChange(false);
+      reset();
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.packages.errors.purchaseFailed",
+          defaultValue: "Nie udało się sprzedać pakietu.",
+        }),
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SidePanel
+      open={open}
+      onOpenChange={(o) => {
+        onOpenChange(o);
+        if (!o) reset();
+      }}
+      title={t("nav.actions.assignPackage")}
+    >
+      <div className="space-y-4">
+        <div className="space-y-1.5">
+          <Label>{t("gabinet.packages.selectPatient", "Patient")}</Label>
+          <Select value={patientId} onValueChange={setPatientId}>
+            <SelectTrigger>
+              <SelectValue
+                placeholder={t(
+                  "gabinet.packages.selectPatientPlaceholder",
+                  "Select a patient...",
+                )}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {(patientsData ?? []).map((p) => (
+                <SelectItem key={p._id} value={p._id}>
+                  {p.firstName} {p.lastName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>{t("gabinet.packages.selectPackage")}</Label>
+          <Select value={packageId} onValueChange={setPackageId}>
+            <SelectTrigger>
+              <SelectValue
+                placeholder={t("gabinet.packages.selectPackagePlaceholder")}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {(packagesData ?? [])
+                .filter((p) => p.isActive)
+                .map((pkg) => (
+                  <SelectItem key={pkg._id} value={pkg._id}>
+                    {pkg.name} — {pkg.totalPrice} {pkg.currency ?? "PLN"}
+                  </SelectItem>
+                ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>{t("gabinet.packages.paymentMethod")}</Label>
+          <Select value={paymentMethod} onValueChange={setPaymentMethod}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="cash">
+                {t("gabinet.packages.paymentMethods.cash")}
+              </SelectItem>
+              <SelectItem value="card">
+                {t("gabinet.packages.paymentMethods.card")}
+              </SelectItem>
+              <SelectItem value="transfer">
+                {t("gabinet.packages.paymentMethods.transfer")}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <Button
+          className="w-full"
+          disabled={!patientId || !packageId || submitting}
+          onClick={handleSubmit}
+        >
+          {submitting && (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" variant="stroke" />
+          )}
+          {t("gabinet.packages.purchaseButton")}
+        </Button>
+      </div>
+    </SidePanel>
+  );
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -14,7 +14,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { ChevronLeft, ChevronRight, Plus, Search, Users, X } from "@/lib/ez-icons";
+import { ChevronLeft, ChevronRight, Gift, Plus, Search, Users, X } from "@/lib/ez-icons";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -45,6 +45,7 @@ import { CalendarWeekView } from "@/components/gabinet/calendar/calendar-week-vi
 import { CalendarMonthView } from "@/components/gabinet/calendar/calendar-month-view";
 import { AppointmentDialog } from "@/components/gabinet/calendar/appointment-dialog";
 import { AppointmentCard } from "@/components/gabinet/calendar/appointment-card";
+import { SellPackagePanel } from "@/components/gabinet/sell-package-panel";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { toast } from "sonner";
 import type { Id } from "@cvx/_generated/dataModel";
@@ -138,6 +139,7 @@ function GabinetCalendarPage() {
 
   // Dialog state
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [sellPackageOpen, setSellPackageOpen] = useState(false);
   const [createDefaultDate, setCreateDefaultDate] = useState<
     string | undefined
   >();
@@ -1116,6 +1118,18 @@ function GabinetCalendarPage() {
                 <Plus className="mr-1 h-3.5 w-3.5" variant="stroke" />
                 {t("gabinet.appointments.createAppointment", "Nowa wizyta")}
               </Button>
+
+              {/* Sell package button */}
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 text-xs"
+                data-testid="calendar-sell-package-button"
+                onClick={() => setSellPackageOpen(true)}
+              >
+                <Gift className="mr-1 h-3.5 w-3.5" variant="stroke" />
+                {t("gabinet.packages.purchaseButton")}
+              </Button>
             </div>
           </div>
 
@@ -1385,6 +1399,13 @@ function GabinetCalendarPage() {
           defaultTime={createDefaultTime}
           defaultEndTime={createDefaultEndTime}
           defaultEmployeeId={createDefaultEmployeeId}
+        />
+
+        {/* Sell package side panel */}
+        <SellPackagePanel
+          organizationId={organizationId}
+          open={sellPackageOpen}
+          onOpenChange={setSellPackageOpen}
         />
       </div>
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -5,7 +5,6 @@ import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseGabinetTreatmentPackagesList, useSupabaseGabinetPackageUsageActive } from "@/hooks/use-supabase-gabinet-packages";
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
-import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { PageHeader } from "@/components/layout/page-header";
 import { SidePanel } from "@/components/crm/side-panel";
@@ -39,7 +38,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Plus, Trash2, Package, Pencil, Loader2, X } from "@/lib/ez-icons";
+import { Plus, Trash2, Package, Pencil, X } from "@/lib/ez-icons";
 import { useState, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -47,6 +46,7 @@ import { formatActionError } from "@/lib/format-action-error";
 
 import { EmptyState } from "@/components/layout/empty-state";
 import { QuickActionBar } from "@/components/crm/quick-action-bar";
+import { SellPackagePanel } from "@/components/gabinet/sell-package-panel";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import type { MappedGabinetTreatmentPackage } from "@/lib/supabase/mappers/gabinet/treatment-packages";
 import type { MappedGabinetPackageUsage } from "@/lib/supabase/mappers/gabinet/package-usage";
@@ -146,16 +146,11 @@ function PackagesIndex() {
   const updatePkg = useAction(api.gabinet.packages.update);
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
   const removePkg = useAction(api.gabinet.packages.remove);
-  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
-  const purchasePackage = useAction(api.gabinet.packages.purchasePackage);
-  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
-  const createPayment = useAction(api.payments.create);
 
   // Supabase-backed queries (replacing convexQuery)
   const { data: packagesData } = useSupabaseGabinetTreatmentPackagesList(organizationId);
   const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId);
   const { data: activeUsagesData } = useSupabaseGabinetPackageUsageActive(organizationId);
-  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId);
 
   // Filter treatments to active-only (original Convex query was listActive)
   const treatments = useMemo(
@@ -183,10 +178,6 @@ function PackagesIndex() {
   const [statusFilter, setStatusFilter] = useState<"all" | "active" | "inactive">("all");
   const [expiringOnly, setExpiringOnly] = useState(false);
   const [assignPanelOpen, setAssignPanelOpen] = useState(false);
-  const [assignPatientId, setAssignPatientId] = useState<string>("");
-  const [assignPackageId, setAssignPackageId] = useState<string>("");
-  const [assignPaymentMethod, setAssignPaymentMethod] = useState<string>("cash");
-  const [assignSubmitting, setAssignSubmitting] = useState(false);
 
   useSidebarDispatch("openFilter", () => setFilterPanelOpen(true));
   useSidebarDispatch("viewExpiring", () => setExpiringOnly(true));
@@ -326,50 +317,6 @@ function PackagesIndex() {
     } finally {
       setDeleteDialogOpen(false);
       setDeletingId(null);
-    }
-  };
-
-  const resetAssignForm = useCallback(() => {
-    setAssignPatientId("");
-    setAssignPackageId("");
-    setAssignPaymentMethod("cash");
-  }, []);
-
-  const handleAssignPackage = async () => {
-    if (!assignPatientId || !assignPackageId) return;
-    const pkg = (packagesData ?? []).find((p) => p._id === assignPackageId);
-    if (!pkg) return;
-    setAssignSubmitting(true);
-    try {
-      const usageId = await purchasePackage({
-        organizationId,
-        patientId: assignPatientId,
-        packageId: assignPackageId,
-        paidAmount: pkg.totalPrice,
-        paymentMethod: assignPaymentMethod,
-      });
-      await createPayment({
-        organizationId,
-        patientId: assignPatientId,
-        packageUsageId: usageId,
-        amount: pkg.totalPrice,
-        currency: pkg.currency ?? "PLN",
-        paymentMethod: assignPaymentMethod as "cash" | "card" | "transfer",
-        notes: `Package: ${pkg.name}`,
-      });
-      toast.success(t("gabinet.packages.purchased"));
-      invalidatePackages();
-      setAssignPanelOpen(false);
-      resetAssignForm();
-    } catch (e) {
-      toast.error(
-        formatActionError(e, t, {
-          key: "gabinet.packages.errors.purchaseFailed",
-          defaultValue: "Nie udało się sprzedać pakietu.",
-        }),
-      );
-    } finally {
-      setAssignSubmitting(false);
     }
   };
 
@@ -746,73 +693,11 @@ function PackagesIndex() {
         </div>
       </SidePanel>
 
-      <SidePanel
+      <SellPackagePanel
+        organizationId={organizationId}
         open={assignPanelOpen}
-        onOpenChange={(open) => {
-          setAssignPanelOpen(open);
-          if (!open) resetAssignForm();
-        }}
-        title={t("nav.actions.assignPackage")}
-      >
-        <div className="space-y-4">
-          <div className="space-y-1.5">
-            <Label>{t("gabinet.packages.selectPatient", "Patient")}</Label>
-            <Select value={assignPatientId} onValueChange={setAssignPatientId}>
-              <SelectTrigger>
-                <SelectValue placeholder={t("gabinet.packages.selectPatientPlaceholder", "Select a patient...")} />
-              </SelectTrigger>
-              <SelectContent>
-                {(patientsData ?? []).map((p) => (
-                  <SelectItem key={p._id} value={p._id}>
-                    {p.firstName} {p.lastName}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="space-y-1.5">
-            <Label>{t("gabinet.packages.selectPackage")}</Label>
-            <Select value={assignPackageId} onValueChange={setAssignPackageId}>
-              <SelectTrigger>
-                <SelectValue placeholder={t("gabinet.packages.selectPackagePlaceholder")} />
-              </SelectTrigger>
-              <SelectContent>
-                {(packagesData ?? [])
-                  .filter((p) => p.isActive)
-                  .map((pkg) => (
-                    <SelectItem key={pkg._id} value={pkg._id}>
-                      {pkg.name} — {pkg.totalPrice} {pkg.currency ?? "PLN"}
-                    </SelectItem>
-                  ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="space-y-1.5">
-            <Label>{t("gabinet.packages.paymentMethod")}</Label>
-            <Select value={assignPaymentMethod} onValueChange={setAssignPaymentMethod}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="cash">{t("gabinet.packages.paymentMethods.cash")}</SelectItem>
-                <SelectItem value="card">{t("gabinet.packages.paymentMethods.card")}</SelectItem>
-                <SelectItem value="transfer">{t("gabinet.packages.paymentMethods.transfer")}</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <Button
-            className="w-full"
-            disabled={!assignPatientId || !assignPackageId || assignSubmitting}
-            onClick={handleAssignPackage}
-          >
-            {assignSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" variant="stroke" />}
-            {t("gabinet.packages.purchaseButton")}
-          </Button>
-        </div>
-      </SidePanel>
+        onOpenChange={setAssignPanelOpen}
+      />
 
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <AlertDialogContent>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1038.

Closes #1038

---

## Claude summary

Committed. Summary of changes:

- New component `src/components/gabinet/sell-package-panel.tsx` — slide-out panel with patient/package/payment-method pickers; calls `purchasePackage` + `createPayment` and invalidates Supabase caches.
- `_layout.gabinet.calendar.index.lazy.tsx` — adds a "Dodaj sprzedaż" button (Gift icon, outline variant) to the toolbar next to "Nowa wizyta", wired to open the new panel.
- `_layout.gabinet.packages.index.tsx` — replaces the inline assign-package panel with the shared `SellPackagePanel`, removing ~70 lines of duplicated state/logic. Sidebar dispatch `assignPackage` still triggers the same UI.

The button reuses the existing `gabinet.packages.purchaseButton` translation ("Dodaj sprzedaż" / "Purchase") that #1036 renamed, so the calendar button label matches what users already see on the packages page. Frontend tests pass and no new typecheck errors are introduced.