### PR TITLE
Sprzęt dodawanie wizyty

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -79,6 +79,32 @@ function getSmsTargetStatus(intent: "confirm" | "cancel") {
   return intent === "confirm" ? "confirmed" : "cancelled";
 }
 
+// Issue #1504: reject appointment writes whose treatment requires equipment
+// the resolved location does not have. No-op when location is unset (no
+// location to validate against) or when the treatment lists no equipment.
+async function assertRequiredEquipmentAtLocation(
+  db: ReturnType<typeof createSupabaseDb>,
+  args: {
+    organizationId: string;
+    treatment: GabinetTreatmentRow | null;
+    locationId: string | null;
+  },
+) {
+  const required = args.treatment?.requiredEquipmentIds as string[] | null | undefined;
+  if (!args.locationId || !required?.length) return;
+
+  const atLocation = (await db
+    .query("gabinetEquipment")
+    .eq("organizationId", args.organizationId)
+    .eq("currentLocationId", args.locationId)
+    .collect()) as Array<{ _id: string }>;
+  const present = new Set(atLocation.map((e) => String(e._id)));
+  const missing = required.filter((id) => !present.has(String(id)));
+  if (missing.length > 0) {
+    throw new Error("Required equipment is not available at this location");
+  }
+}
+
 async function emitAutomationEvent(
   ctx: MutationCtx,
   args: {
@@ -1116,6 +1142,17 @@ export const create = action({
       });
     }
 
+    // --- Equipment check (issue #1504) ---
+    // Block creation when the resolved location is missing any equipment the
+    // treatment requires. Matches the client-side block in appointment-form
+    // and appointment-dialog so the rule is enforced even when callers bypass
+    // the UI.
+    await assertRequiredEquipmentAtLocation(db, {
+      organizationId: String(args.organizationId),
+      treatment,
+      locationId: resolvedLocationId,
+    });
+
     const patientName = patient
       ? `${patient.firstName}${patient.lastName ? " " + (patient.lastName as string) : ""}`
       : "Patient";
@@ -1387,6 +1424,31 @@ export const update = action({
       if (conflict.hasConflict) {
         throw new Error(conflict.reason ?? "Time slot conflict");
       }
+    }
+
+    // --- Equipment check on location/treatment change (issue #1504) ---
+    // Re-validate only when the caller is touching the location or treatment;
+    // status-only or notes-only edits on existing appointments shouldn't trip
+    // a check whose inputs haven't changed.
+    if (args.locationId !== undefined || args.treatmentId !== undefined) {
+      const effectiveTreatmentId =
+        args.treatmentId !== undefined
+          ? args.treatmentId
+          : (appt.treatmentId as string | null);
+      const effectiveLocationId =
+        args.locationId !== undefined
+          ? args.locationId
+          : (appt.locationId as string | null);
+      const effectiveTreatment = effectiveTreatmentId
+        ? ((await db.get("gabinetTreatments", String(effectiveTreatmentId))) as
+            | GabinetTreatmentRow
+            | null)
+        : null;
+      await assertRequiredEquipmentAtLocation(db, {
+        organizationId: String(args.organizationId),
+        treatment: effectiveTreatment,
+        locationId: effectiveLocationId,
+      });
     }
 
     const {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2792,7 +2792,7 @@
       "room": "Room",
       "autoLocation": "Auto (from schedule)",
       "roomConflict": "Room is occupied at this time",
-      "equipmentWarning": "Required equipment not at this location",
+      "equipmentWarning": "Required equipment not at this location — cannot save appointment",
       "warnings": {
         "title": "Warning",
         "qualification": "Employee is not qualified for this treatment",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2821,7 +2821,7 @@
       "room": "Gabinet",
       "autoLocation": "Auto (z grafiku)",
       "roomConflict": "Gabinet zajęty w tym terminie",
-      "equipmentWarning": "Brak wymaganego sprzętu w tej lokalizacji",
+      "equipmentWarning": "Brak wymaganego sprzętu w tej lokalizacji — nie można zapisać wizyty",
       "warnings": {
         "title": "Ostrzeżenie",
         "qualification": "Pracownik nie ma kwalifikacji do tego zabiegu",

--- a/src/components/gabinet/appointment-form.tsx
+++ b/src/components/gabinet/appointment-form.tsx
@@ -258,7 +258,8 @@ export function AppointmentForm({
   const selectedPatient = patients.find((p) => p._id === patientId);
   const dateStr = date ? format(date, "yyyy-MM-dd") : "";
 
-  // Equipment warning — advisory only, which required equipment is missing at the selected location
+  // Equipment check — block submit when the selected location is missing
+  // required equipment for the chosen treatment (issue #1504).
   const missingEquipmentIds = useMemo(() => {
     if (!locationId || !selectedTreatment?.requiredEquipmentIds?.length) return [];
     const atLocationIds = new Set(equipmentAtLocation?.map((e) => e._id) ?? []);
@@ -266,6 +267,7 @@ export function AppointmentForm({
       (id) => !atLocationIds.has(id),
     );
   }, [locationId, selectedTreatment, equipmentAtLocation]);
+  const equipmentBlocking = missingEquipmentIds.length > 0;
 
   // Approved leaves for selected employee — used to surface a warning when
   // the chosen date overlaps with an approved leave. The available-slots
@@ -930,9 +932,12 @@ export function AppointmentForm({
         </div>
       )}
 
-      {/* Equipment warnings — advisory only */}
-      {missingEquipmentIds.length > 0 && (
-        <div className="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-400">
+      {/* Equipment error — blocks submission (issue #1504) */}
+      {equipmentBlocking && (
+        <div
+          role="alert"
+          className="flex items-center gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
           <AlertTriangle className="size-4 shrink-0" />
           {t("gabinet.appointments.equipmentWarning")}
         </div>
@@ -1006,6 +1011,7 @@ export function AppointmentForm({
             !employeeId ||
             !date ||
             !selectedSlot ||
+            equipmentBlocking ||
             isSubmitting
           }
         >

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -607,12 +607,14 @@ export function AppointmentDialog({
     );
   }, [employeeLeaves, dateStr]);
 
-  // Equipment warning — advisory only
+  // Equipment check — block submit when the selected location is missing
+  // required equipment for the chosen treatment (issue #1504).
   const missingEquipmentIds = useMemo(() => {
     if (!locationId || !selectedTreatment?.requiredEquipmentIds?.length) return [];
     const atLocationIds = new Set(equipmentAtLocation?.map((e: { _id: string }) => e._id) ?? []);
     return selectedTreatment.requiredEquipmentIds.filter((id: string) => !atLocationIds.has(id));
   }, [locationId, selectedTreatment, equipmentAtLocation]);
+  const equipmentBlocking = missingEquipmentIds.length > 0;
 
   // -------------------------------------------------------------------------
   // Auto-select employee when only one qualified
@@ -843,6 +845,7 @@ export function AppointmentDialog({
     !!employeeId &&
     !!dateStr &&
     !!selectedSlot &&
+    !equipmentBlocking &&
     !submitting;
 
   const performCreate = useCallback(async () => {
@@ -1378,9 +1381,12 @@ export function AppointmentDialog({
                       )}
                     </div>
 
-                    {/* Equipment warnings — advisory only */}
-                    {missingEquipmentIds.length > 0 && (
-                      <div className="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-400">
+                    {/* Equipment error — blocks submission (issue #1504) */}
+                    {equipmentBlocking && (
+                      <div
+                        role="alert"
+                        className="flex items-center gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+                      >
                         <AlertTriangle className="size-3.5 shrink-0" />
                         {t("gabinet.appointments.equipmentWarning")}
                       </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1504.

Closes #1504

---

## Claude summary

Committed. Summary:

- `src/components/gabinet/appointment-form.tsx` and `src/components/gabinet/calendar/appointment-dialog.tsx`: when the selected location is missing equipment that the chosen treatment requires, the save button is now disabled and the notice is rendered as a destructive (red) alert with an explicit "cannot save" message.
- `convex/gabinet/appointments.ts`: added `assertRequiredEquipmentAtLocation` and call it from `create` (after location resolution) and `update` (when locationId or treatmentId is being changed). The action throws so API callers can't bypass the UI block.
- Translations updated in PL/EN to make the message read as a block, not a soft warning.

Verified with `npm run typecheck` (clean) and `npx vitest run appointment` (16 tests, all passing).