### PR TITLE
feat(migration): move appointmentSmsEvents writes from Convex DB to Supabase

### DIFF
--- a/convex/gabinet/appointmentSms.ts
+++ b/convex/gabinet/appointmentSms.ts
@@ -1,9 +1,7 @@
 import { internal } from "../_generated/api";
 import { Doc, Id } from "../_generated/dataModel";
-import { query, internalMutation, internalQuery, MutationCtx } from "../_generated/server";
-import { verifyOrgAccess } from "../_helpers/auth";
+import { action, internalMutation, MutationCtx } from "../_generated/server";
 import { publishActivityEnvelope } from "../_helpers/activityEnvelope";
-import { checkPermission } from "../_helpers/permissions";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
 
@@ -140,25 +138,27 @@ async function logSmsSharedActivities(
   });
 }
 
-export const listByAppointment = query({
+export const listByAppointment = action({
   args: {
     organizationId: v.id("organizations"),
     appointmentId: v.string(),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    const perm = await checkPermission(
-      ctx,
-      args.organizationId,
-      "gabinet_appointments",
-      "view",
-    );
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
+      organizationId: args.organizationId,
+      feature: "gabinet_appointments",
+      action: "view",
+    }) as { allowed: boolean; scope: string };
     if (!perm.allowed) throw new Error("Permission denied");
 
-    return await ctx.db
+    const db = createSupabaseDb();
+    return await db
       .query("appointmentSmsEvents")
-      .withIndex("by_appointment", (q) => q.eq("appointmentId", args.appointmentId))
-      .order("desc")
+      .eq("appointmentId", args.appointmentId)
+      .order("createdAt", false)
       .collect();
   },
 });
