### PR TITLE
numerek

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
@@ -91,6 +91,7 @@ function PatientDetail() {
   const removePatient = useAction(api.gabinet.patients.remove);
   const updatePaymentAction = useAction(api.payments.update);
   const trackView = useAction(api.recentlyViewed.track);
+  const listDocumentsByEntity = useAction(api.documents.documents.listByEntity);
   const queryClient = useQueryClient();
 
   const [editDrawerOpen, setEditDrawerOpen] = useState(false);
@@ -159,6 +160,22 @@ function PatientDetail() {
   const { data: treatmentPackages } = useSupabaseGabinetTreatmentPackagesList(
     organizationId,
   );
+
+  const { data: patientDocuments } = useQuery({
+    queryKey: [
+      "documents.documents.listByEntity",
+      organizationId,
+      "patient",
+      patientId,
+    ],
+    queryFn: () =>
+      listDocumentsByEntity({
+        organizationId,
+        entityType: "patient",
+        entityId: patientId,
+      }),
+    enabled: !!organizationId && !!patientId,
+  });
 
   const getPaymentForLabel = (payment: {
     appointmentId?: string;
@@ -997,6 +1014,7 @@ function PatientDetail() {
     },
     {
       label: t("gabinet.patients.tabs.documents"),
+      count: patientDocuments?.length ?? 0,
       content: (
         <EntityDocumentsTab
           entityType="patient"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1134.

Closes #1134

---

## Claude summary

Triage confirmed and fix shipped. The "Dokumenty" tab on the patient detail page (src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx) now shows a count badge — same pattern as "Wizyty {n}" and "Płatności {n}" already use (line 686 and 782). I fetch `api.documents.documents.listByEntity` with the same query key the inner `EntityDocumentsTab` uses, so React Query deduplicates the request — no extra network call.

Verified with `tsc -p tsconfig.app.json --noEmit` (clean). Committed as `d09c671` referencing #1134.

## Follow-ups
- Add document count to other entity detail tabs: contacts, leads, companies, employees, and treatments all render `EntityDocumentsTab` without a count — same UX gap as the patient page had