### PR TITLE
dodaj klienta 

### DIFF
--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -114,7 +114,7 @@ export const gabinetManifest: ModuleManifest = {
         {
           labelKey: "nav.actions.addPatient",
           icon: UserPlus,
-          quickCreate: "patient",
+          dispatch: "openAddPatient",
           permissionFeature: "gabinet_patients",
         },
         { labelKey: "nav.actions.importCsv", icon: Upload, dispatch: "importCsv" },

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -79,6 +79,7 @@ function PatientsIndex() {
   const { handleExport } = useCsvExport(organizationId, "patients", "pacjenci");
 
   // Sidebar dispatch handlers
+  useSidebarDispatch("openAddPatient", () => setPanelOpen(true));
   useSidebarDispatch("exportCsv", () => handleExport());
   useSidebarDispatch("importCsv", () => {
     // Could open import dialog - for now show toast


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1084.

Closes #1084

---

## Claude summary

Fixed. The "Dodaj klienta" button in the Akcje sidebar on `/dashboard/gabinet/patients` was calling the multi-entity Quick Create menu (`openQuickCreate("patient")`), which exposed CRM/Gabinet/System tabs and the full list of unrelated entities (Wizyta, Zabieg, Pakiet, Pracownik, Nieobecność).

Now it dispatches `openAddPatient`, which the patients route handles by opening the existing add-client SidePanel + PatientForm — the same panel the page header's "Dodaj klienta" button already opens. The action no longer offers any non-patient creation paths.

Files changed:
- `src/modules/gabinet/manifest.ts:115` — swap `quickCreate: "patient"` for `dispatch: "openAddPatient"`
- `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx:82` — register `useSidebarDispatch("openAddPatient", () => setPanelOpen(true))`