### PR TITLE
Audit Convex DB writes for orphan `oauthConnections`/`emailAccounts` rows

### DIFF
--- a/convex/emailAccounts.ts
+++ b/convex/emailAccounts.ts
@@ -4,8 +4,18 @@ import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
 import { verifyOrgAccess } from "./_helpers/auth";
 
-// Dual-write refs removed — Supabase is now primary for email account writes
+// Source of truth: Supabase `email_accounts`. The Convex `emailAccounts`
+// table is the pre-migration schema and is no longer being written to —
+// `upsert`/`remove` below go straight to Supabase, and the frontend reads
+// via `useSupabaseEmailAccounts` (see src/hooks/use-supabase-email-config.ts).
+// The `oauthConnections` table, by contrast, is still Convex-owned (sensitive
+// tokens stay in Convex), which is why convex/documents/signing.ts reads the
+// default sender from Supabase but the Gmail access token from Convex.
 
+// NOTE: `list` below is the legacy public query and reads the orphan Convex
+// table. It currently has no callers in this repo (the frontend uses
+// `useSupabaseEmailAccounts`), but until it can be safely removed it will
+// return stale/empty data in production. Do not introduce new callers.
 export const list = query({
   args: {
     organizationId: v.id("organizations"),

--- a/convex/oauthConnections.ts
+++ b/convex/oauthConnections.ts
@@ -4,6 +4,16 @@ import { v } from "convex/values";
 import { Doc } from "./_generated/dataModel";
 import { verifyOrgAccess, requireOrgAdmin } from "./_helpers/auth";
 
+// Source of truth: Convex `oauthConnections`. Unlike most CRM tables, this
+// one was intentionally NOT migrated to Supabase — refresh/access tokens are
+// sensitive and the OAuth callback (convex/google/oauth.ts) writes them
+// straight into Convex via `createOrUpdate` below. `getValidAccessToken` in
+// convex/google/_helpers.ts reads from the same Convex row, so the
+// Gmail-OAuth signing branch in convex/documents/signing.ts reliably finds
+// a token even though the surrounding `emailAccounts` reads were migrated
+// to Supabase. Both fields hold the same Convex `Id<"organizations">`
+// string, so the cross-DB id lookup matches.
+
 /** Strip sensitive tokens from an OAuth connection before returning to the client. */
 function stripTokens(c: Doc<"oauthConnections">) {
   return {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1132.

Closes #1132

---

## Claude summary

Audit complete.

The signing branch in `convex/documents/signing.ts` reliably finds a Gmail token because the two halves of its lookup correctly target their respective sources of truth:

`oauthConnections` stayed in Convex on purpose. The OAuth callback at `convex/google/oauth.ts:110` writes via `createOrUpdate` into `ctx.db.insert("oauthConnections", …)` (`convex/oauthConnections.ts:210`), and `getValidAccessToken` reads from the same Convex row via the internal `getActiveGoogle` query (`convex/google/_helpers.ts:14`, `convex/oauthConnections.ts:149`). There is no Supabase mirror for this table — I grepped `convex/supabase/` and the rest of the repo for any `oauth_connections` / `oauthConnections` write outside `convex/oauthConnections.ts` and found nothing.

`emailAccounts` moved to Supabase: `upsert` and `remove` in `convex/emailAccounts.ts` go straight through `createSupabaseDb`, and `signing.ts:112` already reads the default sender from Supabase. Both sides key off the Convex `Id<"organizations">` string (organizations are still a Convex auth table — see `convex/organizations.ts:11` and the `_createOrgInternal` insert at line 68), and `documents/documents.ts:213` stores `formDocuments.organizationId` as `String(args.organizationId)`. So when signing.ts does `getValidAccessToken(ctx, data.organizationId as Id<"organizations">)`, the value is the same Convex ID stored in `oauthConnections.organizationId` and the index lookup matches.

I committed header comments on `convex/oauthConnections.ts` and `convex/emailAccounts.ts` documenting this split so the next person auditing the migration doesn't have to re-derive it.

While doing the audit I did find genuine orphan reads in other code paths (Convex `emailAccounts` is queried but writes only go to Supabase). They are outside the scope of this issue but worth tracking:

## Follow-ups
- Route `findEmailAccountByAddress` through Supabase: `convex/emails_internal.ts:17` does `ctx.db.query("emailAccounts").collect()` to match the Resend inbound webhook (`convex/http.ts:398`) to an org. Writes go to Supabase, so in production this returns empty and every inbound email gets dropped with "No matching account".
- Route automation emailAccounts reads through Supabase: `convex/automation.ts:445`, `:1263`, `:1286` query Convex `emailAccounts` to find the default sender / advertise the `send_email` action capability. With the dual-write removed, automation rules in production will see "No default email account configured" or report no email capability. Note `insertAutomationEmail` runs in `MutationCtx` and would need to be split into an action like the existing `_sendAutomationEmail`.
- Delete or fix orphan `api.emailAccounts.list`: `convex/emailAccounts.ts:19` is a public query against the stale Convex table with no callers in this repo (frontend uses `useSupabaseEmailAccounts`). Safe to remove now, or convert to an action that reads Supabase.