### PR TITLE
menu boczne

### DIFF
--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -14,6 +14,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import { useSidebarActions } from "@/components/layout/sidebar-context";
 import { useSidebarSlot } from "@/components/layout/sidebar-slot-context";
@@ -34,6 +35,10 @@ export function AppSidebar() {
   const matchRoute = useMatchRoute();
   const { t } = useTranslation();
   const { openQuickCreate, navigateTo, dispatch } = useSidebarActions();
+  const { isMobile, setOpenMobile } = useSidebar();
+  const closeMobile = () => {
+    if (isMobile) setOpenMobile(false);
+  };
   const { organizationId } = useOrganization();
   const { state: miniCalState } = useMiniCalendar();
   const { content: sidebarSlotContent, wideContent, dayAgendaDate, shellSidebarMode } = useSidebarSlot();
@@ -92,7 +97,7 @@ export function AppSidebar() {
                 className="gap-2.5 !bg-transparent group-data-[collapsible=icon]:size-9! group-data-[collapsible=icon]:p-1! [&>svg]:size-5"
                 asChild
               >
-                <Link to="/dashboard">
+                <Link to="/dashboard" onClick={closeMobile}>
                   <Logo className="[&_rect]:fill-card [&_rect:first-child]:fill-primary" />
                   <span className="text-xl font-semibold">CRM</span>
                 </Link>
@@ -106,6 +111,7 @@ export function AppSidebar() {
               <WorkspaceSwitcher
                 activeWorkspace={activeWorkspace}
                 workspaces={visibleModules.map((module) => module.workspace)}
+                onSelect={closeMobile}
               />
             </div>
           )}
@@ -126,7 +132,7 @@ export function AppSidebar() {
                         isActive={isActive}
                         asChild
                       >
-                        <Link to={item.href}>
+                        <Link to={item.href} onClick={closeMobile}>
                           <item.icon variant="stroke" />
                           <span>{t(item.labelKey)}</span>
                         </Link>

--- a/src/components/layout/workspace-switcher.tsx
+++ b/src/components/layout/workspace-switcher.tsx
@@ -13,9 +13,10 @@ import {
 interface WorkspaceSwitcherProps {
   activeWorkspace: ModuleId;
   workspaces: ModuleWorkspaceOption[];
+  onSelect?: () => void;
 }
 
-export function WorkspaceSwitcher({ activeWorkspace, workspaces }: WorkspaceSwitcherProps) {
+export function WorkspaceSwitcher({ activeWorkspace, workspaces, onSelect }: WorkspaceSwitcherProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
@@ -41,7 +42,10 @@ export function WorkspaceSwitcher({ activeWorkspace, workspaces }: WorkspaceSwit
         {workspaces.map((workspace) => (
           <DropdownMenuItem
             key={workspace.id}
-            onClick={() => navigate({ to: workspace.href })}
+            onClick={() => {
+              navigate({ to: workspace.href });
+              onSelect?.();
+            }}
           >
             <div className="flex items-center gap-2.5">
               <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1219.

Closes #1219

---

## Claude summary

Fixed and committed. On mobile, the sidebar opens as an off-canvas Sheet, but the nav `<Link>` elements (and workspace switcher) only navigated — they didn't dismiss the sheet, so the menu stayed on top of the destination page. The fix calls `setOpenMobile(false)` (via a `closeMobile` helper that no-ops on desktop) on the logo link, every primary nav link, and a new `onSelect` callback wired into `WorkspaceSwitcher`. Commit `c773054`.