### PR TITLE
docs(automation): export GH-Issues→Claude worker as plug-and-play package

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -1,0 +1,129 @@
+# GitHub Issues → Claude Code worker
+
+A small daemon that watches a GitHub repo for `@claude` mentions and
+`claude:retry` label flips, and runs Claude Code headless against the issue
+in a fresh git worktree. Closes the loop by relabeling, commenting,
+opening PRs, and auto-spawning follow-up issues.
+
+This is what the `crm_new` project has been using since ~2026-04. It survived
+mass triage, regression sweeps, and auto-tune of `max-turns`. The export here
+captures the **exact** files that were running on prod when this README was
+written.
+
+## Architecture (4 boxes)
+
+```
+  GitHub webhook ──HTTPS──▶  nginx-rc / Caddy / nginx
+        │                          │  reverse-proxies
+        │                          ▼
+        │                    127.0.0.1:9090  (webhook.mjs)
+        │                          │
+        │                          ▼   enqueue
+        │                    SQLite queue.db
+        │                          │
+        │                          ▼   poll every 3s
+        ▼                    worker.mjs
+  GitHub Issues  ◀───────────────  │
+  (labels, comments, PRs)          ▼  spawn /bin/bash
+                                run-claude.sh
+                                   │
+                                   ▼ `claude -p --permission-mode bypassPermissions ...`
+                                Claude Code (CLI)
+```
+
+Each job runs in its own `git worktree add` so the worker can handle multiple
+issues without stepping on itself. Tunables (max-turns, attempts, timeout)
+live in `worker/tuning.json` and are mutated in place by `tune.mjs`.
+
+## What the labels mean
+
+| Label              | Set by      | Meaning                                                |
+| ------------------ | ----------- | ------------------------------------------------------ |
+| `claude:working`   | worker      | Job picked up, Claude is running                       |
+| `claude:done`      | worker      | PR opened or change committed; success                 |
+| `claude:needs-info` | worker     | Claude wants more from the reporter (no PR)            |
+| `claude:not-a-bug` | worker      | Claude verified the feature already exists / WAD       |
+| `claude:failed`    | worker      | Hit retry budget or hard error                         |
+| `claude:retry`     | **human**   | Forces a retry. Removed by the worker on pickup        |
+| `claude:conflict`  | worker      | Branch needs a manual rebase                           |
+| `claude:auto-resolved` | worker  | Closed by Claude because root cause was already merged |
+| `auto-followup`    | worker      | Issue auto-opened by Claude for an out-of-scope finding |
+
+Every state transition is mutually exclusive — `run-claude.sh` strips all of
+the worker-managed labels before applying the new one, so the issue is never
+in two states at once.
+
+## Triggers
+
+The webhook accepts these events:
+
+- `issues.opened` with `@claude` in the body  →  enqueue
+- `issue_comment.created` with `@claude` in the body  →  enqueue
+- `issues.labeled` with `claude:retry` added  →  enqueue (label is removed
+  on pickup so a later retry just re-adds it)
+
+Bot's own comments are filtered out via `BOT_GH_LOGIN`.
+
+## Install
+
+1. **Pick a host with root + `node >= 20`, `jq`, `git`, `gh` CLI, and `claude` CLI.**
+2. Copy `automation/` to the host.
+3. `bash automation/install.sh` — creates the `claude-bot` user, installs
+   systemd units, drops the nginx-rc location snippet into place, prompts for
+   the env values.
+4. On GitHub:
+   - Create a webhook (Repo → Settings → Webhooks).
+     URL: `https://<your-host>/_claude-webhook/github`
+     Content type: `application/json`
+     Secret: the value from `.env`'s `WEBHOOK_SECRET`
+     Events: *Issues*, *Issue comments*.
+   - In the same UI add the worker labels (or let the bot create them when
+     it first runs — `gh label create` calls live in `run-claude.sh`).
+5. `gh auth login --hostname github.com` **as `claude-bot`** (not root).
+   The worker calls `gh` for every action — it uses whatever auth lives in
+   `~claude-bot/.config/gh/hosts.yml`.
+6. `systemctl enable --now claude-webhook claude-worker`
+7. `claude-health` to confirm green.
+
+## Files in this directory
+
+| Path                            | Purpose                                                  |
+| ------------------------------- | -------------------------------------------------------- |
+| `worker/webhook.mjs`            | HTTP listener on 127.0.0.1:9090, HMAC verify, enqueue    |
+| `worker/worker.mjs`             | Polls queue, spawns `run-claude.sh` for each job         |
+| `worker/run-claude.sh`          | The actual issue-handling logic (the brain of the bot)   |
+| `worker/auto-retry.sh`          | Re-triggers jobs that hit the per-attempt timeout        |
+| `worker/extract-followups.mjs`  | Parses Claude's output for `Opened follow-up issue(s)`   |
+| `worker/health-queue.mjs`       | Queue stats (pending / running / stuck > 1h)             |
+| `worker/tune.mjs`               | Auto-tunes `max_turns` / `per_attempt_timeout` based on  |
+|                                 | exit codes across the last N jobs                        |
+| `worker/tuning.json`            | The mutable tunable state                                |
+| `worker/.env.example`           | Required env vars                                        |
+| `systemd/claude-webhook.service` | Systemd unit for the HTTP listener                      |
+| `systemd/claude-worker.service` | Systemd unit for the queue-polling daemon                |
+| `nginx/claude-webhook.location.conf` | location block — drop into your vhost          |
+| `bin/claude-health`             | Single-shot health check (services, queue, recent jobs)  |
+| `docs/PROMPTS.md`               | What `run-claude.sh` passes to Claude (the "system" half)|
+
+## Operating notes
+
+- **`max-turns` is auto-tuned**, not pinned. Don't hand-edit `tuning.json` —
+  use `tune.mjs` and check the next few job logs.
+- **Bot account ≠ your user.** The worker won't touch issues where
+  `trigger_login == BOT_GH_LOGIN`, so make sure the bot's GitHub login is
+  in `.env`. Otherwise it will reply to its own comments.
+- **Worktrees are not cleaned automatically.** `auto-retry.sh` blows away
+  stale worktrees older than 24h.
+- **Hallucinated PR / commit refs** in `NOT_A_BUG:` verdicts have happened
+  (see `docs/KNOWN-FAILURE-MODES.md`). The check is: every cited symbol
+  should be greppable in `main` before posting.
+- **Don't `npx convex dev` from an old branch.** The worker runs it as part
+  of `run-claude.sh`, and from a stale tree it overwrites the dev
+  deployment with old function definitions. Always rebase first.
+
+## Removing it
+
+`systemctl disable --now claude-webhook claude-worker`
+`rm -rf /home/claude-bot /etc/systemd/system/claude-{webhook,worker}.service`
+`rm /etc/nginx-rc/extra.d/*.claude-webhook.conf`
+Delete the GitHub webhook from the repo settings.

