### PR TITLE
wyszukiwarka

### DIFF
--- a/src/components/documents/generate-document-dialog.tsx
+++ b/src/components/documents/generate-document-dialog.tsx
@@ -899,6 +899,7 @@ export function GenerateDocumentDialog({
 
                 {!templatesLoading && filteredTemplates.length > 0 && (
                   <TemplateFolderTree
+                    key={filteredTemplates.map((tpl) => tpl._id).join(",")}
                     templates={filteredTemplates}
                     search={search}
                     onSelect={handleTemplateSelect}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1102.

Closes #1102

---

## Claude summary

Fixed and committed.

The bug: on the patient detail page, opening Documents tab → "Wygeneruj dokument" → typing a character in the template search input would crash and close the dialog. Console showed `Error: Headless Tree: sync dataLoader returned undefined`.

Root cause: `TemplateFolderTree` in `src/components/documents/generate-document-dialog.tsx` uses `@headless-tree/react`'s `useTree` with a sync `dataLoader` that reads from a `useMemo`'d `treeData`. When `search` changes, `treeData.items` is rebuilt (filtered set), but the tree's internal state still references old item IDs. The `useEffect(() => tree.rebuildTree(), [treeDataKey])` only fires after render, so during the first render after filtering, `tree.getItems()` calls `getItem(oldId)` which returns `undefined` and headless-tree throws. The error boundary then unmounts the dialog — the user sees the "search turn off".

Fix: pass `key={filteredTemplates.map((tpl) => tpl._id).join(",")}` to `TemplateFolderTree`. When the filtered list changes, React fully remounts the tree with fresh internal state matching the new data.

## Follow-ups
- Apply same headless-tree remount fix in form-templates settings: `TemplateTree` in `src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx` uses the same useTree + sync dataLoader + search-filtered treeData pattern and will crash identically when its search input filters items.