### PR TITLE
Nie ma jak z tego wyjść 

### DIFF
--- a/src/components/gabinet/appointment-form.tsx
+++ b/src/components/gabinet/appointment-form.tsx
@@ -565,6 +565,8 @@ export function AppointmentForm({
                 placeholder={t("gabinet.appointments.searchPatient")}
                 value={patientSearch}
                 onValueChange={setPatientSearch}
+                onClose={() => setPatientOpen(false)}
+                closeLabel={t("common.close")}
               />
               <CommandList className="flex-1 min-h-0">
                 {filteredPatients.length === 0 &&
@@ -687,6 +689,8 @@ export function AppointmentForm({
             <Command>
               <CommandInput
                 placeholder={t("gabinet.appointments.searchTreatment")}
+                onClose={() => setTreatmentOpen(false)}
+                closeLabel={t("common.close")}
               />
               <CommandList className="flex-1 min-h-0">
                 <CommandEmpty>{t("common.noResults")}</CommandEmpty>

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -1093,6 +1093,8 @@ export function AppointmentDialog({
                           )}
                           value={patientSearch}
                           onValueChange={setPatientSearch}
+                          onClose={() => setPatientOpen(false)}
+                          closeLabel={t("common.close")}
                         />
                         <CommandList className="flex-1 min-h-0">
                           <CommandEmpty>
@@ -1181,6 +1183,8 @@ export function AppointmentDialog({
                           )}
                           value={treatmentSearch}
                           onValueChange={setTreatmentSearch}
+                          onClose={() => setTreatmentOpen(false)}
+                          closeLabel={t("common.close")}
                         />
                         <CommandList className="flex-1 min-h-0">
                           <CommandEmpty>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { type DialogProps } from "@radix-ui/react-dialog"
 import { Command as CommandPrimitive } from "cmdk"
-import { Search } from "lucide-react"
+import { Search, X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
@@ -39,10 +39,23 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
   )
 }
 
+type CommandInputProps = React.ComponentPropsWithoutRef<
+  typeof CommandPrimitive.Input
+> & {
+  /**
+   * When provided, renders a close (X) button next to the input. Lets mobile
+   * users dismiss a Popover+Command picker without selecting an item, since
+   * tapping "outside" is hard once the on-screen keyboard fills the screen
+   * (issue #1472).
+   */
+  onClose?: () => void
+  closeLabel?: string
+}
+
 const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(({ className, ...props }, ref) => (
+  CommandInputProps
+>(({ className, onClose, closeLabel = "Close", ...props }, ref) => (
   <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
     <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
     <CommandPrimitive.Input
@@ -53,6 +66,16 @@ const CommandInput = React.forwardRef<
       )}
       {...props}
     />
+    {onClose && (
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label={closeLabel}
+        className="ml-2 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    )}
   </div>
 ))
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1472.

Closes #1472

---

## Claude summary

Fix committed. Here's the summary:

The bug: on iOS, when the user tapped the patient/treatment search picker in the appointment dialog, the on-screen keyboard filled half the screen and the full-width Popover+Command picker filled most of the rest — leaving no discoverable way to dismiss the picker without selecting an item. The Radix Popover relies on tapping "outside" to close, but on mobile there was effectively no tappable "outside".

The fix adds an optional `onClose` prop to `CommandInput` (`src/components/ui/command.tsx`) that renders a small X button next to the search input. It's then wired into the patient and treatment pickers in both `src/components/gabinet/calendar/appointment-dialog.tsx` and `src/components/gabinet/appointment-form.tsx`. The change is backward-compatible — existing `CommandInput` consumers that don't pass `onClose` render unchanged.

## Follow-ups
- Add close button to other mobile Popover+Command pickers: the same iOS dismiss issue applies to crm/advanced-filter, data-table-faceted-filter, gabinet treatment-form equipment picker, and gabinet appointment-preview-content / appointment detail route treatment picker — all of which got the height-cap fix in #1470 but still have no close affordance.