### PR TITLE
wyświetlanie na telefonie

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.calendar.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calendar.tsx
@@ -69,7 +69,13 @@ function getMonday(date: Date): Date {
 }
 
 function formatDateStr(d: Date): string {
-  return d.toISOString().split("T")[0];
+  // Use local date parts, not toISOString — for users east of UTC, a Date at
+  // local midnight has a UTC date one day earlier, which would shift the
+  // calendar's "today" highlight and event placement to the next column.
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
 }
 
 function dateToHourMin(ts: number): { hour: number; min: number } {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1217.

Closes #1217

---

## Claude summary

Fix committed.

The screenshot showed the CRM calendar (`/dashboard/calendar`) on mobile, where Monday 1 June 2026 should have been highlighted as today but Tuesday 2 was lit up instead. The cause was `formatDateStr` in `src/routes/_app/_auth/dashboard/_layout.calendar.tsx:71-73` returning `d.toISOString().split("T")[0]` — i.e. the UTC date. The week-column Dates sit at local midnight; in Poland (CEST = UTC+2) that's 22:00 UTC the previous day, so every column's date string was off by one. That shifted both the `isToday` highlight and the event-by-date grouping one column to the right. Switching to local `getFullYear/getMonth/getDate` parts (the same shape the gabinet calendar already uses) realigns everything with the user's local calendar.