### PR TITLE
Reconcile two near-duplicate appointment-creation components

### DIFF
--- a/src/components/gabinet/appointment-form.tsx
+++ b/src/components/gabinet/appointment-form.tsx
@@ -40,7 +40,7 @@ import {
   Building2,
   UserPlus,
 } from "@/lib/ez-icons";
-import { AlertTriangle, CalendarSearch } from "lucide-react";
+import { CalendarSearch } from "lucide-react";
 import { format } from "date-fns";
 import { pl } from "date-fns/locale";
 import { cn } from "@/lib/utils";
@@ -50,7 +50,14 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
 import { SidePanel } from "@/components/crm/side-panel";
 import { PatientForm } from "@/components/forms/patient-form";
-import { useSupabaseGabinetLeavesList } from "@/hooks/use-supabase-gabinet-leaves";
+import {
+  EquipmentWarning,
+  LeaveWarning,
+} from "@/components/gabinet/appointment-shared/warnings";
+import {
+  useEmployeeLeaveOnDate,
+  useMissingEquipment,
+} from "@/components/gabinet/appointment-shared/use-appointment-warnings";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 
@@ -236,17 +243,6 @@ export function AppointmentForm({
   });
   const activeRooms = locationWithRooms?.rooms?.filter((r) => r.isActive) ?? [];
 
-  // Equipment at selected location — for advisory warnings
-  const listEquipmentAction = useAction(api.gabinet.equipment.listEquipment);
-  const { data: equipmentAtLocation } = useQuery({
-    queryKey: ["gabinet.equipment.listEquipment", organizationId, locationId],
-    queryFn: () => listEquipmentAction({
-      organizationId: organizationId!,
-      locationId: locationId,
-    }),
-    enabled: !!organizationId && !!locationId,
-  });
-
   const activeLocations = locations?.filter((l) => l.isActive) ?? [];
 
   // Popover open states