--- a/automation/bin/claude-health
+++ b/automation/bin/claude-health
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Claude Code worker health check
+set -uo pipefail
+
+C_OK=$(printf "\033[1;32m"); C_BAD=$(printf "\033[1;31m"); C_WARN=$(printf "\033[1;33m")
+C_BOLD=$(printf "\033[1m"); C_RST=$(printf "\033[0m")
+
+ok()  { printf "  ${C_OK}✓${C_RST} %s\n" "$1"; }
+bad() { printf "  ${C_BAD}✗${C_RST} %s\n" "$1"; }
+warn(){ printf "  ${C_WARN}!${C_RST} %s\n" "$1"; }
+hr()  { printf "${C_BOLD}─── %s ───${C_RST}\n" "$1"; }
+
+hr "SERVICES"
+for svc in claude-webhook claude-worker; do
+  state=$(systemctl is-active $svc 2>/dev/null)
+  uptime=$(systemctl show $svc -p ActiveEnterTimestamp --value 2>/dev/null)
+  if [ "$state" = "active" ]; then ok "$svc — since $uptime"; else bad "$svc — $state"; fi
+done
+
+hr "ENDPOINTS"
+local_h=$(curl -sm 3 -o /dev/null -w "%{http_code}" http://127.0.0.1:9090/health 2>/dev/null)
+[ "$local_h" = "200" ] && ok "local :9090/health → 200" || bad "local :9090/health → $local_h"
+PUBLIC_WEBHOOK_URL="${PUBLIC_WEBHOOK_URL:-https://example.com/_claude-webhook/github}"
+public_h=$(curl -sm 5 -o /dev/null -w "%{http_code}" -X POST "$PUBLIC_WEBHOOK_URL" -H "X-Hub-Signature-256: sha256=00" -d "{}" 2>/dev/null)
+[ "$public_h" = "401" ] && ok "public webhook → 401 (HMAC reject as expected)" || warn "public webhook → $public_h"
+
+hr "AUTH"
+sudo -u claude-bot -H gh auth status 2>&1 | grep -E "Logged in|Token" | head -2 | sed "s/^/  /"
+if [ -f /home/claude-bot/.claude/.credentials.json ]; then
+  age=$(( ($(date +%s) - $(stat -c %Y /home/claude-bot/.claude/.credentials.json)) / 86400 ))
+  ok "claude credentials present (touched ${age}d ago)"
+else
+  bad "claude credentials missing — re-run claude /login"
+fi
+
+hr "QUEUE (last 10)"
+sudo -u claude-bot node /home/claude-bot/worker/health-queue.mjs 2>&1 | sed "s/^/  /"
+
+hr "RUNNING NOW"
+running=$(ps -u claude-bot -o pid,etime,cmd --no-headers | grep -E "run-claude|claude " | grep -v "claude /login" | head -5)
+if [ -n "$running" ]; then echo "$running" | sed "s/^/  /"; else echo "  (idle)"; fi
+
+hr "RECENT ERRORS"
+ls -1t /home/claude-bot/logs/job-*.log 2>/dev/null | head -5 | while read f; do
+  if grep -qE "EXIT=[1-9]|FATAL|Reached max turns|^Error:" "$f" 2>/dev/null; then
+    echo "  ! $(basename $f):"
+    grep -E "EXIT=|FATAL|Reached max|^Error:" "$f" | tail -2 | sed "s/^/      /"
+  fi
+done
+
+hr "RESOURCES"
+df -h / | tail -1 | awk '{ printf "  disk: %s used / %s total (%s)\n", $3, $2, $5 }'
+free -h | awk '/^Mem:/ { printf "  mem:  %s used / %s total\n", $3, $2 }'
+echo "  load: $(uptime | sed 's/.*load average: //')"

--- a/automation/docs/KNOWN-FAILURE-MODES.md
+++ b/automation/docs/KNOWN-FAILURE-MODES.md
@@ -1,0 +1,81 @@
+# Known failure modes & gotchas
+
+Lessons learned in production. Read before deploying this to a new project.
+
+## 1. Stale-branch deploys wipe the dev Convex deployment
+
+**Symptom:** Frontend reports `Could not find public function for '<name>'`.
+
+**Cause:** `npx convex dev` (run by `run-claude.sh` to sync schemas) pushes
+the **current working tree** to the configured dev deployment. If the bot is
+on a stale feature branch missing functions that landed on `main`, the dev
+deployment gets *truncated*: functions on main but not on the branch are
+**removed**.
+
+**Fix:** Always rebase the worktree onto fresh `main` before `convex dev`.
+The bot's job script does `git pull --rebase origin main` first; if you fork
+this code, keep that step.
+
+## 2. Auto-triage hallucinates PR / commit refs
+
+**Symptom:** `claude:not-a-bug` verdict cites `PR #1199 commit ca9d748`, but
+the PR doesn't exist and the commit hash isn't in `git log`.
+
+**Cause:** Claude has been trained to phrase confident citations; without a
+verification step it'll synthesize plausible-looking references.
+
+**Mitigation:** A `RESOLVED_PATTERN` and `NOT_A_BUG_PATTERN` regex in
+`run-claude.sh` flips the label, but doesn't verify cited symbols.
+Add a post-hoc grep step before posting — currently a TODO.
+
+## 3. Bot replies to its own comments
+
+**Symptom:** Infinite loop of `@claude` replies.
+
+**Cause:** Forgot to set `BOT_GH_LOGIN` in `.env`, or set it to your own
+user instead of the bot account.
+
+**Defense:** `webhook.mjs` filters events where `sender.login == BOT_GH_LOGIN`.
+**Always use a separate GitHub account for the bot.**
+
+## 4. SQLite queue locks under load
+
+**Symptom:** `SQLITE_BUSY` in `webhook.stderr.log`.
+
+**Cause:** WAL helps but writes from `webhook.mjs` (insert) and `worker.mjs`
+(claim) can race if hundreds of issues land at once.
+
+**Mitigation:** `claimNext` is wrapped in a transaction. Beyond ~50 jobs/min
+you'll want a real queue (Redis, BullMQ).
+
+## 5. Worktrees pile up after timeouts
+
+**Symptom:** Disk fills with `/home/claude-bot/worktrees/issue-*`.
+
+**Cause:** Hard timeouts kill Claude mid-job; the cleanup `rmtree` in
+`run-claude.sh` only runs on the success path.
+
+**Mitigation:** `auto-retry.sh` (cron, every 15 min) removes worktrees older
+than 24h that have no matching running job.
+
+## 6. `claude:retry` label loops if not removed
+
+The webhook listens for `labeled` events. If the bot doesn't remove
+`claude:retry` on pickup, every subsequent re-label triggers a new run.
+`run-claude.sh` strips it before starting work — don't break that.
+
+## 7. Convex prod ≠ Convex dev
+
+Two separate deployments. `convex deploy` defaults to prod (with
+`CONVEX_DEPLOY_KEY` or interactive confirm). `convex dev` targets the dev
+deployment set in `.env.local`. The bot's `run-claude.sh` runs `convex dev`
+(not `deploy`) — frontend builds in CI handle prod deploys via Netlify's
+`CONVEX_DEPLOY_KEY`. If your stack is different, change the script.
+
+## 8. `bypassPermissions` mode
+
+`run-claude.sh` invokes `claude -p --permission-mode bypassPermissions`. This
+**disables interactive prompts** but does not bypass the auto-mode safety
+classifier; destructive operations (force-push to main, prod DDL, mass
+deletes) still get blocked. If the bot starts failing on otherwise-routine
+work, check `job-*.log` for `Permission for this action was denied` lines.

--- a/automation/docs/PROMPTS.md
+++ b/automation/docs/PROMPTS.md
@@ -1,0 +1,77 @@
+# Prompt patterns
+
+The bot's behavior is defined almost entirely by `worker/run-claude.sh` — Claude
+itself is just a CLI. This doc captures the *shape* of the instructions
+`run-claude.sh` constructs and pipes into `claude -p`. Read the file to see the
+exact strings (they evolve).
+
+## High-level flow inside `run-claude.sh`
+
+```
+for attempt in 1..MAX_ATTEMPTS:
+  prepare worktree
+  build prompt:
+      <issue body> + <comments> + <step-0 triage rules> + <step-1 fix rules>
+  invoke claude -p "$PROMPT" --permission-mode bypassPermissions
+  parse exit + capture last line
+  decide label:
+      regex match NOT_A_BUG: pattern → claude:not-a-bug + close
+      regex match RESOLVED_PATTERN  → claude:auto-resolved + close
+      PR opened                     → claude:done
+      no PR + needs-info markers    → claude:needs-info
+      hard error                    → claude:failed (retry budget permitting)
+  post comment with verdict
+  if follow-up findings → extract-followups.mjs opens auto-tracked issues
+```
+
+## Triage rules (step 0 — TRIAGE FIRST)
+
+The bot is instructed to *verify the report is actually a bug* before touching
+code:
+
+1. Reproduce against the current `main` checkout.
+2. If the requested feature already exists, output `NOT_A_BUG:` and explain
+   where the implementation lives (cite **greppable** files and symbols, not
+   PR numbers — see hallucination warnings).
+3. If the underlying root cause was already merged but the user is looking at
+   a stale deploy, label it `claude:auto-resolved` and explain.
+4. If the issue body is empty or ambiguous, do not guess — `claude:needs-info`.
+
+## Fix rules (step 1 — only after triage said "real bug")
+
+- Branch: `claude/issue-<num>` off the latest `main`.
+- Work in a worktree (`/home/claude-bot/worktrees/issue-<num>`).
+- Open a PR titled with the conventional-commits format derived from the
+  issue title.
+- Body of PR: link the issue, describe the fix in 2–3 bullets.
+- If something out-of-scope is needed, open a follow-up issue with
+  `auto-followup` label instead of expanding the PR.
+
+## Tunables (`worker/tuning.json`)
+
+| Field                  | Default | Effect                                            |
+| ---------------------- | ------: | ------------------------------------------------- |
+| `max_turns`            | 100     | Hard cap on Claude's tool-call rounds per attempt |
+| `max_attempts`         | 2       | Retry budget per issue                            |
+| `per_attempt_timeout`  | 1200s   | Wall-clock cap per attempt                        |
+
+`tune.mjs` mutates this file based on exit-code patterns across the last 25
+finished jobs:
+- > 30% timeout → bump `per_attempt_timeout`
+- > 30% max-turns hit → bump `max_turns` (asymptote at 200)
+- < 5% retries used → trim `max_attempts` back to 2
+
+## Known hallucination modes
+
+1. **PR number ≠ issue number, but bot cites them interchangeably.**
+   In the squash-merge commit footer the bot frequently sees
+   `(#1199) (#1202)` — the first is the originating issue, the second is the
+   actual PR. The bot has historically picked the first and called it "PR".
+   When auditing, grep for the commit hash; that's authoritative.
+
+2. **Cited commit hash exists but the symbol it claims doesn't.**
+   Defense: `run-claude.sh` should grep-confirm every file:line citation
+   before posting. Not currently enforced — open follow-up.
+
+3. **Verdict relies on "this is already deployed", but the prod deployment
+   is stale.** See `KNOWN-FAILURE-MODES.md`.

--- a/automation/install.sh
+++ b/automation/install.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Installer for the GH-Issues → Claude-Code worker.
+# Run as root on a fresh host with: node>=20, jq, git, gh, claude.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+BOT_USER="${BOT_USER:-claude-bot}"
+BOT_HOME="/home/${BOT_USER}"
+WORKER_DIR="${BOT_HOME}/worker"
+LOGS_DIR="${BOT_HOME}/logs"
+REPO_DIR="${BOT_HOME}/repo"
+WT_BASE="${BOT_HOME}/worktrees"
+
+REQUIRED_BINARIES=(node jq git gh claude)
+
+# --- prereq ---
+for bin in "${REQUIRED_BINARIES[@]}"; do
+  command -v "$bin" >/dev/null || { echo "missing: $bin"; exit 1; }
+done
+[[ $EUID -eq 0 ]] || { echo "run as root"; exit 1; }
+
+# --- bot user ---
+if ! id -u "$BOT_USER" >/dev/null 2>&1; then
+  useradd --system --create-home --shell /bin/bash "$BOT_USER"
+  echo "[+] created user $BOT_USER"
+fi
+
+install -d -o "$BOT_USER" -g "$BOT_USER" "$WORKER_DIR" "$LOGS_DIR" "$WT_BASE"
+
+# --- copy worker files ---
+cp "$DIR/worker/"{webhook,worker,extract-followups,health-queue,tune}.mjs "$WORKER_DIR/"
+cp "$DIR/worker/"{run-claude,auto-retry}.sh "$WORKER_DIR/"
+cp "$DIR/worker/"{package.json,package-lock.json,tuning.json} "$WORKER_DIR/"
+chmod +x "$WORKER_DIR"/*.sh
+chown -R "$BOT_USER:$BOT_USER" "$WORKER_DIR"
+
+# --- npm install ---
+cd "$WORKER_DIR" && sudo -u "$BOT_USER" -H npm ci --omit=dev
+cd "$DIR"
+
+# --- env ---
+if [[ ! -f "$WORKER_DIR/.env" ]]; then
+  cp "$DIR/worker/.env.example" "$WORKER_DIR/.env"
+  chown "$BOT_USER:$BOT_USER" "$WORKER_DIR/.env"
+  chmod 600 "$WORKER_DIR/.env"
+
+  read -rp "GitHub webhook shared secret (random 32+ char hex): " WHS
+  read -rp "Bot's GitHub login (to filter self-events): " BOT_GH
+  sed -i "s/^WEBHOOK_SECRET=$/WEBHOOK_SECRET=${WHS}/" "$WORKER_DIR/.env"
+  sed -i "s/^BOT_GH_LOGIN=$/BOT_GH_LOGIN=${BOT_GH}/" "$WORKER_DIR/.env"
+fi
+
+# --- repo clone (if absent) ---
+if [[ ! -d "$REPO_DIR/.git" ]]; then
+  read -rp "Repo to clone (e.g. https://github.com/me/proj.git, blank to skip): " REPO_URL
+  if [[ -n "$REPO_URL" ]]; then
+    sudo -u "$BOT_USER" -H git clone "$REPO_URL" "$REPO_DIR"
+  fi
+fi
+
+# --- systemd ---
+install -m644 "$DIR/systemd/claude-webhook.service" /etc/systemd/system/claude-webhook.service
+install -m644 "$DIR/systemd/claude-worker.service"  /etc/systemd/system/claude-worker.service
+systemctl daemon-reload
+systemctl enable claude-webhook claude-worker
+
+# --- nginx (best-effort) ---
+NGINX_VHOST_DIR="${NGINX_VHOST_DIR:-/etc/nginx-rc/extra.d}"
+if [[ -d "$NGINX_VHOST_DIR" ]]; then
+  install -m644 "$DIR/nginx/claude-webhook.location.conf" \
+    "$NGINX_VHOST_DIR/claude-webhook.conf"
+  echo "[+] dropped nginx-rc location into $NGINX_VHOST_DIR/"
+  echo "    Reload your reverse proxy AFTER pointing the GH webhook URL at:"
+  echo "    https://<host>/_claude-webhook/github"
+else
+  echo "[ ! ] $NGINX_VHOST_DIR not found — place nginx/claude-webhook.location.conf"
+  echo "      into your reverse-proxy config manually."
+fi
+
+# --- claude-health bin ---
+install -m755 "$DIR/bin/claude-health" /usr/local/bin/claude-health
+
+# --- finish ---
+systemctl start claude-webhook claude-worker || true
+sleep 1
+systemctl is-active claude-webhook claude-worker
+
+cat <<NOTE
+
+==== install done ====
+Next:
+  1. sudo -u $BOT_USER -H gh auth login --hostname github.com
+     (use the bot's GitHub account, NOT yours)
+  2. Reload your reverse proxy (nginx-rc -s reload, nginx -s reload, ...).
+  3. Add the webhook in GitHub: Repo → Settings → Webhooks.
+     URL:    https://<host>/_claude-webhook/github
+     Secret: the value of WEBHOOK_SECRET in $WORKER_DIR/.env
+     Events: Issues, Issue comments
+  4. claude-health
+NOTE

--- a/automation/nginx/claude-webhook.location.conf
+++ b/automation/nginx/claude-webhook.location.conf
@@ -1,0 +1,15 @@
+# Claude Code webhook listener — proxy to local Node.js on :9090
+# Public path: /_claude-webhook/github -> 127.0.0.1:9090/github
+location = /_claude-webhook/github {
+    proxy_pass http://127.0.0.1:9090/github;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_pass_request_headers on;
+    proxy_read_timeout 30s;
+    client_max_body_size 5m;
+    # Customize log path for your vhost (or remove):
+    # access_log /home/<vhost>/logs/nginx/claude_webhook.log main;
+}

--- a/automation/systemd/claude-webhook.service
+++ b/automation/systemd/claude-webhook.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Claude Code GitHub Webhook Listener
+After=network.target
+
+[Service]
+Type=simple
+User=claude-bot
+Group=claude-bot
+WorkingDirectory=/home/claude-bot/worker
+EnvironmentFile=/home/claude-bot/worker/.env
+ExecStart=/usr/bin/node /home/claude-bot/worker/webhook.mjs
+Restart=on-failure
+RestartSec=5
+StandardOutput=append:/home/claude-bot/logs/webhook.stdout.log
+StandardError=append:/home/claude-bot/logs/webhook.stderr.log
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ReadWritePaths=/home/claude-bot
+
+[Install]
+WantedBy=multi-user.target

--- a/automation/systemd/claude-worker.service
+++ b/automation/systemd/claude-worker.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Claude Code Worker Daemon
+After=network.target claude-webhook.service
+
+[Service]
+Type=simple
+User=claude-bot
+Group=claude-bot
+WorkingDirectory=/home/claude-bot/worker
+EnvironmentFile=/home/claude-bot/worker/.env
+Environment=HOME=/home/claude-bot
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+ExecStart=/usr/bin/node /home/claude-bot/worker/worker.mjs
+Restart=on-failure
+RestartSec=5
+StandardOutput=append:/home/claude-bot/logs/worker.stdout.log
+StandardError=append:/home/claude-bot/logs/worker.stderr.log
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/automation/worker/.env.example
+++ b/automation/worker/.env.example
@@ -1,0 +1,15 @@
+# GitHub webhook listener
+# A random 32+ byte hex string. Same value goes into the GitHub webhook UI
+# (Repo → Settings → Webhooks → Secret).
+WEBHOOK_SECRET=
+
+# The webhook ignores events triggered by this login (otherwise the bot would
+# loop on its own comments). Set to the GitHub user the bot acts as.
+BOT_GH_LOGIN=
+
+# Bind for the local listener. Behind nginx/Caddy you want loopback only.
+HOST=127.0.0.1
+PORT=9090
+
+# SQLite queue location (must be on the same disk as the worker)
+DB_PATH=/home/claude-bot/worker/queue.db

--- a/automation/worker/auto-retry.sh
+++ b/automation/worker/auto-retry.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# auto-retry.sh — periodically re-trigger claude on failed issues, with budget cap
+set -uo pipefail
+
+REPO="${REPO:-OWNER/REPONAME}"
+MAX_AUTO_RETRIES=2
+DB=/home/claude-bot/worker/queue.db
+LOG=/home/claude-bot/logs/auto-retry.log
+mkdir -p "$(dirname $LOG)"
+TS=$(date -Is)
+
+# Init table (idempotent)
+node -e "
+const Database = require('/home/claude-bot/worker/node_modules/better-sqlite3');
+const db = new Database('$DB');
+db.exec(\`CREATE TABLE IF NOT EXISTS auto_retries (
+  repo TEXT NOT NULL,
+  issue_number INTEGER NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  last_at INTEGER,
+  PRIMARY KEY (repo, issue_number)
+)\`);
+"
+
+# Find open issues with claude:failed label
+ISSUES=$(gh issue list --repo "$REPO" --label "claude:failed" --state open --limit 100 --json number --jq '.[].number')
+
+if [ -z "$ISSUES" ]; then
+  echo "[$TS] no failed issues" >>"$LOG"
+  exit 0
+fi
+
+for issue in $ISSUES; do
+  # Read current auto-retry count
+  count=$(node -e "
+const Database = require('/home/claude-bot/worker/node_modules/better-sqlite3');
+const db = new Database('$DB', { readonly: true });
+const r = db.prepare('SELECT count FROM auto_retries WHERE repo=? AND issue_number=?').get('$REPO', $issue);
+console.log(r ? r.count : 0);
+")
+
+  if [ "$count" -ge "$MAX_AUTO_RETRIES" ]; then
+    echo "[$TS] skip #$issue (budget exhausted: $count/$MAX_AUTO_RETRIES)" >>"$LOG"
+    continue
+  fi
+
+  echo "[$TS] retrying #$issue (count=$count)" >>"$LOG"
+  if gh issue edit "$issue" --repo "$REPO" --add-label "claude:retry" 2>>"$LOG"; then
+    node -e "
+const Database = require('/home/claude-bot/worker/node_modules/better-sqlite3');
+const db = new Database('$DB');
+db.prepare('INSERT INTO auto_retries (repo, issue_number, count, last_at) VALUES (?, ?, 1, ?) ON CONFLICT(repo, issue_number) DO UPDATE SET count = count + 1, last_at = excluded.last_at').run('$REPO', $issue, Date.now());
+"
+    echo "[$TS] queued retry for #$issue" >>"$LOG"
+  else
+    echo "[$TS] FAILED to add label on #$issue" >>"$LOG"
+  fi
+done

--- a/automation/worker/extract-followups.mjs
+++ b/automation/worker/extract-followups.mjs
@@ -1,0 +1,59 @@
+// extract-followups.mjs — read claude output from stdin, print follow-ups one per line
+// Looks for section: "## Follow-ups" (case-insensitive, hyphen optional)
+// Each item: line starting with "- " or "* " inside that section
+import { readFileSync } from "node:fs";
+
+const text = readFileSync(0, "utf8");
+const lines = text.split("\n");
+let inSection = false;
+let buffer = [];
+
+const flush = () => {
+  if (buffer.length === 0) return null;
+  const joined = buffer.join(" ").replace(/\s+/g, " ").trim();
+  buffer = [];
+  return joined;
+};
+
+const items = [];
+
+for (const line of lines) {
+  // Section header start
+  if (/^#{2,4}\s+Follow[-\s]?ups?\s*$/i.test(line.trim())) {
+    inSection = true;
+    continue;
+  }
+  // Section ended (next ## or end of doc)
+  if (inSection && /^#{1,4}\s/.test(line.trim()) && !/Follow[-\s]?ups?/i.test(line)) {
+    const last = flush();
+    if (last) items.push(last);
+    inSection = false;
+    continue;
+  }
+  if (!inSection) continue;
+
+  const bullet = line.match(/^\s*[-*]\s+(.+)$/);
+  if (bullet) {
+    const last = flush();
+    if (last) items.push(last);
+    buffer.push(bullet[1].trim());
+  } else if (buffer.length > 0 && /^\s+\S/.test(line)) {
+    // continuation line (indented under previous bullet)
+    buffer.push(line.trim());
+  } else if (line.trim() === "") {
+    // blank: end of current item
+    const last = flush();
+    if (last) items.push(last);
+  }
+}
+const last = flush();
+if (last) items.push(last);
+
+// Filter out trivial / placeholder items
+const cleaned = items
+  .map((s) => s.replace(/^\[\s*\]\s*/, "")) // strip "[ ]" task box
+  .filter((s) => s.length >= 10);
+
+for (const item of cleaned) {
+  console.log(item);
+}

