### PR TITLE
Allow clearing cancellationReason on already-cancelled appointments

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1391,9 +1391,17 @@ export const update = action({
       if (status === "cancelled") {
         patch.cancelledAt = now;
         patch.cancelledBy = String(authResult.userId);
-        if (cancellationReason) {
-          patch.cancellationReason = cancellationReason;
-        }
+      }
+    }
+
+    // Allow editing or clearing cancellationReason independently of the
+    // status change — required so users can update/clear the reason on an
+    // already-cancelled appointment (status is then undefined in args).
+    if (cancellationReason !== undefined) {
+      const willBeCancelled =
+        status === "cancelled" || (!status && appt.status === "cancelled");
+      if (willBeCancelled) {
+        patch.cancellationReason = cancellationReason;
       }
     }
 

--- a/tests/convex/appointmentStateMachine.test.ts
+++ b/tests/convex/appointmentStateMachine.test.ts
@@ -251,4 +251,70 @@ describe("appointment state machine", () => {
     )) as Record<string, any> | null;
     expect(activity?.isCompleted).toBe(true);
   });
+
+  test("cancellationReason can be edited on an already-cancelled appointment", async () => {
+    const t = createManagedTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    const apptId = await createAppointment(t, identity, {
+      organizationId, patientId, treatmentId, employeeId: userId,
+    });
+
+    await t.withIdentity(identity).action(api.gabinet.appointments.update, {
+      organizationId,
+      appointmentId: apptId,
+      status: "cancelled",
+      cancellationReason: "initial reason",
+    });
+    expect((await getAppointment(apptId))?.cancellationReason).toBe("initial reason");
+
+    await t.withIdentity(identity).action(api.gabinet.appointments.update, {
+      organizationId,
+      appointmentId: apptId,
+      cancellationReason: "corrected reason",
+    });
+    expect((await getAppointment(apptId))?.cancellationReason).toBe("corrected reason");
+  });
+
+  test("cancellationReason can be cleared with null on a cancelled appointment", async () => {
+    const t = createManagedTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    const apptId = await createAppointment(t, identity, {
+      organizationId, patientId, treatmentId, employeeId: userId,
+    });
+
+    await t.withIdentity(identity).action(api.gabinet.appointments.update, {
+      organizationId,
+      appointmentId: apptId,
+      status: "cancelled",
+      cancellationReason: "initial reason",
+    });
+
+    await t.withIdentity(identity).action(api.gabinet.appointments.update, {
+      organizationId,
+      appointmentId: apptId,
+      cancellationReason: null,
+    });
+    expect((await getAppointment(apptId))?.cancellationReason).toBeNull();
+  });
+
+  test("cancellationReason on a non-cancelled appointment is ignored", async () => {
+    const t = createManagedTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    const apptId = await createAppointment(t, identity, {
+      organizationId, patientId, treatmentId, employeeId: userId,
+    });
+
+    await t.withIdentity(identity).action(api.gabinet.appointments.update, {
+      organizationId,
+      appointmentId: apptId,
+      cancellationReason: "should not stick",
+    });
+    expect((await getAppointment(apptId))?.cancellationReason).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1330.

Closes #1330

---

## Claude summary

Committed as `cf90bdc`.

The bug was real: in `convex/gabinet/appointments.ts:1391`, the update handler only wrote `cancellationReason` to the patch when both a status transition to `"cancelled"` was happening AND the supplied value was truthy. Two failures combined to make the field uneditable post-cancel — first, an update that doesn't change status (the post-hoc edit case) skipped the cancellation block entirely; second, even within that block, a `null` would have been dropped by the `if (cancellationReason)` truthiness check.

The fix moves the `cancellationReason` write into its own block that runs whenever the field is explicitly provided. It still only writes when the appointment is, or is being transitioned to, cancelled — so a stray `cancellationReason` on a scheduled appointment is ignored. Three new tests in `tests/convex/appointmentStateMachine.test.ts` cover edit, clear-with-null, and the safety guard. All 12 tests in the state-machine suite pass.

Typecheck has a pre-existing `TS2589` "type instantiation is excessively deep" issue in convex code that exists on `main` and is unrelated to this change.