### PR TITLE
scal klienta

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -529,6 +529,283 @@ export const _removeSideEffects = internalMutation({
   },
 });
 
+export const merge = action({
+  args: {
+    organizationId: v.id("organizations"),
+    targetPatientId: v.string(),
+    sourcePatientId: v.string(),
+  },
+  handler: async (ctx, args): Promise<{
+    movedAppointments: number;
+    movedDocuments: number;
+    movedPackageUsage: number;
+    movedLoyaltyTransactions: number;
+    movedPayments: number;
+    movedNotes: number;
+    movedActivities: number;
+    movedRelationships: number;
+    movedPortalSessions: number;
+    movedSmsEvents: number;
+    movedReferrals: number;
+    movedBookedBy: number;
+    consolidatedLoyaltyBalance: number;
+  }> => {
+    if (args.targetPatientId === args.sourcePatientId) {
+      throw new Error("Cannot merge a patient with itself");
+    }
+
+    const authResult = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      {
+        organizationId: args.organizationId,
+        feature: "gabinet_patients",
+        action: "delete",
+      },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    const db = createSupabaseDb();
+    const orgIdStr = String(args.organizationId);
+
+    const [target, source] = await Promise.all([
+      db.get("gabinetPatients", args.targetPatientId),
+      db.get("gabinetPatients", args.sourcePatientId),
+    ]);
+    if (!target || String(target.organizationId) !== orgIdStr) {
+      throw new Error("Target patient not found");
+    }
+    if (!source || String(source.organizationId) !== orgIdStr) {
+      throw new Error("Source patient not found");
+    }
+    if (perm.scope === "own") {
+      const userIdStr = String(authResult.userId);
+      if (String(target.createdBy) !== userIdStr || String(source.createdBy) !== userIdStr) {
+        throw new Error("Permission denied: you can only merge your own records");
+      }
+    }
+
+    const client = db.raw();
+
+    async function reassignByColumn(
+      table: string,
+      column: string,
+    ): Promise<number> {
+      const { data, error } = await client
+        .from(table)
+        .update({ [column]: args.targetPatientId })
+        .eq("organization_id", orgIdStr)
+        .eq(column, args.sourcePatientId)
+        .select("id");
+      if (error) {
+        throw new Error(`merge: failed updating ${table}.${column}: ${error.message}`);
+      }
+      return data?.length ?? 0;
+    }
+
+    // Bulk reassign foreign keys pointing at the source patient over to the target.
+    const movedAppointments = await reassignByColumn("gabinet_appointments", "patient_id");
+    const movedBookedBy = await reassignByColumn("gabinet_appointments", "booked_by_patient_id");
+    const movedDocuments = await reassignByColumn("gabinet_documents", "patient_id");
+    const movedPackageUsage = await reassignByColumn("gabinet_package_usage", "patient_id");
+    const movedLoyaltyTransactions = await reassignByColumn(
+      "gabinet_loyalty_transactions",
+      "patient_id",
+    );
+    const movedPayments = await reassignByColumn("payments", "patient_id");
+    const movedPortalSessions = await reassignByColumn(
+      "gabinet_portal_sessions",
+      "patient_id",
+    );
+    const movedSmsEvents = await reassignByColumn(
+      "appointment_sms_events",
+      "patient_id",
+    );
+    const movedReferrals = await reassignByColumn(
+      "gabinet_patients",
+      "referred_by_patient_id",
+    );
+
+    // Polymorphic reassignment: activities/notes/object_relationships scope by
+    // entity_type so we filter on both the type discriminator and the patient id.
+    async function reassignPolymorphic(
+      table: string,
+      typeColumn: string,
+      idColumn: string,
+      entityType: string,
+    ): Promise<number> {
+      const { data, error } = await client
+        .from(table)
+        .update({ [idColumn]: args.targetPatientId })
+        .eq("organization_id", orgIdStr)
+        .eq(typeColumn, entityType)
+        .eq(idColumn, args.sourcePatientId)
+        .select("id");
+      if (error) {
+        throw new Error(
+          `merge: failed updating ${table}.${idColumn} (type=${entityType}): ${error.message}`,
+        );
+      }
+      return data?.length ?? 0;
+    }
+
+    const movedNotes = await reassignPolymorphic(
+      "notes",
+      "entity_type",
+      "entity_id",
+      "gabinetPatient",
+    );
+    const movedActivities = await reassignPolymorphic(
+      "activities",
+      "entity_type",
+      "entity_id",
+      "gabinetPatient",
+    );
+    const movedRelationshipsSource = await reassignPolymorphic(
+      "object_relationships",
+      "source_type",
+      "source_id",
+      "gabinetPatient",
+    );
+    const movedRelationshipsTarget = await reassignPolymorphic(
+      "object_relationships",
+      "target_type",
+      "target_id",
+      "gabinetPatient",
+    );
+    const movedRelationships = movedRelationshipsSource + movedRelationshipsTarget;
+
+    // Loyalty points have a unique (organization_id, patient_id) constraint, so
+    // we can't reassign a source row onto an existing target row. Read both,
+    // sum the balances onto the target (or just rename the source row if the
+    // target has none), then delete the source row.
+    const [targetLoyalty, sourceLoyalty] = await Promise.all([
+      db
+        .query("gabinetLoyaltyPoints")
+        .eq("organizationId", orgIdStr)
+        .eq("patientId", args.targetPatientId)
+        .first(),
+      db
+        .query("gabinetLoyaltyPoints")
+        .eq("organizationId", orgIdStr)
+        .eq("patientId", args.sourcePatientId)
+        .first(),
+    ]);
+
+    let consolidatedLoyaltyBalance = 0;
+    if (sourceLoyalty) {
+      const sBalance = Number(sourceLoyalty.balance ?? 0);
+      const sEarned = Number(sourceLoyalty.lifetimeEarned ?? 0);
+      const sSpent = Number(sourceLoyalty.lifetimeSpent ?? 0);
+      if (targetLoyalty) {
+        const newBalance = Number(targetLoyalty.balance ?? 0) + sBalance;
+        await db.patch("gabinetLoyaltyPoints", String(targetLoyalty._id), {
+          balance: newBalance,
+          lifetimeEarned: Number(targetLoyalty.lifetimeEarned ?? 0) + sEarned,
+          lifetimeSpent: Number(targetLoyalty.lifetimeSpent ?? 0) + sSpent,
+          updatedAt: Date.now(),
+        });
+        await db.delete("gabinetLoyaltyPoints", String(sourceLoyalty._id));
+        consolidatedLoyaltyBalance = newBalance;
+      } else {
+        await db.patch("gabinetLoyaltyPoints", String(sourceLoyalty._id), {
+          patientId: args.targetPatientId,
+          updatedAt: Date.now(),
+        });
+        consolidatedLoyaltyBalance = sBalance;
+      }
+    } else if (targetLoyalty) {
+      consolidatedLoyaltyBalance = Number(targetLoyalty.balance ?? 0);
+    }
+
+    // Soft-delete the source patient and annotate why it was deactivated.
+    const now = Date.now();
+    const sourceNotesPrefix = `[Merged into patient ${args.targetPatientId} at ${new Date(now).toISOString()}]`;
+    const existingNotes = (source.medicalNotes as string | null | undefined) ?? "";
+    await db.patch("gabinetPatients", args.sourcePatientId, {
+      isActive: false,
+      medicalNotes: existingNotes ? `${sourceNotesPrefix}\n${existingNotes}` : sourceNotesPrefix,
+      updatedAt: now,
+    });
+
+    try {
+      await ctx.runMutation(internal.gabinet.patients._mergeSideEffects, {
+        organizationId: args.organizationId,
+        targetPatientId: args.targetPatientId,
+        sourcePatientId: args.sourcePatientId,
+        targetName: `${target.firstName ?? ""} ${target.lastName ?? ""}`.trim(),
+        sourceName: `${source.firstName ?? ""} ${source.lastName ?? ""}`.trim(),
+        performedBy: String(authResult.userId),
+      });
+    } catch (e) {
+      console.error(
+        "[patients.merge] Side effects FAILED for target/source",
+        args.targetPatientId,
+        args.sourcePatientId,
+        ":",
+        e,
+      );
+    }
+
+    return {
+      movedAppointments,
+      movedDocuments,
+      movedPackageUsage,
+      movedLoyaltyTransactions,
+      movedPayments,
+      movedNotes,
+      movedActivities,
+      movedRelationships,
+      movedPortalSessions,
+      movedSmsEvents,
+      movedReferrals,
+      movedBookedBy,
+      consolidatedLoyaltyBalance,
+    };
+  },
+});
+
+export const _mergeSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    targetPatientId: v.string(),
+    sourcePatientId: v.string(),
+    targetName: v.string(),
+    sourceName: v.string(),
+    performedBy: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const performedByUserId = args.performedBy as Id<"users">;
+
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetPatient",
+      entityId: args.targetPatientId as Id<"gabinetPatients">,
+      action: "updated",
+      description: `Scalono klienta "${args.sourceName}" do "${args.targetName}"`,
+      metadata: {
+        merge: { sourcePatientId: args.sourcePatientId },
+      },
+      performedBy: performedByUserId,
+    });
+
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetPatient",
+      entityId: args.sourcePatientId as Id<"gabinetPatients">,
+      action: "deleted",
+      description: `Klient scalony do "${args.targetName}"`,
+      metadata: {
+        merge: { targetPatientId: args.targetPatientId },
+      },
+      performedBy: performedByUserId,
+    });
+  },
+});
+
 export const getByContact = action({
   args: {
     organizationId: v.id("organizations"),

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2225,6 +2225,22 @@
       "errors": {
         "createFailed": "Could not add the client.",
         "saveFailed": "Could not save client changes."
+      },
+      "merge": {
+        "action": "Merge with...",
+        "title": "Merge clients",
+        "description": "Pick the client that data should be moved to. The source client will be deactivated.",
+        "sourceLabel": "Source (will be deactivated)",
+        "searchPlaceholder": "Search by name, email or phone...",
+        "matchEmail": "Same email",
+        "matchPhone": "Same phone",
+        "matchSearch": "Search",
+        "noDuplicates": "No duplicates by email or phone. Use the search above to pick another client.",
+        "noContactInfo": "This client has no email or phone, so automatic matching is unavailable. Search manually.",
+        "warning": "All appointments, documents, payments, loyalty points and notes will be transferred. This operation cannot be undone.",
+        "confirm": "Merge",
+        "success": "Client merged. {{count}} related records were moved.",
+        "error": "Could not merge clients."
       }
     },
     "treatments": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2251,6 +2251,22 @@
       "errors": {
         "createFailed": "Nie udało się dodać klienta.",
         "saveFailed": "Nie udało się zapisać zmian klienta."
+      },
+      "merge": {
+        "action": "Scal z...",
+        "title": "Scal klientów",
+        "description": "Wybierz klienta, do którego mają zostać przeniesione dane. Klient źródłowy zostanie dezaktywowany.",
+        "sourceLabel": "Źródło (zostanie dezaktywowane)",
+        "searchPlaceholder": "Szukaj klienta po imieniu, e-mailu lub telefonie...",
+        "matchEmail": "Ten sam e-mail",
+        "matchPhone": "Ten sam telefon",
+        "matchSearch": "Wyszukiwanie",
+        "noDuplicates": "Brak duplikatów po e-mailu lub telefonie. Skorzystaj z wyszukiwarki powyżej, aby wybrać innego klienta.",
+        "noContactInfo": "Klient nie ma e-maila ani telefonu, więc automatyczne dopasowanie nie jest możliwe. Wyszukaj klienta ręcznie.",
+        "warning": "Wszystkie wizyty, dokumenty, płatności, punkty lojalnościowe i notatki zostaną przeniesione. Operacja jest nieodwracalna.",
+        "confirm": "Scal",
+        "success": "Scalono klienta. Przeniesiono {{count}} powiązanych rekordów.",
+        "error": "Nie udało się scalić klientów."
       }
     },
     "treatments": {

--- a/src/components/gabinet/merge-patients-dialog.tsx
+++ b/src/components/gabinet/merge-patients-dialog.tsx
@@ -1,0 +1,276 @@
+import { useMemo, useState } from "react";
+import { useAction } from "convex/react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { api } from "@cvx/_generated/api";
+import type { Id } from "@cvx/_generated/dataModel";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Loader2, ArrowRight, AlertCircle } from "@/lib/ez-icons";
+import type { MappedGabinetPatient } from "@/lib/supabase/mappers/gabinet/patients";
+import { formatPhoneNumber } from "@/lib/phone";
+import { formatActionError } from "@/lib/format-action-error";
+import { cn } from "@/lib/utils";
+
+interface MergePatientsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationId: string;
+  sourcePatient: MappedGabinetPatient | null;
+  allPatients: MappedGabinetPatient[];
+  onMerged?: () => void;
+}
+
+function normalizeEmail(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function normalizePhone(value: string | null | undefined): string {
+  return (value ?? "").replace(/\D/g, "");
+}
+
+function fullName(p: MappedGabinetPatient): string {
+  return `${p.firstName ?? ""} ${p.lastName ?? ""}`.trim();
+}
+
+export function MergePatientsDialog({
+  open,
+  onOpenChange,
+  organizationId,
+  sourcePatient,
+  allPatients,
+  onMerged,
+}: MergePatientsDialogProps) {
+  const { t } = useTranslation();
+  const mergePatients = useAction(api.gabinet.patients.merge);
+
+  const [targetId, setTargetId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [isMerging, setIsMerging] = useState(false);
+
+  const sourceEmail = normalizeEmail(sourcePatient?.email);
+  const sourcePhone = normalizePhone(sourcePatient?.phone);
+
+  const candidates = useMemo(() => {
+    if (!sourcePatient) return [] as Array<MappedGabinetPatient & { matchReason: string }>;
+
+    const matches: Array<MappedGabinetPatient & { matchReason: string }> = [];
+    const seen = new Set<string>();
+
+    for (const p of allPatients) {
+      if (p._id === sourcePatient._id) continue;
+      const pEmail = normalizeEmail(p.email);
+      const pPhone = normalizePhone(p.phone);
+
+      const matchesEmail = sourceEmail && pEmail && pEmail === sourceEmail;
+      const matchesPhone = sourcePhone && pPhone && pPhone === sourcePhone;
+
+      if (matchesEmail || matchesPhone) {
+        const reasons: string[] = [];
+        if (matchesEmail) reasons.push(t("gabinet.patients.merge.matchEmail"));
+        if (matchesPhone) reasons.push(t("gabinet.patients.merge.matchPhone"));
+        matches.push({ ...p, matchReason: reasons.join(" • ") });
+        seen.add(p._id);
+      }
+    }
+
+    const q = search.trim().toLowerCase();
+    if (q) {
+      const tokens = q.split(/\s+/).filter(Boolean);
+      for (const p of allPatients) {
+        if (p._id === sourcePatient._id || seen.has(p._id)) continue;
+        const haystack = [p.firstName, p.lastName, p.email, p.phone]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        if (tokens.every((token) => haystack.includes(token))) {
+          matches.push({ ...p, matchReason: t("gabinet.patients.merge.matchSearch") });
+          seen.add(p._id);
+        }
+      }
+    }
+
+    return matches.slice(0, 50);
+  }, [allPatients, sourcePatient, sourceEmail, sourcePhone, search, t]);
+
+  const target = useMemo(
+    () => candidates.find((c) => c._id === targetId) ?? null,
+    [candidates, targetId],
+  );
+
+  function handleClose() {
+    if (isMerging) return;
+    setTargetId(null);
+    setSearch("");
+    onOpenChange(false);
+  }
+
+  async function handleMerge() {
+    if (!sourcePatient || !target) return;
+    setIsMerging(true);
+    try {
+      const result = await mergePatients({
+        organizationId: organizationId as Id<"organizations">,
+        targetPatientId: target._id,
+        sourcePatientId: sourcePatient._id,
+      });
+      const moved =
+        result.movedAppointments +
+        result.movedDocuments +
+        result.movedPackageUsage +
+        result.movedLoyaltyTransactions +
+        result.movedPayments +
+        result.movedNotes +
+        result.movedActivities +
+        result.movedRelationships;
+      toast.success(
+        t("gabinet.patients.merge.success", {
+          defaultValue: "Scalono pacjenta. Przeniesiono {{count}} powiązanych rekordów.",
+          count: moved,
+        }),
+      );
+      onMerged?.();
+      handleClose();
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.patients.merge.error",
+          defaultValue: "Nie udało się scalić pacjentów.",
+        }),
+      );
+    } finally {
+      setIsMerging(false);
+    }
+  }
+
+  if (!sourcePatient) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{t("gabinet.patients.merge.title", { defaultValue: "Scal klientów" })}</DialogTitle>
+          <DialogDescription>
+            {t("gabinet.patients.merge.description", {
+              defaultValue:
+                "Wybierz klienta, do którego mają zostać przeniesione dane. Klient źródłowy zostanie dezaktywowany.",
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="rounded-md border bg-muted/30 p-3">
+            <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {t("gabinet.patients.merge.sourceLabel", { defaultValue: "Źródło (zostanie dezaktywowane)" })}
+            </div>
+            <div className="mt-1 font-medium">{fullName(sourcePatient)}</div>
+            <div className="text-sm text-muted-foreground">
+              {sourcePatient.email || "—"}
+              {sourcePatient.phone ? ` • ${formatPhoneNumber(sourcePatient.phone)}` : ""}
+            </div>
+          </div>
+
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t("gabinet.patients.merge.searchPlaceholder", {
+              defaultValue: "Szukaj klienta po imieniu, e-mailu lub telefonie...",
+            })}
+          />
+
+          <div className="max-h-64 overflow-y-auto rounded-md border">
+            {candidates.length === 0 ? (
+              <div className="p-4 text-sm text-muted-foreground">
+                {sourceEmail || sourcePhone
+                  ? t("gabinet.patients.merge.noDuplicates", {
+                      defaultValue:
+                        "Brak duplikatów po e-mailu lub telefonie. Skorzystaj z wyszukiwarki powyżej, aby wybrać innego klienta.",
+                    })
+                  : t("gabinet.patients.merge.noContactInfo", {
+                      defaultValue:
+                        "Klient nie ma e-maila ani telefonu, więc automatyczne dopasowanie nie jest możliwe. Wyszukaj klienta ręcznie.",
+                    })}
+              </div>
+            ) : (
+              <ul className="divide-y">
+                {candidates.map((c) => {
+                  const isSelected = c._id === targetId;
+                  return (
+                    <li key={c._id}>
+                      <button
+                        type="button"
+                        onClick={() => setTargetId(c._id)}
+                        className={cn(
+                          "flex w-full items-start justify-between gap-3 p-3 text-left transition-colors hover:bg-muted/50",
+                          isSelected && "bg-primary/10 hover:bg-primary/10",
+                        )}
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate font-medium">{fullName(c) || "—"}</div>
+                          <div className="truncate text-sm text-muted-foreground">
+                            {c.email || "—"}
+                            {c.phone ? ` • ${formatPhoneNumber(c.phone)}` : ""}
+                          </div>
+                        </div>
+                        <Badge
+                          variant={isSelected ? "default" : "outline"}
+                          className="shrink-0 text-[10px]"
+                        >
+                          {c.matchReason}
+                        </Badge>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+
+          {target && (
+            <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+              <div className="flex items-start gap-2">
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" variant="stroke" />
+                <div>
+                  <div className="flex flex-wrap items-center gap-1.5 font-medium">
+                    <span>{fullName(sourcePatient) || "—"}</span>
+                    <ArrowRight className="h-3.5 w-3.5" variant="stroke" />
+                    <span>{fullName(target) || "—"}</span>
+                  </div>
+                  <p className="mt-1">
+                    {t("gabinet.patients.merge.warning", {
+                      defaultValue:
+                        "Wszystkie wizyty, dokumenty, płatności, punkty lojalnościowe i notatki zostaną przeniesione. Operacja jest nieodwracalna.",
+                    })}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={isMerging}>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            onClick={handleMerge}
+            disabled={!target || isMerging}
+            variant="destructive"
+          >
+            {isMerging && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {t("gabinet.patients.merge.confirm", { defaultValue: "Scal" })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -1,10 +1,12 @@
 import { createFileRoute, useNavigate, useSearch, Link } from "@tanstack/react-router";
 import { useAction } from "convex/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
 import { api } from "@cvx/_generated/api";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseGabinetRecentVisitPatientIds } from "@/hooks/use-supabase-gabinet-appointments";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { useOrganization } from "@/components/org-context";
 import { PageHeader } from "@/components/layout/page-header";
 import { CrmDataTable, useColumnVisibility, useAllColumns, type CrmColumn } from "@/components/crm/enhanced-data-table";
@@ -12,10 +14,11 @@ import { DataListFilterBar } from "@/components/crm/data-list-filter-bar";
 import { MiniChartsRow } from "@/components/crm/mini-charts";
 import { SidePanel } from "@/components/crm/side-panel";
 import { PatientForm } from "@/components/forms/patient-form";
+import { MergePatientsDialog } from "@/components/gabinet/merge-patients-dialog";
 import { Button } from "@/components/ui/button";
 import { AvatarLabelGroup } from "@untitled/base/avatar/avatar-label-group";
 import { Badge } from "@/components/ui/badge";
-import { Plus, Trash2, Download, X } from "@/lib/ez-icons";
+import { Plus, Trash2, Download, X, Users } from "@/lib/ez-icons";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { Id } from "@cvx/_generated/dataModel";
@@ -56,12 +59,14 @@ function PatientsIndex() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { nudge: nudgeFilter } = useSearch({ from: Route.id });
   const createPatient = useAction(api.gabinet.patients.create);
   const removePatient = useAction(api.gabinet.patients.remove);
 
   const [panelOpen, setPanelOpen] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
+  const [mergeSourcePatient, setMergeSourcePatient] = useState<Patient | null>(null);
   const [leftTimeRange, setLeftTimeRange] = useState<TimeRange>("last30days");
   const [rightTimeRange, setRightTimeRange] = useState<TimeRange>("all");
   const [savedViewsDialogOpen, setSavedViewsDialogOpen] = useState(false);
@@ -415,6 +420,11 @@ function PatientsIndex() {
           navigate({ to: `/dashboard/gabinet/patients/${row._id}` }),
       },
       {
+        label: t("gabinet.patients.merge.action", { defaultValue: "Scal z..." }),
+        icon: <Users className="h-4 w-4" variant="stroke" />,
+        onClick: () => setMergeSourcePatient(row),
+      },
+      {
         label: t("common.delete"),
         icon: <Trash2 className="h-4 w-4" variant="stroke" />,
         onClick: async () => {
@@ -564,6 +574,21 @@ function PatientsIndex() {
         organizationId={organizationId}
         entityType="gabinetPatient"
         categories={categories}
+      />
+
+      <MergePatientsDialog
+        open={!!mergeSourcePatient}
+        onOpenChange={(open) => {
+          if (!open) setMergeSourcePatient(null);
+        }}
+        organizationId={organizationId}
+        sourcePatient={mergeSourcePatient}
+        allPatients={patients}
+        onMerged={() => {
+          void queryClient.invalidateQueries({
+            queryKey: supabaseKeys.gabinetPatients.list(organizationId),
+          });
+        }}
       />
     </div>
   );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1503.

Closes #1503

---

## Claude summary

Committed `6adbd98`. The change adds a "Scal z..." (Merge with...) row action on the gabinet patients list. Clicking it opens a dialog that auto-detects candidates by exact email or normalized phone match against the loaded patient list, with a manual search fallback. Selecting a target shows a warning and confirmation; the backend `merge` action in `convex/gabinet/patients.ts:563` reassigns `patient_id` across appointments, documents, package usage, loyalty transactions, payments, portal sessions, SMS events, referrals (`referred_by_patient_id`), `booked_by_patient_id`, and polymorphic `entity_id` in `notes`/`activities`/`object_relationships` filtered to `entity_type='gabinetPatient'`. Loyalty points are consolidated (the table has a unique `(org, patient)` index), and the source patient is soft-deleted (`is_active=false`) with a `[Merged into …]` marker prepended to its medical notes. The merge is logged via `logActivity` on both target and source. Typecheck passes; the existing `patientsUpdate` test still passes.

## Follow-ups
- Add a unit test for gabinet patients merge: cover loyalty-point consolidation, polymorphic activities/notes reassignment, and the org-scoping guard.
- Expose duplicate detection at list level: a top-of-page banner showing how many patients share an email/phone with someone else, with a one-click "review duplicates" entry into the merge flow.