### PR TITLE
Data urodzenia klient edycja

### DIFF
--- a/src/components/forms/patient-form.tsx
+++ b/src/components/forms/patient-form.tsx
@@ -20,6 +20,7 @@ import {
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { GENDERS, PATIENT_REFERRAL_SOURCES, patientReferralSourceOptions } from "@/lib/options";
+import { parseBirthDateToIso } from "@/lib/format-date";
 import type { Id } from "@cvx/_generated/dataModel";
 
 interface TagDef {
@@ -85,7 +86,9 @@ export function PatientForm({
   const [email, setEmail] = useState(initialData?.email ?? "");
   const [phone, setPhone] = useState(initialData?.phone ?? "");
   const [pesel, setPesel] = useState(initialData?.pesel ?? "");
-  const [dateOfBirth, setDateOfBirth] = useState(initialData?.dateOfBirth ?? "");
+  const [dateOfBirth, setDateOfBirth] = useState(
+    parseBirthDateToIso(initialData?.dateOfBirth),
+  );
   const [gender, setGender] = useState<string>(initialData?.gender ?? "");
   const [street, setStreet] = useState(initialData?.address?.street ?? "");
   const [city, setCity] = useState(initialData?.address?.city ?? "");

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -1,13 +1,44 @@
 /**
- * Format a YYYY-MM-DD birth date string as DD.MM.YYYY for Polish display.
- * Falls back to the raw value if it can't be parsed (e.g., legacy free-text
- * entries that were typed without separators).
+ * Parse a birth-date string into ISO `YYYY-MM-DD` form. Accepts the canonical
+ * ISO format plus common Polish entries: `DD.MM.YYYY`, `DD/MM/YYYY`,
+ * `DD-MM-YYYY`, and the separator-less `DDMMYYYY` (e.g. "12072006") that
+ * leaked into legacy rows. Returns "" when the value can't be confidently
+ * parsed so the caller can decide how to fall back.
+ */
+export function parseBirthDateToIso(value: string | null | undefined): string {
+  if (!value) return "";
+  const trimmed = value.trim();
+  const iso = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+  if (iso) return trimmed;
+  const sep = /^(\d{2})[./-](\d{2})[./-](\d{4})$/.exec(trimmed);
+  if (sep) {
+    const [, d, m, y] = sep;
+    if (Number(m) >= 1 && Number(m) <= 12 && Number(d) >= 1 && Number(d) <= 31) {
+      return `${y}-${m}-${d}`;
+    }
+  }
+  const ddmmyyyy = /^(\d{2})(\d{2})(\d{4})$/.exec(trimmed);
+  if (ddmmyyyy) {
+    const [, d, m, y] = ddmmyyyy;
+    if (Number(m) >= 1 && Number(m) <= 12 && Number(d) >= 1 && Number(d) <= 31) {
+      return `${y}-${m}-${d}`;
+    }
+  }
+  return "";
+}
+
+/**
+ * Format a birth date string as DD.MM.YYYY for Polish display. Accepts ISO
+ * `YYYY-MM-DD` as well as the legacy formats handled by
+ * `parseBirthDateToIso`. Falls back to the raw value if it can't be parsed.
  */
 export function formatBirthDate(value: string | null | undefined): string {
   if (!value) return "";
   const trimmed = value.trim();
-  const isoMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
-  if (!isoMatch) return trimmed;
-  const [, y, m, d] = isoMatch;
-  return `${d}.${m}.${y}`;
+  const iso = parseBirthDateToIso(trimmed);
+  if (iso) {
+    const [y, m, d] = iso.split("-");
+    return `${d}.${m}.${y}`;
+  }
+  return trimmed;
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1294.

Closes #1294

---

## Claude summary

Fixed and committed.

Root cause: the screenshot confirms patient `dateOfBirth` is stored as `"12072006"` (DDMMYYYY without separators — likely entered via an earlier free-text form or import). The sidebar's `formatBirthDate` fell back to printing the raw value, so the user saw it there. But the edit form binds the value to a native `<input type="date">`, which silently shows nothing for any value that isn't `YYYY-MM-DD`.

Fix in `src/lib/format-date.ts` and `src/components/forms/patient-form.tsx`:
- Added `parseBirthDateToIso()` that normalises `YYYY-MM-DD`, `DD.MM.YYYY`, `DD/MM/YYYY`, `DD-MM-YYYY`, and the separator-less `DDMMYYYY` to `YYYY-MM-DD`, with day/month range checks.
- `PatientForm` seeds its `dateOfBirth` state through the parser, so legacy values populate the date input correctly. Saving the form then rewrites the row in canonical ISO.
- `formatBirthDate` reuses the same parser, so the sidebar now also renders `"12072006"` as `12.07.2006` instead of raw digits.