### PR TITLE
rozliczenie

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2360,6 +2360,9 @@ export interface AppointmentFullDetail {
   loyaltyTransactions: GabinetLoyaltyTransactionRow[];
   allPatientPayments: PaymentRow[];
   workflowHistory: AppointmentWorkflowHistoryRow[];
+  // Available patient credit (overpayment carry-forward) derived from the
+  // `payments` ledger. See issue #1059.
+  patientCreditBalance: number;
 }
 
 export const getFullDetail = action({
@@ -2413,6 +2416,7 @@ export const getFullDetail = action({
       loyaltyBalanceRow,
       loyaltyTransactionsRaw,
       allPatientPaymentsRaw,
+      patientCreditRowsRaw,
       workflowHistoryRaw,
     ] = await Promise.all([
       db.get("gabinetPatients", patientId),
@@ -2462,6 +2466,13 @@ export const getFullDetail = action({
         .eq("patientId", patientId)
         .order("createdAt", false)
         .take(50)
+        .collect(),
+      // Separate scan for credit balance — avoids the 50-row cap on
+      // `allPatientPaymentsRaw` so old credit ledger rows still count.
+      db.query("payments")
+        .eq("organizationId", orgIdStr)
+        .eq("patientId", patientId)
+        .eq("status", "completed")
         .collect(),
       db.query("appointmentWorkflowHistory")
         .eq("appointmentId", args.appointmentId)
@@ -2610,9 +2621,29 @@ export const getFullDetail = action({
       loyaltyTransactions,
       allPatientPayments,
       workflowHistory,
+      patientCreditBalance: computePatientCreditFromRows(
+        patientCreditRowsRaw as unknown as PaymentRow[],
+      ),
     };
   },
 });
+
+/**
+ * Patient credit balance derived from the patient's payments ledger:
+ *   sum over completed rows of (creditEarned − creditApplied).
+ * Caller is expected to pass already-filtered rows (status="completed").
+ */
+function computePatientCreditFromRows(rows: PaymentRow[]): number {
+  let balance = 0;
+  for (const r of rows) {
+    const earned = (r as PaymentRow & { creditEarned?: number | null })
+      .creditEarned;
+    const applied = (r as PaymentRow & { creditApplied?: number | null })
+      .creditApplied;
+    balance += (earned ?? 0) - (applied ?? 0);
+  }
+  return Math.round(balance * 100) / 100;
+}
 
 export type AppointmentWarningCode =
   | "past"

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -111,6 +111,15 @@ export const create = action({
     paymentMethod: paymentMethodValidator,
     notes: v.optional(v.string()),
     status: v.optional(paymentStatusValidator),
+    // Patient-credit accounting (issue #1059).
+    // creditEarned: overpayment portion of `amount` to add to the patient's
+    // credit balance. Caller is expected to compute this against the visit
+    // price; the backend only sanity-checks that it doesn't exceed `amount`.
+    // creditApplied: pre-existing patient credit consumed to settle this
+    // visit. Reduces outstanding without contributing to `amount`. Must not
+    // exceed the patient's current available balance.
+    creditEarned: v.optional(v.number()),
+    creditApplied: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(
@@ -121,6 +130,42 @@ export const create = action({
     const db = createSupabaseDb();
     const now = Date.now();
     const status = args.status ?? "completed";
+
+    const creditEarned =
+      args.creditEarned !== undefined && args.creditEarned !== 0
+        ? args.creditEarned
+        : null;
+    const creditApplied =
+      args.creditApplied !== undefined && args.creditApplied !== 0
+        ? args.creditApplied
+        : null;
+
+    if (creditEarned !== null) {
+      if (!Number.isFinite(creditEarned) || creditEarned < 0) {
+        throw new Error("creditEarned must be a non-negative number");
+      }
+      if (creditEarned > args.amount + 0.005) {
+        throw new Error("creditEarned cannot exceed amount");
+      }
+    }
+    if (creditApplied !== null) {
+      if (!Number.isFinite(creditApplied) || creditApplied <= 0) {
+        throw new Error("creditApplied must be a positive number");
+      }
+      if (!args.patientId) {
+        throw new Error("creditApplied requires a patientId");
+      }
+      const balance = await computePatientCreditBalance(
+        db,
+        String(args.organizationId),
+        String(args.patientId),
+      );
+      if (creditApplied > balance + 0.005) {
+        throw new Error(
+          `creditApplied ${creditApplied} exceeds available balance ${balance}`,
+        );
+      }
+    }
 
     const paymentId = await db.insert("payments", {
       organizationId: String(args.organizationId),
@@ -133,6 +178,9 @@ export const create = action({
       status,
       paidAt: status === "completed" ? now : null,
       notes: args.notes ?? null,
+      creditEarned,
+      creditApplied,
+      kind: "payment",
       createdBy: String(authResult.userId),
       createdAt: now,
       updatedAt: now,
@@ -146,6 +194,161 @@ export const create = action({
         userId: authResult.userId,
         amount: args.amount,
         currency: args.currency,
+      });
+    } catch {
+      // side effects are best-effort
+    }
+
+    return paymentId;
+  },
+});
+
+/**
+ * Available patient credit derived from the `payments` ledger:
+ *   sum over completed payments of (creditEarned − creditApplied).
+ * Refunded / pending / cancelled rows don't contribute, so reversing a
+ * payment with creditEarned > 0 naturally drains the balance.
+ */
+async function computePatientCreditBalance(
+  db: ReturnType<typeof createSupabaseDb>,
+  organizationId: string,
+  patientId: string,
+): Promise<number> {
+  const rows = await db
+    .query<{
+      creditEarned?: number | null;
+      creditApplied?: number | null;
+    }>("payments")
+    .eq("organizationId", organizationId)
+    .eq("patientId", patientId)
+    .eq("status", "completed")
+    .collect();
+  let balance = 0;
+  for (const r of rows) {
+    balance += (r.creditEarned ?? 0) - (r.creditApplied ?? 0);
+  }
+  return Math.round(balance * 100) / 100;
+}
+
+export const getPatientCredit = action({
+  args: {
+    organizationId: v.id("organizations"),
+    patientId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+
+    const db = createSupabaseDb();
+    const rows = await db
+      .query("payments")
+      .eq("organizationId", String(args.organizationId))
+      .eq("patientId", args.patientId)
+      .eq("status", "completed")
+      .order("createdAt", false)
+      .collect();
+
+    let balance = 0;
+    const history: Array<{
+      _id: string;
+      createdAt: number;
+      amount: number;
+      creditEarned: number;
+      creditApplied: number;
+      kind: string;
+      appointmentId: string | null;
+      paymentMethod: string;
+      notes: string | null;
+    }> = [];
+    for (const r of rows) {
+      const earned = (r.creditEarned as number | null | undefined) ?? 0;
+      const applied = (r.creditApplied as number | null | undefined) ?? 0;
+      balance += earned - applied;
+      if (earned !== 0 || applied !== 0) {
+        history.push({
+          _id: String(r._id),
+          createdAt: r.createdAt as number,
+          amount: r.amount as number,
+          creditEarned: earned,
+          creditApplied: applied,
+          kind: ((r.kind as string | null | undefined) ?? "payment") as string,
+          appointmentId: (r.appointmentId as string | null) ?? null,
+          paymentMethod: r.paymentMethod as string,
+          notes: (r.notes as string | null) ?? null,
+        });
+      }
+    }
+    return {
+      balance: Math.round(balance * 100) / 100,
+      history,
+    };
+  },
+});
+
+/**
+ * Refund part or all of a patient's credit balance back to them as cash/card.
+ * Inserts a `kind="credit_refund"` ledger row with `creditEarned = -amount`,
+ * draining the balance. Admin-only (issue #1059).
+ */
+export const refundCredit = action({
+  args: {
+    organizationId: v.id("organizations"),
+    patientId: v.string(),
+    amount: v.number(),
+    paymentMethod: paymentMethodValidator,
+    notes: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const authResult = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    if (authResult.role !== "owner" && authResult.role !== "admin") {
+      throw new Error("Only organization admins can refund patient credit");
+    }
+    if (!Number.isFinite(args.amount) || args.amount <= 0) {
+      throw new Error("Refund amount must be positive");
+    }
+
+    const db = createSupabaseDb();
+    const balance = await computePatientCreditBalance(
+      db,
+      String(args.organizationId),
+      String(args.patientId),
+    );
+    if (args.amount > balance + 0.005) {
+      throw new Error(
+        `Refund amount ${args.amount} exceeds available credit ${balance}`,
+      );
+    }
+
+    const now = Date.now();
+    const paymentId = await db.insert("payments", {
+      organizationId: String(args.organizationId),
+      patientId: args.patientId,
+      appointmentId: null,
+      packageUsageId: null,
+      amount: args.amount,
+      currency: "PLN",
+      paymentMethod: args.paymentMethod,
+      status: "completed",
+      paidAt: now,
+      notes: args.notes ?? null,
+      creditEarned: -args.amount,
+      creditApplied: null,
+      kind: "credit_refund",
+      createdBy: String(authResult.userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    try {
+      await ctx.runMutation(internal.payments._refundCreditSideEffects, {
+        paymentId,
+        organizationId: args.organizationId,
+        userId: authResult.userId,
+        amount: args.amount,
       });
     } catch {
       // side effects are best-effort
@@ -489,6 +692,25 @@ export const _refundSideEffects = internalMutation({
       entityType: "payment",
       entityId: args.paymentId as any,
       details: JSON.stringify({ amount: args.amount, reason: args.reason }),
+    });
+  },
+});
+
+export const _refundCreditSideEffects = internalMutation({
+  args: {
+    paymentId: v.string(),
+    organizationId: v.id("organizations"),
+    userId: v.id("users"),
+    amount: v.number(),
+  },
+  handler: async (ctx, args) => {
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: args.userId,
+      action: "patient_credit_refunded",
+      entityType: "payment",
+      entityId: args.paymentId as any,
+      details: JSON.stringify({ amount: args.amount }),
     });
   },
 });

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -438,6 +438,20 @@ export function createCrmTables({
     ),
     paidAt: v.optional(v.number()),
     notes: v.optional(v.string()),
+    // Patient-credit accounting (issue #1059).
+    // creditEarned: portion of `amount` that became patient credit (overpayment
+    // on this row). May be negative on `kind="credit_refund"` rows to drain the
+    // balance when an admin refunds outstanding credit to the patient.
+    // creditApplied: amount of pre-existing patient credit consumed by this row
+    // to settle an appointment — it reduces the patient's available balance
+    // but doesn't add to the `amount` (which is the cash/card leg).
+    // kind: discriminates ordinary payments from credit-refund bookkeeping
+    // rows so the balance computation can treat the latter as pure deductions.
+    creditEarned: v.optional(v.number()),
+    creditApplied: v.optional(v.number()),
+    kind: v.optional(
+      v.union(v.literal("payment"), v.literal("credit_refund")),
+    ),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),
@@ -445,6 +459,11 @@ export function createCrmTables({
     .index("by_org", ["organizationId"])
     .index("by_orgAndStatus", ["organizationId", "status"])
     .index("by_orgAndPatient", ["organizationId", "patientId"])
+    .index("by_orgAndPatientAndStatus", [
+      "organizationId",
+      "patientId",
+      "status",
+    ])
     .index("by_appointment", ["appointmentId"]),
 
   // --- Saved Views ---

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3254,7 +3254,12 @@
       "summary": "Summary",
       "totalPaid": "Total paid",
       "totalSpent": "Total spent",
-      "treatmentPrice": "Treatment price"
+      "treatmentPrice": "Treatment price",
+      "creditBalance": "Credit balance",
+      "useCredit": "Use credit balance",
+      "creditAmountToApply": "Amount from credit",
+      "creditExceedsBalance": "Credit amount exceeds available balance.",
+      "overpaymentNote": "Overpayment of {{amount}} will be added to the patient's credit balance and can be used on future visits."
     },
     "schedules": {
       "break": "Break",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3283,7 +3283,12 @@
       "summary": "Podsumowanie",
       "totalPaid": "Zapłacono łącznie",
       "totalSpent": "Wydano łącznie",
-      "treatmentPrice": "Cena zabiegu"
+      "treatmentPrice": "Cena zabiegu",
+      "creditBalance": "Saldo nadpłat",
+      "useCredit": "Użyj salda nadpłat",
+      "creditAmountToApply": "Kwota z salda",
+      "creditExceedsBalance": "Kwota użytego salda nadpłat przekracza dostępne środki.",
+      "overpaymentNote": "Nadpłata {{amount}} zostanie dopisana do salda klienta i można ją wykorzystać przy kolejnych wizytach."
     },
     "schedules": {
       "break": "Przerwa",

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -275,6 +275,9 @@ export function AppointmentPreviewContent({
   >("card");
   const [settleFirstSplitAmount, setSettleFirstSplitAmount] = useState("");
   const [settleSecondSplitAmount, setSettleSecondSplitAmount] = useState("");
+  // Patient credit (overpayment carry-forward) — issue #1059.
+  const [settleUseCredit, setSettleUseCredit] = useState(false);
+  const [settleCreditAmount, setSettleCreditAmount] = useState("");
 
   const { tags: tagDefinitions } = useTagDefinitions(organizationId);
   const { dispatch } = useSidebarActions();
@@ -590,6 +593,8 @@ export function AppointmentPreviewContent({
     ? `${t("gabinet.payments.totalPaid")}: ${formatCurrencyPLN(completedPaid)} / ${formatCurrencyPLN(treatmentPrice)}`
     : null;
 
+  const patientCreditBalance = (detail.patientCreditBalance ?? 0) as number;
+
   const handleOpenSettleDialog = () => {
     if (saving || settleSubmitting) return;
     setSettleAmount(outstanding > 0 ? outstanding.toFixed(2) : "");
@@ -601,6 +606,10 @@ export function AppointmentPreviewContent({
     setSettleSecondSplitMethod("card");
     setSettleFirstSplitAmount("");
     setSettleSecondSplitAmount("");
+    setSettleUseCredit(false);
+    setSettleCreditAmount(
+      Math.min(patientCreditBalance, outstanding).toFixed(2),
+    );
     setSettleDialogOpen(true);
   };
 
@@ -619,6 +628,28 @@ export function AppointmentPreviewContent({
     parsedSecondSplitAmount <= 0;
   const splitSameMethod =
     settleSplitPayment && settleFirstSplitMethod === settleSecondSplitMethod;
+
+  // Credit applied + overpayment derivation. Only active on the non-split path:
+  // split payment + credit is out of scope for #1059.
+  const parsedSettleAmount =
+    parseFloat(settleAmount.replace(",", ".")) || 0;
+  const parsedCreditAmount =
+    parseFloat(settleCreditAmount.replace(",", ".")) || 0;
+  const creditMaxApplicable = !settleSplitPayment
+    ? Math.min(patientCreditBalance, outstanding)
+    : 0;
+  const creditApplied =
+    !settleSplitPayment && settleUseCredit && parsedCreditAmount > 0
+      ? Math.min(parsedCreditAmount, creditMaxApplicable)
+      : 0;
+  const creditApplyExceedsBalance =
+    !settleSplitPayment &&
+    settleUseCredit &&
+    parsedCreditAmount > patientCreditBalance + 0.005;
+  const overpaymentAmount =
+    !settleSplitPayment
+      ? Math.max(0, parsedSettleAmount + creditApplied - outstanding)
+      : 0;
 
   const handleConfirmSettle = async () => {
     if (settleSubmitting) return;
@@ -657,7 +688,16 @@ export function AppointmentPreviewContent({
         toast.error(t("gabinet.payments.amountRequired"));
         return;
       }
-      if (!hasAmount && !settleMarkCompleted) {
+      if (creditApplyExceedsBalance) {
+        toast.error(
+          t("gabinet.payments.creditExceedsBalance", {
+            defaultValue:
+              "Kwota użytego salda nadpłat przekracza dostępne środki.",
+          }),
+        );
+        return;
+      }
+      if (!hasAmount && creditApplied <= 0 && !settleMarkCompleted) {
         toast.error(
           t("gabinet.appointmentDetail.settleNothingToDo", {
             defaultValue: "Wpisz kwotę lub zaznacz zamknięcie wizyty.",
@@ -702,15 +742,22 @@ export function AppointmentPreviewContent({
             notes: combinedNote,
           });
         }
-      } else if (hasAmount && parsedAmount > 0 && patient?._id) {
+      } else if (
+        patient?._id &&
+        ((hasAmount && parsedAmount > 0) || creditApplied > 0)
+      ) {
         await createPaymentAction({
           organizationId,
           patientId: patient._id,
           appointmentId: appointment._id,
-          amount: parsedAmount,
+          amount: parsedAmount > 0 ? parsedAmount : 0,
           currency: "PLN",
           paymentMethod: settleMethod,
           notes: settleNotes.trim() || undefined,
+          ...(overpaymentAmount > 0
+            ? { creditEarned: overpaymentAmount }
+            : {}),
+          ...(creditApplied > 0 ? { creditApplied } : {}),
         });
       }
       if (settleMarkCompleted && canMarkCompleted) {
@@ -1308,6 +1355,18 @@ export function AppointmentPreviewContent({
                 {formatCurrencyPLN(outstanding)}
               </span>
             </div>
+            {patientCreditBalance > 0 && (
+              <div className="flex justify-between gap-3 border-t pt-1 text-emerald-700 dark:text-emerald-400">
+                <span>
+                  {t("gabinet.payments.creditBalance", {
+                    defaultValue: "Saldo nadpłat",
+                  })}
+                </span>
+                <span className="font-medium tabular-nums">
+                  {formatCurrencyPLN(patientCreditBalance)}
+                </span>
+              </div>
+            )}
           </div>
 
           {!settleSplitPayment && (
@@ -1365,6 +1424,93 @@ export function AppointmentPreviewContent({
                   </SelectItem>
                 </SelectContent>
               </Select>
+            </div>
+          )}
+
+          {!settleSplitPayment && patient?._id && patientCreditBalance > 0 && (
+            <div className="space-y-2 rounded-md border border-emerald-200 bg-emerald-50 p-2.5 dark:border-emerald-900 dark:bg-emerald-950/30">
+              <div className="flex items-start gap-2">
+                <Checkbox
+                  id="settle-use-credit"
+                  checked={settleUseCredit}
+                  onCheckedChange={(v) => {
+                    const next = v === true;
+                    setSettleUseCredit(next);
+                    if (next) {
+                      const def = Math.min(
+                        patientCreditBalance,
+                        outstanding,
+                      );
+                      setSettleCreditAmount(
+                        def > 0 ? def.toFixed(2) : "",
+                      );
+                      const remaining = Math.max(0, outstanding - def);
+                      setSettleAmount(
+                        remaining > 0 ? remaining.toFixed(2) : "",
+                      );
+                    } else {
+                      setSettleCreditAmount("");
+                      setSettleAmount(
+                        outstanding > 0 ? outstanding.toFixed(2) : "",
+                      );
+                    }
+                  }}
+                />
+                <Label
+                  htmlFor="settle-use-credit"
+                  className="cursor-pointer text-sm font-normal leading-snug"
+                >
+                  {t("gabinet.payments.useCredit", {
+                    defaultValue: "Użyj salda nadpłat",
+                    amount: formatCurrencyPLN(patientCreditBalance),
+                  })}{" "}
+                  <span className="text-muted-foreground">
+                    ({formatCurrencyPLN(patientCreditBalance)})
+                  </span>
+                </Label>
+              </div>
+              {settleUseCredit && (
+                <div className="space-y-1">
+                  <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                    {t("gabinet.payments.creditAmountToApply", {
+                      defaultValue: "Kwota z salda",
+                    })}
+                  </Label>
+                  <Input
+                    type="text"
+                    inputMode="decimal"
+                    value={settleCreditAmount}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                        setSettleCreditAmount(v);
+                      }
+                    }}
+                    placeholder={Math.min(
+                      patientCreditBalance,
+                      outstanding,
+                    ).toFixed(2)}
+                  />
+                  {creditApplyExceedsBalance && (
+                    <p className="text-[11px] text-destructive">
+                      {t("gabinet.payments.creditExceedsBalance", {
+                        defaultValue:
+                          "Kwota użytego salda nadpłat przekracza dostępne środki.",
+                      })}
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {!settleSplitPayment && overpaymentAmount > 0 && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300">
+              {t("gabinet.payments.overpaymentNote", {
+                defaultValue:
+                  "Nadpłata {{amount}} zostanie dopisana do salda klienta i można ją wykorzystać przy kolejnych wizytach.",
+                amount: formatCurrencyPLN(overpaymentAmount),
+              })}
             </div>
           )}
 

--- a/supabase/migrations/00008_payments_patient_credit.sql
+++ b/supabase/migrations/00008_payments_patient_credit.sql
@@ -1,0 +1,32 @@
+-- Patient credit / overpayment carry-forward (issue #1059).
+--
+-- Two new columns on `payments` track credit accounting:
+--   credit_earned   numeric — overpayment portion that became patient credit
+--                            (negative on credit-refund rows that drain the
+--                            balance back to the patient as cash)
+--   credit_applied  numeric — pre-existing credit consumed by this payment to
+--                            settle a visit (does NOT add to `amount`)
+--
+-- A nullable `kind` column distinguishes ordinary payments from bookkeeping
+-- rows produced by `refundCredit` so reports can filter them out.
+--
+-- All three columns are nullable so existing rows remain valid without
+-- backfill. Patient credit balance is derived from completed/pending payments
+-- as: SUM(coalesce(credit_earned, 0) - coalesce(credit_applied, 0)).
+
+ALTER TABLE payments
+  ADD COLUMN IF NOT EXISTS credit_earned NUMERIC,
+  ADD COLUMN IF NOT EXISTS credit_applied NUMERIC,
+  ADD COLUMN IF NOT EXISTS kind TEXT;
+
+-- Restrict `kind` values to the allowed discriminators. Existing NULLs are
+-- treated as "payment".
+ALTER TABLE payments
+  DROP CONSTRAINT IF EXISTS payments_kind_check;
+ALTER TABLE payments
+  ADD CONSTRAINT payments_kind_check
+  CHECK (kind IS NULL OR kind IN ('payment', 'credit_refund'));
+
+-- Composite index used by getPatientCredit to scan completed rows per patient.
+CREATE INDEX IF NOT EXISTS payments_org_patient_status_idx
+  ON payments (organization_id, patient_id, status);

--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -260,6 +260,226 @@ describe("payments", () => {
     expect(new Set(allIds).size).toBe(5);
   });
 
+  // Patient credit / overpayment carry-forward (#1059) -----------------------
+  //
+  // The payments backend treats `patientId` as an opaque string for credit
+  // computations — it just keys the ledger and never reads from
+  // `gabinetPatients`. So we don't need to seed a real patient row; a
+  // stable string suffices to scope these tests.
+  const TEST_PATIENT_ID = "test-patient-credit-1";
+
+  test("getPatientCredit returns zero for a patient with no payments", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    const patientId = TEST_PATIENT_ID;
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.payments.getPatientCredit, {
+        organizationId,
+        patientId: String(patientId),
+      });
+
+    expect(result.balance).toBe(0);
+    expect(result.history).toHaveLength(0);
+  });
+
+  test("overpayment writes credit and increases patient balance", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    const patientId = TEST_PATIENT_ID;
+
+    await t.withIdentity(identity).action(api.payments.create, {
+      organizationId,
+      patientId: String(patientId),
+      amount: 600,
+      currency: "PLN",
+      paymentMethod: "cash",
+      creditEarned: 500,
+    });
+
+    const credit = await t
+      .withIdentity(identity)
+      .action(api.payments.getPatientCredit, {
+        organizationId,
+        patientId: String(patientId),
+      });
+    expect(credit.balance).toBe(500);
+    expect(credit.history).toHaveLength(1);
+    expect(credit.history[0].creditEarned).toBe(500);
+  });
+
+  test("applying credit reduces patient balance", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    const patientId = TEST_PATIENT_ID;
+
+    // Seed 500 credit
+    await t.withIdentity(identity).action(api.payments.create, {
+      organizationId,
+      patientId: String(patientId),
+      amount: 600,
+      currency: "PLN",
+      paymentMethod: "cash",
+      creditEarned: 500,
+    });
+
+    // Apply 200 credit on a next visit (cash leg = 0)
+    await t.withIdentity(identity).action(api.payments.create, {
+      organizationId,
+      patientId: String(patientId),
+      amount: 0,
+      currency: "PLN",
+      paymentMethod: "cash",
+      creditApplied: 200,
+    });
+
+    const credit = await t
+      .withIdentity(identity)
+      .action(api.payments.getPatientCredit, {
+        organizationId,
+        patientId: String(patientId),
+      });
+    expect(credit.balance).toBe(300);
+  });
+
+  test("creditApplied exceeding balance is rejected", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    const patientId = TEST_PATIENT_ID;
+
+    // Seed 100 credit
+    await t.withIdentity(identity).action(api.payments.create, {
+      organizationId,
+      patientId: String(patientId),
+      amount: 200,
+      currency: "PLN",
+      paymentMethod: "cash",
+      creditEarned: 100,
+    });
+
+    await expect(
+      t.withIdentity(identity).action(api.payments.create, {
+        organizationId,
+        patientId: String(patientId),
+        amount: 0,
+        currency: "PLN",
+        paymentMethod: "cash",
+        creditApplied: 200,
+      }),
+    ).rejects.toThrow(/exceeds available balance/);
+  });
+
+  test("refundCredit drains the credit balance", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    const patientId = TEST_PATIENT_ID;
+
+    await t.withIdentity(identity).action(api.payments.create, {
+      organizationId,
+      patientId: String(patientId),
+      amount: 500,
+      currency: "PLN",
+      paymentMethod: "cash",
+      creditEarned: 500,
+    });
+
+    await t.withIdentity(identity).action(api.payments.refundCredit, {
+      organizationId,
+      patientId: String(patientId),
+      amount: 300,
+      paymentMethod: "cash",
+    });
+
+    const credit = await t
+      .withIdentity(identity)
+      .action(api.payments.getPatientCredit, {
+        organizationId,
+        patientId: String(patientId),
+      });
+    expect(credit.balance).toBe(200);
+  });
+
+  test("refundCredit beyond balance is rejected", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    const patientId = TEST_PATIENT_ID;
+
+    await t.withIdentity(identity).action(api.payments.create, {
+      organizationId,
+      patientId: String(patientId),
+      amount: 100,
+      currency: "PLN",
+      paymentMethod: "cash",
+      creditEarned: 100,
+    });
+
+    await expect(
+      t.withIdentity(identity).action(api.payments.refundCredit, {
+        organizationId,
+        patientId: String(patientId),
+        amount: 500,
+        paymentMethod: "cash",
+      }),
+    ).rejects.toThrow(/exceeds available credit/);
+  });
+
+  test("refundCredit is admin-only", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t, {
+      role: "member",
+    });
+    const patientId = TEST_PATIENT_ID;
+
+    await expect(
+      t.withIdentity(identity).action(api.payments.refundCredit, {
+        organizationId,
+        patientId: String(patientId),
+        amount: 50,
+        paymentMethod: "cash",
+      }),
+    ).rejects.toThrow(/admins can refund/);
+  });
+
+  test("refunding a payment with creditEarned releases that credit", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    const patientId = TEST_PATIENT_ID;
+
+    const paymentId = await t
+      .withIdentity(identity)
+      .action(api.payments.create, {
+        organizationId,
+        patientId: String(patientId),
+        amount: 600,
+        currency: "PLN",
+        paymentMethod: "cash",
+        creditEarned: 500,
+      });
+
+    let credit = await t
+      .withIdentity(identity)
+      .action(api.payments.getPatientCredit, {
+        organizationId,
+        patientId: String(patientId),
+      });
+    expect(credit.balance).toBe(500);
+
+    await t.withIdentity(identity).action(api.payments.refund, {
+      organizationId,
+      paymentId,
+      reason: "Patient cancelled",
+    });
+
+    credit = await t
+      .withIdentity(identity)
+      .action(api.payments.getPatientCredit, {
+        organizationId,
+        patientId: String(patientId),
+      });
+    expect(credit.balance).toBe(0);
+  });
+
   test("markPaid can change payment method", async () => {
     const t = createTestCtx();
     const { organizationId, identity } = await seedTestUser(t);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1059.

Closes #1059

---

## Claude summary

Phase 1 of #1059 is implemented and committed.

What landed:
- Schema: `payments` gains optional `creditEarned`, `creditApplied`, `kind` columns plus a `by_orgAndPatientAndStatus` index (supabase migration 00008 mirrors it).
- Backend (`convex/payments.ts`): `create` accepts the two new fields with balance/sanity checks; `getPatientCredit` derives balance + history from the ledger (no denormalized field); `refundCredit` is admin-only and writes a `credit_refund` row. Refunding a payment that earned credit naturally drains the balance because completed-only rows count.
- `getFullDetail` surfaces `patientCreditBalance` so the settle dialog doesn't need a second round trip.
- Settle dialog shows the available balance, a "use credit" checkbox with editable amount (clamped to outstanding), and an overpayment hint that appears whenever cash + applied credit > outstanding — matching the user's "świadome użycie" requirement.
- 8 new unit tests cover earn, apply, exceed-balance, refund, admin-only, and refund-released cases. All 121 convex tests + 20 frontend tests pass, and `npm run typecheck` is clean.

The credit balance is derivable from one table (no drift), refunds work via the existing status flow, and the split-payment path is intentionally untouched (out of scope for #1059).

## Follow-ups
- Add patient-detail credit panel for gabinet: surface credit balance + history list + admin "refund credit" action on the patient page so non-settle flows can manage credit.
- Add calendar tile credit indicator: small "Saldo +X" dot on the patient's next unpaid visit when balance > 0 (calendar-month-view.tsx, appointment-card.tsx).
- Backfill historical overpayments into creditEarned: one-off migration that scans completed appointment-linked payments where amount > linked treatment price and records the excess as creditEarned, per user's "historyczna migracja" answer.
- Support credit + split payment in settle dialog: currently mutually exclusive; allow combining credit with multi-method cash/card split.
- Include credit rows in payment history view: `_layout.gabinet.appointments.$appointmentId` payments tab should label rows with creditEarned/creditApplied/credit_refund kind so accountants can read the ledger.