### PR TITLE
Route remaining ctx.db.get calls in convex/crm/documentDataSources.ts through Su

### DIFF
--- a/convex/crm/documentDataSources.ts
+++ b/convex/crm/documentDataSources.ts
@@ -1,4 +1,5 @@
 import type { DataSourceDefinition } from "../documentDataSources";
+import { createSupabaseDb } from "../_helpers/supabaseDb";
 
 const contactSource: DataSourceDefinition = {
   key: "contact",
@@ -12,9 +13,15 @@ const contactSource: DataSourceDefinition = {
     { key: "phone", label: "Telefon", type: "phone" },
     { key: "title", label: "Stanowisko", type: "text" },
   ],
-  resolve: async (ctx, contactId): Promise<Record<string, string>> => {
+  resolve: async (_ctx, contactId): Promise<Record<string, string>> => {
     if (!contactId) return {};
-    const contact = await ctx.db.get(contactId as any) as any;
+    // contacts live in Supabase as UUIDs — ctx.db.get fails with
+    // "Unable to decode ID". Read from Supabase instead; same fix pattern
+    // as #1125.
+    const contact = (await createSupabaseDb().get(
+      "contacts",
+      String(contactId),
+    )) as any;
     if (!contact) return {};
     return {
       firstName: contact.firstName ?? "",
@@ -39,9 +46,15 @@ const companySource: DataSourceDefinition = {
     { key: "website", label: "Strona www", type: "text" },
     { key: "address", label: "Adres", type: "text" },
   ],
-  resolve: async (ctx, companyId): Promise<Record<string, string>> => {
+  resolve: async (_ctx, companyId): Promise<Record<string, string>> => {
     if (!companyId) return {};
-    const company = await ctx.db.get(companyId as any) as any;
+    // companies live in Supabase as UUIDs — ctx.db.get fails with
+    // "Unable to decode ID". Read from Supabase instead; same fix pattern
+    // as #1125.
+    const company = (await createSupabaseDb().get(
+      "companies",
+      String(companyId),
+    )) as any;
     if (!company) return {};
     return {
       name: company.name ?? "",
@@ -67,9 +80,15 @@ const leadSource: DataSourceDefinition = {
     { key: "source", label: "Źródło", type: "text" },
     { key: "expectedCloseDate", label: "Oczekiwana data zamknięcia", type: "date" },
   ],
-  resolve: async (ctx, leadId): Promise<Record<string, string>> => {
+  resolve: async (_ctx, leadId): Promise<Record<string, string>> => {
     if (!leadId) return {};
-    const lead = await ctx.db.get(leadId as any) as any;
+    // leads live in Supabase as UUIDs — ctx.db.get fails with
+    // "Unable to decode ID". Read from Supabase instead; same fix pattern
+    // as #1125.
+    const lead = (await createSupabaseDb().get(
+      "leads",
+      String(leadId),
+    )) as any;
     if (!lead) return {};
     return {
       title: lead.title ?? "",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1143.

Closes #1143

---

## Claude summary

Triage confirmed the bug: `convex/crm/documentDataSources.ts:17,44,72` call `ctx.db.get` on contact/company/lead IDs that now live in Supabase as UUIDs, mirroring the #1125 anti-pattern. Convex `ctx.db.get` would throw "Unable to decode ID" and document template field bindings against the `contact`/`company`/`lead` CRM sources would fail in `resolveSourceValues`.

Fix: switched each resolver to `createSupabaseDb().get("<table>", String(id))`, matching the pattern from #1125 (`convex/gabinet/documentDataSources.ts`). `mapRowFromSnake` preserves the field names the resolvers read (`firstName`, `lastName`, `email`, etc., plus the JSONB `address` object on companies). Renamed the unused `ctx` param to `_ctx`. Convex typecheck passes clean. Committed as `77012ae`.