### PR TITLE
scalanie

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2234,6 +2234,8 @@
       },
       "merge": {
         "action": "Merge with...",
+        "bulkAction": "Merge selected",
+        "selectExactlyTwo": "Select exactly two clients to merge.",
         "title": "Merge clients",
         "description": "Pick the client that data should be moved to. The source client will be deactivated.",
         "sourceLabel": "Source (will be deactivated)",
@@ -2241,6 +2243,7 @@
         "matchEmail": "Same email",
         "matchPhone": "Same phone",
         "matchSearch": "Search",
+        "matchSelected": "Selected",
         "noDuplicates": "No duplicates by email or phone. Use the search above to pick another client.",
         "noContactInfo": "This client has no email or phone, so automatic matching is unavailable. Search manually.",
         "warning": "All appointments, documents, payments, loyalty points and notes will be transferred. This operation cannot be undone.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2262,6 +2262,8 @@
       },
       "merge": {
         "action": "Scal z...",
+        "bulkAction": "Scal zaznaczonych",
+        "selectExactlyTwo": "Aby scalić, zaznacz dokładnie dwóch klientów.",
         "title": "Scal klientów",
         "description": "Wybierz klienta, do którego mają zostać przeniesione dane. Klient źródłowy zostanie dezaktywowany.",
         "sourceLabel": "Źródło (zostanie dezaktywowane)",
@@ -2269,6 +2271,7 @@
         "matchEmail": "Ten sam e-mail",
         "matchPhone": "Ten sam telefon",
         "matchSearch": "Wyszukiwanie",
+        "matchSelected": "Wybrany",
         "noDuplicates": "Brak duplikatów po e-mailu lub telefonie. Skorzystaj z wyszukiwarki powyżej, aby wybrać innego klienta.",
         "noContactInfo": "Klient nie ma e-maila ani telefonu, więc automatyczne dopasowanie nie jest możliwe. Wyszukaj klienta ręcznie.",
         "warning": "Wszystkie wizyty, dokumenty, płatności, punkty lojalnościowe i notatki zostaną przeniesione. Operacja jest nieodwracalna.",

--- a/src/components/gabinet/merge-patients-dialog.tsx
+++ b/src/components/gabinet/merge-patients-dialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useAction } from "convex/react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -27,6 +27,7 @@ interface MergePatientsDialogProps {
   organizationId: string;
   sourcePatient: MappedGabinetPatient | null;
   allPatients: MappedGabinetPatient[];
+  preselectedTargetId?: string | null;
   onMerged?: () => void;
 }
 
