### PR TITLE
dodaj

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3175,6 +3175,7 @@
       "amountRequired": "Amount is required",
       "create": "Create payment",
       "created": "Payment created",
+      "for": "For",
       "lastPayment": "Last payment",
       "linkedToAppointment": "Linked to appointment",
       "method": "Payment method",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3204,6 +3204,7 @@
       "amountRequired": "Kwota jest wymagana",
       "create": "Utwórz płatność",
       "created": "Płatność utworzona",
+      "for": "Za co",
       "lastPayment": "Ostatnia płatność",
       "linkedToAppointment": "Powiązana z wizytą",
       "method": "Metoda płatności",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -16,6 +16,10 @@ import {
 import type { MappedGabinetAppointment } from "@/lib/supabase/mappers/gabinet/appointments";
 import { useSupabaseGabinetLoyaltyBalance, useSupabaseGabinetLoyaltyTransactions } from "@/hooks/use-supabase-gabinet-loyalty";
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
+import {
+  useSupabaseGabinetPackageUsageByPatient,
+  useSupabaseGabinetTreatmentPackagesList,
+} from "@/hooks/use-supabase-gabinet-packages";
 import { useSupabasePaymentsByPatient } from "@/hooks/use-supabase-payments";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { SidePanel } from "@/components/crm/side-panel";
@@ -118,6 +122,38 @@ function PatientDetail() {
     organizationId,
     patientId,
   );
+
+  const { data: patientPackageUsage } = useSupabaseGabinetPackageUsageByPatient(
+    organizationId,
+    patientId,
+  );
+
+  const { data: treatmentPackages } = useSupabaseGabinetTreatmentPackagesList(
+    organizationId,
+  );
+
+  const getPaymentForLabel = (payment: {
+    appointmentId?: string;
+    packageUsageId?: string;
+    notes?: string;
+  }): string => {
+    if (payment.appointmentId) {
+      const apt = patientAppointments?.find((a) => a._id === payment.appointmentId);
+      const treatmentName = apt?.treatmentId
+        ? treatmentsData?.find((tr) => tr._id === apt.treatmentId)?.name
+        : undefined;
+      if (treatmentName) return treatmentName;
+    }
+    if (payment.packageUsageId) {
+      const usage = patientPackageUsage?.find((u) => u._id === payment.packageUsageId);
+      const pkgName = usage
+        ? treatmentPackages?.find((p) => p._id === usage.packageId)?.name
+        : undefined;
+      if (pkgName) return pkgName;
+    }
+    if (payment.notes) return payment.notes;
+    return "—";
+  };
 
   // Treatment-number indicator IDs ("X/Y" like in the calendar — issue #1086).
   // Package usage takes precedence; recurring series is the fallback.
@@ -758,6 +794,9 @@ function PatientDetail() {
                             {t("gabinet.payments.amount")}
                           </th>
                           <th className="text-left p-3 text-sm font-medium">
+                            {t("gabinet.payments.for")}
+                          </th>
+                          <th className="text-left p-3 text-sm font-medium">
                             {t("gabinet.payments.method")}
                           </th>
                           <th className="text-left p-3 text-sm font-medium">
@@ -766,7 +805,6 @@ function PatientDetail() {
                           <th className="text-left p-3 text-sm font-medium">
                             {t("common.status")}
                           </th>
-                          <th className="text-left p-3 text-sm font-medium" />
                         </tr>
                       </thead>
                       <tbody>
@@ -792,6 +830,14 @@ function PatientDetail() {
                             <td className="p-3 font-medium">
                               {payment.amount.toFixed(2)}{" "}
                               {payment.currency ?? "PLN"}
+                            </td>
+                            <td className="p-3 text-sm">
+                              <div
+                                className="max-w-[260px] truncate"
+                                title={getPaymentForLabel(payment)}
+                              >
+                                {getPaymentForLabel(payment)}
+                              </div>
                             </td>
                             <td className="p-3">
                               <Badge variant="outline">
@@ -819,11 +865,6 @@ function PatientDetail() {
                                   `gabinet.payments.status.${payment.status}`,
                                 )}
                               </Badge>
-                            </td>
-                            <td className="p-3 text-xs text-muted-foreground">
-                              {payment.appointmentId
-                                ? t("gabinet.payments.linkedToAppointment")
-                                : null}
                             </td>
                           </tr>
                         ))}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1129.

Closes #1129

---

## Claude summary

Committed. Summary of changes:

Added a "For" / "Za co" column to the payment history table on `/dashboard/gabinet/patients/:id` (Payments tab). The column resolves the payment's purpose in this order: linked appointment's treatment name → linked package name → free-text notes → `—`. Removed the redundant "Linked to appointment" indicator column since the new column already names the target.

Files touched:
- `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx` — added two hook calls (`useSupabaseGabinetPackageUsageByPatient`, `useSupabaseGabinetTreatmentPackagesList`), a `getPaymentForLabel` resolver, and the new column.
- `public/locales/{pl,en}/translation.json` — added `gabinet.payments.for` ("Za co" / "For").

Note: I couldn't run typecheck — this fresh worktree has no `node_modules` and `npm install` requires network access I don't have. The changes follow existing patterns in the file (same hook style, same Tailwind classes, same column markup), so risk is low, but a typecheck/dev-server smoke test is worth running before merge.