### PR TITLE
Podzielona płatność

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -610,6 +610,9 @@ export function AppointmentPreviewContent({
     parseFloat(settleSecondSplitAmount.replace(",", ".")) || 0;
   const splitTotal =
     Math.round((parsedFirstSplitAmount + parsedSecondSplitAmount) * 100) / 100;
+  const splitExpectedTotal = Math.round(outstanding * 100) / 100;
+  const splitMismatch =
+    settleSplitPayment && splitTotal !== splitExpectedTotal;
   const splitMissingAmount =
     settleSplitPayment &&
     parsedFirstSplitAmount <= 0 &&
@@ -627,6 +630,15 @@ export function AppointmentPreviewContent({
           t(
             "gabinet.packages.splitMissingAmount",
             "Podaj kwotę co najmniej jednej metody płatności",
+          ),
+        );
+        return;
+      }
+      if (splitMismatch) {
+        toast.error(
+          t(
+            "gabinet.packages.splitMismatchError",
+            "Suma rozdzielonych płatności musi być równa cenie",
           ),
         );
         return;
@@ -1465,21 +1477,31 @@ export function AppointmentPreviewContent({
               <div
                 className={cn(
                   "flex items-center justify-between text-xs",
-                  splitSameMethod ? "text-destructive" : "text-muted-foreground",
+                  splitMismatch || splitSameMethod
+                    ? "text-destructive"
+                    : "text-muted-foreground",
                 )}
               >
                 <span>
                   {t("gabinet.packages.splitSum", "Suma")}:{" "}
                   {formatCurrencyPLN(splitTotal)}
+                  {` / ${formatCurrencyPLN(splitExpectedTotal)}`}
                 </span>
-                {splitSameMethod && (
+                {splitSameMethod ? (
                   <span>
                     {t(
                       "gabinet.packages.splitSameMethod",
                       "Metody muszą się różnić",
                     )}
                   </span>
-                )}
+                ) : splitMismatch ? (
+                  <span>
+                    {t(
+                      "gabinet.packages.splitMismatch",
+                      "Musi się zgadzać z ceną",
+                    )}
+                  </span>
+                ) : null}
               </div>
             </div>
           )}
@@ -1540,7 +1562,7 @@ export function AppointmentPreviewContent({
               disabled={
                 settleSubmitting ||
                 (settleSplitPayment &&
-                  (splitMissingAmount || splitSameMethod))
+                  (splitMissingAmount || splitMismatch || splitSameMethod))
               }
             >
               {settleSubmitting


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1211.

Closes #1211

---

## Claude summary

Committed. Summary of the change:

Background: PR #1199 added split payment to the appointment settle dialog 14 minutes before this issue was filed, but didn't include the "sum must match" validation that exists in the "Sprzedaj pakiet" sell-package panel. The user asked for that validation to be added.

Change in `src/components/gabinet/calendar/appointment-preview-content.tsx`:
- Added `splitExpectedTotal` (= `outstanding`) and `splitMismatch` flag, mirroring `sell-package-panel.tsx:67-72`.
- `handleConfirmSettle` now toasts `gabinet.packages.splitMismatchError` and returns early when the two split amounts don't sum to the outstanding balance.
- The sum line now reads `Suma: X / Y` (where Y is the outstanding) and turns destructive-red with the `Musi się zgadzać z ceną` message when there's a mismatch.
- The Rozlicz wizytę confirm button is disabled while `splitMismatch` is true.

All translation keys (`gabinet.packages.splitMismatch`, `splitMismatchError`) already existed in both PL and EN bundles, so no locale changes were needed. `npm run typecheck` (tsc app config) ran clean.