### PR TITLE
zmiana nazwy

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2226,6 +2226,7 @@
         "purchaseFailed": "Could not sell the treatment."
       },
       "patientTreatments": "Treatments",
+      "addOrSell": "Add / Sell",
       "noPatientTreatments": "No treatments purchased",
       "purchaseTreatment": "Sell treatment",
       "selectTreatment": "Treatment",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2252,6 +2252,7 @@
         "purchaseFailed": "Nie udało się sprzedać zabiegu."
       },
       "patientTreatments": "Zabiegi",
+      "addOrSell": "Dodaj/Sprzedaj",
       "noPatientTreatments": "Brak zakupionych zabiegów",
       "purchaseTreatment": "Sprzedaj zabieg",
       "selectTreatment": "Zabieg",

--- a/src/components/gabinet/patient-treatments-card.tsx
+++ b/src/components/gabinet/patient-treatments-card.tsx
@@ -80,7 +80,7 @@ export function PatientTreatmentsCard({ patientId, organizationId }: PatientTrea
             </CardTitle>
             <Button variant="ghost" size="sm" className="h-7" onClick={() => setPurchaseOpen(true)}>
               <Plus className="mr-1 h-[17px] w-[17px]" variant="stroke" />
-              {t("common.add")}
+              {t("gabinet.treatments.addOrSell", "Dodaj/Sprzedaj")}
             </Button>
           </div>
         </CardHeader>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1095.

Closes #1095

---

## Claude summary

Renamed the "Dodaj" button on the Zabiegi card (patient detail page) to "Dodaj/Sprzedaj" in `src/components/gabinet/patient-treatments-card.tsx:83`, using a new dedicated translation key `gabinet.treatments.addOrSell` (with EN: "Add / Sell") rather than altering the global `common.add` which is used in many other places. Committed as `580cb1d`.