### PR TITLE
Apply same grosz-stepping fix to other money inputs

### DIFF
--- a/src/components/crm/lead-products-sidebar-card.tsx
+++ b/src/components/crm/lead-products-sidebar-card.tsx
@@ -161,22 +161,30 @@ export function LeadProductsDialogBody({
           <label className="text-sm font-medium" htmlFor="lead-product-unit-price">{unitPriceLabel}</label>
           <Input
             id="lead-product-unit-price"
-            type="number"
-            min="0"
-            step="0.01"
+            type="text"
+            inputMode="decimal"
             value={unitPrice}
-            onChange={(event) => onUnitPriceChange(event.target.value)}
+            onChange={(event) => {
+              const v = event.target.value;
+              if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                onUnitPriceChange(v);
+              }
+            }}
           />
         </div>
         <div className="space-y-2">
           <label className="text-sm font-medium" htmlFor="lead-product-discount">{discountLabel}</label>
           <Input
             id="lead-product-discount"
-            type="number"
-            min="0"
-            step="0.01"
+            type="text"
+            inputMode="decimal"
             value={discount}
-            onChange={(event) => onDiscountChange(event.target.value)}
+            onChange={(event) => {
+              const v = event.target.value;
+              if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                onDiscountChange(v);
+              }
+            }}
           />
         </div>
       </div>

