### PR TITLE
Audit outer "Advanced Filters" PopoverContent in advanced-filter.tsx

### DIFF
--- a/src/components/crm/advanced-filter.tsx
+++ b/src/components/crm/advanced-filter.tsx
@@ -333,7 +333,14 @@ export function AdvancedFilter({
             )}
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-auto min-w-[500px] p-4" align="start">
+        <PopoverContent
+          className="w-auto sm:min-w-[500px] p-4 overflow-y-auto"
+          align="start"
+          style={{
+            maxHeight: "var(--radix-popover-content-available-height)",
+            maxWidth: "var(--radix-popover-content-available-width)",
+          }}
+        >
           <div className="space-y-3">
             <div className="flex items-center justify-between">
               <h4 className="text-sm font-medium">Advanced Filters</h4>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1471.

Closes #1471

---

## Claude summary

Committed. Summary of the fix for #1471:

The outer "Advanced Filters" `PopoverContent` at `src/components/crm/advanced-filter.tsx:336` previously used `w-auto min-w-[500px] p-4` with no inline style. On a 360–414px phone viewport this forced a 500px-wide popover (horizontal overflow), and an unbounded condition list could push the popover taller than the screen.

The change applies the same available-height pattern landed in #1465 for the inner pickers, plus a width pair: `maxHeight: var(--radix-popover-content-available-height)`, `maxWidth: var(--radix-popover-content-available-width)`, `overflow-y-auto` to scroll inside the cap, and gates the 500px min-width to `sm:` so phones get a content-sized popover instead. No behavioral change on desktop — the popover still renders at its natural ≥500px width when the viewport has the room.