### PR TITLE
Fix undefined-stripped bug in gabinet packages.update

### DIFF
--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -114,16 +114,16 @@ export const create = action({
   args: {
     organizationId: v.id("organizations"),
     name: v.string(),
-    description: v.optional(v.string()),
+    description: v.optional(v.union(v.string(), v.null())),
     treatments: v.array(v.object({
       treatmentId: v.string(),
       quantity: v.number(),
     })),
     totalPrice: v.number(),
-    currency: v.optional(v.string()),
-    discountPercent: v.optional(v.number()),
-    validityDays: v.optional(v.number()),
-    loyaltyPointsAwarded: v.optional(v.number()),
+    currency: v.optional(v.union(v.string(), v.null())),
+    discountPercent: v.optional(v.union(v.number(), v.null())),
+    validityDays: v.optional(v.union(v.number(), v.null())),
+    loyaltyPointsAwarded: v.optional(v.union(v.number(), v.null())),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(
@@ -194,16 +194,16 @@ export const update = action({
     organizationId: v.id("organizations"),
     packageId: v.string(),
     name: v.optional(v.string()),
-    description: v.optional(v.string()),
+    description: v.optional(v.union(v.string(), v.null())),
     treatments: v.optional(v.array(v.object({
       treatmentId: v.string(),
       quantity: v.number(),
     }))),
     totalPrice: v.optional(v.number()),
-    currency: v.optional(v.string()),
-    discountPercent: v.optional(v.number()),
-    validityDays: v.optional(v.number()),
-    loyaltyPointsAwarded: v.optional(v.number()),
+    currency: v.optional(v.union(v.string(), v.null())),
+    discountPercent: v.optional(v.union(v.number(), v.null())),
+    validityDays: v.optional(v.union(v.number(), v.null())),
+    loyaltyPointsAwarded: v.optional(v.union(v.number(), v.null())),
     isActive: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {

--- a/src/components/forms/package-form.tsx
+++ b/src/components/forms/package-form.tsx
@@ -22,11 +22,11 @@ import { formatCurrencyPLN } from "@/lib/format-currency";
 
 export interface PackageFormData {
   name: string;
-  description?: string;
+  description?: string | null;
   totalPrice: number;
-  validityDays?: number;
-  discountPercent?: number;
-  loyaltyPointsAwarded?: number;
+  validityDays?: number | null;
+  discountPercent?: number | null;
+  loyaltyPointsAwarded?: number | null;
   treatments: Array<{ treatmentId: string; quantity: number }>;
 }
 
@@ -115,11 +115,11 @@ export function PackageForm({
 
     onSubmit({
       name,
-      description: description || undefined,
+      description: description || null,
       totalPrice: parseFloat(totalPrice.replace(",", ".")),
-      validityDays: validityDays ? parseInt(validityDays) : undefined,
-      discountPercent: discountPercent ? parseFloat(discountPercent) : undefined,
-      loyaltyPointsAwarded: loyaltyPoints ? parseInt(loyaltyPoints) : undefined,
+      validityDays: validityDays ? parseInt(validityDays) : null,
+      discountPercent: discountPercent ? parseFloat(discountPercent) : null,
+      loyaltyPointsAwarded: loyaltyPoints ? parseInt(loyaltyPoints) : null,
       treatments: selectedTreatments.map((t) => ({
         treatmentId: t.treatmentId,
         quantity: t.quantity,

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -260,24 +260,24 @@ function PackagesIndex() {
           organizationId,
           packageId: editingId,
           name,
-          description: description || undefined,
+          description: description || null,
           treatments: treatmentsList,
           totalPrice: parseFloat(totalPrice),
-          validityDays: validityDays ? parseInt(validityDays) : undefined,
-          discountPercent: discountPercent ? parseFloat(discountPercent) : undefined,
-          loyaltyPointsAwarded: loyaltyPoints ? parseInt(loyaltyPoints) : undefined,
+          validityDays: validityDays ? parseInt(validityDays) : null,
+          discountPercent: discountPercent ? parseFloat(discountPercent) : null,
+          loyaltyPointsAwarded: loyaltyPoints ? parseInt(loyaltyPoints) : null,
         });
         toast.success(t("common.saved"));
       } else {
         await createPkg({
           organizationId,
           name,
-          description: description || undefined,
+          description: description || null,
           treatments: treatmentsList,
           totalPrice: parseFloat(totalPrice),
-          validityDays: validityDays ? parseInt(validityDays) : undefined,
-          discountPercent: discountPercent ? parseFloat(discountPercent) : undefined,
-          loyaltyPointsAwarded: loyaltyPoints ? parseInt(loyaltyPoints) : undefined,
+          validityDays: validityDays ? parseInt(validityDays) : null,
+          discountPercent: discountPercent ? parseFloat(discountPercent) : null,
+          loyaltyPointsAwarded: loyaltyPoints ? parseInt(loyaltyPoints) : null,
         });
         toast.success(t("gabinet.packages.created"));
       }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1315.

Closes #1315

---

## Claude summary

Fix committed as 399f2f0. The bug was the same `undefined`-stripped pattern as the sibling PRs (#1309–#1314): Convex's `v.optional()` validator drops `undefined` values across the action boundary, so the spread `...updates` into `db.patch` at convex/gabinet/packages.ts:229 silently kept the existing description/currency/discount/validity/loyalty values instead of clearing them.

Changes:
- convex/gabinet/packages.ts:117–126,197–206 — `create` and `update` validators now accept `null` for description, currency, discountPercent, validityDays, loyaltyPointsAwarded
- src/components/forms/package-form.tsx — `PackageFormData` allows `| null` and submit sends `null` instead of `undefined` for cleared fields
- src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx — both create and edit submit paths send `null` for cleared optionals so they reach the backend

Typecheck wasn't run because node_modules is absent in the worktree, but the change mirrors the verified pattern from the prior six sibling fixes.