### PR TITLE
Reject creating appointments whose start time is in the past

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1015,6 +1015,11 @@ export const create = action({
     roomId: v.optional(v.string()),
     tagIds: v.optional(v.array(v.string())),
     categoryId: v.optional(v.string()),
+    // When true, allow booking a slot whose start time is already in the past
+    // (walk-in / retroactive recording). Defaults to false so a stale dialog
+    // or crafted API call cannot silently create a past appointment. Issue
+    // #1414.
+    allowPast: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     // --- Auth + permissions (via internal queries) ---
@@ -1032,6 +1037,18 @@ export const create = action({
 
     const now = Date.now();
     const db = createSupabaseDb();
+
+    // --- Past-time guard (issue #1414) ---
+    // Reject appointments whose start is already in the past unless the
+    // caller explicitly opts in via `allowPast` (walk-in flow). The same
+    // ISO-string parsing as `dueDateMs` below is used so the comparison is
+    // consistent with how the slot is later persisted.
+    if (!args.allowPast) {
+      const apptMs = new Date(`${args.date}T${args.startTime}:00`).getTime();
+      if (Number.isFinite(apptMs) && apptMs <= now) {
+        throw new Error("Appointment start time is in the past");
+      }
+    }
 
     // --- Org settings (reminder default) ---
     const orgSettings = await ctx.runQuery(

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2782,6 +2782,7 @@
         "outsideEmployeeHours": "Outside employee working hours.",
         "clinicClosed": "Clinic is closed on this day.",
         "outsideClinicHours": "Outside clinic working hours.",
+        "startInPast": "This appointment's start time has already passed. Refresh the available slots or enable \"Record past appointment\" mode.",
         "notFound": "Appointment not found. Refresh the calendar and try again.",
         "permissionDenied": "You do not have permission to edit this appointment.",
         "invalidStatusTransition": "Cannot change the appointment status from its current value.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2811,6 +2811,7 @@
         "outsideEmployeeHours": "Termin poza godzinami pracy pracownika.",
         "clinicClosed": "Gabinet jest zamknięty w tym dniu.",
         "outsideClinicHours": "Termin poza godzinami pracy gabinetu.",
+        "startInPast": "Nie można utworzyć wizyty z czasem w przeszłości. Odśwież listę dostępnych godzin lub włącz tryb „Zapisz wizytę z przeszłości”.",
         "notFound": "Nie znaleziono wizyty. Odśwież kalendarz i spróbuj ponownie.",
         "permissionDenied": "Brak uprawnień do edycji tej wizyty.",
         "invalidStatusTransition": "Nie można zmienić statusu wizyty z bieżącej wartości.",

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -783,6 +783,7 @@ export function AppointmentDialog({
         locationId: locationId ? (locationId as Id<"gabinetLocations">) : undefined,
         roomId: roomId ? (roomId as Id<"gabinetRooms">) : undefined,
         packageUsageId: packageUsageId ?? undefined,
+        allowPast: recordWalkIn || undefined,
       });
       // Refresh the calendar immediately — Convex actions don't invalidate
       // the Supabase React Query cache automatically.

--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -90,6 +90,11 @@ const APPOINTMENT_ERROR_MAP: Array<{
     fallback: "Termin koliduje z innym wydarzeniem w kalendarzu.",
   },
   {
+    test: (m) => /appointment start time is in the past/i.test(m),
+    key: "gabinet.appointments.errors.startInPast",
+    fallback: "Nie można utworzyć wizyty z czasem w przeszłości.",
+  },
+  {
     test: (m) => /appointment not found/i.test(m),
     key: "gabinet.appointments.errors.notFound",
     fallback: "Nie znaleziono wizyty. Odśwież kalendarz i spróbuj ponownie.",

--- a/tests/convex/appointmentSms.test.ts
+++ b/tests/convex/appointmentSms.test.ts
@@ -66,6 +66,9 @@ async function createAppointment(
     date: args.date ?? "2026-03-15",
     startTime: args.startTime ?? "09:00",
     endTime: args.endTime ?? "09:30",
+    // Test fixtures use fixed dates that may already be in the past relative
+    // to the test runner's clock — bypass the past-time guard (#1414).
+    allowPast: true,
   });
 }
 

--- a/tests/convex/appointmentStateMachine.test.ts
+++ b/tests/convex/appointmentStateMachine.test.ts
@@ -52,6 +52,9 @@ async function createAppointment(
     date: args.date ?? "2026-03-16",
     startTime: args.startTime ?? "09:00",
     endTime: args.endTime ?? "09:30",
+    // Test fixtures use fixed dates that may already be in the past relative
+    // to the test runner's clock — bypass the past-time guard (#1414).
+    allowPast: true,
   });
 }
 

--- a/tests/convex/automation.test.ts
+++ b/tests/convex/automation.test.ts
@@ -132,6 +132,9 @@ async function createAppointment(
     date: args.date ?? "2026-03-17",
     startTime: args.startTime ?? "10:00",
     endTime: args.endTime ?? "10:30",
+    // Test fixtures use fixed dates that may already be in the past relative
+    // to the test runner's clock — bypass the past-time guard (#1414).
+    allowPast: true,
   });
 }
 

