### PR TITLE
Scheduled Netlify deploy health check

### DIFF
--- a/.github/workflows/netlify-deploy-healthcheck.yml
+++ b/.github/workflows/netlify-deploy-healthcheck.yml
@@ -1,0 +1,102 @@
+name: Netlify Deploy Health Check
+
+# Hourly cron that queries the latest Netlify deploy on `main` and opens a
+# GitHub issue if it is in the `error` state and the commit is newer than
+# MAX_AGE_HOURS. Redundant with Netlify's own notifications, but surfacing
+# failures as GitHub issues makes them visible to the @claude worker bots and
+# anyone watching the repo, not just whoever is subscribed to Netlify emails.
+# Tracking issue: #1162. Companion to the in-workflow polling added in #1182.
+
+on:
+  schedule:
+    # Every hour at :17 — offset from :00 to avoid GitHub's scheduling crush
+    # at the top of the hour (cron jobs on the hour are routinely delayed).
+    - cron: "17 * * * *"
+  workflow_dispatch:
+    inputs:
+      max_age_hours:
+        description: "Only alert on failed deploys newer than this many hours."
+        required: false
+        default: "24"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-deploy:
+    name: Check latest Netlify deploy on main
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Query Netlify for latest main deploy
+        id: check
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          MAX_AGE_HOURS: ${{ github.event.inputs.max_age_hours || '24' }}
+        run: node scripts/netlify-deploy-healthcheck.mjs
+
+      - name: Open issue for failed deploy
+        if: steps.check.outputs.should_alert == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOY_ID: ${{ steps.check.outputs.deploy_id }}
+          COMMIT_SHA: ${{ steps.check.outputs.commit_sha }}
+          SHORT_SHA: ${{ steps.check.outputs.short_sha }}
+          CREATED_AT: ${{ steps.check.outputs.created_at }}
+          BRANCH: ${{ steps.check.outputs.branch }}
+          ADMIN_URL: ${{ steps.check.outputs.admin_url }}
+          COMMIT_URL: ${{ steps.check.outputs.commit_url }}
+          ERROR_MESSAGE: ${{ steps.check.outputs.error_message }}
+        run: |
+          set -euo pipefail
+          title="Netlify deploy failed on main (${SHORT_SHA})"
+
+          # Idempotency: a previous run of this workflow may have already
+          # opened an issue for the same SHA. Searching by SHA in the body
+          # avoids duplicates if the same broken commit keeps being the
+          # latest deploy across multiple hourly runs.
+          existing=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "in:body \"${COMMIT_SHA}\" \"netlify-deploy-healthcheck\"" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            echo "Open issue #${existing} already tracks ${SHORT_SHA} — not creating a duplicate."
+            exit 0
+          fi
+
+          body=$(cat <<EOF
+          The scheduled Netlify deploy health check found that the latest deploy on \`${BRANCH}\` is in the \`error\` state.
+
+          - Deploy: [${DEPLOY_ID}](${ADMIN_URL})
+          - Commit: [\`${SHORT_SHA}\`](${COMMIT_URL})
+          - Created at: ${CREATED_AT}
+
+          Error message from Netlify:
+
+          \`\`\`
+          ${ERROR_MESSAGE}
+          \`\`\`
+
+          ---
+
+          This issue was opened automatically by \`.github/workflows/netlify-deploy-healthcheck.yml\` (netlify-deploy-healthcheck). Close it once the deploy has been fixed or the commit has been rolled past. Tracking: #1162.
+          EOF
+          )
+
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$title" \
+            --body "$body" \
+            --label "bug"

--- a/scripts/netlify-deploy-healthcheck.mjs
+++ b/scripts/netlify-deploy-healthcheck.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// Scheduled health check for the latest Netlify deploy on `main`. Issue #1162:
+// the in-workflow polling added by #1161/#1182 catches failures of deploys
+// triggered by our push-to-main job, but it does not catch failures of deploys
+// triggered by anything else (Netlify auto-deploy on its own schedule, manual
+// "Trigger deploy" clicks in the UI, drift after a rollback). This script
+// queries the Netlify API for the most recent deploy on `main`, and if it is
+// in the `error` state and the commit is newer than MAX_AGE_HOURS, signals
+// the calling workflow to open a tracking issue.
+//
+// Inputs (env):
+//   NETLIFY_AUTH_TOKEN — Personal access token (User settings -> Applications)
+//   NETLIFY_SITE_ID    — Site API ID (Site settings -> General -> Site ID)
+//   MAX_AGE_HOURS      — Optional, default 24. Skip alerting on older failures
+//                         so that we do not spam issues for known-broken commits
+//                         that have already been triaged or rolled past.
+//   GITHUB_OUTPUT      — Set by GitHub Actions; receives structured outputs.
+//
+// Exits 0 in all non-exceptional cases. The decision to alert is communicated
+// via the `should_alert` output, not the exit code, so the workflow run stays
+// green on healthy deploys.
+
+const NETLIFY_API = "https://api.netlify.com/api/v1";
+const DEFAULT_MAX_AGE_HOURS = 24;
+const BRANCH = "main";
+
+const token = process.env.NETLIFY_AUTH_TOKEN;
+const siteId = process.env.NETLIFY_SITE_ID;
+const maxAgeHours = Number(process.env.MAX_AGE_HOURS ?? DEFAULT_MAX_AGE_HOURS);
+
+if (!token || !siteId) {
+  console.log(
+    "::warning::NETLIFY_AUTH_TOKEN and/or NETLIFY_SITE_ID secret not set — skipping deploy health check.",
+  );
+  await writeOutputs({ should_alert: "false", reason: "missing-credentials" });
+  process.exit(0);
+}
+
+if (!Number.isFinite(maxAgeHours) || maxAgeHours <= 0) {
+  console.error(`MAX_AGE_HOURS must be a positive number, got: ${process.env.MAX_AGE_HOURS}`);
+  process.exit(2);
+}
+
+async function netlifyGet(path) {
+  const res = await fetch(`${NETLIFY_API}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Netlify API ${path} -> ${res.status}: ${body}`);
+  }
+  return res.json();
+}
+
+async function writeOutputs(outputs) {
+  const path = process.env.GITHUB_OUTPUT;
+  if (!path) return;
+  const { writeFile } = await import("node:fs/promises");
+  const lines = Object.entries(outputs)
+    .map(([k, v]) => `${k}=${String(v).replace(/\r?\n/g, " ")}`)
+    .join("\n");
+  await writeFile(path, lines + "\n", { flag: "a" });
+}
+
+// `branch=main` filters server-side, but we still need `per_page` because the
+// most recent deploy on `main` is what we want — not the most recent ever.
+const deploys = await netlifyGet(
+  `/sites/${siteId}/deploys?branch=${encodeURIComponent(BRANCH)}&per_page=5`,
+);
+
+if (!Array.isArray(deploys) || deploys.length === 0) {
+  console.log(`No deploys found for branch ${BRANCH} — nothing to check.`);
+  await writeOutputs({ should_alert: "false", reason: "no-deploys" });
+  process.exit(0);
+}
+
+const latest = deploys[0];
+const ageHours = latest.created_at
+  ? (Date.now() - Date.parse(latest.created_at)) / (1000 * 60 * 60)
+  : Number.POSITIVE_INFINITY;
+
+console.log(
+  `Latest ${BRANCH} deploy: id=${latest.id} state=${latest.state} created=${latest.created_at} age=${ageHours.toFixed(2)}h commit=${latest.commit_ref ?? "?"}`,
+);
+
+if (latest.state !== "error") {
+  console.log(`Deploy state is "${latest.state}" — healthy, no alert.`);
+  await writeOutputs({ should_alert: "false", reason: `state-${latest.state}` });
+  process.exit(0);
+}
+
+if (ageHours > maxAgeHours) {
+  console.log(
+    `Deploy errored but is ${ageHours.toFixed(1)}h old (> ${maxAgeHours}h threshold) — skipping alert.`,
+  );
+  await writeOutputs({ should_alert: "false", reason: "too-old" });
+  process.exit(0);
+}
+
+const sha = latest.commit_ref ?? "unknown";
+const shortSha = sha === "unknown" ? "unknown" : sha.slice(0, 7);
+const adminUrl = latest.admin_url ?? `https://app.netlify.com/sites/${siteId}/deploys/${latest.id}`;
+const commitUrl = latest.commit_url ?? "";
+const errorMessage = latest.error_message ?? "(no error_message returned by Netlify API)";
+
+console.log(`::warning::Netlify deploy ${latest.id} on main is in error state (commit ${shortSha}).`);
+
+await writeOutputs({
+  should_alert: "true",
+  deploy_id: latest.id,
+  commit_sha: sha,
+  short_sha: shortSha,
+  created_at: latest.created_at ?? "",
+  branch: latest.branch ?? BRANCH,
+  admin_url: adminUrl,
+  commit_url: commitUrl,
+  error_message: errorMessage,
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1162.

Closes #1162

---

## Claude summary

Committed `1822d85`. Two new files:

- `scripts/netlify-deploy-healthcheck.mjs` queries the Netlify API for the most recent deploy on `main`, compares its state and age against `MAX_AGE_HOURS` (default 24), and writes structured outputs (`should_alert`, `deploy_id`, `commit_sha`, `admin_url`, etc.) to `GITHUB_OUTPUT`. Fail-open if `NETLIFY_AUTH_TOKEN`/`NETLIFY_SITE_ID` are unset, mirroring the existing `netlify-poll-deploy.mjs` posture.
- `.github/workflows/netlify-deploy-healthcheck.yml` runs hourly (`17 * * * *` — offset from `:00` to dodge GitHub's top-of-hour scheduling crush), plus `workflow_dispatch` with a `max_age_hours` input. On `should_alert == true` it deduplicates against open issues via a SHA-in-body search before creating a new issue with the `bug` label. Has `issues: write` permission.

Verified: script passes `node --check`, fails fast on `MAX_AGE_HOURS=0`, and the YAML parses cleanly with the de-indented bash inside passing `bash -n`.

The workflow degrades silently when the two Netlify secrets are not set — the same two secrets `#1182` already documents, so no new setup is required if those are already configured.