### PR TITLE
Fix undefined-stripped bug in gabinet locations.updateLocation

### DIFF
--- a/convex/gabinet/locations.ts
+++ b/convex/gabinet/locations.ts
@@ -52,15 +52,18 @@ export const createLocation = action({
   args: {
     organizationId: v.id("organizations"),
     name: v.string(),
-    address: v.optional(v.object({
-      street: v.optional(v.string()),
-      city: v.optional(v.string()),
-      postalCode: v.optional(v.string()),
-      country: v.optional(v.string()),
-    })),
-    phone: v.optional(v.string()),
-    email: v.optional(v.string()),
-    color: v.optional(v.string()),
+    address: v.optional(v.union(
+      v.object({
+        street: v.optional(v.union(v.string(), v.null())),
+        city: v.optional(v.union(v.string(), v.null())),
+        postalCode: v.optional(v.union(v.string(), v.null())),
+        country: v.optional(v.union(v.string(), v.null())),
+      }),
+      v.null(),
+    )),
+    phone: v.optional(v.union(v.string(), v.null())),
+    email: v.optional(v.union(v.string(), v.null())),
+    color: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(
@@ -98,15 +101,18 @@ export const updateLocation = action({
     organizationId: v.id("organizations"),
     locationId: v.string(),
     name: v.optional(v.string()),
-    address: v.optional(v.object({
-      street: v.optional(v.string()),
-      city: v.optional(v.string()),
-      postalCode: v.optional(v.string()),
-      country: v.optional(v.string()),
-    })),
-    phone: v.optional(v.string()),
-    email: v.optional(v.string()),
-    color: v.optional(v.string()),
+    address: v.optional(v.union(
+      v.object({
+        street: v.optional(v.union(v.string(), v.null())),
+        city: v.optional(v.union(v.string(), v.null())),
+        postalCode: v.optional(v.union(v.string(), v.null())),
+        country: v.optional(v.union(v.string(), v.null())),
+      }),
+      v.null(),
+    )),
+    phone: v.optional(v.union(v.string(), v.null())),
+    email: v.optional(v.union(v.string(), v.null())),
+    color: v.optional(v.union(v.string(), v.null())),
     isActive: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
@@ -148,14 +148,14 @@ function LocationCard({
         organizationId,
         locationId,
         name: editName.trim(),
-        phone: editPhone?.trim() || undefined,
-        email: editEmail?.trim() || undefined,
-        color: editColor?.trim() || undefined,
+        phone: editPhone?.trim() || null,
+        email: editEmail?.trim() || null,
+        color: editColor?.trim() || null,
         address: {
-          street: editStreet?.trim() || undefined,
-          city: editCity?.trim() || undefined,
-          postalCode: editPostal?.trim() || undefined,
-          country: editCountry?.trim() || undefined,
+          street: editStreet?.trim() || null,
+          city: editCity?.trim() || null,
+          postalCode: editPostal?.trim() || null,
+          country: editCountry?.trim() || null,
         },
       });
       toast.success(t("common.saved"));
@@ -527,9 +527,9 @@ function LocationsSettingsPage() {
       await createLocation({
         organizationId,
         name: newName.trim(),
-        phone: newPhone.trim() || undefined,
-        email: newEmail.trim() || undefined,
-        address: newCity.trim() ? { city: newCity.trim() } : undefined,
+        phone: newPhone.trim() || null,
+        email: newEmail.trim() || null,
+        address: newCity.trim() ? { city: newCity.trim() } : null,
       });
       toast.success(t("gabinet.locations.addLocation"));
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetLocations.list(organizationId) });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1316.

Closes #1316

---

## Claude summary

Fixed the undefined-stripped bug in `convex/gabinet/locations.ts` for both `createLocation` and `updateLocation`. The validators now accept `null` for `phone`, `email`, `color`, and address subfields, and the settings page (`_layout.gabinet.settings.locations.tsx`) sends `null` instead of `undefined` for cleared optional fields. Same pattern as fixes #1309-#1315. Committed as `aa8d7e6`.

Pre-existing typecheck errors in `convex/companies.ts:125` and `src/components/gabinet/treatment-form.tsx:137` are unrelated to this change.