### PR TITLE
Show paid indicator on calendar tiles directly

### DIFF
--- a/src/components/gabinet/calendar/appointment-card.tsx
+++ b/src/components/gabinet/calendar/appointment-card.tsx
@@ -8,7 +8,13 @@ export interface AppointmentTag {
   color: string;
 }
 
-export type AppointmentIndicatorKind = "firstVisit" | "payment" | "count";
+export type AppointmentIndicatorKind =
+  | "firstVisit"
+  | "payment"
+  | "count"
+  | "paid"
+  | "partial"
+  | "unpaid";
 
 export interface AppointmentIndicator {
   kind: AppointmentIndicatorKind;
@@ -32,6 +38,9 @@ const INDICATOR_CLASS: Record<AppointmentIndicatorKind, string> = {
   firstVisit: "bg-emerald-500 text-white",
   payment: "bg-amber-500 text-white",
   count: "bg-sky-500 text-white",
+  paid: "bg-emerald-600 text-white",
+  partial: "bg-amber-500 text-white",
+  unpaid: "bg-red-500 text-white",
 };
 
 export function AppointmentCard({

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -635,6 +635,11 @@ export function AppointmentPreviewContent({
         queryClient.invalidateQueries({
           queryKey: supabaseKeys.scheduledActivities.all,
         }),
+        // Refresh the per-tile paid/unpaid indicator on the calendar
+        // (issue #1040) after a settle action records a new payment.
+        queryClient.invalidateQueries({
+          queryKey: supabaseKeys.payments.all,
+        }),
       ]);
       await refetch();
       setSettleDialogOpen(false);

--- a/src/hooks/use-supabase-gabinet-appointments.ts
+++ b/src/hooks/use-supabase-gabinet-appointments.ts
@@ -426,6 +426,64 @@ export function useSupabaseGabinetAppointmentRecurringPositions(
 }
 
 // ---------------------------------------------------------------------------
+// Completed-payment Totals by Appointment
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the sum of completed payments per appointment for the given IDs.
+ * Used by the gabinet calendar to render a paid/partial/unpaid indicator on
+ * each tile (issue #1040). Only payments with status="completed" count —
+ * pending payments are auto-created at booking time and must not be treated
+ * as actual receipts (mirrors `appointment-preview-content.tsx` logic).
+ *
+ * Returned map keys are appointment IDs; values are the total in PLN.
+ */
+export function useSupabaseGabinetAppointmentPaymentTotals(
+  organizationId: string,
+  appointmentIds: string[],
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  const stableIds = [...appointmentIds].sort();
+
+  return useQuery<Map<string, number>, Error>({
+    queryKey: [
+      ...supabaseKeys.payments.list(organizationId),
+      "completedTotalsByAppointment",
+      stableIds.join(","),
+    ],
+    queryFn: async (): Promise<Map<string, number>> => {
+      const result = new Map<string, number>();
+      if (!client) throw new Error("Supabase client not ready");
+      if (stableIds.length === 0) return result;
+
+      const { data, error } = await client
+        .from("payments")
+        .select("appointment_id, amount")
+        .eq("organization_id", organizationId)
+        .eq("status", "completed")
+        .in("appointment_id", stableIds);
+
+      if (error) throw error;
+
+      for (const row of (data ?? []) as {
+        appointment_id: string | null;
+        amount: number;
+      }[]) {
+        if (!row.appointment_id) continue;
+        const current = result.get(row.appointment_id) ?? 0;
+        result.set(row.appointment_id, current + (Number(row.amount) || 0));
+      }
+      return result;
+    },
+    enabled:
+      enabled && isReady && !!organizationId && stableIds.length > 0,
+  } satisfies UseQueryOptions<Map<string, number>, Error>);
+}
+
+// ---------------------------------------------------------------------------
 // Single Appointment
 // ---------------------------------------------------------------------------
 

--- a/src/lib/supabase/query-keys.ts
+++ b/src/lib/supabase/query-keys.ts
@@ -88,6 +88,9 @@ export const supabaseKeys = {
   gabinetLoyaltyPoints: entityKeys("gabinetLoyaltyPoints"),
   gabinetLoyaltyTransactions: entityKeys("gabinetLoyaltyTransactions"),
 
+  // ── Payments ─────────────────────────────────────────────────────────────
+  payments: entityKeys("payments"),
+
   // ── Platform Entities ───────────────────────────────────────────────────
   organizations: entityKeys("organizations"),
   teamMemberships: entityKeys("teamMemberships"),

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -398,11 +398,14 @@ function AppointmentDetail() {
   // Refresh the Supabase-backed appointment lists (calendar, dashboards, etc.)
   // after a Convex action mutates the appointment — Convex actions do not
   // automatically invalidate the React Query cache for Supabase reads.
+  // Payments are included so the calendar's per-tile paid/unpaid indicator
+  // (issue #1040) reflects new receipts immediately.
   const invalidateAppointmentCaches = async () => {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetAppointments.all }),
       queryClient.invalidateQueries({ queryKey: supabaseKeys.scheduledActivities.all }),
       queryClient.invalidateQueries({ queryKey: supabaseKeys.activities.all }),
+      queryClient.invalidateQueries({ queryKey: supabaseKeys.payments.all }),
     ]);
   };
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -54,6 +54,7 @@ import {
   useSupabaseGabinetFirstAppointmentIdsByPatient,
   useSupabaseGabinetAppointmentPackagePositions,
   useSupabaseGabinetAppointmentRecurringPositions,
+  useSupabaseGabinetAppointmentPaymentTotals,
 } from "@/hooks/use-supabase-gabinet-appointments";
 import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
@@ -164,7 +165,13 @@ function GabinetCalendarPage() {
     color?: string;
     tags?: Array<{ name: string; color: string }>;
     indicators?: Array<{
-      kind: "firstVisit" | "payment" | "count";
+      kind:
+        | "firstVisit"
+        | "payment"
+        | "count"
+        | "paid"
+        | "partial"
+        | "unpaid";
       label: string;
       title?: string;
     }>;
@@ -283,10 +290,14 @@ function GabinetCalendarPage() {
   }, [patients]);
 
   const treatmentMap = useMemo(() => {
-    const map = new Map<string, { name: string; color?: string }>();
+    const map = new Map<string, { name: string; color?: string; price: number }>();
     if (treatments) {
       for (const tr of treatments) {
-        map.set(tr._id, { name: tr.name, color: tr.color });
+        map.set(tr._id, {
+          name: tr.name,
+          color: tr.color,
+          price: typeof tr.price === "number" ? tr.price : 0,
+        });
       }
     }
     return map;
@@ -469,22 +480,27 @@ function GabinetCalendarPage() {
     return set;
   }, [rawAppointments]);
 
-  // Distinct patient + package usage + recurring group IDs from the rendered
-  // range — used to compute the "first visit" and "visit X/Y" indicators on
-  // appointment cards.
+  // Distinct patient + package usage + recurring group + appointment IDs
+  // from the rendered range — used to compute the "first visit", "visit X/Y",
+  // and paid/partial/unpaid indicators on appointment cards.
   const indicatorLookupIds = useMemo(() => {
     const patientIds = new Set<string>();
     const packageUsageIds = new Set<string>();
     const recurringGroupIds = new Set<string>();
+    const appointmentIds = new Set<string>();
     for (const a of rawAppointments ?? []) {
       if (a.patientId) patientIds.add(a.patientId);
       if (a.packageUsageId) packageUsageIds.add(a.packageUsageId);
       if (a.recurringGroupId) recurringGroupIds.add(a.recurringGroupId);
+      // Only payable appointments contribute to the paid/unpaid indicator
+      // lookup. Cancelled appointments can't be paid by definition.
+      if (a.status !== "cancelled" && a.treatmentId) appointmentIds.add(a._id);
     }
     return {
       patientIds: Array.from(patientIds),
       packageUsageIds: Array.from(packageUsageIds),
       recurringGroupIds: Array.from(recurringGroupIds),
+      appointmentIds: Array.from(appointmentIds),
     };
   }, [rawAppointments]);
 
@@ -506,10 +522,24 @@ function GabinetCalendarPage() {
       indicatorLookupIds.recurringGroupIds,
     );
 
+  // Aggregated completed-payment totals per appointment — drives the
+  // paid/partial/unpaid tile indicator (issue #1040).
+  const { data: appointmentPaymentTotals } =
+    useSupabaseGabinetAppointmentPaymentTotals(
+      organizationId,
+      indicatorLookupIds.appointmentIds,
+    );
+
   // Transform and filter appointments for view components
   const viewAppointments = useMemo(() => {
     type Indicator = {
-      kind: "firstVisit" | "payment" | "count";
+      kind:
+        | "firstVisit"
+        | "payment"
+        | "count"
+        | "paid"
+        | "partial"
+        | "unpaid";
       label: string;
       title?: string;
     };
@@ -611,6 +641,46 @@ function GabinetCalendarPage() {
           }
         }
 
+        // Paid / partial / unpaid indicator — surfaces the visit's payment
+        // settlement state directly on the tile so staff can spot unpaid
+        // completed visits without opening each one (issue #1040). Mirrors
+        // the badge logic in appointment-preview-content.tsx: only counts
+        // completed payments (pending ones are auto-created at booking and
+        // mustn't be treated as receipts). Skipped for cancelled visits and
+        // visits whose treatment has no price.
+        const treatmentPrice = treatment?.price ?? 0;
+        if (a.status !== "cancelled" && treatmentPrice > 0) {
+          const paid = appointmentPaymentTotals?.get(a._id) ?? 0;
+          if (paid >= treatmentPrice) {
+            indicators.push({
+              kind: "paid",
+              label: "✓",
+              title: t(
+                "gabinet.calendar.indicators.paid",
+                "Wizyta opłacona",
+              ),
+            });
+          } else if (paid > 0) {
+            indicators.push({
+              kind: "partial",
+              label: "½",
+              title: t(
+                "gabinet.calendar.indicators.partial",
+                "Częściowo opłacona",
+              ),
+            });
+          } else {
+            indicators.push({
+              kind: "unpaid",
+              label: "!",
+              title: t(
+                "gabinet.calendar.indicators.unpaid",
+                "Wizyta nieopłacona",
+              ),
+            });
+          }
+        }
+
         items.push({
           _id: a._id,
           date: a.date,
@@ -663,7 +733,7 @@ function GabinetCalendarPage() {
     }
 
     return items;
-  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, tagMap, employeeColorMap, firstAppointmentIds, packagePositions, recurringPositions, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
+  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, tagMap, employeeColorMap, firstAppointmentIds, packagePositions, recurringPositions, appointmentPaymentTotals, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
 
   // Build print-friendly appointment data for the current day
   const printDate = formatDateStr(currentDate);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1040.

Closes #1040

---

## Claude summary

Done. Committed as `e2b2471` on `claude/issue-1040`.

Summary: Added a paid/partial/unpaid indicator on each calendar tile. Implementation:

- New aggregated Supabase query `useSupabaseGabinetAppointmentPaymentTotals` returns a `Map<appointmentId, completedPaymentsTotal>` scoped to the visible appointment IDs in the calendar range (`src/hooks/use-supabase-gabinet-appointments.ts`).
- Calendar route wires that into the per-appointment indicator builder. For each non-cancelled appointment whose treatment has a price > 0, it compares completed-payment total against the treatment price and pushes a `paid` (green ✓), `partial` (amber ½), or `unpaid` (red !) indicator. Mirrors the badge logic from `appointment-preview-content.tsx` introduced in #1031 — pending payments are intentionally excluded.
- Extended `AppointmentCard`'s `AppointmentIndicatorKind` union with the three new kinds and added their badge classes.
- Added `payments` to `supabaseKeys`, and invalidate `supabaseKeys.payments.all` in the calendar settle dialog and on the appointment-detail page so the tile updates immediately after recording a payment.

Typecheck passes for all touched files; remaining `tsc` errors (`convex/gabinetRoles.ts`, `_layout.settings.team.tsx`) are pre-existing and unrelated.