### PR TITLE
Kategoria dodawanie klienta

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -32,9 +32,6 @@ import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-s
 import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
 import { formatPhoneNumber } from "@/lib/phone";
 import { formatBirthDate } from "@/lib/format-date";
-import { TagsPicker } from "@/components/categories-tags/tags-picker";
-import { CategoryPicker } from "@/components/categories-tags/category-picker";
-import { Label } from "@/components/ui/label";
 import { plateJsonToText } from "@/components/gabinet/rich-text-editor";
 import { displayReferralSource } from "@/lib/options";
 
@@ -75,8 +72,6 @@ function PatientsIndex() {
   const { categories } = useCategoryDefinitions(organizationId, "gabinetPatient");
   const [tagsSlideoutOpen, setTagsSlideoutOpen] = useState(false);
   const [categoriesSlideoutOpen, setCategoriesSlideoutOpen] = useState(false);
-  const [tagIds, setTagIds] = useState<Id<"tagDefinitions">[]>([]);
-  const [categoryId, setCategoryId] = useState<Id<"categoryDefinitions"> | undefined>(undefined);
   const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor | undefined>({
     column: "firstName",
     direction: "ascending",
@@ -381,18 +376,16 @@ function PatientsIndex() {
       emergencyContactName?: string | null;
       emergencyContactPhone?: string | null;
       referralSource?: string | null;
+      tagIds?: Id<"tagDefinitions">[];
+      categoryId?: Id<"categoryDefinitions">;
     }) => {
       setIsCreating(true);
       try {
         await createPatient({
           organizationId,
           ...formData,
-          tagIds,
-          categoryId,
         });
         setPanelOpen(false);
-        setTagIds([]);
-        setCategoryId(undefined);
       } catch (e) {
         toast.error(
           formatActionError(e, t, {
@@ -404,7 +397,7 @@ function PatientsIndex() {
         setIsCreating(false);
       }
     },
-    [createPatient, organizationId, tagIds, categoryId, t],
+    [createPatient, organizationId, t],
   );
 
   const handleBulkAction = useCallback(
@@ -549,13 +542,7 @@ function PatientsIndex() {
 
       <SidePanel
         open={panelOpen}
-        onOpenChange={(open) => {
-          setPanelOpen(open);
-          if (!open) {
-            setTagIds([]);
-            setCategoryId(undefined);
-          }
-        }}
+        onOpenChange={setPanelOpen}
         title={t("gabinet.patients.createPatient")}
         description={t("gabinet.patients.createDescription")}
       >
@@ -564,23 +551,9 @@ function PatientsIndex() {
           onCancel={() => setPanelOpen(false)}
           isSubmitting={isCreating}
           organizationId={organizationId}
+          tagDefinitions={tags}
+          categoryDefinitions={categories}
         />
-        {tags.length > 0 && (
-          <div className="space-y-1.5">
-            <Label>{t('common.tags', { defaultValue: "Tagi" })}</Label>
-            <TagsPicker tags={tags} selectedIds={tagIds} onChange={setTagIds} />
-          </div>
-        )}
-        <div className="space-y-1.5">
-          <Label>{t('common.category', { defaultValue: "Kategoria" })}</Label>
-          <CategoryPicker
-            categories={categories}
-            selectedId={categoryId}
-            onChange={setCategoryId}
-            organizationId={organizationId}
-            entityType="gabinetPatient"
-          />
-        </div>
       </SidePanel>
 
       <TagsManagerSlideout


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1361.

Closes #1361

---

## Claude summary

Committed. The fix moves Tags above the buttons and removes the duplicate Kategoria.

Summary of what I did:

The "Add patient" SidePanel was rendering `TagsPicker` and `CategoryPicker` twice — once inside `<PatientForm>` (the form already has internal Tags/Category sections that render when `tagDefinitions`/`organizationId` are passed) and a second time outside the form, below the Cancel/Create buttons. The route never passed `tagDefinitions` so the inner Tags section stayed hidden, but `organizationId` was passed so the inner Category section rendered — producing the duplicate Kategoria the user saw at the bottom, and pushing Tags entirely below the buttons.

Fix in `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx`: pass `tagDefinitions={tags}` and `categoryDefinitions={categories}` to `<PatientForm>`, drop the extra `<TagsPicker>`/`<CategoryPicker>` blocks rendered outside the form, and let `handleCreate` read `tagIds`/`categoryId` from the form's submit payload instead of route-level state. New render order inside the form: form fields → Tags → Category → Cancel/Create buttons.