### PR TITLE
Apply formatCurrencyPLN to remaining appointment detail amounts

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1359,8 +1359,7 @@ function AppointmentDetail() {
                     {t("common.price")}
                   </span>
                   <span className="font-medium">
-                    {treatment.price.toFixed(2)}{" "}
-                    {treatment.currency ?? "PLN"}
+                    {formatCurrencyPLN(treatment.price, treatment.currency ?? "PLN")}
                   </span>
                 </div>
               )}
@@ -1835,8 +1834,10 @@ function AppointmentDetail() {
                         >
                           <td className="p-3">
                             <p className="font-medium">
-                              {(payment.amount as number).toFixed(2)}{" "}
-                              {(payment.currency as string) ?? "PLN"}
+                              {formatCurrencyPLN(
+                                payment.amount as number,
+                                (payment.currency as string) ?? "PLN",
+                              )}
                             </p>
                           </td>
                           <td className="p-3">
@@ -2231,14 +2232,14 @@ function AppointmentDetail() {
                         {t("gabinet.payments.totalSpent")}
                       </p>
                       <p className="text-2xl font-bold text-green-600">
-                        {allPatientPayments
-                          .filter((p: Record<string, unknown>) => p.status === "completed")
-                          .reduce(
-                            (sum: number, p: Record<string, unknown>) => sum + (p.amount as number),
-                            0,
-                          )
-                          .toFixed(2)}{" "}
-                        PLN
+                        {formatCurrencyPLN(
+                          allPatientPayments
+                            .filter((p: Record<string, unknown>) => p.status === "completed")
+                            .reduce(
+                              (sum: number, p: Record<string, unknown>) => sum + (p.amount as number),
+                              0,
+                            ),
+                        )}
                       </p>
                     </div>
                     <div className="text-center p-4 bg-muted/50 rounded-lg">
@@ -2281,8 +2282,10 @@ function AppointmentDetail() {
                               className="border-b last:border-0 hover:bg-muted/30"
                             >
                               <td className="p-3 font-medium">
-                                {(payment.amount as number).toFixed(2)}{" "}
-                                {(payment.currency as string) ?? "PLN"}
+                                {formatCurrencyPLN(
+                                  payment.amount as number,
+                                  (payment.currency as string) ?? "PLN",
+                                )}
                               </td>
                               <td className="p-3">
                                 <Badge variant="outline">
@@ -2684,8 +2687,7 @@ function AppointmentDetail() {
               />
               {outstanding > 0 && (
                 <p className="text-xs text-muted-foreground mt-1">
-                  {t("gabinet.payments.outstanding")}: {outstanding.toFixed(2)}{" "}
-                  PLN
+                  {t("gabinet.payments.outstanding")}: {formatCurrencyPLN(outstanding)}
                 </p>
               )}
             </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1187.

Closes #1187

---

## Claude summary

Committed. Replaced the 5 remaining `.toFixed(2) {currency}` patterns in `_layout.gabinet.appointments.$appointmentId.lazy.tsx` with `formatCurrencyPLN(...)`:

- Line 1361-1363 — treatment price display
- Line 1837 — payment amount in payments table
- Line 2239 — total spent KPI (sum of completed payments)
- Line 2283 — payment amount in patient payments history table
- Line 2686 — outstanding balance in payment dialog

The `outstanding.toFixed(2)` on line 2683 was intentionally left alone — it's the placeholder of a numeric `<Input>` for editing, not a display.