### PR TITLE
Default form-field editor `filledBy` to "client"

### DIFF
--- a/src/components/documents/form-field-node.tsx
+++ b/src/components/documents/form-field-node.tsx
@@ -148,18 +148,18 @@ function FormFieldConfig({
           {t("formEditor.filledBy.label", "Wypełnia")}
         </Label>
         <Select
-          value={attrs.filledBy ?? "employee"}
+          value={attrs.filledBy ?? "client"}
           onValueChange={(v) => onChange({ filledBy: v as FilledBy })}
         >
           <SelectTrigger className="h-8 text-sm">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="employee">
-              {t("formEditor.filledBy.employee", "Pracownik")}
-            </SelectItem>
             <SelectItem value="client">
               {t("formEditor.filledBy.client", "Klient")}
+            </SelectItem>
+            <SelectItem value="employee">
+              {t("formEditor.filledBy.employee", "Pracownik")}
             </SelectItem>
           </SelectContent>
         </Select>
@@ -238,7 +238,7 @@ export const FormFieldNode = Node.create({
       options: { default: "" },
       required: { default: false },
       placeholder: { default: "" },
-      filledBy: { default: "employee" as FilledBy },
+      filledBy: { default: "client" as FilledBy },
     };
   },
 
@@ -291,7 +291,7 @@ export function insertFormField(
     .focus()
     .insertContent({
       type: "formField",
-      attrs: { fieldId, fieldType: "text", label: "New field", filledBy: "employee", ...attrs },
+      attrs: { fieldId, fieldType: "text", label: "New field", filledBy: "client", ...attrs },
     })
     .run();
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1099.

Closes #1099

---

## Claude summary

Fixed. Flipped the default in `src/components/documents/form-field-node.tsx` so new form fields in the template editor are tagged `filledBy="client"` instead of `"employee"`. Changed in four spots: the `addAttributes` schema default (line 241), the Select fallback (`?? "client"`), the dropdown order (client listed first), and the `insertFormField` insertion default. Left `parseHTML`/`renderHTML` fallbacks as `"employee"` to preserve semantics for legacy pre-#1093 saved fields that omit `data-filled-by`. Typecheck clean, committed as 6cb2459.