### PR TITLE
Show linked package in treatment list/detail badges

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2289,8 +2289,10 @@
       "noPackagesAvailable": "No packages available. Add one in the \"Packages\" tab.",
       "type": "Type",
       "packageBadge": "Package · {{count}}x",
+      "packageBadgeNamed": "Package · {{name}}",
       "singleBadge": "Single",
       "isPackageTooltip": "Package — {{count}} sessions in a course",
+      "isPackageTooltipNamed": "Linked package: {{name}}",
       "isRegularTooltip": "Regular treatment",
       "views": {
         "all": "All Treatments",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2317,8 +2317,10 @@
       "noPackagesAvailable": "Brak pakietów. Dodaj pakiet w zakładce \"Pakiety\".",
       "type": "Typ",
       "packageBadge": "Pakiet · {{count}}x",
+      "packageBadgeNamed": "Pakiet · {{name}}",
       "singleBadge": "Pojedynczy",
       "isPackageTooltip": "Pakiet — {{count}} zabiegów w cyklu",
+      "isPackageTooltipNamed": "Powiązany pakiet: {{name}}",
       "isRegularTooltip": "Zwykły zabieg",
       "views": {
         "all": "Wszystkie zabiegi",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -5,6 +5,7 @@ import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseGabinetTreatment, useSupabaseGabinetTreatmentVariants } from "@/hooks/use-supabase-gabinet-treatments";
+import { useSupabaseGabinetTreatmentPackagesList } from "@/hooks/use-supabase-gabinet-packages";
 import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
 import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
 import { useSupabaseGabinetEquipmentList } from "@/hooks/use-supabase-gabinet-equipment";
@@ -163,6 +164,14 @@ function TreatmentDetail() {
 
   const { categories } = useCategoryDefinitions(organizationId, "gabinetTreatment");
 
+  const { data: allPackages } = useSupabaseGabinetTreatmentPackagesList(organizationId);
+  const linkedPackageName = useMemo(() => {
+    if (!treatment?.packageId) return null;
+    return (
+      allPackages?.find((p) => p._id === treatment.packageId)?.name ?? null
+    );
+  }, [allPackages, treatment?.packageId]);
+
   const getDetailedStatsAction = useAction(api.gabinet.treatments.getTreatmentDetailedStats);
   const listTreatmentAppointmentsAction = useAction(api.gabinet.treatments.listTreatmentAppointments);
   const getTreatmentEmployeesAction = useAction(api.gabinet.treatments.getTreatmentEmployees);
@@ -307,11 +316,24 @@ function TreatmentDetail() {
     if (treatment.requiresApproval) {
       fields.push({ label: t("gabinet.treatments.requiresApproval"), value: <Badge variant="outline" className="text-[10px]">{t("common.yes")}</Badge>, fieldKey: "approval" });
     }
-    if (treatment.treatmentCount && treatment.treatmentCount > 1) {
+    if (treatment.packageId) {
+      fields.push({
+        label: t("gabinet.treatments.linkedPackage", "Powiązany pakiet"),
+        value: (
+          <Badge
+            variant="secondary"
+            className="border-violet-200 bg-violet-100 text-[10px] text-violet-800 dark:border-violet-900 dark:bg-violet-950/60 dark:text-violet-200"
+          >
+            {linkedPackageName ?? t("gabinet.treatments.package", "Pakiet")}
+          </Badge>
+        ),
+        fieldKey: "package",
+      });
+    } else if (treatment.treatmentCount && treatment.treatmentCount > 1) {
       fields.push({ label: t("gabinet.treatments.treatmentCount", "Liczba zabiegów"), value: <Badge variant="outline" className="text-[10px]">{treatment.treatmentCount}x</Badge>, fieldKey: "count" });
     }
     return fields;
-  }, [treatment, equipmentList, t, categoryName]);
+  }, [treatment, equipmentList, t, categoryName, linkedPackageName]);
 
   // Derived: unassigned employees (those that don't have this treatment in qualifiedTreatmentIds)
   const assignedEmployeeIds = useMemo(() => {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -5,6 +5,7 @@ import { useAction } from "convex/react";
 import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
+import { useSupabaseGabinetTreatmentPackagesList } from "@/hooks/use-supabase-gabinet-packages";
 import { useOrganization } from "@/components/org-context";
 import { PageHeader } from "@/components/layout/page-header";
 import { CrmDataTable, useColumnVisibility, useAllColumns } from "@/components/crm/enhanced-data-table";
@@ -175,6 +176,13 @@ function TreatmentsIndex() {
   );
 
   const { data: allTreatments = [], isLoading } = useSupabaseGabinetTreatmentsList(organizationId);
+  const { data: allPackages } = useSupabaseGabinetTreatmentPackagesList(organizationId);
+
+  const packageNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const pkg of allPackages ?? []) map.set(pkg._id, pkg.name);
+    return map;
+  }, [allPackages]);
 
   const {
     views,
@@ -270,12 +278,29 @@ function TreatmentsIndex() {
         label: t("gabinet.treatments.type", "Typ"),
         sortable: true,
         render: (item) => {
-          const isPackage = (item.treatmentCount ?? 1) > 1;
+          const linkedPackageName = item.packageId
+            ? packageNameById.get(item.packageId)
+            : undefined;
+          const isPackage = !!item.packageId || (item.treatmentCount ?? 1) > 1;
           if (isPackage) {
-            const tooltipLabel = t("gabinet.treatments.isPackageTooltip", {
-              count: item.treatmentCount ?? 0,
-              defaultValue: "Pakiet — {{count}} zabiegów w cyklu",
-            });
+            const badgeLabel = linkedPackageName
+              ? t("gabinet.treatments.packageBadgeNamed", {
+                  name: linkedPackageName,
+                  defaultValue: "Pakiet · {{name}}",
+                })
+              : t("gabinet.treatments.packageBadge", {
+                  count: item.treatmentCount ?? 0,
+                  defaultValue: "Pakiet · {{count}}x",
+                });
+            const tooltipLabel = linkedPackageName
+              ? t("gabinet.treatments.isPackageTooltipNamed", {
+                  name: linkedPackageName,
+                  defaultValue: "Powiązany pakiet: {{name}}",
+                })
+              : t("gabinet.treatments.isPackageTooltip", {
+                  count: item.treatmentCount ?? 0,
+                  defaultValue: "Pakiet — {{count}} zabiegów w cyklu",
+                });
             return (
               <TooltipProvider>
                 <Tooltip>
@@ -284,10 +309,7 @@ function TreatmentsIndex() {
                       variant="secondary"
                       className="border-violet-200 bg-violet-100 text-violet-800 dark:border-violet-900 dark:bg-violet-950/60 dark:text-violet-200"
                     >
-                      {t("gabinet.treatments.packageBadge", {
-                        count: item.treatmentCount ?? 0,
-                        defaultValue: "Pakiet · {{count}}x",
-                      })}
+                      {badgeLabel}
                     </Badge>
                   </TooltipTrigger>
                   <TooltipContent>{tooltipLabel}</TooltipContent>
@@ -301,7 +323,8 @@ function TreatmentsIndex() {
             </Badge>
           );
         },
-        getSortValue: (item) => ((item.treatmentCount ?? 1) > 1 ? 1 : 0),
+        getSortValue: (item) =>
+          item.packageId || (item.treatmentCount ?? 1) > 1 ? 1 : 0,
       },
       {
         id: "category",
@@ -345,7 +368,7 @@ function TreatmentsIndex() {
         ),
       },
     ],
-    [t, getCategoryLabel],
+    [t, getCategoryLabel, packageNameById],
   );
 
   const { allColumns, defaultHidden } = useAllColumns(columns, filterableFields);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1534.

Closes #1534

---

## Claude summary

Committed. Summary:

When `gabinetTreatments.packageId` is set, the treatments list "Typ" column badge now shows `Pakiet · <package name>` (with a matching tooltip), and the detail-view sidebar surfaces a "Powiązany pakiet" field rendering the same name. Treatments without `packageId` but with `treatmentCount > 1` keep the existing `{{count}}x` legacy fallback. Frontend typecheck (`tsc -p tsconfig.app.json --noEmit`) passes clean.

Files touched:
- `src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx` — fetches packages, builds id→name map, renders named badge.
- `src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx` — resolves linked package, replaces the `treatmentCount` sidebar fallback with a named package badge when `packageId` is set.
- `public/locales/{en,pl}/translation.json` — adds `packageBadgeNamed` and `isPackageTooltipNamed` keys.