### PR TITLE
Fix undefined-stripped bug in gabinet appointments.update

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1284,20 +1284,20 @@ export const update = action({
     date: v.optional(v.string()),
     startTime: v.optional(v.string()),
     endTime: v.optional(v.string()),
-    notes: v.optional(v.string()),
-    internalNotes: v.optional(v.string()),
-    color: v.optional(v.string()),
+    notes: v.optional(v.union(v.string(), v.null())),
+    internalNotes: v.optional(v.union(v.string(), v.null())),
+    color: v.optional(v.union(v.string(), v.null())),
     employeeId: v.optional(v.string()),
     treatmentId: v.optional(v.string()),
     packageUsageId: v.optional(v.string()),
     status: v.optional(gabinetAppointmentStatusValidator),
-    cancellationReason: v.optional(v.string()),
+    cancellationReason: v.optional(v.union(v.string(), v.null())),
     bodyChartData: v.optional(v.string()),
-    treatmentParameterValues: v.optional(v.string()),
-    interviewNotes: v.optional(v.string()),
-    clinicalRemarks: v.optional(v.string()),
-    locationId: v.optional(v.string()),
-    roomId: v.optional(v.string()),
+    treatmentParameterValues: v.optional(v.union(v.string(), v.null())),
+    interviewNotes: v.optional(v.union(v.string(), v.null())),
+    clinicalRemarks: v.optional(v.union(v.string(), v.null())),
+    locationId: v.optional(v.union(v.string(), v.null())),
+    roomId: v.optional(v.union(v.string(), v.null())),
     photos: v.optional(
       v.array(
         v.object({
@@ -1345,6 +1345,10 @@ export const update = action({
     const newEmployee = args.employeeId ?? (appt.employeeId as string);
 
     if (args.date || args.startTime || args.endTime || args.employeeId) {
+      const effectiveRoomId =
+        args.roomId !== undefined
+          ? (args.roomId ?? undefined)
+          : (appt.roomId as string | undefined);
       const conflict = await checkConflictSupabase(db, {
         organizationId: String(args.organizationId),
         userId: newEmployee,
@@ -1352,7 +1356,7 @@ export const update = action({
         startTime: newStart,
         endTime: newEnd,
         excludeAppointmentId: args.appointmentId,
-        roomId: args.roomId ?? (appt.roomId as string | undefined),
+        roomId: effectiveRoomId,
       });
       if (conflict.hasConflict) {
         throw new Error(conflict.reason ?? "Time slot conflict");

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -519,7 +519,7 @@ export function AppointmentPreviewContent({
           args.startTime = startTime;
         if (endTime !== appointment.endTime.slice(0, 5)) args.endTime = endTime;
         if (internalNotes !== (appointment.internalNotes ?? ""))
-          args.internalNotes = internalNotes;
+          args.internalNotes = internalNotes || null;
         if (treatmentId && treatmentId !== initialTreatmentId)
           args.treatmentId = treatmentId;
         if (tagsDirty) args.tagIds = tagIds.map((id) => String(id));

--- a/src/components/gabinet/documentation-tab.tsx
+++ b/src/components/gabinet/documentation-tab.tsx
@@ -180,7 +180,7 @@ export function DocumentationTab({
       await updateAppointment({
         organizationId,
         appointmentId,
-        interviewNotes: interview || undefined,
+        interviewNotes: interview || null,
       });
       toast.success(t("common.saved"));
       await onChanged?.();
@@ -208,7 +208,7 @@ export function DocumentationTab({
       await updateAppointment({
         organizationId,
         appointmentId,
-        clinicalRemarks: remarks || undefined,
+        clinicalRemarks: remarks || null,
       });
       toast.success(t("common.saved"));
       await onChanged?.();

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -912,7 +912,7 @@ function AppointmentDetail() {
       await updateAppointment({
         organizationId,
         appointmentId: appointment._id,
-        internalNotes: internalNotes.trim() || undefined,
+        internalNotes: internalNotes.trim() || null,
       });
       toast.success(t("common.saved"));
       refetch();
@@ -947,10 +947,10 @@ function AppointmentDetail() {
       if (editStartTime && editStartTime !== currentStart) args.startTime = editStartTime;
       if (editEndTime && editEndTime !== currentEnd) args.endTime = editEndTime;
       if (editLocationId !== currentLocation) {
-        args.locationId = editLocationId || undefined;
+        args.locationId = editLocationId || null;
       }
       if (editRoomId !== currentRoom) {
-        args.roomId = editRoomId || undefined;
+        args.roomId = editRoomId || null;
       }
 
       await updateAppointment(args);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1312.

Closes #1312

---

## Claude summary

Fix committed. Summary:

Same `undefined`-stripped pattern as the recent contacts/companies/products fixes. I updated the `update` action's validator in `convex/gabinet/appointments.ts:1287-1300` to accept `null` for the nine clearable fields the issue named, and switched the corresponding form handlers (detail page's internal notes / location / room; documentation tab's interview notes and clinical remarks; calendar preview's internal notes) from `|| undefined` to `|| null` so cleared values actually reach `db.patch`.

One non-obvious cleanup along the way: the conflict-check at the top of `update` used `args.roomId ?? appt.roomId`, which would have ignored a deliberate clear-room (null) and run the room conflict against the *old* room. Replaced with a small `effectiveRoomId` discriminator that maps null → undefined.

`npm run typecheck` is clean and the appointment-related unit tests (13/13) pass.

## Follow-ups
- Allow clearing bodyChartData and other appointment optional fields: convex/gabinet/appointments.ts `update` still strips `bodyChartData`, `photos`, `tagIds`, `categoryId`, `packageUsageId`, `treatmentId`, `employeeId` when forms send undefined — same root cause, out of scope for this issue's listed fields
- Allow clearing cancellationReason on already-cancelled appointments: handler only writes `cancellationReason` when `status === "cancelled"` AND value is truthy; can't be cleared post-hoc
- Apply the same null-clear pattern to gabinet create/update flows for patients, treatments, employees, packages, locations, rooms: likely have the same undefined-stripped bug as the CRM entities did