### PR TITLE
dolne menue

### DIFF
--- a/src/components/layout/app-footer.tsx
+++ b/src/components/layout/app-footer.tsx
@@ -68,6 +68,11 @@ const routeActions: Record<string, FooterAction[]> = {
   ],
 };
 
+const defaultGabinetActions: FooterAction[] = [
+  { labelKey: "nav.actions.bookAppointment", icon: CalendarCheck, quickCreate: "appointment" },
+  { labelKey: "nav.actions.addPatient", icon: UserPlus, quickCreate: "patient" },
+];
+
 const gabinetRouteActions: Record<string, FooterAction[]> = {
   calendar: [
     { labelKey: "nav.actions.bookAppointment", icon: CalendarCheck, quickCreate: "appointment" },
@@ -109,8 +114,7 @@ export function AppFooter() {
   const { openQuickCreate, navigateTo, dispatch } = useSidebarActions();
 
   const isGabinetRoute = !!matchRoute({ to: "/dashboard/gabinet", fuzzy: true });
-  const isGabinetSettingsRoute = !!matchRoute({ to: "/dashboard/gabinet/settings", fuzzy: true });
-  const showGabinetQuickActions = isGabinetRoute && !isGabinetSettingsRoute;
+  const showGabinetQuickActions = isGabinetRoute;
 
   let actions: FooterAction[] = [];
 
@@ -118,7 +122,7 @@ export function AppFooter() {
     const key = gabinetRouteKeys.find((k) =>
       matchRoute({ to: `/dashboard/gabinet/${k}`, fuzzy: true })
     );
-    if (key) actions = gabinetRouteActions[key] ?? [];
+    actions = key ? (gabinetRouteActions[key] ?? defaultGabinetActions) : defaultGabinetActions;
   } else {
     const key = crmRouteKeys.find((k) =>
       matchRoute({ to: `/dashboard/${k}`, fuzzy: true })


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1062.

Closes #1062

---

## Claude summary

Committed.

Summary: The bottom action bar (`AppFooter`) was already rendered on every dashboard page, but its buttons were configured per-route. On gabinet subpages outside the six mapped keys (reports, settings, detail views, the module index), the right side was empty. The fix adds a default action set (Umów wizytę + Dodaj klienta) used as fallback on any gabinet route, and removes the settings exclusion so the "+ Szybkie akcje" dropdown — which gives access to all gabinet quick-create and navigation actions — now also appears on settings pages. `src/components/layout/app-footer.tsx:71-74,116-125,165`.