--- a/src/components/forms/package-form.tsx
+++ b/src/components/forms/package-form.tsx
@@ -116,7 +116,7 @@ export function PackageForm({
     onSubmit({
       name,
       description: description || undefined,
-      totalPrice: parseFloat(totalPrice),
+      totalPrice: parseFloat(totalPrice.replace(",", ".")),
       validityDays: validityDays ? parseInt(validityDays) : undefined,
       discountPercent: discountPercent ? parseFloat(discountPercent) : undefined,
       loyaltyPointsAwarded: loyaltyPoints ? parseInt(loyaltyPoints) : undefined,
@@ -155,11 +155,15 @@ export function PackageForm({
             {t("gabinet.packages.totalPrice")} <span className="text-destructive">*</span>
           </Label>
           <Input
-            type="number"
-            step="0.01"
-            min="0"
+            type="text"
+            inputMode="decimal"
             value={totalPrice}
-            onChange={(e) => setTotalPrice(e.target.value)}
+            onChange={(e) => {
+              const v = e.target.value;
+              if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                setTotalPrice(v);
+              }
+            }}
             placeholder="0.00"
             required
           />

--- a/src/components/gabinet/package-purchase-drawer.tsx
+++ b/src/components/gabinet/package-purchase-drawer.tsx
@@ -90,8 +90,8 @@ export function PackagePurchaseDrawer({
     ? Math.round((installmentAmount + installmentRemainder) * 100) / 100
     : 0;
 
-  const parsedFirstSplit = Number.parseFloat(firstSplitAmount) || 0;
-  const parsedSecondSplit = Number.parseFloat(secondSplitAmount) || 0;
+  const parsedFirstSplit = Number.parseFloat(firstSplitAmount.replace(",", ".")) || 0;
+  const parsedSecondSplit = Number.parseFloat(secondSplitAmount.replace(",", ".")) || 0;
   const splitTotal = Math.round((parsedFirstSplit + parsedSecondSplit) * 100) / 100;
   const splitExpectedTotal = selectedPkg
     ? isInstallment
@@ -444,13 +444,16 @@ export function PackagePurchaseDrawer({
                   </Select>
                   <Input
                     id="split-first-amount"
-                    type="number"
+                    type="text"
                     inputMode="decimal"
-                    min="0"
-                    step="0.01"
                     placeholder="0.00"
                     value={firstSplitAmount}
-                    onChange={(e) => setFirstSplitAmount(e.target.value)}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                        setFirstSplitAmount(v);
+                      }
+                    }}
                   />
                 </div>
                 <div className="rounded-md border p-2 space-y-2">
@@ -475,13 +478,16 @@ export function PackagePurchaseDrawer({
                   </Select>
                   <Input
                     id="split-second-amount"
-                    type="number"
+                    type="text"
                     inputMode="decimal"
-                    min="0"
-                    step="0.01"
                     placeholder="0.00"
                     value={secondSplitAmount}
-                    onChange={(e) => setSecondSplitAmount(e.target.value)}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                        setSecondSplitAmount(v);
+                      }
+                    }}
                   />
                 </div>
               </div>

--- a/src/components/gabinet/patient-packages-card.tsx
+++ b/src/components/gabinet/patient-packages-card.tsx
@@ -354,8 +354,8 @@ function InstallmentPayButton({
     setOpen(next);
   };
 
-  const parsedFirst = Number.parseFloat(firstAmount) || 0;
-  const parsedSecond = Number.parseFloat(secondAmount) || 0;
+  const parsedFirst = Number.parseFloat(firstAmount.replace(",", ".")) || 0;
+  const parsedSecond = Number.parseFloat(secondAmount.replace(",", ".")) || 0;
   const splitTotal = Math.round((parsedFirst + parsedSecond) * 100) / 100;
   const expectedTotal = Math.round(amount * 100) / 100;
   const splitMismatch = splitPayment && splitTotal !== expectedTotal;
@@ -494,13 +494,16 @@ function InstallmentPayButton({
                   </SelectContent>
                 </Select>
                 <Input
-                  type="number"
+                  type="text"
                   inputMode="decimal"
-                  min="0"
-                  step="0.01"
                   placeholder="0.00"
                   value={firstAmount}
-                  onChange={(e) => setFirstAmount(e.target.value)}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                      setFirstAmount(v);
+                    }
+                  }}
                 />
               </div>
               <div className="space-y-1.5">
@@ -522,13 +525,16 @@ function InstallmentPayButton({
                   </SelectContent>
                 </Select>
                 <Input
-                  type="number"
+                  type="text"
                   inputMode="decimal"
-                  min="0"
-                  step="0.01"
                   placeholder="0.00"
                   value={secondAmount}
-                  onChange={(e) => setSecondAmount(e.target.value)}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                      setSecondAmount(v);
+                    }
+                  }}
                 />
               </div>
             </div>

--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -206,7 +206,7 @@ export function TreatmentForm({
       name,
       description: description || undefined,
       duration: parseInt(duration) || 30,
-      price: parseFloat(price) || 0,
+      price: parseFloat(price.replace(",", ".")) || 0,
       currency: currency || undefined,
       taxRate: numericTaxRate,
       taxExempt: isExempt ? true : false,
@@ -255,16 +255,17 @@ export function TreatmentForm({
             {t("gabinet.treatments.price")} <span className="text-destructive">*</span>
           </Label>
           <Input
-            type="number"
-            step="0.01"
-            min="0"
+            type="text"
             inputMode="decimal"
             value={price}
-            onChange={(e) => setPrice(e.target.value)}
-            onWheel={(e) => (e.currentTarget as HTMLInputElement).blur()}
+            onChange={(e) => {
+              const v = e.target.value;
+              if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                setPrice(v);
+              }
+            }}
             placeholder="0.00"
             required
-            className="[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           />
         </div>
         <div className="space-y-1.5">

--- a/src/components/gabinet/treatment-purchase-drawer.tsx
+++ b/src/components/gabinet/treatment-purchase-drawer.tsx
@@ -92,8 +92,8 @@ export function TreatmentPurchaseDrawer({
     ? Math.round((installmentAmount + installmentRemainder) * 100) / 100
     : 0;
 
-  const parsedFirstSplit = Number.parseFloat(firstSplitAmount) || 0;
-  const parsedSecondSplit = Number.parseFloat(secondSplitAmount) || 0;
+  const parsedFirstSplit = Number.parseFloat(firstSplitAmount.replace(",", ".")) || 0;
+  const parsedSecondSplit = Number.parseFloat(secondSplitAmount.replace(",", ".")) || 0;
   const splitTotal = Math.round((parsedFirstSplit + parsedSecondSplit) * 100) / 100;
   const splitExpectedTotal = selectedTreatment
     ? isInstallment
@@ -480,13 +480,16 @@ export function TreatmentPurchaseDrawer({
                     </SelectContent>
                   </Select>
                   <Input
-                    type="number"
+                    type="text"
                     inputMode="decimal"
-                    min="0"
-                    step="0.01"
                     placeholder="0.00"
                     value={firstSplitAmount}
-                    onChange={(e) => setFirstSplitAmount(e.target.value)}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                        setFirstSplitAmount(v);
+                      }
+                    }}
                   />
                 </div>
                 <div className="rounded-md border p-2 space-y-2">
@@ -516,13 +519,16 @@ export function TreatmentPurchaseDrawer({
                     </SelectContent>
                   </Select>
                   <Input
-                    type="number"
+                    type="text"
                     inputMode="decimal"
-                    min="0"
-                    step="0.01"
                     placeholder="0.00"
                     value={secondSplitAmount}
-                    onChange={(e) => setSecondSplitAmount(e.target.value)}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                        setSecondSplitAmount(v);
+                      }
+                    }}
                   />
                 </div>
               </div>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -967,7 +967,8 @@ function AppointmentDetail() {
 
   // Payment handlers
   const handleCreatePayment = async () => {
-    if (!paymentAmount || isNaN(parseFloat(paymentAmount))) {
+    const normalizedAmount = paymentAmount.replace(",", ".");
+    if (!paymentAmount || isNaN(parseFloat(normalizedAmount))) {
       toast.error(t("gabinet.payments.amountRequired"));
       return;
     }
@@ -978,7 +979,7 @@ function AppointmentDetail() {
         organizationId,
         patientId: patient!._id,
         appointmentId: appointment._id,
-        amount: parseFloat(paymentAmount),
+        amount: parseFloat(normalizedAmount),
         currency: "PLN",
         paymentMethod: paymentMethod as "cash" | "card" | "transfer" | "other",
         notes: paymentNote || undefined,
@@ -2679,10 +2680,15 @@ function AppointmentDetail() {
             <div>
               <Label>{t("gabinet.payments.amount")}</Label>
               <Input
-                type="number"
-                step="0.01"
+                type="text"
+                inputMode="decimal"
                 value={paymentAmount}
-                onChange={(e) => setPaymentAmount(e.target.value)}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                    setPaymentAmount(v);
+                  }
+                }}
                 placeholder={outstanding > 0 ? outstanding.toFixed(2) : "0.00"}
               />
               {outstanding > 0 && (

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -472,7 +472,7 @@ function TreatmentDetail() {
           variantId: editingVariant as Id<"gabinetTreatmentVariants">,
           name: variantForm.name,
           ...(variantForm.overridePrice
-            ? { price: parseFloat(variantForm.price) || 0 }
+            ? { price: parseFloat(variantForm.price.replace(",", ".")) || 0 }
             : { clearPrice: true }),
           ...(variantForm.overrideDuration
             ? { duration: parseInt(variantForm.duration) || 0 }
@@ -492,7 +492,7 @@ function TreatmentDetail() {
           treatmentId: treatmentId as Id<"gabinetTreatments">,
           name: variantForm.name,
           ...(variantForm.overridePrice
-            ? { price: parseFloat(variantForm.price) || 0 }
+            ? { price: parseFloat(variantForm.price.replace(",", ".")) || 0 }
             : {}),
           ...(variantForm.overrideDuration
             ? { duration: parseInt(variantForm.duration) || 0 }
@@ -1315,12 +1315,15 @@ function TreatmentDetail() {
               </div>
               {variantForm.overridePrice ? (
                 <Input
-                  type="number"
-                  step="0.01"
+                  type="text"
+                  inputMode="decimal"
                   value={variantForm.price}
-                  onChange={(e) =>
-                    setVariantForm((prev) => ({ ...prev, price: e.target.value }))
-                  }
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                      setVariantForm((prev) => ({ ...prev, price: v }));
+                    }
+                  }}
                 />
               ) : (
                 <p className="text-sm text-muted-foreground/60 italic">

--- a/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
@@ -769,8 +769,8 @@ function LeadDetail() {
     if (!selectedProductId) return;
 
     const quantity = Number(productQuantity);
-    const unitPrice = Number(productUnitPrice);
-    const discount = productDiscount.trim() ? Number(productDiscount) : undefined;
+    const unitPrice = Number(productUnitPrice.replace(",", "."));
+    const discount = productDiscount.trim() ? Number(productDiscount.replace(",", ".")) : undefined;
 
     if (!Number.isFinite(quantity) || quantity <= 0) return;
     if (!Number.isFinite(unitPrice) || unitPrice < 0) return;

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -228,6 +228,7 @@ function ProductsPage() {
         ? parseFloat(taxRate)
         : undefined
       : undefined;
+    const normalizedUnitPrice = unitPrice.replace(",", ".");
     try {
       if (editingProduct) {
         await updateProduct({
@@ -235,7 +236,7 @@ function ProductsPage() {
           productId: editingProduct._id,
           name: name.trim(),
           sku: sku.trim(),
-          unitPrice: parseFloat(unitPrice),
+          unitPrice: parseFloat(normalizedUnitPrice),
           taxRate: numericTaxRate,
           taxExempt: isExempt,
           description: description.trim() || undefined,
@@ -247,7 +248,7 @@ function ProductsPage() {
           organizationId,
           name: name.trim(),
           sku: sku.trim(),
-          unitPrice: parseFloat(unitPrice),
+          unitPrice: parseFloat(normalizedUnitPrice),
           taxRate: numericTaxRate,
           taxExempt: isExempt,
           isActive,
@@ -449,11 +450,15 @@ function ProductsPage() {
                 {t('products.unitPrice')} <span className="text-destructive">*</span>
               </Label>
               <Input
-                type="number"
-                step="0.01"
-                min="0"
+                type="text"
+                inputMode="decimal"
                 value={unitPrice}
-                onChange={(e) => setUnitPrice(e.target.value)}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                    setUnitPrice(v);
+                  }
+                }}
                 placeholder="0.00"
               />
             </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1201.

Closes #1201

---

## Claude summary

Applied the same fix from #1198 to all nine money inputs listed in the issue. Each input switched from `type="number" step="0.01"` (which exposed browser spinner arrows) to `type="text" inputMode="decimal"` with a regex-guarded onChange that accepts an optional `[.,]` separator. Every `parseFloat`/`Number` parse site (including the lead-products dialog consumer in `_layout.leads.$leadId.lazy.tsx`) was updated to `.replace(",", ".")` before parsing so users can type a Polish comma decimal. `npm run typecheck` passes cleanly. Committed as `dedf043`.