### PR TITLE
ContactForm emits `source` but neither `contacts.create` nor `contacts.update` a

### DIFF
--- a/convex/contacts.ts
+++ b/convex/contacts.ts
@@ -104,6 +104,7 @@ export const create = action({
     title: v.optional(v.union(v.string(), v.null())),
     avatarUrl: v.optional(v.union(v.string(), v.null())),
     notes: v.optional(v.union(v.string(), v.null())),
+    source: v.optional(v.union(v.string(), v.null())),
     tags: v.optional(v.array(v.string())),
     customFields: v.optional(v.array(v.object({
       fieldDefinitionId: v.string(),
@@ -139,6 +140,7 @@ export const create = action({
       title: args.title ?? null,
       avatarUrl: args.avatarUrl ?? null,
       notes: args.notes ?? null,
+      source: args.source ?? null,
       tags: args.tags ?? null,
       tagIds: args.tagIds ?? null,
       categoryId: args.categoryId ?? null,
@@ -219,6 +221,7 @@ export const update = action({
     title: v.optional(v.union(v.string(), v.null())),
     avatarUrl: v.optional(v.union(v.string(), v.null())),
     notes: v.optional(v.union(v.string(), v.null())),
+    source: v.optional(v.union(v.string(), v.null())),
     tags: v.optional(v.array(v.string())),
     customFields: v.optional(v.array(v.object({
       fieldDefinitionId: v.string(),

--- a/src/components/forms/contact-form.tsx
+++ b/src/components/forms/contact-form.tsx
@@ -28,7 +28,7 @@ interface ContactFormData {
   email?: string | null;
   phone?: string | null;
   title?: string | null;
-  source?: string;
+  source?: string | null;
   tags?: string[];
   tagIds?: Id<"tagDefinitions">[];
   categoryId?: Id<"categoryDefinitions"> | null;
@@ -115,7 +115,7 @@ export function ContactForm({
         email: email || null,
         phone: phone || null,
         title: title || null,
-        source: source || undefined,
+        source: source || null,
         tags: tags.length > 0 ? tags : undefined,
         tagIds: tagIds.length > 0 ? tagIds : undefined,
         categoryId: categoryId || null,

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
@@ -266,7 +266,7 @@ function ContactDetail() {
       email?: string | null;
       phone?: string | null;
       title?: string | null;
-      source?: string;
+      source?: string | null;
       tags?: string[];
       tagIds?: Id<"tagDefinitions">[];
       categoryId?: Id<"categoryDefinitions"> | null;
@@ -284,6 +284,7 @@ function ContactDetail() {
         email: formData.email,
         phone: formData.phone,
         title: formData.title,
+        source: formData.source,
         notes: formData.notes,
         tags: formData.tags,
         tagIds: formData.tagIds,

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
@@ -288,7 +288,7 @@ function ContactsIndex() {
         email?: string | null;
         phone?: string | null;
         title?: string | null;
-        source?: string;
+        source?: string | null;
         tags?: string[];
         notes?: string | null;
       },
@@ -303,6 +303,7 @@ function ContactsIndex() {
           email: formData.email,
           phone: formData.phone,
           title: formData.title,
+          source: formData.source,
           notes: formData.notes,
           tags: formData.tags,
         });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1325.

Closes #1325

---

## Claude summary

Fixed and committed (a8de0e3) on `claude/issue-1325`. The `source` field is now declared in both `contacts.create` and `contacts.update` validators, persisted in the Supabase insert, and forwarded from both call sites that render the source input (the contacts list create panel and the contact detail edit drawer). Following the precedent set by #1324, the form sends `null` instead of `undefined` for an empty value so users can clear an existing source. Convex + app typechecks pass.