### PR TITLE
dodaj wizytę

### DIFF
--- a/src/components/layout/app-footer.tsx
+++ b/src/components/layout/app-footer.tsx
@@ -75,7 +75,7 @@ const defaultGabinetActions: FooterAction[] = [
 
 const gabinetRouteActions: Record<string, FooterAction[]> = {
   calendar: [
-    { labelKey: "nav.actions.bookAppointment", icon: CalendarCheck, quickCreate: "appointment" },
+    { labelKey: "nav.actions.bookAppointment", icon: CalendarCheck, action: "openCreateAppointment" },
     { labelKey: "nav.actions.filters", icon: Filter, action: "openFilter" },
     { labelKey: "nav.actions.addPatient", icon: UserPlus, quickCreate: "patient" },
     { labelKey: "nav.actions.manageTags", icon: Tag, action: "manageTags" },

--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -99,7 +99,7 @@ export const gabinetManifest: ModuleManifest = {
         {
           labelKey: "nav.actions.addAppointment",
           icon: CalendarCheck,
-          quickCreate: "appointment",
+          dispatch: "openCreateAppointment",
           permissionFeature: "gabinet_appointments",
         },
         { labelKey: "nav.actions.filters", icon: Filter, dispatch: "openFilter" },

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -888,6 +888,10 @@ function GabinetCalendarPage() {
   useSidebarDispatch("goToToday", goToday);
   useSidebarDispatch("openFilter", () => setFilterOpen(true));
   useSidebarDispatch("manageTags", () => setTagsSlideoutOpen(true));
+  // Route the sidebar/footer "Add appointment" entries to the same dialog
+  // used by the toolbar's "Nowa wizyta" button so all entry points behave
+  // identically on the calendar page (issue #1502).
+  useSidebarDispatch("openCreateAppointment", openCreateDialog);
 
   // ?action=sell-package opens the sell package side panel after navigation
   // from the gabinet quick-actions dropdown (issue #1236). Clear the param


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1502.

Closes #1502

---

## Claude summary

Committed as `0b309e5`.

Summary: On `/dashboard/gabinet/calendar`, three controls for "add appointment" existed — the toolbar button (`AppointmentDialog`), the left-sidebar pageContext button, and the app-footer button. The latter two opened a different, simpler form in a SidePanel sheet. I rerouted both to the same `AppointmentDialog` by switching them from `quickCreate: "appointment"` to a `openCreateAppointment` dispatch that the calendar route now handles via `useSidebarDispatch`, calling the existing `openCreateDialog`. Off-calendar entry points (dashboard pageContext, gabinet quick-actions dropdown) keep the SidePanel flow since they need to work without the calendar context.

## Follow-ups
- Consider unifying off-calendar appointment creation too: dashboard pageContext and `GabinetQuickActionsDropdown` still open the simpler `AppointmentForm` SidePanel; long-term those could navigate to calendar and open the dialog, or AppointmentDialog could be promoted to a global modal.
- Reconcile two near-duplicate appointment-creation components: `src/components/gabinet/calendar/appointment-dialog.tsx` (1916 lines) and `src/components/gabinet/appointment-form.tsx` (1034 lines) have heavy overlap (patient/treatment/slot pickers, leaves warning, equipment warning) — split into shared subcomponents.