### PR TITLE
Extract shared appointment SlotPicker subcomponent

### DIFF
--- a/src/components/gabinet/appointment-shared/slot-picker.tsx
+++ b/src/components/gabinet/appointment-shared/slot-picker.tsx
@@ -1,0 +1,99 @@
+import { useCallback } from "react";
+import { cn } from "@/lib/utils";
+
+export interface AppointmentSlot {
+  start: string;
+  end: string;
+}
+
+interface SlotPickerProps {
+  slots: readonly AppointmentSlot[];
+  selectedStart: string | null | undefined;
+  onSelect: (slot: AppointmentSlot) => void;
+  layout: "list" | "grid";
+  /**
+   * When true, scrolls the selected slot button into view as soon as it
+   * mounts. Used by the calendar appointment dialog so a pre-filled time
+   * (from a calendar click or "Find nearest slot") is visible without
+   * manual scrolling through the full day. Issue #786.
+   */
+  autoScrollSelected?: boolean;
+}
+
+export function SlotPicker({
+  slots,
+  selectedStart,
+  onSelect,
+  layout,
+  autoScrollSelected = false,
+}: SlotPickerProps) {
+  const selectedRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      if (autoScrollSelected && node) {
+        node.scrollIntoView({ block: "nearest" });
+      }
+    },
+    [autoScrollSelected],
+  );
+
+  if (layout === "list") {
+    return (
+      <div className="space-y-1.5">
+        {slots.map((slot) => {
+          const isSelected = selectedStart === slot.start;
+          return (
+            <button
+              key={slot.start}
+              ref={isSelected ? selectedRef : undefined}
+              type="button"
+              onClick={() => onSelect(slot)}
+              className={cn(
+                "w-full flex items-center justify-between px-3 py-2 rounded-md text-sm transition-colors",
+                "hover:bg-accent hover:text-accent-foreground",
+                "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+                isSelected
+                  ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
+                  : "bg-muted/40",
+              )}
+            >
+              <span className="font-medium tabular-nums">{slot.start}</span>
+              <span
+                className={cn(
+                  "text-xs",
+                  isSelected
+                    ? "text-primary-foreground/70"
+                    : "text-muted-foreground",
+                )}
+              >
+                {slot.end}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+      {slots.map((slot) => {
+        const isSelected = selectedStart === slot.start;
+        return (
+          <button
+            key={slot.start}
+            ref={isSelected ? selectedRef : undefined}
+            type="button"
+            onClick={() => onSelect(slot)}
+            className={cn(
+              "rounded-lg border px-3 py-2 text-center text-sm font-medium transition-colors",
+              "hover:bg-primary hover:text-primary-foreground active:bg-primary/90",
+              isSelected && "bg-primary text-primary-foreground",
+            )}
+          >
+            {slot.start}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -86,6 +86,7 @@ import {
   useEmployeeLeaveOnDate,
   useMissingEquipment,
 } from "@/components/gabinet/appointment-shared/use-appointment-warnings";
+import { SlotPicker } from "@/components/gabinet/appointment-shared/slot-picker";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { formatPhoneNumber } from "@/lib/phone";
@@ -428,15 +429,6 @@ export function AppointmentDialog({
     },
     [applyDragTransform, clampDragOffset],
   );
-
-  // Auto-scroll the currently-selected slot button into view so the user
-  // doesn't have to scroll through the full day's slot list to find a time
-  // pre-filled from a calendar click or "Find nearest slot". Issue #786.
-  const selectedSlotButtonRef = useCallback((node: HTMLButtonElement | null) => {
-    if (node) {
-      node.scrollIntoView({ block: "nearest" });
-    }
-  }, []);
 
   // -------------------------------------------------------------------------
   // Derived data
@@ -1729,40 +1721,13 @@ export function AppointmentDialog({
                         </p>
                       </div>
                     ) : availableSlots && availableSlots.length > 0 ? (
-                      availableSlots.map((slot) => (
-                        <button
-                          key={slot.start}
-                          ref={
-                            selectedSlot?.start === slot.start
-                              ? selectedSlotButtonRef
-                              : undefined
-                          }
-                          type="button"
-                          onClick={() => handleSlotSelect(slot)}
-                          className={cn(
-                            "w-full flex items-center justify-between px-3 py-2 rounded-md text-sm transition-colors",
-                            "hover:bg-accent hover:text-accent-foreground",
-                            "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
-                            selectedSlot?.start === slot.start
-                              ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
-                              : "bg-muted/40",
-                          )}
-                        >
-                          <span className="font-medium tabular-nums">
-                            {slot.start}
-                          </span>
-                          <span
-                            className={cn(
-                              "text-xs",
-                              selectedSlot?.start === slot.start
-                                ? "text-primary-foreground/70"
-                                : "text-muted-foreground",
-                            )}
-                          >
-                            {slot.end}
-                          </span>
-                        </button>
-                      ))
+                      <SlotPicker
+                        slots={availableSlots}
+                        selectedStart={selectedSlot?.start ?? null}
+                        onSelect={handleSlotSelect}
+                        layout="list"
+                        autoScrollSelected
+                      />
                     ) : (
                       <div className="py-8 text-center">
                         <p className="text-sm text-muted-foreground">

--- a/src/routes/_app/patient/_layout.book.tsx
+++ b/src/routes/_app/patient/_layout.book.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import type { Id } from "@cvx/_generated/dataModel";
 import { PlateText } from "@/components/plate-text";
 import { formatAppointmentError } from "@/lib/format-action-error";
+import { SlotPicker } from "@/components/gabinet/appointment-shared/slot-picker";
 
 export const Route = createFileRoute("/_app/patient/_layout/book")({
   component: PatientBooking,
@@ -425,22 +426,12 @@ function PatientBooking() {
               )}
             </div>
           ) : (
-            <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
-              {slots.map((slot) => (
-                <button
-                  key={slot.start}
-                  type="button"
-                  onClick={() => handleSelectTime(slot.start)}
-                  className={`rounded-lg border px-3 py-2 text-center text-sm font-medium transition-colors hover:bg-primary hover:text-primary-foreground active:bg-primary/90 ${
-                    selectedTime === slot.start
-                      ? "bg-primary text-primary-foreground"
-                      : ""
-                  }`}
-                >
-                  {slot.start}
-                </button>
-              ))}
-            </div>
+            <SlotPicker
+              slots={slots}
+              selectedStart={selectedTime}
+              onSelect={(slot) => handleSelectTime(slot.start)}
+              layout="grid"
+            />
           )}
         </div>
       )}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1520.

Closes #1520

---

## Claude summary

Committed as `5a2d923`. Summary:

Added `src/components/gabinet/appointment-shared/slot-picker.tsx` exporting a `SlotPicker` with props `slots`, `selectedStart`, `onSelect`, `layout: "list" | "grid"`, and optional `autoScrollSelected`. The list layout reproduces the dialog's `start—end` rows (selected-into-view scroll preserved from #786); the grid layout reproduces the patient portal's `grid-cols-3 sm:grid-cols-4` of `start` buttons.

Wired the dialog (`src/components/gabinet/calendar/appointment-dialog.tsx`) and patient portal book step (`src/routes/_app/patient/_layout.book.tsx`) to the shared component, removing the duplicated inline markup and the now-unused `selectedSlotButtonRef` in the dialog. Loading / error / empty states stay with their callers since they differ by surface.

Verified: `node scripts/typecheck-portable.mjs` exits 0; eslint reports only the three pre-existing `any` warnings in `appointment-dialog.tsx` (lines 222/230/237), unrelated to this change.