### PR TITLE
Fix same full-name search bug in gabinet calendar appointment dialog

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -378,13 +378,18 @@ export function AppointmentDialog({
     const all = patients?.page ?? [];
     if (!patientSearch.trim()) return all;
     const q = patientSearch.toLowerCase();
-    return all.filter(
-      (p) =>
-        (p.firstName ?? "").toLowerCase().includes(q) ||
-        (p.lastName ?? "").toLowerCase().includes(q) ||
+    return all.filter((p) => {
+      const first = (p.firstName ?? "").toLowerCase();
+      const last = (p.lastName ?? "").toLowerCase();
+      const fullName = `${first} ${last}`;
+      const reverseName = `${last} ${first}`;
+      return (
+        fullName.includes(q) ||
+        reverseName.includes(q) ||
         (p.email ?? "").toLowerCase().includes(q) ||
-        (p.phone ?? "").toLowerCase().includes(q),
-    );
+        (p.phone ?? "").toLowerCase().includes(q)
+      );
+    });
   }, [patients, patientSearch]);
 
   // Filter treatments by search


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1353.

Closes #1353

---

## Claude summary

Applied the same `${first} ${last}` / `${last} ${first}` concatenation fix from #1350 to `src/components/gabinet/calendar/appointment-dialog.tsx:381-393`. The patient picker in the new-appointment dialog now matches typed full names like "Jan Kowalski" instead of failing because neither field individually contains the whole string. Committed as `0d06589`.