### PR TITLE
W zakładce raporty wywala błąd

### DIFF
--- a/src/lib/error-reporter.ts
+++ b/src/lib/error-reporter.ts
@@ -112,15 +112,31 @@ export function isChunkLoadError(err: unknown): boolean {
   );
 }
 
-// Reload once per tab when a stale chunk is detected, so the browser fetches
-// the new index.html (and the chunk hashes it references). sessionStorage
-// guards against an infinite reload loop if the failure persists.
+// Reload when a stale chunk is detected, so the browser fetches the new
+// index.html (and the chunk hashes it references). A time-boxed sessionStorage
+// marker guards against an infinite reload loop if the failure persists
+// immediately after reload, while still allowing recovery from later deploys
+// in long-running tab sessions (e.g. active testing on the dev deployment).
+// Issue #1536 — the original one-shot guard from #1368 left users stuck on
+// the error UI after a second deploy in the same session.
 const CHUNK_RELOAD_KEY = "chunk-reload-attempted-v1";
+const CHUNK_RELOAD_COOLDOWN_MS = 30_000;
 export function maybeReloadForStaleChunk(err: unknown): boolean {
   if (typeof window === "undefined") return false;
   if (!isChunkLoadError(err)) return false;
   try {
-    if (sessionStorage.getItem(CHUNK_RELOAD_KEY)) return false;
+    const prev = sessionStorage.getItem(CHUNK_RELOAD_KEY);
+    if (prev) {
+      const ts = Number.parseInt(prev, 10);
+      // If we already reloaded recently and the chunk error came back inside
+      // the cooldown window, assume the reload didn't fix it (CDN still
+      // serving a stale index.html, missing chunk on server, etc.) and stop
+      // looping. Outside the cooldown, treat this as a fresh stale-chunk
+      // situation from a later deploy and reload again.
+      if (Number.isFinite(ts) && Date.now() - ts < CHUNK_RELOAD_COOLDOWN_MS) {
+        return false;
+      }
+    }
     sessionStorage.setItem(CHUNK_RELOAD_KEY, String(Date.now()));
   } catch {
     // sessionStorage may be unavailable (private mode, etc.) — proceed anyway.


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1536.

Closes #1536

---

## Claude summary

Fixed. Summary of what's happening and the fix.

The screenshot from the issue shows the route error boundary rendering "Failed to fetch dynamically imported module: …_layout.gabinet.reports.lazy-BRUKLhY5.js". This is the classic stale-chunk class of error: after a new deploy on `quera-dev.helloalex.pl`, the user's cached `index.html` still references the old hashed chunk filenames; navigating to `/dashboard/gabinet/reports` lazy-imports a chunk URL that 404s.

There was already a recovery path for this in `src/lib/error-reporter.ts:119` (`maybeReloadForStaleChunk`, added in #1368) that the route error boundary calls in a `useEffect` — it triggers `window.location.reload()` once per tab so the browser pulls fresh `index.html`. But the sessionStorage guard guarding against infinite reload loops was one-shot per tab session. After the first stale-chunk reload, any subsequent stale-chunk error in the same tab — e.g. a second deploy lands while the user is still in the tab — found the marker set and short-circuited, leaving the boundary's "Something went wrong" UI permanently visible. On the active-dev deployment with multiple deploys per day, that's a frequent occurrence.

The change in `src/lib/error-reporter.ts` swaps the boolean guard for a 30-second cooldown: if a chunk error reappears within 30s of the previous reload, we assume the reload didn't fix it and stop looping (same anti-loop behavior); after the cooldown the marker is treated as expired and the next stale-chunk situation reloads again.