### PR TITLE
Audit "Convex-only side effects" comments for accuracy

### DIFF
--- a/convex/README.md
+++ b/convex/README.md
@@ -67,7 +67,8 @@ frontend hook).
 ## Stale comments
 
 In-file comments written before the migration may still describe Convex as
-"the database", talk about `ctx.db` as the canonical write path, or refer
-to "Convex-only side effects" when the side effects in fact dual-write
-through `publishActivityEnvelope` and friends. Trust the code, not the
-comment — and if you touch the file, fix the comment.
+"the database" or talk about `ctx.db` as the canonical write path. The
+historical "Convex-only side effects" phrase was renamed to "post-write
+side effects" (issue #1394) because those mutations also dual-write
+activities to Supabase through `publishActivityEnvelope`. Trust the code,
+not the comment — and if you touch the file, fix the comment.

--- a/convex/companies.ts
+++ b/convex/companies.ts
@@ -141,7 +141,7 @@ export const create = action({
       updatedAt: now,
     });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.companies._createSideEffects, {
         companyId,
@@ -257,7 +257,7 @@ export const update = action({
     const { organizationId, companyId, customFields, ...updates } = args;
     await db.patch("companies", companyId, { ...updates, updatedAt: Date.now() });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.companies._updateSideEffects, {
         companyId,
@@ -365,7 +365,7 @@ export const remove = action({
     // --- DELETE from Supabase ---
     await db.delete("companies", args.companyId);
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.companies._removeSideEffects, {
         companyId: args.companyId,

--- a/convex/contacts.ts
+++ b/convex/contacts.ts
@@ -135,7 +135,7 @@ export const create = action({
       updatedAt: now,
     });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.contacts._createSideEffects, {
         contactId,
@@ -247,7 +247,7 @@ export const update = action({
     const { organizationId, contactId, customFields, ...updates } = args;
     await db.patch("contacts", contactId, { ...updates, updatedAt: Date.now() });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.contacts._updateSideEffects, {
         contactId,
@@ -355,7 +355,7 @@ export const remove = action({
     // --- DELETE from Supabase ---
     await db.delete("contacts", args.contactId);
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.contacts._removeSideEffects, {
         contactId: args.contactId,

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -241,7 +241,7 @@ export const send = action({
       updatedAt: now,
     });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.emails._sendSideEffects, {
         emailId,

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -810,7 +810,7 @@ export const _checkDocumentGateQuery = internalQuery({
 });
 
 /**
- * Internal mutation that handles all Convex-only side effects after the
+ * Internal mutation that handles post-write side effects after the
  * appointment has been written to Supabase by the create action.
  */
 export const _createSideEffects = internalMutation({
@@ -1239,7 +1239,7 @@ export const create = action({
       console.warn("[create] scheduled_activity_id patch failed (non-fatal):", e);
     }
 
-    // --- Delegate Convex-only side effects (automation event, docs, reminders) ---
+    // --- Delegate post-write side effects (automation event, docs, reminders) ---
     try {
       await ctx.runMutation(
         internal.gabinet.appointments._createSideEffects,

--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -230,7 +230,7 @@ export const create = action({
       updatedAt: now,
     });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.employees._createSideEffects, {
         employeeId,
@@ -596,7 +596,7 @@ export const update = action({
     const { organizationId, employeeId, ...updates } = args;
     await db.patch("gabinetEmployees", employeeId, { ...updates, updatedAt: Date.now() });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.employees._updateSideEffects, {
         employeeId,
@@ -690,7 +690,7 @@ export const remove = action({
       updatedAt: Date.now(),
     });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.employees._removeSideEffects, {
         employeeId: args.employeeId,
@@ -805,7 +805,7 @@ export const setQualifiedTreatments = action({
       updatedAt: Date.now(),
     });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.employees._setQualifiedSideEffects, {
         employeeId: args.employeeId,

--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -280,7 +280,7 @@ export const create = action({
       updatedAt: now,
     });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.patients._createSideEffects, {
         patientId,
@@ -413,7 +413,7 @@ export const update = action({
     const { organizationId, patientId, ...updates } = args;
     await db.patch("gabinetPatients", patientId, { ...updates, updatedAt: Date.now() });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.patients._updateSideEffects, {
         patientId,
@@ -490,7 +490,7 @@ export const remove = action({
       updatedAt: Date.now(),
     });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.patients._removeSideEffects, {
         patientId: args.patientId,

--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -152,7 +152,7 @@ export const create = action({
       updatedAt: now,
     });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.treatments._createSideEffects, {
         treatmentId,
@@ -253,7 +253,7 @@ export const update = action({
     }
     await db.patch("gabinetTreatments", treatmentId, patchPayload);
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.treatments._updateSideEffects, {
         treatmentId,
@@ -328,7 +328,7 @@ export const remove = action({
       updatedAt: Date.now(),
     });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.treatments._removeSideEffects, {
         treatmentId: args.treatmentId,
@@ -915,7 +915,7 @@ export const setRequiredFormTemplates = action({
       updatedAt: Date.now(),
     });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.treatments._updateSideEffects, {
         treatmentId: args.treatmentId,
@@ -981,7 +981,7 @@ export const saveTreatmentParameters = action({
         updatedAt: Date.now(),
       });
 
-      // --- Delegate Convex-only side effects ---
+      // --- Delegate post-write side effects ---
       try {
         await ctx.runMutation(internal.gabinet.treatments._updateSideEffects, {
           treatmentId: args.treatmentId,
@@ -1209,7 +1209,7 @@ export const createVariant = action({
       sortOrder: args.sortOrder ?? null,
     });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.treatments._createSideEffects, {
         treatmentId: args.treatmentId,
@@ -1291,7 +1291,7 @@ export const updateVariant = action({
     // --- PATCH to Supabase ---
     await db.patch("gabinetTreatmentVariants", args.variantId, updates);
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.treatments._updateSideEffects, {
         treatmentId: variant.treatmentId as string,
@@ -1337,7 +1337,7 @@ export const deleteVariant = action({
     // --- DELETE from Supabase ---
     await db.delete("gabinetTreatmentVariants", args.variantId);
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.treatments._updateSideEffects, {
         treatmentId: variant.treatmentId as string,

--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -186,7 +186,7 @@ export const create = action({
       updatedAt: now,
     });
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.leads._createSideEffects, {
         leadId,
@@ -337,7 +337,7 @@ export const update = action({
     // --- PATCH to Supabase ---
     await db.patch("leads", leadId, supabaseUpdates);
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.leads._updateSideEffects, {
         leadId,
@@ -558,7 +558,7 @@ export const remove = action({
     // --- DELETE from Supabase ---
     await db.delete("leads", args.leadId);
 
-    // --- Delegate Convex-only side effects ---
+    // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.leads._removeSideEffects, {
         leadId: args.leadId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1394.

Closes #1394

---

## Claude summary

Confirmed the issue: across `convex/leads.ts`, `convex/companies.ts`, `convex/contacts.ts`, `convex/emails.ts`, and the gabinet files (`appointments.ts`, `employees.ts`, `patients.ts`, `treatments.ts`), the `_createSideEffects` / `_updateSideEffects` / `_removeSideEffects` internal mutations call `logActivity` → `publishActivityEnvelope` (convex/_helpers/activityEnvelope.ts:155-178), which writes the activity row to Convex *and* schedules `writeActivityToSupabase` to dual-write the same row to Supabase. So labelling those delegated mutations "Convex-only side effects" was wrong.

Chose to rename rather than split: the side-effects mutations are a single coherent unit (notifications, custom field values, activity logging, automation events, document generation, membership mirrors) bound together by the same retry boundary. Splitting them would just produce two `try/catch`-wrapped delegates with no functional benefit.

Renamed `// --- Delegate Convex-only side effects ---` → `// --- Delegate post-write side effects ---` in all 27 sites across 8 files, plus the JSDoc on `_createSideEffects` in `gabinet/appointments.ts`. Also updated the "Stale comments" note in `convex/README.md` to reflect the rename and reference #1394. Comment-only change; commit `5623d9d`.