### PR TITLE
dodaj

### DIFF
--- a/src/hooks/use-supabase-payments.ts
+++ b/src/hooks/use-supabase-payments.ts
@@ -1,0 +1,56 @@
+/**
+ * React Query hooks for fetching payments from Supabase (PostgreSQL).
+ */
+
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+import { useSupabase } from "@/components/supabase-provider";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
+import {
+  mapPaymentFromSupabase,
+  type MappedPayment,
+} from "@/lib/supabase/mappers/payments";
+
+// ---------------------------------------------------------------------------
+// Payments by Patient
+// ---------------------------------------------------------------------------
+
+interface UseSupabasePaymentsByPatientOptions {
+  enabled?: boolean;
+  limit?: number;
+}
+
+/**
+ * Fetches all payments for a given patient, ordered by most recent first.
+ * Used by the patient detail page Payments tab to show payment history.
+ */
+export function useSupabasePaymentsByPatient(
+  organizationId: string,
+  patientId: string | undefined,
+  options: UseSupabasePaymentsByPatientOptions = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true, limit = 100 } = options;
+
+  return useQuery<MappedPayment[], Error>({
+    queryKey: [
+      ...supabaseKeys.payments.list(organizationId),
+      "byPatient",
+      patientId ?? "",
+    ],
+    queryFn: async (): Promise<MappedPayment[]> => {
+      if (!client || !patientId) return [];
+
+      const { data, error } = await client
+        .from("payments")
+        .select("*")
+        .eq("organization_id", organizationId)
+        .eq("patient_id", patientId)
+        .order("created_at", { ascending: false })
+        .limit(limit);
+
+      if (error) throw error;
+      return (data ?? []).map(mapPaymentFromSupabase);
+    },
+    enabled: enabled && isReady && !!organizationId && !!patientId,
+  } satisfies UseQueryOptions<MappedPayment[], Error>);
+}

--- a/src/lib/supabase/mappers/payments.ts
+++ b/src/lib/supabase/mappers/payments.ts
@@ -1,0 +1,35 @@
+/**
+ * Payments Mapper — Supabase ↔ Frontend
+ */
+
+import type { Database } from "../database.types";
+import { createEntityMapper } from "./generic";
+
+type PaymentRow = Database["public"]["Tables"]["payments"]["Row"];
+
+export interface MappedPayment {
+  _id: string;
+  _creationTime: number;
+  organizationId: string;
+  patientId?: string;
+  appointmentId?: string;
+  packageUsageId?: string;
+  amount: number;
+  currency: string;
+  paymentMethod: string;
+  status: string;
+  paidAt?: number;
+  notes?: string;
+  createdBy: string;
+  createdAt: number;
+  updatedAt: number;
+  _source: "supabase";
+}
+
+const mapper = createEntityMapper<PaymentRow, MappedPayment>({});
+
+export const mapPaymentFromSupabase = (row: PaymentRow): MappedPayment => {
+  const mapped = mapper.mapFromSupabase(row);
+  return { ...mapped, _creationTime: mapped.createdAt };
+};
+export const mapPaymentToSupabase = mapper.mapToSupabase;

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -16,6 +16,7 @@ import {
 import type { MappedGabinetAppointment } from "@/lib/supabase/mappers/gabinet/appointments";
 import { useSupabaseGabinetLoyaltyBalance, useSupabaseGabinetLoyaltyTransactions } from "@/hooks/use-supabase-gabinet-loyalty";
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
+import { useSupabasePaymentsByPatient } from "@/hooks/use-supabase-payments";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { SidePanel } from "@/components/crm/side-panel";
 import { PatientForm } from "@/components/forms/patient-form";
@@ -39,6 +40,7 @@ import {
   Minus,
   ArrowUpRight,
   ArrowDownRight,
+  CreditCard,
 } from "@/lib/ez-icons";
 
 import { useTranslation } from "react-i18next";
@@ -110,6 +112,11 @@ function PatientDetail() {
   );
 
   const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId);
+
+  const { data: patientPayments } = useSupabasePaymentsByPatient(
+    organizationId,
+    patientId,
+  );
 
   // Treatment-number indicator IDs ("X/Y" like in the calendar — issue #1086).
   // Package usage takes precedence; recurring series is the fallback.
