### PR TITLE
Consider unifying off-calendar appointment creation too

### DIFF
--- a/src/components/layout/app-footer.tsx
+++ b/src/components/layout/app-footer.tsx
@@ -22,6 +22,7 @@ interface FooterAction {
   icon: React.ElementType;
   quickCreate?: string;
   href?: string;
+  search?: Record<string, string>;
   action?: string;
 }
 
@@ -69,7 +70,14 @@ const routeActions: Record<string, FooterAction[]> = {
 };
 
 const defaultGabinetActions: FooterAction[] = [
-  { labelKey: "nav.actions.bookAppointment", icon: CalendarCheck, quickCreate: "appointment" },
+  // "Bookings" off-calendar pages route through the calendar so every
+  // entry point opens the same AppointmentDialog (issue #1506).
+  {
+    labelKey: "nav.actions.bookAppointment",
+    icon: CalendarCheck,
+    href: "/dashboard/gabinet/calendar",
+    search: { action: "create-appointment" },
+  },
   { labelKey: "nav.actions.addPatient", icon: UserPlus, quickCreate: "patient" },
 ];
 
@@ -154,7 +162,7 @@ export function AppFooter() {
                 } else if (action.action) {
                   dispatch(action.action);
                 } else if (action.href) {
-                  navigateTo(action.href);
+                  navigateTo(action.href, action.search);
                 }
               }}
             >

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -226,7 +226,7 @@ export function AppSidebar() {
                                 } else if (action.dispatch) {
                                   dispatch(action.dispatch);
                                 } else if (action.href) {
-                                  navigateTo(action.href);
+                                  navigateTo(action.href, action.search);
                                 }
                               }}
                             >

