### PR TITLE
Format dates in rendered documents

### DIFF
--- a/src/components/documents/document-renderer.tsx
+++ b/src/components/documents/document-renderer.tsx
@@ -17,6 +17,18 @@ import {
   VariableMentionAt,
   VariableMentionCurly,
 } from "@/components/gabinet/variable-mention";
+import { VARIABLE_REGISTRY } from "@/lib/document-variables";
+import { formatBirthDate } from "@/lib/format-date";
+
+// Variable paths whose values are stored as YYYY-MM-DD and should render as
+// DD.MM.YYYY in generated documents. Derived from VARIABLE_REGISTRY so the
+// set stays in sync as new date-typed variables are added.
+const DATE_VARIABLE_PATHS = new Set<string>(
+  Object.values(VARIABLE_REGISTRY)
+    .flat()
+    .filter((f) => f.type === "date")
+    .map((f) => f.path),
+);
 
 // ---------------------------------------------------------------------------
 // Types
@@ -129,7 +141,9 @@ export function renderDocument(
   doc.querySelectorAll("[data-variable]").forEach((el) => {
     const path = el.getAttribute("data-variable");
     if (path && scopeData[path] !== undefined && scopeData[path].trim() !== "") {
-      el.replaceWith(document.createTextNode(scopeData[path]));
+      const raw = scopeData[path];
+      const value = DATE_VARIABLE_PATHS.has(path) ? formatBirthDate(raw) : raw;
+      el.replaceWith(document.createTextNode(value));
     } else if (path) {
       if (highlightMissing) {
         const span = doc.createElement("span");


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1304.

Closes #1304

---

## Claude summary

Committed. Summary:

Modified `renderDocument()` in `src/components/documents/document-renderer.tsx:140-146` to format date-typed variables (derived from `VARIABLE_REGISTRY` `type: "date"` entries — `patient.dateOfBirth`, `appointment.date`, `lead.expectedCloseDate`) as DD.MM.YYYY using the existing `formatBirthDate()` helper. The helper falls back to the raw value when input isn't a parseable date, so non-ISO values render unchanged. Typecheck passes (`tsc -p tsconfig.app.json`).

## Follow-ups
- Format `lead.expectedCloseDate` Unix timestamp in templates: schema stores it as `v.number()` (ms), so `formatBirthDate` falls through and the raw millisecond string renders. Either generalize the formatter to handle numeric timestamps or coerce dates to YYYY-MM-DD inside `flattenScopeData`.
- Reconcile `system.date` vs `system.today` variable naming: `scopeResolver.ts:158-163` advertises `system.date`/`system.date_pl` to template UIs while `addCommonScope` in `scopeResolver_supabase.ts:192-196` actually emits `system.today`/`system.now`/`system.year`, so the documented variables resolve to nothing.