### PR TITLE
Consolidate inline formatCurrency helpers

### DIFF
--- a/src/components/dashboard/kpi-cards.tsx
+++ b/src/components/dashboard/kpi-cards.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useTranslation } from "react-i18next";
 import { useMemo } from "react";
 import { Link } from "@tanstack/react-router";
+import { formatCurrencyPLN } from "@/lib/format-currency";
 
 interface KpiCardsProps {
   totalContacts: number;
@@ -10,15 +11,6 @@ interface KpiCardsProps {
   openDeals: number;
   pipelineValue: number;
   winRate: number;
-}
-
-function formatCurrency(value: number) {
-  return new Intl.NumberFormat("pl-PL", {
-    style: "currency",
-    currency: "PLN",
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(value);
 }
 
 export function KpiCards({
@@ -53,7 +45,7 @@ export function KpiCards({
       },
       {
         title: t("dashboard.pipelineValue"),
-        value: formatCurrency(pipelineValue),
+        value: formatCurrencyPLN(pipelineValue, "PLN", { fractionDigits: 0 }),
         icon: DollarSign,
         href: "/dashboard/pipelines" as const,
       },

--- a/src/lib/format-currency.ts
+++ b/src/lib/format-currency.ts
@@ -3,12 +3,20 @@
  * as thousands separator, comma as decimal separator), followed by the currency
  * code. Example: 10000 → "10 000,00 PLN".
  *
+ * Pass `fractionDigits: 0` for rounded displays (dashboard KPIs, reports):
+ * 10000 → "10 000 PLN".
+ *
  * Issue #1139 — amounts must be readable with thousand separators.
  */
-export function formatCurrencyPLN(amount: number, currency = "PLN"): string {
+export function formatCurrencyPLN(
+  amount: number,
+  currency = "PLN",
+  options: { fractionDigits?: number } = {}
+): string {
+  const { fractionDigits = 2 } = options;
   const formatted = new Intl.NumberFormat("pl-PL", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
   }).format(amount);
   return `${formatted} ${currency}`;
 }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -6,6 +6,7 @@ import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-t
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
 import { useOrganization } from "@/components/org-context";
+import { formatCurrencyPLN } from "@/lib/format-currency";
 import { PageHeader } from "@/components/layout/page-header";
 import { SidePanel } from "@/components/crm/side-panel";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
@@ -108,14 +109,6 @@ function slugify(s: string): string {
   );
 }
 
-function formatCurrency(amount: number, currency = "PLN") {
-  return new Intl.NumberFormat("pl-PL", {
-    style: "currency",
-    currency,
-    maximumFractionDigits: 0,
-  }).format(amount);
-}
-
 function bucketizePairs(
   pairs: [string, number][],
 ): { index: number; count: number }[] {
@@ -197,7 +190,7 @@ function RevenueSummaryCard({
             {t("gabinet.reports.today")}
           </span>
           <span className="text-xl font-semibold">
-            {formatCurrency(dailyRevenue, currency)}
+            {formatCurrencyPLN(dailyRevenue, currency, { fractionDigits: 0 })}
           </span>
         </div>
         <div className="flex flex-col gap-1 border-r pr-4 last:border-r-0">
@@ -205,7 +198,7 @@ function RevenueSummaryCard({
             {t("gabinet.reports.thisWeek")}
           </span>
           <span className="text-xl font-semibold">
-            {formatCurrency(weeklyRevenue, currency)}
+            {formatCurrencyPLN(weeklyRevenue, currency, { fractionDigits: 0 })}
           </span>
         </div>
         <div className="flex flex-col gap-1">
@@ -213,7 +206,7 @@ function RevenueSummaryCard({
             {t("gabinet.reports.thisMonth")}
           </span>
           <span className="text-xl font-semibold">
-            {formatCurrency(monthlyRevenue, currency)}
+            {formatCurrencyPLN(monthlyRevenue, currency, { fractionDigits: 0 })}
           </span>
         </div>
       </CardContent>
@@ -770,7 +763,7 @@ function TopTreatmentsByRevenue({
                 <div className="flex items-center gap-2 text-muted-foreground shrink-0">
                   <span>{item.count}×</span>
                   <span className="font-semibold text-foreground">
-                    {formatCurrency(item.revenue)}
+                    {formatCurrencyPLN(item.revenue, "PLN", { fractionDigits: 0 })}
                   </span>
                 </div>
               </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1165.

Closes #1165

---

## Claude summary

Consolidated both inline `formatCurrency` helpers in `src/components/dashboard/kpi-cards.tsx` and `src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx` onto the shared `formatCurrencyPLN`. Extended the shared utility with an optional `fractionDigits` option so the rounded-display call sites keep their no-decimals look. Typecheck passes. One intentional visual change: output goes from `10 000 zł` (currency symbol) to `10 000 PLN` (currency code), matching the format adopted in #1184.

## Follow-ups
- Replace inline formatCurrency in src/components/dashboard/top-performers.tsx: same Intl.NumberFormat duplication as #1165, should use formatCurrencyPLN with fractionDigits 0