### PR TITLE
Apply formatCurrencyPLN to remaining treatment-purchase-drawer amounts

### DIFF
--- a/src/components/gabinet/treatment-purchase-drawer.tsx
+++ b/src/components/gabinet/treatment-purchase-drawer.tsx
@@ -311,7 +311,7 @@ export function TreatmentPurchaseDrawer({
                   {t("gabinet.treatments.unitPrice", "Cena za sesję")}
                 </span>
                 <span>
-                  {(selectedTreatment.price ?? 0).toFixed(2)} {currency}
+                  {formatCurrencyPLN(selectedTreatment.price ?? 0, currency)}
                 </span>
               </div>
               <div className="flex items-center justify-between text-xs">
@@ -325,7 +325,7 @@ export function TreatmentPurchaseDrawer({
                   {t("gabinet.packages.totalPrice", "Cena całkowita")}
                 </span>
                 <span className="font-bold">
-                  {totalPrice.toFixed(2)} {currency}
+                  {formatCurrencyPLN(totalPrice, currency)}
                 </span>
               </div>
             </div>
@@ -438,7 +438,7 @@ export function TreatmentPurchaseDrawer({
                   {t("gabinet.packages.installmentAmount", "Kwota raty")}
                 </span>
                 <span className="font-medium">
-                  {installmentAmount.toFixed(2)} {currency}
+                  {formatCurrencyPLN(installmentAmount, currency)}
                 </span>
               </div>
               <p className="text-xs text-muted-foreground">
@@ -533,7 +533,7 @@ export function TreatmentPurchaseDrawer({
               >
                 <span>
                   {t("gabinet.packages.splitSum", "Suma")}: {splitTotal.toFixed(2)} /{" "}
-                  {splitExpectedTotal.toFixed(2)} {currency}
+                  {formatCurrencyPLN(splitExpectedTotal, currency)}
                 </span>
                 {splitSameMethod ? (
                   <span>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1186.

Closes #1186

---

## Claude summary

Replaced four `.toFixed(2)} {currency}` patterns in `treatment-purchase-drawer.tsx` (lines 314, 328, 441, 536) with `formatCurrencyPLN(...)` calls — covering the unit-price preview, total price, installment amount, and split-payment expected total. The remaining `splitTotal.toFixed(2)` at line 535 is the left half of a "current / expected" ratio display and is intentionally left bare, matching the precedent set in #1184 for the parallel `package-purchase-drawer.tsx`. TypeScript check passes; committed as 04a0961.