### PR TITLE
Allow clearing bodyChartData and other appointment optional fields

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1288,28 +1288,31 @@ export const update = action({
     internalNotes: v.optional(v.union(v.string(), v.null())),
     color: v.optional(v.union(v.string(), v.null())),
     employeeId: v.optional(v.string()),
-    treatmentId: v.optional(v.string()),
-    packageUsageId: v.optional(v.string()),
+    treatmentId: v.optional(v.union(v.string(), v.null())),
+    packageUsageId: v.optional(v.union(v.string(), v.null())),
     status: v.optional(gabinetAppointmentStatusValidator),
     cancellationReason: v.optional(v.union(v.string(), v.null())),
-    bodyChartData: v.optional(v.string()),
+    bodyChartData: v.optional(v.union(v.string(), v.null())),
     treatmentParameterValues: v.optional(v.union(v.string(), v.null())),
     interviewNotes: v.optional(v.union(v.string(), v.null())),
     clinicalRemarks: v.optional(v.union(v.string(), v.null())),
     locationId: v.optional(v.union(v.string(), v.null())),
     roomId: v.optional(v.union(v.string(), v.null())),
     photos: v.optional(
-      v.array(
-        v.object({
-          storageId: v.string(),
-          type: v.union(v.literal("before"), v.literal("after")),
-          caption: v.optional(v.string()),
-          uploadedAt: v.number(),
-        }),
+      v.union(
+        v.array(
+          v.object({
+            storageId: v.string(),
+            type: v.union(v.literal("before"), v.literal("after")),
+            caption: v.optional(v.string()),
+            uploadedAt: v.number(),
+          }),
+        ),
+        v.null(),
       ),
     ),
-    tagIds: v.optional(v.array(v.string())),
-    categoryId: v.optional(v.string()),
+    tagIds: v.optional(v.union(v.array(v.string()), v.null())),
+    categoryId: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
     // --- Auth + permissions (via internal queries) ---

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1115,7 +1115,7 @@ function AppointmentDetail() {
         organizationId,
         appointmentId: appointment._id,
         bodyChartData:
-          bodyChartData.length > 0 ? JSON.stringify(bodyChartData) : undefined,
+          bodyChartData.length > 0 ? JSON.stringify(bodyChartData) : null,
       });
       toast.success(t("common.saved"));
       refetch();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1329.

Closes #1329

---

## Claude summary

Committed. Summary of changes:

The fix mirrors PR #1312 for the remaining schema-optional appointment fields. The `update` action in `convex/gabinet/appointments.ts:1280` now accepts `null` for `bodyChartData`, `photos`, `tagIds`, `categoryId`, `packageUsageId`, and `treatmentId` (in addition to the previously-fixed `notes`/`internalNotes`/`color`/etc.). The body-chart save handler at `_layout.gabinet.appointments.$appointmentId.lazy.tsx:1117` was the only existing form caller actually sending `undefined` to clear; it now sends `null` so the cleared state persists. `employeeId` is intentionally left as a non-nullable optional string because the schema defines it as required (`v.id("users")`) — it can't be cleared.