### PR TITLE
Pole do zaznaczenia

### DIFF
--- a/src/components/application/table/table.tsx
+++ b/src/components/application/table/table.tsx
@@ -147,7 +147,7 @@ const TableHeader = <T extends object>({ columns, children, bordered = true, cla
             }
         >
             {selectionBehavior === "toggle" && (
-                <AriaColumn className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-9 md:pl-5" : "w-11 md:pl-6")}>
+                <AriaColumn className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-12 md:pl-5" : "w-14 md:pl-6")}>
                     {selectionMode === "multiple" && (
                         <Checkbox
                             slot="selection"
@@ -244,7 +244,7 @@ const TableRow = <T extends object>({ columns, children, className, highlightSel
             }
         >
             {selectionBehavior === "toggle" && (
-                <AriaCell className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "md:pl-5" : "md:pl-6")}>
+                <AriaCell className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-12 md:pl-5" : "w-14 md:pl-6")}>
                     <Checkbox
                         slot="selection"
                         size="md"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1541.

Closes #1541

---

## Claude summary

Committed. Summary of the change:

The `CrmDataTable` selection column was previously `w-9` (sm) / `w-11` (md) — about 36–44px wide. Even after #1540 made the checkbox label fill the cell, the click target was narrow and the row's avatar (kółko) sat right against it because the next-column rule (`nth-2:pl-3`) intentionally pulls the avatar close.

The fix widens the selection column to `w-12` / `w-14` in `src/components/application/table/table.tsx:150` and `:247`. The checkbox keeps the same left offset (`pl-4 md:pl-5/6`), so visually it stays where it was, but each row's selection hit area is now 12px wider AND the avatar in the first data column starts 12px further to the right — addressing both asks at once. This benefits the gabinet patients list (which needs two checkbox clicks for the merge action) as well as the CRM contacts list, since both use the same shared `Table` component.