### PR TITLE
Remove dead `getDayOfWeek` helper in `src/components/gabinet/calendar/calendar-w

### DIFF
--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -77,12 +77,6 @@ function timeToTop(time: string): number {
   return (((h - 7) * 60 + m) * HOUR_HEIGHT) / 60;
 }
 
-function getDayOfWeek(date: string): number {
-  const d = new Date(date + "T00:00:00");
-  const day = d.getDay();
-  return day === 0 ? 6 : day - 1; // Monday = 0, Sunday = 6
-}
-
 // Google Calendar-style cascading layout: each overlapping appointment
 // offsets further right but still extends to the column edge.
 interface LayoutedAppointment {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1207.

Closes #1207

---

## Claude summary

Removed the dead `getDayOfWeek` helper at `src/components/gabinet/calendar/calendar-week-view.tsx:80-84`. It was never called and its Mon=0..Sun=6 convention conflicted with the codebase's stored format (per recent fix in #1205). Committed as `588bb60`.