### PR TITLE
Reconsider `useSupabaseSafe` ergonomics

### DIFF
--- a/src/components/supabase-provider.tsx
+++ b/src/components/supabase-provider.tsx
@@ -105,14 +105,34 @@ export function useSupabase(): SupabaseContextValue {
  * Non-throwing variant of `useSupabase()`.
  *
  * Returns `{ client: null, isReady: false }` when called outside
- * `<SupabaseProvider>` instead of throwing. Use in components that
- * render *above* the provider but conditionally need the client
- * (e.g. the dashboard layout which both renders the provider and
- * uses global search).
+ * `<SupabaseProvider>` instead of throwing. Reserved for rare cases
+ * where a component genuinely renders both above and below the provider
+ * (none exist in this codebase as of #1499). Prefer `useSupabase()` —
+ * the throwing variant surfaces misuse instead of silently disabling
+ * fetches.
+ *
+ * In development, logs a one-shot warning when called outside the
+ * provider so a "called above provider" bug doesn't sit dormant the
+ * way `useSupabaseScheduledActivityById` did before #1499.
  */
+let warnedSupabaseSafeOutsideProvider = false;
+
 export function useSupabaseSafe(): SupabaseContextValue {
   const ctx = useContext(SupabaseContext);
-  return ctx ?? { client: null, isReady: false };
+  if (ctx === null) {
+    if (import.meta.env.DEV && !warnedSupabaseSafeOutsideProvider) {
+      warnedSupabaseSafeOutsideProvider = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[useSupabaseSafe] called outside <SupabaseProvider>. " +
+          "Returning { client: null, isReady: false } — fetches will be disabled. " +
+          "If this hook is supposed to fetch data, the component is mounted above " +
+          "the provider; switch to useSupabase() or move the consumer below the provider.",
+      );
+    }
+    return { client: null, isReady: false };
+  }
+  return ctx;
 }
 
 /**

--- a/src/hooks/use-supabase-scheduled-activities.ts
+++ b/src/hooks/use-supabase-scheduled-activities.ts
@@ -3,7 +3,7 @@
  */
 
 import { useQuery } from "@tanstack/react-query";
-import { useSupabaseSafe as useSupabase } from "@/components/supabase-provider";
+import { useSupabase } from "@/components/supabase-provider";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { mapScheduledActivityFromSupabase, type MappedScheduledActivity } from "@/lib/supabase/mappers";
 

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -5,7 +5,7 @@ import { useAction } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
-import { useSupabaseSafe } from "@/components/supabase-provider";
+import { useSupabase } from "@/components/supabase-provider";
 import { supabaseGlobalSearch } from "@/hooks/use-supabase-search";
 import { useSupabaseScheduledActivityById } from "@/hooks/use-supabase-scheduled-activities";
 import { useSupabaseCustomFieldDefinitions } from "@/hooks/use-supabase-custom-fields";
@@ -212,7 +212,7 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
   const quickCreateRef = useRef<QuickCreateMenuHandle>(null);
   const signOut = useSignOut();
   const navigate = useNavigate();
-  const { client: supabase } = useSupabaseSafe();
+  const { client: supabase } = useSupabase();
   const queryClient = useQueryClient();
 
   const [searchOpen, setSearchOpen] = useState(false);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1499.

Closes #1499

---

## Claude summary

Committed `8cd804a`. Summary of changes:

`src/components/supabase-provider.tsx` — `useSupabaseSafe()` now logs a one-shot `console.warn` in dev when called outside the provider, explaining how to fix it. Updated JSDoc to clarify it's a rare-case fallback and recommend `useSupabase()` by default.

`src/hooks/use-supabase-scheduled-activities.ts` — switched the module-wide import from `useSupabaseSafe as useSupabase` back to plain `useSupabase`. This was the outlier; every other `use-supabase-*` hook in the codebase already uses the throwing variant. Restores fetch behavior for `useSupabaseScheduledActivityById` (the dormant hook the issue called out) and all sibling hooks in that file.

`src/routes/_app/_auth/dashboard/_layout.tsx` — `DashboardLayoutInner` now uses `useSupabase()`. After #1496 the inner component lives inside `<SupabaseProvider>`, so the safe variant was no longer needed.

Typecheck passes; lint emits only pre-existing warnings.