### PR TITLE
Snap recurring-occurrence override time input in appointment-dialog

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -114,6 +114,21 @@ function computeEndTime(start: string, durationMinutes: number): string {
 }
 
 /**
+ * Snap a "HH:MM" string to the nearest 15-minute boundary. Chrome's clock
+ * picker and direct typing ignore the input's `step` attribute, so we enforce
+ * the grid on every change. Mirrors the helper used by the appointment preview
+ * popover and detail page (issue #1365).
+ */
+function snapTimeTo15Min(value: string): string {
+  if (!value) return value;
+  const [h, m] = value.split(":").map(Number);
+  if (!Number.isFinite(h) || !Number.isFinite(m)) return value;
+  const total = Math.min(Math.max(h * 60 + m, 0), 24 * 60 - 1);
+  const snapped = Math.min(Math.round(total / 15) * 15, 24 * 60 - 1);
+  return `${String(Math.floor(snapped / 60)).padStart(2, "0")}:${String(snapped % 60).padStart(2, "0")}`;
+}
+
+/**
  * Mirror of backend `generateRecurringDates` (convex/gabinet/appointments.ts).
  * Keep in sync — both compute the list of recurrence dates following the base.
  * For "custom" frequency there is no cycle: every occurrence defaults to the
@@ -1401,6 +1416,7 @@ export function AppointmentDialog({
                                     )}
                                     <input
                                       type="time"
+                                      step={900}
                                       value={occ.startTime}
                                       disabled={occ.index === 0}
                                       onChange={(e) =>
@@ -1408,7 +1424,9 @@ export function AppointmentDialog({
                                           ...prev,
                                           [occ.index]: {
                                             ...prev[occ.index],
-                                            startTime: e.target.value,
+                                            startTime: snapTimeTo15Min(
+                                              e.target.value,
+                                            ),
                                           },
                                         }))
                                       }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1372.

Closes #1372

---

## Claude summary

Committed. Summary:

Added a module-level `snapTimeTo15Min` helper in `src/components/gabinet/calendar/appointment-dialog.tsx` (mirroring the inline helpers from #1365 in `appointment-preview-content.tsx` and the appointment detail page) and applied it to the recurring-occurrence override time input at line 1402 along with `step={900}`. Typed values and Chrome clock-picker values now snap to the nearest 15-minute boundary, consistent with the OD/DO inputs fixed in #1365.

I could not run `npm run typecheck` — `node_modules` is not installed in this worktree. The change is a one-line analogue of an already-merged pattern, so confidence is high; CI typecheck will catch any issue.