### PR TITLE
Sidebar header "CRM" label is hardcoded

### DIFF
--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -97,9 +97,9 @@ export function AppSidebar() {
                 className="gap-2.5 !bg-transparent group-data-[collapsible=icon]:size-9! group-data-[collapsible=icon]:p-1! [&>svg]:size-5"
                 asChild
               >
-                <Link to="/dashboard" onClick={closeMobile}>
+                <Link to={activeModule.workspace.href} onClick={closeMobile}>
                   <Logo className="[&_rect]:fill-card [&_rect:first-child]:fill-primary" />
-                  <span className="text-xl font-semibold">CRM</span>
+                  <span className="text-xl font-semibold">{t(activeModule.workspace.nameKey)}</span>
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1224.

Closes #1224

---

## Claude summary

Fix committed. The sidebar header at `src/components/layout/app-sidebar.tsx:102` now uses `t(activeModule.workspace.nameKey)` (resolves to "CRM" or "Gabinet" depending on the active workspace), and I also updated the brand link's `to` from the hardcoded `/dashboard` to `activeModule.workspace.href` so clicking the header in the Gabinet workspace doesn't yank the user back to CRM — the label and target stay consistent.