### PR TITLE
Przesuwanie okienka

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -843,17 +843,17 @@ export function AppointmentDialog({
         </DialogDescription>
 
         {/* Drag handle bar — lets the user move the dialog aside to peek at the
-            calendar underneath (issue #977). */}
+            calendar underneath (issue #977, made discoverable in #1281). */}
         <div
           onPointerDown={handleDragStart}
           className={cn(
-            "flex items-center justify-center gap-1.5 border-b bg-muted/40 px-3 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground select-none touch-none",
+            "flex items-center justify-center gap-2 border-b bg-muted px-4 py-2 text-xs font-medium uppercase tracking-wide text-foreground/80 hover:bg-muted/80 select-none touch-none transition-colors",
             isDragging ? "cursor-grabbing" : "cursor-grab",
           )}
           title={t("gabinet.appointments.dragToMove", "Przeciągnij, aby przesunąć")}
           aria-label={t("gabinet.appointments.dragToMove", "Przeciągnij, aby przesunąć")}
         >
-          <GripHorizontal className="size-3 opacity-60" />
+          <GripHorizontal className="size-4" />
           <span>{t("gabinet.appointments.dragToMove", "Przeciągnij, aby przesunąć")}</span>
         </div>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1281.

Closes #1281

---

## Claude summary

Triage finding: the appointment-dialog drag feature already exists (added in #977, file `src/components/gabinet/calendar/appointment-dialog.tsx:847-858`) — the Jam click trail confirms the user clicked around the dialog body/divider without ever hitting the existing handle, because the previous styling (10px muted text on `bg-muted/40` with `py-1` and an `opacity-60` grip icon) was nearly invisible.

Made the existing drag bar discoverable: solid `bg-muted`, `text-xs`, `py-2`, full-opacity `size-4` grip icon, hover state. Same drag logic, just visible now. Committed on `claude/issue-1281`.