### PR TITLE
Apply same nowrap to phone columns in contacts and companies tables

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
@@ -222,7 +222,12 @@ function CompaniesIndex() {
     {
       id: "phone",
       label: t('common.phone'),
-      render: (item) => item.phone ? formatPhoneNumber(item.phone) : "—",
+      render: (item) =>
+        item.phone ? (
+          <span className="whitespace-nowrap">{formatPhoneNumber(item.phone)}</span>
+        ) : (
+          "—"
+        ),
     },
     {
       id: "industry",

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
@@ -255,7 +255,12 @@ function ContactsIndex() {
     {
       id: "phone",
       label: t('common.phone'),
-      render: (item) => item.phone ? formatPhoneNumber(item.phone) : "—",
+      render: (item) =>
+        item.phone ? (
+          <span className="whitespace-nowrap">{formatPhoneNumber(item.phone)}</span>
+        ) : (
+          "—"
+        ),
     },
     {
       id: "title",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1254.

Closes #1254

---

## Claude summary

Applied the same `whitespace-nowrap` span wrapper to the phone column render functions in both `_layout.contacts.index.tsx:258` and `_layout.companies.index.tsx:225`, mirroring the fix from #1242. Committed as `691625c`.