### PR TITLE
Po zalogowaniu jest porblem

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -195,14 +195,21 @@ const typeIcons: Record<string, React.ReactNode> = {
   product: <Package className="h-4 w-4" variant="stroke" />,
 };
 
-function DashboardLayout() {
+// Inner component runs inside the provider stack so Supabase hooks (e.g.
+// useSupabaseCustomFieldDefinitions) resolve their context. Mounting the
+// providers and calling these hooks in the same component would throw —
+// the context lookup walks ancestors, not descendants. See #1496.
+interface DashboardLayoutInnerProps {
+  // Loose typing avoids fighting Convex codegen's deep instantiation here.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  user: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  firstOrg: any;
+}
+
+function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
   const { t } = useTranslation();
   const quickCreateRef = useRef<QuickCreateMenuHandle>(null);
-  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
-  const { data: user } = useQuery(convexQuery(api.app.getCurrentUser, {}));
-  const { data: orgs } = useQuery(
-    convexQuery(api.organizations.getMyOrganizations, {})
-  );
   const signOut = useSignOut();
   const navigate = useNavigate();
   const { client: supabase } = useSupabaseSafe();
@@ -232,8 +239,6 @@ function DashboardLayout() {
   // Global activity detail drawer
   const [activityDetailId, setActivityDetailId] = useState<string | null>(null);
   const [activityDetailSubmitting, setActivityDetailSubmitting] = useState(false);
-
-  const firstOrg = orgs?.[0];
 
   // Tag & category definitions for quick-create forms.
   // Tag defs are org-scoped (not entity-typed) so a single fetch covers all forms.
@@ -721,22 +726,8 @@ function DashboardLayout() {
     [navigate, lastDispatch]
   );
 
-  if (!user || !orgs) {
-    return null;
-  }
-
-  if (!firstOrg) {
-    return null;
-  }
-
   return (
-    <DateRangeProvider>
-    <OrgProvider initialOrgId={firstOrg?._id}>
-      <SupabaseProvider>
-      <NudgesProvider>
-      <MiniCalendarProvider>
-      <SidebarSlotProvider>
-      <HeaderSlotProvider>
+    <>
       <div className="flex h-dvh w-full flex-col overflow-hidden">
         {/* Beta strip */}
         <div
@@ -931,13 +922,36 @@ function DashboardLayout() {
         }}
         isSubmitting={activityDetailSubmitting}
       />
+    </>
+  );
+}
 
-    </HeaderSlotProvider>
-    </SidebarSlotProvider>
-    </MiniCalendarProvider>
-    </NudgesProvider>
-    </SupabaseProvider>
-    </OrgProvider>
+function DashboardLayout() {
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
+  const { data: user } = useQuery(convexQuery(api.app.getCurrentUser, {}));
+  const { data: orgs } = useQuery(
+    convexQuery(api.organizations.getMyOrganizations, {})
+  );
+
+  if (!user || !orgs) return null;
+  const firstOrg = orgs[0];
+  if (!firstOrg) return null;
+
+  return (
+    <DateRangeProvider>
+      <OrgProvider initialOrgId={firstOrg._id}>
+        <SupabaseProvider>
+          <NudgesProvider>
+            <MiniCalendarProvider>
+              <SidebarSlotProvider>
+                <HeaderSlotProvider>
+                  <DashboardLayoutInner user={user} firstOrg={firstOrg} />
+                </HeaderSlotProvider>
+              </SidebarSlotProvider>
+            </MiniCalendarProvider>
+          </NudgesProvider>
+        </SupabaseProvider>
+      </OrgProvider>
     </DateRangeProvider>
   );
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1496.

Closes #1496

---

## Claude summary

Committed. Summary of the fix:

The post-login error `useSupabase() must be used inside <SupabaseProvider>` came from `DashboardLayout` calling `useSupabaseCustomFieldDefinitions` (line 274) at the top of the component while mounting `<SupabaseProvider>` further down inside its own JSX. React context flows from ancestors to descendants — a provider rendered as a child of a component cannot serve that same component's hooks, so the throwing variant of `useSupabase()` fired on every render of the authenticated dashboard.

This is the same shape of bug fixed previously in c6a5a95; the latest offender was introduced in 43aa95e (PR #1478) when contact custom-field definitions were wired into the global quick-create flow.

Fix: split `DashboardLayout` into a thin outer component that fetches `user`/`orgs` and mounts the provider stack, plus a new `DashboardLayoutInner` that contains all the existing hooks, callbacks, and JSX. The inner now runs inside `<SupabaseProvider>`, so `useSupabaseCustomFieldDefinitions` resolves its context, and `useSupabaseScheduledActivityById` (which had been silently inert under `useSupabaseSafe`) starts working too.

Typecheck passes; lint reports only pre-existing `any` warnings unrelated to the change. Committed as 5711c11 on `claude/issue-1496`.

## Follow-ups
- Add an ESLint rule or runtime guard against mounting context providers in the same component that calls their hooks: this exact mistake has now shipped twice (c6a5a95, #1478) on `_layout.tsx`; a custom rule or a small wrapper component pattern would prevent the third.
- Reconsider `useSupabaseSafe` ergonomics: silently returning `{client: null, isReady: false}` masks "called above provider" misuse — a dev-only warning would surface bugs like the dormant `useSupabaseScheduledActivityById` call that never fetched data.