### PR TITLE
Investigate Netlify deploy-failure alerting

### DIFF
--- a/DEPLOYMENT-CHECKLIST.md
+++ b/DEPLOYMENT-CHECKLIST.md
@@ -173,6 +173,50 @@ npm run migrations:apply
 - [ ] Monitor performance (Lighthouse, WebPageTest)
 - [ ] Check analytics (Google Analytics, Plausible, etc.)
 
+### 5. Deploy-Failure Alerting (Netlify)
+
+Background: After commit `10773a1` (#1015), `npx convex deploy` inside the
+Netlify build started failing on a Convex TypeScript error. Every subsequent
+push to `main` produced a failed Netlify build for ~24h, but no one noticed
+until a user reported a missing Convex function (#1119). The frontend stayed
+on the last successful deploy; any backend functions added after `10773a1`
+were silently absent from production. Root cause was a type error (fixed in
+#1135) and missing convex typecheck in CI (tracked in #1136). This section
+addresses the third gap: nobody was watching Netlify build status.
+
+Verification checklist (one-time, then re-verify after any Netlify org / member
+change):
+
+- [ ] Open Netlify → Site settings → Build & deploy → Deploy notifications.
+- [ ] Confirm at least one notification exists for "Deploy failed" pointing at
+      a channel that is actively monitored by a human. Acceptable channels:
+      - Email to a real maintainer (NOT a shared inbox no one reads)
+      - Slack incoming webhook posted into a channel the team watches
+      - GitHub commit status (so failed deploys mark the commit red on the PR
+        / `main` history)
+      - Outgoing webhook into an existing alerting pipeline
+- [ ] Confirm at least one notification exists for "Deploy succeeded" OR rely
+      on the GitHub commit status above, so the absence of a green check on a
+      recent merge to `main` is itself a signal something is wrong.
+- [ ] Trigger a deliberately-failing deploy on a throwaway branch (e.g. push
+      a commit that introduces a TypeScript error in `convex/`) and confirm
+      the notification actually reaches the channel. Then revert.
+- [ ] Document the chosen channel(s) here in this file so the next person
+      to onboard knows where to look:
+      - Channel(s) in use: _TBD — fill in when configured_
+      - Owner / on-call: _TBD_
+
+In-repo safety nets (already in place or planned):
+
+- `.github/workflows/supabase-migrations.yml` POSTs to a Netlify build hook
+  after migrations succeed, but does NOT poll the resulting Netlify deploy
+  status. A failed build there will not surface as a failed GitHub Actions
+  run. The Netlify dashboard / notification config is currently the only
+  signal — see #1137.
+- Convex backend typecheck in CI (#1136) catches the most common class of
+  Netlify build failures (Convex push aborting on type errors) BEFORE the
+  push to `main` ever reaches Netlify.
+
 ---
 
 ## Environment Variables Required


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1137.

Closes #1137

---

## Claude summary

Triage outcome and what I did

This issue asks the maintainer to verify Netlify dashboard-level notification configuration — something I genuinely can't do from inside the repo (no Netlify API token, no dashboard access). So I treated the in-repo half of the work as "make the gap impossible to lose track of again" rather than guessing at what's configured.

Investigation findings: `netlify.toml` only has redirects + the production build command (`npm run migrations:apply && npx convex deploy --cmd 'npm run build'`). `.github/workflows/supabase-migrations.yml` POSTs to the Netlify build hook but doesn't poll the resulting deploy status, so a failed Netlify build does NOT surface as a red GitHub Actions run. There is zero in-repo notification wiring anywhere — confirming the issue's premise that the only signal for a failed deploy is whatever Netlify is configured to send from its dashboard.

Change committed (commit `776203a`): added a "Deploy-Failure Alerting (Netlify)" section to `DEPLOYMENT-CHECKLIST.md` with the incident context (commit `10773a1` → 24h of silent failures → user-reported in #1119 → fixed in #1135, partial fix in #1136), a concrete verification checklist for the Netlify dashboard, an explicit "channel(s) in use / owner" line the maintainer can fill in, and a callout that `supabase-migrations.yml` only triggers but does not poll the deploy result.

What the maintainer still needs to do (the part I can't): walk through the checklist on the Netlify dashboard, pick a monitored channel, do the deliberate-failure test, and fill in the `Channel(s) in use` line.

## Follow-ups
- Poll Netlify deploy status after build-hook trigger: extend `.github/workflows/supabase-migrations.yml` deploy job to poll the Netlify API (`/api/v1/sites/:site_id/deploys`) after POSTing the hook, fail the workflow if the resulting deploy state is `error`, so a broken Netlify build also turns the GitHub Actions run red instead of relying solely on Netlify-side notifications. Needs `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` secrets.
- Scheduled Netlify deploy health check: optional cron-triggered GH Action that queries the latest deploy on `main` once an hour and opens an issue if its state is `error` and the commit is newer than X hours; redundant with notifications but agent-friendly since it surfaces in GitHub.