### PR TITLE
menu tel

### DIFF
--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -101,6 +101,14 @@ export function AppSidebar() {
           </SidebarMenu>
         </SidebarHeader>
         <SidebarContent>
+          {visibleModules.length > 1 && (
+            <div className="px-2 lg:hidden group-data-[collapsible=icon]:hidden">
+              <WorkspaceSwitcher
+                activeWorkspace={activeWorkspace}
+                workspaces={visibleModules.map((module) => module.workspace)}
+              />
+            </div>
+          )}
           <SidebarGroup>
             <SidebarGroupContent>
               <SidebarMenu>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1218.

Closes #1218

---

## Claude summary

Committed the fix as `fe16c3e`.

Summary: On mobile/tablet the sidebar opens as a Sheet whose contents come from `<Sidebar>` in `src/components/layout/app-sidebar.tsx`. The WorkspaceSwitcher was only rendered in a separate desktop secondary panel with `max-lg:hidden`, so users below 1024px could only see CRM nav with no way to switch to Gabinet (matching the screenshot). I added the switcher inside `<Sidebar>` with `lg:hidden group-data-[collapsible=icon]:hidden` so it appears in the mobile Sheet and on the md–lg expanded desktop sidebar, but stays hidden on lg+ (where the secondary panel still owns it) and in icon-collapsed mode. The guard `visibleModules.length > 1` keeps it from appearing for orgs with a single active module.

## Follow-ups
- Sidebar header "CRM" label is hardcoded: `src/components/layout/app-sidebar.tsx:97` always shows "CRM" even when the user is in the Gabinet workspace; it should reflect the active module's name.
- HeaderModuleSwitcher always shows all `moduleRegistry` workspaces: `src/routes/_app/_auth/dashboard/_layout.tsx:122` ignores `productSubscriptions` / `getVisibleModules`, so orgs without Gabinet still see it as a switchable target in the icon-only header dropdown.