### PR TITLE
Add convex typecheck to CI

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,31 @@
+name: Convex Typecheck
+
+# Catches type errors in convex/ on every PR so they cannot silently freeze
+# production deploys for ~24h (see #1015 → #1119). Runs the same tsconfig
+# Convex itself uses to typecheck function code at deploy time.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  convex-typecheck:
+    name: tsc -p convex/tsconfig.json
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Typecheck convex/
+        run: npx tsc -p convex/tsconfig.json


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1136.

Closes #1136

---

## Claude summary

Added `.github/workflows/typecheck.yml` — a dedicated CI job that runs `tsc -p convex/tsconfig.json` on every PR and push to main. Verified locally that the convex tsconfig passes cleanly today, so the job will be green on first run.

Why a dedicated job (vs. relying on the existing typecheck step in `e2e.yml:54-55`): the e2e job requires secrets, installs Playwright + a browser, and bundles many concerns — when convex typecheck fails there, it's slower and the failure attribution is muddier. An isolated job gives fast, clear feedback that maps directly to "did I break convex types?".

Why just the convex tsconfig (vs. `npm run typecheck`): the issue offered both options and preferred the narrower one. `npm run typecheck` would also include `tsconfig.app.json`, which currently has 8 pre-existing errors on main (5 unused-import errors in `src/routes/_app/_auth/dashboard/_layout.settings.team.tsx`, 2 errors in convex files surfaced by app-level `noUnusedParameters`, and 1 `TS2589` in `src/routes/sign.form.$token.tsx`). Adding a job that's red on day one would defeat the purpose.

## Follow-ups
- Fix pre-existing tsconfig.app.json type errors: 8 errors on main today (`src/routes/_app/_auth/dashboard/_layout.settings.team.tsx` has 5 unused-import errors; `src/routes/sign.form.$token.tsx:41` has TS2589; `convex/documents/documents.ts:47` has TS2589; `convex/gabinet/appointments.ts:2120` has unused `ctx` param). These block adding a full `npm run typecheck` CI job.
- Deduplicate Unit Tests workflows: `.github/workflows/unit.yml` and `.github/workflows/unit-tests.yml` both define a job named "Unit Tests" running `npm run test:unit`; one should be removed.