### PR TITLE
Set short cache-control on built index.html in Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,25 @@
   to = "/index.html"
   status = 200
 
+# Entry HTML must not be long-cached: it references hashed chunk filenames
+# that change every deploy. A stale cached index.html points to chunks that
+# no longer exist, producing the lazy-import failure class fixed in #1368.
+# Hashed assets under /assets/* keep their long immutable cache below.
+[[headers]]
+  for = "/index.html"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/assets/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
 [context.production]
   # Apply pending Supabase migrations before the frontend goes live so the
   # newly-deployed UI never hits a DB that's missing columns it expects.


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1376.

Closes #1376

---

## Claude summary

Added Netlify `[[headers]]` blocks in `netlify.toml:10-23`:
- `/index.html` and `/` → `Cache-Control: public, max-age=0, must-revalidate` so browsers always revalidate the entry HTML and pick up new hashed chunk filenames immediately after deploy.
- `/assets/*` → `Cache-Control: public, max-age=31536000, immutable` so the long-hash JS/CSS bundles keep their long cache (filenames change on content change, so this is safe).

This directly addresses the recurrence vector for #1368 — a cached old `index.html` referencing chunks that no longer exist on disk. Committed as `fc945e0`.