### PR TITLE
Add calendar tile credit indicator

### DIFF
--- a/src/components/gabinet/calendar/appointment-card.tsx
+++ b/src/components/gabinet/calendar/appointment-card.tsx
@@ -14,7 +14,8 @@ export type AppointmentIndicatorKind =
   | "count"
   | "paid"
   | "partial"
-  | "unpaid";
+  | "unpaid"
+  | "credit";
 
 export interface AppointmentIndicator {
   kind: AppointmentIndicatorKind;
@@ -41,6 +42,7 @@ const INDICATOR_CLASS: Record<AppointmentIndicatorKind, string> = {
   paid: "bg-emerald-600 text-white",
   partial: "bg-amber-500 text-white",
   unpaid: "bg-red-500 text-white",
+  credit: "bg-indigo-500 text-white",
 };
 
 export function AppointmentCard({

--- a/src/components/gabinet/calendar/calendar-month-view.tsx
+++ b/src/components/gabinet/calendar/calendar-month-view.tsx
@@ -20,6 +20,12 @@ interface CalendarMonthViewProps {
   leaveDates?: Set<string>;
   /** Dates with at least one non-cancelled appointment whose prepayment is required but unpaid. */
   paymentDueDates?: Set<string>;
+  /**
+   * Dates carrying at least one patient's next unpaid visit whose available
+   * credit balance > 0 — drives a small "Saldo" dot so users can spot
+   * carry-forward credit at a glance (issue #1286).
+   */
+  creditDates?: Set<string>;
 }
 
 function getMonthGrid(year: number, month: number): (string | null)[][] {
@@ -59,7 +65,7 @@ const DAY_LABEL_DEFAULTS: Record<(typeof DAY_LABEL_KEYS)[number], string> = {
   sun: "Nd",
 };
 
-export function CalendarMonthView({ year, month, appointments, onDayClick, selectedDate, leaveDates, paymentDueDates }: CalendarMonthViewProps) {
+export function CalendarMonthView({ year, month, appointments, onDayClick, selectedDate, leaveDates, paymentDueDates, creditDates }: CalendarMonthViewProps) {
   const { t } = useTranslation();
   const grid = useMemo(() => getMonthGrid(year, month), [year, month]);
   const now = new Date();
@@ -99,6 +105,7 @@ export function CalendarMonthView({ year, month, appointments, onDayClick, selec
           const isToday = date === today;
           const isLeave = leaveDates?.has(date) ?? false;
           const hasPaymentDue = paymentDueDates?.has(date) ?? false;
+          const hasCredit = creditDates?.has(date) ?? false;
 
           return (
             <div
@@ -124,7 +131,7 @@ export function CalendarMonthView({ year, month, appointments, onDayClick, selec
                   </span>
                 </div>
               )}
-              {(count > 0 || hasPaymentDue) && (
+              {(count > 0 || hasPaymentDue || hasCredit) && (
                 <div className="mt-0.5 flex flex-wrap items-center gap-1">
                   {count > 0 && (
                     <span className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary">
@@ -142,6 +149,19 @@ export function CalendarMonthView({ year, month, appointments, onDayClick, selec
                       className="inline-flex h-4 min-w-4 items-center justify-center rounded-sm bg-amber-500 px-0.5 text-[10px] font-bold leading-none text-white"
                     >
                       $
+                    </span>
+                  )}
+                  {hasCredit && (
+                    <span
+                      title={t("gabinet.calendar.indicators.credit", {
+                        defaultValue: "Pacjent ma saldo do wykorzystania",
+                      })}
+                      aria-label={t("gabinet.calendar.indicators.credit", {
+                        defaultValue: "Pacjent ma saldo do wykorzystania",
+                      })}
+                      className="inline-flex h-4 min-w-4 items-center justify-center rounded-sm bg-indigo-500 px-0.5 text-[10px] font-bold leading-none text-white"
+                    >
+                      +
                     </span>
                   )}
                 </div>

--- a/src/hooks/use-supabase-payments.ts
+++ b/src/hooks/use-supabase-payments.ts
@@ -11,6 +11,73 @@ import {
 } from "@/lib/supabase/mappers/payments";
 
 // ---------------------------------------------------------------------------
+// Patient Credit Balances (bulk)
+// ---------------------------------------------------------------------------
+
+/**
+ * For a given set of patient IDs, returns each patient's available credit
+ * balance derived from the payments ledger (issue #1059):
+ *   balance = SUM(coalesce(credit_earned, 0) - coalesce(credit_applied, 0))
+ * over completed payments. Returned map only contains patients with a strictly
+ * positive balance — patients with zero or negative balance are omitted so the
+ * caller can `has()` to drive an indicator.
+ *
+ * Powers the calendar's "Saldo +X" tile indicator (issue #1286).
+ */
+export function useSupabaseGabinetPatientCreditBalances(
+  organizationId: string,
+  patientIds: string[],
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  const stableIds = [...patientIds].sort();
+
+  return useQuery<Map<string, number>, Error>({
+    queryKey: [
+      ...supabaseKeys.payments.list(organizationId),
+      "creditBalancesByPatient",
+      stableIds.join(","),
+    ],
+    queryFn: async (): Promise<Map<string, number>> => {
+      const result = new Map<string, number>();
+      if (!client) throw new Error("Supabase client not ready");
+      if (stableIds.length === 0) return result;
+
+      const { data, error } = await client
+        .from("payments")
+        .select("patient_id, credit_earned, credit_applied")
+        .eq("organization_id", organizationId)
+        .eq("status", "completed")
+        .in("patient_id", stableIds);
+
+      if (error) throw error;
+
+      const sums = new Map<string, number>();
+      for (const row of (data ?? []) as {
+        patient_id: string | null;
+        credit_earned: number | null;
+        credit_applied: number | null;
+      }[]) {
+        if (!row.patient_id) continue;
+        const delta =
+          (Number(row.credit_earned) || 0) -
+          (Number(row.credit_applied) || 0);
+        sums.set(row.patient_id, (sums.get(row.patient_id) ?? 0) + delta);
+      }
+      for (const [pid, bal] of sums) {
+        const rounded = Math.round(bal * 100) / 100;
+        if (rounded > 0) result.set(pid, rounded);
+      }
+      return result;
+    },
+    enabled:
+      enabled && isReady && !!organizationId && stableIds.length > 0,
+  } satisfies UseQueryOptions<Map<string, number>, Error>);
+}
+
+// ---------------------------------------------------------------------------
 // Payments by Patient
 // ---------------------------------------------------------------------------
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -69,6 +69,7 @@ import { useSupabaseGabinetEmployeeSchedulesList } from "@/hooks/use-supabase-ga
 import { useSupabaseGabinetWorkingHoursList } from "@/hooks/use-supabase-gabinet-working-hours";
 import { useSupabaseGabinetLeavesList } from "@/hooks/use-supabase-gabinet-leaves";
 import { useSupabaseScheduledActivitiesByDateRange } from "@/hooks/use-supabase-scheduled-activities";
+import { useSupabaseGabinetPatientCreditBalances } from "@/hooks/use-supabase-payments";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
@@ -182,7 +183,8 @@ function GabinetCalendarPage() {
         | "count"
         | "paid"
         | "partial"
-        | "unpaid";
+        | "unpaid"
+        | "credit";
       label: string;
       title?: string;
     }>;
@@ -543,6 +545,69 @@ function GabinetCalendarPage() {
       indicatorLookupIds.appointmentIds,
     );
 
+  // Patient credit balances (only patients with balance > 0). Used to render
+  // the "Saldo +X" tile + month-day indicator on each patient's next unpaid
+  // visit (issue #1286). Carry-forward credit comes from #1059.
+  const { data: patientCreditBalances } =
+    useSupabaseGabinetPatientCreditBalances(
+      organizationId,
+      indicatorLookupIds.patientIds,
+    );
+
+  // For each patient with credit > 0, identify the appointment ID of their
+  // earliest non-cancelled, not-fully-paid visit in the visible range — that
+  // tile gets the "Saldo +X" badge. Only one appointment per patient is
+  // marked so the indicator unambiguously points at the next visit credit
+  // can be applied to (issue #1286).
+  const creditByAppointmentId = useMemo(() => {
+    const result = new Map<string, number>();
+    if (!rawAppointments || !patientCreditBalances || patientCreditBalances.size === 0) {
+      return result;
+    }
+    // Group candidate appointments per patient, sorted by (date, startTime).
+    const earliest = new Map<
+      string,
+      { id: string; date: string; startTime: string }
+    >();
+    for (const a of rawAppointments) {
+      if (a.status === "cancelled" || a.status === "no_show") continue;
+      const balance = patientCreditBalances.get(a.patientId);
+      if (!balance || balance <= 0) continue;
+      const treatment = treatmentMap.get(a.treatmentId as string);
+      const price = treatment?.price ?? 0;
+      if (price <= 0) continue;
+      const paid = appointmentPaymentTotals?.get(a._id) ?? 0;
+      if (paid >= price) continue; // already settled
+      const current = earliest.get(a.patientId);
+      if (
+        !current ||
+        a.date < current.date ||
+        (a.date === current.date && a.startTime < current.startTime)
+      ) {
+        earliest.set(a.patientId, {
+          id: a._id,
+          date: a.date,
+          startTime: a.startTime,
+        });
+      }
+    }
+    for (const [pid, info] of earliest) {
+      result.set(info.id, patientCreditBalances.get(pid) ?? 0);
+    }
+    return result;
+  }, [rawAppointments, patientCreditBalances, treatmentMap, appointmentPaymentTotals]);
+
+  // Dates carrying at least one credit-flagged appointment — feeds the month
+  // view's day-level "Saldo" dot (issue #1286).
+  const creditDates = useMemo(() => {
+    const set = new Set<string>();
+    if (!rawAppointments || creditByAppointmentId.size === 0) return set;
+    for (const a of rawAppointments) {
+      if (creditByAppointmentId.has(a._id)) set.add(a.date);
+    }
+    return set;
+  }, [rawAppointments, creditByAppointmentId]);
+
   // Transform and filter appointments for view components
   const viewAppointments = useMemo(() => {
     type Indicator = {
@@ -552,7 +617,8 @@ function GabinetCalendarPage() {
         | "count"
         | "paid"
         | "partial"
-        | "unpaid";
+        | "unpaid"
+        | "credit";
       label: string;
       title?: string;
     };
@@ -654,6 +720,25 @@ function GabinetCalendarPage() {
           }
         }
 
+        // Patient credit indicator — flags the patient's next unpaid visit
+        // when they have an available credit balance from carry-forward
+        // overpayments (issue #1286, ledger from #1059). Shown alongside the
+        // unpaid/partial badge so staff know credit is sitting ready to be
+        // applied at settle time.
+        const creditBalance = creditByAppointmentId.get(a._id);
+        if (creditBalance && creditBalance > 0) {
+          // Round to whole units for the compact pill so the badge stays
+          // legible at the small tile size. Tooltip shows the precise amount.
+          indicators.push({
+            kind: "credit",
+            label: `+${Math.round(creditBalance)}`,
+            title: t("gabinet.calendar.indicators.credit", {
+              defaultValue: "Saldo {{amount}} do wykorzystania",
+              amount: creditBalance.toFixed(2),
+            }),
+          });
+        }
+
         // Paid / partial / unpaid indicator — surfaces the visit's payment
         // settlement state directly on the tile so staff can spot unpaid
         // completed visits without opening each one (issue #1040). Mirrors
@@ -746,7 +831,7 @@ function GabinetCalendarPage() {
     }
 
     return items;
-  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, tagMap, employeeColorMap, firstAppointmentIds, packagePositions, recurringPositions, appointmentPaymentTotals, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
+  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, tagMap, employeeColorMap, firstAppointmentIds, packagePositions, recurringPositions, appointmentPaymentTotals, creditByAppointmentId, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
 
   // Build print-friendly appointment data for the current day
   const printDate = formatDateStr(currentDate);
@@ -1617,6 +1702,7 @@ function GabinetCalendarPage() {
               selectedDate={formatDateStr(currentDate)}
               leaveDates={leaveDates}
               paymentDueDates={paymentDueDates}
+              creditDates={creditDates}
             />
           )}
         </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1286.

Closes #1286

---

## Claude summary

Committed `c0f442d`.

Summary of the change for issue #1286:

`src/hooks/use-supabase-payments.ts` — new `useSupabaseGabinetPatientCreditBalances(orgId, patientIds)` hook that issues a single `payments` query (`status = completed`, filtered by patient ids) and returns a `Map<patientId, balance>` containing only patients with positive `Σ(credit_earned − credit_applied)`.

`src/components/gabinet/calendar/appointment-card.tsx` — adds a new `credit` indicator kind with an indigo badge (`bg-indigo-500`) so it reads distinctly from the existing emerald (`paid`/`firstVisit`), amber (`payment`/`partial`) and red (`unpaid`) badges.

`src/components/gabinet/calendar/calendar-month-view.tsx` — new optional `creditDates?: Set<string>` prop that paints a small indigo `+` dot inside the day cell, alongside the existing `$` payment-due dot.

`src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx` — calls the new hook, pre-computes `creditByAppointmentId` by selecting each patient's earliest non-cancelled, not-fully-paid visit in the visible range (so the badge appears on exactly one tile per patient), pushes a `credit` indicator with label `+N` (rounded zł) and a Polish tooltip showing the precise amount, and derives `creditDates` from the same set for the month view.

Verified with `tsc -p tsconfig.app.json` (clean) and frontend vitest run (20/20 passing). The pre-existing eslint warning at line 1188 exists on `main` and is unrelated.