### PR TITLE
Consider replacing the legacy "Zapłacona / Częściowo opłacona / Niezapłacona" te

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2823,11 +2823,6 @@
       "settleMarkCompleted": "Mark appointment as completed",
       "settleNothingToDo": "Enter an amount or check the close option.",
       "settleSuccess": "Appointment settled",
-      "paymentBadge": {
-        "paid": "Paid",
-        "partial": "Partially paid",
-        "unpaid": "Unpaid"
-      },
       "history": {
         "unifiedDescription": "Unified operational history for this appointment, including messages and workflow events.",
         "metadata": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2852,11 +2852,6 @@
       "settleMarkCompleted": "Oznacz wizytę jako zakończoną",
       "settleNothingToDo": "Wpisz kwotę lub zaznacz zamknięcie wizyty.",
       "settleSuccess": "Wizyta rozliczona",
-      "paymentBadge": {
-        "paid": "Zapłacona",
-        "partial": "Częściowo opłacona",
-        "unpaid": "Niezapłacona"
-      },
       "history": {
         "unifiedDescription": "Ujednolicona historia operacyjna tej wizyty, w tym wiadomości i zdarzenia workflow.",
         "metadata": {

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -608,38 +608,12 @@ export function AppointmentPreviewContent({
   const outstanding = Math.max(0, treatmentPrice - totalPaid);
   const canMarkCompleted = availableTransitions.includes("completed");
 
-  // Completed-only total drives the visible "Paid / Partial / Unpaid" badge —
-  // pending payments are auto-created when an appointment is booked, so they
-  // mustn't count as actually paid. Issue #1031.
+  // Completed-only total drives the visible paid/partial/unpaid pill in the
+  // indicator row — pending payments are auto-created when an appointment is
+  // booked, so they mustn't count as actually paid. Issue #1031.
   const completedPaid = (detail.payments ?? [])
     .filter((p) => p.status === "completed")
     .reduce((sum, p) => sum + (p.amount ?? 0), 0);
-  const paymentBadge: { kind: "paid" | "partial" | "unpaid"; label: string } | null =
-    treatmentPrice > 0
-      ? completedPaid >= treatmentPrice
-        ? {
-            kind: "paid",
-            label: t("gabinet.appointmentDetail.paymentBadge.paid", {
-              defaultValue: "Zapłacona",
-            }),
-          }
-        : completedPaid > 0
-          ? {
-              kind: "partial",
-              label: t("gabinet.appointmentDetail.paymentBadge.partial", {
-                defaultValue: "Częściowo opłacona",
-              }),
-            }
-          : {
-              kind: "unpaid",
-              label: t("gabinet.appointmentDetail.paymentBadge.unpaid", {
-                defaultValue: "Niezapłacona",
-              }),
-            }
-      : null;
-  const paymentBadgeTooltip = paymentBadge
-    ? `${t("gabinet.payments.totalPaid")}: ${formatCurrencyPLN(completedPaid)} / ${formatCurrencyPLN(treatmentPrice)}`
-    : null;
 
   const patientCreditBalance = (detail.patientCreditBalance ?? 0) as number;
 
@@ -1092,23 +1066,6 @@ export function AppointmentPreviewContent({
                   />
                 ))}
               </div>
-            )}
-            {paymentBadge && (
-              <Badge
-                variant="outline"
-                title={paymentBadgeTooltip ?? undefined}
-                className={cn(
-                  "text-xs",
-                  paymentBadge.kind === "paid" &&
-                    "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300",
-                  paymentBadge.kind === "partial" &&
-                    "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300",
-                  paymentBadge.kind === "unpaid" &&
-                    "border-red-300 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300",
-                )}
-              >
-                {paymentBadge.label}
-              </Badge>
             )}
             <Badge variant="outline" className="text-xs">
               <span


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1442.

Closes #1442

---

## Claude summary

Removed the redundant "Zapłacona / Częściowo opłacona / Niezapłacona" text Badge from the appointment preview popover header in `src/components/gabinet/calendar/appointment-preview-content.tsx`, along with the now-unused `paymentBadge`/`paymentBadgeTooltip` derivation and the orphan `gabinet.appointmentDetail.paymentBadge.*` i18n keys in both PL and EN locale files. The compact pill row (✓ / ½ / !) introduced in #730 already encodes the same paid/partial/unpaid state with the same tooltip semantics. Typecheck passes (the 2 remaining errors in `convex/gabinet/appointmentSms.ts` are pre-existing and unrelated to this change).