### PR TITLE
wyszukiwarka

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -210,13 +210,18 @@ function PatientsIndex() {
     }
     const q = searchValue.trim().toLowerCase();
     if (q) {
-      data = data.filter(
-        (p) =>
-          p.firstName.toLowerCase().includes(q) ||
-          p.lastName.toLowerCase().includes(q) ||
+      data = data.filter((p) => {
+        const first = p.firstName.toLowerCase();
+        const last = p.lastName.toLowerCase();
+        const fullName = `${first} ${last}`;
+        const reverseName = `${last} ${first}`;
+        return (
+          fullName.includes(q) ||
+          reverseName.includes(q) ||
           (p.email && p.email.toLowerCase().includes(q)) ||
-          (p.phone && p.phone.toLowerCase().includes(q)),
-      );
+          (p.phone && p.phone.toLowerCase().includes(q))
+        );
+      });
     }
     return data;
   }, [patients, activeViewId, applyFilters, activeFilters, searchValue, nudgeFilter, recentVisitPatientIds]);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1350.

Closes #1350

---

## Claude summary

Fixed and committed.

The bug was in `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx:211-220`. The search filter checked `firstName.includes(q) || lastName.includes(q)` separately, so typing `"Jan Kowalski"` failed because neither field on its own contains the full string. Now the filter matches against the concatenated `"first last"` (and reversed `"last first"`) string, so partial queries (`"jan"`, `"kowalski"`), full names (`"jan kowalski"`), and Polish-style reversed names (`"kowalski jan"`) all match.