### PR TITLE
Fix latent full-name search bug in `useSupabaseGabinetPatientsList` hook

### DIFF
--- a/src/hooks/use-supabase-gabinet-patients.ts
+++ b/src/hooks/use-supabase-gabinet-patients.ts
@@ -42,8 +42,18 @@ export function useSupabaseGabinetPatientsList(
         .eq("organization_id", organizationId);
 
       if (search?.trim()) {
-        const term = `%${search.trim()}%`;
-        query = query.or(`first_name.ilike.${term},last_name.ilike.${term}`);
+        // Each whitespace-separated token must match either first_name or
+        // last_name. Chained .or() filters are AND-combined by PostgREST,
+        // so "John Smith" becomes
+        //   (first_name ILIKE %John% OR last_name ILIKE %John%)
+        //   AND
+        //   (first_name ILIKE %Smith% OR last_name ILIKE %Smith%)
+        for (const token of search.trim().split(/\s+/)) {
+          const pattern = `%${token}%`;
+          query = query.or(
+            `first_name.ilike.${pattern},last_name.ilike.${pattern}`,
+          );
+        }
       }
 
       const { data, error } = await query


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1444.

Closes #1444

---

## Claude summary

Fixed and committed. The change at `src/hooks/use-supabase-gabinet-patients.ts:44` now splits the search term on whitespace and chains one `.or()` per token, so a query like "John Smith" matches rows where each token appears in either `first_name` or `last_name` (AND-combined across tokens, OR-combined within a token). Single-token queries behave the same as before.

## Follow-ups
- Apply the same full-name tokenization fix in `src/hooks/use-supabase-search.ts:53`: global contact search has the identical `first_name.ilike OR last_name.ilike` bug for multi-token queries