### PR TITLE
fix(ci): re-sync convex/_generated/api.d.ts with backfillCreditEarned

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -127,6 +127,7 @@ import type * as mail_emailShell from "../mail/emailShell.js";
 import type * as mail_testConnectionNode from "../mail/testConnectionNode.js";
 import type * as mailProviders from "../mailProviders.js";
 import type * as microsoft_oauth from "../microsoft/oauth.js";
+import type * as migrations_backfillCreditEarned from "../migrations/backfillCreditEarned.js";
 import type * as migrations_backfillMailProviders from "../migrations/backfillMailProviders.js";
 import type * as migrations_backfillTreatmentCategories from "../migrations/backfillTreatmentCategories.js";
 import type * as migrations_emailTemplateMigrations from "../migrations/emailTemplateMigrations.js";
@@ -309,6 +310,7 @@ declare const fullApi: ApiFromModules<{
   "mail/testConnectionNode": typeof mail_testConnectionNode;
   mailProviders: typeof mailProviders;
   "microsoft/oauth": typeof microsoft_oauth;
+  "migrations/backfillCreditEarned": typeof migrations_backfillCreditEarned;
   "migrations/backfillMailProviders": typeof migrations_backfillMailProviders;
   "migrations/backfillTreatmentCategories": typeof migrations_backfillTreatmentCategories;
   "migrations/emailTemplateMigrations": typeof migrations_emailTemplateMigrations;


### PR DESCRIPTION
## Why
E2E workflow has been red on every push to main since **2026-06-03** (15 failures in a row). Root cause was sneaky: it's not a real Playwright failure — the pre-flight `check:convex-codegen` step in the E2E workflow exits with code 1 before any tests run, masquerading as an E2E failure in the GitHub Actions UI.

The actual error:
```
convex/_generated/api.d.ts is out of sync with convex/.

Missing from api.d.ts (file exists under convex/, no import):
  - migrations/backfillCreditEarned

Fix: run `npx convex dev` (or `npx convex codegen`) locally to regenerate
```

`convex/migrations/backfillCreditEarned.ts` was added in an earlier merge without the regenerated `api.d.ts`. Two lines missing.

## Fix
`npx convex codegen` — adds the import + module-map entry for the migration. Verified locally: `api.d.ts is in sync (175 modules)`.