@@ -48,14 +49,19 @@ export function MergePatientsDialog({
   organizationId,
   sourcePatient,
   allPatients,
+  preselectedTargetId,
   onMerged,
 }: MergePatientsDialogProps) {
   const { t } = useTranslation();
   const mergePatients = useAction(api.gabinet.patients.merge);
 
-  const [targetId, setTargetId] = useState<string | null>(null);
+  const [targetId, setTargetId] = useState<string | null>(preselectedTargetId ?? null);
   const [search, setSearch] = useState("");
   const [isMerging, setIsMerging] = useState(false);
+
+  useEffect(() => {
+    if (open) setTargetId(preselectedTargetId ?? null);
+  }, [open, preselectedTargetId, sourcePatient?._id]);
 
   const sourceEmail = normalizeEmail(sourcePatient?.email);
   const sourcePhone = normalizePhone(sourcePatient?.phone);
@@ -66,8 +72,19 @@ export function MergePatientsDialog({
     const matches: Array<MappedGabinetPatient & { matchReason: string }> = [];
     const seen = new Set<string>();
 
+    if (preselectedTargetId && preselectedTargetId !== sourcePatient._id) {
+      const preselected = allPatients.find((p) => p._id === preselectedTargetId);
+      if (preselected) {
+        matches.push({
+          ...preselected,
+          matchReason: t("gabinet.patients.merge.matchSelected", { defaultValue: "Wybrany" }),
+        });
+        seen.add(preselected._id);
+      }
+    }
+
     for (const p of allPatients) {
-      if (p._id === sourcePatient._id) continue;
+      if (p._id === sourcePatient._id || seen.has(p._id)) continue;
       const pEmail = normalizeEmail(p.email);
       const pPhone = normalizePhone(p.phone);
 
@@ -100,7 +117,7 @@ export function MergePatientsDialog({
     }
 
     return matches.slice(0, 50);
-  }, [allPatients, sourcePatient, sourceEmail, sourcePhone, search, t]);
+  }, [allPatients, sourcePatient, sourceEmail, sourcePhone, search, t, preselectedTargetId]);
 
   const target = useMemo(
     () => candidates.find((c) => c._id === targetId) ?? null,

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -77,6 +77,7 @@ function PatientsIndex() {
   const [panelOpen, setPanelOpen] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const [mergeSourcePatient, setMergeSourcePatient] = useState<Patient | null>(null);
+  const [mergePreselectedTargetId, setMergePreselectedTargetId] = useState<string | null>(null);
   const [leftTimeRange, setLeftTimeRange] = useState<TimeRange>("last30days");
   const [rightTimeRange, setRightTimeRange] = useState<TimeRange>("all");
   const [savedViewsDialogOpen, setSavedViewsDialogOpen] = useState(false);
@@ -447,9 +448,20 @@ function PatientsIndex() {
         for (const row of selectedRows) {
           await removePatient({ organizationId, patientId: row._id as Id<"gabinetPatients"> });
         }
+      } else if (action === "merge") {
+        if (selectedRows.length !== 2) {
+          toast.error(
+            t("gabinet.patients.merge.selectExactlyTwo", {
+              defaultValue: "Aby scalić, zaznacz dokładnie dwóch klientów.",
+            }),
+          );
+          return;
+        }
+        setMergeSourcePatient(selectedRows[0]);
+        setMergePreselectedTargetId(selectedRows[1]._id);
       }
     },
-    [removePatient, organizationId],
+    [removePatient, organizationId, t],
   );
 
   const rowActions = useCallback(
@@ -608,6 +620,10 @@ function PatientsIndex() {
         enableBulkSelect
         bulkActions={[
           {
+            label: t("gabinet.patients.merge.bulkAction", { defaultValue: "Scal zaznaczonych" }),
+            value: "merge",
+          },
+          {
             label: t("common.delete"),
             value: "delete",
             variant: "destructive",
@@ -653,11 +669,15 @@ function PatientsIndex() {
       <MergePatientsDialog
         open={!!mergeSourcePatient}
         onOpenChange={(open) => {
-          if (!open) setMergeSourcePatient(null);
+          if (!open) {
+            setMergeSourcePatient(null);
+            setMergePreselectedTargetId(null);
+          }
         }}
         organizationId={organizationId}
         sourcePatient={mergeSourcePatient}
         allPatients={patients}
+        preselectedTargetId={mergePreselectedTargetId}
         onMerged={() => {
           void queryClient.invalidateQueries({
             queryKey: supabaseKeys.gabinetPatients.list(organizationId),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1514.

Closes #1514

---

## Claude summary

Committed as `8d07ec6`.

Summary: The user's screenshot showed they had selected duplicate patients (same email `a1@medicana.pl`) via the row checkboxes and expected a "Scal" (merge) button to appear in the bulk-actions bar — but the only bulk action wired up was Delete. Added a `merge` bulk action to `_layout.gabinet.patients.index.tsx` which, when exactly two rows are selected, opens the existing `MergePatientsDialog` with the first as source and the second pre-selected as target (new `preselectedTargetId` prop on the dialog, badge label `Wybrany` / `Selected`). Selecting a different count shows a toast asking for exactly two. PL/EN strings added. `npm run typecheck` and the 8 `patientsMerge` Convex tests pass.