### PR TITLE
Clean up unused `ctx` parameters in `convex/gabinet/appointmentSms.ts

### DIFF
--- a/convex/gabinet/appointmentSms.ts
+++ b/convex/gabinet/appointmentSms.ts
@@ -368,7 +368,7 @@ export const markEventProcessed = internalMutation({
     providerMessageId: v.optional(v.string()),
     metadata: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     const db = createSupabaseDb();
     await db.patch("appointmentSmsEvents", args.eventId, {
       providerMessageId: args.providerMessageId,
@@ -386,7 +386,7 @@ export const markEventFailed = internalMutation({
     error: v.string(),
     metadata: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     const db = createSupabaseDb();
     await db.patch("appointmentSmsEvents", args.eventId, {
       processingStatus: "failed",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1492.

Closes #1492

---

## Claude summary

Renamed the unused `ctx` parameters to `_ctx` at `convex/gabinet/appointmentSms.ts:371` and `:389` to silence TS6133. Both handlers use `createSupabaseDb()` instead of the Convex context, so the parameter is genuinely unused. The `_ctx` convention is used across 21 other files in `convex/`, so this matches the existing style. Committed as `c987978`.