### PR TITLE
Wybór godziny 

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -1707,8 +1707,19 @@ export function AppointmentDialog({
 
                 <Separator />
 
-                {/* Slots list */}
-                <ScrollShadow className="flex-1 min-h-0 overflow-y-auto">
+                {/* Slots list.
+                    On mobile (#1463) the right panel has no defined height
+                    — `md:h-[600px]` lives on the 3-panel wrapper and only
+                    applies on md+. With `min-h-0` on mobile the flex item
+                    collapses to 0px, hiding the slot buttons and leaving
+                    the user with no way to pick a time (and therefore no
+                    Confirmation area / "Potwierdź rezerwację" button below).
+                    Gating both `min-h-0` and the inner `overflow-y-auto` on
+                    `md:` lets the slot list expand to its content on mobile
+                    (the outer DialogContent already handles overall scroll,
+                    per #1462) while keeping desktop's in-panel scroll
+                    behavior intact. */}
+                <ScrollShadow className="flex-1 md:min-h-0 md:overflow-y-auto">
                   <div className="p-3 space-y-1.5">
                     {slotsLoading ? (
                       // Skeleton loading


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1463.

Closes #1463

---

## Claude summary

Fix committed.

Summary: The user's follow-up on #1463 ("na telefonie nic się nie przesuwa ani nie pokazuje żadnej opcji np zapisz") is a real residual bug after PR #1467. #1467 made the outer `DialogContent` scrollable on mobile but didn't fix the slot list inside the right panel, which was still collapsing to 0px. The slot list `ScrollShadow` had `flex-1 min-h-0 overflow-y-auto` (line 1711), and on mobile the right panel has no defined height (`md:h-[600px]` only applies on `md:`). `min-h-0` + `flex-basis: 0%` in an auto-height flex-col container resolves the item's hypothetical main size to 0, so iOS users saw the "Dostępne terminy" header followed by nothing — no slots to tap, and therefore no Confirmation area / "Potwierdź rezerwację" Save button (which is conditional on `selectedSlot`). The fix gates `min-h-0` and the inner `overflow-y-auto` on `md:` so mobile lets the slot list expand to content and rely on the outer DialogContent scroll, while desktop keeps its in-panel scroll. Typecheck passes.