@@ -258,32 +254,17 @@ export function AppointmentForm({
   const selectedPatient = patients.find((p) => p._id === patientId);
   const dateStr = date ? format(date, "yyyy-MM-dd") : "";
 
-  // Equipment check — block submit when the selected location is missing
-  // required equipment for the chosen treatment (issue #1504).
-  const missingEquipmentIds = useMemo(() => {
-    if (!locationId || !selectedTreatment?.requiredEquipmentIds?.length) return [];
-    const atLocationIds = new Set(equipmentAtLocation?.map((e) => e._id) ?? []);
-    return (selectedTreatment.requiredEquipmentIds as Id<"gabinetEquipment">[]).filter(
-      (id) => !atLocationIds.has(id),
-    );
-  }, [locationId, selectedTreatment, equipmentAtLocation]);
-  const equipmentBlocking = missingEquipmentIds.length > 0;
+  const { blocking: equipmentBlocking } = useMissingEquipment({
+    organizationId,
+    locationId,
+    treatment: selectedTreatment,
+  });
 
-  // Approved leaves for selected employee — used to surface a warning when
-  // the chosen date overlaps with an approved leave. The available-slots
-  // backend already excludes leave time, but the user otherwise sees an
-  // empty/short slot list with no explanation. Issue #652.
-  const { data: employeeLeaves } = useSupabaseGabinetLeavesList(
-    organizationId ?? "",
-    { userId: employeeId || undefined, status: "approved", enabled: !!organizationId && !!employeeId },
-  );
-
-  const employeeLeaveOnSelectedDate = useMemo(() => {
-    if (!dateStr || !employeeLeaves || employeeLeaves.length === 0) return null;
-    return employeeLeaves.find(
-      (l) => l.startDate <= dateStr && l.endDate >= dateStr,
-    ) ?? null;
-  }, [employeeLeaves, dateStr]);
+  const employeeLeaveOnSelectedDate = useEmployeeLeaveOnDate({
+    organizationId,
+    employeeId,
+    dateStr,
+  });
 
   // Filter employees by treatment qualification
   const qualifiedEmployees = useMemo(() => {
@@ -818,24 +799,7 @@ export function AppointmentForm({
 
       {/* Leave warning — employee is on approved leave overlapping selected date */}
       {employeeId && date && employeeLeaveOnSelectedDate && (
-        <div
-          role="alert"
-          className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
-        >
-          <AlertTriangle className="mt-0.5 size-4 shrink-0" />
-          <span>
-            {employeeLeaveOnSelectedDate.startTime && employeeLeaveOnSelectedDate.endTime
-              ? t("gabinet.appointments.warnings.leavePartial", {
-                  start: employeeLeaveOnSelectedDate.startTime,
-                  end: employeeLeaveOnSelectedDate.endTime,
-                  defaultValue:
-                    "Pracownik jest na urlopie w tym dniu w godzinach {{start}}–{{end}}.",
-                })
-              : t("gabinet.appointments.warnings.leave", {
-                  defaultValue: "Pracownik jest na urlopie w tym terminie",
-                })}
-          </span>
-        </div>
+        <LeaveWarning leave={employeeLeaveOnSelectedDate} />
       )}
 
       {/* Available time slots */}
@@ -933,15 +897,7 @@ export function AppointmentForm({
       )}
 
       {/* Equipment error — blocks submission (issue #1504) */}
-      {equipmentBlocking && (
-        <div
-          role="alert"
-          className="flex items-center gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
-        >
-          <AlertTriangle className="size-4 shrink-0" />
-          {t("gabinet.appointments.equipmentWarning")}
-        </div>
-      )}
+      {equipmentBlocking && <EquipmentWarning />}
 
       {/* Notes */}
       <div className="space-y-1.5">

--- a/src/components/gabinet/appointment-shared/use-appointment-warnings.ts
+++ b/src/components/gabinet/appointment-shared/use-appointment-warnings.ts
@@ -1,0 +1,83 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAction } from "convex/react";
+import { api } from "@cvx/_generated/api";
+import type { Id } from "@cvx/_generated/dataModel";
+import { useSupabaseGabinetLeavesList } from "@/hooks/use-supabase-gabinet-leaves";
+
+/**
+ * Returns the approved leave (if any) that overlaps the chosen date for the
+ * selected employee. The available-slots backend already excludes leave time,
+ * but the UI surfaces this so the user knows why the slot list is short/empty
+ * (issue #652). Shared between the calendar appointment-dialog and the
+ * SidePanel appointment-form.
+ */
+export function useEmployeeLeaveOnDate(params: {
+  organizationId: Id<"organizations"> | string | null | undefined;
+  employeeId: string;
+  dateStr: string;
+}) {
+  const { organizationId, employeeId, dateStr } = params;
+
+  const { data: employeeLeaves } = useSupabaseGabinetLeavesList(
+    organizationId ?? "",
+    {
+      userId: employeeId || undefined,
+      status: "approved",
+      enabled: !!organizationId && !!employeeId,
+    },
+  );
+
+  return useMemo(() => {
+    if (!dateStr || !employeeLeaves || employeeLeaves.length === 0) return null;
+    return (
+      employeeLeaves.find(
+        (l) => l.startDate <= dateStr && l.endDate >= dateStr,
+      ) ?? null
+    );
+  }, [employeeLeaves, dateStr]);
+}
+
+interface TreatmentForEquipment {
+  requiredEquipmentIds?: ReadonlyArray<string> | null;
+}
+
+/**
+ * Returns the equipment-IDs that the selected treatment requires but which the
+ * chosen location does not have, and a `blocking` flag the parent can use to
+ * disable the submit button. Shared between the calendar appointment-dialog
+ * and the SidePanel appointment-form (issue #1504).
+ */
+export function useMissingEquipment(params: {
+  organizationId: Id<"organizations"> | string | null | undefined;
+  locationId: string;
+  treatment: TreatmentForEquipment | undefined | null;
+}) {
+  const { organizationId, locationId, treatment } = params;
+
+  const listEquipmentAction = useAction(api.gabinet.equipment.listEquipment);
+  const { data: equipmentAtLocation } = useQuery({
+    queryKey: ["gabinet.equipment.listEquipment", organizationId, locationId],
+    queryFn: () =>
+      listEquipmentAction({
+        organizationId: organizationId as Id<"organizations">,
+        locationId,
+      }),
+    enabled: !!organizationId && !!locationId,
+  });
+
+  const missingEquipmentIds = useMemo(() => {
+    if (!locationId || !treatment?.requiredEquipmentIds?.length) return [];
+    const atLocationIds = new Set(
+      equipmentAtLocation?.map((e: { _id: string }) => e._id) ?? [],
+    );
+    return (treatment.requiredEquipmentIds as string[]).filter(
+      (id) => !atLocationIds.has(id),
+    );
+  }, [locationId, treatment, equipmentAtLocation]);
+
+  return {
+    missingEquipmentIds,
+    blocking: missingEquipmentIds.length > 0,
+  };
+}

--- a/src/components/gabinet/appointment-shared/warnings.tsx
+++ b/src/components/gabinet/appointment-shared/warnings.tsx
@@ -1,0 +1,78 @@
+import { useTranslation } from "react-i18next";
+import { AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface LeaveOnDate {
+  startTime?: string;
+  endTime?: string;
+}
+
+interface LeaveWarningProps {
+  leave: LeaveOnDate;
+  className?: string;
+  size?: "sm" | "compact";
+}
+
+export function LeaveWarning({
+  leave,
+  className,
+  size = "sm",
+}: LeaveWarningProps) {
+  const { t } = useTranslation();
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200",
+        size === "sm" ? "px-3 py-2 text-sm" : "px-2.5 py-2 text-xs",
+        className,
+      )}
+    >
+      <AlertTriangle
+        className={cn(
+          "mt-0.5 shrink-0",
+          size === "sm" ? "size-4" : "size-3.5",
+        )}
+      />
+      <span>
+        {leave.startTime && leave.endTime
+          ? t("gabinet.appointments.warnings.leavePartial", {
+              start: leave.startTime,
+              end: leave.endTime,
+              defaultValue:
+                "Pracownik jest na urlopie w tym dniu w godzinach {{start}}–{{end}}.",
+            })
+          : t("gabinet.appointments.warnings.leave", {
+              defaultValue: "Pracownik jest na urlopie w tym terminie",
+            })}
+      </span>
+    </div>
+  );
+}
+
+interface EquipmentWarningProps {
+  className?: string;
+  size?: "sm" | "compact";
+}
+
+export function EquipmentWarning({
+  className,
+  size = "sm",
+}: EquipmentWarningProps) {
+  const { t } = useTranslation();
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex items-center gap-2 rounded-md border border-destructive/40 bg-destructive/10 text-destructive",
+        size === "sm" ? "px-3 py-2 text-sm" : "px-3 py-2 text-xs",
+        className,
+      )}
+    >
+      <AlertTriangle
+        className={cn("shrink-0", size === "sm" ? "size-4" : "size-3.5")}
+      />
+      {t("gabinet.appointments.equipmentWarning")}
+    </div>
+  );
+}

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -72,13 +72,20 @@ import {
   MapPin,
   Building2,
 } from "@/lib/ez-icons";
