### PR TITLE
Route `findEmailAccountByAddress` through Supabase

### DIFF
--- a/convex/emails_internal.ts
+++ b/convex/emails_internal.ts
@@ -1,22 +1,34 @@
-import { internalQuery, internalMutation } from "./_generated/server";
+import { internalQuery, internalMutation, internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { publishActivityEnvelope } from "./_helpers/activityEnvelope";
 import { internal } from "./_generated/api";
+import { createSupabaseDb } from "./_helpers/supabaseDb";
+import type { SupabaseRow } from "./_helpers/supabaseRows";
 
 // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
 const writeEmailRef = internal.supabase.emails.writeEmailToSupabase;
 
-export const findEmailAccountByAddress = internalQuery({
+type EmailAccountRow = SupabaseRow<"emailAccounts">;
+
+// Source of truth: Supabase `email_accounts`. The Convex `emailAccounts`
+// table is no longer being written to (see convex/emailAccounts.ts header),
+// so reading via `ctx.db` returns empty in production and every inbound
+// Resend webhook gets dropped with "No matching account". Read from
+// Supabase via an action instead.
+export const findEmailAccountByAddress = internalAction({
   args: { addresses: v.array(v.string()) },
-  handler: async (ctx, args) => {
-    // Check each address against all email accounts
+  handler: async (_ctx, args): Promise<EmailAccountRow | null> => {
+    const db = createSupabaseDb();
+    // No `fromEmail` index in Supabase either, so scan all accounts once
+    // and match in memory. Pulled out of the address loop since each
+    // iteration would otherwise re-fetch the same set.
+    const allAccounts = (await db
+      .query("emailAccounts")
+      .collect()) as EmailAccountRow[];
     for (const address of args.addresses) {
       const normalizedAddress = address.toLowerCase().trim();
-      // We need to scan email accounts - no index on fromEmail, so scan by org is not possible
-      // Instead, collect all and match
-      const allAccounts = await ctx.db.query("emailAccounts").collect();
       const match = allAccounts.find(
-        (a) => a.fromEmail.toLowerCase() === normalizedAddress
+        (a) => a.fromEmail.toLowerCase() === normalizedAddress,
       );
       if (match) return match;
     }

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -394,8 +394,9 @@ http.route({
         ? from.match(/<(.+)>/)?.[1] ?? from
         : from;
 
-      // Match to address to an email account to find the org
-      const emailAccount = await ctx.runQuery(
+      // Match to address to an email account to find the org.
+      // emailAccounts is Supabase-primary, so this runs as an action.
+      const emailAccount = await ctx.runAction(
         internal.emails_internal.findEmailAccountByAddress,
         { addresses: toAddresses }
       );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1154.

Closes #1154

---

## Claude summary

Done. Committed as `1d9c04f`.

Summary: Converted `findEmailAccountByAddress` from a Convex `internalQuery` to an `internalAction` that reads `emailAccounts` from Supabase via `createSupabaseDb()`. Updated the Resend inbound webhook in `convex/http.ts` to call it via `ctx.runAction`. Also moved the `collect()` outside the address loop now that each call is a network round-trip. Verified with `tsc -p convex/tsconfig.json` and the existing `emailActivities` vitest suite — both clean.

The fix matches the pattern established by the recent `listAll`/`listByTemplate`/`listByStatus`/`findSignableDocument` Supabase routing fixes (#1146–#1149, #1174).