--- a/src/components/layout/sidebar-context.tsx
+++ b/src/components/layout/sidebar-context.tsx
@@ -7,7 +7,7 @@ export interface SidebarDispatch {
 
 interface SidebarActionsContextValue {
   openQuickCreate: (type: string) => void;
-  navigateTo: (href: string) => void;
+  navigateTo: (href: string, search?: Record<string, string>) => void;
   dispatch: (actionId: string) => void;
   lastDispatch: SidebarDispatch | null;
   openActivityDetail: (activityId: string) => void;

--- a/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
+++ b/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
@@ -27,6 +27,13 @@ export function GabinetQuickActionsDropdown() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { openQuickCreate } = useSidebarActions();
+  // "Umów wizytę" routes through the calendar so every appointment entry
+  // point opens the same AppointmentDialog (issue #1506).
+  const goToCalendarCreateAppointment = () =>
+    navigate({
+      to: "/dashboard/gabinet/calendar",
+      search: { action: "create-appointment" },
+    });
 
   return (
     <DropdownMenu>
@@ -44,7 +51,7 @@ export function GabinetQuickActionsDropdown() {
       >
         <DropdownMenuItem
           className="px-3 py-2.5 text-sm"
-          onSelect={() => openQuickCreate("appointment")}
+          onSelect={goToCalendarCreateAppointment}
         >
           <CalendarCheck className="text-foreground size-5" />
           {t("sidebar.gabinet.bookAppointment", "Umów wizytę")}

--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -77,7 +77,8 @@ export const gabinetManifest: ModuleManifest = {
         {
           labelKey: "nav.actions.bookAppointment",
           icon: CalendarCheck,
-          quickCreate: "appointment",
+          href: "/dashboard/gabinet/calendar",
+          search: { action: "create-appointment" },
           permissionFeature: "gabinet_appointments",
         },
         { labelKey: "nav.actions.viewCalendar", icon: Calendar, href: "/dashboard/gabinet/calendar" },

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -30,6 +30,7 @@ export interface ModuleContextAction {
   icon: ElementType;
   quickCreate?: string;
   href?: string;
+  search?: Record<string, string>;
   dispatch?: string;
   permissionFeature?: Feature;
 }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -894,18 +894,25 @@ function GabinetCalendarPage() {
   useSidebarDispatch("openCreateAppointment", openCreateDialog);
 
   // ?action=sell-package opens the sell package side panel after navigation
-  // from the gabinet quick-actions dropdown (issue #1236). Clear the param
-  // after consuming so a refresh doesn't reopen it.
+  // from the gabinet quick-actions dropdown (issue #1236).
+  // ?action=create-appointment opens the AppointmentDialog so off-calendar
+  // entry points (dashboard pageContext, footer, quick-actions dropdown)
+  // converge on the same flow as the toolbar button (issue #1506).
+  // Clear the param after consuming so a refresh doesn't reopen it.
   useEffect(() => {
     if (actionParam === "sell-package") {
       setSellPackageOpen(true);
-      routeNavigate({
-        to: "/dashboard/gabinet/calendar",
-        search: { nudge: nudgeFilter, action: undefined },
-        replace: true,
-      });
+    } else if (actionParam === "create-appointment") {
+      openCreateDialog();
+    } else {
+      return;
     }
-  }, [actionParam, nudgeFilter, routeNavigate]);
+    routeNavigate({
+      to: "/dashboard/gabinet/calendar",
+      search: { nudge: nudgeFilter, action: undefined },
+      replace: true,
+    });
+  }, [actionParam, nudgeFilter, routeNavigate, openCreateDialog]);
 
   // Click-to-create handler
   const handleSlotClick = useCallback(

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 type CalendarNudgeFilter = "unconfirmed-today";
-type CalendarAction = "sell-package";
+type CalendarAction = "sell-package" | "create-appointment";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/calendar/",
@@ -14,7 +14,7 @@ export const Route = createFileRoute(
         ? (search.nudge as CalendarNudgeFilter)
         : undefined,
     action:
-      search.action === "sell-package"
+      search.action === "sell-package" || search.action === "create-appointment"
         ? (search.action as CalendarAction)
         : undefined,
   }),

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -715,7 +715,8 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
       openQuickCreate: (type: string) => {
         quickCreateRef.current?.open(type as FormEntityType);
       },
-      navigateTo: (href: string) => navigate({ to: href }),
+      navigateTo: (href: string, search?: Record<string, string>) =>
+        navigate(search ? { to: href, search } : { to: href }),
       dispatch: (actionId: string) => {
         dispatchSeqRef.current += 1;
         setLastDispatch({ id: actionId, seq: dispatchSeqRef.current });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1506.

Closes #1506

---

## Claude summary

Committed. Summary of changes:

The fix routes every off-calendar "Add appointment" entry point through the calendar page so they all spawn the same `AppointmentDialog` modal, matching what `#1505` already did for the calendar-page entries.

The mechanism reuses the existing `?action=...` query-param pattern (already used for `sell-package` in #1236):

- `_layout.gabinet.calendar.index.tsx:4,17` adds `"create-appointment"` to the `CalendarAction` search schema.
- `_layout.gabinet.calendar.index.lazy.tsx:896-915` consumes `?action=create-appointment` by calling `openCreateDialog()`, then clears the param.
- `modules/gabinet/manifest.ts:80-81` dashboard pageContext "Dodaj wizytę" now uses `href` + `search: { action: "create-appointment" }` instead of `quickCreate: "appointment"`.
- `app-footer.tsx:73-80` `defaultGabinetActions` (off-calendar gabinet pages) does the same.
- `quick-actions-dropdown.tsx:30-36,54` "Umów wizytę" navigates instead of `openQuickCreate("appointment")`.

To express "navigate + open dialog" in declarative manifests, `ModuleContextAction` and the footer's `FooterAction` gained an optional `search?: Record<string, string>` field, and `navigateTo` in `sidebar-context.tsx` accepts an optional second `search` argument that the sidebar and footer click handlers pass through. The change is backward-compatible — existing `href`-only entries keep working unchanged.

Verified: `npx tsc -p tsconfig.app.json` clean, `npm run test:manifests` 4/4 pass, `npm run test:unit:frontend` 20/20 pass, no new lint errors.