### PR TITLE
Fix the same full-name search bug in CRM contacts hook

### DIFF
--- a/src/hooks/use-supabase-contacts.ts
+++ b/src/hooks/use-supabase-contacts.ts
@@ -50,13 +50,22 @@ export function useSupabaseContactsList(
 
       const trimmedSearch = search?.trim();
       if (trimmedSearch) {
-        query = query.or(
-          [
-            `first_name.ilike.%${trimmedSearch}%`,
-            `last_name.ilike.%${trimmedSearch}%`,
-            `email.ilike.%${trimmedSearch}%`,
-          ].join(","),
-        );
+        // Each whitespace-separated token must match first_name, last_name,
+        // or email. Chained .or() filters are AND-combined by PostgREST, so
+        // "John Smith" becomes
+        //   (first_name ILIKE %John% OR last_name ILIKE %John% OR email ILIKE %John%)
+        //   AND
+        //   (first_name ILIKE %Smith% OR last_name ILIKE %Smith% OR email ILIKE %Smith%)
+        for (const token of trimmedSearch.split(/\s+/)) {
+          const pattern = `%${token}%`;
+          query = query.or(
+            [
+              `first_name.ilike.${pattern}`,
+              `last_name.ilike.${pattern}`,
+              `email.ilike.${pattern}`,
+            ].join(","),
+          );
+        }
       }
 
       const { data, error } = await query


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1445.

Closes #1445

---

## Claude summary

Fixed and committed. The CRM contacts hook (`src/hooks/use-supabase-contacts.ts:51-69`) now tokenizes the search term on whitespace and chains one `.or()` per token across `first_name`, `last_name`, and `email`. PostgREST AND-combines the chained `.or()` calls, so "John Smith" now matches a contact named John Smith (one token matching `first_name`, the other matching `last_name`) instead of looking for the literal substring "John Smith" inside a single column.

This is the same shape fix that landed in #1444 for gabinet patients, extended to keep the existing `email` branch. Verified that real callers (`_layout.leads.$leadId.lazy.tsx:426/440/463`, `_layout.companies.$companyId.tsx:224/237/243`, `_layout.contacts.$contactId.lazy.tsx:239`) do pass `search`, so this bug was user-facing — not latent.