### PR TITLE
Deduplicate inline `AppointmentIndicator` re-imports across calendar views

### DIFF
--- a/src/components/gabinet/calendar/calendar-day-by-employee-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-by-employee-view.tsx
@@ -6,7 +6,7 @@ import { DroppableSlot } from "./droppable-slot";
 import { useDragToCreate } from "./use-drag-to-create";
 import { useCurrentTime } from "@/hooks/use-current-time";
 import { cn } from "@/lib/utils";
-import type { AppointmentIndicator } from "./appointment-card";
+import type { AppointmentIndicator } from "./appointment-indicators";
 
 interface Appointment {
   _id: string;

--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -4,7 +4,7 @@ import { DraggableAppointment } from "./draggable-appointment";
 import { DroppableSlot } from "./droppable-slot";
 import { useDragToCreate } from "./use-drag-to-create";
 import { useCurrentTime } from "@/hooks/use-current-time";
-import type { AppointmentIndicator } from "./appointment-card";
+import type { AppointmentIndicator } from "./appointment-indicators";
 
 interface Appointment {
   _id: string;

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -6,7 +6,7 @@ import { DroppableSlot } from "./droppable-slot";
 import { useDragToCreate } from "./use-drag-to-create";
 import { useCurrentTime } from "@/hooks/use-current-time";
 import { cn } from "@/lib/utils";
-import type { AppointmentIndicator } from "./appointment-card";
+import type { AppointmentIndicator } from "./appointment-indicators";
 
 interface Appointment {
   _id: string;

--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -8,8 +8,8 @@ import {
 import {
   AppointmentCard,
   type AppointmentTag,
-  type AppointmentIndicator,
 } from "./appointment-card";
+import type { AppointmentIndicator } from "./appointment-indicators";
 import { AppointmentPreviewContent } from "./appointment-preview-content";
 
 interface Appointment {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1441.

Closes #1441

---

## Claude summary

Swapped `AppointmentIndicator` imports in `calendar-day-view.tsx`, `calendar-week-view.tsx`, `calendar-day-by-employee-view.tsx`, and `draggable-appointment.tsx` from `./appointment-card` to the canonical `./appointment-indicators` module. In `draggable-appointment.tsx` the import was split into two statements so `AppointmentCard` / `AppointmentTag` still come from `appointment-card`. Typecheck on `tsconfig.app.json` reports no errors on the affected files. Committed as `7b72e38`.