### PR TITLE
Audit category-picker.tsx and tags-picker.tsx for iOS Popover sizing

### DIFF
--- a/src/components/categories-tags/category-picker.tsx
+++ b/src/components/categories-tags/category-picker.tsx
@@ -191,7 +191,13 @@ export function CategoryPicker({
             </span>
           </button>
         </PopoverTrigger>
-        <PopoverContent className="w-60 p-0" align="start">
+        <PopoverContent
+          className="flex w-60 flex-col p-0"
+          align="start"
+          style={{
+            maxHeight: "var(--radix-popover-content-available-height)",
+          }}
+        >
           <div className="p-2">
             <Input
               size="sm"
@@ -201,7 +207,7 @@ export function CategoryPicker({
               autoFocus
             />
           </div>
-          <div className="max-h-48 overflow-y-auto px-1 pb-1">
+          <div className="max-h-48 min-h-0 overflow-y-auto px-1 pb-1">
             {filteredFlat
               ? filteredFlat.map((cat) => (
                   <button

--- a/src/components/categories-tags/tags-picker.tsx
+++ b/src/components/categories-tags/tags-picker.tsx
@@ -128,7 +128,13 @@ export function TagsPicker({
             </span>
           </button>
         </PopoverTrigger>
-        <PopoverContent className="w-60 p-0" align="start">
+        <PopoverContent
+          className="flex w-60 flex-col p-0"
+          align="start"
+          style={{
+            maxHeight: "var(--radix-popover-content-available-height)",
+          }}
+        >
           <div className="p-2">
             <Input
               size="sm"
@@ -138,7 +144,7 @@ export function TagsPicker({
               autoFocus
             />
           </div>
-          <div className="max-h-48 overflow-y-auto px-1 pb-1">
+          <div className="max-h-48 min-h-0 overflow-y-auto px-1 pb-1">
             {filtered.map((tag) => (
               <button
                 key={tag._id}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1474.

Closes #1474

---

## Claude summary

Committed as `5734ea5`.

Summary: confirmed the audit was a real concern — both `category-picker.tsx` and `tags-picker.tsx` had a `PopoverContent` with no `maxHeight`, relying solely on the inner list's `max-h-48` cap. On iOS the popover could grow past available viewport once additional content sits above/below the list (e.g. the search input plus the "Add new category" footer that already exists in category-picker). Applied the same pattern used in #1465 / #1466: `PopoverContent` gets `flex flex-col` + `maxHeight: var(--radix-popover-content-available-height)`, and the scrollable list adds `min-h-0` so it can shrink and still scroll when the popover is squeezed by the keyboard. No API changes.