### PR TITLE
Nazwa zmien status

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2796,7 +2796,7 @@
     "appointmentDetail": {
       "title": "Appointment Details",
       "time": "Time",
-      "changeStatus": "Change status",
+      "changeStatus": "Change appointment status",
       "statusChanged": "Appointment status changed",
       "addPhone": "Add phone number",
       "phoneAdded": "Phone number added",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2825,7 +2825,7 @@
     "appointmentDetail": {
       "title": "Szczegóły wizyty",
       "time": "Godzina",
-      "changeStatus": "Zmień status",
+      "changeStatus": "Zmień status wizyty",
       "statusChanged": "Status wizyty zmieniony",
       "addPhone": "Dodaj nr telefonu",
       "phoneAdded": "Numer telefonu dodany",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1367.

Closes #1367

---

## Claude summary

Renamed the appointment status label in the calendar preview popover. The PL string at `public/locales/pl/translation.json:2828` (`gabinet.appointmentDetail.changeStatus`) is now "Zmień status wizyty", and the EN counterpart is "Change appointment status". The label is consumed at `src/components/gabinet/calendar/appointment-preview-content.tsx:1105` (and the matching `aria-label` at line 1110).