### PR TITLE
dodaj

### DIFF
--- a/src/components/gabinet/flexible-schedule-editor.tsx
+++ b/src/components/gabinet/flexible-schedule-editor.tsx
@@ -413,6 +413,19 @@ export function FlexibleScheduleEditor({
                     const entry = period.entries.find(
                       (e) => e.dayOfWeek === i,
                     );
+                    const dayDates =
+                      entry?.isWorking &&
+                      period.effectiveFrom &&
+                      period.effectiveTo
+                        ? getDatesForDayOfWeek(
+                            period.effectiveFrom,
+                            period.effectiveTo,
+                            i,
+                          )
+                        : [];
+                    const dayDatesLabel = dayDates
+                      .map((d) => formatShortDate(d, i18n.language))
+                      .join(", ");
                     return (
                       <div
                         key={i}
@@ -421,6 +434,14 @@ export function FlexibleScheduleEditor({
                         <div className="font-medium">
                           {dayNames[i].substring(0, 3)}
                         </div>
+                        {dayDatesLabel && (
+                          <div
+                            className="text-[9px] leading-tight text-muted-foreground break-words"
+                            title={dayDatesLabel}
+                          >
+                            {dayDatesLabel}
+                          </div>
+                        )}
                         {entry?.isWorking ? (
                           <div>
                             {entry.startTime}–{entry.endTime}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
@@ -159,6 +159,13 @@ function getWeekDates(today: string): Map<number, string> {
   return map;
 }
 
+function formatShortDate(iso: string | undefined, lang: string): string {
+  if (!iso) return "";
+  const [, month, day] = iso.split("-");
+  if (!month || !day) return "";
+  return lang === "pl" ? `${day}.${month}` : `${month}/${day}`;
+}
+
 function findLeaveForDate(
   leaves: MappedGabinetLeave[] | undefined,
   userId: string,
@@ -388,14 +395,27 @@ function TimetablePage() {
               <th className="px-4 py-2 text-left min-w-[200px]">
                 {t("gabinet.timetable.employee")}
               </th>
-              {DISPLAY_ORDER.map((dayIdx, i) => (
-                <th
-                  key={dayIdx}
-                  className="px-2 py-2 text-center min-w-[90px]"
-                >
-                  {dayNames[i]}
-                </th>
-              ))}
+              {DISPLAY_ORDER.map((dayIdx, i) => {
+                const dateLabel = formatShortDate(
+                  weekDates.get(dayIdx),
+                  i18n.language,
+                );
+                return (
+                  <th
+                    key={dayIdx}
+                    className="px-2 py-2 text-center min-w-[90px]"
+                  >
+                    <div className="flex flex-col items-center leading-tight">
+                      <span>{dayNames[i]}</span>
+                      {dateLabel && (
+                        <span className="text-[10px] font-normal text-muted-foreground">
+                          {dateLabel}
+                        </span>
+                      )}
+                    </div>
+                  </th>
+                );
+              })}
               <th className="px-2 py-2 w-[80px]"></th>
             </tr>
           </thead>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1057.

Closes #1057

---

## Claude summary

Committed `6b94e78`.

I investigated all places in the codebase where weekday names appear without date context. After PR #1058 (timetable header) and PR #1054 (schedule editor in edit mode), the remaining gap was the read-only period summary card inside the same `FlexibleScheduleEditor` (the cards listed when not editing a period, shown in the Sheet that opens from the timetable settings page). I extended it to render the dates that each weekday falls on within the period's `effectiveFrom`–`effectiveTo` range, reusing the existing `getDatesForDayOfWeek` / `formatShortDate` helpers.

I deliberately did not modify these:

- `_layout.gabinet.settings.scheduling.tsx` (clinic working hours): rules are weekly-recurring with no specific date, so attaching "this week's Monday" would be semantically wrong.
- `calendar-week-view.tsx`, unified `_layout.calendar.tsx` week view, employee detail calendar at `_layout.gabinet.employees.$employeeId.tsx:892`: these already display weekday + day-of-month and a date-range navigator above.
- `calendar-month-view.tsx`: month grid where each cell already has its own date.

If the user had a different specific view in mind that still shows weekday-only labels, please point me at the URL/screenshot.