### PR TITLE
niech się nie chowa

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -1079,7 +1079,7 @@ function GabinetCalendarPage() {
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
     >
-      <div className="flex h-[calc(100vh-4rem)] flex-col">
+      <div className="flex min-h-0 flex-1 flex-col">
         {nudgeFilter === "unconfirmed-today" && (
           <div className="flex shrink-0 items-center justify-between border-b border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
             <span>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1064.

Closes #1064

---

## Claude summary

Committed. The gabinet calendar page now sizes itself with `min-h-0 flex-1` to fit exactly inside `main` instead of overflowing it with a hard-coded `100vh - 4rem`. With main no longer scrolling, only the week view's internal overflow-auto scrolls — letting the existing `sticky top-0` day-header row stay pinned at the top as the user scrolls through appointments.

## Follow-ups
- Apply same calendar height fix to CRM calendar: `src/routes/_app/_auth/dashboard/_layout.calendar.tsx:421` uses the same incorrect `h-[calc(100vh-4rem)]`, will have the same sticky-row issue once the page has enough appointments to scroll