### PR TITLE
Fix undefined-stripped bug in gabinet equipment.updateEquipment

### DIFF
--- a/convex/gabinet/equipment.ts
+++ b/convex/gabinet/equipment.ts
@@ -80,10 +80,10 @@ export const createEquipment = action({
   args: {
     organizationId: v.id("organizations"),
     name: v.string(),
-    description: v.optional(v.string()),
-    serialNumber: v.optional(v.string()),
-    currentLocationId: v.optional(v.string()),
-    currentRoomId: v.optional(v.string()),
+    description: v.optional(v.union(v.string(), v.null())),
+    serialNumber: v.optional(v.union(v.string(), v.null())),
+    currentLocationId: v.optional(v.union(v.string(), v.null())),
+    currentRoomId: v.optional(v.union(v.string(), v.null())),
     status: v.optional(equipmentStatusValidator),
   },
   handler: async (ctx, args) => {
@@ -122,8 +122,8 @@ export const updateEquipment = action({
     organizationId: v.id("organizations"),
     equipmentId: v.string(),
     name: v.optional(v.string()),
-    description: v.optional(v.string()),
-    serialNumber: v.optional(v.string()),
+    description: v.optional(v.union(v.string(), v.null())),
+    serialNumber: v.optional(v.union(v.string(), v.null())),
     status: v.optional(equipmentStatusValidator),
   },
   handler: async (ctx, args) => {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
@@ -202,8 +202,8 @@ function EquipmentCard({
         organizationId,
         equipmentId: item._id,
         name: editName.trim(),
-        description: editDescription.trim() || undefined,
-        serialNumber: editSerial.trim() || undefined,
+        description: editDescription.trim() || null,
+        serialNumber: editSerial.trim() || null,
         status: editStatus,
       });
       toast.success(t("common.saved"));
@@ -533,10 +533,10 @@ function EquipmentSettingsPage() {
       await createEquipment({
         organizationId,
         name: newName.trim(),
-        description: newDescription.trim() || undefined,
-        serialNumber: newSerial.trim() || undefined,
+        description: newDescription.trim() || null,
+        serialNumber: newSerial.trim() || null,
         status: newStatus,
-        currentLocationId: newLocationId || undefined,
+        currentLocationId: newLocationId || null,
       });
       toast.success(t("gabinet.equipment.addEquipment"));
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetEquipment.list(organizationId) });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1317.

Closes #1317

---

## Claude summary

Fixed the undefined-stripped bug in `gabinet/equipment.updateEquipment` following the established pattern from #1309–#1316.

Changes:
- `convex/gabinet/equipment.ts`: validators on `createEquipment` and `updateEquipment` now accept `v.union(v.string(), v.null())` for `description`, `serialNumber` (and `currentLocationId`/`currentRoomId` on create), so cleared values pass through instead of being stripped at the action boundary.
- `src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx`: both edit and create handlers send `null` instead of `undefined` when clearing optional fields. The `{ ...updates }` spread in the handler now correctly patches `null` into the row.

Typecheck shows two pre-existing TS2589 errors on the same files that are present on baseline (`main`) and unrelated to this change.