### PR TITLE
Add a unit test for gabinet patients merge

### DIFF
--- a/tests/convex/_supabase_inmemory.ts
+++ b/tests/convex/_supabase_inmemory.ts
@@ -114,11 +114,96 @@ export function createInMemorySupabaseDb() {
     },
 
     raw() {
-      throw new Error(
-        "supabaseDb(inmemory).raw(): raw client access is not available under vitest",
-      );
+      return createInMemoryRawClient();
     },
   };
+}
+
+// Snake → camel conversion used to bridge the raw client (which uses
+// PostgREST-style snake_case identifiers) to the in-memory store (which
+// keeps tables/rows in Convex camelCase). The merge action is the only
+// caller of `db.raw()` so we only need this one direction.
+function snakeToCamel(s: string): string {
+  return s.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+/**
+ * Minimal raw-client stand-in for the merge action's bulk-update pattern:
+ *   client.from(snakeTable).update({col: val}).eq(...).eq(...).select("id")
+ *
+ * Returns `{ data, error }` where `data` is the list of updated row ids
+ * (so `data.length` reports the count, matching PostgREST semantics).
+ */
+function createInMemoryRawClient() {
+  return {
+    from(table: string) {
+      return new InMemoryRawQuery(snakeToCamel(table));
+    },
+  };
+}
+
+class InMemoryRawQuery {
+  private table: string;
+  private mode: "select" | "update" | "delete" | "insert" = "select";
+  private updatePayload: Record<string, unknown> | null = null;
+  private filters: Array<(row: Row) => boolean> = [];
+
+  constructor(table: string) {
+    this.table = table;
+  }
+
+  update(values: Record<string, unknown>) {
+    this.mode = "update";
+    const camelValues: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(values)) {
+      camelValues[snakeToCamel(k)] = v;
+    }
+    this.updatePayload = camelValues;
+    return this;
+  }
+
+  delete() {
+    this.mode = "delete";
+    return this;
+  }
+
+  eq(field: string, value: unknown) {
+    const camelField = snakeToCamel(field);
+    this.filters.push((r) => r[camelField] === value);
+    return this;
+  }
+
+  in(field: string, values: unknown[]) {
+    const camelField = snakeToCamel(field);
+    const set = new Set(values);
+    this.filters.push((r) => set.has(r[camelField]));
+    return this;
+  }
+
+  async select(_cols?: string) {
+    const t = getTable(this.table);
+    const matched: Row[] = [];
+    for (const row of t.values()) {
+      if (this.filters.every((f) => f(row))) {
+        matched.push(row);
+      }
+    }
+    if (this.mode === "update" && this.updatePayload) {
+      for (const row of matched) {
+        const id = String(row.id);
+        const next: Row = { ...row, ...this.updatePayload, id };
+        t.set(id, next);
+      }
+    } else if (this.mode === "delete") {
+      for (const row of matched) {
+        t.delete(String(row.id));
+      }
+    }
+    return {
+      data: matched.map((r) => ({ id: String(r.id) })),
+      error: null as null | { message: string },
+    };
+  }
 }
 
 class InMemoryQueryBuilder<T = Record<string, unknown>> {

--- a/tests/convex/patientsMerge.test.ts
+++ b/tests/convex/patientsMerge.test.ts
@@ -1,0 +1,435 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import {
+  createTestCtx,
+  seedTestUser,
+  seedGabinetPrereqs,
+} from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  // Let pending setTimeout(0) side-effect callbacks fire against the current
+  // instance; the process-wide scheduler-noise filter (tests/convex/_setup.ts)
+  // swallows orphan-write rejections that still escape this yield.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+// Spin up a second patient in the in-memory Supabase store. The first patient
+// is created by seedGabinetPrereqs; the second is what we merge into / from.
+async function seedSecondPatient(
+  organizationId: string,
+  userId: string,
+  patientId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  const db = createSupabaseDb();
+  const now = Date.now();
+  await db.insert("gabinetPatients", {
+    _id: patientId,
+    organizationId,
+    firstName: "Anna",
+    lastName: "Nowak",
+    email: "anna@example.com",
+    isActive: true,
+    createdBy: userId,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  });
+}
+
+describe("gabinet/patients.merge", () => {
+  describe("self-merge guard", () => {
+    test("throws when target and source are the same id", async () => {
+      const t = createTestCtx();
+      const { organizationId, userId, identity } = await seedTestUser(t);
+      const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+      await expect(
+        t
+          .withIdentity(identity)
+          .action(api.gabinet.patients.merge, {
+            organizationId,
+            targetPatientId: String(patientId),
+            sourcePatientId: String(patientId),
+          }),
+      ).rejects.toThrow(/Cannot merge a patient with itself/);
+    });
+  });
+
+  describe("org-scoping guard", () => {
+    test("rejects when target patient belongs to a different organization", async () => {
+      const t = createTestCtx();
+      const { organizationId, userId, identity } = await seedTestUser(t);
+      // Seed a patient that lives in a completely different org.
+      await seedSecondPatient(
+        "org_other_999",
+        String(userId),
+        "patient_target_foreign",
+      );
+      // Source belongs to the caller's org so we isolate the failure to target.
+      const { patientId: sourcePatientId } = await seedGabinetPrereqs(
+        t,
+        organizationId,
+        userId,
+      );
+
+      await expect(
+        t
+          .withIdentity(identity)
+          .action(api.gabinet.patients.merge, {
+            organizationId,
+            targetPatientId: "patient_target_foreign",
+            sourcePatientId: String(sourcePatientId),
+          }),
+      ).rejects.toThrow(/Target patient not found/);
+    });
+
+    test("rejects when source patient belongs to a different organization", async () => {
+      const t = createTestCtx();
+      const { organizationId, userId, identity } = await seedTestUser(t);
+      const { patientId: targetPatientId } = await seedGabinetPrereqs(
+        t,
+        organizationId,
+        userId,
+      );
+      await seedSecondPatient(
+        "org_other_999",
+        String(userId),
+        "patient_source_foreign",
+      );
+
+      await expect(
+        t
+          .withIdentity(identity)
+          .action(api.gabinet.patients.merge, {
+            organizationId,
+            targetPatientId: String(targetPatientId),
+            sourcePatientId: "patient_source_foreign",
+          }),
+      ).rejects.toThrow(/Source patient not found/);
+    });
+  });
+
+  describe("loyalty point consolidation", () => {
+    test("sums balances when both patients have loyalty rows", async () => {
+      const t = createTestCtx();
+      const { organizationId, userId, identity } = await seedTestUser(t);
+      const { patientId: targetId } = await seedGabinetPrereqs(
+        t,
+        organizationId,
+        userId,
+      );
+      const sourceId = "patient_loyalty_source";
+      await seedSecondPatient(String(organizationId), String(userId), sourceId);
+
+      const db = createSupabaseDb();
+      await db.insert("gabinetLoyaltyPoints", {
+        _id: "loyalty_target",
+        organizationId: String(organizationId),
+        patientId: String(targetId),
+        balance: 100,
+        lifetimeEarned: 150,
+        lifetimeSpent: 50,
+        updatedAt: Date.now(),
+      });
+      await db.insert("gabinetLoyaltyPoints", {
+        _id: "loyalty_source",
+        organizationId: String(organizationId),
+        patientId: sourceId,
+        balance: 40,
+        lifetimeEarned: 60,
+        lifetimeSpent: 20,
+        updatedAt: Date.now(),
+      });
+
+      const result = await t
+        .withIdentity(identity)
+        .action(api.gabinet.patients.merge, {
+          organizationId,
+          targetPatientId: String(targetId),
+          sourcePatientId: sourceId,
+        });
+
+      expect(result.consolidatedLoyaltyBalance).toBe(140);
+
+      // Target row now carries the combined totals.
+      const targetLoyalty = await db.get<{
+        balance: number;
+        lifetimeEarned: number;
+        lifetimeSpent: number;
+      }>("gabinetLoyaltyPoints", "loyalty_target");
+      expect(targetLoyalty?.balance).toBe(140);
+      expect(targetLoyalty?.lifetimeEarned).toBe(210);
+      expect(targetLoyalty?.lifetimeSpent).toBe(70);
+
+      // Source loyalty row is removed (unique constraint on org+patient).
+      const sourceLoyalty = await db.get(
+        "gabinetLoyaltyPoints",
+        "loyalty_source",
+      );
+      expect(sourceLoyalty).toBeNull();
+    });
+
+    test("reassigns source loyalty row when target has none", async () => {
+      const t = createTestCtx();
+      const { organizationId, userId, identity } = await seedTestUser(t);
+      const { patientId: targetId } = await seedGabinetPrereqs(
+        t,
+        organizationId,
+        userId,
+      );
+      const sourceId = "patient_loyalty_source";
+      await seedSecondPatient(String(organizationId), String(userId), sourceId);
+
+      const db = createSupabaseDb();
+      await db.insert("gabinetLoyaltyPoints", {
+        _id: "loyalty_source",
+        organizationId: String(organizationId),
+        patientId: sourceId,
+        balance: 25,
+        lifetimeEarned: 30,
+        lifetimeSpent: 5,
+        updatedAt: Date.now(),
+      });
+
+      const result = await t
+        .withIdentity(identity)
+        .action(api.gabinet.patients.merge, {
+          organizationId,
+          targetPatientId: String(targetId),
+          sourcePatientId: sourceId,
+        });
+
+      expect(result.consolidatedLoyaltyBalance).toBe(25);
+
+      // The source row was rewired onto the target patient instead of deleted.
+      const reassigned = await db.get<{
+        patientId: string;
+        balance: number;
+      }>("gabinetLoyaltyPoints", "loyalty_source");
+      expect(reassigned?.patientId).toBe(String(targetId));
+      expect(reassigned?.balance).toBe(25);
+    });
+
+    test("returns target balance unchanged when source has no loyalty row", async () => {
+      const t = createTestCtx();
+      const { organizationId, userId, identity } = await seedTestUser(t);
+      const { patientId: targetId } = await seedGabinetPrereqs(
+        t,
+        organizationId,
+        userId,
+      );
+      const sourceId = "patient_no_loyalty";
+      await seedSecondPatient(String(organizationId), String(userId), sourceId);
+
+      const db = createSupabaseDb();
+      await db.insert("gabinetLoyaltyPoints", {
+        _id: "loyalty_target",
+        organizationId: String(organizationId),
+        patientId: String(targetId),
+        balance: 75,
+        lifetimeEarned: 100,
+        lifetimeSpent: 25,
+        updatedAt: Date.now(),
+      });
+
+      const result = await t
+        .withIdentity(identity)
+        .action(api.gabinet.patients.merge, {
+          organizationId,
+          targetPatientId: String(targetId),
+          sourcePatientId: sourceId,
+        });
+
+      expect(result.consolidatedLoyaltyBalance).toBe(75);
+      const targetLoyalty = await db.get<{ balance: number }>(
+        "gabinetLoyaltyPoints",
+        "loyalty_target",
+      );
+      expect(targetLoyalty?.balance).toBe(75);
+    });
+  });
+
+  describe("polymorphic activities/notes reassignment", () => {
+    test("reassigns only rows whose entityType matches gabinetPatient", async () => {
+      const t = createTestCtx();
+      const { organizationId, userId, identity } = await seedTestUser(t);
+      const { patientId: targetId } = await seedGabinetPrereqs(
+        t,
+        organizationId,
+        userId,
+      );
+      const sourceId = "patient_poly_source";
+      await seedSecondPatient(String(organizationId), String(userId), sourceId);
+
+      const db = createSupabaseDb();
+      const orgIdStr = String(organizationId);
+
+      // Note pointing at the source patient — should move.
+      await db.insert("notes", {
+        _id: "note_patient",
+        organizationId: orgIdStr,
+        entityType: "gabinetPatient",
+        entityId: sourceId,
+        content: "patient note",
+      });
+      // Same id collision but different entityType — must NOT move
+      // (a contact happens to share an id namespace with the patient).
+      await db.insert("notes", {
+        _id: "note_contact_collision",
+        organizationId: orgIdStr,
+        entityType: "contact",
+        entityId: sourceId,
+        content: "contact note",
+      });
+      // Different patient id, same entityType — must NOT move.
+      await db.insert("notes", {
+        _id: "note_other_patient",
+        organizationId: orgIdStr,
+        entityType: "gabinetPatient",
+        entityId: "patient_unrelated",
+        content: "unrelated patient note",
+      });
+
+      // Activities: one matching, one with different entityType.
+      await db.insert("activities", {
+        _id: "act_patient",
+        organizationId: orgIdStr,
+        entityType: "gabinetPatient",
+        entityId: sourceId,
+        action: "created",
+      });
+      await db.insert("activities", {
+        _id: "act_contact_collision",
+        organizationId: orgIdStr,
+        entityType: "contact",
+        entityId: sourceId,
+        action: "created",
+      });
+
+      // object_relationships: polymorphic on BOTH source_* and target_*.
+      await db.insert("objectRelationships", {
+        _id: "rel_source_side",
+        organizationId: orgIdStr,
+        sourceType: "gabinetPatient",
+        sourceId: sourceId,
+        targetType: "contact",
+        targetId: "c_1",
+      });
+      await db.insert("objectRelationships", {
+        _id: "rel_target_side",
+        organizationId: orgIdStr,
+        sourceType: "contact",
+        sourceId: "c_2",
+        targetType: "gabinetPatient",
+        targetId: sourceId,
+      });
+      // Wrong type discriminator on the source side — must NOT move.
+      await db.insert("objectRelationships", {
+        _id: "rel_wrong_type",
+        organizationId: orgIdStr,
+        sourceType: "contact",
+        sourceId: sourceId,
+        targetType: "contact",
+        targetId: "c_3",
+      });
+
+      const result = await t
+        .withIdentity(identity)
+        .action(api.gabinet.patients.merge, {
+          organizationId,
+          targetPatientId: String(targetId),
+          sourcePatientId: sourceId,
+        });
+
+      expect(result.movedNotes).toBe(1);
+      expect(result.movedActivities).toBe(1);
+      // 1 source-side + 1 target-side = 2
+      expect(result.movedRelationships).toBe(2);
+
+      // Verify the matching note moved to the target.
+      const movedNote = await db.get<{ entityId: string }>("notes", "note_patient");
+      expect(movedNote?.entityId).toBe(String(targetId));
+
+      // Verify the entityType-mismatched note did NOT move.
+      const untouchedContactNote = await db.get<{ entityId: string }>(
+        "notes",
+        "note_contact_collision",
+      );
+      expect(untouchedContactNote?.entityId).toBe(sourceId);
+
+      // Verify the unrelated patient's note did NOT move.
+      const otherPatientNote = await db.get<{ entityId: string }>(
+        "notes",
+        "note_other_patient",
+      );
+      expect(otherPatientNote?.entityId).toBe("patient_unrelated");
+
+      // Activity matching the discriminator moved; the contact one did not.
+      const movedActivity = await db.get<{ entityId: string }>(
+        "activities",
+        "act_patient",
+      );
+      expect(movedActivity?.entityId).toBe(String(targetId));
+      const untouchedActivity = await db.get<{ entityId: string }>(
+        "activities",
+        "act_contact_collision",
+      );
+      expect(untouchedActivity?.entityId).toBe(sourceId);
+
+      // Relationships rewired on the correct side only.
+      const relSource = await db.get<{ sourceId: string; targetId: string }>(
+        "objectRelationships",
+        "rel_source_side",
+      );
+      expect(relSource?.sourceId).toBe(String(targetId));
+      const relTarget = await db.get<{ sourceId: string; targetId: string }>(
+        "objectRelationships",
+        "rel_target_side",
+      );
+      expect(relTarget?.targetId).toBe(String(targetId));
+      const relUntouched = await db.get<{ sourceId: string }>(
+        "objectRelationships",
+        "rel_wrong_type",
+      );
+      expect(relUntouched?.sourceId).toBe(sourceId);
+    });
+  });
+
+  describe("source patient deactivation", () => {
+    test("marks source patient inactive and annotates medicalNotes", async () => {
+      const t = createTestCtx();
+      const { organizationId, userId, identity } = await seedTestUser(t);
+      const { patientId: targetId } = await seedGabinetPrereqs(
+        t,
+        organizationId,
+        userId,
+      );
+      const sourceId = "patient_deactivation_source";
+      await seedSecondPatient(String(organizationId), String(userId), sourceId, {
+        medicalNotes: "Existing notes about source",
+      });
+
+      await t
+        .withIdentity(identity)
+        .action(api.gabinet.patients.merge, {
+          organizationId,
+          targetPatientId: String(targetId),
+          sourcePatientId: sourceId,
+        });
+
+      const db = createSupabaseDb();
+      const source = await db.get<{
+        isActive: boolean;
+        medicalNotes: string | null;
+      }>("gabinetPatients", sourceId);
+
+      expect(source?.isActive).toBe(false);
+      expect(source?.medicalNotes).toContain(
+        `[Merged into patient ${String(targetId)}`,
+      );
+      expect(source?.medicalNotes).toContain("Existing notes about source");
+    });
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1510.

Closes #1510

---

## Claude summary

Committed. Summary:

Added `tests/convex/patientsMerge.test.ts` with 8 tests covering the three areas the issue called out:

- **Loyalty-point consolidation** — all three branches: both rows present (sum + delete source), source-only (reassign source row), target-only (untouched).
- **Polymorphic activities / notes / object_relationships reassignment** — verifies the entity-type discriminator is honored (a `contact` row with a colliding id is left alone), unrelated patient rows aren't touched, and both `source_*` and `target_*` sides of `object_relationships` are walked.
- **Org-scoping guard** — rejects merge when target or source belongs to another org; rejects self-merge.
- Plus the source-patient deactivation breadcrumb (`isActive=false` + merge marker prepended to `medicalNotes`).

The merge action does bulk reassignments through `db.raw()` — the in-memory Supabase stub previously threw on that, so I extended `tests/convex/_supabase_inmemory.ts` with a minimal raw-client stand-in supporting the `from(t).update(v).eq(...).eq(...).select("id")` chain (with snake→camel translation to match the in-memory store). Confirmed all 146 convex tests pass (138 prior + 8 new) and `tsc -p convex/tsconfig.json` is clean.