### PR TITLE
sprzedaż zabiegu

### DIFF
--- a/convex/gabinetRoles.ts
+++ b/convex/gabinetRoles.ts
@@ -11,7 +11,7 @@
  * "none" everywhere until overrides land).
  */
 
-import { mutation, query, action, internalMutation } from "./_generated/server";
+import { query, action, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import { Id } from "./_generated/dataModel";
@@ -23,7 +23,7 @@ import {
   isSystemGabinetRole,
   type SystemGabinetRole,
 } from "./_helpers/gabinetRolePermissions";
-import type { Feature, Action, Scope, FeaturePermissions } from "./_helpers/permissionTypes";
+import type { FeaturePermissions } from "./_helpers/permissionTypes";
 
 // --- Definitions ---
 
@@ -50,6 +50,7 @@ export const listDefinitions = query({
       color: SYSTEM_GABINET_ROLE_LABELS[r].color,
       isSystem: true,
       isClinical: SYSTEM_GABINET_ROLE_LABELS[r].isClinical,
+      order: undefined as number | undefined,
       virtual: true as const,
     }));
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1119.

Closes #1119

---

## Claude summary

Fix committed. Here's a summary:

The Jam recording showed two identical Convex errors:
```
Could not find public function for 'gabinet/packages:purchaseTreatment'.
Did you forget to run `npx convex dev`?
```

`gabinet.packages.purchaseTreatment` exists in main (added in #1094 / commit 0177fe9), but it never reached the deployed backend. Root cause: `convex/gabinetRoles.ts` (introduced in #1015 / 10773a1, the day before) had six hard TypeScript errors. Netlify deploys via `npx convex deploy --cmd 'npm run build'` with no `--typecheck=disable`, so Convex aborts the push before any new function — including `purchaseTreatment` — gets registered. Anything merged after 10773a1 has been silently stuck.

Changes in `convex/gabinetRoles.ts`:
- Removed unused imports `mutation`, `Feature`, `Action`, `Scope` (TS6133/6196).
- Added `order: undefined as number | undefined` to the virtual system-role objects in `listDefinitions` so the union with real DB rows uniformly carries the optional `order` field (fixes TS2339 at lines 57-58).

Verified with `npx tsc -p convex/tsconfig.json --noEmit` — exit 0, no remaining errors. Once this lands on main, the next Netlify build should successfully deploy the backend and `purchaseTreatment` will exist on the server.

## Follow-ups
- Add convex typecheck to CI: add a `tsc -p convex/tsconfig.json --noEmit` job (or `npm run typecheck`) on PR/push so future type errors in convex/ are caught before they silently freeze production deploys for ~24h, as happened with #1015 → #1119.
- Investigate Netlify deploy-failure alerting: deploys have apparently been failing since 10773a1 without any human noticing — confirm Netlify build-failure notifications are wired to a channel someone watches.