### PR TITLE
wizyta po terminie

### DIFF
--- a/convex/gabinet/_availability_supabase.ts
+++ b/convex/gabinet/_availability_supabase.ts
@@ -109,6 +109,11 @@ export async function getAvailableSlotsSupabase(
     date: string;
     duration: number;
     locationId?: string;
+    // When set, slots starting at or before `nowTime` on `nowDate` are
+    // filtered out. Server doesn't know the clinic timezone so the caller
+    // (frontend) is the source of truth for "now". Issue #1402.
+    nowDate?: string;
+    nowTime?: string;
   },
 ): Promise<TimeSlot[]> {
   const dayOfWeek = new Date(args.date + "T00:00:00").getDay();
@@ -255,6 +260,11 @@ export async function getAvailableSlotsSupabase(
       end: minutesToTime(slotStart + args.duration),
     });
     slotStart += 15;
+  }
+
+  if (args.nowDate && args.nowTime && args.nowDate === args.date) {
+    const nowMinutes = timeToMinutes(args.nowTime);
+    return slots.filter((s) => timeToMinutes(s.start) > nowMinutes);
   }
 
   return slots;

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -651,6 +651,8 @@ export const getAvailableSlotsQuery = action({
     date: v.string(),
     duration: v.number(),
     locationId: v.optional(v.string()),
+    nowDate: v.optional(v.string()),
+    nowTime: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
@@ -670,6 +672,8 @@ export const getAvailableSlotsQuery = action({
       date: args.date,
       duration: args.duration,
       locationId: args.locationId,
+      nowDate: args.nowDate,
+      nowTime: args.nowTime,
     });
   },
 });

--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -328,6 +328,8 @@ export const getPublicAvailableSlots = action({
     employeeId: v.string(),
     date: v.string(),
     duration: v.number(),
+    nowDate: v.optional(v.string()),
+    nowTime: v.optional(v.string()),
   },
   handler: async (_ctx, args) => {
     const db = createSupabaseDb();
@@ -342,6 +344,8 @@ export const getPublicAvailableSlots = action({
       date: args.date,
       duration: args.duration,
       locationId: undefined,
+      nowDate: args.nowDate,
+      nowTime: args.nowTime,
     });
   },
 });

