### PR TITLE
Pipe `formatAppointmentError` into `src/routes/_app/patient/_layout.book.tsx`

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3503,7 +3503,8 @@
       "pendingNote": "Your booking requires confirmation from the clinic. You will be notified once approved.",
       "submit": "Book Appointment",
       "submitting": "Booking...",
-      "success": "Your booking has been sent for confirmation"
+      "success": "Your booking has been sent for confirmation",
+      "bookingFailed": "Could not book your appointment."
     }
   },
   "invite": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3532,7 +3532,8 @@
       "pendingNote": "Rezerwacja wymaga potwierdzenia przez recepcję. Otrzymasz powiadomienie po zatwierdzeniu.",
       "submit": "Zarezerwuj wizytę",
       "submitting": "Rezerwacja...",
-      "success": "Twoja rezerwacja została wysłana do potwierdzenia"
+      "success": "Twoja rezerwacja została wysłana do potwierdzenia",
+      "bookingFailed": "Nie udało się zarezerwować wizyty."
     }
   },
   "invite": {

--- a/src/routes/_app/patient/_layout.book.tsx
+++ b/src/routes/_app/patient/_layout.book.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import type { Id } from "@cvx/_generated/dataModel";
 import { PlateText } from "@/components/plate-text";
+import { formatAppointmentError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute("/_app/patient/_layout/book")({
   component: PatientBooking,
@@ -209,8 +210,12 @@ function PatientBooking() {
       toast.success(t("patientPortal.booking.success"));
       navigate({ to: "/patient/appointments" });
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Booking failed";
-      toast.error(message);
+      toast.error(
+        formatAppointmentError(err, t, {
+          key: "patientPortal.booking.bookingFailed",
+          defaultValue: "Nie udało się zarezerwować wizyty.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1421.

Closes #1421

---

## Claude summary

Committed. The patient portal book page (`src/routes/_app/patient/_layout.book.tsx`) now runs booking errors through `formatAppointmentError`, so the past-time guard from `bookFromPortal` (`convex/gabinet/patientPortal.ts:377` → `"Appointment start time is in the past"`) maps to the existing `gabinet.appointments.errors.startInPast` PL/EN copy via `src/lib/format-action-error.ts:93`. Added a new `patientPortal.booking.bookingFailed` fallback key in both locale files for the generic case. Typecheck and JSON validation pass.