### PR TITLE
Data urodzenia

### DIFF
--- a/src/components/documents/generate-document-dialog.tsx
+++ b/src/components/documents/generate-document-dialog.tsx
@@ -579,6 +579,7 @@ function MissingDataFormStep({
                   ? varInfo.labelEn
                   : varInfo.label
                 : path;
+              const inputType = varInfo?.type === "date" ? "date" : "text";
               return (
                 <div key={path} className="space-y-1.5">
                   <Label htmlFor={`missing-${path}`} className="text-sm">
@@ -586,6 +587,7 @@ function MissingDataFormStep({
                   </Label>
                   <Input
                     id={`missing-${path}`}
+                    type={inputType}
                     value={values[path] ?? ""}
                     onChange={(e) =>
                       setValues((prev) => ({
@@ -593,7 +595,7 @@ function MissingDataFormStep({
                         [path]: e.target.value,
                       }))
                     }
-                    placeholder={label}
+                    placeholder={inputType === "date" ? undefined : label}
                   />
                 </div>
               );

--- a/src/lib/document-variables.ts
+++ b/src/lib/document-variables.ts
@@ -15,6 +15,8 @@ export interface VariableField {
   labelEn: string;
   /** Grouping category, e.g. "patient", "contact" */
   category: string;
+  /** Input type hint — drives the form control used when collecting missing data */
+  type?: "text" | "date";
 }
 
 // ---------------------------------------------------------------------------
@@ -52,7 +54,7 @@ export const VARIABLE_REGISTRY: Record<string, VariableField[]> = {
     { path: "patient.email", label: "Email pacjenta", labelEn: "Patient email", category: "patient" },
     { path: "patient.phone", label: "Telefon pacjenta", labelEn: "Patient phone", category: "patient" },
     { path: "patient.pesel", label: "PESEL pacjenta", labelEn: "Patient PESEL", category: "patient" },
-    { path: "patient.dateOfBirth", label: "Data urodzenia", labelEn: "Date of birth", category: "patient" },
+    { path: "patient.dateOfBirth", label: "Data urodzenia", labelEn: "Date of birth", category: "patient", type: "date" },
     { path: "patient.gender", label: "Płeć", labelEn: "Gender", category: "patient" },
     { path: "patient.bloodType", label: "Grupa krwi", labelEn: "Blood type", category: "patient" },
     { path: "patient.allergies", label: "Alergie", labelEn: "Allergies", category: "patient" },
@@ -85,7 +87,7 @@ export const VARIABLE_REGISTRY: Record<string, VariableField[]> = {
     { path: "treatment.aftercareInstructions", label: "Zalecenia pozabiegowe", labelEn: "Aftercare instructions", category: "treatment" },
   ],
   appointment: [
-    { path: "appointment.date", label: "Data wizyty", labelEn: "Appointment date", category: "appointment" },
+    { path: "appointment.date", label: "Data wizyty", labelEn: "Appointment date", category: "appointment", type: "date" },
     { path: "appointment.startTime", label: "Godzina rozpoczęcia", labelEn: "Start time", category: "appointment" },
     { path: "appointment.endTime", label: "Godzina zakończenia", labelEn: "End time", category: "appointment" },
     { path: "appointment.status", label: "Status wizyty", labelEn: "Appointment status", category: "appointment" },
@@ -97,7 +99,7 @@ export const VARIABLE_REGISTRY: Record<string, VariableField[]> = {
     { path: "lead.currency", label: "Waluta", labelEn: "Currency", category: "lead" },
     { path: "lead.status", label: "Status leada", labelEn: "Lead status", category: "lead" },
     { path: "lead.priority", label: "Priorytet", labelEn: "Priority", category: "lead" },
-    { path: "lead.expectedCloseDate", label: "Planowana data zamknięcia", labelEn: "Expected close date", category: "lead" },
+    { path: "lead.expectedCloseDate", label: "Planowana data zamknięcia", labelEn: "Expected close date", category: "lead", type: "date" },
     { path: "lead.source", label: "Źródło leada", labelEn: "Lead source", category: "lead" },
   ],
 };

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -1,0 +1,13 @@
+/**
+ * Format a YYYY-MM-DD birth date string as DD.MM.YYYY for Polish display.
+ * Falls back to the raw value if it can't be parsed (e.g., legacy free-text
+ * entries that were typed without separators).
+ */
+export function formatBirthDate(value: string | null | undefined): string {
+  if (!value) return "";
+  const trimmed = value.trim();
+  const isoMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+  if (!isoMatch) return trimmed;
+  const [, y, m, d] = isoMatch;
+  return `${d}.${m}.${y}`;
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -76,6 +76,7 @@ import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
 import { displayReferralSource } from "@/lib/options";
 import { formatPhoneNumber } from "@/lib/phone";
 import { formatCurrencyPLN } from "@/lib/format-currency";
+import { formatBirthDate } from "@/lib/format-date";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/patients/$patientId",
@@ -305,7 +306,7 @@ function PatientDetail() {
     const fields: DetailField[] = [];
     if (patient.email) fields.push({ label: t("common.email"), value: patient.email, fieldKey: "email" });
     if (patient.phone) fields.push({ label: t("common.phone"), value: formatPhoneNumber(patient.phone), fieldKey: "phone" });
-    if (patient.dateOfBirth) fields.push({ label: t("gabinet.patients.dateOfBirth"), value: patient.dateOfBirth, fieldKey: "dob" });
+    if (patient.dateOfBirth) fields.push({ label: t("gabinet.patients.dateOfBirth"), value: formatBirthDate(patient.dateOfBirth), fieldKey: "dob" });
     if (patient.gender) fields.push({ label: t("gabinet.patients.gender"), value: t(`gabinet.patients.genderOptions.${patient.gender}`), fieldKey: "gender" });
     if (patient.pesel) fields.push({ label: t("gabinet.patients.pesel"), value: patient.pesel, fieldKey: "pesel" });
     if (patient.bloodType) fields.push({ label: t("gabinet.patients.bloodType"), value: <Badge variant="outline" className="text-[10px]">{patient.bloodType}</Badge>, fieldKey: "bloodType" });

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -31,6 +31,7 @@ import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
 import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
 import { formatPhoneNumber } from "@/lib/phone";
+import { formatBirthDate } from "@/lib/format-date";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { Label } from "@/components/ui/label";
@@ -307,7 +308,7 @@ function PatientsIndex() {
         id: "dateOfBirth",
         label: t("gabinet.patients.dateOfBirth"),
         sortable: true,
-        render: (item) => item.dateOfBirth ?? "—",
+        render: (item) => (item.dateOfBirth ? formatBirthDate(item.dateOfBirth) : "—"),
         getSortValue: (item) => item.dateOfBirth ?? "",
       },
       {

--- a/src/routes/_app/patient/_layout.profile.tsx
+++ b/src/routes/_app/patient/_layout.profile.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
+import { formatBirthDate } from "@/lib/format-date";
 
 export const Route = createFileRoute("/_app/patient/_layout/profile")({
   component: PatientProfile,
@@ -79,7 +80,7 @@ function PatientProfile() {
         <p className="text-sm"><span className="text-muted-foreground">{t("patientPortal.profile.name")}:</span> {profile.firstName} {profile.lastName}</p>
         <p className="text-sm"><span className="text-muted-foreground">{t("common.email")}:</span> {profile.email}</p>
         {profile.dateOfBirth && (
-          <p className="text-sm"><span className="text-muted-foreground">{t("gabinet.patients.dateOfBirth")}:</span> {profile.dateOfBirth}</p>
+          <p className="text-sm"><span className="text-muted-foreground">{t("gabinet.patients.dateOfBirth")}:</span> {formatBirthDate(profile.dateOfBirth)}</p>
         )}
       </div>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1292.

Closes #1292

---

## Claude summary

Committed.

Summary of the fix for #1292: the patient birth date was stored as raw text (the "complete missing data" step in the document-generation dialog used a plain `<Input>`, so a user typing "12072006" had that exact string persisted to `gabinetPatients.dateOfBirth`). Two changes:

1. `src/lib/format-date.ts` — new helper that turns `YYYY-MM-DD` into `DD.MM.YYYY` and falls back to the raw string for anything that doesn't parse. Applied in `_layout.gabinet.patients.$patientId.tsx:309`, `_layout.gabinet.patients.index.tsx:311`, and `_layout.profile.tsx:83`.
2. `MissingDataFormStep` in `generate-document-dialog.tsx:582` now picks `type="date"` for fields tagged as dates. The variable registry gains a `type?: "text" | "date"` hint, set on `patient.dateOfBirth`, `appointment.date`, and `lead.expectedCloseDate`. Going forward, users get the native date picker so storage is always ISO.

I couldn't run `npm run typecheck` — `node_modules` isn't installed in this worktree — but the changes are scoped and consistent with the existing typing.

## Follow-ups
- Format dates in rendered documents: `renderDocument()` in `src/components/documents/document-renderer.tsx` substitutes `{{patient.dateOfBirth}}` with the raw ISO string; templates referencing the variable still print `2006-07-12` rather than `12.07.2006`.
- Format `employee.dateOfBirth` consistently: only the employee detail view formats it; other surfaces (e.g. employees list) likely show the raw ISO string.