-import { AlertTriangle, CalendarSearch, GripHorizontal } from "lucide-react";
+import { CalendarSearch, GripHorizontal } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { SidePanel } from "@/components/crm/side-panel";
 import { PatientForm } from "@/components/forms/patient-form";
 import { PackageUsageSelector } from "@/components/gabinet/package-usage-selector";
-import { useSupabaseGabinetLeavesList } from "@/hooks/use-supabase-gabinet-leaves";
+import {
+  EquipmentWarning,
+  LeaveWarning,
+} from "@/components/gabinet/appointment-shared/warnings";
+import {
+  useEmployeeLeaveOnDate,
+  useMissingEquipment,
+} from "@/components/gabinet/appointment-shared/use-appointment-warnings";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { formatPhoneNumber } from "@/lib/phone";
@@ -577,44 +584,19 @@ export function AppointmentDialog({
   });
   const activeRooms = locationWithRooms?.rooms?.filter((r) => r.isActive) ?? [];
 
-  // Equipment at selected location — for advisory warnings
-  const listEquipmentAction = useAction(api.gabinet.equipment.listEquipment);
-  const { data: equipmentAtLocation } = useQuery({
-    queryKey: ["gabinet.equipment.listEquipment", organizationId, locationId],
-    queryFn: () => listEquipmentAction({
-      organizationId,
-      locationId,
-    }),
-    enabled: !!organizationId && !!locationId,
-  });
-
   const activeLocations = locations?.filter((l) => l.isActive) ?? [];
 
-  // Approved leaves for the selected employee — flag overlaps with the chosen
-  // date so the user sees an explicit warning. The available-slots backend
-  // already filters leave time but does not tell the user why. Issue #652.
-  const { data: employeeLeaves } = useSupabaseGabinetLeavesList(
+  const employeeLeaveOnSelectedDate = useEmployeeLeaveOnDate({
     organizationId,
-    { userId: employeeId || undefined, status: "approved", enabled: !!employeeId },
-  );
+    employeeId,
+    dateStr,
+  });
 
