### PR TITLE
Surface indicators in the appointment detail/preview popover

### DIFF
--- a/src/components/gabinet/calendar/appointment-card.tsx
+++ b/src/components/gabinet/calendar/appointment-card.tsx
@@ -2,25 +2,17 @@ import {
   appointmentEmployeeStyle,
   appointmentStatusBadgeClass,
 } from "@/lib/gabinet-appointment-status";
+import {
+  AppointmentIndicatorBadge,
+  type AppointmentIndicator,
+  type AppointmentIndicatorKind,
+} from "./appointment-indicators";
+
+export type { AppointmentIndicator, AppointmentIndicatorKind };
 
 export interface AppointmentTag {
   name: string;
   color: string;
-}
-
-export type AppointmentIndicatorKind =
-  | "firstVisit"
-  | "payment"
-  | "count"
-  | "paid"
-  | "partial"
-  | "unpaid"
-  | "credit";
-
-export interface AppointmentIndicator {
-  kind: AppointmentIndicatorKind;
-  label: string;
-  title?: string;
 }
 
 interface AppointmentCardProps {
@@ -34,16 +26,6 @@ interface AppointmentCardProps {
   indicators?: AppointmentIndicator[];
   onClick?: () => void;
 }
-
-const INDICATOR_CLASS: Record<AppointmentIndicatorKind, string> = {
-  firstVisit: "bg-emerald-500 text-white",
-  payment: "bg-amber-500 text-white",
-  count: "bg-sky-500 text-white",
-  paid: "bg-emerald-600 text-white",
-  partial: "bg-amber-500 text-white",
-  unpaid: "bg-red-500 text-white",
-  credit: "bg-indigo-500 text-white",
-};
 
 export function AppointmentCard({
   startTime,
@@ -99,13 +81,10 @@ export function AppointmentCard({
               />
             ))}
             {indicators?.map((ind, i) => (
-              <span
+              <AppointmentIndicatorBadge
                 key={`ind-${ind.kind}-${i}`}
-                title={ind.title ?? ind.label}
-                className={`inline-flex h-3.5 min-w-3.5 items-center justify-center rounded-sm px-0.5 text-[9px] font-bold leading-none ring-1 ring-white/60 ${INDICATOR_CLASS[ind.kind]}`}
-              >
-                {ind.label}
-              </span>
+                indicator={ind}
+              />
             ))}
           </div>
         )}

--- a/src/components/gabinet/calendar/appointment-indicators.tsx
+++ b/src/components/gabinet/calendar/appointment-indicators.tsx
@@ -1,0 +1,48 @@
+export type AppointmentIndicatorKind =
+  | "firstVisit"
+  | "payment"
+  | "count"
+  | "paid"
+  | "partial"
+  | "unpaid"
+  | "credit";
+
+export interface AppointmentIndicator {
+  kind: AppointmentIndicatorKind;
+  label: string;
+  title?: string;
+}
+
+const INDICATOR_CLASS: Record<AppointmentIndicatorKind, string> = {
+  firstVisit: "bg-emerald-500 text-white",
+  payment: "bg-amber-500 text-white",
+  count: "bg-sky-500 text-white",
+  paid: "bg-emerald-600 text-white",
+  partial: "bg-amber-500 text-white",
+  unpaid: "bg-red-500 text-white",
+  credit: "bg-indigo-500 text-white",
+};
+
+interface AppointmentIndicatorBadgeProps {
+  indicator: AppointmentIndicator;
+  /**
+   * Ring color override per surface. The calendar card sits on a dark header
+   * (`bg-black/30`) and uses `ring-white/60`; the popover header is lighter
+   * and looks better with `ring-black/10`.
+   */
+  ringClass?: string;
+}
+
+export function AppointmentIndicatorBadge({
+  indicator,
+  ringClass = "ring-white/60",
+}: AppointmentIndicatorBadgeProps) {
+  return (
+    <span
+      title={indicator.title ?? indicator.label}
+      className={`inline-flex h-3.5 min-w-3.5 items-center justify-center rounded-sm px-0.5 text-[9px] font-bold leading-none ring-1 ${ringClass} ${INDICATOR_CLASS[indicator.kind]}`}
+    >
+      {indicator.label}
+    </span>
+  );
+}

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -85,6 +85,15 @@ import {
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useSidebarActions } from "@/components/layout/sidebar-context";
+import {
+  useSupabaseGabinetFirstAppointmentIdsByPatient,
+  useSupabaseGabinetAppointmentPackagePositions,
+  useSupabaseGabinetAppointmentRecurringPositions,
+} from "@/hooks/use-supabase-gabinet-appointments";
+import {
+  AppointmentIndicatorBadge,
+  type AppointmentIndicator,
+} from "./appointment-indicators";
 
 // All statuses can transition to any other status. Lets staff correct mistakes
 // after a visit was already marked completed/cancelled/no_show (issue #1027).
