### PR TITLE
nieprawidłowe dane

### DIFF
--- a/convex/gabinet/_availability.ts
+++ b/convex/gabinet/_availability.ts
@@ -124,6 +124,11 @@ export async function getAvailableSlots(
     date: string; // YYYY-MM-DD
     duration: number; // minutes
     locationId?: Id<"gabinetLocations">;
+    // Caller's current local wall-clock; when args.date matches nowDate the
+    // slot generation skips past times. The client knows its timezone, so we
+    // accept the values pre-computed rather than guessing on the server.
+    nowDate?: string;
+    nowMinutes?: number;
   }
 ): Promise<TimeSlot[]> {
   const dayOfWeek = new Date(args.date + "T00:00:00").getDay();
@@ -252,7 +257,11 @@ export async function getAvailableSlots(
   const dayEnd = timeToMinutes(endTime);
   const slots: TimeSlot[] = [];
 
-  let cursor = dayStart;
+  const earliest =
+    args.nowDate === args.date && typeof args.nowMinutes === "number"
+      ? Math.max(dayStart, args.nowMinutes)
+      : dayStart;
+  let cursor = earliest;
   for (const b of blocked) {
     if (cursor + args.duration <= b.start) {
       // Generate slots in this gap

--- a/convex/gabinet/_availability_supabase.ts
+++ b/convex/gabinet/_availability_supabase.ts
@@ -109,6 +109,11 @@ export async function getAvailableSlotsSupabase(
     date: string;
     duration: number;
     locationId?: string;
+    // Caller's current local wall-clock; when args.date matches nowDate the
+    // slot generation skips past times. The client knows its timezone, so we
+    // accept the values pre-computed rather than guessing on the server.
+    nowDate?: string;
+    nowMinutes?: number;
   },
 ): Promise<TimeSlot[]> {
   const dayOfWeek = new Date(args.date + "T00:00:00").getDay();
@@ -233,7 +238,11 @@ export async function getAvailableSlotsSupabase(
   const dayEnd = timeToMinutes(endTime);
   const slots: TimeSlot[] = [];
 
-  let cursor = dayStart;
+  const earliest =
+    args.nowDate === args.date && typeof args.nowMinutes === "number"
+      ? Math.max(dayStart, args.nowMinutes)
+      : dayStart;
+  let cursor = earliest;
   for (const b of blocked) {
     if (cursor + args.duration <= b.start) {
       let slotStart = cursor;

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -651,6 +651,8 @@ export const getAvailableSlotsQuery = action({
     date: v.string(),
     duration: v.number(),
     locationId: v.optional(v.string()),
+    nowDate: v.optional(v.string()),
+    nowMinutes: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
@@ -670,6 +672,8 @@ export const getAvailableSlotsQuery = action({
       date: args.date,
       duration: args.duration,
       locationId: args.locationId,
+      nowDate: args.nowDate,
+      nowMinutes: args.nowMinutes,
     });
   },
 });
@@ -789,6 +793,8 @@ export const _getAvailableSlotsQuery = internalQuery({
     date: v.string(),
     duration: v.number(),
     locationId: v.optional(v.string()),
+    nowDate: v.optional(v.string()),
+    nowMinutes: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     return await getAvailableSlots(ctx, {

--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -328,6 +328,8 @@ export const getPublicAvailableSlots = action({
     employeeId: v.string(),
     date: v.string(),
     duration: v.number(),
+    nowDate: v.optional(v.string()),
+    nowMinutes: v.optional(v.number()),
   },
   handler: async (_ctx, args) => {
     const db = createSupabaseDb();
@@ -342,6 +344,8 @@ export const getPublicAvailableSlots = action({
       date: args.date,
       duration: args.duration,
       locationId: undefined,
+      nowDate: args.nowDate,
+      nowMinutes: args.nowMinutes,
     });
   },
 });

--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -632,6 +632,8 @@ export const findNextAvailableSlot = action({
     durationMinutes: v.number(),
     fromDate: v.optional(v.string()), // YYYY-MM-DD, defaults to today
     maxDaysToSearch: v.optional(v.number()), // defaults to 30
+    nowDate: v.optional(v.string()),
+    nowMinutes: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
@@ -661,6 +663,8 @@ export const findNextAvailableSlot = action({
         date: dateStr,
         duration: args.durationMinutes,
         locationId: undefined,
+        nowDate: args.nowDate,
+        nowMinutes: args.nowMinutes,
       });
 
       if (slots.length > 0) {

--- a/src/components/gabinet/appointment-form.tsx
+++ b/src/components/gabinet/appointment-form.tsx
@@ -309,13 +309,19 @@ export function AppointmentForm({
       dateStr,
       selectedTreatment?.duration ?? 30,
     ],
-    queryFn: () =>
-      getAvailableSlots({
+    queryFn: () => {
+      const n = new Date();
+      const nowDate = `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, "0")}-${String(n.getDate()).padStart(2, "0")}`;
+      const nowMinutes = n.getHours() * 60 + n.getMinutes();
+      return getAvailableSlots({
         organizationId: organizationId!,
         userId: employeeId as string,
         date: dateStr,
         duration: selectedTreatment?.duration ?? 30,
-      }),
+        nowDate,
+        nowMinutes,
+      });
+    },
     enabled: !!employeeId && !!dateStr && !!selectedTreatment && !!organizationId,
   });
 
@@ -325,14 +331,16 @@ export function AppointmentForm({
     if (!employeeId || !selectedTreatment || !organizationId) return;
     setSearchingSlot(true);
     try {
-      const fromDate = date
-        ? format(date, "yyyy-MM-dd")
-        : new Date().toISOString().split("T")[0];
+      const n = new Date();
+      const todayStr = `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, "0")}-${String(n.getDate()).padStart(2, "0")}`;
+      const fromDate = date ? format(date, "yyyy-MM-dd") : todayStr;
       const result = await findNextSlotAction({
         organizationId,
         employeeId: employeeId as string,
         durationMinutes: selectedTreatment.duration,
         fromDate,
+        nowDate: todayStr,
+        nowMinutes: n.getHours() * 60 + n.getMinutes(),
       });
       if (result) {
         setDate(new Date(result.date + "T00:00:00"));

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -431,13 +431,19 @@ export function AppointmentDialog({
       dateStr,
       selectedTreatment?.duration ?? 30,
     ],
-    queryFn: () =>
-      getAvailableSlots({
+    queryFn: () => {
+      const n = new Date();
+      const nowDate = `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, "0")}-${String(n.getDate()).padStart(2, "0")}`;
+      const nowMinutes = n.getHours() * 60 + n.getMinutes();
+      return getAvailableSlots({
         organizationId,
         userId: employeeId as string,
         date: dateStr,
         duration: selectedTreatment?.duration ?? 30,
-      }),
+        nowDate,
+        nowMinutes,
+      });
+    },
     enabled: !!employeeId && !!dateStr && !!selectedTreatment,
   });
 
@@ -578,12 +584,15 @@ export function AppointmentDialog({
     if (!employeeId || !selectedTreatment) return;
     setSearchingSlot(true);
     try {
+      const n = new Date();
+      const todayStr = `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, "0")}-${String(n.getDate()).padStart(2, "0")}`;
       const result = await findNextSlotAction({
         organizationId,
         employeeId: employeeId as string,
         durationMinutes: selectedTreatment.duration,
-        fromDate:
-          dateStr || (() => { const n = new Date(); return `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, "0")}-${String(n.getDate()).padStart(2, "0")}`; })(),
+        fromDate: dateStr || todayStr,
+        nowDate: todayStr,
+        nowMinutes: n.getHours() * 60 + n.getMinutes(),
       });
       if (result) {
         const d = new Date(result.date + "T00:00:00");

--- a/src/routes/_app/patient/_layout.book.tsx
+++ b/src/routes/_app/patient/_layout.book.tsx
@@ -94,13 +94,19 @@ function PatientBooking() {
       dateStr,
       selectedTreatment?.duration,
     ],
-    queryFn: () =>
-      getPublicSlots({
+    queryFn: () => {
+      const n = new Date();
+      const nowDate = `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, "0")}-${String(n.getDate()).padStart(2, "0")}`;
+      const nowMinutes = n.getHours() * 60 + n.getMinutes();
+      return getPublicSlots({
         tokenHash,
         employeeId: (selectedEmployee?.userId as string) ?? "",
         date: dateStr || "1970-01-01",
         duration: selectedTreatment?.duration ?? 0,
-      }),
+        nowDate,
+        nowMinutes,
+      });
+    },
     enabled: slotsEnabled,
   });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1401.

Closes #1401

---

## Claude summary

Committed `20a324c` on `claude/issue-1401`.

Summary: The reported "nieprawidłowe dane" (incorrect data) was that the Gabinet "Nowa wizyta" dialog shows today's already-passed slots (08:00 etc. at 14:37 local) as available, and "Znajdź najbliższy termin" then picks the first one — booking past-due as the related #1402 complained.

Root cause in `convex/gabinet/_availability_supabase.ts:230` (and the parallel Convex-DB version `_availability.ts`): the slot generator starts at `dayStart` with no awareness of current time. Since Convex runs in UTC, the server can't reliably compute "now in the user's local timezone" on its own.

Fix: the slot generators now accept optional `nowDate` + `nowMinutes` from the caller. When the queried date equals `nowDate`, the cursor is raised to `max(dayStart, nowMinutes)`, naturally skipping every slot starting in the past. The values are threaded through `getAvailableSlotsQuery`, `findNextAvailableSlot`, and `getPublicAvailableSlots`, with the three client call sites (calendar dialog, side-panel form, patient portal book page) computing them from `new Date()`. The change-employee modal intentionally does not pass them, so it can still validate slots on past appointments. Typechecks pass; the existing `conflictChecking` test suite still passes.

## Follow-ups
- Reject creating appointments whose start time is in the past: `convex/gabinet/appointments.ts` `create` action does not currently validate this server-side, so a stale dialog (kept open across the threshold) or a crafted API call could still book a past slot.
- Reject past-time bookings in `bookFromPortal`: the patient portal `bookFromPortal` action uses an internal availability check that does not receive `nowDate`/`nowMinutes`, so a crafted request bypassing the UI list could still book a past slot.