### PR TITLE
Wizyta z pakietu

### DIFF
--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -10,6 +10,7 @@ const paymentMethodValidator = v.union(
   v.literal("cash"),
   v.literal("card"),
   v.literal("transfer"),
+  v.literal("package"),
   v.literal("other"),
 );
 

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -408,6 +408,7 @@ export function createCrmTables({
       v.literal("cash"),
       v.literal("card"),
       v.literal("transfer"),
+      v.literal("package"),
       v.literal("other"),
     ),
     status: v.union(

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3264,6 +3264,7 @@
         "card": "Card",
         "cash": "Cash",
         "other": "Other",
+        "package": "Series/Package",
         "transfer": "Transfer"
       },
       "noPayments": "No payments",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3293,6 +3293,7 @@
         "card": "Karta",
         "cash": "Gotówka",
         "other": "Inna",
+        "package": "Seria/Karnet",
         "transfer": "Przelew"
       },
       "noPayments": "Brak płatności",

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -280,17 +280,17 @@ export function AppointmentPreviewContent({
   const [settleDialogOpen, setSettleDialogOpen] = useState(false);
   const [settleAmount, setSettleAmount] = useState("");
   const [settleMethod, setSettleMethod] = useState<
-    "cash" | "card" | "transfer" | "other"
+    "cash" | "card" | "transfer" | "package" | "other"
   >("cash");
   const [settleNotes, setSettleNotes] = useState("");
   const [settleMarkCompleted, setSettleMarkCompleted] = useState(true);
   const [settleSubmitting, setSettleSubmitting] = useState(false);
   const [settleSplitPayment, setSettleSplitPayment] = useState(false);
   const [settleFirstSplitMethod, setSettleFirstSplitMethod] = useState<
-    "cash" | "card" | "transfer" | "other"
+    "cash" | "card" | "transfer" | "package" | "other"
   >("cash");
   const [settleSecondSplitMethod, setSettleSecondSplitMethod] = useState<
-    "cash" | "card" | "transfer" | "other"
+    "cash" | "card" | "transfer" | "package" | "other"
   >("card");
   const [settleFirstSplitAmount, setSettleFirstSplitAmount] = useState("");
   const [settleSecondSplitAmount, setSettleSecondSplitAmount] = useState("");
@@ -848,7 +848,7 @@ export function AppointmentPreviewContent({
       }
       if (settleSplitPayment && patient?._id) {
         const parts: Array<{
-          method: "cash" | "card" | "transfer" | "other";
+          method: "cash" | "card" | "transfer" | "package" | "other";
           amount: number;
         }> = [];
         if (parsedFirstSplitAmount > 0)
@@ -1587,6 +1587,9 @@ export function AppointmentPreviewContent({
                   <SelectItem value="transfer">
                     {t("gabinet.payments.methods.transfer")}
                   </SelectItem>
+                  <SelectItem value="package">
+                    {t("gabinet.payments.methods.package")}
+                  </SelectItem>
                   <SelectItem value="other">
                     {t("gabinet.payments.methods.other")}
                   </SelectItem>
@@ -1730,6 +1733,9 @@ export function AppointmentPreviewContent({
                       <SelectItem value="transfer">
                         {t("gabinet.payments.methods.transfer")}
                       </SelectItem>
+                      <SelectItem value="package">
+                        {t("gabinet.payments.methods.package")}
+                      </SelectItem>
                       <SelectItem value="other">
                         {t("gabinet.payments.methods.other")}
                       </SelectItem>
@@ -1772,6 +1778,9 @@ export function AppointmentPreviewContent({
                       </SelectItem>
                       <SelectItem value="transfer">
                         {t("gabinet.payments.methods.transfer")}
+                      </SelectItem>
+                      <SelectItem value="package">
+                        {t("gabinet.payments.methods.package")}
                       </SelectItem>
                       <SelectItem value="other">
                         {t("gabinet.payments.methods.other")}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1005,7 +1005,7 @@ function AppointmentDetail() {
         appointmentId: appointment._id,
         amount: parseFloat(normalizedAmount),
         currency: "PLN",
-        paymentMethod: paymentMethod as "cash" | "card" | "transfer" | "other",
+        paymentMethod: paymentMethod as "cash" | "card" | "transfer" | "package" | "other",
         notes: paymentNote || undefined,
       });
 
@@ -2823,6 +2823,9 @@ function AppointmentDetail() {
                   </SelectItem>
                   <SelectItem value="transfer">
                     {t("gabinet.payments.methods.transfer")}
+                  </SelectItem>
+                  <SelectItem value="package">
+                    {t("gabinet.payments.methods.package")}
                   </SelectItem>
                   <SelectItem value="other">
                     {t("gabinet.payments.methods.other")}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -117,7 +117,7 @@ function PatientDetail() {
   const [editingPaymentId, setEditingPaymentId] = useState<string | null>(null);
   const [paymentEditAmount, setPaymentEditAmount] = useState("");
   const [paymentEditMethod, setPaymentEditMethod] = useState<
-    "cash" | "card" | "transfer" | "other"
+    "cash" | "card" | "transfer" | "package" | "other"
   >("cash");
   const [paymentEditNotes, setPaymentEditNotes] = useState("");
   const [isPaymentEditSubmitting, setIsPaymentEditSubmitting] = useState(false);
@@ -451,11 +451,13 @@ function PatientDetail() {
       | "cash"
       | "card"
       | "transfer"
+      | "package"
       | "other";
     setPaymentEditMethod(
       method === "cash" ||
         method === "card" ||
         method === "transfer" ||
+        method === "package" ||
         method === "other"
         ? method
         : "cash",
@@ -1528,7 +1530,7 @@ function PatientDetail() {
                 value={paymentEditMethod}
                 onValueChange={(v) =>
                   setPaymentEditMethod(
-                    v as "cash" | "card" | "transfer" | "other",
+                    v as "cash" | "card" | "transfer" | "package" | "other",
                   )
                 }
               >
@@ -1544,6 +1546,9 @@ function PatientDetail() {
                   </SelectItem>
                   <SelectItem value="transfer">
                     {t("gabinet.payments.methods.transfer")}
+                  </SelectItem>
+                  <SelectItem value="package">
+                    {t("gabinet.payments.methods.package")}
                   </SelectItem>
                   <SelectItem value="other">
                     {t("gabinet.payments.methods.other")}

--- a/supabase/migrations/00009_payments_package_method.sql
+++ b/supabase/migrations/00009_payments_package_method.sql
@@ -1,0 +1,8 @@
+-- Add 'package' to the payment_method_enum (issue #1508).
+--
+-- Visits booked from a treatment package (gabinetPackageUsage) are already
+-- covered by the package purchase, so the patient doesn't pay again per
+-- visit. Staff need a payment method that records "settled by package" on
+-- the per-visit payment row without booking a new cash/card/transfer leg.
+
+ALTER TYPE payment_method_enum ADD VALUE IF NOT EXISTS 'package';


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1508.

Closes #1508

---

## Claude summary

Added a new `package` (seria/karnet) payment method end-to-end so staff can record that a package-linked visit is settled by the package rather than booking another cash/card/transfer leg.

Changes:
- `convex/payments.ts` — extended `paymentMethodValidator` with `v.literal("package")` so the `create`, `update`, `markPaid`, `splitMarkPaid`, and `refundCredit` actions all accept it.
- `convex/schema/crm.ts` — mirrored the same literal on the `payments` table validator.
- `supabase/migrations/00009_payments_package_method.sql` — `ALTER TYPE payment_method_enum ADD VALUE IF NOT EXISTS 'package'` so Postgres inserts succeed.
- `src/components/gabinet/calendar/appointment-preview-content.tsx` — widened the three settle-method state types (single + two split methods + the `parts` array) and added a `package` `SelectItem` to all three dropdowns.
- `src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx` — added the `package` option to the standalone payment dialog and widened the cast on `paymentMethod`.
- `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx` — added the `package` option and method-validation branch to the edit-payment dialog (refund dropdown intentionally left without `package` since refunds always settle in cash/card/transfer/other).
- `public/locales/{pl,en}/translation.json` — added `gabinet.payments.methods.package` ("Seria/Karnet" / "Series/Package") so existing display code `t(\`gabinet.payments.methods.${paymentMethod}\`)` renders the new method everywhere it's already used.

Verified `npm run typecheck` clean and `tests/convex/payments.test.ts` still passes (17/17).

## Follow-ups
- Auto-mark package-linked visits as paid: when a visit with `packageUsageId` is completed (`convex/gabinet/appointments.ts:2329-2347` currently skips creating a payment), insert a completed `paymentMethod: "package"` row with `amount = treatment.price` so the calendar's "unpaid" indicator clears without manual settling.