### PR TITLE
aktualna data

### DIFF
--- a/src/components/gabinet/flexible-schedule-editor.tsx
+++ b/src/components/gabinet/flexible-schedule-editor.tsx
@@ -98,6 +98,20 @@ function getMondayOfDate(d: Date): Date {
   return result;
 }
 
+function toLocalIsoDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function getCurrentWeekRange(): { from: string; to: string } {
+  const monday = getMondayOfDate(new Date());
+  const sunday = new Date(monday);
+  sunday.setDate(sunday.getDate() + 6);
+  return { from: toLocalIsoDate(monday), to: toLocalIsoDate(sunday) };
+}
+
 interface PeriodWeek {
   monday: Date;
   sunday: Date;
@@ -272,8 +286,9 @@ export function FlexibleScheduleEditor({
   const openNewPeriod = () => {
     setAddingNew(true);
     setEditingPeriodKey(null);
-    setPeriodFrom("");
-    setPeriodTo("");
+    const { from, to } = getCurrentWeekRange();
+    setPeriodFrom(from);
+    setPeriodTo(to);
     setPeriodHours(buildDefaultSchedule(clinicHours));
   };
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1410.

Closes #1410

---

## Claude summary

Committed.

Summary: in `src/components/gabinet/flexible-schedule-editor.tsx`, the `openNewPeriod` function (triggered by the "Add period" button inside the timetable edit sheet at `/dashboard/gabinet/settings/timetable`) used to leave the "Effective from"/"Effective to" fields blank. It now defaults to the current week's Monday and Sunday via a new `getCurrentWeekRange()` helper, so the form suggests the active week as the user requested. Editing an existing period still preserves that period's saved dates (unchanged behavior in `openEditPeriod`).