### PR TITLE
Reject past-time bookings in `bookFromPortal`

### DIFF
--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -365,6 +365,18 @@ export const bookFromPortal = action({
       await validatePortalSessionSupabase(db, args.tokenHash);
     const organizationId = orgIdStr as Id<"organizations">;
 
+    // Past-time guard (issue #1415). The portal slot picker already hides
+    // past slots client-side, but a crafted request could send any
+    // preferredDate/preferredTime. Parse the same way the appointment row is
+    // later persisted and reject if the start is already in the past — there
+    // is no walk-in concept for self-service portal bookings.
+    const apptMs = new Date(
+      `${args.preferredDate}T${args.preferredTime}:00`,
+    ).getTime();
+    if (Number.isFinite(apptMs) && apptMs <= Date.now()) {
+      throw new Error("Appointment start time is in the past");
+    }
+
     // Read treatment from Supabase
     const treatment = await db.get("gabinetTreatments", args.treatmentId);
     if (

--- a/tests/convex/bookFromPortal.test.ts
+++ b/tests/convex/bookFromPortal.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+import { createHash } from "crypto";
+import { api } from "../../convex/_generated/api";
+import {
+  createTestCtx,
+  seedTestUser,
+  seedGabinetPrereqs,
+} from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+function sha256Sync(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+async function seedActivePortalSession(
+  patientId: string,
+  organizationId: string,
+) {
+  const token = "portal-test-token";
+  const tokenHash = sha256Sync(token);
+  const db = createSupabaseDb();
+  const now = Date.now();
+  await db.insert("gabinetPortalSessions", {
+    patientId,
+    organizationId,
+    isActive: true,
+    tokenHash,
+    lastAccessedAt: now,
+    createdAt: now,
+    expiresAt: now + 30 * 24 * 60 * 60 * 1000,
+  });
+  return { tokenHash };
+}
+
+describe("bookFromPortal past-time guard (issue #1415)", () => {
+  test("rejects bookings whose start time is already in the past", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+    const { tokenHash } = await seedActivePortalSession(
+      String(patientId),
+      String(organizationId),
+    );
+
+    // A clearly-past date (server clock will be later than this).
+    await expect(
+      t.action(api.gabinet.patientPortal.bookFromPortal, {
+        tokenHash,
+        treatmentId: String(treatmentId),
+        preferredDate: "2020-01-01",
+        preferredTime: "09:00",
+      }),
+    ).rejects.toThrow(/start time is in the past/i);
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1415.

Closes #1415

---

## Claude summary

Fixed and committed. Summary of changes for issue #1415:

What I changed — added a server-side past-time guard at the top of `bookFromPortal` in `convex/gabinet/patientPortal.ts:368-378`. It parses `preferredDate + preferredTime` the same way the appointment row is later persisted (`new Date(...T...:00).getTime()`) and throws "Appointment start time is in the past" when the timestamp is `<= Date.now()`. Unconditional — the patient portal has no walk-in concept, so there's no `allowPast` opt-out.

Why this approach instead of plumbing `nowDate`/`nowTime` into the internal `getAvailableSlotsSupabase` call — relying on caller-supplied "now" defeats the purpose of a server-side check (a crafted request would just lie about it). The absolute server-clock guard mirrors the pattern that #1414 just landed for `appointments.create` and uses the same error message, so it picks up the existing `appointments.errors.startInPast` mapping in `format-action-error.ts`.

Verification — added `tests/convex/bookFromPortal.test.ts` with a targeted test that seeds a portal session and confirms a 2020-01-01 booking is rejected; the full convex test suite (18 files / 136 tests) still passes, and `tsc -p convex/tsconfig.json` is clean.

## Follow-ups
- Pipe `formatAppointmentError` into `src/routes/_app/patient/_layout.book.tsx`: the portal book page currently shows raw `err.message` in the toast, so the past-time guard (and other localized appointment errors) won't render in PL/EN.