### PR TITLE
Apply same calendar height fix to CRM calendar

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.calendar.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calendar.tsx
@@ -418,7 +418,7 @@ function UnifiedCalendarPage() {
   );
 
   return (
-    <div className="flex h-[calc(100vh-4rem)] flex-col">
+    <div className="flex min-h-0 flex-1 flex-col">
       {nudgeFilter === "yesterday-overdue" && (
         <div className="flex shrink-0 items-center justify-between border-b border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
           <span>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1068.

Closes #1068

---

## Claude summary

Applied the same fix as #1064 to the CRM calendar at `src/routes/_app/_auth/dashboard/_layout.calendar.tsx:421`: swapped `h-[calc(100vh-4rem)]` for `min-h-0 flex-1` so the page sits inside `main` and the inner week-view scroll container owns the scroll, letting the sticky day-header row work as designed. Committed as `50ae29a`.