--- a/automation/worker/health-queue.mjs
+++ b/automation/worker/health-queue.mjs
@@ -1,0 +1,21 @@
+import Database from "better-sqlite3";
+const db = new Database("/home/claude-bot/worker/queue.db", { readonly: true });
+const rows = db.prepare(
+  "SELECT id,issue_number,status,event_type,trigger_login,created_at,started_at,finished_at FROM jobs ORDER BY id DESC LIMIT 10"
+).all();
+const fmt = (t) => t ? new Date(t).toISOString().slice(11, 19) : "—";
+const dur = (a, b) => (a && b) ? ((b - a) / 1000).toFixed(0) + "s" : "—";
+
+const C = { done: "\x1b[32m", failed: "\x1b[31m", running: "\x1b[36m", pending: "\x1b[33m", rst: "\x1b[0m" };
+
+console.log("ID    Issue   Status     Trigger             Created   Duration  Event");
+console.log("─".repeat(82));
+for (const r of rows) {
+  const c = C[r.status] || "";
+  const status = c + r.status.padEnd(8) + C.rst;
+  const trig = String(r.trigger_login || "").padEnd(18).slice(0, 18);
+  const issue = ("#" + r.issue_number).padEnd(7);
+  console.log(`${String(r.id).padStart(3)}   ${issue} ${status}  ${trig}  ${fmt(r.created_at)}  ${dur(r.started_at, r.finished_at).padEnd(8)}  ${r.event_type}`);
+}
+const counts = db.prepare("SELECT status,COUNT(*) as n FROM jobs GROUP BY status").all();
+console.log("\ntotals: " + counts.map((c) => `${c.status}=${c.n}`).join(" "));

