### PR TITLE
Route `listByStatus` in convex/documents/documents.ts through Supabase

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -1,8 +1,7 @@
-import { query, action } from "../_generated/server";
+import { action } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { v } from "convex/values";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
-import { verifyOrgAccess } from "../_helpers/auth";
 import { validatePortalSessionSupabase } from "../_helpers/portalSession";
 import { formDocumentStatusValidator } from "../schema/documents";
 import { resolveComponentsInContent } from "./resolveComponents";
@@ -171,19 +170,21 @@ export const listByTemplate = action({
   },
 });
 
-export const listByStatus = query({
+export const listByStatus = action({
   args: {
     organizationId: v.id("organizations"),
     status: formDocumentStatusValidator,
   },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    return await ctx.db
+  handler: async (ctx, args): Promise<FormDocumentRow[]> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const db = createSupabaseDb();
+    return (await db
       .query("formDocuments")
-      .withIndex("by_orgAndStatus", (q) =>
-        q.eq("organizationId", args.organizationId).eq("status", args.status),
-      )
-      .collect();
+      .eq("organizationId", String(args.organizationId))
+      .eq("status", args.status)
+      .collect()) as FormDocumentRow[];
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1148.

Closes #1148

---

## Claude summary

Done. Converted `listByStatus` in `convex/documents/documents.ts:174` from a Convex `query` to an `action` that reads from Supabase via `createSupabaseDb()`, matching the pattern of sibling functions `listAll`, `listByEntity`, `listByTemplate`, and `getById`. Removed now-unused `query` and `verifyOrgAccess` imports.

Verified with `npm run typecheck:portable`: the change introduces no new errors (the remaining errors — TS2589 on `listAll`, plus unused-import warnings in unrelated files — are pre-existing on main). The function had no callers in the codebase, so no client-side updates were needed.