@@ -213,6 +220,19 @@ function PatientDetail() {
               {t("gabinet.loyalty.balance")}
             </span>
             <span className="text-xs font-semibold tabular-nums">{loyaltyBalance?.balance ?? 0}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <CreditCard size={12} variant="stroke" />
+              {t("gabinet.payments.totalSpent")}
+            </span>
+            <span className="text-xs font-semibold tabular-nums">
+              {(patientPayments ?? [])
+                .filter((p) => p.status === "completed")
+                .reduce((sum, p) => sum + (p.amount ?? 0), 0)
+                .toFixed(2)}{" "}
+              PLN
+            </span>
           </div>
         </div>
       </div>
@@ -793,6 +813,192 @@ function PatientDetail() {
           </div>
         </div>
       ),
+    },
+    {
+      label: t("gabinet.payments.payments"),
+      count: patientPayments?.length ?? 0,
+      content: (() => {
+        const completedPayments = (patientPayments ?? []).filter(
+          (p) => p.status === "completed",
+        );
+        const totalSpent = completedPayments.reduce(
+          (sum, p) => sum + (p.amount ?? 0),
+          0,
+        );
+        const pendingPayments = (patientPayments ?? []).filter(
+          (p) => p.status === "pending",
+        );
+        const outstanding = pendingPayments.reduce(
+          (sum, p) => sum + (p.amount ?? 0),
+          0,
+        );
+        const lastPayment = patientPayments?.[0];
+        return (
+          <div className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-3">
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="flex items-center gap-3">
+                    <CreditCard
+                      className="h-4 w-4 text-green-600"
+                      variant="stroke"
+                    />
+                    <div>
+                      <p className="text-sm text-muted-foreground">
+                        {t("gabinet.payments.totalSpent")}
+                      </p>
+                      <p className="text-2xl font-bold">
+                        {totalSpent.toFixed(2)} PLN
+                      </p>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="flex items-center gap-3">
+                    <CreditCard
+                      className="h-4 w-4 text-amber-600"
+                      variant="stroke"
+                    />
+                    <div>
+                      <p className="text-sm text-muted-foreground">
+                        {t("gabinet.payments.outstanding")}
+                      </p>
+                      <p className="text-2xl font-bold">
+                        {outstanding.toFixed(2)} PLN
+                      </p>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="flex items-center gap-3">
+                    <Calendar
+                      className="h-4 w-4 text-muted-foreground"
+                      variant="stroke"
+                    />
+                    <div>
+                      <p className="text-sm text-muted-foreground">
+                        {t("gabinet.payments.lastPayment")}
+                      </p>
+                      <p className="font-medium">
+                        {lastPayment
+                          ? new Date(lastPayment.createdAt).toLocaleDateString(
+                              "pl-PL",
+                            )
+                          : "—"}
+                      </p>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            <Card>
+              <CardContent className="pt-6 space-y-4">
+                <h3 className="text-sm font-semibold flex items-center gap-2">
+                  <CreditCard
+                    className="h-4 w-4 text-muted-foreground"
+                    variant="stroke"
+                  />
+                  {t("gabinet.payments.paymentHistory")}
+                </h3>
+                {!patientPayments || patientPayments.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-12 text-center">
+                    <CreditCard className="h-10 w-10 text-muted-foreground/40 mb-3" />
+                    <p className="text-sm text-muted-foreground">
+                      {t("gabinet.payments.noPayments")}
+                    </p>
+                  </div>
+                ) : (
+                  <div className="overflow-x-auto border rounded-lg">
+                    <table className="w-full">
+                      <thead>
+                        <tr className="border-b bg-muted/50">
+                          <th className="text-left p-3 text-sm font-medium">
+                            {t("gabinet.payments.amount")}
+                          </th>
+                          <th className="text-left p-3 text-sm font-medium">
+                            {t("gabinet.payments.method")}
+                          </th>
+                          <th className="text-left p-3 text-sm font-medium">
+                            {t("common.date")}
+                          </th>
+                          <th className="text-left p-3 text-sm font-medium">
+                            {t("common.status")}
+                          </th>
+                          <th className="text-left p-3 text-sm font-medium" />
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {patientPayments.map((payment) => (
+                          <tr
+                            key={payment._id}
+                            className={`border-b last:border-0 hover:bg-muted/30 ${
+                              payment.appointmentId
+                                ? "cursor-pointer"
+                                : ""
+                            }`}
+                            onClick={() => {
+                              if (payment.appointmentId) {
+                                navigate({
+                                  to: "/dashboard/gabinet/appointments/$appointmentId",
+                                  params: {
+                                    appointmentId: payment.appointmentId,
+                                  },
+                                });
+                              }
+                            }}
+                          >
+                            <td className="p-3 font-medium">
+                              {payment.amount.toFixed(2)}{" "}
+                              {payment.currency ?? "PLN"}
+                            </td>
+                            <td className="p-3">
+                              <Badge variant="outline">
+                                {t(
+                                  `gabinet.payments.methods.${payment.paymentMethod}`,
+                                )}
+                              </Badge>
+                            </td>
+                            <td className="p-3 text-sm text-muted-foreground">
+                              {new Date(
+                                payment.createdAt,
+                              ).toLocaleDateString("pl-PL")}
+                            </td>
+                            <td className="p-3">
+                              <Badge
+                                variant={
+                                  payment.status === "completed"
+                                    ? "default"
+                                    : payment.status === "refunded"
+                                      ? "destructive"
+                                      : "secondary"
+                                }
+                              >
+                                {t(
+                                  `gabinet.payments.status.${payment.status}`,
+                                )}
+                              </Badge>
+                            </td>
+                            <td className="p-3 text-xs text-muted-foreground">
+                              {payment.appointmentId
+                                ? t("gabinet.payments.linkedToAppointment")
+                                : null}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        );
+      })(),
     },
     {
       label: t("gabinet.patients.tabs.activity"),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1088.

Closes #1088

---

## Claude summary

Committed. Summary of changes:

The patient detail page (`/dashboard/gabinet/patients/:id`) previously showed appointments, documents, loyalty, and activity, but no payment information — that lived only on the per-appointment screen. Three changes:

- `src/lib/supabase/mappers/payments.ts` — new mapper translating the `payments` Supabase row into a camelCase frontend object.
- `src/hooks/use-supabase-payments.ts` — new `useSupabasePaymentsByPatient` React Query hook fetching all payments for a patient, ordered most recent first.
- `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx` — adds a "Płatności" tab with three KPI cards (total spent / outstanding / last payment) and a full history table (amount, method, date, status). Rows that have an `appointmentId` are clickable and navigate to that appointment. Also surfaces a "Wydano łącznie" line in the sidebar statistics block alongside the appointment count and loyalty balance. All i18n keys (`gabinet.payments.*`, `common.date`, `common.status`) already existed in both PL and EN locales — no translation file changes needed.

Typecheck passes for the edited files (no errors in `_layout.gabinet.patients.$patientId.tsx`, `use-supabase-payments.ts`, or `mappers/payments.ts`).