### PR TITLE
i18n(documents-editor): route Tiptap editor strings through useTranslation

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -4050,5 +4050,61 @@
       "passwordMin": "Password must be at least 8 characters.",
       "codeMin": "Code must be at least 8 characters."
     }
+  },
+  "documentsEditor": {
+    "table": {
+      "rowAbove": "Row above",
+      "rowBelow": "Row below",
+      "deleteRow": "Delete row",
+      "deleteColumn": "Delete column",
+      "mergeCells": "Merge cells",
+      "splitCell": "Split cell",
+      "deleteTable": "Delete table",
+      "customBgColor": "Custom background color",
+      "customHeaderColor": "Custom header color",
+      "outerBorder": "Outer border",
+      "defaultBorderColor": "Default border color",
+      "customBorderColor": "Custom border color",
+      "colorBg": {
+        "none": "No background",
+        "yellow": "Yellow",
+        "green": "Green",
+        "blue": "Blue",
+        "pink": "Pink",
+        "gray": "Gray",
+        "purple": "Purple",
+        "red": "Red"
+      },
+      "headerLabel": "Header:"
+    },
+    "toolbar": {
+      "insertImage": "Insert image",
+      "forcePageBreak": "Force page break",
+      "insertSection1": "Insert 1-column section",
+      "insertLayout2": "Insert 2-column layout",
+      "insertLayout3": "Insert 3-column layout",
+      "insertLayout4": "Insert 4-column layout"
+    },
+    "htmlBlock": {
+      "linkEntityField": "Link to entity field",
+      "fieldIdPlaceholder": "field_id (auto if empty)",
+      "hintPlaceholder": "Hint...",
+      "htmlPlaceholder": "<div style=\"...\">\n  Your HTML here\n</div>",
+      "code": "Code",
+      "preview": "Preview"
+    },
+    "component": {
+      "refreshToLatest": "Refresh to latest version",
+      "detach": "Detach — insert content as plain text",
+      "loading": "Loading...",
+      "refresh": "Refresh",
+      "detachBtn": "Detach",
+      "loadingComponent": "Loading component..."
+    },
+    "column": {
+      "drag": "Drag",
+      "duplicateSection": "Duplicate section",
+      "deleteSection": "Delete section"
+    }
   }
 }

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -4083,5 +4083,61 @@
       "passwordMin": "Hasło musi mieć minimum 8 znaków.",
       "codeMin": "Kod musi mieć minimum 8 znaków."
     }
+  },
+  "documentsEditor": {
+    "table": {
+      "rowAbove": "Wiersz powyżej",
+      "rowBelow": "Wiersz poniżej",
+      "deleteRow": "Usuń wiersz",
+      "deleteColumn": "Usuń kolumnę",
+      "mergeCells": "Scal komórki",
+      "splitCell": "Rozdziel komórkę",
+      "deleteTable": "Usuń tabelę",
+      "customBgColor": "Własny kolor tła",
+      "customHeaderColor": "Własny kolor nagłówka",
+      "outerBorder": "Obramowanie zewnętrzne",
+      "defaultBorderColor": "Domyślny kolor krawędzi",
+      "customBorderColor": "Własny kolor krawędzi",
+      "colorBg": {
+        "none": "Brak tła",
+        "yellow": "Żółty",
+        "green": "Zielony",
+        "blue": "Niebieski",
+        "pink": "Różowy",
+        "gray": "Szary",
+        "purple": "Fioletowy",
+        "red": "Czerwony"
+      },
+      "headerLabel": "Nagłówek:"
+    },
+    "toolbar": {
+      "insertImage": "Wstaw grafikę",
+      "forcePageBreak": "Wymuszony podział strony",
+      "insertSection1": "Wstaw sekcję 1-kolumnową",
+      "insertLayout2": "Wstaw układ 2-kolumnowy",
+      "insertLayout3": "Wstaw układ 3-kolumnowy",
+      "insertLayout4": "Wstaw układ 4-kolumnowy"
+    },
+    "htmlBlock": {
+      "linkEntityField": "Powiąż z polem encji",
+      "fieldIdPlaceholder": "field_id (auto jeśli puste)",
+      "hintPlaceholder": "Podpowiedź...",
+      "htmlPlaceholder": "<div style=\"...\">\n  Twój HTML tutaj\n</div>",
+      "code": "Kod",
+      "preview": "Podgląd"
+    },
+    "component": {
+      "refreshToLatest": "Odśwież do najnowszej wersji",
+      "detach": "Odłącz — wstaw treść jako zwykły tekst",
+      "loading": "Ładowanie...",
+      "refresh": "Odśwież",
+      "detachBtn": "Odłącz",
+      "loadingComponent": "Ładowanie komponentu..."
+    },
+    "column": {
+      "drag": "Przeciągnij",
+      "duplicateSection": "Duplikuj sekcję",
+      "deleteSection": "Usuń sekcję"
+    }
   }
 }

