### PR TITLE
wyślij

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -480,38 +480,17 @@ export const resendSigningEmail = action({
     if (!doc.signingToken)
       throw new Error("Document has no signing token");
 
-    // Delegate email sending to side effects (needs Convex db reads for patient lookup)
-    try {
-      await ctx.runMutation(internal.documents.documents._resendSigningSideEffects, {
-        documentId: args.documentId,
-        entityType: doc.entityType as string,
-        entityId: doc.entityId as string,
-      });
-    } catch (e) {
-      console.error("[documents.resendSigningEmail] Side effects FAILED:", e);
-      throw e;
-    }
-
-    return { sent: true };
-  },
-});
-
-export const _resendSigningSideEffects = internalMutation({
-  args: {
-    documentId: v.string(),
-    entityType: v.string(),
-    entityId: v.string(),
-  },
-  handler: async (ctx, args) => {
     let recipientEmail: string | undefined;
     let recipientName: string | undefined;
+    const entityType = doc.entityType as string | undefined;
+    const entityId = doc.entityId as string | undefined;
 
-    if (args.entityType === "appointment" && args.entityId) {
-      const appointment = await ctx.db.get(args.entityId as any);
+    if (entityType === "appointment" && entityId) {
+      const appointment = await db.get("gabinetAppointments", entityId);
       if (appointment && typeof appointment === "object") {
-        const appt = appointment as { patientId?: any };
+        const appt = appointment as { patientId?: string };
         if (appt.patientId) {
-          const patient = await ctx.db.get(appt.patientId);
+          const patient = await db.get("gabinetPatients", String(appt.patientId));
           if (patient && typeof patient === "object") {
             const p = patient as { email?: string; firstName?: string; lastName?: string };
             recipientEmail = p.email;
@@ -519,8 +498,8 @@ export const _resendSigningSideEffects = internalMutation({
           }
         }
       }
-    } else if (args.entityType === "patient" && args.entityId) {
-      const patient = await ctx.db.get(args.entityId as any);
+    } else if (entityType === "patient" && entityId) {
+      const patient = await db.get("gabinetPatients", entityId);
       if (patient && typeof patient === "object") {
         const p = patient as { email?: string; firstName?: string; lastName?: string };
         recipientEmail = p.email;
@@ -541,6 +520,8 @@ export const _resendSigningSideEffects = internalMutation({
         recipientName,
       },
     );
+
+    return { sent: true };
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1105.

Closes #1105

---

## Claude summary

Fixed and committed. The "Wyślij" button on the patient documents tab failed because `resendSigningEmail` forwarded the entity lookup to an `internalMutation` that called `ctx.db.get(entityId)` — but `gabinetAppointments` and `gabinetPatients` live in Supabase (UUID-keyed), not Convex (base32-keyed). Console showed `Invalid argument 'id' for 'db.get': Unable to decode ID: ID wasn't valid base32`. I moved the recipient lookup into the action itself (which already has Supabase access via `createSupabaseDb()`) and removed the broken side-effects mutation.

## Follow-ups
- Fix same Supabase ID bug in _submitEmployeeSideEffects: convex/documents/documents.ts:355 calls ctx.db.get on appointment/patient entity IDs, will fail identically when a staff member submits a form on behalf of a client
- Audit other ctx.db.get calls on gabinet entities: convex/documents/documents.ts:371, convex/documents/scopeResolver.ts:80, convex/gabinet/reminders.ts:29, convex/gabinet/appointments.ts:149 and convex/gabinet/_helpers/autoGenerateDocuments.ts:174 all use Convex db.get on patient/appointment IDs that may now be Supabase UUIDs