### PR TITLE
Apply same headless-tree remount fix in form-templates settings

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -721,6 +721,22 @@ function FormTemplatesListPage() {
     [allTemplates],
   );
 
+  // Force TemplateTree to remount when the visible set changes.
+  // headless-tree's sync dataLoader keeps internal item IDs; the
+  // useEffect-based rebuildTree runs after render, so the first render
+  // after filtering would crash inside the loader (see fix #1102).
+  const templateTreeKey = useMemo(() => {
+    const searchLower = search.toLowerCase().trim();
+    const visible = searchLower
+      ? allTemplates.filter(
+          (tpl) =>
+            tpl.name.toLowerCase().includes(searchLower) ||
+            (tpl.description ?? "").toLowerCase().includes(searchLower),
+        )
+      : allTemplates;
+    return visible.map((tpl) => tpl._id).join(",");
+  }, [allTemplates, search]);
+
   return (
     <div className="flex h-full w-full flex-col gap-6">
       <SectionHeader.Root className="pt-4">
@@ -823,6 +839,7 @@ function FormTemplatesListPage() {
         !isPending && (
           <div className="rounded-lg border bg-card p-4">
             <TemplateTree
+              key={templateTreeKey}
               templates={allTemplates}
               search={search}
               onEditTemplate={(id) => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1109.

Closes #1109

---

## Claude summary

Committed as `25e674b`. The fix applies the same pattern as c6c7eb5 (#1102): a `useMemo`-computed `templateTreeKey` in the parent `FormTemplatesListPage` that joins the IDs of the search-filtered template subset, used as a `key` on `<TemplateTree>` so headless-tree gets a clean remount whenever the visible set changes — sidestepping the `useEffect`-after-render gap that crashes the sync `dataLoader`.