### PR TITLE
Add pagination/export to the log tab

### DIFF
--- a/convex/emailSendLog.ts
+++ b/convex/emailSendLog.ts
@@ -1,5 +1,6 @@
 import { query, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
+import { paginationOptsValidator } from "convex/server";
 import { requireOrgAdmin } from "./_helpers/auth";
 
 const sourceValidator = v.union(
@@ -25,6 +26,12 @@ const statusValidator = v.union(
   v.literal("failed"),
   v.literal("skipped"),
 );
+
+// Hard cap on rows returned by `exportRows` to keep a single query under
+// Convex's per-query document/byte limits. ~5k rows of log metadata fits
+// comfortably under the 16 MiB return budget while still covering most
+// real-world export needs for a single org.
+const EXPORT_ROW_CAP = 5000;
 
 export const record = internalMutation({
   args: {
@@ -56,7 +63,7 @@ export const record = internalMutation({
 export const list = query({
   args: {
     organizationId: v.id("organizations"),
-    limit: v.optional(v.number()),
+    paginationOpts: paginationOptsValidator,
     startDate: v.optional(v.number()),
     endDate: v.optional(v.number()),
     status: v.optional(statusValidator),
@@ -66,30 +73,99 @@ export const list = query({
   },
   handler: async (ctx, args) => {
     await requireOrgAdmin(ctx, args.organizationId);
-    const limit = Math.min(args.limit ?? 100, 500);
 
-    const entries = await ctx.db
+    const result = await ctx.db
       .query("emailSendLog")
       .withIndex("by_org_sentAt", (q) =>
         q.eq("organizationId", args.organizationId),
       )
       .order("desc")
-      .collect();
+      .filter((q) => {
+        const exprs = [];
+        if (args.status) exprs.push(q.eq(q.field("status"), args.status));
+        if (args.source) exprs.push(q.eq(q.field("source"), args.source));
+        if (args.provider) exprs.push(q.eq(q.field("provider"), args.provider));
+        if (args.startDate !== undefined) {
+          exprs.push(q.gte(q.field("sentAt"), args.startDate));
+        }
+        if (args.endDate !== undefined) {
+          exprs.push(q.lte(q.field("sentAt"), args.endDate));
+        }
+        if (exprs.length === 0) {
+          // Tautology — the index already restricts to this org. Returned only
+          // because `.filter` requires an expression.
+          return q.eq(q.field("organizationId"), args.organizationId);
+        }
+        if (exprs.length === 1) return exprs[0];
+        return q.and(...exprs);
+      })
+      .paginate(args.paginationOpts);
 
     const recipientNeedle = args.recipient?.trim().toLowerCase();
+    if (recipientNeedle) {
+      return {
+        ...result,
+        page: result.page.filter((e) =>
+          e.recipientEmail.toLowerCase().includes(recipientNeedle),
+        ),
+      };
+    }
+    return result;
+  },
+});
 
-    const filtered = entries.filter((e) => {
-      if (args.status && e.status !== args.status) return false;
-      if (args.source && e.source !== args.source) return false;
-      if (args.provider && e.provider !== args.provider) return false;
-      if (args.startDate !== undefined && e.sentAt < args.startDate) return false;
-      if (args.endDate !== undefined && e.sentAt > args.endDate) return false;
-      if (recipientNeedle && !e.recipientEmail.toLowerCase().includes(recipientNeedle)) {
-        return false;
-      }
-      return true;
-    });
+// Returns up to `EXPORT_ROW_CAP` matching rows in a single response for CSV
+// download. Filters mirror `list`. Callers should display a warning when the
+// returned array length equals the cap (export was truncated).
+export const exportRows = query({
+  args: {
+    organizationId: v.id("organizations"),
+    startDate: v.optional(v.number()),
+    endDate: v.optional(v.number()),
+    status: v.optional(statusValidator),
+    source: v.optional(sourceValidator),
+    provider: v.optional(providerValidator),
+    recipient: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await requireOrgAdmin(ctx, args.organizationId);
 
-    return filtered.slice(0, limit);
+    const rows = await ctx.db
+      .query("emailSendLog")
+      .withIndex("by_org_sentAt", (q) =>
+        q.eq("organizationId", args.organizationId),
+      )
+      .order("desc")
+      .filter((q) => {
+        const exprs = [];
+        if (args.status) exprs.push(q.eq(q.field("status"), args.status));
+        if (args.source) exprs.push(q.eq(q.field("source"), args.source));
+        if (args.provider) exprs.push(q.eq(q.field("provider"), args.provider));
+        if (args.startDate !== undefined) {
+          exprs.push(q.gte(q.field("sentAt"), args.startDate));
+        }
+        if (args.endDate !== undefined) {
+          exprs.push(q.lte(q.field("sentAt"), args.endDate));
+        }
+        if (exprs.length === 0) {
+          return q.eq(q.field("organizationId"), args.organizationId);
+        }
+        if (exprs.length === 1) return exprs[0];
+        return q.and(...exprs);
+      })
+      .take(EXPORT_ROW_CAP);
+
+    const recipientNeedle = args.recipient?.trim().toLowerCase();
+    const filtered = recipientNeedle
+      ? rows.filter((e) =>
+          e.recipientEmail.toLowerCase().includes(recipientNeedle),
+        )
+      : rows;
+
+    return {
+      rows: filtered,
+      truncated: rows.length === EXPORT_ROW_CAP,
+      cap: EXPORT_ROW_CAP,
+    };
   },
 });

--- a/src/components/settings/mail-send-log-tab.tsx
+++ b/src/components/settings/mail-send-log-tab.tsx
@@ -1,10 +1,13 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { convexQuery } from "@convex-dev/react-query";
+import { toast } from "sonner";
+import { Download } from "lucide-react";
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
@@ -55,12 +58,15 @@ const PROVIDERS: Provider[] = [
   "dev_intercept",
 ];
 
+const PAGE_SIZE = 50;
+
 interface MailSendLogTabProps {
   organizationId: Id<"organizations">;
 }
 
 export function MailSendLogTab({ organizationId }: MailSendLogTabProps) {
   const { t, i18n } = useTranslation();
+  const queryClient = useQueryClient();
 
   const [statusFilter, setStatusFilter] = useState<Status | "all">("all");
   const [sourceFilter, setSourceFilter] = useState<Source | "all">("all");
@@ -69,10 +75,14 @@ export function MailSendLogTab({ organizationId }: MailSendLogTabProps) {
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
 
-  const { data: entries } = useQuery(
-    convexQuery(api.emailSendLog.list, {
+  // Cursor stack for keyset Prev/Next. `null` is the first page. Every Next
+  // pushes the previous result's `continueCursor`; Prev pops back.
+  const [cursorStack, setCursorStack] = useState<(string | null)[]>([null]);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const filters = useMemo(
+    () => ({
       organizationId,
-      limit: 200,
       status: statusFilter !== "all" ? statusFilter : undefined,
       source: sourceFilter !== "all" ? sourceFilter : undefined,
       provider: providerFilter !== "all" ? providerFilter : undefined,
@@ -80,7 +90,44 @@ export function MailSendLogTab({ organizationId }: MailSendLogTabProps) {
       startDate: startDate ? new Date(startDate).getTime() : undefined,
       endDate: endDate ? new Date(endDate + "T23:59:59").getTime() : undefined,
     }),
+    [
+      organizationId,
+      statusFilter,
+      sourceFilter,
+      providerFilter,
+      recipient,
+      startDate,
+      endDate,
+    ],
   );
+
+  // Reset to the first page whenever any filter changes.
+  const filterKey = JSON.stringify(filters);
+  useEffect(() => {
+    setCursorStack([null]);
+  }, [filterKey]);
+
+  const currentCursor = cursorStack[cursorStack.length - 1];
+  const pageNumber = cursorStack.length;
+
+  const resetFilters = () => {
+    setStatusFilter("all");
+    setSourceFilter("all");
+    setProviderFilter("all");
+    setRecipient("");
+    setStartDate("");
+    setEndDate("");
+  };
+
+  const { data, isLoading } = useQuery(
+    convexQuery(api.emailSendLog.list, {
+      ...filters,
+      paginationOpts: { numItems: PAGE_SIZE, cursor: currentCursor },
+    }),
+  );
+
+  const entries = data?.page;
+  const isDone = data?.isDone ?? false;
 
   const formatTimestamp = (ts: number) =>
     new Date(ts).toLocaleString(i18n.language, {
@@ -92,13 +139,126 @@ export function MailSendLogTab({ organizationId }: MailSendLogTabProps) {
       second: "2-digit",
     });
 
+  const handlePrev = () => {
+    if (cursorStack.length > 1) {
+      setCursorStack((prev) => prev.slice(0, -1));
+    }
+  };
+
+  const handleNext = () => {
+    if (data && !data.isDone && data.continueCursor) {
+      setCursorStack((prev) => [...prev, data.continueCursor]);
+    }
+  };
+
+  const escapeCsv = (value: string | number | null | undefined): string => {
+    if (value === null || value === undefined) return "";
+    const s = String(value);
+    if (/[",\n\r]/.test(s)) {
+      return `"${s.replace(/"/g, '""')}"`;
+    }
+    return s;
+  };
+
+  const handleExport = async () => {
+    setIsExporting(true);
+    try {
+      const result = await queryClient.fetchQuery(
+        convexQuery(api.emailSendLog.exportRows, filters),
+      );
+
+      const header = [
+        "sentAt",
+        "status",
+        "source",
+        "provider",
+        "recipientEmail",
+        "recipientName",
+        "fromEmail",
+        "subject",
+        "templateId",
+        "errorMessage",
+        "relatedEntityType",
+        "relatedEntityId",
+      ];
+      const csvLines = [header.join(",")];
+      for (const r of result.rows) {
+        csvLines.push(
+          [
+            new Date(r.sentAt).toISOString(),
+            r.status,
+            r.source,
+            r.provider ?? "",
+            r.recipientEmail,
+            r.recipientName ?? "",
+            r.fromEmail ?? "",
+            r.subject ?? "",
+            r.templateId ?? "",
+            r.errorMessage ?? "",
+            r.relatedEntityType ?? "",
+            r.relatedEntityId ?? "",
+          ]
+            .map(escapeCsv)
+            .join(","),
+        );
+      }
+
+      const csv = csvLines.join("\n");
+      const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      const ts = new Date().toISOString().replace(/[:.]/g, "-");
+      a.download = `mail-send-log-${ts}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+
+      if (result.truncated) {
+        toast.warning(
+          t("settings.mail.logs.exportTruncated", {
+            cap: result.cap,
+            defaultValue: `Eksport ograniczony do {{cap}} najnowszych wpisów.`,
+          }),
+        );
+      } else {
+        toast.success(
+          t("settings.mail.logs.exportSuccess", {
+            count: result.rows.length,
+            defaultValue: `Wyeksportowano {{count}} wpisów.`,
+          }),
+        );
+      }
+    } catch (e) {
+      console.error("[mail-send-log] export failed", e);
+      toast.error(
+        t("settings.mail.logs.exportError", "Nie udało się wyeksportować dziennika."),
+      );
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
   return (
     <div className="space-y-6">
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0">
           <CardTitle className="text-base">
             {t("settings.mail.logs.filters", "Filtry")}
           </CardTitle>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleExport}
+            disabled={isExporting}
+          >
+            <Download className="mr-2 h-4 w-4" />
+            {isExporting
+              ? t("settings.mail.logs.exporting", "Eksportowanie...")
+              : t("settings.mail.logs.exportCsv", "Eksportuj CSV")}
+          </Button>
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
@@ -317,6 +477,56 @@ export function MailSendLogTab({ organizationId }: MailSendLogTabProps) {
           </table>
         </CardContent>
       </Card>
+
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs text-muted-foreground">
+          {t("settings.mail.logs.page", { page: pageNumber, defaultValue: "Strona {{page}}" })}
+          {entries !== undefined && (
+            <>
+              {" · "}
+              {t("settings.mail.logs.shown", {
+                count: entries.length,
+                defaultValue: "{{count}} wpisów",
+              })}
+            </>
+          )}
+        </p>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handlePrev}
+            disabled={pageNumber <= 1 || isLoading}
+          >
+            {t("settings.mail.logs.prev", "Poprzednia")}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleNext}
+            disabled={isDone || isLoading || !data?.continueCursor}
+          >
+            {t("settings.mail.logs.next", "Następna")}
+          </Button>
+          {(statusFilter !== "all" ||
+            sourceFilter !== "all" ||
+            providerFilter !== "all" ||
+            recipient ||
+            startDate ||
+            endDate) && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={resetFilters}
+            >
+              {t("settings.mail.logs.resetFilters", "Wyczyść filtry")}
+            </Button>
+          )}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1270.

Closes #1270

---

## Claude summary

Committed as `8f482c7`.

Summary of changes:

Backend (`convex/emailSendLog.ts`):
- `list` query switched from "collect all org rows + filter in JS + slice" to keyset pagination on the `by_org_sentAt` index using `.paginate(paginationOpts)`. Indexable filters (status, source, provider, sentAt range) are pushed down via `.filter()`. Recipient substring stays as a per-page JS filter (best effort, since it's a substring match).
- Added `exportRows` query returning up to 5000 matching rows in a single response, plus a `truncated` flag so the client can warn the user when the cap was hit.

Frontend (`src/components/settings/mail-send-log-tab.tsx`):
- Replaced single bulk fetch (`limit: 200`) with paginated fetch (`PAGE_SIZE = 50`). Cursor stack drives Prev/Next; cursor resets on any filter change.
- New "Eksportuj CSV" button in the filters card calls `exportRows`, generates a CSV blob (with proper quoting/escaping), triggers a download, and shows a sonner toast (success or truncated warning).
- Added a "Wyczyść filtry" button that appears when any filter is active.

Verification: `tsc -p convex/tsconfig.json --noEmit`, `tsc -p tsconfig.app.json --noEmit`, `eslint` on both files, and both `npm run test:unit:convex` (112 tests) and `test:unit:frontend` (20 tests) pass clean.