### PR TITLE
widok

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2350,7 +2350,7 @@
       "upcomingLeaveBadge": "Leave: {{start}} — {{end}}",
       "onLeaveCell": "Leave",
       "leaveBadgeHint": "Approved leave covering this date range.",
-      "totalHours": "Total",
+      "totalHours": "Hours",
       "totalHoursHint": "Total working hours per week (excluding breaks and approved leaves)."
     },
     "scheduling": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2378,7 +2378,7 @@
       "upcomingLeaveBadge": "Urlop: {{start}} — {{end}}",
       "onLeaveCell": "Urlop",
       "leaveBadgeHint": "Zatwierdzony urlop pokrywający ten zakres dat.",
-      "totalHours": "Razem",
+      "totalHours": "Ilość godzin",
       "totalHoursHint": "Łączna liczba godzin pracy w tygodniu (bez przerw i urlopów)."
     },
     "scheduling": {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
@@ -272,14 +272,13 @@ function computeWeeklyMinutes(
   return total;
 }
 
-function formatMinutesAsHours(minutes: number, lang: string): string {
-  if (minutes <= 0) return lang === "pl" ? "0 godz." : "0 h";
+function formatMinutesAsHours(minutes: number): string {
+  if (minutes <= 0) return "0";
   const hours = Math.floor(minutes / 60);
   const mins = minutes % 60;
-  const suffix = lang === "pl" ? "godz." : "h";
-  if (mins === 0) return `${hours} ${suffix}`;
+  if (mins === 0) return `${hours}`;
   const minutesPart = mins.toString().padStart(2, "0");
-  return `${hours}:${minutesPart} ${suffix}`;
+  return `${hours}:${minutesPart}`;
 }
 
 function TimetablePage() {
@@ -498,21 +497,21 @@ function TimetablePage() {
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b bg-muted/50 text-xs font-medium text-muted-foreground">
-                      <th className="px-4 py-2 text-left min-w-[200px]">
+                      <th className="px-3 py-2 text-left min-w-[180px]">
                         {t("gabinet.timetable.employee")}
                       </th>
                       {DISPLAY_ORDER.map((dayIdx, i) => (
                         <th
                           key={dayIdx}
-                          className="px-2 py-2 text-center min-w-[90px]"
+                          className="px-1.5 py-2 text-center min-w-[72px]"
                         >
                           <span>{dayNames[i]}</span>
                         </th>
                       ))}
-                      <th className="px-2 py-2 text-center min-w-[90px]">
+                      <th className="px-1.5 py-2 text-center min-w-[64px] whitespace-nowrap">
                         {t("gabinet.timetable.totalHours")}
                       </th>
-                      <th className="px-2 py-2 w-[110px]"></th>
+                      <th className="px-1.5 py-2 w-[88px]"></th>
                     </tr>
                   </thead>
                   <tbody>
@@ -570,7 +569,7 @@ function TimetablePage() {
                           key={`${emp._id}-${week.monday}`}
                           className="border-b last:border-b-0"
                         >
-                          <td className="px-4 py-2 align-top">
+                          <td className="px-3 py-2 align-top">
                             <div className="flex flex-col">
                               <span className="font-medium">
                                 {employeeName(emp)}
@@ -642,7 +641,7 @@ function TimetablePage() {
                             return (
                               <td
                                 key={dayIdx}
-                                className="px-2 py-2 text-center align-middle"
+                                className="px-1.5 py-2 text-center align-middle"
                               >
                                 <div className="flex flex-col items-center leading-tight">
                                   {dateLabel && (
@@ -692,18 +691,15 @@ function TimetablePage() {
                               </td>
                             );
                           })}
-                          <td className="px-2 py-2 text-center align-middle">
+                          <td className="px-1.5 py-2 text-center align-middle">
                             <span
                               className="text-xs font-medium tabular-nums"
                               title={t("gabinet.timetable.totalHoursHint")}
                             >
-                              {formatMinutesAsHours(
-                                totalWeeklyMinutes,
-                                i18n.language,
-                              )}
+                              {formatMinutesAsHours(totalWeeklyMinutes)}
                             </span>
                           </td>
-                          <td className="px-2 py-2 text-right align-top">
+                          <td className="px-1.5 py-2 text-right align-top">
                             <Button
                               size="sm"
                               variant="outline"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1078.

Closes #1078

---

## Claude summary

Committed. Here's what I changed in `src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx` and the PL/EN translation files:

1. Header rename — `timetable.totalHours`: `Razem` → `Ilość godzin`, `Total` → `Hours`. The unit now lives in the header.
2. Dropped the per-row `godz.`/`h` suffix — `formatMinutesAsHours()` now returns just `8` or `8:30`. The `lang` parameter and the unused branch logic are gone.
3. Tightened column widths so the table fits without horizontal scroll: employee col `200→180px`, day cols `90→72px`, total col `90→64px` (also `whitespace-nowrap`), edit col `110→88px`, and horizontal cell padding reduced from `px-4`/`px-2` to `px-3`/`px-1.5`. Approximate minimum table width drops from ~1206px to ~1012px, comfortable on the user's 1536px viewport.

Note: I couldn't run `npm run typecheck` — `node_modules` isn't installed in this worktree — but the edits are mechanical (rename, signature change, Tailwind class tweaks) and I verified `i18n` is still referenced elsewhere so the only call site that lost the `lang` argument is the one updated.