### PR TITLE
Dzień wolny pracownik kalendarz

### DIFF
--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -467,7 +467,10 @@ export function CalendarWeekView({ weekStart, appointments, onSlotClick, onSlotD
         const layouts = layoutsByDate.get(date) ?? [];
         const isToday = date === today;
         const isSelected = date === selectedDate;
-        const schedule = employeeSchedules?.get(`${di}`);
+        // dayOfWeek is stored as Sun=0..Sat=6 (matches Date.getDay()) — see
+        // convex/gabinet/_availability_supabase.ts. Issue #1205.
+        const dow = new Date(date + "T00:00:00").getDay();
+        const schedule = employeeSchedules?.get(`${dow}`);
 
         return (
           <WeekDayColumn

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -385,11 +385,13 @@ function GabinetCalendarPage() {
     return map;
   }, [employeeFilter, employeeSchedulesRaw, clinicWorkingHours]);
 
-  // Get working hours for day view (today's schedule)
+  // Get working hours for day view (today's schedule).
+  // dayOfWeek is stored as Sun=0..Sat=6 (matches Date.getDay()) — see
+  // convex/gabinet/_availability_supabase.ts and the timetable settings page.
+  // Issue #1205.
   const dayWorkingHours = useMemo(() => {
     if (viewMode !== "day") return null;
-    const dayOfWeek = new Date(currentDate).getDay();
-    const dow = dayOfWeek === 0 ? 6 : dayOfWeek - 1; // Monday = 0
+    const dow = new Date(currentDate).getDay();
     return employeeSchedules.get(`${dow}`) ?? null;
   }, [viewMode, currentDate, employeeSchedules]);
 
@@ -1037,8 +1039,8 @@ function GabinetCalendarPage() {
   // so the grid can paint closed-hours and leave overlays per column.
   const dayByEmployeeColumns: DayByEmployeeColumn[] = useMemo(() => {
     if (!isDayByEmployeeView) return [];
-    const dayOfWeek = new Date(currentDate).getDay();
-    const dow = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+    // dayOfWeek is stored as Sun=0..Sat=6 (matches Date.getDay()). Issue #1205.
+    const dow = new Date(currentDate).getDay();
     const list = employees ?? [];
     return list.map((emp) => {
       const name = getEmployeeName(emp);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1205.

Closes #1205

---

## Claude summary

Fix committed. Summary of what was wrong and what changed:

The day-by-employee calendar column showed "dzień wolny" for an employee whose schedule said 12-20 because the calendar was using a Mon=0..Sun=6 convention to index the employee schedule map, while the database (and the availability backend in `convex/gabinet/_availability_supabase.ts`) store `dayOfWeek` as Sun=0..Sat=6 (matching `Date.getDay()`). The mismatch shifted every weekday's lookup back by one day, so Monday's view picked up Sunday's row (typically `isWorking: false` for receptionists), producing the wrong "dzień wolny" label.

Fix removes the off-by-one in three lookup sites:
- `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx:392-396` — `dayWorkingHours` (single-employee day view overlay).
- `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx:1042-1043` — `dayByEmployeeColumns` (per-employee column header + closed-hours overlay).
- `src/components/gabinet/calendar/calendar-week-view.tsx:470-473` — per-day schedule overlay in the week view (was using the iteration index `di`, which is Mon=0).

## Follow-ups
- Remove dead `getDayOfWeek` helper in `src/components/gabinet/calendar/calendar-week-view.tsx:80-84`: declared but never called and encodes the wrong Mon=0..Sun=6 convention, which could mislead future readers.