### PR TITLE
Reconcile `system.date` vs `system.today` variable naming

### DIFF
--- a/convex/documents/scopeResolver_supabase.ts
+++ b/convex/documents/scopeResolver_supabase.ts
@@ -189,10 +189,26 @@ async function addCommonScope(
   if (org) {
     scope.organization = flattenEntity(org);
   }
+  const now = new Date();
+  const isoDate = now.toISOString().split("T")[0];
+  const datePl = now.toLocaleDateString("pl-PL", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+  const timeStr = now.toLocaleTimeString("pl-PL", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
   scope.system = {
-    today: new Date().toISOString().split("T")[0],
-    now: new Date().toISOString(),
-    year: new Date().getFullYear(),
+    date: isoDate,
+    date_pl: datePl,
+    time: timeStr,
+    year: now.getFullYear(),
+    // Aliases retained for back-compat with templates authored before the
+    // catalog/emitter naming was reconciled (#1320).
+    today: isoDate,
+    now: now.toISOString(),
   };
 }
 

--- a/src/lib/document-variables.ts
+++ b/src/lib/document-variables.ts
@@ -26,8 +26,10 @@ export interface VariableField {
 export const VARIABLE_REGISTRY: Record<string, VariableField[]> = {
   common: [
     { path: "organization.name", label: "Nazwa organizacji", labelEn: "Organization name", category: "organization" },
-    { path: "system.today", label: "Dzisiejsza data", labelEn: "Today's date", category: "system" },
+    { path: "system.date", label: "Dzisiejsza data", labelEn: "Today's date", category: "system" },
     { path: "system.date_pl", label: "Data (format PL)", labelEn: "Date (PL format)", category: "system" },
+    { path: "system.time", label: "Aktualny czas", labelEn: "Current time", category: "system" },
+    { path: "system.year", label: "Rok", labelEn: "Year", category: "system" },
   ],
   contact: [
     { path: "contact.firstName", label: "Imię kontaktu", labelEn: "Contact first name", category: "contact" },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1320.

Closes #1320

---

## Claude summary

Committed. Summary of the fix:

The bug was real. `convex/documents/scopeResolver.ts:158-163` advertises `system.date`, `system.date_pl`, `system.time`, `system.year` to template UIs, but `addCommonScope` in `convex/documents/scopeResolver_supabase.ts:192-196` was emitting `system.today`, `system.now`, `system.year`. Templates using `{{system.date_pl}}` (e.g. `convex/documents/seed.ts:1236`, `convex/documents/components.ts:500`) only rendered because a client-side fallback in `src/components/documents/entity-documents-tab.tsx:267-274` synthesized the missing values.

Changes:
- `convex/documents/scopeResolver_supabase.ts`: emit `date`/`date_pl`/`time`/`year` (matching the catalog), with `date_pl` formatted to match the existing client fallback. Kept `today` and `now` as aliases for back-compat with any pre-existing templates.
- `src/lib/document-variables.ts`: replaced `system.today` with `system.date` and added `system.time`/`system.year` so the frontend picker matches the catalog and the emitter.

Left the client-side fallback in `entity-documents-tab.tsx` intact as a defensive safety net.

Convex typecheck passes; app typecheck has two pre-existing TS2589 errors unrelated to this change (confirmed by stashing).