### PR TITLE
Route `listAll` in convex/documents/documents.ts through Supabase

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -11,29 +11,25 @@ import { Id } from "../_generated/dataModel";
 
 // Dual-write refs removed — Supabase is now primary for document writes
 
-export const listAll = query({
+export const listAll = action({
   args: {
     organizationId: v.id("organizations"),
     status: v.optional(formDocumentStatusValidator),
   },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    if (args.status) {
-      return await ctx.db
-        .query("formDocuments")
-        .withIndex("by_orgAndStatus", (q) =>
-          q
-            .eq("organizationId", args.organizationId)
-            .eq("status", args.status!),
-        )
-        .order("desc")
-        .collect();
-    }
-    return await ctx.db
+  handler: async (ctx, args): Promise<FormDocumentRow[]> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const db = createSupabaseDb();
+    let q = db
       .query("formDocuments")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .order("desc")
-      .collect();
+      .eq("organizationId", String(args.organizationId));
+    if (args.status) {
+      q = q.eq("status", args.status);
+    }
+    return (await q
+      .order("createdAt", false)
+      .collect()) as FormDocumentRow[];
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1146.

Closes #1146

---

## Claude summary

Converted `listAll` from a Convex query to an action that reads `formDocuments` via Supabase, matching the pattern used elsewhere in the file (`listByEntity`, `getById`). No frontend or convex callers exist for this function, so the query→action signature change is safe. Typecheck passes; the only TS errors are pre-existing on main.

## Follow-ups
- Route `listByTemplate` in convex/documents/documents.ts through Supabase: still reads `formDocuments` via ctx.db at L167 with the same Supabase-primary inconsistency as listAll
- Route `listByStatus` in convex/documents/documents.ts through Supabase: still reads `formDocuments` via ctx.db at L181 with the same Supabase-primary inconsistency as listAll