--- a/tests/convex/conflictChecking.test.ts
+++ b/tests/convex/conflictChecking.test.ts
@@ -36,6 +36,7 @@ describe("conflict checking", () => {
       date: "2026-03-20",
       startTime: "09:00",
       endTime: "09:30",
+      allowPast: true,
     });
 
     // Try to create overlapping appointment for same employee
@@ -48,6 +49,7 @@ describe("conflict checking", () => {
         date: "2026-03-20",
         startTime: "09:15",
         endTime: "09:45",
+        allowPast: true,
       }),
     ).rejects.toThrow();
   });
@@ -66,6 +68,7 @@ describe("conflict checking", () => {
       date: "2026-03-20",
       startTime: "09:00",
       endTime: "09:30",
+      allowPast: true,
     });
 
     // 09:30-10:00 — immediately after, should be fine
@@ -79,6 +82,7 @@ describe("conflict checking", () => {
         date: "2026-03-20",
         startTime: "09:30",
         endTime: "10:00",
+        allowPast: true,
       },
     );
 
@@ -127,6 +131,7 @@ describe("conflict checking", () => {
       date: "2026-03-20",
       startTime: "09:00",
       endTime: "09:30",
+      allowPast: true,
     });
 
     // Employee 2: same time, should be allowed
@@ -140,6 +145,7 @@ describe("conflict checking", () => {
         date: "2026-03-20",
         startTime: "09:00",
         endTime: "09:30",
+        allowPast: true,
       },
     );
 
@@ -160,6 +166,7 @@ describe("conflict checking", () => {
       date: "2026-03-20",
       startTime: "09:00",
       endTime: "09:30",
+      allowPast: true,
     });
 
     // Day 2 — same time, different date
@@ -173,6 +180,7 @@ describe("conflict checking", () => {
         date: "2026-03-21",
         startTime: "09:00",
         endTime: "09:30",
+        allowPast: true,
       },
     );
 
@@ -195,6 +203,7 @@ describe("conflict checking", () => {
         date: "2026-03-20",
         startTime: "09:00",
         endTime: "09:30",
+        allowPast: true,
       },
     );
 
@@ -214,9 +223,69 @@ describe("conflict checking", () => {
         date: "2026-03-20",
         startTime: "09:00",
         endTime: "09:30",
+        allowPast: true,
       },
     );
 
     expect(newApptId).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Past-time guard (issue #1414)
+  // ---------------------------------------------------------------------------
+
+  test("rejects appointment whose start time is in the past", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    // Pick a date 1 day in the past relative to the test runner's clock so
+    // the comparison is robust against timezone drift between the runtime's
+    // local interpretation of `date+startTime` and `Date.now()`.
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const yyyy = yesterday.getUTCFullYear();
+    const mm = String(yesterday.getUTCMonth() + 1).padStart(2, "0");
+    const dd = String(yesterday.getUTCDate()).padStart(2, "0");
+    const pastDate = `${yyyy}-${mm}-${dd}`;
+
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.appointments.create, {
+        organizationId,
+        patientId,
+        treatmentId,
+        employeeId: userId,
+        date: pastDate,
+        startTime: "09:00",
+        endTime: "09:30",
+      }),
+    ).rejects.toThrow(/past/i);
+  });
+
+  test("allowPast bypasses the past-time guard (walk-in flow)", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const yyyy = yesterday.getUTCFullYear();
+    const mm = String(yesterday.getUTCMonth() + 1).padStart(2, "0");
+    const dd = String(yesterday.getUTCDate()).padStart(2, "0");
+    const pastDate = `${yyyy}-${mm}-${dd}`;
+
+    const apptId = await t.withIdentity(identity).action(
+      api.gabinet.appointments.create,
+      {
+        organizationId,
+        patientId,
+        treatmentId,
+        employeeId: userId,
+        date: pastDate,
+        startTime: "09:00",
+        endTime: "09:30",
+        allowPast: true,
+      },
+    );
+
+    expect(apptId).toBeTruthy();
   });
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1414.

Closes #1414

---

## Claude summary

Committed as `9ad579e`. Summary of the fix:

The `create` action in `convex/gabinet/appointments.ts` now rejects appointments whose `date + startTime` resolves to `<= Date.now()`, throwing "Appointment start time is in the past". A new optional `allowPast: boolean` arg bypasses the guard for the walk-in flow.

The walk-in toggle in `src/components/gabinet/calendar/appointment-dialog.tsx:786` passes `allowPast: recordWalkIn || undefined`, so the existing "Record past appointment (walk-in)" UX still works. The side-panel quick-create form has no walk-in mode and benefits purely from the new safety net.

User-facing copy is added under `gabinet.appointments.errors.startInPast` in both `pl` and `en` translations, with a regex mapping in `src/lib/format-action-error.ts` so the toast renders nicely. Existing test helpers and direct callers in the four affected test files pass `allowPast: true` (their fixture dates are deliberately fixed at 2026-03-15…21 and are now in the past). Two new tests in `tests/convex/conflictChecking.test.ts` cover the guard: one verifies a past date is rejected, the other verifies `allowPast: true` lets it through. `npm run typecheck`, the 135-test convex suite, and the 20-test frontend suite all pass.