### PR TITLE
Apply the same available-height cap to other Popover+Command pickers in the app

### DIFF
--- a/src/components/crm/advanced-filter.tsx
+++ b/src/components/crm/advanced-filter.tsx
@@ -99,10 +99,16 @@ function QuickFilterChip({
           <ChevronDown className="ml-1 h-3 w-3 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[200px] p-0" align="start">
+      <PopoverContent
+        className="w-[200px] p-0"
+        align="start"
+        style={{
+          maxHeight: "var(--radix-popover-content-available-height)",
+        }}
+      >
         <Command>
           <CommandInput placeholder={`Filter ${filter.label}...`} />
-          <CommandList>
+          <CommandList className="flex-1 min-h-0">
             <CommandEmpty>No options found.</CommandEmpty>
             <CommandGroup>
               {filter.options.map((option) => {

--- a/src/components/data-table/data-table-faceted-filter.tsx
+++ b/src/components/data-table/data-table-faceted-filter.tsx
@@ -74,10 +74,16 @@ export function DataTableFacetedFilter<TData, TValue>({
           )}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[200px] p-0" align="start">
+      <PopoverContent
+        className="w-[200px] p-0"
+        align="start"
+        style={{
+          maxHeight: "var(--radix-popover-content-available-height)",
+        }}
+      >
         <Command>
           <CommandInput placeholder={title} />
-          <CommandList>
+          <CommandList className="flex-1 min-h-0">
             <CommandEmpty>No results found.</CommandEmpty>
             <CommandGroup>
               {options.map((option) => {

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -1016,14 +1016,20 @@ export function AppointmentPreviewContent({
                   <ChevronsUpDown className="size-3.5 shrink-0 opacity-60" />
                 </button>
               </PopoverTrigger>
-              <PopoverContent className="w-72 p-0" align="start">
+              <PopoverContent
+                className="w-72 p-0"
+                align="start"
+                style={{
+                  maxHeight: "var(--radix-popover-content-available-height)",
+                }}
+              >
                 <Command shouldFilter={false}>
                   <CommandInput
                     placeholder={t("gabinet.appointments.searchTreatment")}
                     value={treatmentSearch}
                     onValueChange={setTreatmentSearch}
                   />
-                  <CommandList>
+                  <CommandList className="flex-1 min-h-0">
                     <CommandEmpty>{t("common.noResults")}</CommandEmpty>
                     <CommandGroup>
                       {filteredTreatments.map((tr) => (

--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -373,7 +373,13 @@ export function TreatmentForm({
                 <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+            <PopoverContent
+              className="w-[var(--radix-popover-trigger-width)] p-0"
+              align="start"
+              style={{
+                maxHeight: "var(--radix-popover-content-available-height)",
+              }}
+            >
               {addingNewEquipment ? (
                 <div className="p-2 space-y-2">
                   <Label className="text-xs">
@@ -417,7 +423,7 @@ export function TreatmentForm({
               ) : (
                 <Command>
                   <CommandInput placeholder={t("gabinet.treatments.searchEquipment", "Search equipment...")} />
-                  <CommandList>
+                  <CommandList className="flex-1 min-h-0">
                     <CommandEmpty>{t("common.noResults", "No results found.")}</CommandEmpty>
                     <CommandGroup>
                       {(equipmentList ?? []).map((eq) => {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1341,7 +1341,11 @@ function AppointmentDetail() {
                   <PopoverContent
                     className="p-0"
                     align="start"
-                    style={{ width: "var(--radix-popover-trigger-width)" }}
+                    style={{
+                      width: "var(--radix-popover-trigger-width)",
+                      maxHeight:
+                        "var(--radix-popover-content-available-height)",
+                    }}
                   >
                     <Command shouldFilter={false}>
                       <CommandInput
@@ -1349,7 +1353,7 @@ function AppointmentDetail() {
                         value={treatmentSearch}
                         onValueChange={setTreatmentSearch}
                       />
-                      <CommandList>
+                      <CommandList className="flex-1 min-h-0">
                         <CommandEmpty>{t("common.noResults")}</CommandEmpty>
                         <CommandGroup>
                           {(treatmentsList ?? [])


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1465.

Closes #1465

---

## Claude summary

Committed. Five Popover+Command pickers now use the same iOS-keyboard fix that `appointment-dialog.tsx` and `appointment-form.tsx` already had: `PopoverContent` capped to `var(--radix-popover-content-available-height)` and `CommandList` switched to `flex-1 min-h-0` so the list shrinks/scrolls within the constrained popover instead of clipping past the viewport.

I chose call-site patches over baking into `command.tsx`/`popover.tsx` because (a) the fix needs both `PopoverContent` and `CommandList` to cooperate — `CommandList` alone can't enforce the popover-level cap, and (b) adding a default `maxHeight` to `PopoverContent` would affect every popover in the app (datepickers, dropdowns, etc.) where capping to available height without scrollable content would clip instead of help. The targeted patch matches the pattern already established for the gabinet appointment surfaces.

Files mentioned in the issue but not affected:
- `relationship-field.tsx` — custom dropdown, not Popover+Command
- `custom-fields/*` — no Popover+Command pattern in any of those files
- `global-search.tsx` — uses `CommandDialog` (Dialog-wrapped, different layout context)

## Follow-ups
- Audit outer "Advanced Filters" PopoverContent in advanced-filter.tsx:336: 500px min-width popover with no maxHeight; not directly hit by iOS keyboard since it lacks an input, but tall on small viewports