### PR TITLE
Allow clearing numeric/array employee fields (baseSalary, commissionPercent, ski

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -526,19 +526,22 @@ export const update = action({
     endDate: v.optional(v.union(v.string(), v.null())),
     position: v.optional(v.union(v.string(), v.null())),
     department: v.optional(v.union(v.string(), v.null())),
-    skills: v.optional(v.array(v.string())),
-    yearsOfExperience: v.optional(v.number()),
+    skills: v.optional(v.union(v.array(v.string()), v.null())),
+    yearsOfExperience: v.optional(v.union(v.number(), v.null())),
     certifications: v.optional(
-      v.array(
-        v.object({
-          name: v.string(),
-          dateObtained: v.optional(v.string()),
-          expiryDate: v.optional(v.string()),
-        }),
+      v.union(
+        v.array(
+          v.object({
+            name: v.string(),
+            dateObtained: v.optional(v.string()),
+            expiryDate: v.optional(v.string()),
+          }),
+        ),
+        v.null(),
       ),
     ),
-    baseSalary: v.optional(v.number()),
-    commissionPercent: v.optional(v.number()),
+    baseSalary: v.optional(v.union(v.number(), v.null())),
+    commissionPercent: v.optional(v.union(v.number(), v.null())),
     bankAccount: v.optional(v.union(v.string(), v.null())),
     tagIds: v.optional(v.array(v.string())),
     categoryId: v.optional(v.union(v.string(), v.null())),

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -1777,21 +1777,22 @@ function DetailedDataTab({
         updatePayload.role = formData.role as GabinetEmployeeRole;
         updatePayload.notes = formData.notes || null;
       } else if (section === "qualifications") {
-        updatePayload.skills = formData.skills
+        const skillsList = formData.skills
           ? formData.skills.split(",").map((s: string) => s.trim()).filter(Boolean)
-          : undefined;
+          : [];
+        updatePayload.skills = skillsList.length > 0 ? skillsList : null;
         updatePayload.yearsOfExperience = formData.yearsOfExperience
           ? Number(formData.yearsOfExperience)
-          : undefined;
+          : null;
         updatePayload.certifications =
-          certifications.length > 0 ? certifications : undefined;
+          certifications.length > 0 ? certifications : null;
       } else if (section === "compensation") {
         updatePayload.baseSalary = formData.baseSalary
           ? Number(formData.baseSalary)
-          : undefined;
+          : null;
         updatePayload.commissionPercent = formData.commissionPercent
           ? Number(formData.commissionPercent)
-          : undefined;
+          : null;
         updatePayload.bankAccount = formData.bankAccount || null;
       }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1335.

Closes #1335

---

## Claude summary

Fix applied and committed. 

Summary: extended the same `null`-handling pattern from #1314 and #1334 to the remaining clearable employee fields. Validator in `convex/gabinet/employees.ts:529-547` now accepts `v.null()` for `skills`, `yearsOfExperience`, `certifications`, `baseSalary`, `commissionPercent`. Form code in `_layout.gabinet.employees.$employeeId.tsx:1779-1795` (qualifications + compensation sections) now sends `null` instead of `undefined` for cleared values so the patch actually reaches Supabase. Typecheck passes.