### PR TITLE
Nazwa dodaj aktywność kalendarz

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -124,6 +124,7 @@
       "viewUnread": "Unread",
       "activate": "Activate/Deactivate",
       "bookAppointment": "Book Appointment",
+      "addAppointment": "Add Appointment",
       "addPatient": "Add Client",
       "printSchedule": "Print",
       "addTreatment": "Add Treatment",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -137,6 +137,7 @@
       "viewUnread": "Nieprzeczytane",
       "activate": "Aktywuj/Dezaktywuj",
       "bookAppointment": "Umów wizytę",
+      "addAppointment": "Dodaj wizytę",
       "addPatient": "Dodaj klienta",
       "printSchedule": "Drukuj",
       "addTreatment": "Dodaj zabieg",

--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -97,7 +97,7 @@ export const gabinetManifest: ModuleManifest = {
       matches: [{ to: "/dashboard/gabinet/calendar", fuzzy: true }],
       actions: [
         {
-          labelKey: "nav.actions.addActivity",
+          labelKey: "nav.actions.addAppointment",
           icon: CalendarCheck,
           quickCreate: "appointment",
           permissionFeature: "gabinet_appointments",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1430.

Closes #1430

---

## Claude summary

Renamed the gabinet calendar's sidebar "Akcje → Dodaj aktywność" action to "Dodaj wizytę" (and "Add Appointment" in EN). The CRM, which shares the `nav.actions.addActivity` key on its own pages, is unaffected because I added a new `nav.actions.addAppointment` key and only switched the gabinet calendar manifest to it (`src/modules/gabinet/manifest.ts:100`). Committed as `beb5fe0`.