### PR TITLE
mail

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -552,15 +552,13 @@ export const resendSigningEmail = action({
       throw new Error("Nie znaleziono adresu e-mail pacjenta");
     }
 
-    await ctx.scheduler.runAfter(
-      0,
-      internal.documents.signing.sendSigningEmailInternal,
-      {
-        documentId: args.documentId as Id<"formDocuments">,
-        recipientEmail,
-        recipientName,
-      },
-    );
+    // Call the send action directly (not via scheduler) so failures
+    // propagate back to the UI instead of being silently swallowed.
+    await ctx.runAction(internal.documents.signing.sendSigningEmailInternal, {
+      documentId: args.documentId as Id<"formDocuments">,
+      recipientEmail,
+      recipientName,
+    });
 
     return { sent: true };
   },

--- a/convex/documents/signing.ts
+++ b/convex/documents/signing.ts
@@ -223,32 +223,35 @@ export const sendSigningEmailInternal = internalAction({
       return;
     }
 
-    try {
-      // Try sending via Gmail OAuth (tenant's configured connection)
-      const googleToken = await getValidAccessToken(
-        ctx,
-        data.organizationId as Id<"organizations">,
-      );
+    // Try sending via Gmail OAuth (tenant's configured connection)
+    const googleToken = await getValidAccessToken(
+      ctx,
+      data.organizationId as Id<"organizations">,
+    );
 
-      if (googleToken && data.senderEmail) {
-        const fromAddress = data.senderName
-          ? `${data.senderName} <${data.senderEmail}>`
-          : data.senderEmail;
+    let gmailError: string | null = null;
 
-        // Build RFC 2822 MIME message
-        let rawMessage = `From: ${fromAddress}\r\n`;
-        rawMessage += `To: ${args.recipientEmail}\r\n`;
-        rawMessage += `Subject: ${subject}\r\n`;
-        rawMessage += `Content-Type: text/html; charset=utf-8\r\n`;
-        rawMessage += `\r\n`;
-        rawMessage += html;
+    if (googleToken && data.senderEmail) {
+      const fromAddress = data.senderName
+        ? `${data.senderName} <${data.senderEmail}>`
+        : data.senderEmail;
 
-        const encoded = btoa(unescape(encodeURIComponent(rawMessage)))
-          .replace(/\+/g, "-")
-          .replace(/\//g, "_")
-          .replace(/=+$/, "");
+      // Build RFC 2822 MIME message
+      let rawMessage = `From: ${fromAddress}\r\n`;
+      rawMessage += `To: ${args.recipientEmail}\r\n`;
+      rawMessage += `Subject: ${subject}\r\n`;
+      rawMessage += `Content-Type: text/html; charset=utf-8\r\n`;
+      rawMessage += `\r\n`;
+      rawMessage += html;
 
-        const response = await fetch(
+      const encoded = btoa(unescape(encodeURIComponent(rawMessage)))
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+
+      let response: Response | null = null;
+      try {
+        response = await fetch(
           "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
           {
             method: "POST",
@@ -259,22 +262,21 @@ export const sendSigningEmailInternal = internalAction({
             body: JSON.stringify({ raw: encoded }),
           },
         );
+      } catch (fetchErr) {
+        gmailError =
+          fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
+        console.error("[signing] Gmail fetch threw:", gmailError);
+        await ctx.runMutation(internal.emailSendLog.record, {
+          ...logBase,
+          provider: "gmail",
+          status: "failed",
+          fromEmail: fromAddress,
+          errorMessage: `Gmail send failed: ${gmailError.slice(0, 500)}`,
+        });
+      }
 
-        if (!response.ok) {
-          const errText = await response.text();
-          console.error("[signing] Gmail send failed:", errText);
-          await ctx.runMutation(internal.emailSendLog.record, {
-            ...logBase,
-            provider: "gmail",
-            status: "failed",
-            fromEmail: fromAddress,
-            errorMessage: `Gmail send failed (${response.status}): ${errText.slice(0, 500)}`,
-          });
-          throw new Error("Gmail send failed — falling back to Resend");
-        }
-
+      if (response?.ok) {
         console.log("[signing] Signing email sent via Gmail to", args.recipientEmail);
-
         await ctx.runMutation(internal.emailSendLog.record, {
           ...logBase,
           provider: "gmail",
@@ -285,61 +287,75 @@ export const sendSigningEmailInternal = internalAction({
         return;
       }
 
-      // Fallback: send via Resend
-      if (!RESEND_API_KEY) {
-        console.warn("[signing] No Gmail connection and RESEND_API_KEY not set — cannot send signing email");
+      if (response) {
+        const errText = await response.text();
+        gmailError = `Gmail send failed (${response.status}): ${errText.slice(0, 500)}`;
+        console.error("[signing] Gmail send failed:", errText);
         await ctx.runMutation(internal.emailSendLog.record, {
           ...logBase,
-          provider: "resend",
-          status: "skipped",
-          errorMessage: "No Gmail connection and RESEND_API_KEY not set",
+          provider: "gmail",
+          status: "failed",
+          fromEmail: fromAddress,
+          errorMessage: gmailError,
         });
-        return;
       }
+      // fall through to Resend fallback below
+    }
 
-      const resend = new Resend(RESEND_API_KEY);
-      const fromAddress = data.senderEmail && data.senderName
+    // Resend fallback — used both when no Gmail is configured and when
+    // Gmail attempted but failed.
+    if (!RESEND_API_KEY) {
+      const reason = gmailError
+        ? `Gmail send failed and RESEND_API_KEY not set: ${gmailError}`
+        : "No Gmail connection and RESEND_API_KEY not set";
+      console.warn("[signing]", reason);
+      await ctx.runMutation(internal.emailSendLog.record, {
+        ...logBase,
+        provider: "resend",
+        status: "skipped",
+        errorMessage: reason,
+      });
+      throw new Error("Nie udało się wysłać e-maila: brak skonfigurowanego dostawcy poczty");
+    }
+
+    const resend = new Resend(RESEND_API_KEY);
+    const fromAddress =
+      data.senderEmail && data.senderName
         ? `${data.senderName} <${data.senderEmail}>`
         : data.senderEmail
           ? data.senderEmail
           : (RESEND_FROM ?? "noreply@example.com");
-      const toAddress = args.recipientName
-        ? `${args.recipientName} <${args.recipientEmail}>`
-        : args.recipientEmail;
+    const toAddress = args.recipientName
+      ? `${args.recipientName} <${args.recipientEmail}>`
+      : args.recipientEmail;
 
-      try {
-        await resend.emails.send({
-          from: fromAddress,
-          to: toAddress,
-          subject,
-          html,
-        });
+    try {
+      await resend.emails.send({
+        from: fromAddress,
+        to: toAddress,
+        subject,
+        html,
+      });
 
-        console.log("[signing] Signing email sent via Resend to", args.recipientEmail);
-
-        await ctx.runMutation(internal.emailSendLog.record, {
-          ...logBase,
-          provider: "resend",
-          status: "sent",
-          fromEmail: fromAddress,
-        });
-        await markSent(db, args.documentId);
-      } catch (resendErr) {
-        await ctx.runMutation(internal.emailSendLog.record, {
-          ...logBase,
-          provider: "resend",
-          status: "failed",
-          fromEmail: fromAddress,
-          errorMessage:
-            resendErr instanceof Error ? resendErr.message : String(resendErr),
-        });
-        throw resendErr;
-      }
-    } catch (err) {
-      console.error(
-        "[signing] Failed to send signing email:",
-        err instanceof Error ? err.message : err,
-      );
+      console.log("[signing] Signing email sent via Resend to", args.recipientEmail);
+      await ctx.runMutation(internal.emailSendLog.record, {
+        ...logBase,
+        provider: "resend",
+        status: "sent",
+        fromEmail: fromAddress,
+      });
+      await markSent(db, args.documentId);
+    } catch (resendErr) {
+      const msg = resendErr instanceof Error ? resendErr.message : String(resendErr);
+      await ctx.runMutation(internal.emailSendLog.record, {
+        ...logBase,
+        provider: "resend",
+        status: "failed",
+        fromEmail: fromAddress,
+        errorMessage: msg,
+      });
+      console.error("[signing] Failed to send signing email via Resend:", msg);
+      throw new Error(`Nie udało się wysłać e-maila: ${msg}`);
     }
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1290.

Closes #1290

---

## Claude summary

Committed.

Summary of what was happening and what I changed:

The Jam shows the user clicked "Wyślij" on a draft/pending document in the patient Dokumenty tab. The toast confirmed "Wysłano e-mail do klienta", but the email never arrived. Root cause was that `resendSigningEmail` in `convex/documents/documents.ts` scheduled the send via `ctx.scheduler.runAfter(0, ...)` and returned `{ sent: true }` before the send actually ran. The inner `sendSigningEmailInternal` in `convex/documents/signing.ts` then caught every failure in an outer `try/catch` and only `console.error`'d it — so any Gmail/Resend failure was invisible to the user.

There was also a latent fallback bug: when Gmail send returned `!response.ok` the code threw `"Gmail send failed — falling back to Resend"` inside the outer try, which jumped straight to the catch and skipped the Resend fallback block immediately below.

Both are fixed. `sendSigningEmailInternal` now genuinely falls through Gmail → Resend on failure, throws a Polish-language error if neither succeeds, and preserves the per-provider `emailSendLog` audit rows. `resendSigningEmail` now calls the internal action via `ctx.runAction` so failures propagate to the UI's existing `toast.error(err.message)` handler. Auto-send callers (document generation, auto-generated appointment docs) still use `scheduler.runAfter`, so their fire-and-forget behavior is unchanged — when those throw, Convex just logs the scheduled-function error.

Typechecks pass for both convex and frontend tsconfigs.

## Follow-ups
- Fix mismatched appointment reminder event type in convex/gabinet/appointmentReminders.ts:202: `triggerEmailEvent` is called with `"appointment.reminder"`, but `seedEmailEvents.ts` only registers `"gabinet.appointment.reminder_24h"`/`_1h`/`_custom`, so no binding ever matches and reminder emails are silently marked `skipped`.