### PR TITLE
Add close button to other mobile Popover+Command pickers

### DIFF
--- a/src/components/crm/advanced-filter.tsx
+++ b/src/components/crm/advanced-filter.tsx
@@ -107,7 +107,11 @@ function QuickFilterChip({
         }}
       >
         <Command>
-          <CommandInput placeholder={`Filter ${filter.label}...`} />
+          <CommandInput
+            placeholder={`Filter ${filter.label}...`}
+            onClose={() => setOpen(false)}
+            closeLabel="Close"
+          />
           <CommandList className="flex-1 min-h-0">
             <CommandEmpty>No options found.</CommandEmpty>
             <CommandGroup>

--- a/src/components/data-table/data-table-faceted-filter.tsx
+++ b/src/components/data-table/data-table-faceted-filter.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { Column } from "@tanstack/react-table";
 import { Check, PlusCircle } from "@/lib/ez-icons";
 import { cn } from "@/lib/utils";
@@ -32,9 +33,10 @@ export function DataTableFacetedFilter<TData, TValue>({
 }: DataTableFacetedFilterProps<TData, TValue>) {
   const facets = column?.getFacetedUniqueValues();
   const selectedValues = new Set(column?.getFilterValue() as string[]);
+  const [open, setOpen] = React.useState(false);
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button variant="outline" size="sm" className="h-9 border-dashed">
           <PlusCircle className="mr-2 h-4 w-4" />
@@ -82,7 +84,11 @@ export function DataTableFacetedFilter<TData, TValue>({
         }}
       >
         <Command>
-          <CommandInput placeholder={title} />
+          <CommandInput
+            placeholder={title}
+            onClose={() => setOpen(false)}
+            closeLabel="Close"
+          />
           <CommandList className="flex-1 min-h-0">
             <CommandEmpty>No results found.</CommandEmpty>
             <CommandGroup>

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -1028,6 +1028,8 @@ export function AppointmentPreviewContent({
                     placeholder={t("gabinet.appointments.searchTreatment")}
                     value={treatmentSearch}
                     onValueChange={setTreatmentSearch}
+                    onClose={() => setTreatmentOpen(false)}
+                    closeLabel={t("common.close")}
                   />
                   <CommandList className="flex-1 min-h-0">
                     <CommandEmpty>{t("common.noResults")}</CommandEmpty>

--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -422,7 +422,11 @@ export function TreatmentForm({
                 </div>
               ) : (
                 <Command>
-                  <CommandInput placeholder={t("gabinet.treatments.searchEquipment", "Search equipment...")} />
+                  <CommandInput
+                    placeholder={t("gabinet.treatments.searchEquipment", "Search equipment...")}
+                    onClose={() => setEquipmentOpen(false)}
+                    closeLabel={t("common.close")}
+                  />
                   <CommandList className="flex-1 min-h-0">
                     <CommandEmpty>{t("common.noResults", "No results found.")}</CommandEmpty>
                     <CommandGroup>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1352,6 +1352,8 @@ function AppointmentDetail() {
                         placeholder={t("gabinet.appointments.searchTreatment")}
                         value={treatmentSearch}
                         onValueChange={setTreatmentSearch}
+                        onClose={() => setTreatmentPickerOpen(false)}
+                        closeLabel={t("common.close")}
                       />
                       <CommandList className="flex-1 min-h-0">
                         <CommandEmpty>{t("common.noResults")}</CommandEmpty>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1483.

Closes #1483

---

## Claude summary

Committed `da49f31`. Wired the existing `onClose`/`closeLabel` props (introduced for the patient/treatment picker in #1472) into the five remaining Popover+Command pickers called out in the issue. The faceted filter was uncontrolled, so it gets a local `useState` for the open flag; the other four already had controlled popover state. Portable typecheck reports only pre-existing unrelated errors in `convex/gabinet/appointmentSms.ts`.