### PR TITLE
Nie da się kliknąć w wizytę

### DIFF
--- a/src/components/layout/route-error-boundary.tsx
+++ b/src/components/layout/route-error-boundary.tsx
@@ -2,7 +2,10 @@ import { useEffect } from "react";
 import { useRouter } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
 import { AlertTriangle } from "lucide-react";
-import { reportError } from "@/lib/error-reporter";
+import {
+  maybeReloadForStaleChunk,
+  reportError,
+} from "@/lib/error-reporter";
 
 export function RouteErrorBoundary({
   error,
@@ -17,6 +20,9 @@ export function RouteErrorBoundary({
   // boundary. reportError de-duplicates the same key within a 5s window so a
   // re-rendering boundary won't spam the table.
   useEffect(() => {
+    // Stale chunk after a deploy → reload once instead of showing the
+    // generic error UI. Issue #1368.
+    if (maybeReloadForStaleChunk(error)) return;
     reportError(error, {
       scope: "route-error-boundary",
       fnName:

--- a/src/lib/error-reporter.ts
+++ b/src/lib/error-reporter.ts
@@ -99,6 +99,36 @@ export async function reportError(
   }
 }
 
+// Detect "stale chunk" errors that happen after a deploy regenerates hashed
+// asset filenames: the user's cached index.html references a lazy chunk that
+// no longer exists, so the dynamic import 404s. Issue #1368.
+export function isChunkLoadError(err: unknown): boolean {
+  const msg =
+    err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  return (
+    /Failed to fetch dynamically imported module/i.test(msg) ||
+    /error loading dynamically imported module/i.test(msg) ||
+    /Importing a module script failed/i.test(msg)
+  );
+}
+
+// Reload once per tab when a stale chunk is detected, so the browser fetches
+// the new index.html (and the chunk hashes it references). sessionStorage
+// guards against an infinite reload loop if the failure persists.
+const CHUNK_RELOAD_KEY = "chunk-reload-attempted-v1";
+export function maybeReloadForStaleChunk(err: unknown): boolean {
+  if (typeof window === "undefined") return false;
+  if (!isChunkLoadError(err)) return false;
+  try {
+    if (sessionStorage.getItem(CHUNK_RELOAD_KEY)) return false;
+    sessionStorage.setItem(CHUNK_RELOAD_KEY, String(Date.now()));
+  } catch {
+    // sessionStorage may be unavailable (private mode, etc.) — proceed anyway.
+  }
+  window.location.reload();
+  return true;
+}
+
 let installed = false;
 export function installGlobalErrorHandlers(): void {
   if (installed) return;
@@ -108,6 +138,7 @@ export function installGlobalErrorHandlers(): void {
   // Uncaught synchronous errors
   window.addEventListener("error", (event) => {
     const err = event.error ?? new Error(event.message || "window.onerror");
+    if (maybeReloadForStaleChunk(err)) return;
     reportError(err, {
       scope: "window.onerror",
       fnName: event.filename
@@ -119,6 +150,7 @@ export function installGlobalErrorHandlers(): void {
   // Unhandled promise rejections (most async failures land here)
   window.addEventListener("unhandledrejection", (event) => {
     const reason = event.reason;
+    if (maybeReloadForStaleChunk(reason)) return;
     reportError(reason, { scope: "unhandledrejection" });
   });
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1368.

Closes #1368

---

## Claude summary

Root cause: stale lazy-chunk import. The Jam network log showed exactly one failed request — a 404 GET for `/assets/_layout.gabinet.appointments._appointmentId.lazy-DDmciRc6.js` — followed by two `errorLogs:record` mutations reporting `TypeError: Failed to fetch dynamically imported module`. The user's cached `index.html` pointed at a chunk hash that a previous deploy already overwrote, so TanStack Router's lazy import 404'd and surfaced the "Something went wrong" UI when they tried to open any appointment.

Fix in commit 21f5e78: added `isChunkLoadError()` + `maybeReloadForStaleChunk()` to `src/lib/error-reporter.ts`, and wired the global `error` / `unhandledrejection` listeners and `RouteErrorBoundary` to call it. When a dynamic-import failure is detected, the page reloads once (guarded by a `sessionStorage` flag) to pick up the freshly-deployed `index.html` and its current chunk hashes.

## Follow-ups
- Set short cache-control on built index.html in Netlify: long-cached entry HTML guarantees the stale-chunk class of bug will recur on every deploy; the long-hash JS/CSS chunks under `/assets/` should keep their long cache, but the entry HTML should be `Cache-Control: no-cache` or short max-age.
- Document the inconsistency between CLAUDE.md and the live dev deployment: the Jam shows quera-dev hitting `supabase.tytan.kolabogroup.pl` directly from the browser, while CLAUDE.md describes Convex actions as the data layer; worth verifying whether the architecture changed or this is a different deploy variant.