-  const employeeLeaveOnSelectedDate = useMemo(() => {
-    if (!dateStr || !employeeLeaves || employeeLeaves.length === 0) return null;
-    return (
-      employeeLeaves.find(
-        (l) => l.startDate <= dateStr && l.endDate >= dateStr,
-      ) ?? null
-    );
-  }, [employeeLeaves, dateStr]);
-
-  // Equipment check — block submit when the selected location is missing
-  // required equipment for the chosen treatment (issue #1504).
-  const missingEquipmentIds = useMemo(() => {
-    if (!locationId || !selectedTreatment?.requiredEquipmentIds?.length) return [];
-    const atLocationIds = new Set(equipmentAtLocation?.map((e: { _id: string }) => e._id) ?? []);
-    return selectedTreatment.requiredEquipmentIds.filter((id: string) => !atLocationIds.has(id));
-  }, [locationId, selectedTreatment, equipmentAtLocation]);
-  const equipmentBlocking = missingEquipmentIds.length > 0;
+  const { blocking: equipmentBlocking } = useMissingEquipment({
+    organizationId,
+    locationId,
+    treatment: selectedTreatment,
+  });
 
   // -------------------------------------------------------------------------
   // Auto-select employee when only one qualified
@@ -1382,15 +1364,7 @@ export function AppointmentDialog({
                     </div>
 
                     {/* Equipment error — blocks submission (issue #1504) */}
-                    {equipmentBlocking && (
-                      <div
-                        role="alert"
-                        className="flex items-center gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive"
-                      >
-                        <AlertTriangle className="size-3.5 shrink-0" />
-                        {t("gabinet.appointments.equipmentWarning")}
-                      </div>
-                    )}
+                    {equipmentBlocking && <EquipmentWarning size="compact" />}
                   </>
                 )}
 
@@ -1703,26 +1677,11 @@ export function AppointmentDialog({
                 </div>
 
                 {employeeLeaveOnSelectedDate && (
-                  <div
-                    role="alert"
-                    className="mx-3 mb-2 flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-2.5 py-2 text-xs text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
-                  >
-                    <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
-                    <span>
-                      {employeeLeaveOnSelectedDate.startTime &&
-                      employeeLeaveOnSelectedDate.endTime
-                        ? t("gabinet.appointments.warnings.leavePartial", {
-                            start: employeeLeaveOnSelectedDate.startTime,
-                            end: employeeLeaveOnSelectedDate.endTime,
-                            defaultValue:
-                              "Pracownik jest na urlopie w tym dniu w godzinach {{start}}–{{end}}.",
-                          })
-                        : t("gabinet.appointments.warnings.leave", {
-                            defaultValue:
-                              "Pracownik jest na urlopie w tym terminie",
-                          })}
-                    </span>
-                  </div>
+                  <LeaveWarning
+                    leave={employeeLeaveOnSelectedDate}
+                    size="compact"
+                    className="mx-3 mb-2"
+                  />
                 )}
 
                 <Separator />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1507.

Closes #1507

---

## Claude summary

Done. Extracted the two pieces of pure duplication between the appointment-creation components into a new `src/components/gabinet/appointment-shared/` module:

- `LeaveWarning` + `EquipmentWarning` components (amber leave-overlap box and red missing-equipment box, with a `size`/`className` API so each parent can use the same markup at different densities)
- `useEmployeeLeaveOnDate` + `useMissingEquipment` hooks (wrap the leaves and equipment queries plus the on-date / missing-IDs derivation)

Each consumer dropped ~45 lines (form: 86→44 net, dialog: 89→45 net) and the equipment-blocking rule from #1504 now lives in a single place. Typecheck and lint pass on both modified files (only pre-existing `any` warnings remain).

The patient/treatment/slot pickers and the find-slot button were intentionally left in place — the dialog uses a 3-panel layout with a treatment info card, package-usage selector, recurring/walk-in state, and a stacked slot list with end-times; the form uses a vertical stack with CRM contact search and a 4×N slot grid. Forcing them through one shared component would push their UX differences into a wide `variant` API that adds more code than it removes, so I'm flagging it as a separate follow-up.

## Follow-ups
- Extract shared appointment PatientPicker subcomponent: form has CRM unlinked-contact search inline; dialog doesn't — design a shared combobox+inline-create-SidePanel primitive that accepts optional "extra command groups" so both consumers can render their own patient sources without copying the popover/command shell.
- Extract shared appointment TreatmentPicker subcomponent: both have the same popover+command structure but the dialog shows a richer info card (description, duration, price badges) below the picker; treatment-card UI could become an optional render-prop slot on the shared picker.
- Extract shared appointment SlotPicker subcomponent: dialog uses a vertical list of `start—end` buttons with selected-into-view scroll; form uses a 4-col grid of `start` buttons. A shared component with `layout: "list" | "grid"` and an optional "auto-scroll selected" prop would unify the two.