### PR TITLE
przenieś

### DIFF
--- a/src/components/sidebar-widgets/gabinet/patients-widgets.tsx
+++ b/src/components/sidebar-widgets/gabinet/patients-widgets.tsx
@@ -1,11 +1,66 @@
 import { useAction } from "convex/react";
 import { useQuery } from "@tanstack/react-query";
+import { useLocation, useNavigate, useMatchRoute } from "@tanstack/react-router";
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { KpiRow } from "../kpi-row";
 import { RecentItems } from "../recent-items";
 import { BarRanking } from "../bar-ranking";
+import { Button } from "@/components/ui/button";
+import { X } from "@/lib/ez-icons";
 import { useTranslation } from "react-i18next";
+
+type NudgeFilter = "missing-contact" | "no-recent-visit" | "duplicates";
+
+function NudgeFilterCallout() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const matchRoute = useMatchRoute();
+  const location = useLocation();
+
+  const isOnPatientsIndex = !!matchRoute({
+    to: "/dashboard/gabinet/patients",
+  });
+  if (!isOnPatientsIndex) return null;
+
+  const search = location.search as { nudge?: NudgeFilter } | undefined;
+  const nudge = search?.nudge;
+  if (!nudge) return null;
+
+  const message =
+    nudge === "missing-contact"
+      ? t("gabinet.patients.nudgeFilter.missingContact", {
+          defaultValue: "Pokazywani są klienci bez telefonu i e-maila.",
+        })
+      : nudge === "no-recent-visit"
+        ? t("gabinet.patients.nudgeFilter.noRecentVisit", {
+            defaultValue: "Pokazywani są klienci bez wizyty w ostatnich 90 dniach.",
+          })
+        : t("gabinet.patients.nudgeFilter.duplicates", {
+            defaultValue:
+              "Pokazywani są klienci z duplikatem e-maila lub telefonu. Użyj akcji „Scal z…”, aby je połączyć.",
+          });
+
+  return (
+    <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+      <p className="mb-2 leading-snug">{message}</p>
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7 w-full gap-1 text-xs"
+        onClick={() =>
+          navigate({
+            to: "/dashboard/gabinet/patients",
+            search: { nudge: undefined },
+          })
+        }
+      >
+        <X className="h-3.5 w-3.5" variant="stroke" />
+        {t("common.clearFilters")}
+      </Button>
+    </div>
+  );
+}
 
 export function GabinetPatientsWidgets({ organizationId }: { organizationId: Id<"organizations"> }) {
   const { t } = useTranslation();
@@ -22,17 +77,19 @@ export function GabinetPatientsWidgets({ organizationId }: { organizationId: Id<
     enabled: !!organizationId,
   });
 
-  if (!kpis) return null;
-
   return (
     <>
-      <KpiRow
-        size="hero"
-        items={[
-          { label: t("sidebar.gabinet.total"), value: kpis.total, color: "text-primary" },
-          { label: t("sidebar.gabinet.newThisMonth"), value: kpis.newThisMonth, color: "text-emerald-500" },
-        ]}
-      />
+      <NudgeFilterCallout />
+
+      {kpis && (
+        <KpiRow
+          size="hero"
+          items={[
+            { label: t("sidebar.gabinet.total"), value: kpis.total, color: "text-primary" },
+            { label: t("sidebar.gabinet.newThisMonth"), value: kpis.newThisMonth, color: "text-emerald-500" },
+          ]}
+        />
+      )}
 
       {/* Top treatments */}
       {topTreatments && topTreatments.length > 0 && <BarRanking items={topTreatments} />}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -18,7 +18,7 @@ import { MergePatientsDialog } from "@/components/gabinet/merge-patients-dialog"
 import { Button } from "@/components/ui/button";
 import { AvatarLabelGroup } from "@untitled/base/avatar/avatar-label-group";
 import { Badge } from "@/components/ui/badge";
-import { Plus, Trash2, Download, X, Users, AlertCircle } from "@/lib/ez-icons";
+import { Plus, Trash2, Download, Users, AlertCircle } from "@/lib/ez-icons";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { Id } from "@cvx/_generated/dataModel";
@@ -527,40 +527,6 @@ function PatientsIndex() {
             {t("gabinet.patients.duplicatesBanner.action", {
               defaultValue: "Przejrzyj duplikaty",
             })}
-          </Button>
-        </div>
-      )}
-
-      {nudgeFilter && (
-        <div className="flex items-center justify-between rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
-          <span>
-            {nudgeFilter === "missing-contact"
-              ? t("gabinet.patients.nudgeFilter.missingContact", {
-                  defaultValue: "Pokazywani są klienci bez telefonu i e-maila.",
-                })
-              : nudgeFilter === "no-recent-visit"
-              ? t("gabinet.patients.nudgeFilter.noRecentVisit", {
-                  defaultValue:
-                    "Pokazywani są klienci bez wizyty w ostatnich 90 dniach.",
-                })
-              : t("gabinet.patients.nudgeFilter.duplicates", {
-                  defaultValue:
-                    "Pokazywani są klienci z duplikatem e-maila lub telefonu. Użyj akcji „Scal z…”, aby je połączyć.",
-                })}
-          </span>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 gap-1 text-xs"
-            onClick={() =>
-              navigate({
-                to: "/dashboard/gabinet/patients",
-                search: { nudge: undefined },
-              })
-            }
-          >
-            <X className="h-3.5 w-3.5" variant="stroke" />
-            {t("common.clearFilters")}
           </Button>
         </div>
       )}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1547.

Closes #1547

---

## Claude summary

Committed. Summary of the change:

The `?nudge=duplicates` (and the other two nudge variants `missing-contact` / `no-recent-visit`) used to render a full-width amber banner across the top of `/dashboard/gabinet/patients`, repeating the same "Pokazywani są klienci z duplikatem..." message that already explains what filter is active. The screenshots show the user wanted that information consolidated into the left contextual sidebar (the "Klienci → Akcje" column).

I moved the banner — message text plus "Wyczyść filtry" button — into `GabinetPatientsWidgets` as a new `NudgeFilterCallout` component that reads `location.search.nudge` via TanStack Router's `useLocation()` and only renders when the user is on the patients index route (so it doesn't appear when navigating to a patient detail). The in-page banner block in `_layout.gabinet.patients.index.tsx` is removed, freeing vertical space above the table. The separate "X klientów ma duplikat..." CTA banner that nudges users INTO the duplicates view (shown only when `nudge !== "duplicates"`) is preserved on the page since it's a different element.