### PR TITLE
Route `listByTemplate` in convex/documents/documents.ts through Supabase

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -153,17 +153,21 @@ export const getBySigningToken = action({
   },
 });
 
-export const listByTemplate = query({
+export const listByTemplate = action({
   args: {
     organizationId: v.id("organizations"),
     templateId: v.id("formTemplates"),
   },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    return await ctx.db
+  handler: async (ctx, args): Promise<FormDocumentRow[]> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const db = createSupabaseDb();
+    return (await db
       .query("formDocuments")
-      .withIndex("by_template", (q) => q.eq("templateId", args.templateId))
-      .collect();
+      .eq("organizationId", String(args.organizationId))
+      .eq("templateId", String(args.templateId))
+      .collect()) as FormDocumentRow[];
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1147.

Closes #1147

---

## Claude summary

Converted `listByTemplate` in `convex/documents/documents.ts:156` from a Convex `query` reading stale `ctx.db.formDocuments` rows to an `action` that reads from Supabase. Same pattern as `listAll` (PR #1146): uses `internal._helpers.authAction.verifyOrgAccess` and `createSupabaseDb()`, scoped by `organizationId` + `templateId`. No callers needed updating (grep found no references). Typecheck passes. Committed as `f5380fd`.

## Follow-ups
- Route listByStatus through Supabase in convex/documents/documents.ts: same stale ctx.db read on formDocuments at L174 — only remaining query() in this file