### PR TITLE
Add missing PL translations for new documents drag/send UI

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -681,7 +681,14 @@
     "completeMissingData": "Complete missing data",
     "completeMissingDataDesc": "The following data is required to generate the document. After filling in, it will be saved to the profile.",
     "missingDataWarning": "The template requires data that has not been filled in yet. Complete the fields below — they will be saved automatically.",
-    "saveAndContinue": "Save and continue"
+    "saveAndContinue": "Save and continue",
+    "dragToReorder": "Drag to reorder",
+    "send": "Send",
+    "selectTemplateDesc": "Choose a template to generate the document from.",
+    "stepOf": "Step {{current}} of {{total}}",
+    "searchTemplate": "Search template...",
+    "noTemplatesDesc": "Add document templates in settings to generate documents.",
+    "goToSettings": "Go to settings"
   },
   "products": {
     "title": "Products",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -695,7 +695,14 @@
     "completeMissingData": "Uzupełnij brakujące dane",
     "completeMissingDataDesc": "Poniższe dane są wymagane do wygenerowania dokumentu. Po uzupełnieniu zostaną zapisane w profilu.",
     "missingDataWarning": "Szablon wymaga danych, które nie są jeszcze uzupełnione w profilu. Uzupełnij je poniżej — zostaną zapisane automatycznie.",
-    "saveAndContinue": "Zapisz i kontynuuj"
+    "saveAndContinue": "Zapisz i kontynuuj",
+    "dragToReorder": "Przeciągnij, aby zmienić kolejność",
+    "send": "Wyślij",
+    "selectTemplateDesc": "Wybierz szablon, na podstawie którego zostanie wygenerowany dokument.",
+    "stepOf": "Krok {{current}} z {{total}}",
+    "searchTemplate": "Szukaj szablonu...",
+    "noTemplatesDesc": "Dodaj szablony dokumentów w ustawieniach, aby móc generować dokumenty.",
+    "goToSettings": "Przejdź do ustawień"
   },
   "products": {
     "title": "Produkty",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1128.

Closes #1128

---

## Claude summary

Added the seven missing `documents.*` keys (`dragToReorder`, `send`, `selectTemplateDesc`, `stepOf`, `searchTemplate`, `noTemplatesDesc`, `goToSettings`) to both `public/locales/pl/translation.json` and `public/locales/en/translation.json`. Polish strings use proper diacritics (the previous inline fallbacks in `generate-document-dialog.tsx` and `entity-documents-tab.tsx` had ASCII-stripped versions like "Przejdz do ustawien"). JSON validates; committed as `1f49f1d`.