### PR TITLE
polski

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2835,7 +2835,16 @@
       "leaveBadge": "On leave",
       "leaveBadgePartial": "On leave {{start}}–{{end}}",
       "leaveOverlayTitle": "Employee is on approved leave",
-      "dayOff": "day off"
+      "dayOff": "day off",
+      "weekdaysShort": {
+        "mon": "Mon",
+        "tue": "Tue",
+        "wed": "Wed",
+        "thu": "Thu",
+        "fri": "Fri",
+        "sat": "Sat",
+        "sun": "Sun"
+      }
     },
     "packages": {
       "title": "Treatment Packages",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2864,7 +2864,16 @@
       "leaveBadge": "Urlop",
       "leaveBadgePartial": "Urlop {{start}}–{{end}}",
       "leaveOverlayTitle": "Pracownik ma zatwierdzony urlop",
-      "dayOff": "dzień wolny"
+      "dayOff": "dzień wolny",
+      "weekdaysShort": {
+        "mon": "Pon",
+        "tue": "Wt",
+        "wed": "Śr",
+        "thu": "Czw",
+        "fri": "Pt",
+        "sat": "Sob",
+        "sun": "Nd"
+      }
     },
     "packages": {
       "title": "Pakiety zabiegów",

--- a/src/components/gabinet/calendar/calendar-month-view.tsx
+++ b/src/components/gabinet/calendar/calendar-month-view.tsx
@@ -48,7 +48,16 @@ function getMonthGrid(year: number, month: number): (string | null)[][] {
   return grid;
 }
 
-const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const DAY_LABEL_KEYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"] as const;
+const DAY_LABEL_DEFAULTS: Record<(typeof DAY_LABEL_KEYS)[number], string> = {
+  mon: "Pon",
+  tue: "Wt",
+  wed: "Śr",
+  thu: "Czw",
+  fri: "Pt",
+  sat: "Sob",
+  sun: "Nd",
+};
 
 export function CalendarMonthView({ year, month, appointments, onDayClick, selectedDate, leaveDates, paymentDueDates }: CalendarMonthViewProps) {
   const { t } = useTranslation();
@@ -70,9 +79,11 @@ export function CalendarMonthView({ year, month, appointments, onDayClick, selec
     <div className="flex flex-col h-full">
       {/* Header */}
       <div className="grid grid-cols-7 border-b">
-        {DAY_LABELS.map((d) => (
-          <div key={d} className="px-2 py-1 text-center text-xs font-medium text-muted-foreground">
-            {d}
+        {DAY_LABEL_KEYS.map((k) => (
+          <div key={k} className="px-2 py-1 text-center text-xs font-medium text-muted-foreground">
+            {t(`gabinet.calendar.weekdaysShort.${k}`, {
+              defaultValue: DAY_LABEL_DEFAULTS[k],
+            })}
           </div>
         ))}
       </div>

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -39,7 +39,16 @@ const LEAVE_STRIPE_BG =
 
 const HOURS = Array.from({ length: 14 }, (_, i) => i + 7);
 const HOUR_HEIGHT = 90; // pixels per hour — taller rows so short appointments still fit patient + treatment lines
-const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const DAY_LABEL_KEYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"] as const;
+const DAY_LABEL_DEFAULTS: Record<(typeof DAY_LABEL_KEYS)[number], string> = {
+  mon: "Pon",
+  tue: "Wt",
+  wed: "Śr",
+  thu: "Czw",
+  fri: "Pt",
+  sat: "Sob",
+  sun: "Nd",
+};
 
 function buildSlots(slotMinutes: number) {
   const slotsPerHour = 60 / slotMinutes;
@@ -229,7 +238,11 @@ function WeekDayColumn({
             isSelected ? "bg-primary/20 ring-1 ring-inset ring-primary/30" : isToday ? "bg-primary/10" : "bg-muted/50"
           } ${onDayHeaderClick ? "hover:bg-primary/15" : ""}`}
         >
-          <div>{DAY_LABELS[dayIndex]}</div>
+          <div>
+            {t(`gabinet.calendar.weekdaysShort.${DAY_LABEL_KEYS[dayIndex]}`, {
+              defaultValue: DAY_LABEL_DEFAULTS[DAY_LABEL_KEYS[dayIndex]],
+            })}
+          </div>
           <div className={isToday ? "font-bold text-primary" : isSelected ? "font-semibold text-primary" : "text-muted-foreground"}>
             {date.split("-")[2]}
           </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1043.

Closes #1043

---

## Claude summary

Committed as `96319a6`.

The Gabinet calendar's week and month views had hardcoded English day abbreviations (`Mon`, `Tue`, …) while the surrounding toolbar (`Dziś`, `Tydzień`, `Miesiąc`, `Nowa wizyta`) was already in Polish. I routed those labels through i18next with Polish defaults (`Pon`, `Wt`, `Śr`, `Czw`, `Pt`, `Sob`, `Nd`) and added matching `gabinet.calendar.weekdaysShort.*` keys to both `pl/translation.json` and `en/translation.json` so each locale keeps the right labels.

Files changed: `src/components/gabinet/calendar/calendar-week-view.tsx`, `src/components/gabinet/calendar/calendar-month-view.tsx`, and the two `public/locales/*/translation.json` files.