### PR TITLE
Verify date-range-picker.tsx behavior on iOS small viewports

### DIFF
--- a/src/components/crm/date-range-picker.tsx
+++ b/src/components/crm/date-range-picker.tsx
@@ -54,9 +54,16 @@ export function DateRangePicker() {
           <ChevronDownIcon className="size-3.5 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="flex w-auto p-0" sideOffset={8}>
-        {/* Presets sidebar */}
-        <div className="flex flex-col gap-0.5 border-r p-2">
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        className="flex w-auto max-w-[var(--radix-popover-content-available-width)] flex-col overflow-y-auto p-0 sm:flex-row"
+        style={{
+          maxHeight: "var(--radix-popover-content-available-height)",
+        }}
+      >
+        {/* Presets — horizontal wrap on mobile, sidebar on sm+ */}
+        <div className="flex flex-row flex-wrap gap-0.5 border-b p-2 sm:flex-col sm:flex-nowrap sm:border-b-0 sm:border-r">
           {PRESETS.map((preset) => (
             <Button
               key={preset.value}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1475.

Closes #1475

---

## Claude summary

Committed `17a022a`.

Summary: Verified the issue is real — `DateRangePicker` (used in the dashboard top bar) had a `PopoverContent` with no width/height cap and a side-by-side presets-sidebar + 2-month Calendar layout. On iOS 390x844 the content (~420px wide, ~600px tall when months stack) overflows both axes with no scroll. Applied the established Radix-var pattern from #1465/#1466/#1474 — `maxHeight` and `max-w` both pinned to `--radix-popover-content-available-{height,width}`, plus `overflow-y-auto` and a `flex-col → sm:flex-row` flip so on mobile the presets render as a wrapping pill row above the calendar instead of as a sidebar that wouldn't fit. Desktop appearance at `sm:` and above is unchanged.