### PR TITLE
Apply same past-slot filter to `convex/gabinet/_availability.ts`

### DIFF
--- a/convex/gabinet/_availability.ts
+++ b/convex/gabinet/_availability.ts
@@ -124,6 +124,11 @@ export async function getAvailableSlots(
     date: string; // YYYY-MM-DD
     duration: number; // minutes
     locationId?: Id<"gabinetLocations">;
+    // When set, slots starting at or before `nowTime` on `nowDate` are
+    // filtered out. Server doesn't know the clinic timezone so the caller
+    // (frontend) is the source of truth for "now". Issue #1402.
+    nowDate?: string;
+    nowTime?: string;
   }
 ): Promise<TimeSlot[]> {
   const dayOfWeek = new Date(args.date + "T00:00:00").getDay();
@@ -270,6 +275,11 @@ export async function getAvailableSlots(
   while (slotStart + args.duration <= dayEnd) {
     slots.push({ start: minutesToTime(slotStart), end: minutesToTime(slotStart + args.duration) });
     slotStart += 15;
+  }
+
+  if (args.nowDate && args.nowTime && args.nowDate === args.date) {
+    const nowMinutes = timeToMinutes(args.nowTime);
+    return slots.filter((s) => timeToMinutes(s.start) > nowMinutes);
   }
 
   return slots;

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -793,6 +793,8 @@ export const _getAvailableSlotsQuery = internalQuery({
     date: v.string(),
     duration: v.number(),
     locationId: v.optional(v.string()),
+    nowDate: v.optional(v.string()),
+    nowTime: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     return await getAvailableSlots(ctx, {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1405.

Closes #1405

---

## Claude summary

Mirrored the #1402 fix to the legacy Convex `getAvailableSlots` in `convex/gabinet/_availability.ts:119` — added optional `nowDate`/`nowTime` args and a tail filter that drops slots `<= nowTime` when `nowDate === args.date`. Also threaded the params through `_getAvailableSlotsQuery` in `convex/gabinet/appointments.ts:789` so its signature matches the active Supabase variant. The legacy path stays dead in production (no callers found outside the wrapper), but is no longer a trap if rewired.