### PR TITLE
Weryfikacja poprawnosci konfiguracji proxy wysylkowego

### DIFF
--- a/convex/mail/adapters/resend.ts
+++ b/convex/mail/adapters/resend.ts
@@ -1,7 +1,7 @@
 "use node";
 
 import { Resend } from "resend";
-import type { MailAdapter, SendOptions, SendResult } from "../adapter";
+import type { MailAdapter, SendOptions, SendResult, ConnectionTestResult } from "../adapter";
 
 export function createResendAdapter(apiKey: string, fromEmail: string, fromName: string): MailAdapter {
   const resend = new Resend(apiKey);
@@ -25,6 +25,27 @@ export function createResendAdapter(apiKey: string, fromEmail: string, fromName:
         }
 
         return { success: true, messageId: result.data?.id };
+      } catch (err) {
+        return { success: false, error: String(err) };
+      }
+    },
+
+    async testConnection(): Promise<ConnectionTestResult> {
+      if (!apiKey) {
+        return { success: false, error: "Missing API key" };
+      }
+      try {
+        const response = await fetch("https://api.resend.com/domains", {
+          headers: { Authorization: `Bearer ${apiKey}` },
+        });
+        if (!response.ok) {
+          const text = await response.text().catch(() => "");
+          if (response.status === 401 || response.status === 403) {
+            return { success: false, error: "Invalid API key" };
+          }
+          return { success: false, error: text || `HTTP ${response.status}` };
+        }
+        return { success: true, accountEmail: fromEmail };
       } catch (err) {
         return { success: false, error: String(err) };
       }

--- a/convex/mail/testConnectionNode.ts
+++ b/convex/mail/testConnectionNode.ts
@@ -5,6 +5,7 @@ import { internalAction } from "../_generated/server";
 import { createMailgunAdapter } from "./adapters/mailgun";
 import { createGoogleAdapter } from "./adapters/google";
 import { createMicrosoftAdapter } from "./adapters/microsoft";
+import { createResendAdapter } from "./adapters/resend";
 import type { ConnectionTestResult } from "./adapter";
 
 export const runProviderTest = internalAction({
@@ -71,10 +72,15 @@ export const runProviderTest = internalAction({
           ? await adapter.testConnection()
           : { success: true, accountEmail: args.fromEmail };
       }
-      // Resend has no testConnection — check that API key is present
-      return args.apiConfig?.apiKey
-        ? { success: true, accountEmail: args.fromEmail }
-        : { success: false, error: "Missing API key" };
+      // Resend: probe API to verify key validity
+      const resend = createResendAdapter(
+        args.apiConfig?.apiKey ?? "",
+        args.fromEmail,
+        args.fromName,
+      );
+      return resend.testConnection
+        ? await resend.testConnection()
+        : { success: false, error: "testConnection not available" };
     } catch (err) {
       return { success: false, error: String(err) };
     }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -851,6 +851,8 @@
       "connectGoogle": "Connect with Google",
       "connectMicrosoft": "Connect with Microsoft",
       "testConnection": "Test connection",
+      "testSuccess": "Connection works",
+      "testFailed": "Connection test failed",
       "form": {
         "name": "Provider name",
         "fromName": "Sender name",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -864,6 +864,8 @@
       "connectGoogle": "Połącz z Google",
       "connectMicrosoft": "Połącz z Microsoft",
       "testConnection": "Testuj połączenie",
+      "testSuccess": "Połączenie działa poprawnie",
+      "testFailed": "Test połączenia nie powiódł się",
       "form": {
         "name": "Nazwa dostawcy",
         "fromName": "Nazwa nadawcy",

--- a/src/components/settings/mail-provider-card.tsx
+++ b/src/components/settings/mail-provider-card.tsx
@@ -1,5 +1,9 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useAction } from "convex/react";
+import { api } from "@cvx/_generated/api";
+import { Id } from "@cvx/_generated/dataModel";
+import { toast } from "sonner";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -13,7 +17,9 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Pencil, Trash2, Star } from "@/lib/ez-icons";
+import { Pencil, Trash2, Star, Activity, Loader2 } from "@/lib/ez-icons";
+import { useOrganization } from "@/components/org-context";
+import { formatActionError } from "@/lib/format-action-error";
 
 type ProviderType = "google" | "microsoft" | "mailgun" | "resend";
 type ProviderStatus = "active" | "inactive" | "error" | "pending_auth";
@@ -61,7 +67,48 @@ export function MailProviderCard({
   onRemove,
 }: MailProviderCardProps) {
   const { t } = useTranslation();
+  const { organizationId } = useOrganization();
+  const testConnection = useAction(api.mailProviders.testConnection);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [testing, setTesting] = useState(false);
+
+  const handleTest = async () => {
+    setTesting(true);
+    try {
+      const result = await testConnection({
+        organizationId,
+        providerId: provider._id as Id<"mailProviders">,
+      });
+      if (result.success) {
+        toast.success(
+          t("settings.mail.testSuccess", {
+            defaultValue: "Połączenie działa poprawnie",
+          }),
+          {
+            description: result.accountEmail,
+          },
+        );
+      } else {
+        toast.error(
+          t("settings.mail.testFailed", {
+            defaultValue: "Test połączenia nie powiódł się",
+          }),
+          {
+            description: result.error,
+          },
+        );
+      }
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "settings.mail.testFailed",
+          defaultValue: "Test połączenia nie powiódł się",
+        }),
+      );
+    } finally {
+      setTesting(false);
+    }
+  };
 
   return (
     <>
@@ -116,6 +163,20 @@ export function MailProviderCard({
           </div>
 
           <div className="flex items-center gap-1 shrink-0">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              title={t("settings.mail.testConnection")}
+              onClick={handleTest}
+              disabled={testing}
+            >
+              {testing ? (
+                <Loader2 className="h-4 w-4 animate-spin" variant="stroke" />
+              ) : (
+                <Activity className="h-4 w-4" variant="stroke" />
+              )}
+            </Button>
             {!provider.isDefault && (
               <Button
                 variant="ghost"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1263.

Closes #1263

---

## Claude summary

Committed. Here's a summary of what changed and what's still pending.

## Summary

The issue had two requests; I addressed the first one cleanly and tracked the second as a follow-up due to its scope.

### Implemented (part 1 — provider config test)

Added a "Test connection" button on each mail provider card at `/dashboard/settings/mail`. The backend action `api.mailProviders.testConnection` already existed (`convex/mailProviders.ts:277`) but was never wired up — the `settings.mail.testConnection` translation key was dormant.

Changes:
- `src/components/settings/mail-provider-card.tsx` — Activity icon button per provider; spinner while running; sonner toast with `accountEmail` on success or adapter `error` on failure.
- `convex/mail/adapters/resend.ts` — added a real `testConnection()` that probes `GET https://api.resend.com/domains` (previously the action just verified the API key was non-empty).
- `convex/mail/testConnectionNode.ts` — route Resend through the adapter's `testConnection()`.
- Translations: `settings.mail.testSuccess` / `settings.mail.testFailed` in PL and EN.

Typecheck (`tsc -p tsconfig.app.json` + `tsconfig.node.json` + `convex/tsconfig.json`) and ESLint on the touched files both pass.

### Not implemented (part 2 — outgoing email send logs)

The user explicitly asked to "check blast radius" for this one. It's genuinely a multi-file feature: there's no `emailSendLog` table today, and system flows like `convex/documents/signing.ts:286` just `console.error` failures and return — nothing reaches the DB. A proper fix needs a new schema table, instrumentation at every send site (signing, gabinet auto-docs, automations, reminders), a query endpoint, and a filterable admin UI. That's >5 files and warrants its own issue.

## Follow-ups
- Add searchable outgoing email send log: new `emailSendLog` table capturing source/template/provider/status/error/recipient/timestamp; instrument `convex/documents/signing.ts`, `convex/gabinet/_helpers/autoGenerateDocuments.ts`, `convex/emails.ts`, automation `send_email` actions, and `convex/email/index.ts`; add UI at `/dashboard/settings/mail` (new "Logs" tab) with filters by date, status, source, provider, recipient — second half of #1263.