### PR TITLE
Pakiety zabiegów opis

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2870,7 +2870,7 @@
     },
     "packages": {
       "title": "Treatment Packages",
-      "description": "Description",
+      "description": "Manage packages",
       "addPackage": "Add Package",
       "name": "Name",
       "namePlaceholder": "e.g. Relaxation Package",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2899,7 +2899,7 @@
     },
     "packages": {
       "title": "Pakiety zabiegów",
-      "description": "Opis",
+      "description": "Zarządzaj pakietami",
       "addPackage": "Dodaj pakiet",
       "name": "Nazwa",
       "namePlaceholder": "np. Pakiet Relaksacyjny",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1215.

Closes #1215

---

## Claude summary

Replaced the placeholder "Opis" subtitle on the gabinet packages page with "Zarządzaj pakietami" (PL) and updated the EN counterpart from "Description" to "Manage packages" in `public/locales/{pl,en}/translation.json` at the `gabinet.packages.description` key. The form-field label uses a separate `descriptionField` key and was left untouched. Committed as a97ad6f.