### PR TITLE
Wybór klienta

### DIFF
--- a/src/components/application/table/table.tsx
+++ b/src/components/application/table/table.tsx
@@ -149,9 +149,14 @@ const TableHeader = <T extends object>({ columns, children, bordered = true, cla
             {selectionBehavior === "toggle" && (
                 <AriaColumn className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-9 md:pl-5" : "w-11 md:pl-6")}>
                     {selectionMode === "multiple" && (
-                        <div className="flex items-start">
-                            <Checkbox slot="selection" size="md" />
-                        </div>
+                        <Checkbox
+                            slot="selection"
+                            size="md"
+                            className={cx(
+                                "absolute inset-0 !flex !items-center cursor-pointer pl-4",
+                                size === "sm" ? "md:pl-5" : "md:pl-6",
+                            )}
+                        />
                     )}
                 </AriaColumn>
             )}
@@ -240,9 +245,14 @@ const TableRow = <T extends object>({ columns, children, className, highlightSel
         >
             {selectionBehavior === "toggle" && (
                 <AriaCell className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "md:pl-5" : "md:pl-6")}>
-                    <div className="flex items-end">
-                        <Checkbox slot="selection" size="md" />
-                    </div>
+                    <Checkbox
+                        slot="selection"
+                        size="md"
+                        className={cx(
+                            "absolute inset-0 !flex !items-center cursor-pointer pl-4",
+                            size === "sm" ? "md:pl-5" : "md:pl-6",
+                        )}
+                    />
                 </AriaCell>
             )}
             <AriaCollection items={columns}>{children}</AriaCollection>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1539.

Closes #1539

---

## Claude summary

Committed.

Summary: the user reported that hitting the bulk-select checkbox to merge clients on `/dashboard/gabinet/patients` was hard. The cause is that only the ~20px `CheckboxBase` visual was clickable inside a much larger cell. I modified `src/components/application/table/table.tsx` so the `AriaCheckbox` label (which carries `slot="selection"`) is positioned `absolute inset-0` inside its `AriaCell`/`AriaColumn`, with `pl-4 md:pl-5`/`md:pl-6` preserving the visual checkbox position. The entire selection column is now clickable, both in the header (select-all) and each row — improving hit area roughly 5×. The change applies to every `CrmDataTable` with `enableBulkSelect`, and the existing `lastClickTargetRef` detection in `enhanced-data-table.tsx:165-177` still works because it matches on `[slot="selection"]`.