--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -632,6 +632,11 @@ export const findNextAvailableSlot = action({
     durationMinutes: v.number(),
     fromDate: v.optional(v.string()), // YYYY-MM-DD, defaults to today
     maxDaysToSearch: v.optional(v.number()), // defaults to 30
+    // Client local "now" — when present, slots on `nowDate` that are at or
+    // before `nowTime` are excluded so the search never returns a past slot.
+    // Issue #1402.
+    nowDate: v.optional(v.string()),
+    nowTime: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
@@ -642,10 +647,12 @@ export const findNextAvailableSlot = action({
 
     const maxDays = args.maxDaysToSearch ?? 30;
 
-    // Start from fromDate or today
+    // Start from fromDate, then nowDate, then server today (last resort).
     const startDate = args.fromDate
       ? new Date(args.fromDate + "T00:00:00")
-      : new Date();
+      : args.nowDate
+        ? new Date(args.nowDate + "T00:00:00")
+        : new Date();
     // Normalize to YYYY-MM-DD
     const toDateStr = (d: Date) =>
       `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
@@ -661,6 +668,8 @@ export const findNextAvailableSlot = action({
         date: dateStr,
         duration: args.durationMinutes,
         locationId: undefined,
+        nowDate: args.nowDate,
+        nowTime: args.nowTime,
       });
 
       if (slots.length > 0) {

--- a/src/components/gabinet/appointment-form.tsx
+++ b/src/components/gabinet/appointment-form.tsx
@@ -299,6 +299,13 @@ export function AppointmentForm({
     }
   }, [qualifiedEmployees, employeeId]);
 
+  // "Now" in the user's local timezone — used to exclude past slots when the
+  // selected date is today. Backend doesn't know the clinic timezone, so the
+  // client is the source of truth. Issue #1402.
+  const now = new Date();
+  const nowDate = format(now, "yyyy-MM-dd");
+  const nowTime = format(now, "HH:mm");
+
   // Available slots — backend is now an action reading from Supabase
   const getAvailableSlots = useAction(api.gabinet.appointments.getAvailableSlotsQuery);
   const { data: availableSlots, isLoading: slotsLoading } = useQuery({
@@ -308,6 +315,10 @@ export function AppointmentForm({
       employeeId,
       dateStr,
       selectedTreatment?.duration ?? 30,
+      // Bucket by the hour so the query is cached but still refreshes as the
+      // clock advances past past-slot boundaries.
+      nowDate,
+      nowTime.slice(0, 2),
     ],
     queryFn: () =>
       getAvailableSlots({
@@ -315,6 +326,8 @@ export function AppointmentForm({
         userId: employeeId as string,
         date: dateStr,
         duration: selectedTreatment?.duration ?? 30,
+        nowDate,
+        nowTime,
       }),
     enabled: !!employeeId && !!dateStr && !!selectedTreatment && !!organizationId,
   });
@@ -325,14 +338,14 @@ export function AppointmentForm({
     if (!employeeId || !selectedTreatment || !organizationId) return;
     setSearchingSlot(true);
     try {
-      const fromDate = date
-        ? format(date, "yyyy-MM-dd")
-        : new Date().toISOString().split("T")[0];
+      const fromDate = date ? format(date, "yyyy-MM-dd") : nowDate;
       const result = await findNextSlotAction({
         organizationId,
         employeeId: employeeId as string,
         durationMinutes: selectedTreatment.duration,
         fromDate,
+        nowDate,
+        nowTime,
       });
       if (result) {
         setDate(new Date(result.date + "T00:00:00"));

--- a/src/routes/_app/patient/_layout.book.tsx
+++ b/src/routes/_app/patient/_layout.book.tsx
@@ -85,6 +85,11 @@ function PatientBooking() {
     selectedDate &&
     selectedTreatment
   );
+  // Client "now" — used to hide past slots when the selected date is today.
+  // Issue #1402.
+  const now = new Date();
+  const nowDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+  const nowTime = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
   const getPublicSlots = useAction(api.gabinet.patientPortal.getPublicAvailableSlots);
   const { data: slots } = useQuery({
     queryKey: [
@@ -93,6 +98,8 @@ function PatientBooking() {
       selectedEmployee?.userId,
       dateStr,
       selectedTreatment?.duration,
+      nowDate,
+      nowTime.slice(0, 2),
     ],
     queryFn: () =>
       getPublicSlots({
@@ -100,6 +107,8 @@ function PatientBooking() {
         employeeId: (selectedEmployee?.userId as string) ?? "",
         date: dateStr || "1970-01-01",
         duration: selectedTreatment?.duration ?? 0,
+        nowDate,
+        nowTime,
       }),
     enabled: slotsEnabled,
   });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1402.

Closes #1402

---

## Claude summary

Bug confirmed and fixed. The Jam recording (12:43 UTC ≈ 14:43 Warsaw) showed the user clicking a 12:00 slot button matching `src/components/gabinet/appointment-form.tsx:818`, then submitting — the system happily created an appointment ~3 hours in the past.

Root cause: `convex/gabinet/_availability_supabase.ts:104` generated slots from the start of working hours without any "now" cutoff. The calendar dialog (`appointment-dialog.tsx`) has a past-slot warning popup, but the side-panel form `appointment-form.tsx` doesn't — so past slots were directly bookable from there.

Fix: opt-in `nowDate`/`nowTime` filter on the backend (server can't infer clinic timezone), enabled by the side-panel form and patient portal flow. The calendar dialog is intentionally left alone since its existing "record past walk-in" UX is by design.

Verified: typecheck across all three `tsconfig` projects clean; 133 convex tests and 20 frontend tests still pass. Committed as `ea4c318`.

## Follow-ups
- Apply same past-slot filter to `convex/gabinet/_availability.ts`: the legacy Convex-query `getAvailableSlots` (only used by unused `_getAvailableSlotsQuery`) has the same blind-slot-generation bug; harmless today but a trap if any code ever calls it again.
- Replace dialog past-slot warning with backend filter opt-in: `appointment-dialog.tsx` could pass `nowDate`/`nowTime` and skip showing past slots entirely, then drop the confirmation popup — only keep the "record walk-in" path behind an explicit toggle so it's a deliberate choice, not an accidental click-through.