### PR TITLE
Route ctx.db.get on template in `convex/documents/documents.ts

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -6,7 +6,7 @@ import { verifyOrgAccess } from "../_helpers/auth";
 import { validatePortalSessionSupabase } from "../_helpers/portalSession";
 import { formDocumentStatusValidator } from "../schema/documents";
 import { resolveComponentsInContent } from "./resolveComponents";
-import type { FormDocumentRow } from "../_helpers/supabaseRows";
+import type { FormDocumentRow, FormTemplateRow } from "../_helpers/supabaseRows";
 import { Id } from "../_generated/dataModel";
 
 // Dual-write refs removed — Supabase is now primary for document writes
@@ -120,13 +120,20 @@ export const getById = action({
   },
 });
 
-// Get document by signing token (no auth required -- public signing page)
-export const getBySigningToken = query({
+// Get document by signing token (no auth required -- public signing page).
+// Reads from Supabase since `formDocuments`, `formTemplates`, and
+// `documentComponents` are all Supabase-primary now.
+export const getBySigningToken = action({
   args: { token: v.string() },
-  handler: async (ctx, args) => {
-    const doc = await ctx.db
+  handler: async (_ctx, args): Promise<{
+    document: FormDocumentRow;
+    template: FormTemplateRow | null;
+  }> => {
+    const db = createSupabaseDb();
+
+    const doc = await db
       .query("formDocuments")
-      .withIndex("by_signingToken", (q) => q.eq("signingToken", args.token))
+      .eq("signingToken", args.token)
       .first();
     if (!doc) throw new Error("Document not found");
     if (doc.signingTokenExpiresAt && doc.signingTokenExpiresAt < Date.now())
@@ -135,10 +142,16 @@ export const getBySigningToken = query({
     // what to render based on status (fill form, sign, or show success).
 
     // Also fetch template for rendering, with components resolved
-    const template = await ctx.db.get(doc.templateId);
+    const template = await db.get("formTemplates", String(doc.templateId));
     if (template?.contentJson) {
-      const resolved = await resolveComponentsInContent(ctx, template.contentJson);
-      return { document: doc, template: { ...template, contentJson: resolved } };
+      const resolved = await resolveComponentsInContent(
+        db,
+        template.contentJson,
+      );
+      return {
+        document: doc,
+        template: { ...template, contentJson: resolved },
+      };
     }
     return { document: doc, template };
   },

--- a/convex/documents/resolveComponents.ts
+++ b/convex/documents/resolveComponents.ts
@@ -1,14 +1,13 @@
-import type { QueryCtx, MutationCtx } from "../_generated/server";
-import type { Id } from "../_generated/dataModel";
+import type { SupabaseDb } from "../_helpers/supabaseDb";
 
 /**
  * Resolve all componentBlock nodes in a TipTap JSON document.
  * Replaces each componentBlock with the component's actual content nodes.
  * Also appends any protected end-position components (e.g., QUERA footer)
- * if not already present.
+ * if not already present. Reads `documentComponents` from Supabase.
  */
 export async function resolveComponentsInContent(
-  ctx: QueryCtx | MutationCtx,
+  db: SupabaseDb,
   contentJson: string | undefined,
 ): Promise<string | undefined> {
   if (!contentJson) return contentJson;
@@ -28,11 +27,12 @@ export async function resolveComponentsInContent(
   for (const node of doc.content) {
     if (node.type === "componentBlock" && node.attrs?.componentId) {
       try {
-        const comp = await ctx.db.get(
-          node.attrs.componentId as Id<"documentComponents">,
+        const comp = await db.get(
+          "documentComponents",
+          String(node.attrs.componentId),
         );
         if (comp && comp.contentJson) {
-          const compDoc = JSON.parse(comp.contentJson);
+          const compDoc = JSON.parse(comp.contentJson as string);
           if (compDoc.content && Array.isArray(compDoc.content)) {
             resolved.push(...compDoc.content);
           }
@@ -48,16 +48,16 @@ export async function resolveComponentsInContent(
 
   // Append protected footer if not already included
   if (!hasProtectedEnd) {
-    const systemComponents = await ctx.db
+    const systemComponents = await db
       .query("documentComponents")
-      .withIndex("by_scope", (q) => q.eq("scope", "system"))
+      .eq("scope", "system")
       .collect();
     const protectedFooter = systemComponents.find(
       (c) => c.protected && c.positionConstraint === "end" && c.isActive,
     );
     if (protectedFooter?.contentJson) {
       try {
-        const footerDoc = JSON.parse(protectedFooter.contentJson);
+        const footerDoc = JSON.parse(protectedFooter.contentJson as string);
         if (footerDoc.content && Array.isArray(footerDoc.content)) {
           resolved.push(...footerDoc.content);
         }

--- a/scripts/audit-read-sources.sh
+++ b/scripts/audit-read-sources.sh
@@ -21,7 +21,6 @@ ALLOWED_PATTERNS=(
   "api.permissions"
   "api.oauthConnections"
   "api.dev.emails"
-  "api.documents.documents.getBySigningToken"
   "api.signatureRequests"
   "api.automation.listEventCatalog"
   "api.automation.listActionCapabilities"

--- a/src/routes/sign.form.$token.tsx
+++ b/src/routes/sign.form.$token.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useQuery, useAction } from "convex/react";
+import { useAction } from "convex/react";
+import { useQuery } from "@tanstack/react-query";
 import { api } from "@cvx/_generated/api";
 import { useState, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -36,9 +37,17 @@ export const Route = createFileRoute("/sign/form/$token")({
 function FormSigningPage() {
   const { t } = useTranslation();
   const { token } = Route.useParams();
-  const data = useQuery(api.documents.documents.getBySigningToken, { token });
+  const getBySigningToken = useAction(
+    api.documents.documents.getBySigningToken,
+  );
+  const { data, isLoading } = useQuery({
+    queryKey: ["documents.documents.getBySigningToken", token],
+    queryFn: () => getBySigningToken({ token }),
+    enabled: !!token,
+    retry: false,
+  });
 
-  if (data === undefined) {
+  if (isLoading) {
     return (
       <PageShell>
         <LoadingState />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1127.

Closes #1127

---

## Claude summary

Converted `getBySigningToken` from a Convex query to an action that reads `formDocuments`, `formTemplates`, and `documentComponents` via Supabase, updated `resolveComponentsInContent` to take a `SupabaseDb` (its sole caller is now Supabase-backed), and switched the public signing page to invoke the action through `useAction` + react-query. Removed the now-stale `getBySigningToken` entry from the audit allowlist. Typecheck shows no new errors (the pre-existing TS6133 warnings on unrelated files were present before this change).

## Follow-ups
- Route `listAll` in convex/documents/documents.ts through Supabase: still reads `formDocuments` via ctx.db at L22/L32 even though writes are Supabase-only
- Route `listByTemplate` in convex/documents/documents.ts through Supabase: same stale ctx.db read on formDocuments at L155
- Route `listByStatus` in convex/documents/documents.ts through Supabase: same stale ctx.db read on formDocuments at L169
- Route dev/emails.ts formDocuments lookup through Supabase: convex/dev/emails.ts:63 reads from Convex but data lives in Postgres