### PR TITLE
ukryj to pole

### DIFF
--- a/src/components/forms/patient-form.tsx
+++ b/src/components/forms/patient-form.tsx
@@ -91,7 +91,7 @@ export function PatientForm({
   const [city, setCity] = useState(initialData?.address?.city ?? "");
   const [postalCode, setPostalCode] = useState(initialData?.address?.postalCode ?? "");
   const [medicalNotes, setMedicalNotes] = useState(initialData?.medicalNotes ?? "");
-  const [allergies, setAllergies] = useState(initialData?.allergies ?? "");
+  const allergies = initialData?.allergies ?? "";
   const [bloodType, setBloodType] = useState(initialData?.bloodType ?? "");
   const [emergencyContactName, setEmergencyContactName] = useState(initialData?.emergencyContactName ?? "");
   const [emergencyContactPhone, setEmergencyContactPhone] = useState(initialData?.emergencyContactPhone ?? "");
@@ -373,13 +373,6 @@ export function PatientForm({
               </Button>
             </div>
           )}
-        </div>
-        <div className="space-y-1.5">
-          <Label>{t("gabinet.patients.allergies")}</Label>
-          <Input
-            value={allergies}
-            onChange={(e) => setAllergies(e.target.value)}
-          />
         </div>
         <div className="space-y-1.5 sm:col-span-2">
           <Label>{t("gabinet.patients.medicalNotes")}</Label>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1130.

Closes #1130

---

## Claude summary

The commit succeeded (the cwd-write hook failure is unrelated). Done.

Removed the Alergie input from `src/components/forms/patient-form.tsx` (used by both create and edit flows for gabinet patients). Existing `allergies` data from `initialData` is still forwarded on submit, so saving the form doesn't wipe previously-stored values — the field is just no longer shown or editable. Committed as `77d1036`.

Note: the field still appears in the patient detail sidebar (`_layout.gabinet.patients.$patientId.tsx`) when a patient has a non-empty allergies value carried over from before, and is still selectable as a column in the patients list. The user only circled the edit-form input, so I left those alone — if they want it removed everywhere, that's a follow-up.