### PR TITLE
Align ContactForm/PatientForm props across all add-entry points

### DIFF
--- a/src/components/gabinet/appointment-form.tsx
+++ b/src/components/gabinet/appointment-form.tsx
@@ -51,6 +51,8 @@ import { toast } from "sonner";
 import { SidePanel } from "@/components/crm/side-panel";
 import { PatientForm } from "@/components/forms/patient-form";
 import { useSupabaseGabinetLeavesList } from "@/hooks/use-supabase-gabinet-leaves";
+import { useTagDefinitions } from "@/hooks/use-tag-definitions";
+import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 
 function getEmployeeName(emp: {
   firstName?: string;
@@ -184,6 +186,14 @@ export function AppointmentForm({
 
   const createPatient = useAction(api.gabinet.patients.create);
   const findNextSlotAction = useAction(api.gabinet.scheduling.findNextAvailableSlot);
+
+  // Patient tag/category defs for the inline create-patient drawer
+  // (kept in sync with the patients list create-form props).
+  const { tags: orgTags } = useTagDefinitions(organizationId!);
+  const { categories: patientCategories } = useCategoryDefinitions(
+    organizationId!,
+    "gabinetPatient",
+  );
 
   // Locations query
   const listLocationsAction = useAction(api.gabinet.locations.listLocations);
@@ -1015,6 +1025,8 @@ export function AppointmentForm({
         onCancel={() => setAddPatientOpen(false)}
         isSubmitting={isCreatingPatient}
         organizationId={organizationId}
+        tagDefinitions={orgTags}
+        categoryDefinitions={patientCategories}
       />
     </SidePanel>
     </>

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -79,6 +79,8 @@ import { SidePanel } from "@/components/crm/side-panel";
 import { PatientForm } from "@/components/forms/patient-form";
 import { PackageUsageSelector } from "@/components/gabinet/package-usage-selector";
 import { useSupabaseGabinetLeavesList } from "@/hooks/use-supabase-gabinet-leaves";
+import { useTagDefinitions } from "@/hooks/use-tag-definitions";
+import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { formatPhoneNumber } from "@/lib/phone";
 
 // ---------------------------------------------------------------------------
@@ -236,6 +238,14 @@ export function AppointmentDialog({
     queryFn: () => listLocationsAction({ organizationId }),
     enabled: !!organizationId,
   });
+
+  // Patient tag/category defs for the inline create-patient drawer
+  // (kept in sync with the patients list create-form props).
+  const { tags: orgTags } = useTagDefinitions(organizationId);
+  const { categories: patientCategories } = useCategoryDefinitions(
+    organizationId,
+    "gabinetPatient",
+  );
 
   // -------------------------------------------------------------------------
   // State
@@ -1896,6 +1906,8 @@ export function AppointmentDialog({
         onCancel={() => setAddPatientOpen(false)}
         isSubmitting={creatingPatient}
         organizationId={organizationId}
+        tagDefinitions={orgTags}
+        categoryDefinitions={patientCategories}
       />
     </SidePanel>
     </>

--- a/src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx
@@ -9,6 +9,8 @@ import { useSupabaseCompany } from "@/hooks/use-supabase-companies";
 import { useSupabaseNotesByEntity } from "@/hooks/use-supabase-notes";
 import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
 import { useSupabaseCustomFieldValues, useSupabaseCustomFieldDefinitions } from "@/hooks/use-supabase-custom-fields";
+import { useTagDefinitions } from "@/hooks/use-tag-definitions";
+import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import {
   useSupabaseRelationshipsByEntity,
   type MappedRelationship,
@@ -112,6 +114,18 @@ function CompanyDetail() {
   const { data: activityCustomFieldDefs } = useSupabaseCustomFieldDefinitions(
     organizationId,
     "activity",
+  );
+
+  // Contact tag/category/custom-field defs for the create-contact drawer
+  // (kept in sync with the contacts list create-form props).
+  const { data: contactCustomFieldDefs } = useSupabaseCustomFieldDefinitions(
+    organizationId,
+    "contact",
+  );
+  const { tags: orgTags } = useTagDefinitions(organizationId);
+  const { categories: contactCategories } = useCategoryDefinitions(
+    organizationId,
+    "contact",
   );
 
   // Company entity custom fields
@@ -448,18 +462,25 @@ function CompanyDetail() {
       email?: string | null;
       phone?: string | null;
       title?: string | null;
+      source?: string | null;
+      tags?: string[];
+      tagIds?: Id<"tagDefinitions">[];
+      categoryId?: Id<"categoryDefinitions"> | null;
+      notes?: string | null;
     },
-    _customFields: Record<string, unknown>
+    customFieldRecord: Record<string, unknown>
   ) => {
     setIsSubmitting(true);
     try {
+      const customFields = contactCustomFieldDefs && Object.keys(customFieldRecord).length > 0
+        ? contactCustomFieldDefs
+            .filter((d) => customFieldRecord[d.fieldKey] !== undefined && customFieldRecord[d.fieldKey] !== "")
+            .map((d) => ({ fieldDefinitionId: d._id, value: customFieldRecord[d.fieldKey] }))
+        : undefined;
       const contactId = await createContact({
         organizationId,
-        firstName: formData.firstName,
-        lastName: formData.lastName,
-        email: formData.email,
-        phone: formData.phone,
-        title: formData.title,
+        ...formData,
+        customFields: customFields && customFields.length > 0 ? customFields : undefined,
       });
       await createRelationship({
         organizationId,
@@ -1153,6 +1174,11 @@ function CompanyDetail() {
           onSubmit={handleCreateContact}
           onCancel={() => setCreateContactDrawerOpen(false)}
           isSubmitting={isSubmitting}
+          showSourceAndTags
+          customFieldDefinitions={contactCustomFieldDefs as any}
+          tagDefinitions={orgTags}
+          categoryDefinitions={contactCategories}
+          organizationId={organizationId}
         />
       </SidePanel>
 

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
@@ -17,6 +17,8 @@ import { useSupabaseScheduledActivitiesByEntity } from "@/hooks/use-supabase-sch
 import { useSupabaseLeadsList } from "@/hooks/use-supabase-leads";
 import { useSupabaseCompaniesList } from "@/hooks/use-supabase-companies";
 import { useSupabaseCustomFieldDefinitions, useSupabaseCustomFieldValues } from "@/hooks/use-supabase-custom-fields";
+import { useTagDefinitions } from "@/hooks/use-tag-definitions";
+import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatPhoneNumber } from "@/lib/phone";
 import { SidePanel } from "@/components/crm/side-panel";
@@ -104,6 +106,14 @@ function ContactDetail() {
     definitions: contactCfDefs,
     saveValues: _saveContactCfValues,
   } = useCustomFieldForm({ organizationId, entityType: "contact" });
+
+  // Tag and category definitions for the edit drawer ContactForm
+  // (kept in sync with the contacts list create-form props).
+  const { tags: orgTags } = useTagDefinitions(organizationId);
+  const { categories: contactCategories } = useCategoryDefinitions(
+    organizationId,
+    "contact",
+  );
 
   const { data: contactCfValuesRaw } = useSupabaseCustomFieldValues(
     organizationId,
@@ -1083,6 +1093,9 @@ function ContactDetail() {
           onCancel={() => setEditDrawerOpen(false)}
           isSubmitting={isSubmitting}
           showSourceAndTags
+          tagDefinitions={orgTags}
+          categoryDefinitions={contactCategories}
+          organizationId={organizationId}
           extraFields={
             <>
               <RelationshipField

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.new.tsx
@@ -6,6 +6,8 @@ import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseCustomFieldDefinitions } from "@/hooks/use-supabase-custom-fields";
+import { useTagDefinitions } from "@/hooks/use-tag-definitions";
+import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { PageHeader } from "@/components/layout/page-header";
 import { ContactForm } from "@/components/forms/contact-form";
 import { Card, CardContent } from "@/components/ui/card";
@@ -32,6 +34,11 @@ function NewContact() {
     organizationId,
     "contact",
   );
+  const { tags: orgTags } = useTagDefinitions(organizationId);
+  const { categories: contactCategories } = useCategoryDefinitions(
+    organizationId,
+    "contact",
+  );
 
   return (
     <div>
@@ -44,6 +51,10 @@ function NewContact() {
             }
             isSubmitting={isSubmitting}
             onCancel={() => navigate({ to: "/dashboard/contacts" })}
+            showSourceAndTags
+            tagDefinitions={orgTags}
+            categoryDefinitions={contactCategories}
+            organizationId={organizationId}
             onSubmit={async (data, customFieldRecord) => {
               setIsSubmitting(true);
               try {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -6,6 +6,7 @@ import { useAction } from "convex/react";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
 import { api } from "@cvx/_generated/api";
+import type { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseGabinetPatient } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
@@ -22,6 +23,8 @@ import {
   useSupabaseGabinetTreatmentPackagesList,
 } from "@/hooks/use-supabase-gabinet-packages";
 import { useSupabasePaymentsByPatient } from "@/hooks/use-supabase-payments";
+import { useTagDefinitions } from "@/hooks/use-tag-definitions";
+import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { SidePanel } from "@/components/crm/side-panel";
 import { PatientForm } from "@/components/forms/patient-form";
@@ -102,6 +105,14 @@ function PatientDetail() {
 
   const [editDrawerOpen, setEditDrawerOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Tag and category definitions for the edit drawer PatientForm
+  // (kept in sync with the patients list create-form props).
+  const { tags: orgTags } = useTagDefinitions(organizationId);
+  const { categories: patientCategories } = useCategoryDefinitions(
+    organizationId,
+    "gabinetPatient",
+  );
 
   const [editingPaymentId, setEditingPaymentId] = useState<string | null>(null);
   const [paymentEditAmount, setPaymentEditAmount] = useState("");
@@ -403,6 +414,8 @@ function PatientDetail() {
     emergencyContactName?: string | null;
     emergencyContactPhone?: string | null;
     referralSource?: string | null;
+    tagIds?: Id<"tagDefinitions">[];
+    categoryId?: Id<"categoryDefinitions">;
   }) => {
     setIsSubmitting(true);
     try {
@@ -1467,11 +1480,15 @@ function PatientDetail() {
               emergencyContactName: patient.emergencyContactName ?? undefined,
               emergencyContactPhone: patient.emergencyContactPhone ?? undefined,
               referralSource: patient.referralSource ?? undefined,
+              tagIds: patient.tagIds as Id<"tagDefinitions">[] | undefined,
+              categoryId: patient.categoryId as Id<"categoryDefinitions"> | undefined,
             }}
             onSubmit={handleEditSubmit}
             onCancel={() => setEditDrawerOpen(false)}
             isSubmitting={isSubmitting}
             organizationId={organizationId}
+            tagDefinitions={orgTags}
+            categoryDefinitions={patientCategories}
           />
         </SidePanel>
       )}

--- a/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
@@ -25,6 +25,8 @@ import {
   type MappedRelationship,
 } from "@/hooks/use-supabase-relationships";
 import { useSupabaseLostReasonsList } from "@/hooks/use-supabase-lost-reasons";
+import { useTagDefinitions } from "@/hooks/use-tag-definitions";
+import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import {
   EntityDetailLayout,
@@ -277,6 +279,18 @@ function LeadDetail() {
   const { data: activityCustomFieldDefs } = useSupabaseCustomFieldDefinitions(
     organizationId,
     "activity",
+  );
+
+  // Contact tag/category/custom-field defs for the create-contact drawer
+  // (kept in sync with the contacts list create-form props).
+  const { data: contactCustomFieldDefs } = useSupabaseCustomFieldDefinitions(
+    organizationId,
+    "contact",
+  );
+  const { tags: orgTags } = useTagDefinitions(organizationId);
+  const { categories: contactCategories } = useCategoryDefinitions(
+    organizationId,
+    "contact",
   );
 
   // Lead entity custom fields
@@ -691,18 +705,31 @@ function LeadDetail() {
   };
 
   const handleCreateContact = async (
-    formData: { firstName: string; lastName?: string | null; email?: string | null; phone?: string | null; title?: string | null },
-    _customFields: Record<string, unknown>
+    formData: {
+      firstName: string;
+      lastName?: string | null;
+      email?: string | null;
+      phone?: string | null;
+      title?: string | null;
+      source?: string | null;
+      tags?: string[];
+      tagIds?: Id<"tagDefinitions">[];
+      categoryId?: Id<"categoryDefinitions"> | null;
+      notes?: string | null;
+    },
+    customFieldRecord: Record<string, unknown>
   ) => {
     setIsSubmitting(true);
     try {
+      const customFields = contactCustomFieldDefs && Object.keys(customFieldRecord).length > 0
+        ? contactCustomFieldDefs
+            .filter((d) => customFieldRecord[d.fieldKey] !== undefined && customFieldRecord[d.fieldKey] !== "")
+            .map((d) => ({ fieldDefinitionId: d._id, value: customFieldRecord[d.fieldKey] }))
+        : undefined;
       const contactId = await createContactMutation({
         organizationId,
-        firstName: formData.firstName,
-        lastName: formData.lastName,
-        email: formData.email,
-        phone: formData.phone,
-        title: formData.title,
+        ...formData,
+        customFields: customFields && customFields.length > 0 ? customFields : undefined,
       });
       await createRelationship({
         organizationId,
@@ -1540,6 +1567,11 @@ function LeadDetail() {
           onSubmit={handleCreateContact}
           onCancel={() => setCreateContactDrawerOpen(false)}
           isSubmitting={isSubmitting}
+          showSourceAndTags
+          customFieldDefinitions={contactCustomFieldDefs as any}
+          tagDefinitions={orgTags}
+          categoryDefinitions={contactCategories}
+          organizationId={organizationId}
         />
       </SidePanel>
 

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -8,6 +8,7 @@ import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { useSupabaseSafe } from "@/components/supabase-provider";
 import { supabaseGlobalSearch } from "@/hooks/use-supabase-search";
 import { useSupabaseScheduledActivityById } from "@/hooks/use-supabase-scheduled-activities";
+import { useSupabaseCustomFieldDefinitions } from "@/hooks/use-supabase-custom-fields";
 import { AppSidebar } from "@/components/layout/app-sidebar";
 import { AppFooter } from "@/components/layout/app-footer";
 import { RouteErrorBoundary } from "@/components/layout/route-error-boundary";
@@ -234,9 +235,11 @@ function DashboardLayout() {
 
   const firstOrg = orgs?.[0];
 
-  // Tag & category definitions for quick-create appointment form
+  // Tag & category definitions for quick-create forms.
+  // Tag defs are org-scoped (not entity-typed) so a single fetch covers all forms.
+  // Category defs are entity-typed, so one fetch per entity type used in quick-create.
   const listTagDefinitionsAction = useAction(api.tagDefinitions.list);
-  const { data: appointmentTags } = useQuery({
+  const { data: orgTags } = useQuery({
     queryKey: ["tagDefinitions.list", firstOrg?._id ?? null],
     queryFn: () => listTagDefinitionsAction({
       organizationId: firstOrg?._id as Id<"organizations">,
@@ -252,6 +255,27 @@ function DashboardLayout() {
     }),
     enabled: !!firstOrg,
   }) as { data: any[] | undefined };
+  const { data: contactCategories } = useQuery({
+    queryKey: ["categoryDefinitions.list", firstOrg?._id ?? null, "contact"],
+    queryFn: () => listCategoryDefinitionsAction({
+      organizationId: firstOrg?._id as Id<"organizations">,
+      entityType: "contact" as const,
+    }),
+    enabled: !!firstOrg,
+  }) as { data: any[] | undefined };
+  const { data: patientCategories } = useQuery({
+    queryKey: ["categoryDefinitions.list", firstOrg?._id ?? null, "gabinetPatient"],
+    queryFn: () => listCategoryDefinitionsAction({
+      organizationId: firstOrg?._id as Id<"organizations">,
+      entityType: "gabinetPatient" as const,
+    }),
+    enabled: !!firstOrg,
+  }) as { data: any[] | undefined };
+  const { data: contactCustomFieldDefs } = useSupabaseCustomFieldDefinitions(
+    (firstOrg?._id ?? "") as string,
+    "contact",
+    { enabled: !!firstOrg },
+  );
 
   // Global activity detail drawer data — Supabase-primary
   const { data: activityDetailData } = useSupabaseScheduledActivityById(
@@ -382,10 +406,19 @@ function DashboardLayout() {
         case "contact":
           return (
             <ContactForm
-              onSubmit={async (data) => {
+              onSubmit={async (data, customFieldRecord) => {
                 setIsCreating(true);
                 try {
-                  await createContact({ organizationId: orgId, ...data });
+                  const customFields = contactCustomFieldDefs && Object.keys(customFieldRecord).length > 0
+                    ? contactCustomFieldDefs
+                        .filter((d) => customFieldRecord[d.fieldKey] !== undefined && customFieldRecord[d.fieldKey] !== "")
+                        .map((d) => ({ fieldDefinitionId: d._id, value: customFieldRecord[d.fieldKey] }))
+                    : undefined;
+                  await createContact({
+                    organizationId: orgId,
+                    ...data,
+                    customFields: customFields && customFields.length > 0 ? customFields : undefined,
+                  });
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.contacts.list(orgId) });
                   opts.onSuccess();
                 } finally {
@@ -394,6 +427,11 @@ function DashboardLayout() {
               }}
               onCancel={opts.onCancel}
               isSubmitting={isCreating}
+              showSourceAndTags
+              customFieldDefinitions={contactCustomFieldDefs as any}
+              tagDefinitions={orgTags}
+              categoryDefinitions={contactCategories}
+              organizationId={orgId}
             />
           );
         case "company":
@@ -454,6 +492,8 @@ function DashboardLayout() {
               onCancel={opts.onCancel}
               isSubmitting={isCreating}
               organizationId={orgId}
+              tagDefinitions={orgTags}
+              categoryDefinitions={patientCategories}
             />
           );
         case "appointment":
@@ -472,7 +512,7 @@ function DashboardLayout() {
               }}
               onCancel={opts.onCancel}
               isSubmitting={isCreating}
-              tagDefinitions={appointmentTags}
+              tagDefinitions={orgTags}
               categoryDefinitions={appointmentCategories}
             />
           );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1478.

Closes #1478

---

## Claude summary

Committed as `05d113e`. 

The worktree had a partial previous attempt at this issue — 7 of 8 call sites were already aligned but the patient detail edit drawer had imports/hooks added without actually wiring them to the `PatientForm`. I finished that wiring: passed `tagDefinitions`/`categoryDefinitions` to the form, seeded `initialData.tagIds`/`categoryId` from the loaded patient, and added those two fields to `handleEditSubmit`'s signature so they round-trip on save.

Verified the canonical contacts/patients list patterns match what's now passed at every add-entry point (Quick Create in `_layout.tsx`, `/contacts/new`, lead detail, company detail, contact detail edit drawer, patient detail edit drawer, appointment form's inline patient create, calendar appointment dialog's inline patient create). `npm run typecheck` passes on `tsconfig.app.json` — the two remaining errors are pre-existing in `convex/gabinet/appointmentSms.ts` and unrelated.