### PR TITLE
górne menu

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -789,6 +789,16 @@ function GabinetCalendarPage() {
 
   const goToday = () => setCurrentDate(new Date());
 
+  // Opens the create-appointment dialog with the current date pre-filled.
+  // Shared by the mobile and desktop "+" buttons so both spawn the same dialog.
+  const openCreateDialog = useCallback(() => {
+    setCreateDefaultDate(formatDateStr(currentDate));
+    setCreateDefaultTime(undefined);
+    setCreateDefaultEndTime(undefined);
+    setCreateDefaultEmployeeId(undefined);
+    setCreateDialogOpen(true);
+  }, [currentDate]);
+
   // Sidebar dispatch handlers
   useSidebarDispatch("goToToday", goToday);
   useSidebarDispatch("openFilter", () => setFilterOpen(true));
@@ -1135,31 +1145,44 @@ function GabinetCalendarPage() {
 
         {/* Toolbar */}
         <div className="flex shrink-0 flex-col gap-2 border-b bg-background px-4 py-3">
-          {/* Row 1: nav arrows + date title + view switcher + actions */}
+          {/* Row 1: nav arrows + date title + view switcher + actions.
+              On mobile the "+" button is hoisted up to share this row with the
+              nav arrows (justify-between) — it otherwise wraps onto its own
+              row in the actions group below and steals vertical space. */}
           <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-            <div className="flex items-center gap-2">
+            <div className="flex items-center justify-between gap-2 md:justify-start">
+              <div className="flex min-w-0 items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 text-xs"
+                  onClick={() => navigateDate(-1)}
+                  aria-label={t("gabinet.calendar.previousPeriod")}
+                >
+                  <ChevronLeft className="h-3.5 w-3.5" variant="stroke" />
+                </Button>
+                <Button variant="outline" size="sm" className="h-7 text-xs" onClick={goToday}>
+                  {t("gabinet.calendar.today", "Dzis")}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 text-xs"
+                  onClick={() => navigateDate(1)}
+                  aria-label={t("gabinet.calendar.nextPeriod")}
+                >
+                  <ChevronRight className="h-3.5 w-3.5" variant="stroke" />
+                </Button>
+                <h2 className="ml-2 truncate text-xs font-semibold">{title}</h2>
+              </div>
               <Button
-                variant="outline"
                 size="sm"
-                className="h-7 text-xs"
-                onClick={() => navigateDate(-1)}
-                aria-label={t("gabinet.calendar.previousPeriod")}
+                className="h-7 shrink-0 text-xs md:hidden"
+                aria-label={t("gabinet.appointments.createAppointment", "Nowa wizyta")}
+                onClick={openCreateDialog}
               >
-                <ChevronLeft className="h-3.5 w-3.5" variant="stroke" />
+                <Plus className="h-3.5 w-3.5" variant="stroke" />
               </Button>
-              <Button variant="outline" size="sm" className="h-7 text-xs" onClick={goToday}>
-                {t("gabinet.calendar.today", "Dzis")}
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 text-xs"
-                onClick={() => navigateDate(1)}
-                aria-label={t("gabinet.calendar.nextPeriod")}
-              >
-                <ChevronRight className="h-3.5 w-3.5" variant="stroke" />
-              </Button>
-              <h2 className="ml-2 text-xs font-semibold">{title}</h2>
             </div>
 
             <div className="flex flex-wrap items-center gap-2">
@@ -1222,18 +1245,13 @@ function GabinetCalendarPage() {
                 </>
               )}
 
-              {/* Create button */}
+              {/* Create button — hidden on mobile where it lives next to the
+                  date nav (above) to avoid wrapping onto its own row. */}
               <Button
                 size="sm"
-                className="h-7 text-xs"
+                className="hidden h-7 text-xs md:inline-flex"
                 data-testid="calendar-create-appointment-button"
-                onClick={() => {
-                  setCreateDefaultDate(formatDateStr(currentDate));
-                  setCreateDefaultTime(undefined);
-                  setCreateDefaultEndTime(undefined);
-                  setCreateDefaultEmployeeId(undefined);
-                  setCreateDialogOpen(true);
-                }}
+                onClick={openCreateDialog}
               >
                 <Plus className="h-3.5 w-3.5 sm:mr-1" variant="stroke" />
                 <span className="hidden sm:inline">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1246.

Closes #1246

---

## Claude summary

NOT_A_BUG: This issue was already resolved by PR #1257, which was squash-merged to `main` as commit `924609d` on 2026-06-01 (the same day the issue was filed). The change is live on `main`.

What was done: on screens below `md` (mobile), the "+" button is hoisted onto the same row as the date-navigation arrows (right-aligned via `justify-between`), reclaiming the vertical row it previously occupied inside the actions group. Desktop is unchanged — the labeled "Nowa wizyta" button remains in the right-hand actions group.

Where it lives now (`src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx` on `origin/main`):
- `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx:792` — new `openCreateDialog` callback shared by both mobile and desktop "+" buttons.
- `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx:1178-1186` — mobile-only `+` button (`className="h-7 shrink-0 text-xs md:hidden"`) sitting on row 1 next to the prev/today/next navigation, inside a `justify-between gap-2 md:justify-start` flex container.

The current worktree is on a stale branch (`claude/issue-1057`) that doesn't include this merge, but the change is present on `origin/main` (verified via `git show origin/main:…`). No further code changes are needed — pulling latest `main` will surface the already-shipped fix. If aslocka still sees the old layout, it's a stale build/cache, not a missing change.