### PR TITLE
Wszystkie wybory 

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -78,7 +78,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-50 max-h-[var(--radix-select-content-available-height)] min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1466.

Closes #1466

---

## Claude summary

Committed `5add295`.

Summary: the previous PR #1470 fixed all `Popover+Command` pickers but missed the most widely-used picker — shadcn `Select`. Its `SelectContent` had a hard-coded `max-h-96` (384px), which on iOS 390x844 made option lists clip off-screen when the trigger sat near the bottom of the viewport, with no way to scroll. The fix swaps it for `max-h-[var(--radix-select-content-available-height)]`, the standard Radix-provided variable that shrinks to fit between the trigger and the screen edge — the exact pattern `DropdownMenuContent` in the same file already uses. One line, applies to every `<Select>` usage across the app (settings → mail provider, send log, Google Calendar sync, automation builder, etc.).

## Follow-ups
- Audit category-picker.tsx and tags-picker.tsx for iOS Popover sizing: list has `max-h-48 overflow-y-auto` but the wrapping `PopoverContent` itself is uncapped — fine today, but if more content is added above the list it could clip.
- Verify date-range-picker.tsx behavior on iOS small viewports: not inspected for this fix.