### PR TITLE
górne manu

### DIFF
--- a/src/components/layout/app-footer.tsx
+++ b/src/components/layout/app-footer.tsx
@@ -141,13 +141,13 @@ export function AppFooter() {
           <NudgesBadge />
         </div>
 
-        <div className="flex items-center gap-2 flex-wrap">
+        <div className="flex items-center gap-2 max-sm:min-w-0 max-sm:flex-1 max-sm:flex-nowrap max-sm:overflow-x-auto max-sm:-mx-4 max-sm:px-4 max-sm:scrollbar-none sm:flex-wrap">
           {actions.map((action) => (
             <Button
               key={action.labelKey}
               variant="outline"
               size="sm"
-              className="h-7 text-xs"
+              className="h-7 text-xs shrink-0"
               onClick={() => {
                 if (action.quickCreate) {
                   openQuickCreate(action.quickCreate);

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -756,7 +756,9 @@ function DashboardLayout() {
                     renderForm={renderQuickCreateForm}
                   />
                   <NotificationBell />
-                  <ThemeSwitcher />
+                  <div className="hidden sm:block">
+                    <ThemeSwitcher />
+                  </div>
 
                   <DropdownMenu modal={false}>
                     <DropdownMenuTrigger asChild>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1220.

Closes #1220

---

## Claude summary

Cleaned up the mobile layout per the issue. Two focused changes:

1. `src/routes/_app/_auth/dashboard/_layout.tsx:759-761` — wrapped `<ThemeSwitcher />` in `<div className="hidden sm:block">` so it's hidden on phones. Reduces the mobile header from 6 icons to 5, matching the Versum-style density in the user's mock-ups. Theme remains accessible on tablets/desktops and via the avatar dropdown's Settings entry.

2. `src/components/layout/app-footer.tsx:144` — the action button container now horizontally scrolls on mobile (`flex-nowrap overflow-x-auto -mx-4 px-4 scrollbar-none`) instead of wrapping into 3+ stacked rows when there are several actions (the calendar route has 5 actions + the quick-actions dropdown). Buttons get `shrink-0` so they keep their natural width. Above `sm` the original `flex-wrap` behavior is preserved.

Commit: `2c8bf7d fix(layout): tidy mobile header and footer (#1220)`