### PR TITLE
Align clinic working hours editor with Monday-first ordering

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
@@ -22,6 +22,7 @@ export const Route = createFileRoute(
 
 const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 const DAY_NAMES_PL = ["Niedziela", "Poniedziałek", "Wtorek", "Środa", "Czwartek", "Piątek", "Sobota"];
+const DISPLAY_ORDER = [1, 2, 3, 4, 5, 6, 0];
 
 interface DayHours {
   dayOfWeek: number;
@@ -156,7 +157,9 @@ function SchedulingSettings() {
           <span>{t("gabinet.schedules.break")}</span>
         </div>
 
-        {hours.map((h) => {
+        {DISPLAY_ORDER.map((dayOfWeek) => {
+          const h = hours.find((x) => x.dayOfWeek === dayOfWeek);
+          if (!h) return null;
           const hasTimeError = h.isOpen && h.endTime <= h.startTime;
           const hasBreakError = h.isOpen && h.breakStart && h.breakEnd && h.breakEnd <= h.breakStart;
           const hasBreak = Boolean(h.breakStart || h.breakEnd);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1418.

Closes #1418

---

## Claude summary

Fixed and committed. The clinic working hours editor at `src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx` now iterates via `DISPLAY_ORDER = [1, 2, 3, 4, 5, 6, 0]` (Mon..Sun) instead of storage order (Sun..Sat), matching the pattern used in `flexible-schedule-editor.tsx` from the #1412 fix.