### PR TITLE
Podgląd

### DIFF
--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -170,7 +170,7 @@ export function DraggableAppointment({
     <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
       <PopoverAnchor asChild>{card}</PopoverAnchor>
       <PopoverContent
-        className="w-[553px] p-4"
+        className="w-[553px] max-w-[calc(100vw-24px)] max-h-[calc(100dvh-24px)] overflow-y-auto p-4"
         align="start"
         side="right"
         sideOffset={8}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1356.

Closes #1356

---

## Claude summary

Fix committed as `3cda2dc`.

Root cause: the appointment preview popover in `src/components/gabinet/calendar/draggable-appointment.tsx:173` was hard-coded to `w-[553px]` with no max-width or max-height. On a 390×844 iOS viewport this overflowed horizontally and could exceed the screen vertically — matching the screenshot where the preview is partially clipped.

Fix: kept the desktop width but added `max-w-[calc(100vw-24px)]`, `max-h-[calc(100dvh-24px)]`, and `overflow-y-auto` so the popover shrinks to the viewport on small screens and scrolls if the content is taller than the screen. `100dvh` (dynamic viewport height) handles iOS Safari's address-bar resize correctly.