### PR TITLE
Szukanie klienta w kategorii klienta

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -210,17 +210,13 @@ function PatientsIndex() {
     }
     const q = searchValue.trim().toLowerCase();
     if (q) {
+      const tokens = q.split(/\s+/).filter(Boolean);
       data = data.filter((p) => {
-        const first = p.firstName.toLowerCase();
-        const last = p.lastName.toLowerCase();
-        const fullName = `${first} ${last}`;
-        const reverseName = `${last} ${first}`;
-        return (
-          fullName.includes(q) ||
-          reverseName.includes(q) ||
-          (p.email && p.email.toLowerCase().includes(q)) ||
-          (p.phone && p.phone.toLowerCase().includes(q))
-        );
+        const haystack = [p.firstName, p.lastName, p.email, p.phone]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        return tokens.every((token) => haystack.includes(token));
       });
     }
     return data;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1352.

Closes #1352

---

## Claude summary

Committed. Summary:

The patients search at `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx:206-216` already had the "first last" / "last first" fix from #1350 (e9fa3dd), but the audit retriggered for a more robust fix. Replaced the dual-string concatenation with a tokenized approach: the trimmed query splits on whitespace, and every token must appear in the combined `firstName + lastName + email + phone` haystack. This handles "Jan Kowalski" (canonical case), patients with multiple given names like "Jan Marek Kowalski" + query "Jan Kowalski", extra spaces in the input, and queries mixing name fragments with email/phone — all of which would have failed the previous string-concatenation approach.

## Follow-ups
- Fix latent full-name search bug in `useSupabaseGabinetPatientsList` hook: `src/hooks/use-supabase-gabinet-patients.ts:46` does `first_name.ilike OR last_name.ilike` server-side — currently no caller passes `search`, but the bug will surface the moment anyone does.
- Fix the same full-name search bug in CRM contacts hook: `src/hooks/use-supabase-contacts.ts:55-56` filters `first_name.ilike OR last_name.ilike` server-side, so typing a full name in the contacts list fails the same way.
- Fix the same full-name search bug in global search (Cmd+K): `src/hooks/use-supabase-search.ts:53` filters contacts by `first_name.ilike OR last_name.ilike`, so the top-bar global search can't find a contact by full name.