### PR TITLE
Deduplicate unit tests in e2e.yml

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: E2E Tests
 
 on:
   pull_request:
@@ -7,25 +7,6 @@ on:
     branches: [main]
 
 jobs:
-  unit-tests:
-    name: Vitest Unit Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
-
-      - name: Run unit tests
-        run: npm run test:unit
-
   e2e:
     name: Playwright E2E Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1180.

Closes #1180

---

## Claude summary

Verified the duplication: both `e2e.yml` (`unit-tests` job, "Vitest Unit Tests") and `unit.yml` (`convex-unit` job, "Convex Unit Tests") ran `npm run test:unit` on the same `pull_request`/`push` to main triggers.

Removed the `unit-tests` job from `e2e.yml` and renamed the workflow from "Tests" to "E2E Tests" so the responsibility split is unambiguous: `unit.yml` gates unit tests, `e2e.yml` gates Playwright E2E (plus the build/typecheck steps that are E2E prerequisites).