### PR TITLE
Dodawanie wizyty- zmiana godziny wizyty

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -225,7 +225,17 @@ export function AppointmentPreviewContent({
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
 
-  const handleStartTimeChange = (newStart: string) => {
+  const snapTimeTo15Min = (value: string): string => {
+    if (!value) return value;
+    const [h, m] = value.split(":").map(Number);
+    if (!Number.isFinite(h) || !Number.isFinite(m)) return value;
+    const total = Math.min(Math.max(h * 60 + m, 0), 24 * 60 - 1);
+    const snapped = Math.min(Math.round(total / 15) * 15, 24 * 60 - 1);
+    return `${String(Math.floor(snapped / 60)).padStart(2, "0")}:${String(snapped % 60).padStart(2, "0")}`;
+  };
+
+  const handleStartTimeChange = (rawStart: string) => {
+    const newStart = snapTimeTo15Min(rawStart);
     setStartTime(newStart);
     if (!newStart || !startTime || !endTime) return;
     const toMin = (s: string) => {
@@ -1175,7 +1185,7 @@ export function AppointmentPreviewContent({
               type="time"
               step={900}
               value={endTime}
-              onChange={(e) => setEndTime(e.target.value)}
+              onChange={(e) => setEndTime(snapTimeTo15Min(e.target.value))}
               className="h-8 w-[88px] text-sm"
             />
           </div>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -348,6 +348,14 @@ function AppointmentDetail() {
   const [editDate, setEditDate] = useState("");
   const [editStartTime, setEditStartTime] = useState("");
   const [editEndTime, setEditEndTime] = useState("");
+  const snapTimeTo15Min = (value: string): string => {
+    if (!value) return value;
+    const [h, m] = value.split(":").map(Number);
+    if (!Number.isFinite(h) || !Number.isFinite(m)) return value;
+    const total = Math.min(Math.max(h * 60 + m, 0), 24 * 60 - 1);
+    const snapped = Math.min(Math.round(total / 15) * 15, 24 * 60 - 1);
+    return `${String(Math.floor(snapped / 60)).padStart(2, "0")}:${String(snapped % 60).padStart(2, "0")}`;
+  };
   const [editLocationId, setEditLocationId] = useState("");
   const [editRoomId, setEditRoomId] = useState("");
   const [treatmentPickerOpen, setTreatmentPickerOpen] = useState(false);
@@ -1449,7 +1457,7 @@ function AppointmentDetail() {
                     type="time"
                     step={900}
                     value={editStartTime}
-                    onChange={(e) => setEditStartTime(e.target.value)}
+                    onChange={(e) => setEditStartTime(snapTimeTo15Min(e.target.value))}
                     className="h-9 w-[110px]"
                   />
                 </div>
@@ -1461,7 +1469,7 @@ function AppointmentDetail() {
                     type="time"
                     step={900}
                     value={editEndTime}
-                    onChange={(e) => setEditEndTime(e.target.value)}
+                    onChange={(e) => setEditEndTime(snapTimeTo15Min(e.target.value))}
                     className="h-9 w-[110px]"
                   />
                 </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1365.

Closes #1365

---

## Claude summary

Committed the fix.

The bug: even though the OD/DO time inputs on the appointment popover (and the appointment detail page) had `step={900}`, Chrome's clock picker UI and direct typing both bypass the step attribute, so users could still set times to arbitrary 1-minute values like 18:10 / 18:40 as shown in the user's screenshot.

The fix: introduce a small `snapTimeTo15Min` helper that rounds any incoming value to the nearest 15-minute boundary, and call it from the onChange handlers of the start- and end-time inputs in both `src/components/gabinet/calendar/appointment-preview-content.tsx` and `src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx`. The `step={900}` attribute is kept so that the spinner still steps by 15 minutes for users who don't pick via the clock UI.

## Follow-ups
- Snap recurring-occurrence override time input in appointment-dialog: the time input at src/components/gabinet/calendar/appointment-dialog.tsx:1402 (used to override start times of recurring sub-occurrences when creating a recurring appointment) has no `step` and no snap — same 1-minute issue applies there.