### PR TITLE
zrób to samo

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2928,6 +2928,7 @@
       "remaining": "remaining",
       "coveredByPackage": "Covered by package",
       "patientPackages": "Packages",
+      "addOrSell": "Add / Sell",
       "noPatientPackages": "No packages purchased",
       "expires": "Expires",
       "status": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2957,6 +2957,7 @@
       "remaining": "pozostało",
       "coveredByPackage": "Pokryte pakietem",
       "patientPackages": "Pakiety",
+      "addOrSell": "Dodaj/Sprzedaj",
       "noPatientPackages": "Brak zakupionych pakietów",
       "expires": "Wygasa",
       "status": {

--- a/src/components/gabinet/patient-packages-card.tsx
+++ b/src/components/gabinet/patient-packages-card.tsx
@@ -107,7 +107,7 @@ export function PatientPackagesCard({ patientId, organizationId }: PatientPackag
             </CardTitle>
             <Button variant="ghost" size="sm" className="h-7" onClick={() => setPurchaseOpen(true)}>
               <Plus className="mr-1 h-[17px] w-[17px]" variant="stroke" />
-              {t("common.add")}
+              {t("gabinet.packages.addOrSell", "Dodaj/Sprzedaj")}
             </Button>
           </div>
         </CardHeader>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1101.

Closes #1101

---

## Claude summary

Renamed the "+ Dodaj" button on the Pakiety card to "+ Dodaj/Sprzedaj" so it matches the Zabiegi card (#1100). Changed `src/components/gabinet/patient-packages-card.tsx:110` to use the new `gabinet.packages.addOrSell` key, and added that key to both PL ("Dodaj/Sprzedaj") and EN ("Add / Sell") locale files. Commit `290e0a1` on branch `claude/issue-1101`.