### PR TITLE
formularz

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -534,6 +534,43 @@ export const merge = action({
     organizationId: v.id("organizations"),
     targetPatientId: v.string(),
     sourcePatientId: v.string(),
+    // Per-field overrides to apply to the target patient before deactivating
+    // the source. Only fields where the user picked the source-side value need
+    // to be sent; missing keys mean "keep the target's current value".
+    fieldOverrides: v.optional(
+      v.object({
+        firstName: v.optional(v.string()),
+        lastName: v.optional(v.string()),
+        email: v.optional(v.string()),
+        phone: v.optional(v.union(v.string(), v.null())),
+        pesel: v.optional(v.union(v.string(), v.null())),
+        dateOfBirth: v.optional(v.union(v.string(), v.null())),
+        gender: v.optional(
+          v.union(
+            v.literal("male"),
+            v.literal("female"),
+            v.literal("other"),
+            v.null(),
+          ),
+        ),
+        address: v.optional(
+          v.union(
+            v.object({
+              street: v.optional(v.string()),
+              city: v.optional(v.string()),
+              postalCode: v.optional(v.string()),
+            }),
+            v.null(),
+          ),
+        ),
+        allergies: v.optional(v.union(v.string(), v.null())),
+        bloodType: v.optional(v.union(v.string(), v.null())),
+        emergencyContactName: v.optional(v.union(v.string(), v.null())),
+        emergencyContactPhone: v.optional(v.union(v.string(), v.null())),
+        medicalNotes: v.optional(v.union(v.string(), v.null())),
+        referralSource: v.optional(v.union(v.string(), v.null())),
+      }),
+    ),
   },
   handler: async (ctx, args): Promise<{
     movedAppointments: number;
@@ -719,6 +756,15 @@ export const merge = action({
       }
     } else if (targetLoyalty) {
       consolidatedLoyaltyBalance = Number(targetLoyalty.balance ?? 0);
+    }
+
+    // Apply the user's per-field choices to the target before deactivating
+    // the source — the target is the row that survives the merge.
+    if (args.fieldOverrides && Object.keys(args.fieldOverrides).length > 0) {
+      await db.patch("gabinetPatients", args.targetPatientId, {
+        ...args.fieldOverrides,
+        updatedAt: Date.now(),
+      });
     }
 
     // Soft-delete the source patient and annotate why it was deactivated.

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2249,7 +2249,28 @@
         "warning": "All appointments, documents, payments, loyalty points and notes will be transferred. This operation cannot be undone.",
         "confirm": "Merge",
         "success": "Client merged. {{count}} related records were moved.",
-        "error": "Could not merge clients."
+        "error": "Could not merge clients.",
+        "fieldsTitle": "Client merge form",
+        "fieldsIntro": "Some fields differ between the two clients. Pick which value should end up on the resulting client card.",
+        "emptyValue": "—",
+        "field": {
+          "firstName": "First name",
+          "lastName": "Last name",
+          "email": "Email",
+          "phone": "Phone number",
+          "pesel": "PESEL",
+          "dateOfBirth": "Date of birth",
+          "gender": "Gender",
+          "addressStreet": "Address (street, no.)",
+          "addressPostalCode": "Postal code",
+          "addressCity": "City",
+          "allergies": "Allergies",
+          "bloodType": "Blood type",
+          "emergencyContactName": "Emergency contact — name",
+          "emergencyContactPhone": "Emergency contact — phone",
+          "medicalNotes": "Medical notes",
+          "referralSource": "Referral source"
+        }
       }
     },
     "treatments": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2277,7 +2277,28 @@
         "warning": "Wszystkie wizyty, dokumenty, płatności, punkty lojalnościowe i notatki zostaną przeniesione. Operacja jest nieodwracalna.",
         "confirm": "Scal",
         "success": "Scalono klienta. Przeniesiono {{count}} powiązanych rekordów.",