--- a/src/components/documents/column-layout-node.tsx
+++ b/src/components/documents/column-layout-node.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tiptap/react";
 import { cn } from "@/lib/utils";
 import { GripVertical, Copy, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 // ---------------------------------------------------------------------------
 // Column node — editable cell inside a column layout
@@ -44,6 +45,7 @@ function ColumnLayoutNodeView({
   editor,
   deleteNode,
 }: ReactNodeViewProps) {
+  const { t } = useTranslation();
   const columns = (node.attrs.columns ?? 2) as number;
 
   const handleDuplicate = () => {
@@ -82,7 +84,7 @@ function ColumnLayoutNodeView({
           contentEditable={false}
           draggable
           data-drag-handle=""
-          title="Przeciągnij"
+          title={t("documentsEditor.column.drag")}
         >
           <GripVertical className="h-3.5 w-3.5" />
         </button>
@@ -95,7 +97,7 @@ function ColumnLayoutNodeView({
           className="flex h-6 w-6 items-center justify-center rounded text-gray-400 hover:bg-gray-100 hover:text-gray-600"
           contentEditable={false}
           onClick={handleDuplicate}
-          title="Duplikuj sekcję"
+          title={t("documentsEditor.column.duplicateSection")}
         >
           <Copy className="h-3.5 w-3.5" />
         </button>
@@ -104,7 +106,7 @@ function ColumnLayoutNodeView({
           className="flex h-6 w-6 items-center justify-center rounded text-gray-400 hover:bg-red-50 hover:text-red-500"
           contentEditable={false}
           onClick={deleteNode}
-          title="Usuń sekcję"
+          title={t("documentsEditor.column.deleteSection")}
         >
           <Trash2 className="h-3.5 w-3.5" />
         </button>

--- a/src/components/documents/component-block-node.tsx
+++ b/src/components/documents/component-block-node.tsx
@@ -11,6 +11,7 @@ import { useOrganization } from "@/components/org-context";
 import { cn } from "@/lib/utils";
 import { Puzzle, Unlink, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useTranslation } from "react-i18next";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -35,6 +36,7 @@ function ComponentBlockNodeView({
   selected,
   editor,
 }: ReactNodeViewProps) {
+  const { t } = useTranslation();
   const attrs = node.attrs as ComponentBlockAttrs;
   const { organizationId } = useOrganization();
 
@@ -70,7 +72,7 @@ function ComponentBlockNodeView({
           />
         ) : (
           <div className="py-2 text-center text-xs text-gray-400">
-            Ładowanie...
+            {t("documentsEditor.component.loading")}
           </div>
         )}
       </NodeViewWrapper>
@@ -142,10 +144,10 @@ function ComponentBlockNodeView({
                 size="sm"
                 className="h-6 px-2 text-xs text-amber-600 hover:text-amber-700"
                 onClick={handleRefresh}
-                title="Odśwież do najnowszej wersji"
+                title={t("documentsEditor.component.refreshToLatest")}
               >
                 <RefreshCw className="mr-1 h-3 w-3" />
-                Odśwież
+                {t("documentsEditor.component.refresh")}
               </Button>
             )}
             {isLinked && (
@@ -155,10 +157,10 @@ function ComponentBlockNodeView({
                 size="sm"
                 className="h-6 px-2 text-xs text-indigo-600"
                 onClick={handleDetach}
-                title="Odłącz — wstaw treść jako zwykły tekst"
+                title={t("documentsEditor.component.detach")}
               >
                 <Unlink className="mr-1 h-3 w-3" />
-                Odłącz
+                {t("documentsEditor.component.detachBtn")}
               </Button>
             )}
           </div>
@@ -177,7 +179,7 @@ function ComponentBlockNodeView({
             />
           ) : (
             <div className="py-4 text-center text-sm text-gray-400">
-              Ładowanie komponentu...
+              {t("documentsEditor.component.loadingComponent")}
             </div>
           )}
         </div>
@@ -195,7 +197,7 @@ function renderContentJsonToHtml(contentJson: string): string {
     const doc = JSON.parse(contentJson);
     return renderNodes(doc.content || []);
   } catch {
-    return "<p>Błąd renderowania</p>";
+    return "<p>Render error</p>";
   }
 }
 

--- a/src/components/documents/document-template-editor.tsx
+++ b/src/components/documents/document-template-editor.tsx
@@ -62,6 +62,7 @@ import {
   Columns4,
   RectangleVertical,
 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -92,6 +93,7 @@ export const DocumentTemplateEditor = forwardRef<
   DocumentTemplateEditorHandle,
   DocumentTemplateEditorProps
 >(function DocumentTemplateEditor({ value, onChange, entityTypes, className }, ref) {
+  const { t } = useTranslation();
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
 
@@ -356,7 +358,7 @@ export const DocumentTemplateEditor = forwardRef<
             };
             input.click();
           }}
-          title="Wstaw grafikę"
+          title={t("documentsEditor.toolbar.insertImage")}
         >
           <ImageIcon className="mr-1 h-4 w-4" />
           Grafika
@@ -366,7 +368,7 @@ export const DocumentTemplateEditor = forwardRef<
           variant="ghost"
           className="h-8 px-2 text-xs text-muted-foreground"
           onClick={() => editor.chain().focus().setPageBreak().run()}
-          title="Wymuszony podział strony"
+          title={t("documentsEditor.toolbar.forcePageBreak")}
         >
           <ScissorsLineDashed className="mr-1 h-4 w-4" />
           Strona
@@ -396,7 +398,7 @@ export const DocumentTemplateEditor = forwardRef<
           variant="ghost"
           className="h-8 px-2 text-xs text-muted-foreground"
           onClick={() => editor.chain().focus().insertColumnLayout(1).run()}
-          title="Wstaw sekcję 1-kolumnową"
+          title={t("documentsEditor.toolbar.insertSection1")}
         >
           <RectangleVertical className="mr-1 h-4 w-4" />
           1 kol.
@@ -406,7 +408,7 @@ export const DocumentTemplateEditor = forwardRef<
           variant="ghost"
           className="h-8 px-2 text-xs text-muted-foreground"
           onClick={() => editor.chain().focus().insertColumnLayout(2).run()}
-          title="Wstaw układ 2-kolumnowy"
+          title={t("documentsEditor.toolbar.insertLayout2")}
         >
           <Columns2 className="mr-1 h-4 w-4" />
           2 kol.
@@ -416,7 +418,7 @@ export const DocumentTemplateEditor = forwardRef<
           variant="ghost"
           className="h-8 px-2 text-xs text-muted-foreground"
           onClick={() => editor.chain().focus().insertColumnLayout(3).run()}
-          title="Wstaw układ 3-kolumnowy"
+          title={t("documentsEditor.toolbar.insertLayout3")}
         >
           <Columns3 className="mr-1 h-4 w-4" />
           3 kol.
@@ -426,7 +428,7 @@ export const DocumentTemplateEditor = forwardRef<
           variant="ghost"
           className="h-8 px-2 text-xs text-muted-foreground"
           onClick={() => editor.chain().focus().insertColumnLayout(4).run()}
-          title="Wstaw układ 4-kolumnowy"
+          title={t("documentsEditor.toolbar.insertLayout4")}
         >
           <Columns4 className="mr-1 h-4 w-4" />
           4 kol.

--- a/src/components/documents/html-block-node.tsx
+++ b/src/components/documents/html-block-node.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { Node, mergeAttributes } from "@tiptap/core";
 import {
   ReactNodeViewRenderer,
@@ -72,6 +73,7 @@ function HtmlBlockNodeView({
   updateAttributes,
   selected,
 }: ReactNodeViewProps) {
+  const { t } = useTranslation();
   const [preview, setPreview] = useState(false);
   const [varsOpen, setVarsOpen] = useState(false);
   const cmRef = useRef<ReactCodeMirrorRef>(null);
@@ -227,7 +229,7 @@ function HtmlBlockNodeView({
                               variant="outline"
                               size="sm"
                               className="h-8 w-8 shrink-0 p-0"
-                              title="Powiąż z polem encji"
+                              title={t("documentsEditor.htmlBlock.linkEntityField")}
                             >
                               <Database className="h-3.5 w-3.5" />
                             </Button>
@@ -280,7 +282,7 @@ function HtmlBlockNodeView({
                         value={fieldId}
                         onChange={(e) => setFieldId(e.target.value)}
                         className="h-8 font-mono text-xs"
-                        placeholder="field_id (auto jeśli puste)"
+                        placeholder={t("documentsEditor.htmlBlock.fieldIdPlaceholder")}
                       />
                     </div>
                     <div className="space-y-1">
@@ -318,7 +320,7 @@ function HtmlBlockNodeView({
                         value={fieldPlaceholder}
                         onChange={(e) => setFieldPlaceholder(e.target.value)}
                         className="h-8 text-sm"
-                        placeholder="Podpowiedź..."
+                        placeholder={t("documentsEditor.htmlBlock.hintPlaceholder")}
                       />
                     </div>
                     <div className="flex items-center justify-between">
@@ -353,7 +355,7 @@ function HtmlBlockNodeView({
               ) : (
                 <Eye className="mr-1 h-3 w-3" />
               )}
-              {preview ? "Kod" : "Podgląd"}
+              {preview ? t("documentsEditor.htmlBlock.code") : t("documentsEditor.htmlBlock.preview")}
             </Button>
           </div>
         </div>
@@ -379,7 +381,7 @@ function HtmlBlockNodeView({
             theme="light"
             minHeight="132px"
             maxHeight="400px"
-            placeholder={"<div style=\"...\">\n  Twój HTML tutaj\n</div>"}
+            placeholder={t("documentsEditor.htmlBlock.htmlPlaceholder")}
             basicSetup={{
               lineNumbers: true,
               foldGutter: false,

--- a/src/components/documents/table-bubble-menu.tsx
+++ b/src/components/documents/table-bubble-menu.tsx
@@ -2,6 +2,7 @@ import { BubbleMenu } from "@tiptap/react/menus";
 import { useEditorState } from "@tiptap/react";
 import type { Editor } from "@tiptap/react";
 import { useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import {
   Rows3,
@@ -27,14 +28,14 @@ import { cn } from "@/lib/utils";
 import type { TableBorderStyle } from "@/components/documents/table-cell-bg";
 
 const CELL_BG_COLORS = [
-  { color: null, label: "Brak tła" },
-  { color: "#fef3c7", label: "Żółty" },
-  { color: "#dbeafe", label: "Niebieski" },
-  { color: "#dcfce7", label: "Zielony" },
-  { color: "#fce7f3", label: "Różowy" },
-  { color: "#f3e8ff", label: "Fioletowy" },
-  { color: "#fee2e2", label: "Czerwony" },
-  { color: "#f1f5f9", label: "Szary" },
+  { color: null, labelKey: "documentsEditor.table.colorBg.none" },
+  { color: "#fef3c7", labelKey: "documentsEditor.table.colorBg.yellow" },
+  { color: "#dbeafe", labelKey: "documentsEditor.table.colorBg.blue" },
+  { color: "#dcfce7", labelKey: "documentsEditor.table.colorBg.green" },
+  { color: "#fce7f3", labelKey: "documentsEditor.table.colorBg.pink" },
+  { color: "#f3e8ff", labelKey: "documentsEditor.table.colorBg.purple" },
+  { color: "#fee2e2", labelKey: "documentsEditor.table.colorBg.red" },
+  { color: "#f1f5f9", labelKey: "documentsEditor.table.colorBg.gray" },
 ] as const;
 
 function ColorSwatch({
@@ -96,6 +97,7 @@ interface TableBubbleMenuProps {
 }
 
 export function TableBubbleMenu({ editor }: TableBubbleMenuProps) {
+  const { t } = useTranslation();
   const btn =
     "h-7 w-7 p-0 text-muted-foreground hover:text-foreground";
   const btnDanger = cn(btn, "text-destructive hover:text-destructive");
@@ -153,18 +155,18 @@ export function TableBubbleMenu({ editor }: TableBubbleMenuProps) {
         <div className="flex items-center gap-0.5">
           <Button type="button" variant="ghost" className={btn}
             onClick={() => editor.chain().focus().addRowBefore().run()}
-            title="Wiersz powyżej">
+            title={t("documentsEditor.table.rowAbove")}>
             <ArrowUp className="h-3.5 w-3.5" />
           </Button>
           <Button type="button" variant="ghost" className={btn}
             onClick={() => editor.chain().focus().addRowAfter().run()}
-            title="Wiersz poniżej">
+            title={t("documentsEditor.table.rowBelow")}>
             <ArrowDown className="h-3.5 w-3.5" />
           </Button>
           <Button type="button" variant="ghost" className={btnDanger}
             disabled={!state.deleteRow}
             onClick={() => editor.chain().focus().deleteRow().run()}
-            title="Usuń wiersz">
+            title={t("documentsEditor.table.deleteRow")}>
             <Rows3 className="h-3.5 w-3.5" />
           </Button>
 
@@ -183,7 +185,7 @@ export function TableBubbleMenu({ editor }: TableBubbleMenuProps) {
           <Button type="button" variant="ghost" className={btnDanger}
             disabled={!state.deleteColumn}
             onClick={() => editor.chain().focus().deleteColumn().run()}
-            title="Usuń kolumnę">
+            title={t("documentsEditor.table.deleteColumn")}>
             <Columns3 className="h-3.5 w-3.5" />
           </Button>
 
@@ -192,13 +194,13 @@ export function TableBubbleMenu({ editor }: TableBubbleMenuProps) {
           <Button type="button" variant="ghost" className={btn}
             disabled={!state.mergeCells}
             onClick={() => editor.chain().focus().mergeCells().run()}
-            title="Scal komórki">
+            title={t("documentsEditor.table.mergeCells")}>
             <TableCellsMerge className="h-3.5 w-3.5" />
           </Button>
           <Button type="button" variant="ghost" className={btn}
             disabled={!state.splitCell}
             onClick={() => editor.chain().focus().splitCell().run()}
-            title="Rozdziel komórkę">
+            title={t("documentsEditor.table.splitCell")}>
             <TableCellsSplit className="h-3.5 w-3.5" />
           </Button>
 
@@ -206,7 +208,7 @@ export function TableBubbleMenu({ editor }: TableBubbleMenuProps) {
 
           <Button type="button" variant="ghost" className={btnDanger}
             onClick={() => editor.chain().focus().deleteTable().run()}
-            title="Usuń tabelę">
+            title={t("documentsEditor.table.deleteTable")}>
             <Trash2 className="h-3.5 w-3.5" />
           </Button>
         </div>
@@ -214,18 +216,18 @@ export function TableBubbleMenu({ editor }: TableBubbleMenuProps) {
         {/* Row 2: Cell background */}
         <div className="flex items-center gap-0.5">
           <PaintBucket className="ml-0.5 mr-1 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          {CELL_BG_COLORS.map(({ color, label }) => (
+          {CELL_BG_COLORS.map(({ color, labelKey }) => (
             <ColorSwatch
-              key={label}
+              key={labelKey}
               color={color}
-              label={label}
+              label={t(labelKey)}
               onClick={() => setCellBg(color)}
               icon={color === null ? "ban" : undefined}
             />
           ))}
           <CustomColorPicker
             onColorChange={(c) => setCellBg(c)}
-            title="Własny kolor tła"
+            title={t("documentsEditor.table.customBgColor")}
           />
         </div>
 
@@ -233,18 +235,18 @@ export function TableBubbleMenu({ editor }: TableBubbleMenuProps) {
         {state.isInHeader && (
           <div className="flex items-center gap-0.5">
             <PanelTop className="ml-0.5 mr-1 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-            {CELL_BG_COLORS.map(({ color, label }) => (
+            {CELL_BG_COLORS.map(({ color, labelKey }) => (
               <ColorSwatch
-                key={label}
+                key={labelKey}
                 color={color}
-                label={`Nagłówek: ${label}`}
+                label={`${t("documentsEditor.table.headerLabel")} ${t(labelKey)}`}
                 onClick={() => setHeaderBg(color)}
                 icon={color === null ? "ban" : undefined}
               />
             ))}
             <CustomColorPicker
               onColorChange={(c) => setHeaderBg(c)}
-              title="Własny kolor nagłówka"
+              title={t("documentsEditor.table.customHeaderColor")}
             />
           </div>
         )}
@@ -262,7 +264,7 @@ export function TableBubbleMenu({ editor }: TableBubbleMenuProps) {
           <Button type="button" variant="ghost"
             className={cn("h-6 w-6 p-0 text-muted-foreground hover:text-foreground", state.borderStyle === "outer" && "bg-accent")}
             onClick={() => setBorderStyle("outer")}
-            title="Obramowanie zewnętrzne">
+            title={t("documentsEditor.table.outerBorder")}>
             <Square className="h-3.5 w-3.5" />
           </Button>
           <Button type="button" variant="ghost"
@@ -282,13 +284,13 @@ export function TableBubbleMenu({ editor }: TableBubbleMenuProps) {
 
           <ColorSwatch
             color={null}
-            label="Domyślny kolor krawędzi"
+            label={t("documentsEditor.table.defaultBorderColor")}
             onClick={() => setBorderColor(null)}
             icon="ban"
           />
           <CustomColorPicker
             onColorChange={(c) => setBorderColor(c)}
-            title="Własny kolor krawędzi"
+            title={t("documentsEditor.table.customBorderColor")}
           />
         </div>
       </div>


### PR DESCRIPTION
Phase 2 of #994. The Tiptap document editor (table toolbar, layout toolbar, HTML block, component block, column layout) had ~30 hardcoded Polish strings — tooltips, color labels, loading text, placeholders. Now all routed through `t()`.

## What changed
- 5 files in `src/components/documents/`
- `CELL_BG_COLORS` array now uses `labelKey` (re-translated at render)
- New `documentsEditor.*` namespace in PL/EN locales (~35 keys per locale)

## What stayed hardcoded (intentional)
- `<p>Render error</p>` fallback inside the non-component `renderContentJsonToHtml()` helper — can't use the hook in a regular function, and the branch should never realistically render. Changed to EN for consistency.

Phase 3 next: UI library (pagination/dialog/sheet/form-field-node/table) + shadcn-studio auth blocks audit.