### PR TITLE
grafiki

### DIFF
--- a/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
+++ b/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
@@ -4,6 +4,7 @@ import {
   CalendarCheck,
   UserPlus,
   Calendar,
+  Clock,
   Users,
   Package,
   FileText,
@@ -91,6 +92,13 @@ export function GabinetQuickActionsDropdown() {
         >
           <FileText className="text-foreground size-5" />
           {t("sidebar.gabinet.goToDocuments", "Dokumenty")}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="px-3 py-2.5 text-sm"
+          onSelect={() => navigate({ to: "/dashboard/gabinet/settings/timetable" })}
+        >
+          <Clock className="text-foreground size-5" />
+          {t("sidebar.gabinet.goToSchedules", "Grafiki")}
         </DropdownMenuItem>
         <DropdownMenuItem
           className="px-3 py-2.5 text-sm"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1055.

Closes #1055

---

## Claude summary

Added a "Grafiki" entry to the Gabinet Szybkie akcje (Quick actions) dropdown shown in the bottom-right of the app footer. It uses a Clock icon and navigates to `/dashboard/gabinet/settings/timetable` — the existing employee work-schedule editor. Inserted between "Dokumenty" and "Ustawienia" in `src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx`, following the same translation-with-fallback pattern as the surrounding items.