### PR TITLE
Format `lead.expectedCloseDate` Unix timestamp in templates

### DIFF
--- a/src/components/documents/entity-documents-tab.tsx
+++ b/src/components/documents/entity-documents-tab.tsx
@@ -46,6 +46,7 @@ import { DocumentStatusBadge } from "./document-status-badge";
 import { GenerateDocumentDialog } from "./generate-document-dialog";
 import { DocumentViewer } from "./document-viewer";
 import { renderDocument } from "./document-renderer";
+import { flattenScopeData } from "@/lib/document-variables";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -250,17 +251,9 @@ export function EntityDocumentsTab({
       : {};
 
     // Flatten scope data to dot-notation (patient.firstName, treatment.name, etc.)
-    const scopeFlat: Record<string, string> = {};
-    if (scopeData) {
-      for (const [entityType, fields] of Object.entries(scopeData)) {
-        if (typeof fields !== "object" || fields === null) continue;
-        for (const [key, value] of Object.entries(fields as Record<string, unknown>)) {
-          if (value !== null && value !== undefined) {
-            scopeFlat[`${entityType}.${key}`] = String(value);
-          }
-        }
-      }
-    }
+    const scopeFlat: Record<string, string> = scopeData
+      ? flattenScopeData(scopeData as Record<string, Record<string, unknown>>)
+      : {};
 
     // Fallback mappings: if contact.* missing, use patient.* and vice versa
     if (scopeFlat["patient.firstName"] && !scopeFlat["contact.firstName"]) {

--- a/src/lib/document-variables.ts
+++ b/src/lib/document-variables.ts
@@ -179,6 +179,25 @@ export function groupVariablesByCategory(
   return groups;
 }
 
+// Paths declared with type: "date" in VARIABLE_REGISTRY. Some entities (e.g.
+// lead.expectedCloseDate) store these as millisecond timestamps; we normalize
+// them to YYYY-MM-DD during flattening so downstream formatters that expect
+// date strings (formatBirthDate) work uniformly.
+const DATE_PATHS = new Set<string>(
+  Object.values(VARIABLE_REGISTRY)
+    .flat()
+    .filter((f) => f.type === "date")
+    .map((f) => f.path),
+);
+
+function coerceDateValue(value: unknown): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const d = new Date(value);
+    if (!Number.isNaN(d.getTime())) return d.toISOString().slice(0, 10);
+  }
+  return String(value);
+}
+
 /**
  * Flatten nested scope data (from resolveScope) to dot-notation keys
  * for direct use as template inputs. Field names in the template ARE the
@@ -195,7 +214,8 @@ export function flattenScopeData(
     if (typeof fields !== "object" || fields === null) continue;
     for (const [key, value] of Object.entries(fields)) {
       if (value !== null && value !== undefined) {
-        flat[`${entityType}.${key}`] = String(value);
+        const path = `${entityType}.${key}`;
+        flat[path] = DATE_PATHS.has(path) ? coerceDateValue(value) : String(value);
       }
     }
   }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1319.

Closes #1319

---

## Claude summary

Committed as `b85eb99`.

Summary: `flattenScopeData` blindly stringified every value, so `lead.expectedCloseDate` (a `v.number()` ms timestamp) reached `formatBirthDate` as raw digits like `"1735689600000"`, the regex never matched, and the raw ms string rendered. The fix builds a `DATE_PATHS` set from the `type: "date"` entries in `VARIABLE_REGISTRY` and converts numeric values to `YYYY-MM-DD` before stringifying, so `formatBirthDate` then formats them as `DD.MM.YYYY`. The duplicated inline flatten in `entity-documents-tab.tsx` is now routed through the shared helper so the viewer pre-fill benefits from the same coercion.