### PR TITLE
Fix the same full-name search bug in global search (Cmd+K)

### DIFF
--- a/src/hooks/use-supabase-search.ts
+++ b/src/hooks/use-supabase-search.ts
@@ -40,18 +40,33 @@ export async function supabaseGlobalSearch(
   orgId: string,
   query: string,
 ): Promise<SearchGroup[]> {
-  if (!query.trim()) return [];
+  const trimmed = query.trim();
+  if (!trimmed) return [];
 
-  const pattern = `%${query}%`;
+  const pattern = `%${trimmed}%`;
+  const tokens = trimmed.split(/\s+/);
+
+  // Each whitespace-separated token must match first_name or last_name.
+  // Chained .or() filters are AND-combined by PostgREST, so "John Smith"
+  // becomes
+  //   (first_name ILIKE %John% OR last_name ILIKE %John%)
+  //   AND
+  //   (first_name ILIKE %Smith% OR last_name ILIKE %Smith%)
+  // which matches a row whose names are stored in separate columns.
+  let contactsQuery = supabase
+    .from("contacts")
+    .select("*")
+    .eq("organization_id", orgId);
+  for (const token of tokens) {
+    const tokenPattern = `%${token}%`;
+    contactsQuery = contactsQuery.or(
+      `first_name.ilike.${tokenPattern},last_name.ilike.${tokenPattern}`,
+    );
+  }
 
   const [contactsRes, companiesRes, leadsRes, documentsRes, productsRes] =
     await Promise.all([
-      supabase
-        .from("contacts")
-        .select("*")
-        .eq("organization_id", orgId)
-        .or(`first_name.ilike.${pattern},last_name.ilike.${pattern}`)
-        .limit(5),
+      contactsQuery.limit(5),
 
       supabase
         .from("companies")


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1446.

Closes #1446

---

## Claude summary

Fixed `src/hooks/use-supabase-search.ts:53` by tokenizing the contacts query the same way #1457 fixed `useSupabaseContactsList`. A query like "John Smith" now produces `(first_name ILIKE %John% OR last_name ILIKE %John%) AND (first_name ILIKE %Smith% OR last_name ILIKE %Smith%)` instead of an unmatchable single-pattern OR. Companies/leads/documents/products were already single-column searches and didn't need the change.