### PR TITLE
Format `employee.dateOfBirth` consistently

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/gabinet/flexible-schedule-editor";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatPhoneNumber } from "@/lib/phone";
+import { formatBirthDate, parseBirthDateToIso } from "@/lib/format-date";
 import {
   EntityDetailLayout,
   type DetailField,
@@ -1645,7 +1646,7 @@ function DetailedDataTab({
     lastName: employee.lastName ?? "",
     phone: employee.phone ?? "",
     email: employee.email ?? "",
-    dateOfBirth: employee.dateOfBirth ?? "",
+    dateOfBirth: parseBirthDateToIso(employee.dateOfBirth),
     pesel: employee.pesel ?? "",
     addressStreet: employee.address?.street ?? "",
     addressCity: employee.address?.city ?? "",
@@ -1690,7 +1691,7 @@ function DetailedDataTab({
       lastName: employee.lastName ?? "",
       phone: employee.phone ?? "",
       email: employee.email ?? "",
-      dateOfBirth: employee.dateOfBirth ?? "",
+      dateOfBirth: parseBirthDateToIso(employee.dateOfBirth),
       pesel: employee.pesel ?? "",
       addressStreet: employee.address?.street ?? "",
       addressCity: employee.address?.city ?? "",
@@ -1723,7 +1724,7 @@ function DetailedDataTab({
       lastName: employee.lastName ?? "",
       phone: employee.phone ?? "",
       email: employee.email ?? "",
-      dateOfBirth: employee.dateOfBirth ?? "",
+      dateOfBirth: parseBirthDateToIso(employee.dateOfBirth),
       pesel: employee.pesel ?? "",
       addressStreet: employee.address?.street ?? "",
       addressCity: employee.address?.city ?? "",
@@ -1987,13 +1988,7 @@ function DetailedDataTab({
               )}
               {readOnlyField(
                 t("gabinet.employees.detailedData.dateOfBirth"),
-                employee.dateOfBirth
-                  ? new Date(employee.dateOfBirth + "T00:00:00").toLocaleDateString(i18nLanguage, {
-                      day: "numeric",
-                      month: "long",
-                      year: "numeric",
-                    })
-                  : undefined,
+                employee.dateOfBirth ? formatBirthDate(employee.dateOfBirth) : undefined,
               )}
               {readOnlyField(t("gabinet.employees.detailedData.pesel"), employee.pesel)}
               {(employee.address?.street || employee.address?.city) &&


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1305.

Closes #1305

---

## Claude summary

Committed.

Summary: The employee detail page formatted `dateOfBirth` with `toLocaleDateString` (long-form like "12 grudnia 2006"), inconsistent with patient surfaces that use `formatBirthDate` (DD.MM.YYYY) per #1303. I swapped in `formatBirthDate` for display and `parseBirthDateToIso` to seed the edit form's `<input type="date">`, mirroring the patient fix from #1306 so legacy non-ISO values render and edit correctly. The employees list view does not actually expose `dateOfBirth` as a column, so no list-page change was needed.

Verified: `node scripts/typecheck-portable.mjs` exits 0.