### PR TITLE
linie

### DIFF
--- a/src/components/gabinet/calendar/calendar-day-by-employee-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-by-employee-view.tsx
@@ -301,22 +301,22 @@ function EmployeeColumn({
             date={date}
             time={s.time}
             employeeId={employee.userId}
-            className={`border-b border-dashed ${s.isHourMark ? "border-muted" : "border-muted/40"}`}
+            className={`border-b ${s.isHourMark ? "border-border" : "border-border/40"}`}
             style={{ height: `${s.slotHeight}px` }}
           >
             <div className="relative h-full w-full cursor-pointer hover:bg-muted/20">
               {showSubdivisions && (
                 <>
                   <div
-                    className="pointer-events-none absolute left-0 right-0 border-t border-dashed border-muted/40"
+                    className="pointer-events-none absolute left-0 right-0 border-t border-border/30"
                     style={{ top: `${HOUR_HEIGHT / 4}px` }}
                   />
                   <div
-                    className="pointer-events-none absolute left-0 right-0 border-t border-dashed border-muted/60"
+                    className="pointer-events-none absolute left-0 right-0 border-t border-border/60"
                     style={{ top: `${HOUR_HEIGHT / 2}px` }}
                   />
                   <div
-                    className="pointer-events-none absolute left-0 right-0 border-t border-dashed border-muted/40"
+                    className="pointer-events-none absolute left-0 right-0 border-t border-border/30"
                     style={{ top: `${(HOUR_HEIGHT * 3) / 4}px` }}
                   />
                 </>

--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -289,22 +289,22 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
             id={`${date}-${s.time}`}
             date={date}
             time={s.time}
-            className={`border-b border-dashed ${s.isHourMark ? "border-muted" : "border-muted/40"}`}
+            className={`border-b ${s.isHourMark ? "border-border" : "border-border/40"}`}
             style={{ height: `${s.slotHeight}px` }}
           >
             <div className="relative h-full w-full cursor-pointer hover:bg-muted/30">
               {showSubdivisions && (
                 <>
                   <div
-                    className="pointer-events-none absolute left-0 right-0 border-t border-dashed border-muted/40"
+                    className="pointer-events-none absolute left-0 right-0 border-t border-border/30"
                     style={{ top: `${HOUR_HEIGHT / 4}px` }}
                   />
                   <div
-                    className="pointer-events-none absolute left-0 right-0 border-t border-dashed border-muted/60"
+                    className="pointer-events-none absolute left-0 right-0 border-t border-border/60"
                     style={{ top: `${HOUR_HEIGHT / 2}px` }}
                   />
                   <div
-                    className="pointer-events-none absolute left-0 right-0 border-t border-dashed border-muted/40"
+                    className="pointer-events-none absolute left-0 right-0 border-t border-border/30"
                     style={{ top: `${(HOUR_HEIGHT * 3) / 4}px` }}
                   />
                 </>

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -293,22 +293,22 @@ function WeekDayColumn({
             id={`${date}-${s.time}`}
             date={date}
             time={s.time}
-            className={`border-b border-dashed ${s.isHourMark ? "border-muted" : "border-muted/40"}`}
+            className={`border-b ${s.isHourMark ? "border-border" : "border-border/40"}`}
             style={{ height: `${s.slotHeight}px` }}
           >
             <div className="relative h-full w-full cursor-pointer hover:bg-muted/20">
               {showSubdivisions && (
                 <>
                   <div
-                    className="pointer-events-none absolute left-0 right-0 border-t border-dashed border-muted/40"
+                    className="pointer-events-none absolute left-0 right-0 border-t border-border/30"
                     style={{ top: `${HOUR_HEIGHT / 4}px` }}
                   />
                   <div
-                    className="pointer-events-none absolute left-0 right-0 border-t border-dashed border-muted/60"
+                    className="pointer-events-none absolute left-0 right-0 border-t border-border/60"
                     style={{ top: `${HOUR_HEIGHT / 2}px` }}
                   />
                   <div
-                    className="pointer-events-none absolute left-0 right-0 border-t border-dashed border-muted/40"
+                    className="pointer-events-none absolute left-0 right-0 border-t border-border/30"
                     style={{ top: `${(HOUR_HEIGHT * 3) / 4}px` }}
                   />
                 </>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1245.

Closes #1245

---

## Claude summary

Committed. Made calendar hour lines clearly visible across all three timeline views (day, week, day-by-employee) by replacing faint dashed `border-muted` with solid `border-border`. Hour marks are now fully opaque solid lines, half-hour marks are visible but lighter (`border-border/60`), and quarter-hour marks remain subtle (`border-border/30`) — matching the Versum-style clear hour separators from the screenshot.