### PR TITLE
Przycisk zapisz podgląd wizyty

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2802,6 +2802,7 @@
       "phoneAdded": "Phone number added",
       "edit": "Edit",
       "close": "Close",
+      "saveChanges": "Save changes",
       "closeAndSettle": "Settle visit",
       "settleDesc": "Record payment and optionally close the appointment as completed.",
       "settleMarkCompleted": "Mark appointment as completed",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2831,6 +2831,7 @@
       "phoneAdded": "Numer telefonu dodany",
       "edit": "Edytuj",
       "close": "Zamknij",
+      "saveChanges": "Zapisz zmiany",
       "closeAndSettle": "Rozlicz wizytę",
       "settleDesc": "Zarejestruj płatność i opcjonalnie zamknij wizytę jako zakończoną.",
       "settleMarkCompleted": "Oznacz wizytę jako zakończoną",

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -1251,6 +1251,17 @@ export function AppointmentPreviewContent({
           </Link>
         </Button>
         <Button
+          variant="outline"
+          size="sm"
+          className="h-8 text-xs"
+          onClick={handleSave}
+          disabled={!dirty || saving || settleSubmitting}
+        >
+          {saving
+            ? t("common.saving")
+            : t("gabinet.appointmentDetail.saveChanges", "Zapisz zmiany")}
+        </Button>
+        <Button
           size="sm"
           className="h-8 text-xs"
           onClick={handleOpenSettleDialog}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1366.

Closes #1366

---

## Claude summary

Added a "Zapisz zmiany" button to the appointment preview popover between Edit and Settle visit. It reuses the existing `handleSave` (which already supports notes, tags, time, date, and treatment edits) and is disabled when nothing has changed. Translations added for PL/EN.

Files changed:
- `src/components/gabinet/calendar/appointment-preview-content.tsx:1253-1263` — new button
- `public/locales/pl/translation.json` — `saveChanges: "Zapisz zmiany"`
- `public/locales/en/translation.json` — `saveChanges: "Save changes"`

Committed as `c07bf34`.