@@ -293,6 +302,35 @@ export function AppointmentPreviewContent({
   const { dispatch } = useSidebarActions();
 
   const docCounts = useAppointmentDocumentCounts(appointmentId, organizationId);
+
+  // Indicator lookups — mirror the per-card badges the calendar route renders
+  // (issue #730). Hooks must run before the early return so React keeps a
+  // stable hook order; each hook disables itself when its input array is empty.
+  const indicatorPatientIds = detail?.appointment.patientId
+    ? [String(detail.appointment.patientId)]
+    : [];
+  const indicatorPackageUsageIds = detail?.appointment.packageUsageId
+    ? [String(detail.appointment.packageUsageId)]
+    : [];
+  const indicatorRecurringGroupIds = detail?.appointment.recurringGroupId
+    ? [String(detail.appointment.recurringGroupId)]
+    : [];
+
+  const { data: firstAppointmentIds } =
+    useSupabaseGabinetFirstAppointmentIdsByPatient(
+      organizationId,
+      indicatorPatientIds,
+    );
+  const { data: packagePositions } =
+    useSupabaseGabinetAppointmentPackagePositions(
+      organizationId,
+      indicatorPackageUsageIds,
+    );
+  const { data: recurringPositions } =
+    useSupabaseGabinetAppointmentRecurringPositions(
+      organizationId,
+      indicatorRecurringGroupIds,
+    );
 
   // Only seed local form state from `detail` once per appointment. Refetches
   // triggered by status changes must not clobber the user's other unsaved edits
@@ -604,6 +642,113 @@ export function AppointmentPreviewContent({
     : null;
 
   const patientCreditBalance = (detail.patientCreditBalance ?? 0) as number;
+
+  // Compact indicator pills mirroring the calendar card surface (issue #730).
+  // Same rules as `_layout.gabinet.calendar.index.lazy.tsx` so the popover
+  // stays in lockstep — see that file for full context on each indicator.
+  const previewIndicators: AppointmentIndicator[] = (() => {
+    const out: AppointmentIndicator[] = [];
+    const status = appointment.status;
+
+    if (
+      status !== "cancelled" &&
+      status !== "no_show" &&
+      firstAppointmentIds?.has(String(appointment._id))
+    ) {
+      out.push({
+        kind: "firstVisit",
+        label: "1",
+        title: t(
+          "gabinet.calendar.indicators.firstVisit",
+          "Pierwsza wizyta",
+        ),
+      });
+    }
+
+    if (appointment.prepaymentRequired && appointment.prepaymentStatus !== "paid") {
+      out.push({
+        kind: "payment",
+        label: "$",
+        title: t("gabinet.calendar.indicators.paymentDue", "Do zapłacenia"),
+      });
+    }
+
+    const pkgPos = appointment.packageUsageId
+      ? packagePositions?.get(String(appointment._id))
+      : undefined;
+    if (pkgPos) {
+      out.push({
+        kind: "count",
+        label: `${pkgPos.position}/${pkgPos.total}`,
+        title: t(
+          "gabinet.calendar.indicators.packageVisit",
+          "Wizyta pakietowa",
+        ),
+      });
+    } else if (appointment.isRecurring && appointment.recurringRule) {
+      const rule = appointment.recurringRule as { count?: number };
+      if (typeof rule.count === "number" && rule.count > 0) {
+        const dynamicPos = appointment.recurringGroupId
+          ? recurringPositions?.get(String(appointment._id))
+          : undefined;
+        const pos = dynamicPos ?? (appointment.recurringIndex ?? 0) + 1;
+        out.push({
+          kind: "count",
+          label: `${pos}/${rule.count}`,
+          title: t(
+            "gabinet.calendar.indicators.recurringVisit",
+            "Wizyta cykliczna",
+          ),
+        });
+      }
+    }
+
+    if (patientCreditBalance > 0 && status !== "cancelled" && status !== "no_show") {
+      // The calendar surfaces this on the patient's NEXT unpaid visit only,
+      // so the indicator unambiguously points to where the credit will be
+      // applied (issue #1286). The popover always shows the credit when
+      // there's outstanding balance on this visit and the patient has credit
+      // available — staff opened this specific visit, so highlight the
+      // applicability inline.
+      if (treatmentPrice > 0 && completedPaid < treatmentPrice) {
+        out.push({
+          kind: "credit",
+          label: `+${Math.round(patientCreditBalance)}`,
+          title: t("gabinet.calendar.indicators.credit", {
+            defaultValue: "Saldo {{amount}} do wykorzystania",
+            amount: patientCreditBalance.toFixed(2),
+          }),
+        });
+      }
+    }
+
+    if (status !== "cancelled" && treatmentPrice > 0) {
+      if (completedPaid >= treatmentPrice) {
+        out.push({
+          kind: "paid",
+          label: "✓",
+          title: t("gabinet.calendar.indicators.paid", "Wizyta opłacona"),
+        });
+      } else if (completedPaid > 0) {
+        out.push({
+          kind: "partial",
+          label: "½",
+          title: t(
+            "gabinet.calendar.indicators.partial",
+            "Częściowo opłacona",
+          ),
+        });
+      } else {
+        out.push({
+          kind: "unpaid",
+          label: "!",
+          title: t("gabinet.calendar.indicators.unpaid", "Wizyta nieopłacona"),
+        });
+      }
+    }
+
+    return out;
+  })();
 
   const handleOpenSettleDialog = () => {
     if (saving || settleSubmitting) return;
@@ -937,6 +1082,17 @@ export function AppointmentPreviewContent({
             </Popover>
           </div>
           <div className="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
+            {previewIndicators.length > 0 && (
+              <div className="flex items-center gap-0.5">
+                {previewIndicators.map((ind, i) => (
+                  <AppointmentIndicatorBadge
+                    key={`preview-ind-${ind.kind}-${i}`}
+                    indicator={ind}
+                    ringClass="ring-black/10 dark:ring-white/20"
+                  />
+                ))}
+              </div>
+            )}
             {paymentBadge && (
               <Badge
                 variant="outline"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #730.

Closes #730

---

## Claude summary

Committed `97db5ec` on branch `claude/issue-730`.

Summary of what landed: extracted the indicator badge JSX into a new shared `appointment-indicators.tsx` module exporting `AppointmentIndicator` / `AppointmentIndicatorKind` types and an `AppointmentIndicatorBadge` component with a per-surface `ringClass` prop. `AppointmentCard` now imports from the shared module and re-exports the types for existing callers (calendar-day/week/by-employee views, draggable-appointment). `AppointmentPreviewContent` now calls the same three Supabase indicator hooks the calendar route uses (`useSupabaseGabinetFirstAppointmentIdsByPatient`, `useSupabaseGabinetAppointmentPackagePositions`, `useSupabaseGabinetAppointmentRecurringPositions`) scoped to the single appointment, computes a `previewIndicators` array mirroring the calendar rules, and renders the pills in the header next to the existing status badge with `ring-black/10 dark:ring-white/20` for the lighter popover surface. Paid/partial/unpaid and credit pills reuse `completedPaid` / `treatmentPrice` / `detail.patientCreditBalance` already available in the popover. Typecheck and ESLint pass on touched files.

## Follow-ups
- Deduplicate inline `AppointmentIndicator` re-imports across calendar views: `calendar-day-view.tsx`, `calendar-week-view.tsx`, `calendar-day-by-employee-view.tsx`, and `draggable-appointment.tsx` still import the type from `./appointment-card` instead of the new `./appointment-indicators` module; swap to the canonical source.
- Consider replacing the legacy "Zapłacona / Częściowo opłacona / Niezapłacona" text Badge in the popover with the new pill-only payment indicator: it now duplicates the paid/partial/unpaid info shown in the new pill row.