### PR TITLE
widok

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -288,7 +288,12 @@ function PatientsIndex() {
         id: "phone",
         label: t("common.phone"),
         sortable: true,
-        render: (item) => item.phone ? formatPhoneNumber(item.phone) : "—",
+        render: (item) =>
+          item.phone ? (
+            <span className="whitespace-nowrap">{formatPhoneNumber(item.phone)}</span>
+          ) : (
+            "—"
+          ),
         getSortValue: (item) => item.phone ?? "",
       },
       {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1242.

Closes #1242

---

## Claude summary

Fixed and committed. The screenshots show phone numbers in the gabinet patients table breaking mid-number (e.g. `+48 661` on line 1 and `116 742` on line 2), which is what the reporter could not read. I wrapped the formatted phone in `<span className="whitespace-nowrap">` at `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx:288-298` so the number stays on one line and the column can grow / scroll horizontally instead of breaking digits across rows.

## Follow-ups
- Apply same nowrap to phone columns in contacts and companies tables: `_layout.contacts.index.tsx:258` and `_layout.companies.index.tsx:225` render phones identically and will exhibit the same wrap on narrow viewports.