### PR TITLE
Przesuwanie godzin ￼

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -358,6 +358,11 @@ export function AppointmentDialog({
   const handleDragStart = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       if (e.button !== 0) return;
+      // Skip touch input: on mobile the dialog is full-width so dragging it
+      // around is not useful, and capturing touch pointerdown here would
+      // block native vertical scrolling of the now-scrollable DialogContent
+      // (issue #1462).
+      if (e.pointerType === "touch") return;
       // Drag-from-anywhere (issue #1459): users found the small top bar too
       // hard to hit, so the whole dialog now initiates a drag. Bail out when
       // the pointerdown landed on (or inside) an interactive control so
@@ -986,7 +991,13 @@ export function AppointmentDialog({
         ref={dialogContentRef}
         onPointerDown={handleDragStart}
         className={cn(
-          "max-w-5xl p-0 gap-0 overflow-hidden max-h-[90vh] md:max-h-[640px]",
+          // On mobile the 3 panels stack vertically and easily exceed 90vh
+          // (patient/treatment/employee selectors + calendar + slot list).
+          // Without `overflow-y-auto` here the bottom panel — including the
+          // hour/slot picker — gets clipped with no way to scroll to it
+          // (issue #1462). Desktop keeps `overflow-hidden` so each panel
+          // owns its own scroll container at md:h-[600px].
+          "max-w-5xl p-0 gap-0 overflow-y-auto md:overflow-hidden max-h-[90vh] md:max-h-[640px]",
           isDragging && "cursor-grabbing select-none",
         )}
         overlayClassName="bg-black/40"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1462.

Closes #1462

---

## Claude summary

Committed. Summary of what was done.

The appointment dialog at `src/components/gabinet/calendar/appointment-dialog.tsx` stacks its three panels (patient/treatment/employee selectors, calendar, available-slot picker) vertically on mobile, but `DialogContent` carried `overflow-hidden max-h-[90vh]` and the inner wrapper only got a height (`md:h-[600px]`) on desktop. On a 390×844 iPhone the slot picker therefore sat below 90vh with nothing scrollable — exactly what the screenshot shows.

Two changes:
- `appointment-dialog.tsx:998` — switched DialogContent to `overflow-y-auto md:overflow-hidden` so the dialog body scrolls on mobile, while desktop retains its per-panel scroll containers.
- `appointment-dialog.tsx:365` — early-return from `handleDragStart` when `pointerType === "touch"`. Without this, the drag-from-anywhere handler from #1459 would capture the touchdown and `preventDefault()` it, blocking iOS' native scroll on the now-scrollable DialogContent. Drag-to-move isn't useful on a full-width mobile dialog anyway.

No new files, no schema changes; one component touched. Typecheck couldn't run locally (no `node_modules` in this worktree), but the edits are pure JSX/className changes plus a single guard clause.