### PR TITLE
Resolve pre-existing TS2589 in `convex/gabinet/_helpers/autoGenerateDocuments.ts

### DIFF
--- a/convex/gabinet/_helpers/autoGenerateDocuments.ts
+++ b/convex/gabinet/_helpers/autoGenerateDocuments.ts
@@ -164,7 +164,6 @@ export async function autoGenerateAppointmentDocuments(
       );
       if (patient?.email) {
         const patientName = `${patient.firstName}${patient.lastName ? " " + patient.lastName : ""}`;
-        // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
         await ctx.scheduler.runAfter(
           0,
           internal.documents.signing.sendSigningEmailInternal,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1268.

Closes #1268

---

## Claude summary

Removed the `@ts-ignore` masking TS2589 in `convex/gabinet/_helpers/autoGenerateDocuments.ts:167`. Verified by running `npm run typecheck` (all three tsconfigs) with a cleared `.tsbuildinfo` cache — passes cleanly. The other call sites of `internal.documents.signing.sendSigningEmailInternal` (in `convex/documents/documents.ts:558` and `convex/documents/generate.ts:205`) already compiled without suppression, confirming the issue was transient.

## Follow-ups
- Remove remaining @ts-ignore on sendSigningEmailInternal in documents.ts: line 430 in convex/documents/documents.ts has the same suppression and likely also no longer needed — verify with a fresh typecheck and clean up.