### PR TITLE
Allow clearing address, email, endDate, employmentType on gabinet employees

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -501,15 +501,18 @@ export const update = action({
     notes: v.optional(v.union(v.string(), v.null())),
     // Detailed employee data
     phone: v.optional(v.union(v.string(), v.null())),
-    email: v.optional(v.string()),
+    email: v.optional(v.union(v.string(), v.null())),
     dateOfBirth: v.optional(v.union(v.string(), v.null())),
     pesel: v.optional(v.union(v.string(), v.null())),
     address: v.optional(
-      v.object({
-        street: v.optional(v.string()),
-        city: v.optional(v.string()),
-        postalCode: v.optional(v.string()),
-      }),
+      v.union(
+        v.object({
+          street: v.optional(v.string()),
+          city: v.optional(v.string()),
+          postalCode: v.optional(v.string()),
+        }),
+        v.null(),
+      ),
     ),
     employmentType: v.optional(
       v.union(
@@ -517,9 +520,10 @@ export const update = action({
         v.literal("umowa_zlecenie"),
         v.literal("b2b"),
         v.literal("staz"),
+        v.null(),
       ),
     ),
-    endDate: v.optional(v.string()),
+    endDate: v.optional(v.union(v.string(), v.null())),
     position: v.optional(v.union(v.string(), v.null())),
     department: v.optional(v.union(v.string(), v.null())),
     skills: v.optional(v.array(v.string())),

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -1757,7 +1757,7 @@ function DetailedDataTab({
         updatePayload.firstName = formData.firstName || undefined;
         updatePayload.lastName = formData.lastName || undefined;
         updatePayload.phone = formData.phone || null;
-        updatePayload.email = formData.email || undefined;
+        updatePayload.email = formData.email || null;
         updatePayload.dateOfBirth = formData.dateOfBirth || null;
         updatePayload.pesel = formData.pesel || null;
         updatePayload.address =
@@ -1767,11 +1767,11 @@ function DetailedDataTab({
                 city: formData.addressCity || undefined,
                 postalCode: formData.addressPostalCode || undefined,
               }
-            : undefined;
+            : null;
       } else if (section === "employment") {
-        updatePayload.employmentType = (formData.employmentType || undefined) as EmploymentType | undefined;
+        updatePayload.employmentType = (formData.employmentType || null) as EmploymentType | null;
         updatePayload.hireDate = formData.hireDate || null;
-        updatePayload.endDate = formData.endDate || undefined;
+        updatePayload.endDate = formData.endDate || null;
         updatePayload.position = formData.position || null;
         updatePayload.department = formData.department || null;
         updatePayload.role = formData.role as GabinetEmployeeRole;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1334.

Closes #1334

---

## Claude summary

Committed `b310847`. The fix extends PR #1314's pattern to the four fields it missed: `address`, `email`, `employmentType`, and `endDate`. The `update` validator at `convex/gabinet/employees.ts:504-526` now accepts `v.null()` for each, and `DetailedDataTab.saveSection` at `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx:1760-1774` sends `null` instead of `undefined` so the patch actually clears the fields in Supabase. Typecheck passes.