### PR TITLE
kwoty

### DIFF
--- a/src/lib/format-currency.ts
+++ b/src/lib/format-currency.ts
@@ -1,0 +1,14 @@
+/**
+ * Format a monetary amount for display using Polish locale (non-breaking space
+ * as thousands separator, comma as decimal separator), followed by the currency
+ * code. Example: 10000 → "10 000,00 PLN".
+ *
+ * Issue #1139 — amounts must be readable with thousand separators.
+ */
+export function formatCurrencyPLN(amount: number, currency = "PLN"): string {
+  const formatted = new Intl.NumberFormat("pl-PL", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+  return `${formatted} ${currency}`;
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -54,6 +54,7 @@ import { plateJsonToText } from "@/components/gabinet/rich-text-editor";
 import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
 import { displayReferralSource } from "@/lib/options";
 import { formatPhoneNumber } from "@/lib/phone";
+import { formatCurrencyPLN } from "@/lib/format-currency";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/patients/$patientId",
@@ -264,11 +265,11 @@ function PatientDetail() {
               {t("gabinet.payments.totalSpent")}
             </span>
             <span className="text-xs font-semibold tabular-nums">
-              {(patientPayments ?? [])
-                .filter((p) => p.status === "completed")
-                .reduce((sum, p) => sum + (p.amount ?? 0), 0)
-                .toFixed(2)}{" "}
-              PLN
+              {formatCurrencyPLN(
+                (patientPayments ?? [])
+                  .filter((p) => p.status === "completed")
+                  .reduce((sum, p) => sum + (p.amount ?? 0), 0),
+              )}
             </span>
           </div>
         </div>
@@ -721,7 +722,7 @@ function PatientDetail() {
                         {t("gabinet.payments.totalSpent")}
                       </p>
                       <p className="text-2xl font-bold">
-                        {totalSpent.toFixed(2)} PLN
+                        {formatCurrencyPLN(totalSpent)}
                       </p>
                     </div>
                   </div>
@@ -739,7 +740,7 @@ function PatientDetail() {
                         {t("gabinet.payments.outstanding")}
                       </p>
                       <p className="text-2xl font-bold">
-                        {outstanding.toFixed(2)} PLN
+                        {formatCurrencyPLN(outstanding)}
                       </p>
                     </div>
                   </div>
@@ -828,8 +829,10 @@ function PatientDetail() {
                             }}
                           >
                             <td className="p-3 font-medium">
-                              {payment.amount.toFixed(2)}{" "}
-                              {payment.currency ?? "PLN"}
+                              {formatCurrencyPLN(
+                                payment.amount,
+                                payment.currency ?? "PLN",
+                              )}
                             </td>
                             <td className="p-3 text-sm">
                               <div


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1139.

Closes #1139

---

## Claude summary

Committed. Summary:

- Added a tiny shared utility `src/lib/format-currency.ts` exposing `formatCurrencyPLN(amount, currency = "PLN")` that formats numbers via `Intl.NumberFormat("pl-PL", { minimumFractionDigits: 2, maximumFractionDigits: 2 })`, so `10000` renders as `10 000,00 PLN`.
- Replaced four `.toFixed(2)} PLN` call sites on the patient detail page (`src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx`): the sidebar “total spent” stat, and the Payments-tab "total spent", "outstanding", and per-row amount cells.

## Follow-ups
- Apply formatCurrencyPLN across remaining gabinet amount displays: same `.toFixed(2)} PLN` pattern still in `src/components/gabinet/calendar/appointment-preview-content.tsx` (lines 580, 1200, 1208, 1216), `src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx` (lines 577, 1336, 1663, 1731, 1739, 1751, 1766), `src/components/gabinet/package-purchase-drawer.tsx` (lines 409, 494), and `src/components/gabinet/treatment-purchase-drawer.tsx` (line 283).
- Consolidate inline formatCurrency helpers: `src/components/dashboard/kpi-cards.tsx` and `src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx` both define their own `formatCurrency` — replace with shared utility for consistency.