### PR TITLE
Kwota przy rozliczaniu

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -592,7 +592,7 @@ export function AppointmentPreviewContent({
 
   const handleConfirmSettle = async () => {
     if (settleSubmitting) return;
-    const parsedAmount = parseFloat(settleAmount);
+    const parsedAmount = parseFloat(settleAmount.replace(",", "."));
     const hasAmount = settleAmount.trim().length > 0 && !isNaN(parsedAmount);
     if (hasAmount && parsedAmount < 0) {
       toast.error(t("gabinet.payments.amountRequired"));
@@ -1224,11 +1224,15 @@ export function AppointmentPreviewContent({
               {t("gabinet.payments.amount")}
             </Label>
             <Input
-              type="number"
-              step="0.01"
-              min="0"
+              type="text"
+              inputMode="decimal"
               value={settleAmount}
-              onChange={(e) => setSettleAmount(e.target.value)}
+              onChange={(e) => {
+                const v = e.target.value;
+                if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                  setSettleAmount(v);
+                }
+              }}
               placeholder={outstanding > 0 ? outstanding.toFixed(2) : "0.00"}
               disabled={!patient?._id}
             />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1198.

Closes #1198

---

## Claude summary

Fixed. In `src/components/gabinet/calendar/appointment-preview-content.tsx:1226-1238`, the settlement amount input is now `type="text"` with `inputMode="decimal"` instead of `type="number" step="0.01"`. The visit amount is still pre-filled (existing behavior at line 586, `setSettleAmount(outstanding > 0 ? outstanding.toFixed(2) : "")`), but the browser spinner arrows that stepped by 1 grosz are gone. Users can freely type any amount, including with a comma separator (Polish locale), and `handleConfirmSettle` now normalizes comma → dot before `parseFloat`. Committed as `f89fcbe`.

## Follow-ups
- Apply same grosz-stepping fix to other money inputs: `_layout.gabinet.appointments.$appointmentId.lazy.tsx:2683`, `treatment-purchase-drawer.tsx:486/522`, `package-purchase-drawer.tsx:450/481`, `patient-packages-card.tsx:500/528`, `package-form.tsx:159`, `lead-products-sidebar-card.tsx:166/177`, `_layout.products.index.tsx:453`, `_layout.gabinet.treatments.$treatmentId.tsx:1319`, `treatment-form.tsx:259` all still use `step="0.01"` with native spinners