### PR TITLE
Resolve pre-existing TS2589 in `_layout.settings.mail.tsx`

### DIFF
--- a/src/components/settings/mail-send-log-tab.tsx
+++ b/src/components/settings/mail-send-log-tab.tsx
@@ -70,8 +70,6 @@ export function MailSendLogTab({ organizationId }: MailSendLogTabProps) {
   const [endDate, setEndDate] = useState("");
 
   const { data: entries } = useQuery(
-    // @ts-ignore TS2589: deep instantiation in Convex codegen — same pattern
-    // as other settings routes that already work around this.
     convexQuery(api.emailSendLog.list, {
       organizationId,
       limit: 200,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1269.

Closes #1269

---

## Claude summary

Triaged and fixed. The TS2589 the issue reported in `_layout.settings.mail.tsx` no longer fires — `convexQuery(api.app.getCurrentUser, {})` at line 62 of that route now typechecks cleanly without any suppression. The downstream consequence the issue called out (the new logs tab still carrying a `@ts-ignore`) was the only remaining symptom, so I removed the obsolete suppression in `src/components/settings/mail-send-log-tab.tsx`.

Verified all three TS projects (`tsconfig.app.json`, `tsconfig.node.json`, `convex/tsconfig.json`) and ESLint with `--report-unused-disable-directives` — all clean. This mirrors the prior cleanup pattern from #1268 (commit 3e78768) where the same kind of obsolete `@ts-ignore` was removed once the Convex codegen stabilized.