### PR TITLE
Show a specific empty-slots reason in the appointment dialog

### DIFF
--- a/convex/gabinet/_availability_supabase.ts
+++ b/convex/gabinet/_availability_supabase.ts
@@ -27,6 +27,22 @@ export interface TimeSlot {
   end: string;
 }
 
+/**
+ * Why no slots were returned. The dialog renders a specific message per
+ * reason instead of a generic "no slots" so users know what to fix.
+ * Issue #1434.
+ */
+export type NoSlotsReason =
+  | "employee_not_working"
+  | "clinic_closed"
+  | "on_leave"
+  | "fully_booked";
+
+export interface AvailableSlotsResult {
+  slots: TimeSlot[];
+  reason?: NoSlotsReason;
+}
+
 async function resolveScheduleForDate(
   db: SupabaseDb,
   organizationId: string,
@@ -115,7 +131,7 @@ export async function getAvailableSlotsSupabase(
     nowDate?: string;
     nowTime?: string;
   },
-): Promise<TimeSlot[]> {
+): Promise<AvailableSlotsResult> {
   const dayOfWeek = new Date(args.date + "T00:00:00").getDay();
 
   const empSchedule = await resolveScheduleForDate(
@@ -132,7 +148,9 @@ export async function getAvailableSlotsSupabase(
   let breakEnd: string | undefined;
 
   if (empSchedule) {
-    if (!empSchedule.isWorking) return [];
+    if (!empSchedule.isWorking) {
+      return { slots: [], reason: "employee_not_working" };
+    }
     startTime = empSchedule.startTime;
     endTime = empSchedule.endTime;
     breakStart = empSchedule.breakStart;
@@ -158,7 +176,9 @@ export async function getAvailableSlotsSupabase(
         .collect();
       clinicHours = rows[0];
     }
-    if (!clinicHours || !clinicHours.isOpen) return [];
+    if (!clinicHours || !clinicHours.isOpen) {
+      return { slots: [], reason: "clinic_closed" };
+    }
     startTime = clinicHours.startTime;
     endTime = clinicHours.endTime;
     breakStart = clinicHours.breakStart;
@@ -178,7 +198,9 @@ export async function getAvailableSlotsSupabase(
       l.endDate >= args.date,
   );
 
-  if (activeLeaves.some((l) => !l.startTime)) return [];
+  if (activeLeaves.some((l) => !l.startTime)) {
+    return { slots: [], reason: "on_leave" };
+  }
 
   const appointments = await db
     .query("gabinetAppointments")
@@ -262,12 +284,16 @@ export async function getAvailableSlotsSupabase(
     slotStart += 15;
   }
 
+  let finalSlots = slots;
   if (args.nowDate && args.nowTime && args.nowDate === args.date) {
     const nowMinutes = timeToMinutes(args.nowTime);
-    return slots.filter((s) => timeToMinutes(s.start) > nowMinutes);
+    finalSlots = slots.filter((s) => timeToMinutes(s.start) > nowMinutes);
   }
 
-  return slots;
+  if (finalSlots.length === 0) {
+    return { slots: finalSlots, reason: "fully_booked" };
+  }
+  return { slots: finalSlots };
 }
 
 export async function checkConflictSupabase(

--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -413,7 +413,7 @@ export const bookFromPortal = action({
 
       let foundEmployee: string | null = null;
       for (const emp of qualifiedEmployees) {
-        const slots = await getAvailableSlotsSupabase(db, {
+        const { slots } = await getAvailableSlotsSupabase(db, {
           organizationId: String(organizationId),
           userId: String(emp.userId),
           date: args.preferredDate,

--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -662,7 +662,7 @@ export const findNextAvailableSlot = action({
       checkDate.setDate(startDate.getDate() + dayOffset);
       const dateStr = toDateStr(checkDate);
 
-      const slots = await getAvailableSlotsSupabase(db, {
+      const { slots } = await getAvailableSlotsSupabase(db, {
         organizationId: String(args.organizationId),
         userId: args.employeeId,
         date: dateStr,

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2691,6 +2691,12 @@
       "pickDate": "Pick a date",
       "loadingSlots": "Checking availability...",
       "noSlots": "No available slots on this day",
+      "noSlotsReason": {
+        "employee_not_working": "This employee is not working on this day. Pick another date or employee.",
+        "clinic_closed": "The clinic is closed on this day. Pick another date.",
+        "on_leave": "This employee is on leave on this day. Pick another date or employee.",
+        "fully_booked": "This day is fully booked. Pick another day or employee."
+      },
       "selectedTime": "Selected time",
       "create": "Create appointment",
       "frequencies": {
@@ -2753,6 +2759,12 @@
         "selectTreatmentAndEmployee": "Select a treatment and employee to see available slots",
         "selectDateForSlots": "Pick a date on the calendar to see available time slots",
         "noSlotsForDay": "No available slots on this day",
+        "noSlotsReason": {
+          "employee_not_working": "This employee is not working on this day. Pick another date or employee.",
+          "clinic_closed": "The clinic is closed on this day. Pick another date.",
+          "on_leave": "This employee is on leave on this day. Pick another date or employee.",
+          "fully_booked": "All slots for this employee are taken on this day. Pick another day or employee."
+        },
         "confirmBooking": "Book appointment",
         "time": "Time"
       },
@@ -3501,6 +3513,12 @@
       "loading": "Loading...",
       "noTreatments": "No treatments available",
       "noSlots": "No available slots on this date",
+      "noSlotsReason": {
+        "employee_not_working": "The specialist is not working on this day. Pick another date.",
+        "clinic_closed": "The clinic is closed on this day. Pick another date.",
+        "on_leave": "The specialist is on leave on this day. Pick another date.",
+        "fully_booked": "All slots on this day are taken. Pick another day."
+      },
       "pendingNote": "Your booking requires confirmation from the clinic. You will be notified once approved.",
       "submit": "Book Appointment",
       "submitting": "Booking...",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2720,6 +2720,12 @@
       "pickDate": "Wybierz datę",
       "loadingSlots": "Sprawdzanie dostępności...",
       "noSlots": "Brak wolnych terminów w tym dniu",
+      "noSlotsReason": {
+        "employee_not_working": "Pracownik nie pracuje w tym dniu. Zmień datę lub wybierz innego pracownika.",
+        "clinic_closed": "Gabinet jest zamknięty w tym dniu. Wybierz inny dzień.",
+        "on_leave": "Pracownik jest na urlopie w tym dniu. Wybierz inną datę lub innego pracownika.",
+        "fully_booked": "Cały dzień jest zarezerwowany. Wybierz inny dzień lub innego pracownika."
+      },
       "selectedTime": "Wybrany termin",
       "create": "Utwórz wizytę",
       "frequencies": {
@@ -2782,6 +2788,12 @@
         "selectTreatmentAndEmployee": "Wybierz zabieg i pracownika, aby zobaczyć dostępne terminy",
         "selectDateForSlots": "Wybierz datę w kalendarzu, aby zobaczyć wolne godziny",
         "noSlotsForDay": "Brak dostępnych terminów w tym dniu",
+        "noSlotsReason": {
+          "employee_not_working": "Pracownik nie pracuje w tym dniu. Zmień datę lub wybierz innego pracownika.",
+          "clinic_closed": "Gabinet jest zamknięty w tym dniu. Wybierz inny dzień.",
+          "on_leave": "Pracownik jest na urlopie w tym dniu. Wybierz inną datę lub innego pracownika.",
+          "fully_booked": "Cały dzień jest zarezerwowany dla tego pracownika. Wybierz inny dzień lub innego pracownika."
+        },
         "confirmBooking": "Umów wizytę",
         "time": "Godzina"
       },
@@ -3530,6 +3542,12 @@
       "loading": "Ładowanie...",
       "noTreatments": "Brak dostępnych zabiegów",
       "noSlots": "Brak dostępnych terminów w tym dniu",
+      "noSlotsReason": {
+        "employee_not_working": "Specjalista nie pracuje w tym dniu. Wybierz inną datę.",
+        "clinic_closed": "Gabinet jest zamknięty w tym dniu. Wybierz inny dzień.",
+        "on_leave": "Specjalista jest na urlopie w tym dniu. Wybierz inną datę.",
+        "fully_booked": "Wszystkie terminy w tym dniu są zajęte. Wybierz inny dzień."
+      },
       "pendingNote": "Rezerwacja wymaga potwierdzenia przez recepcję. Otrzymasz powiadomienie po zatwierdzeniu.",
       "submit": "Zarezerwuj wizytę",
       "submitting": "Rezerwacja...",

--- a/src/components/gabinet/appointment-form.tsx
+++ b/src/components/gabinet/appointment-form.tsx
@@ -308,7 +308,7 @@ export function AppointmentForm({
 
   // Available slots — backend is now an action reading from Supabase
   const getAvailableSlots = useAction(api.gabinet.appointments.getAvailableSlotsQuery);
-  const { data: availableSlots, isLoading: slotsLoading } = useQuery({
+  const { data: slotsResult, isLoading: slotsLoading } = useQuery({
     queryKey: [
       "gabinet.availableSlots",
       organizationId,
@@ -331,6 +331,8 @@ export function AppointmentForm({
       }),
     enabled: !!employeeId && !!dateStr && !!selectedTreatment && !!organizationId,
   });
+  const availableSlots = slotsResult?.slots;
+  const noSlotsReason = slotsResult?.reason;
 
   const locale = i18n.resolvedLanguage === "pl" ? pl : undefined;
 
@@ -845,7 +847,11 @@ export function AppointmentForm({
             </div>
           ) : (
             <p className="text-muted-foreground py-3 text-center text-sm">
-              {t("gabinet.appointments.noSlots")}
+              {t(
+                noSlotsReason
+                  ? `gabinet.appointments.noSlotsReason.${noSlotsReason}`
+                  : "gabinet.appointments.noSlots",
+              )}
             </p>
           )}
           {selectedSlot && (

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -504,7 +504,7 @@ export function AppointmentDialog({
 
   // Available slots — action reading from Supabase
   const getAvailableSlots = useAction(api.gabinet.appointments.getAvailableSlotsQuery);
-  const { data: availableSlots, isLoading: slotsLoading } = useQuery({
+  const { data: slotsResult, isLoading: slotsLoading } = useQuery({
     queryKey: [
       "gabinet.availableSlots",
       organizationId,
@@ -528,6 +528,8 @@ export function AppointmentDialog({
       }),
     enabled: !!employeeId && !!dateStr && !!selectedTreatment,
   });
+  const availableSlots = slotsResult?.slots;
+  const noSlotsReason = slotsResult?.reason;
 
   // Rooms query — enabled only when a location is selected
   const getLocationAction = useAction(api.gabinet.locations.getLocation);
@@ -1712,7 +1714,9 @@ export function AppointmentDialog({
                       <div className="py-8 text-center">
                         <p className="text-sm text-muted-foreground">
                           {t(
-                            "gabinet.appointments.calendarDialog.noSlotsForDay",
+                            noSlotsReason
+                              ? `gabinet.appointments.calendarDialog.noSlotsReason.${noSlotsReason}`
+                              : "gabinet.appointments.calendarDialog.noSlotsForDay",
                           )}
                         </p>
                       </div>

--- a/src/components/gabinet/change-employee-modal.tsx
+++ b/src/components/gabinet/change-employee-modal.tsx
@@ -191,7 +191,7 @@ export function ChangeEmployeeModal({
   // Check if the current slot specifically is available for the selected employee
   const isSlotAvailable = useMemo(() => {
     if (!selectedId || !availabilityCheck) return false;
-    return availabilityCheck.some(
+    return availabilityCheck.slots.some(
       (slot: { start: string; end: string }) =>
         slot.start === startTime && slot.end === endTime,
     );

--- a/src/routes/_app/patient/_layout.book.tsx
+++ b/src/routes/_app/patient/_layout.book.tsx
@@ -92,7 +92,7 @@ function PatientBooking() {
   const nowDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
   const nowTime = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
   const getPublicSlots = useAction(api.gabinet.patientPortal.getPublicAvailableSlots);
-  const { data: slots } = useQuery({
+  const { data: slotsResult } = useQuery({
     queryKey: [
       "gabinet.publicAvailableSlots",
       tokenHash,
@@ -113,6 +113,8 @@ function PatientBooking() {
       }),
     enabled: slotsEnabled,
   });
+  const slots = slotsResult?.slots;
+  const noSlotsReason = slotsResult?.reason;
 
   const stepIndex = STEPS.indexOf(step);
 
@@ -416,7 +418,11 @@ function PatientBooking() {
             </div>
           ) : slots.length === 0 ? (
             <div className="py-8 text-center text-sm text-muted-foreground">
-              {t("patientPortal.booking.noSlots")}
+              {t(
+                noSlotsReason
+                  ? `patientPortal.booking.noSlotsReason.${noSlotsReason}`
+                  : "patientPortal.booking.noSlots",
+              )}
             </div>
           ) : (
             <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1434.

Closes #1434

---

## Claude summary

Committed. Summary of changes:

**Backend** (`convex/gabinet/_availability_supabase.ts`): `getAvailableSlotsSupabase` now returns `{ slots: TimeSlot[]; reason?: "employee_not_working" | "clinic_closed" | "on_leave" | "fully_booked" }` instead of just `TimeSlot[]`. The four early returns each tag the appropriate reason; the final return tags `"fully_booked"` when the computed slot list comes out empty.

**Internal callers**: `scheduling.ts` (findNextAvailableSlot) and `patientPortal.ts` (bookFromPortal) destructure `{ slots }` from the result.

**Frontend**: `appointment-dialog.tsx`, `appointment-form.tsx`, `change-employee-modal.tsx`, and `_layout.book.tsx` (patient portal) all read `slotsResult?.slots` and `slotsResult?.reason`, and render the reason-specific i18n string when present, falling back to the existing generic "no slots" string.

**i18n**: Added `noSlotsReason.{employee_not_working,clinic_closed,on_leave,fully_booked}` keys in PL and EN for `gabinet.appointments`, `gabinet.appointments.calendarDialog`, and `patientPortal.booking`.

`npm run typecheck` passes.