### PR TITLE
przenieś

### DIFF
--- a/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
+++ b/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
@@ -8,6 +8,7 @@ import {
   Users,
   Package,
   FileText,
+  Gift,
   Settings,
   Stethoscope,
   Plus,
@@ -54,6 +55,18 @@ export function GabinetQuickActionsDropdown() {
         >
           <UserPlus className="text-foreground size-5" />
           {t("sidebar.gabinet.addPatient", "Dodaj klienta")}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="px-3 py-2.5 text-sm"
+          onSelect={() =>
+            navigate({
+              to: "/dashboard/gabinet/calendar",
+              search: { action: "sell-package" },
+            })
+          }
+        >
+          <Gift className="text-foreground size-5" />
+          {t("gabinet.packages.purchaseButton", "Dodaj sprzedaż")}
         </DropdownMenuItem>
 
         <DropdownMenuSeparator />

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -19,7 +19,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { Check, ChevronDown, ChevronLeft, ChevronRight, Gift, Plus, Search, Users, X } from "@/lib/ez-icons";
+import { Check, ChevronDown, ChevronLeft, ChevronRight, Plus, Search, Users, X } from "@/lib/ez-icons";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -30,7 +30,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { PrintSchedule } from "@/components/gabinet/calendar/print-schedule";
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import {
   DndContext,
@@ -114,6 +114,7 @@ function GabinetCalendarPage() {
   const search = useSearch({ from: "/_app/_auth/dashboard/_layout/gabinet/calendar/" });
   const routeNavigate = useNavigate();
   const nudgeFilter = search.nudge;
+  const actionParam = search.action;
 
   // Indicate this page has wide content (hides Column 2 on 1024-1400px screens)
   useWideContent(true);
@@ -793,6 +794,20 @@ function GabinetCalendarPage() {
   useSidebarDispatch("openFilter", () => setFilterOpen(true));
   useSidebarDispatch("manageTags", () => setTagsSlideoutOpen(true));
 
+  // ?action=sell-package opens the sell package side panel after navigation
+  // from the gabinet quick-actions dropdown (issue #1236). Clear the param
+  // after consuming so a refresh doesn't reopen it.
+  useEffect(() => {
+    if (actionParam === "sell-package") {
+      setSellPackageOpen(true);
+      routeNavigate({
+        to: "/dashboard/gabinet/calendar",
+        search: { nudge: nudgeFilter, action: undefined },
+        replace: true,
+      });
+    }
+  }, [actionParam, nudgeFilter, routeNavigate]);
+
   // Click-to-create handler
   const handleSlotClick = useCallback(
     (dateOrTime: string, time?: string) => {
@@ -1223,21 +1238,6 @@ function GabinetCalendarPage() {
                 <Plus className="h-3.5 w-3.5 sm:mr-1" variant="stroke" />
                 <span className="hidden sm:inline">
                   {t("gabinet.appointments.createAppointment", "Nowa wizyta")}
-                </span>
-              </Button>
-
-              {/* Sell package button */}
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 text-xs"
-                data-testid="calendar-sell-package-button"
-                onClick={() => setSellPackageOpen(true)}
-                aria-label={t("gabinet.packages.purchaseButton")}
-              >
-                <Gift className="h-3.5 w-3.5 sm:mr-1" variant="stroke" />
-                <span className="hidden sm:inline">
-                  {t("gabinet.packages.purchaseButton")}
                 </span>
               </Button>
             </div>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.tsx
@@ -1,16 +1,21 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 type CalendarNudgeFilter = "unconfirmed-today";
+type CalendarAction = "sell-package";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/calendar/",
 )({
   validateSearch: (
     search: Record<string, unknown>,
-  ): { nudge?: CalendarNudgeFilter } => ({
+  ): { nudge?: CalendarNudgeFilter; action?: CalendarAction } => ({
     nudge:
       search.nudge === "unconfirmed-today"
         ? (search.nudge as CalendarNudgeFilter)
+        : undefined,
+    action:
+      search.action === "sell-package"
+        ? (search.action as CalendarAction)
         : undefined,
   }),
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1236.

Closes #1236

---

## Claude summary

Changes are committed.

Summary: Moved the "Dodaj sprzedaż" (Sell package) button out of the calendar toolbar and into the existing Gabinet quick-actions dropdown. The dropdown item navigates to `/dashboard/gabinet/calendar?action=sell-package`; the calendar route now reads that search param, opens the `SellPackagePanel`, and clears the param via `replace`. This works reliably whether the user is already on the calendar or coming from another gabinet route, because it doesn't rely on the in-page dispatch (which initializes its seen-seq at mount and would miss a pre-navigation dispatch).

Files changed:
- `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.tsx` — added `action` search param
- `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx` — removed toolbar button, added effect to open panel on `?action=sell-package`
- `src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx` — added the new dropdown item