### PR TITLE
Backfill historical overpayments into creditEarned

### DIFF
--- a/convex/migrations/backfillCreditEarned.ts
+++ b/convex/migrations/backfillCreditEarned.ts
@@ -1,0 +1,181 @@
+import { v } from "convex/values";
+import { internalAction } from "../_generated/server";
+import { createSupabaseDb } from "../_helpers/supabaseDb";
+
+// One-off migration for issue #1287.
+//
+// Patient credit / overpayment carry-forward (#1059) introduced the
+// `creditEarned` column on payments. New visits write the overpayment
+// portion into it so the running patient balance picks it up. Historical
+// completed payments booked *before* #1059 shipped have `creditEarned = NULL`
+// even when the patient overpaid relative to the linked treatment price,
+// so that excess never makes it into the balance.
+//
+// This action backfills those rows. For each completed payment that:
+//   - belongs to the target organization,
+//   - has an `appointmentId` and a `patientId`,
+//   - is a regular payment (`kind` IS NULL or "payment", never
+//     "credit_refund"),
+//   - has `creditEarned` IS NULL (or 0),
+//   - links to an appointment whose `treatmentId` resolves to a treatment
+//     with a positive `price`,
+// we set `creditEarned = amount − treatment.price` when `amount` exceeds
+// `treatment.price` (above a small rounding epsilon).
+//
+// Idempotent: re-runs skip payments whose `creditEarned` is already set
+// (positive or negative), so calling this twice is a no-op for already
+// migrated rows. Supports `dryRun: true` for inspection without writes.
+
+type PaymentRow = {
+  _id: string;
+  organizationId: string;
+  patientId: string | null;
+  appointmentId: string | null;
+  amount: number;
+  status: string;
+  kind: string | null;
+  creditEarned: number | null;
+};
+
+type AppointmentRow = {
+  _id: string;
+  treatmentId: string | null;
+};
+
+type TreatmentRow = {
+  _id: string;
+  price: number | null;
+};
+
+const EPSILON = 0.005;
+
+export const backfillCreditEarned = internalAction({
+  args: {
+    organizationId: v.id("organizations"),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (_ctx, args) => {
+    const { organizationId, dryRun = false } = args;
+    const prefix = dryRun ? "[DRY RUN] " : "";
+    const db = createSupabaseDb();
+
+    const completedPayments = (await db
+      .query("payments")
+      .eq("organizationId", String(organizationId))
+      .eq("status", "completed")
+      .collect()) as PaymentRow[];
+
+    const candidates = completedPayments.filter((p) => {
+      if (!p.appointmentId || !p.patientId) return false;
+      if (p.kind && p.kind !== "payment") return false;
+      if (p.creditEarned !== null && p.creditEarned !== undefined) return false;
+      if (!Number.isFinite(p.amount) || p.amount <= 0) return false;
+      return true;
+    });
+
+    if (candidates.length === 0) {
+      const summary = {
+        organizationId: String(organizationId),
+        paymentsScanned: completedPayments.length,
+        paymentsUpdated: 0,
+        totalCreditBackfilled: 0,
+        dryRun,
+      };
+      console.log(
+        `${prefix}backfillCreditEarned: nothing to do`,
+        JSON.stringify(summary),
+      );
+      return summary;
+    }
+
+    const appointmentIds = Array.from(
+      new Set(candidates.map((p) => String(p.appointmentId))),
+    );
+    const appointments = (await db.getMany(
+      "gabinetAppointments",
+      appointmentIds,
+    )) as AppointmentRow[];
+    const appointmentById = new Map<string, AppointmentRow>();
+    for (const a of appointments) appointmentById.set(String(a._id), a);
+
+    const treatmentIds = Array.from(
+      new Set(
+        appointments
+          .map((a) => a.treatmentId)
+          .filter((id): id is string => !!id),
+      ),
+    );
+    const treatments = (await db.getMany(
+      "gabinetTreatments",
+      treatmentIds,
+    )) as TreatmentRow[];
+    const treatmentById = new Map<string, TreatmentRow>();
+    for (const t of treatments) treatmentById.set(String(t._id), t);
+
+    let paymentsUpdated = 0;
+    let totalCreditBackfilled = 0;
+    let skippedNoAppointment = 0;
+    let skippedNoTreatment = 0;
+    let skippedNoPrice = 0;
+    let skippedNoOverpayment = 0;
+
+    for (const p of candidates) {
+      const appt = appointmentById.get(String(p.appointmentId));
+      if (!appt) {
+        skippedNoAppointment++;
+        continue;
+      }
+      if (!appt.treatmentId) {
+        skippedNoTreatment++;
+        continue;
+      }
+      const treatment = treatmentById.get(String(appt.treatmentId));
+      if (!treatment) {
+        skippedNoTreatment++;
+        continue;
+      }
+      const price = treatment.price ?? 0;
+      if (!Number.isFinite(price) || price <= 0) {
+        skippedNoPrice++;
+        continue;
+      }
+
+      const excess = Math.round((p.amount - price) * 100) / 100;
+      if (excess <= EPSILON) {
+        skippedNoOverpayment++;
+        continue;
+      }
+
+      if (!dryRun) {
+        await db.patch("payments", p._id, {
+          creditEarned: excess,
+          updatedAt: Date.now(),
+        });
+      }
+      paymentsUpdated++;
+      totalCreditBackfilled =
+        Math.round((totalCreditBackfilled + excess) * 100) / 100;
+      console.log(
+        `${prefix}payment ${p._id}: amount=${p.amount}, price=${price}, creditEarned=${excess}`,
+      );
+    }
+
+    const summary = {
+      organizationId: String(organizationId),
+      paymentsScanned: completedPayments.length,
+      candidatesConsidered: candidates.length,
+      paymentsUpdated,
+      totalCreditBackfilled,
+      skippedNoAppointment,
+      skippedNoTreatment,
+      skippedNoPrice,
+      skippedNoOverpayment,
+      dryRun,
+    };
+    console.log(
+      `${prefix}backfillCreditEarned complete:`,
+      JSON.stringify(summary),
+    );
+    return summary;
+  },
+});

--- a/tests/convex/backfillCreditEarned.test.ts
+++ b/tests/convex/backfillCreditEarned.test.ts
@@ -1,0 +1,427 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { internal } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+async function seedTreatment(
+  organizationId: string,
+  userId: string,
+  price: number,
+  id = "t1",
+) {
+  const db = createSupabaseDb();
+  await db.insert("gabinetTreatments", {
+    _id: id,
+    organizationId,
+    name: `Treatment ${id}`,
+    duration: 30,
+    price,
+    isActive: true,
+    createdBy: userId,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  return id;
+}
+
+async function seedAppointment(
+  organizationId: string,
+  patientId: string,
+  treatmentId: string | null,
+  userId: string,
+  id = "a1",
+) {
+  const db = createSupabaseDb();
+  await db.insert("gabinetAppointments", {
+    _id: id,
+    organizationId,
+    patientId,
+    treatmentId,
+    employeeId: userId,
+    date: "2026-03-15",
+    startTime: "09:00",
+    endTime: "09:30",
+    status: "completed",
+    isRecurring: false,
+    createdBy: userId,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  return id;
+}
+
+async function seedPayment(
+  organizationId: string,
+  userId: string,
+  fields: {
+    appointmentId?: string | null;
+    patientId?: string | null;
+    amount: number;
+    status?: string;
+    kind?: string | null;
+    creditEarned?: number | null;
+  },
+  id?: string,
+) {
+  const db = createSupabaseDb();
+  const paymentId =
+    id ?? `p_${Math.random().toString(36).slice(2)}_${Date.now()}`;
+  await db.insert("payments", {
+    _id: paymentId,
+    organizationId,
+    patientId: fields.patientId ?? null,
+    appointmentId: fields.appointmentId ?? null,
+    packageUsageId: null,
+    amount: fields.amount,
+    currency: "PLN",
+    paymentMethod: "cash",
+    status: fields.status ?? "completed",
+    paidAt: Date.now(),
+    notes: null,
+    creditEarned: fields.creditEarned ?? null,
+    creditApplied: null,
+    kind: fields.kind ?? null,
+    createdBy: userId,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  return paymentId;
+}
+
+describe("backfillCreditEarned", () => {
+  test("backfills overpayment as creditEarned on completed appointment payment", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const orgId = String(organizationId);
+    const uid = String(userId);
+
+    const treatmentId = await seedTreatment(orgId, uid, 100);
+    const appointmentId = await seedAppointment(
+      orgId,
+      "patient-1",
+      treatmentId,
+      uid,
+    );
+    const paymentId = await seedPayment(orgId, uid, {
+      appointmentId,
+      patientId: "patient-1",
+      amount: 300,
+    });
+
+    const summary = await t.action(
+      internal.migrations.backfillCreditEarned.backfillCreditEarned,
+      { organizationId },
+    );
+
+    expect(summary.paymentsUpdated).toBe(1);
+    expect(summary.totalCreditBackfilled).toBe(200);
+
+    const db = createSupabaseDb();
+    const updated = await db.get<{ creditEarned: number | null }>(
+      "payments",
+      paymentId,
+    );
+    expect(updated?.creditEarned).toBe(200);
+  });
+
+  test("is idempotent: re-running does not double-credit", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const orgId = String(organizationId);
+    const uid = String(userId);
+
+    const treatmentId = await seedTreatment(orgId, uid, 100);
+    const appointmentId = await seedAppointment(
+      orgId,
+      "patient-1",
+      treatmentId,
+      uid,
+    );
+    const paymentId = await seedPayment(orgId, uid, {
+      appointmentId,
+      patientId: "patient-1",
+      amount: 250,
+    });
+
+    await t.action(
+      internal.migrations.backfillCreditEarned.backfillCreditEarned,
+      { organizationId },
+    );
+    const second = await t.action(
+      internal.migrations.backfillCreditEarned.backfillCreditEarned,
+      { organizationId },
+    );
+
+    expect(second.paymentsUpdated).toBe(0);
+    expect(second.totalCreditBackfilled).toBe(0);
+
+    const db = createSupabaseDb();
+    const updated = await db.get<{ creditEarned: number | null }>(
+      "payments",
+      paymentId,
+    );
+    expect(updated?.creditEarned).toBe(150);
+  });
+
+  test("dryRun reports candidates without persisting changes", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const orgId = String(organizationId);
+    const uid = String(userId);
+
+    const treatmentId = await seedTreatment(orgId, uid, 100);
+    const appointmentId = await seedAppointment(
+      orgId,
+      "patient-1",
+      treatmentId,
+      uid,
+    );
+    const paymentId = await seedPayment(orgId, uid, {
+      appointmentId,
+      patientId: "patient-1",
+      amount: 300,
+    });
+
+    const summary = await t.action(
+      internal.migrations.backfillCreditEarned.backfillCreditEarned,
+      { organizationId, dryRun: true },
+    );
+
+    expect(summary.paymentsUpdated).toBe(1);
+    expect(summary.totalCreditBackfilled).toBe(200);
+    expect(summary.dryRun).toBe(true);
+
+    const db = createSupabaseDb();
+    const row = await db.get<{ creditEarned: number | null }>(
+      "payments",
+      paymentId,
+    );
+    expect(row?.creditEarned ?? null).toBe(null);
+  });
+
+  test("skips payments where amount does not exceed treatment price", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const orgId = String(organizationId);
+    const uid = String(userId);
+
+    const treatmentId = await seedTreatment(orgId, uid, 100);
+    const appointmentId = await seedAppointment(
+      orgId,
+      "patient-1",
+      treatmentId,
+      uid,
+    );
+    const paymentId = await seedPayment(orgId, uid, {
+      appointmentId,
+      patientId: "patient-1",
+      amount: 100,
+    });
+
+    const summary = await t.action(
+      internal.migrations.backfillCreditEarned.backfillCreditEarned,
+      { organizationId },
+    );
+
+    expect(summary.paymentsUpdated).toBe(0);
+    expect(summary.skippedNoOverpayment).toBe(1);
+
+    const db = createSupabaseDb();
+    const row = await db.get<{ creditEarned: number | null }>(
+      "payments",
+      paymentId,
+    );
+    expect(row?.creditEarned ?? null).toBe(null);
+  });
+
+  test("skips payments without an appointment link", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const orgId = String(organizationId);
+    const uid = String(userId);
+
+    await seedPayment(orgId, uid, {
+      appointmentId: null,
+      patientId: "patient-1",
+      amount: 500,
+    });
+
+    const summary = await t.action(
+      internal.migrations.backfillCreditEarned.backfillCreditEarned,
+      { organizationId },
+    );
+
+    expect(summary.paymentsUpdated).toBe(0);
+  });
+
+  test("skips appointments without a treatment", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const orgId = String(organizationId);
+    const uid = String(userId);
+
+    const appointmentId = await seedAppointment(
+      orgId,
+      "patient-1",
+      null,
+      uid,
+    );
+    const paymentId = await seedPayment(orgId, uid, {
+      appointmentId,
+      patientId: "patient-1",
+      amount: 500,
+    });
+
+    const summary = await t.action(
+      internal.migrations.backfillCreditEarned.backfillCreditEarned,
+      { organizationId },
+    );
+
+    expect(summary.paymentsUpdated).toBe(0);
+    expect(summary.skippedNoTreatment).toBe(1);
+
+    const db = createSupabaseDb();
+    const row = await db.get<{ creditEarned: number | null }>(
+      "payments",
+      paymentId,
+    );
+    expect(row?.creditEarned ?? null).toBe(null);
+  });
+
+  test("skips credit_refund bookkeeping rows", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const orgId = String(organizationId);
+    const uid = String(userId);
+
+    const treatmentId = await seedTreatment(orgId, uid, 100);
+    const appointmentId = await seedAppointment(
+      orgId,
+      "patient-1",
+      treatmentId,
+      uid,
+    );
+    await seedPayment(orgId, uid, {
+      appointmentId,
+      patientId: "patient-1",
+      amount: 300,
+      kind: "credit_refund",
+    });
+
+    const summary = await t.action(
+      internal.migrations.backfillCreditEarned.backfillCreditEarned,
+      { organizationId },
+    );
+
+    expect(summary.paymentsUpdated).toBe(0);
+  });
+
+  test("skips non-completed payments (pending / refunded)", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const orgId = String(organizationId);
+    const uid = String(userId);
+
+    const treatmentId = await seedTreatment(orgId, uid, 100);
+    const appointmentId = await seedAppointment(
+      orgId,
+      "patient-1",
+      treatmentId,
+      uid,
+    );
+    await seedPayment(orgId, uid, {
+      appointmentId,
+      patientId: "patient-1",
+      amount: 300,
+      status: "refunded",
+    });
+    await seedPayment(orgId, uid, {
+      appointmentId,
+      patientId: "patient-1",
+      amount: 300,
+      status: "pending",
+    });
+
+    const summary = await t.action(
+      internal.migrations.backfillCreditEarned.backfillCreditEarned,
+      { organizationId },
+    );
+
+    expect(summary.paymentsUpdated).toBe(0);
+  });
+
+  test("scopes to the requested organization only", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const orgId = String(organizationId);
+    const uid = String(userId);
+    const otherOrgId = "other-org-xyz";
+
+    const treatmentMineId = await seedTreatment(orgId, uid, 100, "t-mine");
+    const treatmentOtherId = await seedTreatment(
+      otherOrgId,
+      uid,
+      100,
+      "t-other",
+    );
+    const apptMine = await seedAppointment(
+      orgId,
+      "patient-1",
+      treatmentMineId,
+      uid,
+      "a-mine",
+    );
+    const apptOther = await seedAppointment(
+      otherOrgId,
+      "patient-2",
+      treatmentOtherId,
+      uid,
+      "a-other",
+    );
+
+    const myPaymentId = await seedPayment(
+      orgId,
+      uid,
+      {
+        appointmentId: apptMine,
+        patientId: "patient-1",
+        amount: 250,
+      },
+      "p-mine",
+    );
+    const otherPaymentId = await seedPayment(
+      otherOrgId,
+      uid,
+      {
+        appointmentId: apptOther,
+        patientId: "patient-2",
+        amount: 400,
+      },
+      "p-other",
+    );
+
+    const summary = await t.action(
+      internal.migrations.backfillCreditEarned.backfillCreditEarned,
+      { organizationId },
+    );
+
+    expect(summary.paymentsUpdated).toBe(1);
+    expect(summary.totalCreditBackfilled).toBe(150);
+
+    const db = createSupabaseDb();
+    const mine = await db.get<{ creditEarned: number | null }>(
+      "payments",
+      myPaymentId,
+    );
+    const other = await db.get<{ creditEarned: number | null }>(
+      "payments",
+      otherPaymentId,
+    );
+    expect(mine?.creditEarned).toBe(150);
+    expect(other?.creditEarned ?? null).toBe(null);
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1287.

Closes #1287

---

## Claude summary

Committed.

Summary: Added `convex/migrations/backfillCreditEarned.ts`, a one-off `internalAction` that scans completed, appointment-linked payments for a target org and records overpayments (`amount − treatment.price`) as `creditEarned` so historical overpayments surface in the patient credit balance introduced by #1059. The action is idempotent (skips rows whose `creditEarned` is already set), excludes `credit_refund` bookkeeping rows and non-`completed` statuses, requires both an appointment and a treatment with positive price, and supports `dryRun: true`. Covered by 9 unit tests (`tests/convex/backfillCreditEarned.test.ts`) that exercise the happy path, idempotency, dry-run, every skip reason, and org scoping. Tests pass; `tsc -p convex/tsconfig.json` is clean.

To run on a production org once schema is in place: invoke `internal.migrations.backfillCreditEarned.backfillCreditEarned` with the target `organizationId` (and `dryRun: true` first to preview).