### PR TITLE
Apply the same null-clear pattern to gabinet create/update flows for patients, t

### DIFF
--- a/convex/gabinet/locations.ts
+++ b/convex/gabinet/locations.ts
@@ -211,8 +211,8 @@ export const createRoom = action({
     organizationId: v.id("organizations"),
     locationId: v.string(),
     name: v.string(),
-    description: v.optional(v.string()),
-    floor: v.optional(v.string()),
+    description: v.optional(v.union(v.string(), v.null())),
+    floor: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
     await ctx.runQuery(
@@ -252,8 +252,8 @@ export const updateRoom = action({
     organizationId: v.id("organizations"),
     roomId: v.string(),
     name: v.optional(v.string()),
-    description: v.optional(v.string()),
-    floor: v.optional(v.string()),
+    description: v.optional(v.union(v.string(), v.null())),
+    floor: v.optional(v.union(v.string(), v.null())),
     isActive: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
@@ -196,7 +196,7 @@ function LocationCard({
         organizationId,
         locationId,
         name: newRoomName.trim(),
-        floor: newRoomFloor.trim() || undefined,
+        floor: newRoomFloor.trim() || null,
       });
       toast.success(t("common.saved"));
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetRooms.list(organizationId) });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1331.

Closes #1331

---

## Claude summary

Summary: I triaged the issue's checklist against `git log` and found that 5 of the 6 entities listed (`patients`, `treatments`, `employees`, `packages`, `locations`) were already fixed in earlier PRs (#1291, #1313–#1316). The only remaining entity was `rooms`, which is defined inside `convex/gabinet/locations.ts` and was missed by the locations PR.

Applied the same null-clear pattern to rooms:
- `createRoom`/`updateRoom` validators now accept `v.union(v.string(), v.null())` for `description` and `floor`
- `LocationCard.handleAddRoom` in the locations settings page now sends `null` instead of `undefined` for cleared `floor`

The room create handler already does `description: args.description ?? null` and `floor: args.floor ?? null`, and `updateRoom` already spreads `...updates` into `db.patch`, so no handler changes were needed — only the validators and the one frontend call site.

Committed as `ef9753a` on branch `claude/issue-1331`.