### PR TITLE
widoczność 

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
@@ -564,8 +564,8 @@ function TimetablePage() {
                         )}
                         {activeDatedLabel && (
                           <Badge
-                            variant="default"
-                            className="text-[10px] h-4 px-1 mt-0.5 self-start"
+                            variant="secondary"
+                            className="text-[10px] px-1.5 py-0 mt-0.5 self-start whitespace-nowrap"
                             title={t("gabinet.timetable.activePeriodHint")}
                           >
                             {activeDatedLabel}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1066.

Closes #1066

---

## Claude summary

Committed as `0271519`.

The fix targets the "active dated schedule period" badge in the Week column of `/dashboard/gabinet/settings/timetable` (`src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx:565-573`). In the screenshot, this badge showed text like "2026-05-25 — 2026-07-06" with the bottom of the characters spilling outside a too-short purple pill, making it unreadable.

The change swaps `variant="default"` for `variant="secondary"` (matching the neighbouring datedPeriodsCount badge for visual consistency and softer contrast), removes the clipping `h-4` constraint in favour of `py-0`, and adds `whitespace-nowrap` so the ISO date range stays on a single line.