### PR TITLE
Metoda płatności dodaj sprzedaż z pozycji kalendarza

### DIFF
--- a/src/components/gabinet/sell-package-panel.tsx
+++ b/src/components/gabinet/sell-package-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
@@ -7,6 +7,8 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { SidePanel } from "@/components/crm/side-panel";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -20,6 +22,10 @@ import { useSupabaseGabinetTreatmentPackagesList } from "@/hooks/use-supabase-ga
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatActionError } from "@/lib/format-action-error";
+import { formatCurrencyPLN } from "@/lib/format-currency";
+import { cn } from "@/lib/utils";
+
+type PaymentMethod = "cash" | "card" | "transfer" | "other";
 
 interface SellPackagePanelProps {
   organizationId: Id<"organizations">;
@@ -42,37 +48,111 @@ export function SellPackagePanel({
 
   const [patientId, setPatientId] = useState<string>("");
   const [packageId, setPackageId] = useState<string>("");
-  const [paymentMethod, setPaymentMethod] = useState<string>("cash");
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("cash");
+  const [splitPayment, setSplitPayment] = useState(false);
+  const [firstSplitMethod, setFirstSplitMethod] = useState<PaymentMethod>("cash");
+  const [secondSplitMethod, setSecondSplitMethod] = useState<PaymentMethod>("card");
+  const [firstSplitAmount, setFirstSplitAmount] = useState<string>("");
+  const [secondSplitAmount, setSecondSplitAmount] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
+
+  const selectedPkg = useMemo(
+    () => (packagesData ?? []).find((p) => p._id === packageId),
+    [packagesData, packageId],
+  );
+
+  const parsedFirstSplit = Number.parseFloat(firstSplitAmount.replace(",", ".")) || 0;
+  const parsedSecondSplit = Number.parseFloat(secondSplitAmount.replace(",", ".")) || 0;
+  const splitTotal = Math.round((parsedFirstSplit + parsedSecondSplit) * 100) / 100;
+  const splitExpectedTotal = selectedPkg
+    ? Math.round(selectedPkg.totalPrice * 100) / 100
+    : 0;
+  const splitMismatch = splitPayment && !!selectedPkg && splitTotal !== splitExpectedTotal;
+  const splitMissingAmount = splitPayment && parsedFirstSplit <= 0 && parsedSecondSplit <= 0;
+  const splitSameMethod = splitPayment && firstSplitMethod === secondSplitMethod;
 
   const reset = useCallback(() => {
     setPatientId("");
     setPackageId("");
     setPaymentMethod("cash");
+    setSplitPayment(false);
+    setFirstSplitMethod("cash");
+    setSecondSplitMethod("card");
+    setFirstSplitAmount("");
+    setSecondSplitAmount("");
   }, []);
 
   const handleSubmit = async () => {
-    if (!patientId || !packageId) return;
-    const pkg = (packagesData ?? []).find((p) => p._id === packageId);
-    if (!pkg) return;
+    if (!patientId || !packageId || !selectedPkg) return;
+    if (splitPayment) {
+      if (splitMissingAmount) {
+        toast.error(
+          t(
+            "gabinet.packages.splitMissingAmount",
+            "Podaj kwotę co najmniej jednej metody płatności",
+          ),
+        );
+        return;
+      }
+      if (splitMismatch) {
+        toast.error(
+          t(
+            "gabinet.packages.splitMismatchError",
+            "Suma rozdzielonych płatności musi być równa cenie pakietu",
+          ),
+        );
+        return;
+      }
+      if (splitSameMethod) {
+        toast.error(
+          t(
+            "gabinet.packages.splitSameMethodError",
+            "Wybierz dwie różne metody płatności",
+          ),
+        );
+        return;
+      }
+    }
     setSubmitting(true);
     try {
+      const currency = selectedPkg.currency ?? "PLN";
+      const usagePaymentMethod = splitPayment ? "split" : paymentMethod;
       const usageId = await purchasePackage({
         organizationId,
         patientId,
         packageId,
-        paidAmount: pkg.totalPrice,
-        paymentMethod,
+        paidAmount: selectedPkg.totalPrice,
+        paymentMethod: usagePaymentMethod,
       });
-      await createPayment({
-        organizationId,
-        patientId,
-        packageUsageId: usageId,
-        amount: pkg.totalPrice,
-        currency: pkg.currency ?? "PLN",
-        paymentMethod: paymentMethod as "cash" | "card" | "transfer",
-        notes: `Package: ${pkg.name}`,
-      });
+
+      if (splitPayment) {
+        const parts: Array<{ method: PaymentMethod; amount: number }> = [];
+        if (parsedFirstSplit > 0)
+          parts.push({ method: firstSplitMethod, amount: parsedFirstSplit });
+        if (parsedSecondSplit > 0)
+          parts.push({ method: secondSplitMethod, amount: parsedSecondSplit });
+        for (const part of parts) {
+          await createPayment({
+            organizationId,
+            patientId: patientId as Id<"gabinetPatients">,
+            packageUsageId: usageId,
+            amount: part.amount,
+            currency,
+            paymentMethod: part.method,
+            notes: `Package: ${selectedPkg.name} (split: ${part.method})`,
+          });
+        }
+      } else {
+        await createPayment({
+          organizationId,
+          patientId,
+          packageUsageId: usageId,
+          amount: selectedPkg.totalPrice,
+          currency,
+          paymentMethod,
+          notes: `Package: ${selectedPkg.name}`,
+        });
+      }
       toast.success(t("gabinet.packages.purchased"));
       void queryClient.invalidateQueries({
         queryKey: supabaseKeys.gabinetTreatmentPackages.list(organizationId),
@@ -147,7 +227,11 @@ export function SellPackagePanel({
 
         <div className="space-y-1.5">
           <Label>{t("gabinet.packages.paymentMethod")}</Label>
-          <Select value={paymentMethod} onValueChange={setPaymentMethod}>
+          <Select
+            value={paymentMethod}
+            onValueChange={(v) => setPaymentMethod(v as PaymentMethod)}
+            disabled={splitPayment}
+          >
             <SelectTrigger>
               <SelectValue />
             </SelectTrigger>
@@ -165,9 +249,137 @@ export function SellPackagePanel({
           </Select>
         </div>
 
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="sell-package-split-payment"
+            checked={splitPayment}
+            onCheckedChange={(v) => setSplitPayment(v === true)}
+          />
+          <Label
+            htmlFor="sell-package-split-payment"
+            className="cursor-pointer text-sm font-normal"
+          >
+            {t("gabinet.packages.splitPayment", "Podziel płatność")}
+          </Label>
+        </div>
+
+        {splitPayment && (
+          <div className="rounded-lg border p-3 space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded-md border p-2 space-y-2">
+                <Label className="text-xs font-medium">
+                  {t("gabinet.packages.firstMethod", "Pierwsza metoda")}
+                </Label>
+                <Select
+                  value={firstSplitMethod}
+                  onValueChange={(v) => setFirstSplitMethod(v as PaymentMethod)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="cash">
+                      {t("gabinet.packages.paymentMethods.cash")}
+                    </SelectItem>
+                    <SelectItem value="card">
+                      {t("gabinet.packages.paymentMethods.card")}
+                    </SelectItem>
+                    <SelectItem value="transfer">
+                      {t("gabinet.packages.paymentMethods.transfer")}
+                    </SelectItem>
+                    <SelectItem value="other">
+                      {t("gabinet.packages.paymentMethods.other", "Inna")}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <Input
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="0.00"
+                  value={firstSplitAmount}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                      setFirstSplitAmount(v);
+                    }
+                  }}
+                />
+              </div>
+              <div className="rounded-md border p-2 space-y-2">
+                <Label className="text-xs font-medium">
+                  {t("gabinet.packages.secondMethod", "Druga metoda")}
+                </Label>
+                <Select
+                  value={secondSplitMethod}
+                  onValueChange={(v) => setSecondSplitMethod(v as PaymentMethod)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="cash">
+                      {t("gabinet.packages.paymentMethods.cash")}
+                    </SelectItem>
+                    <SelectItem value="card">
+                      {t("gabinet.packages.paymentMethods.card")}
+                    </SelectItem>
+                    <SelectItem value="transfer">
+                      {t("gabinet.packages.paymentMethods.transfer")}
+                    </SelectItem>
+                    <SelectItem value="other">
+                      {t("gabinet.packages.paymentMethods.other", "Inna")}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <Input
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="0.00"
+                  value={secondSplitAmount}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                      setSecondSplitAmount(v);
+                    }
+                  }}
+                />
+              </div>
+            </div>
+            <div
+              className={cn(
+                "flex items-center justify-between text-xs",
+                splitMismatch || splitSameMethod
+                  ? "text-destructive"
+                  : "text-muted-foreground",
+              )}
+            >
+              <span>
+                {t("gabinet.packages.splitSum", "Suma")}: {splitTotal.toFixed(2)}
+                {selectedPkg
+                  ? ` / ${formatCurrencyPLN(splitExpectedTotal, selectedPkg.currency ?? "PLN")}`
+                  : ""}
+              </span>
+              {splitSameMethod ? (
+                <span>
+                  {t("gabinet.packages.splitSameMethod", "Metody muszą się różnić")}
+                </span>
+              ) : splitMismatch ? (
+                <span>
+                  {t("gabinet.packages.splitMismatch", "Musi się zgadzać z ceną")}
+                </span>
+              ) : null}
+            </div>
+          </div>
+        )}
+
         <Button
           className="w-full"
-          disabled={!patientId || !packageId || submitting}
+          disabled={
+            !patientId ||
+            !packageId ||
+            submitting ||
+            (splitPayment && (splitMissingAmount || splitMismatch || splitSameMethod))
+          }
           onClick={handleSubmit}
         >
           {submitting && (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1210.

Closes #1210

---

## Claude summary

Committed. Summary of changes:

The "Dodaj sprzedaż" button in the calendar toolbar (`src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx:1195-1204`) opens `SellPackagePanel`, which previously only allowed a single payment method. I added split-payment UI mirroring `package-purchase-drawer.tsx` and the appointment settle dialog: a "Podziel płatność" checkbox, a two-method grid (cash/card/transfer/other) with per-method amounts, a sum/mismatch indicator, and validation against the package total. When split is on, the panel records the package usage with `paymentMethod: "split"` and creates one payment per filled part, exactly like the patient-page Sprzedaj pakiet drawer.

All split-payment i18n strings (`splitPayment`, `splitSum`, `splitMismatch`, `splitSameMethod`, `firstMethod`, `secondMethod`, `splitMissingAmount`, `splitMismatchError`, `splitSameMethodError`) already exist in `public/locales/pl/translation.json`.

Note: I couldn't run `npm run typecheck` because `node_modules` isn't installed in this worktree, but the change closely mirrors the existing `package-purchase-drawer.tsx` (which compiles) and uses identical types and Convex action signatures.