### PR TITLE
Update `docs/modules/platform-core.md`, `docs/modules/crm.md`, `docs/modules/gab

### DIFF
--- a/docs/modules/crm.md
+++ b/docs/modules/crm.md
@@ -51,6 +51,12 @@ All entity detail pages (contact, company, lead) follow the same structure: left
 
 - Documents: CRM entities (contact, company, lead) register as data sources. Documents tab on entity detail uses documentInstances filtered by resolvedSources.
 - Activities: CRM actions logged to activities table with entity type/id.
-- Search: contacts, companies, leads, documents, products all indexed in global search.
+- Search: contacts, companies, leads, documents, products all indexed in global search (reads hit Supabase via the `use-supabase-*` hook family).
 - Custom fields: contacts, companies, leads, products support custom field definitions.
 - Notifications: document workflow events generate notifications.
+
+## Data layer (Supabase-primary as of 2026-04)
+
+CRM follows the platform read/write split: the browser reads from self-hosted Supabase Postgres via `supabase-js` and the `src/hooks/use-supabase-*.ts` family (e.g. `use-supabase-activities.ts`, `use-supabase-calls.ts`); writes go through Convex mutations in `convex/contacts.ts`, `convex/leads.ts`, etc., which persist to Supabase via `convex/_helpers/supabaseDb.ts → createSupabaseDb()`.
+
+`convex/schema.ts` remains the structural source of truth, but production query indexes live in `supabase/migrations/` — add any new index there too, not just to the Convex schema. The Convex→Supabase table-name mapping is `TABLE_MAP` in `convex/_helpers/supabaseDb.ts`. If a `convex/*` file or comment in this module still calls Convex "the database" without mentioning Supabase, treat it as pre-2026-04 and trust the code. See the "Migration note" in `CLAUDE.md`.

--- a/docs/modules/gabinet.md
+++ b/docs/modules/gabinet.md
@@ -52,6 +52,12 @@ Book (select patient + treatment + employee + date/time from available slots) ->
 - Patients link to CRM contacts via contactId field.
 - Documents: gabinet entities register as data sources (patient, employee, appointment). Templates filtered by module="gabinet".
 - Activities: appointment actions logged to activities table.
-- Search: patients and treatments indexed in global search.
+- Search: patients and treatments indexed in global search (reads hit Supabase via the `use-supabase-*` hook family).
 - Scheduling: appointments create scheduledActivities for unified calendar.
 - Notifications: appointment status changes generate notifications.
+
+## Data layer (Supabase-primary as of 2026-04)
+
+Gabinet follows the platform read/write split: the browser reads from self-hosted Supabase Postgres via `supabase-js` and the `src/hooks/use-supabase-*.ts` family; writes go through Convex mutations in `convex/gabinet/*.ts` (appointments, patients, employees, schedules, etc.), which persist to Supabase via `convex/_helpers/supabaseDb.ts → createSupabaseDb()`. The patient portal (`src/routes/_app/patient/`) shares the same Supabase JWT bridge — `convex/supabase/jwt.ts → mintSupabaseToken` — under its own auth flow.
+
+`convex/schema.ts` remains the structural source of truth for `gabinet*` tables, but production query indexes live in `supabase/migrations/` — add any new index for a gabinet query there too, not just to the Convex schema. The Convex (camelCase) ↔ Supabase (snake_case) table-name mapping is `TABLE_MAP` in `convex/_helpers/supabaseDb.ts`. If a `convex/gabinet/*` file or comment still calls Convex "the database" without mentioning Supabase, treat it as pre-2026-04 and trust the code. See the "Migration note" in `CLAUDE.md`.

--- a/docs/modules/platform-core.md
+++ b/docs/modules/platform-core.md
@@ -29,6 +29,16 @@ Every mutation must call verifyOrgAccess(ctx, orgId) first. Permission-sensitive
 
 New horizontal features go in convex/ root (not in convex/crm/ or convex/gabinet/). UI components shared across modules go in src/components/ (not in crm/ or gabinet/ subdirs).
 
+## Data layer (Supabase-primary as of 2026-04)
+
+Self-hosted Supabase Postgres (`SUPABASE_URL`) is the primary data store. Convex hosts auth (`@convex-dev/auth`), mutations/actions, the JWT bridge that mints Supabase tokens (`convex/supabase/jwt.ts → mintSupabaseToken`), file storage, and scheduled jobs.
+
+- Read path: the browser holds a Supabase JWT (see `src/components/supabase-provider.tsx`, `src/hooks/use-supabase-token.ts`) and queries Supabase directly via `supabase-js` (the `src/hooks/use-supabase-*.ts` family). RLS scopes rows to the user's org.
+- Write path: React calls Convex mutations, which write to Supabase via `convex/_helpers/supabaseDb.ts → createSupabaseDb()` using the service-role client (`convex/supabase/client.ts`).
+- `convex/schema.ts` is the structural source of truth. Postgres tables live in `supabase/migrations/`. Convex (camelCase) ↔ Supabase (snake_case) table-name mapping is `TABLE_MAP` in `convex/_helpers/supabaseDb.ts`.
+- New indexes needed for a query must exist in `supabase/migrations/` — Convex schema indexes are now legacy/test-suite only.
+- Older docs and in-code comments may still describe Convex as "the database" without Supabase; treat those as stale. See the "Migration note" in `CLAUDE.md` and the superseded plan in `docs/plans/2026-02-17-modular-platform-implementation-plan.md`.
+
 ## Document system architecture
 
 Two document types coexist in documentInstances table: type="template" (created from documentTemplates with field values and rendered HTML) and type="file" (uploaded files with storage reference). Both share the same status workflow: draft -> pending_review -> approved -> pending_signature -> signed -> archived.


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1384.

Closes #1384

---

## Claude summary

Added a "Data layer (Supabase-primary as of 2026-04)" section to each of `docs/modules/platform-core.md`, `docs/modules/crm.md`, and `docs/modules/gabinet.md`. Each section describes the read/write split (browser → Supabase via `supabase-js` + `use-supabase-*` hooks; writes via Convex mutations → `createSupabaseDb`), points to `TABLE_MAP` for the camelCase ↔ snake_case mapping, notes that production indexes live in `supabase/migrations/` (not `convex/schema.ts`), and cross-references the `CLAUDE.md` "Migration note" so agents know to discount older Convex-as-database comments. Committed as `52ee983`.