### PR TITLE
Route ctx.db.get on patient in `convex/gabinet/documentDataSources.ts

### DIFF
--- a/convex/gabinet/documentDataSources.ts
+++ b/convex/gabinet/documentDataSources.ts
@@ -1,4 +1,5 @@
 import type { DataSourceDefinition } from "../documentDataSources";
+import { createSupabaseDb } from "../_helpers/supabaseDb";
 
 const patientSource: DataSourceDefinition = {
   key: "patient",
@@ -17,9 +18,15 @@ const patientSource: DataSourceDefinition = {
     { key: "bloodType", label: "Grupa krwi", type: "text" },
     { key: "emergencyContact", label: "Kontakt awaryjny", type: "text" },
   ],
-  resolve: async (ctx, patientId): Promise<Record<string, string>> => {
+  resolve: async (_ctx, patientId): Promise<Record<string, string>> => {
     if (!patientId) return {};
-    const patient = (await ctx.db.get(patientId as any)) as any;
+    // gabinetPatients lives in Supabase as UUIDs — ctx.db.get fails with
+    // "Unable to decode ID". Read from Supabase instead; same fix pattern
+    // as #1113/#1123.
+    const patient = (await createSupabaseDb().get(
+      "gabinetPatients",
+      String(patientId),
+    )) as any;
     if (!patient) return {};
     return {
       firstName: patient.firstName ?? "",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1125.

Closes #1125

---

## Claude summary

Routed the patient data source resolver in `convex/gabinet/documentDataSources.ts:21-30` through Supabase via `createSupabaseDb().get("gabinetPatients", String(patientId))`, matching the pattern used in #1113/#1123/#1124. Typecheck shows no new errors. Committed as `9a7b932`.

## Follow-ups
- Route remaining ctx.db.get calls in convex/crm/documentDataSources.ts through Supabase: contactSource (line 17), companySource (line 44), and leadSource (line 72) all still call ctx.db.get on contacts/companies/leads which now live in Supabase as UUIDs — same anti-pattern as #1125 will fail document template binding for CRM scopes
- Route current_user/org sources in convex/documentDataSources.ts through Supabase: currentUserSource (line 82) and orgSource (line 98) still do ctx.db.get on userId/orgId — users and organizations now live in Supabase, so resolveSourceValues will fail when these platform sources are requested