### PR TITLE
Fix pre-existing tsconfig.app.json type errors

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2117,7 +2117,7 @@ async function resolveAutoPackageUsageSupabase(
  * treatment price and deduct from linked package if applicable.
  */
 async function handleAppointmentCompletion(
-  ctx: any,
+  _ctx: any,
   args: {
     organizationId: Id<"organizations">;
     appointmentId: Id<"gabinetAppointments">;

--- a/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
@@ -16,8 +16,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   UserInvitationForm,
   type UserInvitationFormData,
@@ -27,7 +25,6 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -92,8 +89,6 @@ function TeamSettings() {
   const createInvitation = useAction(api.invitations.create);
 
   const [inviteOpen, setInviteOpen] = useState(false);
-  const [inviteEmail, setInviteEmail] = useState("");
-  const [inviteRole, setInviteRole] = useState<string>("member");
   const [isSending, setIsSending] = useState(false);
   const [resendingId, setResendingId] = useState<Id<"invitations"> | null>(null);
   const [cancellingId, setCancellingId] = useState<Id<"invitations"> | null>(null);
@@ -189,8 +184,6 @@ function TeamSettings() {
         module: data.module,
         moduleData: data.moduleData,
       });
-      setInviteEmail("");
-      setInviteRole("member");
       setInviteOpen(false);
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(organizationId) });
       setInvitationSentPopup(t("team.invitationSent"));


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1158.

Closes #1158

---

## Claude summary

Fixed and committed. Summary:

- `src/routes/_app/_auth/dashboard/_layout.settings.team.tsx`: dropped 3 unused imports (`Input`, `Label`, `DialogFooter`) and 2 unused state vars (`inviteEmail`, `inviteRole`) — those were leftovers from before `UserInvitationForm` took over the invite UI.
- `convex/gabinet/appointments.ts:2120`: renamed unused `ctx` to `_ctx`. The function now routes everything through `createSupabaseDb()`, so `ctx` is genuinely unused. Matches the existing `_ctx` convention used elsewhere in `convex/`.

The two TS2589 errors the issue mentioned (`src/routes/sign.form.$token.tsx:41` and `convex/documents/documents.ts:47`) no longer exist on main — `tsc` reported only 6 errors, not 8. `npm run typecheck` now passes for all three configs (`tsconfig.app.json`, `tsconfig.node.json`, `convex/tsconfig.json`), so the CI typecheck job from #1136 is unblocked.