### PR TITLE
Add document count to other entity detail tabs

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx
@@ -85,10 +85,27 @@ function CompanyDetail() {
   const removeScheduledActivity = useAction(api.scheduledActivities.remove);
   const setCustomFields = useAction(api.customFields.setValues);
   const trackView = useAction(api.recentlyViewed.track);
+  const listDocumentsByEntity = useAction(api.documents.documents.listByEntity);
 
   const { data: currentUser } = useQuery(
     convexQuery(api.app.getCurrentUser, {})
   );
+
+  const { data: companyDocuments } = useQuery({
+    queryKey: [
+      "documents.documents.listByEntity",
+      organizationId,
+      "company",
+      companyId,
+    ],
+    queryFn: () =>
+      listDocumentsByEntity({
+        organizationId,
+        entityType: "company",
+        entityId: companyId,
+      }),
+    enabled: !!organizationId && !!companyId,
+  });
 
   const { data: activityTypeDefs } = useSupabaseActivityTypesList(organizationId);
 
@@ -920,6 +937,7 @@ function CompanyDetail() {
           },
           {
             label: t('detail.tabs.documents'),
+            count: companyDocuments?.length ?? 0,
             content: (
               <EntityDocumentsTab
                 entityType="company"

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
@@ -84,6 +84,7 @@ function ContactDetail() {
   const removeScheduledActivity = useAction(api.scheduledActivities.remove);
   const setCustomFields = useAction(api.customFields.setValues);
   const trackView = useAction(api.recentlyViewed.track);
+  const listDocumentsByEntity = useAction(api.documents.documents.listByEntity);
 
   const { data: currentUser } = useQuery(
     convexQuery(api.app.getCurrentUser, {})
@@ -187,6 +188,22 @@ function ContactDetail() {
     "contact",
     contactId,
   );
+
+  const { data: contactDocuments } = useQuery({
+    queryKey: [
+      "documents.documents.listByEntity",
+      organizationId,
+      "contact",
+      contactId,
+    ],
+    queryFn: () =>
+      listDocumentsByEntity({
+        organizationId,
+        entityType: "contact",
+        entityId: contactId,
+      }),
+    enabled: !!organizationId && !!contactId,
+  });
 
   const relationshipsQueryKey = [...supabaseKeys.objectRelationships.list(organizationId), "contact", contactId] as const;
   const relationshipsQuery = useSupabaseRelationshipsByEntity(
@@ -853,6 +870,7 @@ function ContactDetail() {
     },
     {
       label: t('detail.tabs.documents'),
+      count: contactDocuments?.length ?? 0,
       content: (
         <EntityDocumentsTab
           entityType="contact"

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -113,6 +113,7 @@ function EmployeeDetail() {
   const saveSchedulePeriod = useAction(api.gabinet.scheduling.saveSchedulePeriod);
   const removeSchedulePeriod = useAction(api.gabinet.scheduling.removeSchedulePeriod);
   const trackView = useAction(api.recentlyViewed.track);
+  const listDocumentsByEntity = useAction(api.documents.documents.listByEntity);
 
   // Supabase cache invalidation helpers
   const invalidateEmployeeCache = () => {
@@ -205,6 +206,22 @@ function EmployeeDetail() {
         employeeId: (employee?.userId ?? "") as string,
       }),
     enabled: !!employee?.userId,
+  });
+
+  const { data: employeeDocuments } = useQuery({
+    queryKey: [
+      "documents.documents.listByEntity",
+      organizationId,
+      "employee",
+      employeeId,
+    ],
+    queryFn: () =>
+      listDocumentsByEntity({
+        organizationId,
+        entityType: "employee",
+        entityId: employeeId,
+      }),
+    enabled: !!organizationId && !!employeeId,
   });
 
   // Employee schedule (per-employee working hours)
@@ -675,6 +692,7 @@ function EmployeeDetail() {
     },
     {
       label: t("gabinet.employees.tabs.documents", "Dokumenty"),
+      count: employeeDocuments?.length ?? 0,
       content: (
         <EntityDocumentsTab
           entityType="employee"

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -166,6 +166,7 @@ function TreatmentDetail() {
   const getDetailedStatsAction = useAction(api.gabinet.treatments.getTreatmentDetailedStats);
   const listTreatmentAppointmentsAction = useAction(api.gabinet.treatments.listTreatmentAppointments);
   const getTreatmentEmployeesAction = useAction(api.gabinet.treatments.getTreatmentEmployees);
+  const listDocumentsByEntity = useAction(api.documents.documents.listByEntity);
 
   const { data: detailedStats } = useQuery({
     queryKey: ["gabinet.treatments.getTreatmentDetailedStats", organizationId, treatmentId],
@@ -203,6 +204,22 @@ function TreatmentDetail() {
       getTreatmentEmployeesAction({
         organizationId,
         treatmentId: treatmentId as string,
+      }),
+    enabled: !!organizationId && !!treatmentId,
+  });
+
+  const { data: treatmentDocuments } = useQuery({
+    queryKey: [
+      "documents.documents.listByEntity",
+      organizationId,
+      "treatment",
+      treatmentId,
+    ],
+    queryFn: () =>
+      listDocumentsByEntity({
+        organizationId,
+        entityType: "treatment",
+        entityId: treatmentId,
       }),
     enabled: !!organizationId && !!treatmentId,
   });
@@ -795,6 +812,7 @@ function TreatmentDetail() {
       },
       {
         label: t("gabinet.treatmentDetail.tabs.documents"),
+        count: treatmentDocuments?.length ?? 0,
         content: (
           <div className="space-y-6">
             <TreatmentRequiredDocuments

--- a/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
@@ -250,6 +250,23 @@ function LeadDetail() {
   const removeScheduledActivity = useAction(api.scheduledActivities.remove);
   const addProductToDeal = useAction(api.products.addToDeal);
   const removeProductFromDeal = useAction(api.products.removeFromDeal);
+  const listDocumentsByEntity = useAction(api.documents.documents.listByEntity);
+
+  const { data: leadDocuments } = useQuery({
+    queryKey: [
+      "documents.documents.listByEntity",
+      organizationId,
+      "lead",
+      leadId,
+    ],
+    queryFn: () =>
+      listDocumentsByEntity({
+        organizationId,
+        entityType: "lead",
+        entityId: leadId,
+      }),
+    enabled: !!organizationId && !!leadId,
+  });
 
   const { data: currentUser } = useQuery(
     convexQuery(api.app.getCurrentUser, {})
@@ -1297,6 +1314,7 @@ function LeadDetail() {
     },
     {
       label: t('detail.tabs.documents'),
+      count: leadDocuments?.length ?? 0,
       content: (
         <EntityDocumentsTab
           entityType="lead"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1280.

Closes #1280

---

## Claude summary

Added a count badge to the Dokumenty/Documents tab on the contact, lead, company, employee, and treatment detail pages, applying the same pattern shipped for patients in #1134. Each detail route now calls `api.documents.documents.listByEntity` via React Query using the exact key `EntityDocumentsTab` already uses, so the fetch is deduped. Could not run `npm run typecheck` because `node_modules` is not installed in this worktree, but the changes are mechanical (same shape as the merged #1134 patch) and the layout's tab type already accepts `count?: number` (entity-detail-layout.tsx:211).