### PR TITLE
Terminy wizyt

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2765,6 +2765,7 @@
           "on_leave": "This employee is on leave on this day. Pick another date or employee.",
           "fully_booked": "All slots for this employee are taken on this day. Pick another day or employee."
         },
+        "slotsLoadError": "Couldn't load available slots. Try again or refresh the page.",
         "confirmBooking": "Book appointment",
         "time": "Time"
       },

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2794,6 +2794,7 @@
           "on_leave": "Pracownik jest na urlopie w tym dniu. Wybierz inną datę lub innego pracownika.",
           "fully_booked": "Cały dzień jest zarezerwowany dla tego pracownika. Wybierz inny dzień lub innego pracownika."
         },
+        "slotsLoadError": "Nie udało się pobrać dostępnych terminów. Spróbuj ponownie lub odśwież stronę.",
         "confirmBooking": "Umów wizytę",
         "time": "Godzina"
       },

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -504,7 +504,12 @@ export function AppointmentDialog({
 
   // Available slots — action reading from Supabase
   const getAvailableSlots = useAction(api.gabinet.appointments.getAvailableSlotsQuery);
-  const { data: slotsResult, isLoading: slotsLoading } = useQuery({
+  const {
+    data: slotsResult,
+    isLoading: slotsLoading,
+    isError: slotsErrored,
+    error: slotsError,
+  } = useQuery({
     queryKey: [
       "gabinet.availableSlots",
       organizationId,
@@ -527,6 +532,7 @@ export function AppointmentDialog({
         nowTime: recordWalkIn ? undefined : nowTime,
       }),
     enabled: !!employeeId && !!dateStr && !!selectedTreatment,
+    retry: false,
   });
   const availableSlots = slotsResult?.slots;
   const noSlotsReason = slotsResult?.reason;
@@ -1675,6 +1681,26 @@ export function AppointmentDialog({
                           className="h-9 w-full rounded-md"
                         />
                       ))
+                    ) : slotsErrored && !slotsResult ? (
+                      // Surface backend errors instead of collapsing them into
+                      // the generic "no slots" empty state — otherwise a
+                      // crashed action looks identical to an unconfigured
+                      // schedule and the user has no way to tell them apart.
+                      // Issue #1429.
+                      <div
+                        role="alert"
+                        className="py-8 text-center space-y-1.5 px-3"
+                      >
+                        <p className="text-sm font-medium text-destructive">
+                          {t(
+                            "gabinet.appointments.calendarDialog.slotsLoadError",
+                          )}
+                        </p>
+                        <p className="text-xs text-muted-foreground break-words">
+                          {extractActionErrorMessage(slotsError) ||
+                            String((slotsError as Error)?.message ?? "")}
+                        </p>
+                      </div>
                     ) : availableSlots && availableSlots.length > 0 ? (
                       availableSlots.map((slot) => (
                         <button


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1429.

Closes #1429

---

## Claude summary

Committed on `claude/issue-1429`.

Triage summary: the previous bot's diagnosis is structurally correct — the slot calculation in `convex/gabinet/_availability_supabase.ts` is sound, and follow-up #1438 (already merged at 55c08f4) makes the backend return a structured `reason` (`employee_not_working` / `clinic_closed` / `on_leave` / `fully_booked`) that the dialog renders as a specific Polish message. Once the dev tenant is redeployed, the user will see e.g. "Pracownik nie pracuje w tym dniu" instead of the generic "Brak dostępnych terminów", which will point them at the actual config to fix (most likely Friday in Aleksander Em's current-period employee schedule, or clinic Friday hours).

What this commit adds: the one real failure mode that wasn't covered by #1438 — when the `getAvailableSlotsQuery` action itself throws (auth failure, deployment skew, network blip), `slotsResult` is undefined and the dialog rendered the same "no slots" empty state as a legitimate empty response. A user reporting "no slots show up" then can't tell whether the backend errored or returned `[]`, which is exactly the pattern that fuels reports like this one. The commit wires `isError`/`error` from `useQuery` into a distinct, localized alert branch in `appointment-dialog.tsx:506-538` and `:1684-1703`, with `retry: false` so failures surface immediately and the extracted server message displayed underneath. The structured-reason empty state from #1438 stays untouched for legitimate empty results.