### PR TITLE
Replace `zł` suffix with formatCurrencyPLN in package-form suggested price

### DIFF
--- a/src/components/forms/package-form.tsx
+++ b/src/components/forms/package-form.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Plus, Trash2 } from "@/lib/ez-icons";
+import { formatCurrencyPLN } from "@/lib/format-currency";
 
 export interface PackageFormData {
   name: string;
@@ -164,7 +165,7 @@ export function PackageForm({
           />
           {suggestedPrice > 0 && (
             <p className="text-xs text-muted-foreground">
-              {t("gabinet.packages.suggestedPrice")}: {suggestedPrice.toFixed(2)} zł
+              {t("gabinet.packages.suggestedPrice")}: {formatCurrencyPLN(suggestedPrice)}
             </p>
           )}
         </div>
@@ -243,7 +244,7 @@ export function PackageForm({
                   <SelectContent>
                     {treatments?.map((t) => (
                       <SelectItem key={t._id} value={t._id}>
-                        {t.name} ({t.duration} min · {t.price} zł)
+                        {t.name} ({t.duration} min · {formatCurrencyPLN(t.price)})
                       </SelectItem>
                     ))}
                   </SelectContent>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1188.

Closes #1188

---

## Claude summary

Replaced both `zł` suffixes in `src/components/forms/package-form.tsx` with `formatCurrencyPLN`: the suggested price hint at line 167 (per the issue) and the treatment select label at line 247 (same anti-pattern, fixed alongside per the recent "remaining amounts" cleanup pattern). Typecheck passes. Committed as `cbfca15`.