### PR TITLE
tło kalendarza

### DIFF
--- a/src/components/gabinet/calendar/calendar-day-by-employee-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-by-employee-view.tsx
@@ -238,7 +238,7 @@ function EmployeeColumn({
         {/* Closed entire day */}
         {workStartTop === null && (
           <div
-            className="pointer-events-none absolute inset-0 z-0 bg-primary/5"
+            className="pointer-events-none absolute inset-0 z-0 bg-zinc-200/60 dark:bg-zinc-950/50"
             style={{ height: `${HOURS.length * HOUR_HEIGHT}px` }}
           />
         )}
@@ -246,7 +246,7 @@ function EmployeeColumn({
         {/* Closed: before working hours */}
         {workStartTop !== null && workStartTop > 0 && (
           <div
-            className="pointer-events-none absolute left-0 right-0 z-0 border-b border-primary/10 bg-primary/5"
+            className="pointer-events-none absolute left-0 right-0 z-0 border-b border-border/40 bg-zinc-200/60 dark:bg-zinc-950/50"
             style={{ top: 0, height: `${workStartTop}px` }}
           />
         )}
@@ -254,7 +254,7 @@ function EmployeeColumn({
         {/* Closed: after working hours */}
         {workEndTop !== null && workEndTop < HOURS.length * HOUR_HEIGHT && (
           <div
-            className="pointer-events-none absolute left-0 right-0 z-0 border-t border-primary/10 bg-primary/5"
+            className="pointer-events-none absolute left-0 right-0 z-0 border-t border-border/40 bg-zinc-200/60 dark:bg-zinc-950/50"
             style={{
               top: `${workEndTop}px`,
               height: `${HOURS.length * HOUR_HEIGHT - workEndTop}px`,

--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -224,7 +224,7 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
         {/* Closed hours background — entire day when clinic is closed */}
         {workStartTop === null && (
           <div
-            className="pointer-events-none absolute inset-0 bg-primary/5"
+            className="pointer-events-none absolute inset-0 bg-zinc-200/60 dark:bg-zinc-950/50"
             style={{ height: `${HOURS.length * HOUR_HEIGHT}px` }}
           />
         )}
@@ -232,7 +232,7 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
         {/* Closed: before clinic opens */}
         {workStartTop !== null && workStartTop > 0 && (
           <div
-            className="pointer-events-none absolute left-0 right-0 bg-primary/5 border-b border-primary/10"
+            className="pointer-events-none absolute left-0 right-0 bg-zinc-200/60 dark:bg-zinc-950/50 border-b border-border/40"
             style={{
               top: 0,
               height: `${workStartTop}px`,
@@ -243,7 +243,7 @@ export function CalendarDayView({ date, appointments, onSlotClick, onSlotDragSel
         {/* Closed: after clinic closes */}
         {workEndTop !== null && workEndTop < HOURS.length * HOUR_HEIGHT && (
           <div
-            className="pointer-events-none absolute left-0 right-0 bg-primary/5 border-t border-primary/10"
+            className="pointer-events-none absolute left-0 right-0 bg-zinc-200/60 dark:bg-zinc-950/50 border-t border-border/40"
             style={{
               top: `${workEndTop}px`,
               height: `${HOURS.length * HOUR_HEIGHT - workEndTop}px`,

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -227,7 +227,7 @@ function WeekDayColumn({
         {/* Closed hours background — entire day when clinic is closed */}
         {!schedule && (
           <div
-            className="pointer-events-none absolute inset-0 bg-primary/5 z-0"
+            className="pointer-events-none absolute inset-0 bg-zinc-200/60 dark:bg-zinc-950/50 z-0"
             style={{ height: `${HOURS.length * HOUR_HEIGHT}px` }}
           />
         )}
@@ -238,7 +238,7 @@ function WeekDayColumn({
             {/* Closed: before clinic opens */}
             {timeToTop(schedule.startTime) > 0 && (
               <div
-                className="pointer-events-none absolute left-0 right-0 bg-primary/5 border-b border-primary/10 z-0"
+                className="pointer-events-none absolute left-0 right-0 bg-zinc-200/60 dark:bg-zinc-950/50 border-b border-border/40 z-0"
                 style={{
                   top: 0,
                   height: `${timeToTop(schedule.startTime)}px`,
@@ -248,7 +248,7 @@ function WeekDayColumn({
             {/* Closed: after clinic closes */}
             {timeToTop(schedule.endTime) < HOURS.length * HOUR_HEIGHT && (
               <div
-                className="pointer-events-none absolute left-0 right-0 bg-primary/5 border-t border-primary/10 z-0"
+                className="pointer-events-none absolute left-0 right-0 bg-zinc-200/60 dark:bg-zinc-950/50 border-t border-border/40 z-0"
                 style={{
                   top: `${timeToTop(schedule.endTime)}px`,
                   height: `${HOURS.length * HOUR_HEIGHT - timeToTop(schedule.endTime)}px`,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1248.

Closes #1248

---

## Claude summary

Fixed: in the gabinet calendar (day, day-by-employee, and week views), unavailable hours — before opening, after closing, and full closed days — now use a clearly visible neutral overlay (`bg-zinc-200/60 dark:bg-zinc-950/50`) instead of the barely-perceptible `bg-primary/5`. Working hours remain on the light/transparent background, so the working-vs-unavailable distinction is now obvious in both light and dark themes, matching the example from versum.com referenced in the issue.

Commit: `26da75d` on `claude/issue-1248`.