### PR TITLE
Surface package linkage on the appointment itself

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3000,6 +3000,8 @@
       "packageUsage": "Package usage",
       "treatmentsUsed": "Treatments used",
       "usedInThisAppointment": "Used in this appointment",
+      "partOfPackage": "Part of: {{name}}",
+      "partOfPackageGeneric": "Part of a package",
       "descriptionField": "Description",
       "used": "Used",
       "of": "of",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3029,6 +3029,8 @@
       "packageUsage": "Wykorzystanie pakietów",
       "treatmentsUsed": "Wykorzystane zabiegi",
       "usedInThisAppointment": "Użyty w tej wizycie",
+      "partOfPackage": "Część pakietu: {{name}}",
+      "partOfPackageGeneric": "Część pakietu",
       "descriptionField": "Opis",
       "used": "Wykorzystano",
       "of": "z",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1190,9 +1190,27 @@ function AppointmentDetail() {
 
   // Header title and subtitle
   const headerTitle = `${treatment?.name ?? t("gabinet.appointments.appointment")} - ${patient?.firstName ?? ""} ${patient?.lastName ?? ""}`.trim();
+  const linkedPackageUsage = appointment.packageUsageId
+    ? patientPackageUsage.find((p) => String(p._id) === String(appointment.packageUsageId)) ?? null
+    : null;
   const headerSubtitle = (
-    <span>
-      {formatDate(appointment.date)} &bull; {formatTime(appointment.startTime)} - {formatTime(appointment.endTime)}
+    <span className="flex flex-wrap items-center gap-x-2 gap-y-1 whitespace-normal">
+      <span>
+        {formatDate(appointment.date)} &bull; {formatTime(appointment.startTime)} - {formatTime(appointment.endTime)}
+      </span>
+      {appointment.packageUsageId && (
+        <Badge
+          variant="outline"
+          className="gap-1 border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-400"
+        >
+          <Package className="h-3 w-3" variant="stroke" />
+          <span className="truncate max-w-[180px]">
+            {linkedPackageUsage?.packageName
+              ? t("gabinet.packages.partOfPackage", { name: linkedPackageUsage.packageName })
+              : t("gabinet.packages.partOfPackageGeneric")}
+          </span>
+        </Badge>
+      )}
     </span>
   );
 
@@ -1973,8 +1991,13 @@ function AppointmentDetail() {
                   {t("gabinet.packages.packageUsage")}
                 </CardTitle>
               </CardHeader>
-              <CardContent className="px-6 py-4">
-                <p className="text-muted-foreground">
+              <CardContent className="px-6 py-4 space-y-1">
+                {linkedPackageUsage?.packageName && (
+                  <p className="text-sm font-medium">
+                    {linkedPackageUsage.packageName}
+                  </p>
+                )}
+                <p className="text-sm text-muted-foreground">
                   {t("gabinet.packages.usedInThisAppointment")}
                 </p>
               </CardContent>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1380.

Closes #1380

---

## Claude summary

Committed. Summary of changes:

When an appointment has `packageUsageId` set, the detail view header now shows a small emerald "Part of: {package name}" badge next to the date/time. The badge resolves the package name by matching `appointment.packageUsageId` against the existing `patientPackageUsage` array already returned by `getFullDetail`, so no schema or backend changes were needed. The existing Package Usage card on the details tab also now displays the package name (previously it only said "Used in this appointment" without identifying which package).

Files changed:
- `src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx` — added `linkedPackageUsage` lookup and a Badge in `headerSubtitle`; enriched the Package Usage card
- `public/locales/en/translation.json` / `public/locales/pl/translation.json` — added `partOfPackage` / `partOfPackageGeneric` keys

Verified with `tsc -p tsconfig.app.json --noEmit` (clean).