### PR TITLE
Wybór zabiegu 

### DIFF
--- a/src/components/gabinet/appointment-form.tsx
+++ b/src/components/gabinet/appointment-form.tsx
@@ -554,7 +554,10 @@ export function AppointmentForm({
           </PopoverTrigger>
           <PopoverContent
             className="p-0"
-            style={{ width: "var(--radix-popover-trigger-width)" }}
+            style={{
+              width: "var(--radix-popover-trigger-width)",
+              maxHeight: "var(--radix-popover-content-available-height)",
+            }}
             align="start"
           >
             <Command shouldFilter={false}>
@@ -563,7 +566,7 @@ export function AppointmentForm({
                 value={patientSearch}
                 onValueChange={setPatientSearch}
               />
-              <CommandList>
+              <CommandList className="flex-1 min-h-0">
                 {filteredPatients.length === 0 &&
                   !isCrmSearching &&
                   (!unlinkedContacts || unlinkedContacts.length === 0) && (
@@ -675,14 +678,17 @@ export function AppointmentForm({
           </PopoverTrigger>
           <PopoverContent
             className="p-0"
-            style={{ width: "var(--radix-popover-trigger-width)" }}
+            style={{
+              width: "var(--radix-popover-trigger-width)",
+              maxHeight: "var(--radix-popover-content-available-height)",
+            }}
             align="start"
           >
             <Command>
               <CommandInput
                 placeholder={t("gabinet.appointments.searchTreatment")}
               />
-              <CommandList>
+              <CommandList className="flex-1 min-h-0">
                 <CommandEmpty>{t("common.noResults")}</CommandEmpty>
                 <CommandGroup>
                   {treatments?.map((tr) => (

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -1069,7 +1069,11 @@ export function AppointmentDialog({
                     <PopoverContent
                       className="p-0"
                       align="start"
-                      style={{ width: "var(--radix-popover-trigger-width)" }}
+                      style={{
+                        width: "var(--radix-popover-trigger-width)",
+                        maxHeight:
+                          "var(--radix-popover-content-available-height)",
+                      }}
                     >
                       <Command shouldFilter={false}>
                         <CommandInput
@@ -1079,7 +1083,7 @@ export function AppointmentDialog({
                           value={patientSearch}
                           onValueChange={setPatientSearch}
                         />
-                        <CommandList>
+                        <CommandList className="flex-1 min-h-0">
                           <CommandEmpty>
                             {t("common.noResults")}
                           </CommandEmpty>
@@ -1153,7 +1157,11 @@ export function AppointmentDialog({
                     <PopoverContent
                       className="p-0"
                       align="start"
-                      style={{ width: "var(--radix-popover-trigger-width)" }}
+                      style={{
+                        width: "var(--radix-popover-trigger-width)",
+                        maxHeight:
+                          "var(--radix-popover-content-available-height)",
+                      }}
                     >
                       <Command shouldFilter={false}>
                         <CommandInput
@@ -1163,7 +1171,7 @@ export function AppointmentDialog({
                           value={treatmentSearch}
                           onValueChange={setTreatmentSearch}
                         />
-                        <CommandList>
+                        <CommandList className="flex-1 min-h-0">
                           <CommandEmpty>
                             {t("common.noResults")}
                           </CommandEmpty>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1461.

Closes #1461

---

## Claude summary

Fixed. The treatment picker (and patient picker, which had the same bug) in the calendar appointment dialog and the QuickCreate appointment form now properly cap their popover height to the available viewport space and let the inner `CommandList` flex-fill + scroll within that constraint.

Root cause: on iOS Safari with the on-screen keyboard open, the popover's natural size (input + the `CommandList`'s fixed `max-h-[300px]`) exceeded the space between the trigger and the visible viewport edge. The popover got visually clipped but `overflow-y-auto` on `CommandList` never activated, because its own content was still within its 300px ceiling — so the user could see only the items that happened to fit and had no way to scroll to the rest.

Fix: set `PopoverContent` `maxHeight: var(--radix-popover-content-available-height)` on each picker, and make `CommandList` a `flex-1 min-h-0` child so it actually shrinks to the constrained popover height and scrolls when its content exceeds it. Applied symmetrically across all four sites (patient + treatment pickers in both `appointment-dialog.tsx` and `appointment-form.tsx`).

## Follow-ups
- Apply the same available-height cap to other Popover+Command pickers in the app: `src/components/gabinet/calendar/appointment-dialog.tsx` and `appointment-form.tsx` were fixed, but the same shadcn pattern (`PopoverContent` with no maxHeight + `CommandList` fixed at `max-h-[300px]`) is used widely (e.g. CRM contact/company/lead pickers, custom-field picker, relationship-field, advanced-filter value picker). All of them will exhibit the same iOS keyboard clipping bug — consider baking the fix into the shared `CommandList` default in `src/components/ui/command.tsx` instead of patching call sites one at a time.