### PR TITLE
Remove unused `gabinet.timetable.week` translation key

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2333,7 +2333,6 @@
       "title": "Employee timetable",
       "description": "Edit schedules for all employees in one place. Each employee shows the current week plus upcoming weeks stacked below — hours can vary if you have dated schedule periods.",
       "employee": "Employee",
-      "week": "Week",
       "currentWeek": "Current week",
       "searchPlaceholder": "Search employee...",
       "filterByRole": "Filter by role",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2359,7 +2359,6 @@
       "title": "Grafik pracowników",
       "description": "Edytuj grafiki wszystkich pracowników w jednym miejscu. Dla każdego pracownika pokazujemy bieżący tydzień i kolejne tygodnie pod spodem — godziny mogą się różnić, jeśli masz datowane okresy grafiku.",
       "employee": "Pracownik",
-      "week": "Tydzień",
       "currentWeek": "Bieżący tydzień",
       "searchPlaceholder": "Szukaj pracownika...",
       "filterByRole": "Filtruj wg roli",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1077.

Closes #1077

---

## Claude summary

Removed the unused `gabinet.timetable.week` key from both `public/locales/en/translation.json` (line 2336) and `public/locales/pl/translation.json` (line 2362). Verified via grep that no code references `timetable.week` or uses `t('week')` within the timetable scope. JSON files validated and committed as f2e111c.