### PR TITLE
Przeciąganie okienka cd

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -292,9 +292,15 @@ export function AppointmentDialog({
   // Drag-to-reposition state — users want to peek at the calendar underneath
   // without closing the dialog (issue #977). Offset resets when the dialog
   // closes so the next open starts centered. The live offset lives in a ref
-  // and is written straight to `transform` via rAF; using React state would
-  // re-render the whole form on every pointermove and make the drag stutter
-  // (issue #1424).
+  // and is written straight to the `translate` CSS property via rAF; using
+  // React state would re-render the whole form on every pointermove and make
+  // the drag stutter (issue #1424). We must write to `translate`, not
+  // `transform`: Tailwind v4 compiles `translate-x-[-50%] translate-y-[-50%]`
+  // (the dialog's centering classes) to the modern `translate:` CSS property,
+  // which is a separate property from `transform:` and composes additively
+  // with it. Writing to `style.transform` left the class translate intact, so
+  // the dialog jumped by its own width/height instead of following the cursor
+  // (issue #1428).
   const dragOffsetRef = useRef({ x: 0, y: 0 });
   const dialogContentRef = useRef<HTMLDivElement | null>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -328,14 +334,16 @@ export function AppointmentDialog({
     const el = dialogContentRef.current;
     if (!el) return;
     const { x, y } = dragOffsetRef.current;
-    el.style.transform =
+    // Write to the CSS `translate:` property so the inline value overrides
+    // the class-defined `translate: -50% -50%` centering. See ref comment.
+    el.style.translate =
       x === 0 && y === 0
         ? ""
-        : `translate(calc(-50% + ${x}px), calc(-50% + ${y}px))`;
+        : `calc(-50% + ${x}px) calc(-50% + ${y}px)`;
   }, []);
 
   // Reapply on every render so an unrelated re-render mid-drag doesn't snap
-  // the dialog back to its class-defined centered transform.
+  // the dialog back to its class-defined centered translate.
   useLayoutEffect(() => {
     applyDragTransform();
   });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1428.

Closes #1428

---

## Claude summary

Fixed and committed. The drag handle on the create-appointment dialog was writing the live offset to `style.transform`, but the dialog's centering classes (`translate-x-[-50%] translate-y-[-50%]`) compile under Tailwind v4 to the modern CSS `translate:` property — which is a separate property from `transform:` and composes additively. So the class translate stayed at `-50% -50%` while inline `transform` added another `(-50% + Xpx, -50% + Ypx)` on top, making the dialog jump by roughly its own width/height the moment the user started dragging instead of tracking the cursor.

The fix writes the drag offset to `style.translate` instead, which overrides the class on the same CSS property — so dragging now follows the cursor 1:1.