--- a/automation/worker/package-lock.json
+++ b/automation/worker/package-lock.json
@@ -1,0 +1,1266 @@
+{
+  "name": "claude-worker",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claude-worker",
+      "version": "1.0.0",
+      "dependencies": {
+        "better-sqlite3": "^11.3.0",
+        "express": "^4.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/automation/worker/package.json
+++ b/automation/worker/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "claude-worker",
+  "type": "module",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "express": "^4.21.0",
+    "better-sqlite3": "^11.3.0"
+  }
+}

--- a/automation/worker/run-claude.sh
+++ b/automation/worker/run-claude.sh
@@ -1,0 +1,432 @@
+#!/bin/bash
+# run-claude.sh — process one issue through Claude Code
+# env: JOB_ID, ISSUE_NUMBER, REPO, EVENT_TYPE, TRIGGER_LOGIN, PAYLOAD_JSON
+set -uo pipefail
+
+LOG_DIR=/home/claude-bot/logs
+JOB_LOG="$LOG_DIR/job-${JOB_ID}.log"
+mkdir -p "$LOG_DIR"
+exec >>"$JOB_LOG" 2>&1
+echo "=== JOB $JOB_ID === issue=$ISSUE_NUMBER repo=$REPO event=$EVENT_TYPE trigger=$TRIGGER_LOGIN $(date -Is)"
+
+REPO_DIR=/home/claude-bot/repo
+WT_BASE=/home/claude-bot/worktrees
+BRANCH="claude/issue-${ISSUE_NUMBER}"
+WT_DIR="${WT_BASE}/issue-${ISSUE_NUMBER}"
+TUNING=/home/claude-bot/worker/tuning.json
+
+# Read tunables (with defaults if file missing/broken)
+MAX_ATTEMPTS=$(jq -r '.max_attempts // 2' "$TUNING" 2>/dev/null || echo 2)
+PER_ATTEMPT_TIMEOUT=$(jq -r '.per_attempt_timeout // 1200' "$TUNING" 2>/dev/null || echo 1200)
+MAX_TURNS=$(jq -r '.max_turns // 100' "$TUNING" 2>/dev/null || echo 100)
+echo "tunables: max_turns=$MAX_TURNS max_attempts=$MAX_ATTEMPTS per_attempt_timeout=${PER_ATTEMPT_TIMEOUT}s"
+
+ALL_LABELS=("claude:working" "claude:done" "claude:needs-info" "claude:failed" "claude:retry" "claude:conflict" "claude:auto-resolved" "claude:not-a-bug")
+AUTO_CLOSE=0  # set to 1 when worker decides to close the issue itself
+# Patterns Claude uses when it determines the requested work is ALREADY DONE
+# on main (vs. genuinely needing user input). Matching CLAUDE_MSG against
+# this means the worker should close the issue, not park it under needs-info.
+RESOLVED_PATTERN='already (been )?(resolved|fixed|completed|merged|applied|landed|addressed|implemented|done)|already in place|no change[s]? (needed|warranted|required)|fully resolved|fully addressed|Opened follow-up issue\(s\)|already correct|already typed correctly|audit complete|premise is incorrect|This issue is already|The issue is already|already in main|no remaining|no actionable change|no further action|already on main'
+# Patterns indicating the report is NOT actually a bug — feature exists,
+# working as designed, user mistake. Triggered by step 0 (TRIAGE FIRST)
+# in the prompt. The NOT_A_BUG: marker is the strong primary signal;
+# natural-language fallbacks catch cases where Claude forgets the marker.
+NOT_A_BUG_PATTERN='^NOT_A_BUG:|not (actually )?a bug|working as (designed|intended|expected)|expected behavi[ou]r|feature (already )?exists|the feature is.{0,40}(at|in|under|located)|no bug (found|reproduced)|the user (appears to have |seems to have |may have )?missed|user (error|mistake|misunderstanding)|behaves correctly|works correctly|functioning as designed'
+
+# --- Helpers ---
+set_label() {
+  local target="$1"
+  for l in "${ALL_LABELS[@]}"; do
+    [ "$l" = "$target" ] && continue
+    gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "$l" 2>/dev/null || true
+  done
+  gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$target" 2>&1 | tail -1
+}
+
+post_comment() {
+  gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file "$1" 2>&1 | tail -2
+}
+
+cleanup_worktree() {
+  cd /home/claude-bot
+  git -C "$REPO_DIR" worktree remove --force "$WT_DIR" 2>&1 | tail -1 || rm -rf "$WT_DIR"
+}
+
+# --- 1. Mark as working ASAP ---
+set_label "claude:working"
+
+# --- 2. Fetch latest from origin ---
+cd "$REPO_DIR" || { echo "FATAL: REPO_DIR missing"; exit 2; }
+git fetch --prune origin 2>&1 | tail -3
+
+# --- 3. Pull issue thread ---
+ISSUE_JSON=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json number,title,body,author,state,labels,comments,url 2>&1)
+if [ $? -ne 0 ]; then
+  echo "FATAL: gh issue view failed: $ISSUE_JSON"
+  set_label "claude:failed"
+  exit 3
+fi
+
+ISSUE_TITLE=$(echo "$ISSUE_JSON" | jq -r .title)
+ISSUE_URL=$(echo "$ISSUE_JSON" | jq -r .url)
+ISSUE_BODY=$(echo "$ISSUE_JSON" | jq -r .body)
+ISSUE_AUTHOR=$(echo "$ISSUE_JSON" | jq -r .author.login)
+
+# --- 4. Set up worktree ---
+if [ -d "$WT_DIR" ]; then
+  git worktree remove --force "$WT_DIR" 2>&1 || rm -rf "$WT_DIR"
+fi
+mkdir -p "$WT_BASE"
+
+if git show-ref --verify --quiet "refs/remotes/origin/${BRANCH}"; then
+  echo "continuing branch $BRANCH"
+  git worktree add -B "$BRANCH" "$WT_DIR" "origin/${BRANCH}"
+else
+  echo "creating new branch $BRANCH from origin/main"
+  git worktree add -b "$BRANCH" "$WT_DIR" origin/main
+fi
+
+cd "$WT_DIR"
+git config user.name "Claude Bot"
+git config user.email "${BOT_GIT_EMAIL:-claude-bot@example.com}"
+
+# --- 5. Build prompt ---
+PROMPT_FILE=$(mktemp)
+{
+  echo "You are working on GitHub issue #${ISSUE_NUMBER} in repo ${REPO}."
+  echo "URL: ${ISSUE_URL}"
+  echo "Title: ${ISSUE_TITLE}"
+  echo "Author: ${ISSUE_AUTHOR}"
+  echo
+  echo "## Issue body"
+  echo "$ISSUE_BODY"
+  echo
+  echo "## Comments (oldest to newest)"
+  echo "$ISSUE_JSON" | jq -r '.comments[] | "### @\(.author.login) at \(.createdAt)\n\(.body)\n"'
+  echo
+  echo "## Your task"
+  echo "0. TRIAGE FIRST (required, before any code changes). Verify the report is actually a problem:"
+  echo "   - Does the feature/path the user mentions actually exist in the codebase?"
+  echo "   - Is the behavior the user calls a 'bug' actually intentional / working as designed?"
+  echo "   - Could the user have missed where the feature lives (wrong screen, wrong menu, different role)?"
+  echo "   - Is there a quick way to verify the user's claim (read the relevant component, check the route, check the schema)?"
+  echo "   If after this check you conclude the report is NOT a real bug:"
+  echo "   - Do NOT commit anything"
+  echo "   - Start your response with the literal marker: NOT_A_BUG:"
+  echo "   - Follow with: a friendly explanation of what the actual state is, exact file:line references where the feature lives, and how the user can use it"
+  echo "   - Example: 'NOT_A_BUG: the export button is in the kebab menu in the top-right of /dashboard/contacts. See src/components/crm/contacts-table.tsx:142. It triggers a CSV download.'"
+  echo "1. Read the issue carefully and understand what is being asked."
+  echo "2. Investigate the codebase as needed (you are in a fresh worktree of branch ${BRANCH} from main)."
+  echo "3. If the issue is a bug or small feature request you can solve cleanly:"
+  echo "   - Make the necessary code changes"
+  echo "   - Verify by running typecheck/tests where reasonable"
+  echo "   - COMMIT your changes with a clear message referencing #${ISSUE_NUMBER}"
+  echo "4. SCOPE CHECK — if the task looks LARGE (>5 files, major refactor, new architecture, or you would need >50 tool calls just to investigate):"
+  echo "   - Do NOT try to implement end-to-end"
+  echo "   - End your response with: your understanding of the task, suggested approach, list of files you would change, and any clarifying questions"
+  echo "   - Do NOT commit anything in this case"
+  echo "5. If you need clarification or more information:"
+  echo "   - Do NOT commit anything"
+  echo "   - End your response with a clear, specific question for the issue author"
+  echo "6. If the issue is unclear, out of scope, or you cannot solve it:"
+  echo "   - Do NOT commit anything"
+  echo "   - Explain what is blocking you"
+  echo
+  echo "## Follow-ups (IMPORTANT)"
+  echo "If during your investigation or fix you discover OTHER bugs, anti-patterns, or technical debt that"
+  echo "are out of scope for THIS issue but should be tracked separately, list them at the end of your final"
+  echo "response under a heading exactly named '## Follow-ups'. One bullet per item."
+  echo "Each bullet: short imperative title, then a colon, then a brief description (one line)."
+  echo "Example:"
+  echo "## Follow-ups"
+  echo "- Replace dynamic imports with static in convex/organizations.ts: same V8 anti-pattern as #${ISSUE_NUMBER}, will fail in production"
+  echo "- Add typecheck for X: missing in CI"
+  echo "Each line will become its own GitHub issue with auto-followup label. Be specific. Do NOT list trivial style nits."
+  echo "If there are no follow-ups, OMIT the section entirely (do not write '## Follow-ups' with empty body)."
+  echo
+  echo "Be concise. Do not run long-running dev servers. Do not delete files outside this worktree."
+} > "$PROMPT_FILE"
+
+echo "--- PROMPT START ---"
+cat "$PROMPT_FILE"
+echo "--- PROMPT END ---"
+
+# --- 6. Run Claude with retry ---
+CLAUDE_OUT=$(mktemp)
+CLAUDE_EXIT=99
+CLAUDE_MSG=""
+LAST_ERROR_KIND=""
+ATTEMPT=0
+while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+  ATTEMPT=$((ATTEMPT+1))
+  echo "--- ATTEMPT $ATTEMPT/$MAX_ATTEMPTS (max_turns=$MAX_TURNS, timeout=${PER_ATTEMPT_TIMEOUT}s) ---"
+  HOME=/home/claude-bot timeout "$PER_ATTEMPT_TIMEOUT" claude \
+    --permission-mode bypassPermissions \
+    --max-turns "$MAX_TURNS" \
+    -p "$(cat $PROMPT_FILE)" \
+    > "$CLAUDE_OUT" 2>&1
+  CLAUDE_EXIT=$?
+  CLAUDE_MSG=$(cat "$CLAUDE_OUT")
+  echo "--- CLAUDE EXIT=$CLAUDE_EXIT (attempt $ATTEMPT) ---"
+  echo "${CLAUDE_MSG:0:500}"
+  echo "--- ---"
+
+  if [ "$CLAUDE_EXIT" -eq 0 ]; then
+    echo "claude exited cleanly on attempt $ATTEMPT"
+    break
+  fi
+
+  if echo "$CLAUDE_MSG" | grep -q "Reached max turns"; then
+    LAST_ERROR_KIND="max-turns"
+  elif [ "$CLAUDE_EXIT" -eq 124 ]; then
+    LAST_ERROR_KIND="wallclock-timeout"
+  else
+    LAST_ERROR_KIND="exit-${CLAUDE_EXIT}"
+  fi
+  echo "claude failed on attempt $ATTEMPT: $LAST_ERROR_KIND"
+
+  if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+    echo "retrying in 5s..."
+    sleep 5
+  fi
+done
+
+# --- 7. Decide outcome ---
+COMMITS_AHEAD=$(git rev-list --count "origin/main..HEAD" 2>/dev/null || echo 0)
+echo "commits ahead of origin/main: $COMMITS_AHEAD (final exit=$CLAUDE_EXIT, kind=$LAST_ERROR_KIND)"
+
+COMMENT_FILE=$(mktemp)
+FINAL_LABEL=""
+
+if [ "$COMMITS_AHEAD" -gt 0 ]; then
+  echo "pushing branch $BRANCH"
+  git push --set-upstream origin "$BRANCH" 2>&1 | tail -3
+
+  PR_NUM=$(gh pr list --repo "$REPO" --head "$BRANCH" --json number --jq ".[0].number" 2>/dev/null)
+  if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "null" ]; then
+    PR_BODY="Auto-generated by Claude in response to issue #${ISSUE_NUMBER}.
+
+Closes #${ISSUE_NUMBER}
+
+---
+
+## Claude summary
+
+${CLAUDE_MSG}"
+    PR_NUM=$(gh pr create --repo "$REPO" --base main --head "$BRANCH" --title "$ISSUE_TITLE" --body "$PR_BODY" 2>&1 | tail -1 | grep -oE "[0-9]+$")
+    echo "created PR #$PR_NUM"
+  else
+    echo "PR #$PR_NUM exists, will retry merge"
+  fi
+
+  # SAFETY: only auto-merge claude/issue-* branches (extra guard beyond the loop's own scoping)
+  if [[ ! "$BRANCH" =~ ^claude/issue-[0-9]+$ ]]; then
+    echo "REFUSE auto-merge: branch '$BRANCH' does not match claude/issue-N pattern"
+    {
+      echo "🤖 Pushed ${COMMITS_AHEAD} commit(s) to **PR #${PR_NUM}** but auto-merge was REFUSED — branch name doesn't match required pattern."
+    } > "$COMMENT_FILE"
+    FINAL_LABEL="claude:conflict"
+  else
+  # Auto-merge unless safety valve label is on the issue
+  ISSUE_LABELS=$(echo "$ISSUE_JSON" | jq -r ".labels[].name" 2>/dev/null)
+  if echo "$ISSUE_LABELS" | grep -q "^claude:no-auto-merge$"; then
+    echo "claude:no-auto-merge present — skipping auto-merge"
+    {
+      echo "🤖 Pushed ${COMMITS_AHEAD} commit(s) to \`${BRANCH}\` and opened **PR #${PR_NUM}**."
+      echo
+      echo "_Auto-merge skipped (\`claude:no-auto-merge\` label is set). Please review and merge manually._"
+      echo
+      echo "---"
+      echo
+      echo "${CLAUDE_MSG}"
+    } > "$COMMENT_FILE"
+    FINAL_LABEL="claude:done"
+  else
+    echo "auto-merging PR #$PR_NUM (squash)"
+    MERGE_OUT=$(gh pr merge "$PR_NUM" --repo "$REPO" --squash --delete-branch --admin 2>&1)
+    MERGE_EXIT=$?
+    echo "merge output: $MERGE_OUT"
+    echo "merge exit: $MERGE_EXIT"
+    if [ "$MERGE_EXIT" -eq 0 ]; then
+      # Confirm actually merged (could be queued via --auto if checks pending)
+      sleep 2
+      PR_STATE=$(gh pr view "$PR_NUM" --repo "$REPO" --json state --jq ".state" 2>/dev/null)
+      if [ "$PR_STATE" = "MERGED" ]; then
+        {
+          echo "🤖 Implemented in **PR #${PR_NUM}** (squash-merged to \`main\`, branch deleted). ✅"
+          echo
+          echo "---"
+          echo
+          echo "${CLAUDE_MSG}"
+        } > "$COMMENT_FILE"
+        FINAL_LABEL="claude:done"
+      else
+        {
+          echo "🤖 **PR #${PR_NUM}** queued for auto-merge (will merge when checks pass)."
+          echo
+          echo "---"
+          echo
+          echo "${CLAUDE_MSG}"
+        } > "$COMMENT_FILE"
+        FINAL_LABEL="claude:done"
+      fi
+    else
+      {
+        echo "🤖 Pushed ${COMMITS_AHEAD} commit(s) to **PR #${PR_NUM}** but **auto-merge failed**."
+        echo
+        echo "Likely cause: merge conflict, failing required check, or branch protection rule."
+        echo
+        echo "<details><summary>gh output</summary>"
+        echo
+        echo "\`\`\`"
+        echo "${MERGE_OUT}" | tail -10
+        echo "\`\`\`"
+        echo
+        echo "</details>"
+        echo
+        echo "Please review the PR and merge manually."
+        echo
+        echo "---"
+        echo
+        echo "${CLAUDE_MSG}"
+      } > "$COMMENT_FILE"
+      FINAL_LABEL="claude:conflict"
+    fi
+  fi
+  fi
+
+elif [ "$CLAUDE_EXIT" -eq 0 ]; then
+  # Clean exit with no commits. Three sub-cases, checked in this order:
+  #   (a) TRIAGE result: NOT a bug (feature exists / working as designed)
+  #   (b) Already done on main (resolved in another PR or delegated)
+  #   (c) Genuine needs-info — Claude has a question for the author
+  if echo "$CLAUDE_MSG" | grep -qiE "$NOT_A_BUG_PATTERN"; then
+    echo "no commits — triage says NOT A BUG, auto-closing"
+    {
+      echo "🤖 ${CLAUDE_MSG}"
+      echo
+      echo "---"
+      echo "_Auto-closed by worker: triage determined this is not a bug (feature exists, working as designed, or user mistake). If you disagree, reopen and comment \`@claude\` with more context — e.g. screenshots, exact steps to reproduce, or the version you're testing._"
+    } > "$COMMENT_FILE"
+    FINAL_LABEL="claude:not-a-bug"
+    AUTO_CLOSE=1
+  elif echo "$CLAUDE_MSG" | grep -qiE "$RESOLVED_PATTERN"; then
+    echo "no commits — worker confirms already resolved on main, auto-closing"
+    {
+      echo "🤖 ${CLAUDE_MSG}"
+      echo
+      echo "---"
+      echo "_Auto-closed by worker: no code change was required (issue already resolved on \`main\` or fully delegated to follow-up issues). Reopen if this was a mistake._"
+    } > "$COMMENT_FILE"
+    FINAL_LABEL="claude:auto-resolved"
+    AUTO_CLOSE=1
+  else
+    echo "no commits, clean exit — genuine needs-info"
+    {
+      echo "🤖 ${CLAUDE_MSG}"
+      echo
+      echo "---"
+      echo "_Reply with \`@claude\` and any additional info to continue._"
+    } > "$COMMENT_FILE"
+    FINAL_LABEL="claude:needs-info"
+  fi
+
+else
+  echo "all $MAX_ATTEMPTS attempts failed (last: $LAST_ERROR_KIND)"
+  case "$LAST_ERROR_KIND" in
+    max-turns)
+      MSG="I tried ${MAX_ATTEMPTS} times but ran out of my turn budget on each attempt. The task is bigger than I can handle in one go."
+      ;;
+    wallclock-timeout)
+      MSG="I tried ${MAX_ATTEMPTS} times but each run exceeded the time limit. The task may require investigation that's too broad."
+      ;;
+    *)
+      MSG="I tried ${MAX_ATTEMPTS} times but failed each attempt (${LAST_ERROR_KIND}). This may be a transient issue with my tooling — try again later, or check the worker logs."
+      ;;
+  esac
+  {
+    echo "🤖 ${MSG}"
+    echo
+    echo "**To unblock me, please:**"
+    echo "- Break this issue into smaller, focused sub-issues, OR"
+    echo "- Point me to the specific files/components I should change, OR"
+    echo "- Share what you have already tried or considered"
+    echo
+    echo "Then mention \`@claude\` again."
+    echo
+    echo "<sub>Worker job #${JOB_ID} on \`${BRANCH}\` — last error: \`${LAST_ERROR_KIND}\`</sub>"
+  } > "$COMMENT_FILE"
+  FINAL_LABEL="claude:failed"
+fi
+
+# --- 8. Post comment + set final label (+ auto-close if applicable) ---
+post_comment "$COMMENT_FILE"
+set_label "$FINAL_LABEL"
+
+if [ "$AUTO_CLOSE" = "1" ]; then
+  echo "auto-closing issue #${ISSUE_NUMBER}"
+  gh issue close "$ISSUE_NUMBER" --repo "$REPO" --reason "completed" 2>&1 | tail -1
+fi
+
+# --- 9. Auto-tune on systemic failure ---
+if [ "$FINAL_LABEL" = "claude:failed" ] && [ -n "$LAST_ERROR_KIND" ]; then
+  echo "--- AUTO-TUNE check (kind=$LAST_ERROR_KIND) ---"
+  node /home/claude-bot/worker/tune.mjs "$LAST_ERROR_KIND" 2>&1 | tail -5
+fi
+
+# --- 10. Extract follow-ups from Claude's output, create separate issues ---
+echo "--- FOLLOW-UPS extraction ---"
+FOLLOWUPS=$(echo "$CLAUDE_MSG" | node /home/claude-bot/worker/extract-followups.mjs 2>/dev/null || true)
+if [ -n "$FOLLOWUPS" ]; then
+  echo "found $(echo "$FOLLOWUPS" | wc -l) follow-up(s)"
+  CREATED_LIST=""
+  while IFS= read -r item; do
+    [ -z "$item" ] && continue
+    # Title: up to 80 chars, prefer up to first colon
+    if [[ "$item" == *:* ]]; then
+      TITLE="${item%%:*}"
+    else
+      TITLE="$item"
+    fi
+    TITLE="${TITLE:0:80}"
+    BODY="Auto-discovered by Claude during work on issue #${ISSUE_NUMBER}.
+
+> ${item}
+
+---
+
+Original issue: #${ISSUE_NUMBER}
+Originating job: \`worker job #${JOB_ID}\` on branch \`${BRANCH}\`
+
+This issue was opened automatically. Add \`@claude\` in a comment to attempt a fix, or close if it's a duplicate / not actionable."
+    NEW_URL=$(gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY" --label "auto-followup" 2>&1 | tail -1)
+    if echo "$NEW_URL" | grep -qE "^https://github.com/.*/issues/[0-9]+$"; then
+      NEW_NUM=$(basename "$NEW_URL")
+      echo "  created #$NEW_NUM: $TITLE"
+      CREATED_LIST="${CREATED_LIST}- #${NEW_NUM} — ${TITLE}\n"
+    else
+      echo "  FAILED to create issue for: $TITLE — output: $NEW_URL"
+    fi
+  done <<< "$FOLLOWUPS"
+
+  # Comment on the original issue with the list of created follow-ups
+  if [ -n "$CREATED_LIST" ]; then
+    FOLLOWUP_COMMENT=$(mktemp)
+    {
+      echo "🤖 Opened follow-up issue(s) for out-of-scope findings discovered while working on this:"
+      echo
+      printf "%b" "$CREATED_LIST"
+    } > "$FOLLOWUP_COMMENT"
+    gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file "$FOLLOWUP_COMMENT" 2>&1 | tail -1
+    rm -f "$FOLLOWUP_COMMENT"
+  fi
+else
+  echo "no follow-ups detected"
+fi
+
+# --- 11. Cleanup ---
+rm -f "$PROMPT_FILE" "$CLAUDE_OUT" "$COMMENT_FILE"
+cleanup_worktree
+
+echo "=== JOB $JOB_ID DONE label=$FINAL_LABEL exit=0 ==="
+exit 0

--- a/automation/worker/tune.mjs
+++ b/automation/worker/tune.mjs
@@ -1,0 +1,99 @@
+// tune.mjs — auto-tune worker config when same failure kind repeats
+// Usage: node tune.mjs <current_error_kind>
+// Reads /home/claude-bot/worker/tuning.json, queries last (N-1) failed jobs,
+// if all match current kind → bump corresponding tunable.
+import Database from "better-sqlite3";
+import fs from "node:fs";
+
+const TUNING_PATH = "/home/claude-bot/worker/tuning.json";
+const DB_PATH = "/home/claude-bot/worker/queue.db";
+const LOG_PATH = "/home/claude-bot/logs/tune.log";
+
+const currentKind = (process.argv[2] || "").trim();
+if (!currentKind || currentKind === "ok") process.exit(0);
+
+function jlog(obj) {
+  const line = JSON.stringify({ ts: new Date().toISOString(), ...obj }) + "\n";
+  fs.appendFileSync(LOG_PATH, line);
+}
+
+function detectKind(resultStr) {
+  if (!resultStr) return "unknown";
+  try {
+    const r = JSON.parse(resultStr);
+    const blob = (r.stdout || "") + "\n" + (r.stderr || "");
+    if (/Reached max turns/i.test(blob)) return "max-turns";
+    if (r.exit === 124) return "wallclock-timeout";
+    if (r.exit !== 0) return `exit-${r.exit}`;
+    return "ok";
+  } catch {
+    return "unknown";
+  }
+}
+
+const tuning = JSON.parse(fs.readFileSync(TUNING_PATH, "utf8"));
+const cfg = tuning.auto_tune;
+const N = cfg.consecutive_fails_to_bump;
+
+const db = new Database(DB_PATH, { readonly: true });
+const prior = db.prepare(
+  "SELECT id, issue_number, status, result FROM jobs WHERE status IN ('failed','done') ORDER BY id DESC LIMIT ?"
+).all(N - 1);
+
+if (prior.length < N - 1) {
+  jlog({ msg: "not-enough-history", have: prior.length, need: N - 1 });
+  process.exit(0);
+}
+
+// Combine current (just failed, not yet in DB) + prior
+const window = [{ id: "current", kind: currentKind }, ...prior.map((j) => ({ id: j.id, kind: detectKind(j.result) }))];
+jlog({ msg: "window", entries: window });
+
+const allSame = window.every((w) => w.kind === currentKind);
+if (!allSame) {
+  jlog({ msg: "no-pattern", current: currentKind });
+  process.exit(0);
+}
+
+let bumped = false;
+let detail = { kind: currentKind };
+
+if (currentKind === "max-turns") {
+  const cur = tuning.max_turns;
+  const next = Math.min(cur + cfg.max_turns_step, cfg.max_turns_cap);
+  if (next > cur) {
+    tuning.max_turns = next;
+    bumped = true;
+    detail = { ...detail, field: "max_turns", from: cur, to: next };
+  } else {
+    detail = { ...detail, field: "max_turns", at_cap: cur };
+  }
+} else if (currentKind === "wallclock-timeout") {
+  const cur = tuning.per_attempt_timeout;
+  const next = Math.min(cur + cfg.per_attempt_timeout_step, cfg.per_attempt_timeout_cap);
+  if (next > cur) {
+    tuning.per_attempt_timeout = next;
+    bumped = true;
+    detail = { ...detail, field: "per_attempt_timeout", from: cur, to: next };
+  } else {
+    detail = { ...detail, field: "per_attempt_timeout", at_cap: cur };
+  }
+} else {
+  jlog({ msg: "no-tunable", kind: currentKind });
+  process.exit(0);
+}
+
+if (bumped) {
+  tuning.history = tuning.history || [];
+  tuning.history.push({
+    ts: new Date().toISOString(),
+    triggered_by: window.map((w) => w.id),
+    ...detail,
+  });
+  // Cap history length
+  if (tuning.history.length > 50) tuning.history = tuning.history.slice(-50);
+  fs.writeFileSync(TUNING_PATH, JSON.stringify(tuning, null, 2));
+  jlog({ msg: "BUMPED", ...detail });
+} else {
+  jlog({ msg: "AT-CAP", ...detail });
+}

--- a/automation/worker/tuning.json
+++ b/automation/worker/tuning.json
@@ -1,0 +1,13 @@
+{
+  "max_turns": 100,
+  "per_attempt_timeout": 1200,
+  "max_attempts": 2,
+  "auto_tune": {
+    "consecutive_fails_to_bump": 3,
+    "max_turns_step": 50,
+    "max_turns_cap": 300,
+    "per_attempt_timeout_step": 600,
+    "per_attempt_timeout_cap": 3000
+  },
+  "history": []
+}

--- a/automation/worker/webhook.mjs
+++ b/automation/worker/webhook.mjs
@@ -1,0 +1,145 @@
+// GitHub webhook listener for Claude Code worker
+// Listens on 127.0.0.1:9090, verifies HMAC, enqueues triggers
+// Triggers: @claude mention in issue body / comment, OR label "claude:retry" added
+import express from "express";
+import crypto from "node:crypto";
+import Database from "better-sqlite3";
+import fs from "node:fs";
+import path from "node:path";
+
+const PORT = parseInt(process.env.PORT || "9090", 10);
+const HOST = process.env.HOST || "127.0.0.1";
+const SECRET = process.env.WEBHOOK_SECRET;
+const BOT_GH_LOGIN = process.env.BOT_GH_LOGIN;
+const RETRY_LABEL = "claude:retry";
+const DB_PATH = process.env.DB_PATH || "/home/claude-bot/worker/queue.db";
+const LOG_DIR = "/home/claude-bot/logs";
+fs.mkdirSync(LOG_DIR, { recursive: true });
+
+if (!SECRET) {
+  console.error("FATAL: WEBHOOK_SECRET not set");
+  process.exit(1);
+}
+if (!BOT_GH_LOGIN) {
+  console.error("FATAL: BOT_GH_LOGIN not set — webhook would loop on bot's own events");
+  process.exit(1);
+}
+
+const db = new Database(DB_PATH);
+db.pragma("journal_mode = WAL");
+db.exec(`
+  CREATE TABLE IF NOT EXISTS jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    issue_number INTEGER NOT NULL,
+    repo TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    trigger_login TEXT,
+    trigger_comment_id INTEGER,
+    payload_json TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at INTEGER NOT NULL,
+    started_at INTEGER,
+    finished_at INTEGER,
+    result TEXT
+  );
+  CREATE INDEX IF NOT EXISTS idx_status_created ON jobs(status, created_at);
+`);
+const insertJob = db.prepare(`
+  INSERT INTO jobs (issue_number, repo, event_type, trigger_login, trigger_comment_id, payload_json, created_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+`);
+
+function verifySig(rawBody, header) {
+  if (!header || !header.startsWith("sha256=")) return false;
+  if (!rawBody || rawBody.length === 0) return false;
+  const sig = header.slice(7);
+  const mac = crypto.createHmac("sha256", SECRET).update(rawBody).digest("hex");
+  try {
+    return crypto.timingSafeEqual(Buffer.from(sig, "hex"), Buffer.from(mac, "hex"));
+  } catch {
+    return false;
+  }
+}
+
+function logEvent(obj) {
+  const line = JSON.stringify({ ts: new Date().toISOString(), ...obj }) + "\n";
+  fs.appendFileSync(path.join(LOG_DIR, "webhook.log"), line);
+}
+
+const app = express();
+app.use(express.json({
+  limit: "5mb",
+  verify: (req, _res, buf) => { req.rawBody = buf; },
+}));
+
+app.get("/health", (_req, res) => res.json({ ok: true }));
+
+app.post("/github", (req, res) => {
+  const sig = req.get("x-hub-signature-256");
+  if (!verifySig(req.rawBody, sig)) {
+    logEvent({ level: "warn", msg: "bad signature", ip: req.ip });
+    return res.status(401).send("invalid signature");
+  }
+  const event = req.get("x-github-event");
+  const payload = req.body;
+
+  let issue, comment, action, isLabelTrigger = false;
+  if (event === "issue_comment" && payload.action === "created") {
+    issue = payload.issue;
+    comment = payload.comment;
+    action = "comment";
+  } else if (event === "issues" && payload.action === "labeled" && payload.label?.name === RETRY_LABEL) {
+    issue = payload.issue;
+    action = "issue.retry-label";
+    isLabelTrigger = true;
+  } else if (event === "issues" && (payload.action === "opened" || payload.action === "edited" || payload.action === "reopened")) {
+    issue = payload.issue;
+    action = `issue.${payload.action}`;
+  } else {
+    return res.status(200).send("ignored event");
+  }
+
+  if (!issue || issue.pull_request) {
+    return res.status(200).send("ignored (PR or no issue)");
+  }
+
+  const triggerBody = comment ? comment.body : issue.body;
+  const triggerLogin = isLabelTrigger
+    ? payload.sender?.login
+    : (comment ? comment.user.login : issue.user.login);
+
+  // Skip our own bot comments (but never skip the bot adding labels — labels can't loop)
+  if (!isLabelTrigger && triggerLogin === BOT_GH_LOGIN && comment) {
+    logEvent({ level: "info", msg: "skip own comment", issue: issue.number });
+    return res.status(200).send("skip own");
+  }
+
+  // For non-label triggers, require @claude mention
+  if (!isLabelTrigger && (!triggerBody || !/@claude\b/i.test(triggerBody))) {
+    return res.status(200).send("no @claude mention");
+  }
+
+  const repo = payload.repository.full_name;
+  const info = insertJob.run(
+    issue.number,
+    repo,
+    `${event}.${payload.action}`,
+    triggerLogin,
+    comment ? comment.id : null,
+    JSON.stringify({
+      title: issue.title,
+      issue_url: issue.html_url,
+      body: issue.body,
+      comment_body: comment ? comment.body : null,
+      label_trigger: isLabelTrigger ? RETRY_LABEL : null,
+    }),
+    Date.now(),
+  );
+
+  logEvent({ level: "info", msg: "queued", id: info.lastInsertRowid, issue: issue.number, repo, action, by: triggerLogin });
+  res.status(200).json({ queued: info.lastInsertRowid, issue: issue.number });
+});
+
+app.listen(PORT, HOST, () => {
+  console.log(`webhook listening on ${HOST}:${PORT}`);
+});

--- a/automation/worker/worker.mjs
+++ b/automation/worker/worker.mjs
@@ -1,0 +1,95 @@
+// Worker daemon — polls SQLite queue, runs run-claude.sh for each job
+import Database from "better-sqlite3";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const DB_PATH = process.env.DB_PATH || "/home/claude-bot/worker/queue.db";
+const RUN_SCRIPT = "/home/claude-bot/worker/run-claude.sh";
+const LOG_DIR = "/home/claude-bot/logs";
+const POLL_INTERVAL_MS = 3000;
+const JOB_TIMEOUT_MS = 60 * 60 * 1000; // 30 min hard cap
+
+fs.mkdirSync(LOG_DIR, { recursive: true });
+
+const db = new Database(DB_PATH);
+db.pragma("journal_mode = WAL");
+
+const claimNext = db.transaction(() => {
+  const job = db.prepare(
+    `SELECT * FROM jobs WHERE status = 'pending' ORDER BY created_at ASC LIMIT 1`
+  ).get();
+  if (!job) return null;
+  db.prepare(
+    `UPDATE jobs SET status = 'running', started_at = ? WHERE id = ?`
+  ).run(Date.now(), job.id);
+  return job;
+});
+
+function finalizeJob(id, status, result) {
+  db.prepare(
+    `UPDATE jobs SET status = ?, finished_at = ?, result = ? WHERE id = ?`
+  ).run(status, Date.now(), result, id);
+}
+
+function jlog(obj) {
+  const line = JSON.stringify({ ts: new Date().toISOString(), ...obj }) + "\n";
+  fs.appendFileSync(path.join(LOG_DIR, "worker.log"), line);
+  console.log(line.trim());
+}
+
+async function runJob(job) {
+  jlog({ level: "info", msg: "start", id: job.id, issue: job.issue_number, repo: job.repo });
+  const env = {
+    ...process.env,
+    JOB_ID: String(job.id),
+    ISSUE_NUMBER: String(job.issue_number),
+    REPO: job.repo,
+    EVENT_TYPE: job.event_type,
+    TRIGGER_LOGIN: job.trigger_login || "",
+    PAYLOAD_JSON: job.payload_json,
+  };
+  return await new Promise((resolve) => {
+    const child = spawn("/bin/bash", [RUN_SCRIPT], {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "", stderr = "";
+    child.stdout.on("data", (d) => { stdout += d.toString(); });
+    child.stderr.on("data", (d) => { stderr += d.toString(); });
+    const timer = setTimeout(() => {
+      jlog({ level: "warn", msg: "timeout-killing", id: job.id });
+      child.kill("SIGKILL");
+    }, JOB_TIMEOUT_MS);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      const result = JSON.stringify({ exit: code, stdout: stdout.slice(-4000), stderr: stderr.slice(-4000) });
+      finalizeJob(job.id, code === 0 ? "done" : "failed", result);
+      jlog({ level: code === 0 ? "info" : "error", msg: "finish", id: job.id, exit: code });
+      resolve();
+    });
+  });
+}
+
+let stopping = false;
+process.on("SIGTERM", () => { stopping = true; });
+process.on("SIGINT", () => { stopping = true; });
+
+async function loop() {
+  while (!stopping) {
+    const job = claimNext();
+    if (!job) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      continue;
+    }
+    try {
+      await runJob(job);
+    } catch (e) {
+      finalizeJob(job.id, "failed", JSON.stringify({ error: String(e) }));
+      jlog({ level: "error", msg: "exception", id: job.id, err: String(e) });
+    }
+  }
+  jlog({ level: "info", msg: "shutdown" });
+}
+
+loop();


### PR DESCRIPTION
Captures the issue-handling worker (webhook listener + queue daemon + run-claude.sh) that's been running on Hetzner since ~2026-04, in a form that can be lifted to another project with `bash automation/install.sh`.

## What's exported (`automation/`)
- **worker/** — exact `.mjs`/`.sh` files from prod, with project-specific strings (`helloalex.pl`, `quera`, bot login) replaced by env-var placeholders. `BOT_GH_LOGIN` now hard-required so a missing value fails fast instead of looping on bot's own comments.
- **systemd/** — both unit files.
- **nginx/** — reverse-proxy location snippet (works with nginx-rc and vanilla nginx).
- **bin/claude-health** — one-shot health probe.
- **install.sh** — root-mode installer (creates `claude-bot` user, installs units, drops nginx snippet, prompts for env values).
- **docs/PROMPTS.md** — what `run-claude.sh` briefs Claude with (triage-first, then fix).
- **docs/KNOWN-FAILURE-MODES.md** — 8 gotchas including the stale-branch-wipes-dev-Convex bug (#1237/#1118/#1238) and the auto-triage hallucination pattern (#1249).
- **README.md** — architecture diagram + label taxonomy + operating notes.

## Not included
- No secrets / credentials / API keys.
- No `.env` — only `.env.example`.
- `run-claude.sh` and `webhook.mjs` reference env vars the host must supply at install time.