### PR TITLE
niedziela

### DIFF
--- a/src/components/gabinet/flexible-schedule-editor.tsx
+++ b/src/components/gabinet/flexible-schedule-editor.tsx
@@ -618,7 +618,9 @@ export function FlexibleScheduleEditor({
                 <span>{t("gabinet.appointments.location")}</span>
               </div>
 
-              {periodHours.map((h) => {
+              {DISPLAY_ORDER.map((dayOfWeek) => {
+                const h = periodHours.find((p) => p.dayOfWeek === dayOfWeek);
+                if (!h) return null;
                 const hasBreak = Boolean(h.breakStart || h.breakEnd);
                 return (
                   <div


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1412.

Closes #1412

---

## Claude summary

Fixed. The "Edytuj okres grafiku" form in `src/components/gabinet/flexible-schedule-editor.tsx:621` was iterating `periodHours` in raw storage order (0=Sunday first), so "Niedziela" appeared above "Poniedziałek". Switched the loop to use the existing `DISPLAY_ORDER = [1,2,3,4,5,6,0]` constant (already used by the rest of the timetable UI) so the editor now lists Pn → Wt → Śr → Cz → Pt → So → Nd. Typecheck passes. Committed as d823fc4.

## Follow-ups
- Align clinic working hours editor with Monday-first ordering: `src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx:159` iterates `hours.map` in storage order (Sunday first); same fix needed for consistency with the timetable UI.