### PR TITLE
edytuj grafik

### DIFF
--- a/src/components/gabinet/flexible-schedule-editor.tsx
+++ b/src/components/gabinet/flexible-schedule-editor.tsx
@@ -392,19 +392,21 @@ export function FlexibleScheduleEditor({
                   </div>
                   <div className="flex gap-1">
                     <Button
-                      variant="ghost"
+                      variant="outline"
                       size="sm"
                       onClick={() => openEditPeriod(period)}
                     >
-                      <Pencil className="h-3.5 w-3.5" variant="stroke" />
+                      <Pencil className="mr-1 h-3.5 w-3.5" variant="stroke" />
+                      {t("common.edit")}
                     </Button>
                     <Button
-                      variant="ghost"
+                      variant="outline"
                       size="sm"
-                      className="text-destructive"
+                      className="text-destructive hover:text-destructive"
                       onClick={() => handleDeletePeriod(period.effectiveFrom)}
                     >
-                      <Trash2 className="h-3.5 w-3.5" variant="stroke" />
+                      <Trash2 className="mr-1 h-3.5 w-3.5" variant="stroke" />
+                      {t("common.delete")}
                     </Button>
                   </div>
                 </div>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
@@ -448,7 +448,7 @@ function TimetablePage() {
                   <span>{dayNames[i]}</span>
                 </th>
               ))}
-              <th className="px-2 py-2 w-[80px]"></th>
+              <th className="px-2 py-2 w-[110px]"></th>
             </tr>
           </thead>
           <tbody>
@@ -638,11 +638,12 @@ function TimetablePage() {
                       >
                         <Button
                           size="sm"
-                          variant="ghost"
+                          variant="outline"
                           onClick={() => setEditingEmployee(emp)}
                           aria-label={t("common.edit")}
                         >
-                          <Pencil className="h-4 w-4" variant="stroke" />
+                          <Pencil className="mr-1 h-4 w-4" variant="stroke" />
+                          {t("common.edit")}
                         </Button>
                       </td>
                     )}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1069.

Closes #1069

---

## Claude summary

Done. The user's screenshot showed them inside the schedule editor sheet with the active period card visible — the edit option WAS there (Pencil and Trash2 icons at flexible-schedule-editor.tsx:394-409) but they were tiny `h-3.5 w-3.5` ghost-variant icon-only buttons with no text, easy to miss against the card background.

Changes:
- `src/components/gabinet/flexible-schedule-editor.tsx`: period card actions switched from ghost to outline variant, with "Edytuj"/"Usuń" text labels next to the icons.
- `src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx`: row-level edit button (also previously ghost-icon-only) now uses outline variant with "Edytuj" text; widened the column from 80px to 110px to fit.

Both files typecheck cleanly. Committed as c4b579c.