### PR TITLE
Fix or delete the two stale `appointmentStateMachine.test.ts` cases ("cannot tra

### DIFF
--- a/tests/convex/appointmentStateMachine.test.ts
+++ b/tests/convex/appointmentStateMachine.test.ts
@@ -200,55 +200,6 @@ describe("appointment state machine", () => {
     expect(appt?.status).toBe("no_show");
   });
 
-  // Invalid transitions
-  test("cannot transition from completed", async () => {
-    const t = createManagedTestCtx();
-    const { organizationId, userId, identity } = await seedTestUser(t);
-    const { patientId, treatmentId } = await seedGabinetPrereqs(t, organizationId, userId);
-
-    const apptId = await createAppointment(t, identity, {
-      organizationId, patientId, treatmentId, employeeId: userId,
-    });
-
-    // Go through full lifecycle
-    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
-      organizationId, appointmentId: apptId, status: "confirmed",
-    });
-    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
-      organizationId, appointmentId: apptId, status: "in_progress",
-    });
-    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
-      organizationId, appointmentId: apptId, status: "completed",
-    });
-
-    // Try any further transition — should fail
-    await expect(
-      t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
-        organizationId, appointmentId: apptId, status: "cancelled",
-      }),
-    ).rejects.toThrow("Cannot transition from completed to cancelled");
-  });
-
-  test("cannot transition from cancelled", async () => {
-    const t = createManagedTestCtx();
-    const { organizationId, userId, identity } = await seedTestUser(t);
-    const { patientId, treatmentId } = await seedGabinetPrereqs(t, organizationId, userId);
-
-    const apptId = await createAppointment(t, identity, {
-      organizationId, patientId, treatmentId, employeeId: userId,
-    });
-
-    await t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
-      organizationId, appointmentId: apptId, status: "cancelled",
-    });
-
-    await expect(
-      t.withIdentity(identity).action(api.gabinet.appointments.updateStatus, {
-        organizationId, appointmentId: apptId, status: "scheduled",
-      }),
-    ).rejects.toThrow("Cannot transition from cancelled to scheduled");
-  });
-
   test("dual write: scheduledActivity created with appointment", async () => {
     const t = createManagedTestCtx();
     const { organizationId, userId, identity } = await seedTestUser(t);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1045.

Closes #1045

---

## Claude summary

Removed the two stale tests in `tests/convex/appointmentStateMachine.test.ts` ("cannot transition from completed" and "cannot transition from cancelled"). They asserted the old restrictive state machine, but #1027 intentionally relaxed `MANUAL_TRANSITIONS` to allow any non-self transition (see `convex/gabinet/appointments.ts:58-76`), so those assertions had been permanently failing. The SMS-path test in `appointmentSms.test.ts` still uses the restrictive `AUTOMATED_TRANSITIONS` map and is left untouched. Committed as `f5a0b3f`.