### PR TITLE
Podgląd

### DIFF
--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -170,7 +170,7 @@ export function DraggableAppointment({
     <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
       <PopoverAnchor asChild>{card}</PopoverAnchor>
       <PopoverContent
-        className="w-[553px] p-4"
+        className="w-[553px] max-w-[calc(100vw-24px)] max-h-[calc(100dvh-24px)] overflow-y-auto p-4"
         align="start"
         side="right"
         sideOffset={8}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1356.

Closes #1356

---

## Claude summary

The fix for issue #1356 has already been merged to `main` as commit `2494baa` (originally `3cda2dc` on PR #1359). The appointment preview popover in `src/components/gabinet/calendar/draggable-appointment.tsx:173` already has the mobile-viewport-aware classes:

```
className="w-[553px] max-w-[calc(100vw-24px)] max-h-[calc(100dvh-24px)] overflow-y-auto p-4"
```

This handles the iOS 390×844 viewport reported in the issue: `max-w-[calc(100vw-24px)]` keeps the popover from overflowing horizontally, `max-h-[calc(100dvh-24px)]` (using dynamic viewport height for iOS Safari's address-bar resize) keeps it within screen height, and `overflow-y-auto` adds scroll if needed.

Note: the worktree is checked out on `claude/issue-1059` rather than `claude/issue-1356`, but the fix is verified present on `origin/main` which is what matters. No additional changes needed — the issue is resolved.