-        "error": "Nie udało się scalić klientów."
+        "error": "Nie udało się scalić klientów.",
+        "fieldsTitle": "Formularz scalania klientów",
+        "fieldsIntro": "Nie wszystkie dane scalanych klientów są identyczne. Wybierz poniżej, które dane zostaną użyte w wynikowej karcie klienta.",
+        "emptyValue": "—",
+        "field": {
+          "firstName": "Imię",
+          "lastName": "Nazwisko",
+          "email": "Email",
+          "phone": "Numer telefonu",
+          "pesel": "PESEL",
+          "dateOfBirth": "Data urodzenia",
+          "gender": "Płeć",
+          "addressStreet": "Adres (ulica, nr)",
+          "addressPostalCode": "Kod pocztowy",
+          "addressCity": "Miasto",
+          "allergies": "Alergie",
+          "bloodType": "Grupa krwi",
+          "emergencyContactName": "Kontakt awaryjny — imię",
+          "emergencyContactPhone": "Kontakt awaryjny — telefon",
+          "medicalNotes": "Notatki medyczne",
+          "referralSource": "Źródło polecenia"
+        }
       }
     },
     "treatments": {

--- a/src/components/gabinet/merge-patients-dialog.tsx
+++ b/src/components/gabinet/merge-patients-dialog.tsx
@@ -4,6 +4,11 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
+import type { FunctionArgs } from "convex/server";
+
+type MergeFieldOverrides = NonNullable<
+  FunctionArgs<typeof api.gabinet.patients.merge>["fieldOverrides"]
+>;
 import {
   Dialog,
   DialogContent,
@@ -41,6 +46,81 @@ function normalizePhone(value: string | null | undefined): string {
 
 function fullName(p: MappedGabinetPatient): string {
   return `${p.firstName ?? ""} ${p.lastName ?? ""}`.trim();
+}
+
+// Whitelisted fields the user can pick a winning value for. Scalar field keys
+// match the patient row directly; `address.*` keys read from the JSON address
+// sub-object and are recomposed into a single `address` patch on submit.
+const SCALAR_FIELDS = [
+  "firstName",
+  "lastName",
+  "email",
+  "phone",
+  "pesel",
+  "dateOfBirth",
+  "gender",
+  "allergies",
+  "bloodType",
+  "emergencyContactName",
+  "emergencyContactPhone",
+  "medicalNotes",
+  "referralSource",
+] as const;
+type ScalarFieldKey = (typeof SCALAR_FIELDS)[number];
+const ADDRESS_SUBFIELDS = ["street", "postalCode", "city"] as const;
+type AddressSubKey = (typeof ADDRESS_SUBFIELDS)[number];
+type MergeFieldKey = ScalarFieldKey | `address.${AddressSubKey}`;
+
+// Required NOT NULL columns — we never patch these with null even if the user
+// somehow lands on an empty source value.
+const REQUIRED_FIELDS = new Set<MergeFieldKey>(["firstName", "lastName", "email"]);
+
+// Display order matches the Versum reference UI.
+const FIELD_ORDER: ReadonlyArray<{ key: MergeFieldKey; labelKey: string }> = [
+  { key: "email", labelKey: "gabinet.patients.merge.field.email" },
+  { key: "firstName", labelKey: "gabinet.patients.merge.field.firstName" },
+  { key: "lastName", labelKey: "gabinet.patients.merge.field.lastName" },
+  { key: "phone", labelKey: "gabinet.patients.merge.field.phone" },
+  { key: "gender", labelKey: "gabinet.patients.merge.field.gender" },
+  { key: "pesel", labelKey: "gabinet.patients.merge.field.pesel" },
+  { key: "dateOfBirth", labelKey: "gabinet.patients.merge.field.dateOfBirth" },
+  { key: "address.street", labelKey: "gabinet.patients.merge.field.addressStreet" },
+  { key: "address.postalCode", labelKey: "gabinet.patients.merge.field.addressPostalCode" },
+  { key: "address.city", labelKey: "gabinet.patients.merge.field.addressCity" },
+  { key: "allergies", labelKey: "gabinet.patients.merge.field.allergies" },
+  { key: "bloodType", labelKey: "gabinet.patients.merge.field.bloodType" },
+  { key: "emergencyContactName", labelKey: "gabinet.patients.merge.field.emergencyContactName" },
+  { key: "emergencyContactPhone", labelKey: "gabinet.patients.merge.field.emergencyContactPhone" },
+  { key: "medicalNotes", labelKey: "gabinet.patients.merge.field.medicalNotes" },
+  { key: "referralSource", labelKey: "gabinet.patients.merge.field.referralSource" },
+];
+
+function readAddressSub(p: MappedGabinetPatient, sub: AddressSubKey): string | null {
+  const addr = p.address as { street?: string; postalCode?: string; city?: string } | null | undefined;
+  if (!addr) return null;
+  const v = addr[sub];
+  return typeof v === "string" && v.trim() !== "" ? v : null;
+}
+
+function readFieldRaw(p: MappedGabinetPatient, key: MergeFieldKey): string | null {
+  if (key.startsWith("address.")) {
+    return readAddressSub(p, key.slice("address.".length) as AddressSubKey);
+  }
+  const v = p[key as ScalarFieldKey];
+  if (v == null) return null;
+  const s = String(v);
+  return s.trim() === "" ? null : s;
+}
+
+function displayValue(
+  p: MappedGabinetPatient,
+  key: MergeFieldKey,
+  emptyPlaceholder: string,
+): string {
+  const raw = readFieldRaw(p, key);
+  if (raw === null) return emptyPlaceholder;
+  if (key === "phone" || key === "emergencyContactPhone") return formatPhoneNumber(raw);
+  return raw;
 }
 
 export function MergePatientsDialog({
@@ -124,21 +204,88 @@ export function MergePatientsDialog({
     [candidates, targetId],
   );
 
+  // Per-field winner picked by the user. Only fields where target/source differ
+  // are stored here; the default for those is "target" (i.e. keep the row that
+  // survives unchanged).
+  const [fieldChoices, setFieldChoices] = useState<Record<string, "target" | "source">>({});
+
+  const comparisonRows = useMemo(() => {
+    if (!sourcePatient || !target) return [] as Array<{
+      key: MergeFieldKey;
+      labelKey: string;
+      targetValue: string | null;
+      sourceValue: string | null;
+      differs: boolean;
+    }>;
+    return FIELD_ORDER.map(({ key, labelKey }) => {
+      const targetValue = readFieldRaw(target, key);
+      const sourceValue = readFieldRaw(sourcePatient, key);
+      const differs = targetValue !== sourceValue;
+      return { key, labelKey, targetValue, sourceValue, differs };
+    });
+  }, [sourcePatient, target]);
+
+  // Reset choices to "target" whenever the comparison changes (target selected,
+  // dialog reopened, etc.). Auto-pick source for rows where target is empty so
+  // the merge picks up missing data by default — matches Versum's behaviour.
+  useEffect(() => {
+    const next: Record<string, "target" | "source"> = {};
+    for (const row of comparisonRows) {
+      if (!row.differs) continue;
+      next[row.key] = row.targetValue === null && row.sourceValue !== null ? "source" : "target";
+    }
+    setFieldChoices(next);
+  }, [comparisonRows]);
+
   function handleClose() {
     if (isMerging) return;
     setTargetId(null);
     setSearch("");
+    setFieldChoices({});
     onOpenChange(false);
+  }
+
+  function buildFieldOverrides(): MergeFieldOverrides | undefined {
+    if (!sourcePatient || !target) return undefined;
+    const scalars: Record<string, unknown> = {};
+    let addressTouched = false;
+    const nextAddress: Record<string, string> = {
+      ...((target.address as { street?: string; city?: string; postalCode?: string } | null | undefined) ?? {}),
+    };
+    for (const row of comparisonRows) {
+      if (!row.differs) continue;
+      if (fieldChoices[row.key] !== "source") continue;
+      // Never null-out a required column — fall through to the existing target value.
+      if (REQUIRED_FIELDS.has(row.key) && row.sourceValue === null) continue;
+      if (row.key.startsWith("address.")) {
+        const sub = row.key.slice("address.".length) as AddressSubKey;
+        if (row.sourceValue === null) {
+          delete nextAddress[sub];
+        } else {
+          nextAddress[sub] = row.sourceValue;
+        }
+        addressTouched = true;
+      } else {
+        scalars[row.key] = row.sourceValue;
+      }
+    }
+    if (addressTouched) {
+      const hasAnySub = ADDRESS_SUBFIELDS.some((s) => typeof nextAddress[s] === "string" && nextAddress[s] !== "");
+      scalars.address = hasAnySub ? nextAddress : null;
+    }
+    return Object.keys(scalars).length > 0 ? (scalars as MergeFieldOverrides) : undefined;
   }
 
   async function handleMerge() {
     if (!sourcePatient || !target) return;
     setIsMerging(true);
     try {
+      const fieldOverrides = buildFieldOverrides();
       const result = await mergePatients({
         organizationId: organizationId as Id<"organizations">,
         targetPatientId: target._id,
         sourcePatientId: sourcePatient._id,
+        ...(fieldOverrides ? { fieldOverrides } : {}),
       });
       const moved =
         result.movedAppointments +
@@ -173,7 +320,7 @@ export function MergePatientsDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{t("gabinet.patients.merge.title", { defaultValue: "Scal klientów" })}</DialogTitle>
           <DialogDescription>
@@ -251,6 +398,111 @@ export function MergePatientsDialog({
               </ul>
             )}
           </div>
+
+          {target && (
+            <div className="rounded-md border">
+              <div className="border-b p-3">
+                <div className="text-sm font-semibold">
+                  {t("gabinet.patients.merge.fieldsTitle", { defaultValue: "Formularz scalania klientów" })}
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t("gabinet.patients.merge.fieldsIntro", {
+                    defaultValue:
+                      "Nie wszystkie dane scalanych klientów są identyczne. Wybierz poniżej, które dane zostaną użyte w wynikowej karcie klienta.",
+                  })}
+                </p>
+              </div>
+              <div className="max-h-72 overflow-y-auto">
+                <table className="w-full table-fixed text-sm">
+                  <thead className="sticky top-0 bg-muted/50 text-xs text-muted-foreground">
+                    <tr>
+                      <th className="w-1/3 p-2 text-left font-medium" />
+                      <th className="w-1/3 truncate p-2 text-left font-medium">
+                        {target.firstName || fullName(target) || "—"}
+                      </th>
+                      <th className="w-1/3 truncate p-2 text-left font-medium">
+                        {sourcePatient.firstName || fullName(sourcePatient) || "—"}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    {comparisonRows.map((row) => {
+                      const emptyPlaceholder = t("gabinet.patients.merge.emptyValue", { defaultValue: "—" });
+                      const targetText = displayValue(target, row.key, emptyPlaceholder);
+                      const sourceText = displayValue(sourcePatient, row.key, emptyPlaceholder);
+                      const choice = fieldChoices[row.key] ?? "target";
+                      const groupName = `merge-${row.key}`;
+                      const targetRadioId = `${groupName}-target`;
+                      const sourceRadioId = `${groupName}-source`;
+                      return (
+                        <tr key={row.key} className="align-top">
+                          <th
+                            scope="row"
+                            className="bg-muted/30 p-2 text-left text-xs font-medium text-muted-foreground"
+                          >
+                            {t(row.labelKey)}
+                          </th>
+                          {row.differs ? (
+                            <>
+                              <td className="p-2">
+                                <label
+                                  htmlFor={targetRadioId}
+                                  className="flex cursor-pointer items-start gap-2 break-words font-normal"
+                                >
+                                  <input
+                                    id={targetRadioId}
+                                    type="radio"
+                                    name={groupName}
+                                    value="target"
+                                    checked={choice === "target"}
+                                    onChange={() =>
+                                      setFieldChoices((prev) => ({
+                                        ...prev,
+                                        [row.key]: "target",
+                                      }))
+                                    }
+                                    className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-primary"
+                                  />
+                                  <span>{targetText}</span>
+                                </label>
+                              </td>
+                              <td className="p-2">
+                                <label
+                                  htmlFor={sourceRadioId}
+                                  className="flex cursor-pointer items-start gap-2 break-words font-normal"
+                                >
+                                  <input
+                                    id={sourceRadioId}
+                                    type="radio"
+                                    name={groupName}
+                                    value="source"
+                                    checked={choice === "source"}
+                                    onChange={() =>
+                                      setFieldChoices((prev) => ({
+                                        ...prev,
+                                        [row.key]: "source",
+                                      }))
+                                    }
+                                    className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-primary"
+                                  />
+                                  <span>{sourceText}</span>
+                                </label>
+                              </td>
+                            </>
+                          ) : (
+                            <>
+                              <td className="break-words p-2 text-muted-foreground">{targetText}</td>
+                              <td className="break-words p-2 text-muted-foreground">{sourceText}</td>
+                            </>
+                          )}
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
 
           {target && (
             <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">

--- a/tests/convex/patientsMerge.test.ts
+++ b/tests/convex/patientsMerge.test.ts
@@ -397,6 +397,102 @@ describe("gabinet/patients.merge", () => {
     });
   });
 
+  describe("field overrides", () => {
+    test("applies per-field overrides onto the target before deactivating source", async () => {
+      const t = createTestCtx();
+      const { organizationId, userId, identity } = await seedTestUser(t);
+      const { patientId: targetId } = await seedGabinetPrereqs(
+        t,
+        organizationId,
+        userId,
+      );
+      const sourceId = "patient_fieldoverrides_source";
+      await seedSecondPatient(String(organizationId), String(userId), sourceId, {
+        firstName: "Ewelina",
+        lastName: "Adamska",
+        email: "eadamska@example.com",
+        phone: "+48797305209",
+        pesel: "90010112345",
+      });
+
+      const db = createSupabaseDb();
+      // Confirm target starts with its seeded data so the assertion below is meaningful.
+      const beforeTarget = await db.get<{
+        firstName: string;
+        email: string;
+        phone: string | null;
+        pesel: string | null;
+      }>("gabinetPatients", String(targetId));
+      expect(beforeTarget?.firstName).not.toBe("Ewelina");
+
+      await t
+        .withIdentity(identity)
+        .action(api.gabinet.patients.merge, {
+          organizationId,
+          targetPatientId: String(targetId),
+          sourcePatientId: sourceId,
+          fieldOverrides: {
+            // Pick the source's first name and PESEL; everything else stays on target.
+            firstName: "Ewelina",
+            pesel: "90010112345",
+          },
+        });
+
+      const afterTarget = await db.get<{
+        firstName: string;
+        email: string;
+        phone: string | null;
+        pesel: string | null;
+      }>("gabinetPatients", String(targetId));
+      expect(afterTarget?.firstName).toBe("Ewelina");
+      expect(afterTarget?.pesel).toBe("90010112345");
+      // Fields not in fieldOverrides remain on the target.
+      expect(afterTarget?.email).toBe(beforeTarget?.email);
+
+      // Source is still deactivated regardless of overrides.
+      const source = await db.get<{ isActive: boolean }>(
+        "gabinetPatients",
+        sourceId,
+      );
+      expect(source?.isActive).toBe(false);
+    });
+
+    test("skipped when fieldOverrides is omitted (back-compat)", async () => {
+      const t = createTestCtx();
+      const { organizationId, userId, identity } = await seedTestUser(t);
+      const { patientId: targetId } = await seedGabinetPrereqs(
+        t,
+        organizationId,
+        userId,
+      );
+      const sourceId = "patient_no_overrides_source";
+      await seedSecondPatient(String(organizationId), String(userId), sourceId, {
+        firstName: "ShouldNotLand",
+      });
+
+      const db = createSupabaseDb();
+      const before = await db.get<{ firstName: string }>(
+        "gabinetPatients",
+        String(targetId),
+      );
+
+      await t
+        .withIdentity(identity)
+        .action(api.gabinet.patients.merge, {
+          organizationId,
+          targetPatientId: String(targetId),
+          sourcePatientId: sourceId,
+        });
+
+      const after = await db.get<{ firstName: string }>(
+        "gabinetPatients",
+        String(targetId),
+      );
+      // Target was untouched in absence of fieldOverrides.
+      expect(after?.firstName).toBe(before?.firstName);
+    });
+  });
+
   describe("source patient deactivation", () => {
     test("marks source patient inactive and annotates medicalNotes", async () => {
       const t = createTestCtx();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1544.

Closes #1544

---

## Claude summary

Committed as `78e4bbc`.

## Summary

The screenshot showed a Versum-style "Formularz scalania klientów" — a comparison table for picking, field by field, which value survives when two customers are merged. Implemented that into the existing `MergePatientsDialog`:

- `convex/gabinet/patients.ts:532` — `merge` action gains an optional `fieldOverrides` arg validated against the patient row shape (scalars + nested `address`); when present, the target is patched with the chosen values before the source is deactivated.
- `src/components/gabinet/merge-patients-dialog.tsx` — after a target is picked, renders a 3-column table (field name / target value / source value) with native radios on rows where the two patients differ. Identical and double-empty rows render without a radio (matches the reference). Required NOT NULL columns (`firstName`, `lastName`, `email`) refuse a null source value. Default selection prefers target, but auto-prefers the source when target is empty.
- `public/locales/{pl,en}/translation.json` — new keys under `gabinet.patients.merge` for the form title, intro, and field labels.
- `tests/convex/patientsMerge.test.ts` — two new tests: `fieldOverrides` actually patches the target, and absence of overrides keeps the existing behaviour (back-compat).

Verification: `tsc -p tsconfig.app.json` and `tsc -p convex/tsconfig.json` clean; full Convex test suite 148/148 passing.