### PR TITLE
PESEL usunięcie

### DIFF
--- a/tests/convex/patientsUpdate.test.ts
+++ b/tests/convex/patientsUpdate.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import {
+  createTestCtx,
+  seedTestUser,
+  seedGabinetPrereqs,
+} from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+describe("gabinet/patients.update — clearing optional fields", () => {
+  test("clearing PESEL via null sets the column to null", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    // Set a starting PESEL value directly via the Supabase mock.
+    const db = createSupabaseDb();
+    await db.patch("gabinetPatients", String(patientId), {
+      pesel: "12345678901",
+    });
+    const before = await db.get("gabinetPatients", String(patientId));
+    expect((before as { pesel?: string | null } | null)?.pesel).toBe(
+      "12345678901",
+    );
+
+    // Edit form sends `pesel: null` when cleared.
+    await t
+      .withIdentity(identity)
+      .action(api.gabinet.patients.update, {
+        organizationId,
+        patientId: String(patientId),
+        pesel: null,
+      });
+
+    const after = await db.get("gabinetPatients", String(patientId));
+    expect((after as { pesel?: string | null } | null)?.pesel).toBeNull();
+  });
+
+  test("clearing address via null sets the column to null", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    const db = createSupabaseDb();
+    await db.patch("gabinetPatients", String(patientId), {
+      address: { street: "Main 1", city: "Warsaw", postalCode: "00-001" },
+    });
+
+    await t
+      .withIdentity(identity)
+      .action(api.gabinet.patients.update, {
+        organizationId,
+        patientId: String(patientId),
+        address: null,
+      });
+
+    const after = await db.get("gabinetPatients", String(patientId));
+    expect((after as { address?: unknown } | null)?.address).toBeNull();
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1354.

Closes #1354

---

## Claude summary

Triage finding: the PESEL-clear bug is already fixed in code. The validator at `convex/gabinet/patients.ts:363` accepts `null`, the form at `src/components/forms/patient-form.tsx:175` sends `null` for cleared PESEL, the address validator at lines 368-372 also accepts `null`, and the Postgres column is nullable with a non-unique index (`supabase/migrations/00001_initial_schema.sql:1617,1645`). PR #1301 / commit 6498b1a (June 2) addressed exactly this — that's what the prior worker correctly identified.

I wrote a convex-test that exercises `gabinet/patients.update` with `pesel: null` and `address: null` and verifies the columns end up null. Both assertions pass against the current code, confirming the fix is intact.

The audit comment's claim that "the PESEL save issue was never addressed" is incorrect — PR #1301's commit message explicitly lists PESEL as the primary cleared field, and the diff to `src/components/forms/patient-form.tsx` changes `pesel: pesel || undefined` to `pesel: pesel || null`. The actual ArgumentValidationError shown in the Jam recording (`.address` = null rejected by old validator) was also fixed in the same PR.

What this commit does add: a regression test, since the previous fix had none. If the deployed quera-dev backend is still rejecting the save, that's a deployment-staleness issue — code-side this is locked in.