### PR TITLE
przesuń

### DIFF
--- a/src/components/application/table/table.tsx
+++ b/src/components/application/table/table.tsx
@@ -173,15 +173,12 @@ interface TableHeadProps extends AriaColumnProps, Omit<ThHTMLAttributes<HTMLTabl
 }
 
 const TableHead = ({ className, tooltip, label, children, ...props }: TableHeadProps) => {
-    const { selectionBehavior } = useTableOptions();
-
     return (
         <AriaColumn
             {...props}
             className={(state) =>
                 cx(
                     "relative p-0 px-6 py-2 outline-hidden focus-visible:z-1 focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-bg-primary focus-visible:ring-inset",
-                    selectionBehavior === "toggle" && "nth-2:pl-3",
                     state.allowsSorting && "cursor-pointer",
                     typeof className === "function" ? className(state) : className,
                 )
@@ -269,7 +266,6 @@ interface TableCellProps extends AriaCellProps, Omit<TdHTMLAttributes<HTMLTableC
 
 const TableCell = ({ className, children, size: sizeProp, ...props }: TableCellProps) => {
     const context = useContext(TableContext);
-    const { selectionBehavior } = useTableOptions();
 
     const size = sizeProp ?? context.size;
 
@@ -281,8 +277,6 @@ const TableCell = ({ className, children, size: sizeProp, ...props }: TableCellP
                     "relative text-sm text-fg-tertiary outline-focus-ring focus-visible:z-1 focus-visible:outline-2 focus-visible:-outline-offset-2",
                     size === "sm" && "px-5 py-3",
                     size === "md" && "px-6 py-4",
-
-                    selectionBehavior === "toggle" && "nth-2:pl-3",
 
                     typeof className === "function" ? className(state) : className,
                 )


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1543.

Closes #1543

---

## Claude summary

Committed. Summary of the fix:

The patients table had checkboxes nearly touching the patient avatars, even after the column-width bumps in #1539/#1541. The cause was the `nth-2:pl-3` rule in `src/components/application/table/table.tsx` that deliberately shrunk the first data column's left padding from `px-5/6` (20–24px) down to 12px when selection was enabled — pulling the avatar tight against the selection column. Removing that override lets the first data column use the standard cell padding, widening the checkbox-to-avatar gap from ~20px to ~28px on sm tables (~24px → ~36px on md). The selection column and checkbox hit area from #1539/#1541 are unchanged.

Commit: `2515a0d` on `claude/issue-1543`.