### PR TITLE
Apply formatCurrencyPLN across remaining gabinet amount displays

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -9,6 +9,7 @@ import type { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatPhoneNumber } from "@/lib/phone";
+import { formatCurrencyPLN } from "@/lib/format-currency";
 import {
   extractActionErrorMessage,
   formatAppointmentError,
@@ -577,7 +578,7 @@ export function AppointmentPreviewContent({
             }
       : null;
   const paymentBadgeTooltip = paymentBadge
-    ? `${t("gabinet.payments.totalPaid")}: ${completedPaid.toFixed(2)} PLN / ${treatmentPrice.toFixed(2)} PLN`
+    ? `${t("gabinet.payments.totalPaid")}: ${formatCurrencyPLN(completedPaid)} / ${formatCurrencyPLN(treatmentPrice)}`
     : null;
 
   const handleOpenSettleDialog = () => {
@@ -1197,7 +1198,7 @@ export function AppointmentPreviewContent({
                 {t("gabinet.payments.treatmentPrice")}
               </span>
               <span className="font-medium tabular-nums">
-                {treatmentPrice.toFixed(2)} PLN
+                {formatCurrencyPLN(treatmentPrice)}
               </span>
             </div>
             <div className="flex justify-between gap-3">
@@ -1205,7 +1206,7 @@ export function AppointmentPreviewContent({
                 {t("gabinet.payments.totalPaid")}
               </span>
               <span className="font-medium tabular-nums">
-                {totalPaid.toFixed(2)} PLN
+                {formatCurrencyPLN(totalPaid)}
               </span>
             </div>
             <div className="flex justify-between gap-3 border-t pt-1">
@@ -1213,7 +1214,7 @@ export function AppointmentPreviewContent({
                 {t("gabinet.payments.outstanding")}
               </span>
               <span className="font-semibold tabular-nums">
-                {outstanding.toFixed(2)} PLN
+                {formatCurrencyPLN(outstanding)}
               </span>
             </div>
           </div>

--- a/src/components/gabinet/package-purchase-drawer.tsx
+++ b/src/components/gabinet/package-purchase-drawer.tsx
@@ -26,6 +26,7 @@ import {
 import { Loader2 } from "@/lib/ez-icons";
 import { PlateText } from "@/components/plate-text";
 import { formatActionError } from "@/lib/format-action-error";
+import { formatCurrencyPLN } from "@/lib/format-currency";
 
 interface PackagePurchaseDrawerProps {
   patientId: string;
@@ -406,7 +407,7 @@ export function PackagePurchaseDrawer({
                   {t("gabinet.packages.installmentAmount", "Per installment")}
                 </span>
                 <span className="font-medium">
-                  {installmentAmount.toFixed(2)} {selectedPkg.currency ?? "PLN"}
+                  {formatCurrencyPLN(installmentAmount, selectedPkg.currency ?? "PLN")}
                 </span>
               </div>
               <p className="text-xs text-muted-foreground">
@@ -491,7 +492,7 @@ export function PackagePurchaseDrawer({
               >
                 <span>
                   {t("gabinet.packages.splitSum", "Sum")}: {splitTotal.toFixed(2)} /{" "}
-                  {splitExpectedTotal.toFixed(2)} {selectedPkg?.currency ?? "PLN"}
+                  {formatCurrencyPLN(splitExpectedTotal, selectedPkg?.currency ?? "PLN")}
                 </span>
                 {splitSameMethod ? (
                   <span>

--- a/src/components/gabinet/treatment-purchase-drawer.tsx
+++ b/src/components/gabinet/treatment-purchase-drawer.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/select";
 import { Loader2 } from "@/lib/ez-icons";
 import { formatActionError } from "@/lib/format-action-error";
+import { formatCurrencyPLN } from "@/lib/format-currency";
 
 interface TreatmentPurchaseDrawerProps {
   patientId: string;
@@ -280,7 +281,7 @@ export function TreatmentPurchaseDrawer({
               <SelectContent>
                 {(treatments ?? []).map((tr) => (
                   <SelectItem key={tr._id} value={tr._id}>
-                    {tr.name} — {(tr.price ?? 0).toFixed(2)} {tr.currency ?? "PLN"}
+                    {tr.name} — {formatCurrencyPLN(tr.price ?? 0, tr.currency ?? "PLN")}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -7,6 +7,7 @@ import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatPhoneNumber } from "@/lib/phone";
+import { formatCurrencyPLN } from "@/lib/format-currency";
 import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
 import { Button } from "@/components/ui/button";
 import {
@@ -574,7 +575,7 @@ function AppointmentDetail() {
       { label: t("common.time"), value: `${appt.startTime?.substring(0, 5) ?? ""} - ${appt.endTime?.substring(0, 5) ?? ""}`, fieldKey: "time" },
     ];
     if (treat?.price !== undefined) {
-      fields.push({ label: t("common.price"), value: `${treat.price.toFixed(2)} ${treat.currency ?? "PLN"}`, fieldKey: "price" });
+      fields.push({ label: t("common.price"), value: formatCurrencyPLN(treat.price, treat.currency ?? "PLN"), fieldKey: "price" });
     }
     if ((appt.status === "completed" || appt.status === "cancelled") && appt.updatedAt) {
       fields.push({
@@ -1333,7 +1334,7 @@ function AppointmentDetail() {
                                   <span className="text-sm">{tr.name}</span>
                                   <span className="text-xs text-muted-foreground">
                                     {tr.duration} min
-                                    {tr.price != null && ` · ${tr.price.toFixed(2)} ${tr.currency ?? "PLN"}`}
+                                    {tr.price != null && ` · ${formatCurrencyPLN(tr.price, tr.currency ?? "PLN")}`}
                                   </span>
                                 </div>
                               </CommandItem>
@@ -1660,7 +1661,7 @@ function AppointmentDetail() {
                     {t("gabinet.appointments.prepaymentAmount")}
                   </span>
                   <span className="font-medium">
-                    {(appointment.prepaymentAmount ?? 0).toFixed(2)} PLN
+                    {formatCurrencyPLN(appointment.prepaymentAmount ?? 0)}
                   </span>
                 </div>
                 <div className="flex items-center justify-between">
@@ -1728,7 +1729,7 @@ function AppointmentDetail() {
                     {t("gabinet.payments.treatmentPrice")}
                   </p>
                   <p className="text-2xl font-bold">
-                    {treatmentPrice.toFixed(2)} PLN
+                    {formatCurrencyPLN(treatmentPrice)}
                   </p>
                 </div>
                 <div className="text-center p-4 bg-green-50 dark:bg-green-950/20 rounded-lg">
@@ -1736,7 +1737,7 @@ function AppointmentDetail() {
                     {t("gabinet.payments.totalPaid")}
                   </p>
                   <p className="text-2xl font-bold text-green-600">
-                    {totalPaid.toFixed(2)} PLN
+                    {formatCurrencyPLN(totalPaid)}
                   </p>
                 </div>
                 <div
@@ -1748,7 +1749,7 @@ function AppointmentDetail() {
                   <p
                     className={`text-2xl font-bold ${outstanding > 0 ? "text-orange-600" : "text-green-600"}`}
                   >
-                    {outstanding.toFixed(2)} PLN
+                    {formatCurrencyPLN(outstanding)}
                   </p>
                 </div>
               </div>
@@ -1763,7 +1764,7 @@ function AppointmentDetail() {
                     </div>
                     <p className="text-sm mt-1">
                       {t("gabinet.appointments.prepaymentAmount")}:{" "}
-                      {appointment.prepaymentAmount.toFixed(2)} PLN
+                      {formatCurrencyPLN(appointment.prepaymentAmount)}
                     </p>
                   </div>
                 )}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1164.

Closes #1164

---

## Claude summary

Replaced the `.toFixed(2) PLN` pattern with `formatCurrencyPLN` at all 14 sites listed in the issue across the four files. Added the import to each file, passed dynamic currency through where the original code did (`treat.currency ?? "PLN"` etc.), and verified `npm run typecheck` passes. Committed as `7b08194`.

During the sweep I noticed several other call sites in non-listed gabinet files still use the same `.toFixed(2) {currency}` pattern (e.g. `patient-treatments-card.tsx`, `patient-packages-card.tsx`, `treatment-purchase-drawer.tsx` lines 313/327/440/534-535, and a couple of additional unlisted lines in the appointmentId.lazy.tsx file at 1361, 1837, 2239, 2283, 2686). These are out of scope for this issue but represent the same inconsistency.

## Follow-ups
- Apply formatCurrencyPLN to remaining patient-card amount displays: `src/components/gabinet/patient-treatments-card.tsx:131`, `src/components/gabinet/patient-packages-card.tsx` lines 280, 542-543, 669, 677, 685, 753 still use `.toFixed(2) {currency}`.
- Apply formatCurrencyPLN to remaining treatment-purchase-drawer amounts: lines 313, 327, 440, 534-535 of `src/components/gabinet/treatment-purchase-drawer.tsx` still use `.toFixed(2) {currency}`.
- Apply formatCurrencyPLN to remaining appointment detail amounts: lines 1361-1363, 1837, 2239, 2283, 2686 of `src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx` still use `.toFixed(2) {currency}`.
- Replace `zł` suffix with formatCurrencyPLN in package-form suggested price: `src/components/forms/package-form.tsx:167` uses `{suggestedPrice.toFixed(2)} zł`, inconsistent with the PLN-based formatting used everywhere else.