### PR TITLE
Instrument `convex/gabinet/patientAuth.ts` OTP sends with `source

### DIFF
--- a/convex/gabinet/patientAuth.ts
+++ b/convex/gabinet/patientAuth.ts
@@ -1,4 +1,4 @@
-import { query, action, internalMutation } from "../_generated/server";
+import { query, action, internalAction } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { validatePortalSessionSupabase } from "../_helpers/portalSession";
@@ -107,14 +107,16 @@ export const sendPortalOtp = action({
       });
     }
 
-    // Send OTP via email — delegate to internalMutation for @cvx/email
+    // Send OTP via email — delegate to internalAction for @cvx/email
     try {
-      await ctx.runMutation(
+      await ctx.runAction(
         internal.gabinet.patientAuth._sendOtpEmail,
         {
           email: args.email,
           organizationId: args.organizationId,
           otp,
+          patientId,
+          patientName: `${patient.firstName} ${patient.lastName}`,
         },
       );
     } catch (e) {
@@ -126,21 +128,28 @@ export const sendPortalOtp = action({
 });
 
 /**
- * Internal: send the OTP email via @cvx/email (requires mutation context for Convex email).
+ * Internal: send the OTP email via @cvx/email. Implemented as an action
+ * because sendEmail() performs an outbound `fetch` (Resend HTTP API) which
+ * is only allowed in Convex actions, and so that we can pass the action
+ * ctx as `log.ctx` to mirror the send into emailSendLog.
  */
-export const _sendOtpEmail = internalMutation({
+export const _sendOtpEmail = internalAction({
   args: {
     email: v.string(),
     organizationId: v.id("organizations"),
     otp: v.string(),
+    patientId: v.string(),
+    patientName: v.string(),
   },
   handler: async (ctx, args) => {
     if (AUTH_RESEND_KEY) {
-      const org = await ctx.db.get(args.organizationId);
-      const orgName = org?.name ?? "Portal Klienta";
+      const db = createSupabaseDb();
+      const org = await db.get("organizations", String(args.organizationId));
+      const orgName = (org?.name as string | undefined) ?? "Portal Klienta";
+      const subject = `Twój kod weryfikacyjny - ${orgName}`;
       await sendEmail({
         to: args.email,
-        subject: `Twój kod weryfikacyjny - ${orgName}`,
+        subject,
         html: `
           <div style="font-family: sans-serif; max-width: 480px; margin: 0 auto; padding: 24px;">
             <h2 style="margin: 0 0 16px; color: #1a1a1a;">Kod weryfikacyjny</h2>
@@ -156,6 +165,14 @@ export const _sendOtpEmail = internalMutation({
           </div>
         `,
         text: `Twój kod weryfikacyjny: ${args.otp}\n\nKod jest ważny przez 10 minut.`,
+        log: {
+          ctx,
+          organizationId: args.organizationId,
+          source: "system",
+          recipientName: args.patientName,
+          relatedEntityType: "gabinetPatient",
+          relatedEntityId: args.patientId,
+        },
       });
     } else {
       console.warn("[Patient Portal OTP] Resend not configured, logging OTP to console");


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1267.

Closes #1267

---

## Claude summary

Committed. Summary of the change:

`convex/gabinet/patientAuth.ts` now mirrors patient-portal OTP sends to `emailSendLog` so they show up in /dashboard/settings/mail → Logs. The fix passes `log: { ctx, organizationId, source: "system", relatedEntityType: "gabinetPatient", relatedEntityId, recipientName }` to `sendEmail()`.

While wiring this up, `_sendOtpEmail` had to be converted from `internalMutation` to `internalAction` for two reasons: (1) `EmailSendLogContext.ctx` is typed as `GenericActionCtx<any>`, and (2) `sendEmail()` performs an outbound `fetch` to Resend, which is only allowed in Convex actions — so the previous mutation indirection was actually a latent runtime bug for any deploy with `AUTH_RESEND_KEY` set. The org name is now read from Supabase, matching the file's existing pattern.

Verified: `npx tsc -p convex/tsconfig.json --noEmit` clean; `tests/convex/patientAuth.test.ts` (15 tests) and `tests/convex/emailActivities.test.ts` (3 tests) all pass.

## Follow-ups
- Add an emailSendLog assertion to `tests/convex/patientAuth.test.ts`: the existing tests verify the OTP flow but don't assert that an `emailSendLog` row is written when `AUTH_RESEND_KEY` is set; a focused test would lock in the instrumentation contract.