@@ -195,15 +195,15 @@ export const queueAutomationSms = internalMutation({
     const now = Date.now();
     const correlationKey = `automation:${args.eventType}:${appointmentId}`;
 
-    const existingEvent = await ctx.db
+    const existingEvent = await db
       .query("appointmentSmsEvents")
-      .withIndex("by_idempotencyKey", (q) => q.eq("idempotencyKey", args.idempotencyKey))
-      .unique();
+      .eq("idempotencyKey", args.idempotencyKey)
+      .first();
     if (existingEvent) {
       return existingEvent._id;
     }
 
-    const eventId = await ctx.db.insert("appointmentSmsEvents", {
+    const eventId = await db.insert("appointmentSmsEvents", {
       organizationId: args.organizationId,
       appointmentId,
       patientId,
@@ -304,10 +304,10 @@ export const queueConfirmationRequest = internalMutation({
       ? `outbound:${args.reminderId}`
       : `${correlationKey}:${now}`;
 
-    const existingEvent = await ctx.db
+    const existingEvent = await db
       .query("appointmentSmsEvents")
-      .withIndex("by_idempotencyKey", (q) => q.eq("idempotencyKey", idempotencyKey))
-      .unique();
+      .eq("idempotencyKey", idempotencyKey)
+      .first();
     if (existingEvent) {
       return existingEvent._id;
     }
@@ -317,7 +317,7 @@ export const queueConfirmationRequest = internalMutation({
       reminderId: args.reminderId ?? null,
     };
 
-    const eventId = await ctx.db.insert("appointmentSmsEvents", {
+    const eventId = await db.insert("appointmentSmsEvents", {
       organizationId: args.organizationId,
       appointmentId,
       patientId,
@@ -364,12 +364,13 @@ export const queueConfirmationRequest = internalMutation({
 
 export const markEventProcessed = internalMutation({
   args: {
-    eventId: v.id("appointmentSmsEvents"),
+    eventId: v.string(),
     providerMessageId: v.optional(v.string()),
     metadata: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await ctx.db.patch(args.eventId, {
+    const db = createSupabaseDb();
+    await db.patch("appointmentSmsEvents", args.eventId, {
       providerMessageId: args.providerMessageId,
       metadata: args.metadata,
       processingStatus: "processed",
@@ -381,12 +382,13 @@ export const markEventProcessed = internalMutation({
 
 export const markEventFailed = internalMutation({
   args: {
-    eventId: v.id("appointmentSmsEvents"),
+    eventId: v.string(),
     error: v.string(),
     metadata: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await ctx.db.patch(args.eventId, {
+    const db = createSupabaseDb();
+    await db.patch("appointmentSmsEvents", args.eventId, {
       processingStatus: "failed",
       processingError: args.error,
       metadata: args.metadata,
@@ -412,20 +414,21 @@ export const processIncomingMessage = internalMutation({
     args,
   ): Promise<{
     duplicate: boolean;
-    eventId?: Id<"appointmentSmsEvents">;
+    eventId?: string;
     processingStatus: "pending" | "processed" | "ignored" | "failed";
     reason?: string;
     appointmentId?: Id<"gabinetAppointments">;
   }> => {
-    const duplicate = await ctx.db
+    const db = createSupabaseDb();
+    const duplicate = await db
       .query("appointmentSmsEvents")
-      .withIndex("by_idempotencyKey", (q) => q.eq("idempotencyKey", args.idempotencyKey))
-      .unique();
+      .eq("idempotencyKey", args.idempotencyKey)
+      .first() as Doc<"appointmentSmsEvents"> | null;
 
     if (duplicate) {
       return {
         duplicate: true,
-        eventId: duplicate._id,
+        eventId: String(duplicate._id),
         processingStatus: duplicate.processingStatus,
       };
     }
@@ -451,13 +454,12 @@ export const processIncomingMessage = internalMutation({
     const parsedIntent = parseAppointmentSmsIntent(args.body);
     const now = Date.now();
 
-    const outboundEvents = await ctx.db
+    const outboundEvents = (await db
       .query("appointmentSmsEvents")
-      .withIndex("by_orgAndPhone", (q) =>
-        q.eq("organizationId", config.organizationId).eq("normalizedPhone", normalizedPhone),
-      )
-      .order("desc")
-      .collect();
+      .eq("organizationId", String(config.organizationId))
+      .eq("normalizedPhone", normalizedPhone)
+      .order("createdAt", false)
+      .collect()) as Array<Doc<"appointmentSmsEvents">>;
 
     const matchingOutbound = outboundEvents.find(
       (event) =>
@@ -466,7 +468,7 @@ export const processIncomingMessage = internalMutation({
         !!event.appointmentId,
     );
 
-    const eventId: Id<"appointmentSmsEvents"> = await ctx.db.insert("appointmentSmsEvents", {
+    const eventId: string = await db.insert("appointmentSmsEvents", {
       organizationId: config.organizationId,
       appointmentId: matchingOutbound?.appointmentId,
       patientId: matchingOutbound?.patientId,
@@ -495,9 +497,8 @@ export const processIncomingMessage = internalMutation({
       | Id<"gabinetPatients">
       | undefined;
 
-    const supabaseDb = createSupabaseDb();
     const matchingAppointment = matchingAppointmentId
-      ? await supabaseDb.get<{
+      ? await db.get<{
           organizationId?: string;
           employeeId?: string;
         }>("gabinetAppointments", String(matchingAppointmentId))
@@ -566,7 +567,7 @@ export const processIncomingMessage = internalMutation({
     });
 
     if (parsedIntent === "unknown") {
-      await ctx.db.patch(eventId, {
+      await db.patch("appointmentSmsEvents", eventId, {
         processingStatus: "ignored",
         processingError: "Reply body did not match TAK/NIE contract",
         processedAt: Date.now(),
@@ -576,7 +577,7 @@ export const processIncomingMessage = internalMutation({
     }
 
     if (!matchingOutbound?.appointmentId) {
-      await ctx.db.patch(eventId, {
+      await db.patch("appointmentSmsEvents", eventId, {
         processingStatus: "ignored",
         processingError: "No outbound appointment confirmation event found for this phone",
         processedAt: Date.now(),
@@ -592,10 +593,10 @@ export const processIncomingMessage = internalMutation({
       organizationId: config.organizationId,
       appointmentId: String(matchingOutbound.appointmentId),
       intent: parsedIntent,
-      smsEventId: String(eventId),
+      smsEventId: eventId,
     });
 
-    await ctx.db.patch(eventId, {
+    await db.patch("appointmentSmsEvents", eventId, {
       processingStatus: transitionResult.processingStatus,
       processingError: transitionResult.reason,
       processedAt: Date.now(),
@@ -612,15 +613,3 @@ export const processIncomingMessage = internalMutation({
   },
 });
 
-export const getLatestByAppointmentInternal = internalQuery({
-  args: {
-    appointmentId: v.string(),
-  },
-  handler: async (ctx, args) => {
-    return await ctx.db
-      .query("appointmentSmsEvents")
-      .withIndex("by_appointment", (q) => q.eq("appointmentId", args.appointmentId))
-      .order("desc")
-      .collect();
-  },
-});

--- a/convex/schema/automation.ts
+++ b/convex/schema/automation.ts
@@ -85,7 +85,9 @@ export function createAutomationTables({
     metadataSnapshot: v.optional(v.string()),
     errorMessage: v.optional(v.string()),
     emailEventLogId: v.optional(v.id("emailEventLog")),
-    appointmentSmsEventId: v.optional(v.id("appointmentSmsEvents")),
+    // FK to Supabase `appointment_sms_events.id` (string) after the #1400
+    // migration. Was `v.id("appointmentSmsEvents")`.
+    appointmentSmsEventId: v.optional(v.string()),
     processedAt: v.optional(v.number()),
     createdAt: v.number(),
     updatedAt: v.number(),

--- a/convex/sms.ts
+++ b/convex/sms.ts
@@ -303,7 +303,7 @@ export const sendAppointmentSms = internalAction({
     organizationId: v.id("organizations"),
     phone: v.string(),
     message: v.string(),
-    eventId: v.optional(v.id("appointmentSmsEvents")),
+    eventId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const config = await ctx.runQuery(internal.sms.getConfigInternal, {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -476,12 +476,28 @@ function AppointmentDetail() {
     enabled: !!organizationId && !!editLocationId,
   }) as { data: { rooms?: Array<{ _id: string; name: string; isActive: boolean }> } | undefined };
 
-  const { data: smsEvents = [] } = useQuery(
-    convexQuery(api.gabinet.appointmentSms.listByAppointment, {
+  const listSmsEventsAction = useAction(api.gabinet.appointmentSms.listByAppointment);
+  const { data: smsEvents = [] } = useQuery({
+    queryKey: [
+      "gabinet.appointmentSms.listByAppointment",
       organizationId,
-      appointmentId: appointmentId as Id<"gabinetAppointments">,
-    }),
-  );
+      appointmentId,
+    ],
+    queryFn: () =>
+      listSmsEventsAction({
+        organizationId,
+        appointmentId: appointmentId as Id<"gabinetAppointments">,
+      }),
+    enabled: !!organizationId && !!appointmentId,
+  }) as { data: Array<{
+    _id: string;
+    direction: "inbound" | "outbound";
+    eventType: string;
+    rawBody?: string;
+    processingStatus?: string;
+    parsedIntent?: string;
+    createdAt: number;
+  }> | undefined };
 
   const { data: activities } = useSupabaseActivitiesByEntity(
     organizationId,

--- a/tests/convex/appointmentSms.test.ts
+++ b/tests/convex/appointmentSms.test.ts
@@ -198,8 +198,7 @@ async function seedOutboundConfirmationEvent(
 ) {
   const createdAt = Date.now() - 1_000;
 
-  return await t.run(async (ctx) => {
-    return await ctx.db.insert("appointmentSmsEvents", {
+  return await createSupabaseDb().insert("appointmentSmsEvents", {
       organizationId: args.organizationId,
       appointmentId: args.appointmentId,
       patientId: args.patientId,
@@ -219,7 +218,6 @@ async function seedOutboundConfirmationEvent(
       createdAt,
       updatedAt: createdAt,
     });
-  });
 }
 
 describe("appointment SMS flow", () => {
@@ -257,9 +255,7 @@ describe("appointment SMS flow", () => {
       },
     );
 
-    const event = await t.run(async (ctx) =>
-      eventId ? ctx.db.get(eventId) : null,
-    );
+    const event = await (eventId ? createSupabaseDb().get("appointmentSmsEvents", eventId) : null);
 
     expect(eventId).toBeTruthy();
     expect(event?.appointmentId).toBe(appointmentId);
@@ -368,12 +364,10 @@ describe("appointment SMS flow", () => {
     );
 
     const appointment = await getAppointment(appointmentId);
-    const smsEvents = await t.run(async (ctx) =>
-      ctx.db
-        .query("appointmentSmsEvents")
-        .withIndex("by_appointment", (q) => q.eq("appointmentId", appointmentId))
-        .collect(),
-    );
+    const smsEvents = await createSupabaseDb()
+      .query("appointmentSmsEvents")
+      .eq("appointmentId", appointmentId)
+      .collect();
     const inboundEvent = smsEvents.find((event) => event.direction === "inbound");
 
     expect(firstResult.duplicate).toBe(false);
@@ -469,9 +463,7 @@ describe("appointment SMS flow", () => {
     );
 
     const appointment = await getAppointment(appointmentId);
-    const inboundEvent = await t.run(async (ctx) =>
-      result.eventId ? ctx.db.get(result.eventId) : null,
-    );
+    const inboundEvent = await (result.eventId ? createSupabaseDb().get("appointmentSmsEvents", result.eventId) : null);
     const auditEntries = await t.run(async (ctx) => ctx.db.query("auditLog").collect());
     const notifications = await t.run(async (ctx) =>
       ctx.db.query("notifications").collect(),
@@ -549,9 +541,7 @@ describe("appointment SMS flow", () => {
     );
 
     const appointment = await getAppointment(appointmentId);
-    const inboundEvent = await t.run(async (ctx) =>
-      result.eventId ? ctx.db.get(result.eventId) : null,
-    );
+    const inboundEvent = await (result.eventId ? createSupabaseDb().get("appointmentSmsEvents", result.eventId) : null);
 
     expect(result.processingStatus).toBe("ignored");
     expect(result.reason).toBe("Cannot transition from completed to confirmed");

--- a/tests/convex/automation.test.ts
+++ b/tests/convex/automation.test.ts
@@ -510,12 +510,14 @@ describe("automation lifecycle", () => {
           runId: run._id,
         })
       : [];
-    const smsEvents = await t.run(async (ctx) =>
-      ctx.db
-        .query("appointmentSmsEvents")
-        .withIndex("by_appointment", (q) => q.eq("appointmentId", appointmentId))
-        .collect(),
-    );
+    const smsEvents = (await createSupabaseDb()
+      .query("appointmentSmsEvents")
+      .eq("appointmentId", appointmentId)
+      .collect()) as Array<{
+        direction?: string;
+        eventType?: string;
+        rawBody?: string;
+      }>;
 
     expect(run?.status).toBe("processed");
     expect(steps).toHaveLength(1);


### PR DESCRIPTION
Closes #1400. Completes the half-finished migration where the Supabase table + RLS + indexes were prepared but writes still went to Convex DB. That left the FK from `automation_run_steps.appointment_sms_event_id` to a Supabase table-id space — practically at risk of `23503` on every automation SMS step.

## What moved
- All 9 `ctx.db.*` calls on `appointmentSmsEvents` → `createSupabaseDb().*`
- `listByAppointment` query → action (queries can't reach Supabase)
- `markEventProcessed` / `markEventFailed` validators: `v.id("appointmentSmsEvents")` → `v.string()`
- `processIncomingMessage` return type updated
- `getLatestByAppointmentInternal` deleted (0 callers)
- `convex/schema/automation.ts`: `automationRunSteps.appointmentSmsEventId` validator updated to match Supabase id space
- `convex/sms.ts`: matching validator change on `sendAppointmentSms.args.eventId`
- Frontend caller switched from `convexQuery` to `useAction` + react-query

## Tests
- 138/138 Convex tests pass
- `tests/convex/appointmentSms.test.ts` + `tests/convex/automation.test.ts` switched to seed/assert through `createSupabaseDb()`
- Fixed a latent `await x ? get() : null` precedence bug exposed by the change

## What's NOT in scope
- Backfilling pre-existing Convex rows into Supabase. The Supabase table is empty by design (no prior production writes landed there).