### PR TITLE
Remove remaining @ts-ignore on sendSigningEmailInternal in documents.ts

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -427,7 +427,6 @@ export const submitEmployeeFormFields = action({
       if (recipientEmail) {
         await ctx.scheduler.runAfter(
           0,
-          // @ts-ignore — deep type instantiation under app tsconfig
           internal.documents.signing.sendSigningEmailInternal,
           {
             documentId: args.documentId as Id<"formDocuments">,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1274.

Closes #1274

---

## Claude summary

Removed the obsolete `@ts-ignore` on line 430 of `convex/documents/documents.ts` and verified with the full `npm run typecheck` (app + node + convex tsconfigs), which passes cleanly. Committed as `436cfe4`.