### PR TITLE
przesuwanie

### DIFF
--- a/src/components/documents/document-gate-dialog.tsx
+++ b/src/components/documents/document-gate-dialog.tsx
@@ -16,6 +16,7 @@ import { AlertTriangle, Circle } from "@/lib/ez-icons";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import { DocumentStatusBadge } from "./document-status-badge";
+import { useDraggableDialog } from "@/hooks/use-draggable-dialog";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -99,9 +100,18 @@ export function DocumentGateDialog({
       ? t("documents.gate.timingBefore", "Przed wizyta")
       : t("documents.gate.timingAfter", "Po wizycie");
 
+  const drag = useDraggableDialog(open);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+        ref={drag.contentRef}
+        onPointerDown={drag.onPointerDown}
+        className={cn(
+          "sm:max-w-md",
+          drag.isDragging && "cursor-grabbing select-none",
+        )}
+      >
         {/* Warning header banner */}
         <div className="rounded-lg bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-800 p-4 -mt-2">
           <div className="flex items-start gap-3">

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -84,6 +84,7 @@ import {
 } from "lucide-react";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
+import { useDraggableDialog } from "@/hooks/use-draggable-dialog";
 import { useSidebarActions } from "@/components/layout/sidebar-context";
 import {
   useSupabaseGabinetFirstAppointmentIdsByPatient,
@@ -278,6 +279,12 @@ export function AppointmentPreviewContent({
   const [changeEmployeeOpen, setChangeEmployeeOpen] = useState(false);
 
   const [settleDialogOpen, setSettleDialogOpen] = useState(false);
+  // Drag-to-reposition for the sub-dialogs that open from the preview popover
+  // (issue #1548). Same drag-from-anywhere behaviour as the appointment dialog
+  // and preview popover (#1459, #1476) — users want to peek at what's behind
+  // these modal confirmations without dismissing them first.
+  const cancelDrag = useDraggableDialog(cancelDialogOpen);
+  const settleDrag = useDraggableDialog(settleDialogOpen);
   const [settleAmount, setSettleAmount] = useState("");
   const [settleMethod, setSettleMethod] = useState<
     "cash" | "card" | "transfer" | "package" | "other"
@@ -1402,7 +1409,14 @@ export function AppointmentPreviewContent({
         if (!o) setCancelReason("");
       }}
     >
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+        ref={cancelDrag.contentRef}
+        onPointerDown={cancelDrag.onPointerDown}
+        className={cn(
+          "sm:max-w-md",
+          cancelDrag.isDragging && "cursor-grabbing select-none",
+        )}
+      >
         <DialogHeader>
           <DialogTitle>{t("gabinet.appointments.cancelTitle")}</DialogTitle>
           <DialogDescription>
@@ -1476,7 +1490,14 @@ export function AppointmentPreviewContent({
         setSettleDialogOpen(o);
       }}
     >
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+        ref={settleDrag.contentRef}
+        onPointerDown={settleDrag.onPointerDown}
+        className={cn(
+          "sm:max-w-md",
+          settleDrag.isDragging && "cursor-grabbing select-none",
+        )}
+      >
         <DialogHeader>
           <DialogTitle>
             {t("gabinet.appointmentDetail.closeAndSettle", "Rozlicz wizytę")}

--- a/src/components/gabinet/change-employee-modal.tsx
+++ b/src/components/gabinet/change-employee-modal.tsx
@@ -38,6 +38,7 @@ import {
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { formatAppointmentError } from "@/lib/format-action-error";
+import { useDraggableDialog } from "@/hooks/use-draggable-dialog";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -289,9 +290,18 @@ export function ChangeEmployeeModal({
 
   const isLoading = isCheckingAvailability || isSearchingSlot;
 
+  const drag = useDraggableDialog(open);
+
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="max-w-md">
+      <DialogContent
+        ref={drag.contentRef}
+        onPointerDown={drag.onPointerDown}
+        className={cn(
+          "max-w-md",
+          drag.isDragging && "cursor-grabbing select-none",
+        )}
+      >
         <DialogHeader>
           <DialogTitle>
             {t("gabinet.appointments.changeEmployee", "Zmień pracownika")}

--- a/src/hooks/use-draggable-dialog.ts
+++ b/src/hooks/use-draggable-dialog.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+// Extracted from `AppointmentDialog` (issues #977, #1281, #1424, #1426, #1459)
+// so the same drag-from-anywhere behaviour can be reused by other small
+// centered dialogs on the calendar workflow (issue #1548). The hook assumes
+// the target is rendered by shadcn `DialogContent`, whose default class adds
+// `translate-x-[-50%] translate-y-[-50%]` (compiled to the modern `translate:`
+// CSS property). The inline value composes additively with `transform:`, so
+// writing to `el.style.translate` overrides only the class translate without
+// disturbing other transforms.
+const DRAG_HEADER_VISIBLE = 60;
+const DRAG_CORNER_VISIBLE = 80;
+
+const INTERACTIVE_SELECTOR =
+  'button, a, input, textarea, select, [role="button"], [role="combobox"], [role="menuitem"], [role="option"], [role="switch"], [role="checkbox"], [role="radio"], [role="tab"], [contenteditable="true"], [data-radix-popper-content-wrapper]';
+
+export interface UseDraggableDialogResult {
+  contentRef: React.RefObject<HTMLDivElement>;
+  onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+  isDragging: boolean;
+}
+
+export function useDraggableDialog(open: boolean): UseDraggableDialogResult {
+  const offsetRef = useRef({ x: 0, y: 0 });
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const apply = useCallback(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    const { x, y } = offsetRef.current;
+    el.style.translate =
+      x === 0 && y === 0
+        ? ""
+        : `calc(-50% + ${x}px) calc(-50% + ${y}px)`;
+  }, []);
+
+  const clamp = useCallback((x: number, y: number) => {
+    const el = contentRef.current;
+    if (!el || typeof window === "undefined") return { x, y };
+    const w = el.offsetWidth;
+    const h = el.offsetHeight;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    let minY = h / 2 - vh / 2;
+    let maxY = vh / 2 + h / 2 - DRAG_HEADER_VISIBLE;
+    if (minY > maxY) minY = maxY = h / 2 - vh / 2;
+    let minX = DRAG_CORNER_VISIBLE - vw / 2 - w / 2;
+    let maxX = vw / 2 + w / 2 - DRAG_CORNER_VISIBLE;
+    if (minX > maxX) minX = maxX = 0;
+    return {
+      x: Math.max(minX, Math.min(maxX, x)),
+      y: Math.max(minY, Math.min(maxY, y)),
+    };
+  }, []);
+
+  // Reapply on every render so unrelated re-renders mid-drag don't snap the
+  // dialog back to its class-defined centered translate (issue #1424).
+  useLayoutEffect(() => {
+    apply();
+  });
+
+  useEffect(() => {
+    if (!open) {
+      offsetRef.current = { x: 0, y: 0 };
+      setIsDragging(false);
+    }
+  }, [open]);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return;
+      // Skip touch input: on mobile the dialog is full-width so drag is not
+      // useful, and capturing touch pointerdown would block native scrolling
+      // of the now-scrollable DialogContent (issue #1462).
+      if (e.pointerType === "touch") return;
+      const target = e.target as HTMLElement | null;
+      if (target?.closest(INTERACTIVE_SELECTOR)) return;
+      e.preventDefault();
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const startOffset = { ...offsetRef.current };
+      setIsDragging(true);
+
+      let rafId: number | null = null;
+      const flush = () => {
+        rafId = null;
+        apply();
+      };
+
+      const handleMove = (ev: PointerEvent) => {
+        offsetRef.current = clamp(
+          startOffset.x + (ev.clientX - startX),
+          startOffset.y + (ev.clientY - startY),
+        );
+        if (rafId === null) rafId = requestAnimationFrame(flush);
+      };
+
+      const handleUp = () => {
+        if (rafId !== null) {
+          cancelAnimationFrame(rafId);
+          rafId = null;
+        }
+        apply();
+        window.removeEventListener("pointermove", handleMove);
+        window.removeEventListener("pointerup", handleUp);
+        setIsDragging(false);
+      };
+
+      window.addEventListener("pointermove", handleMove);
+      window.addEventListener("pointerup", handleUp);
+    },
+    [apply, clamp],
+  );
+
+  return { contentRef, onPointerDown, isDragging };
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -5,6 +5,7 @@ import { api } from "@cvx/_generated/api";
 import { useSupabaseOrganizationMembers } from "@/hooks/use-supabase-organizations";
 import { useOrganization } from "@/components/org-context";
 import { useWideContent } from "@/hooks/use-wide-content";
+import { useDraggableDialog } from "@/hooks/use-draggable-dialog";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -141,6 +142,7 @@ function GabinetCalendarPage() {
 
   // Filter dialog
   const [filterOpen, setFilterOpen] = useState(false);
+  const filterDrag = useDraggableDialog(filterOpen);
 
   // Mobile-only collapsible employee picker (issue #1235). On phones the pill
   // row stole an entire row of vertical space; the popover keeps the same
@@ -1521,7 +1523,14 @@ function GabinetCalendarPage() {
 
           {/* Filter dialog */}
           <Dialog open={filterOpen} onOpenChange={setFilterOpen}>
-            <DialogContent className="sm:max-w-md">
+            <DialogContent
+              ref={filterDrag.contentRef}
+              onPointerDown={filterDrag.onPointerDown}
+              className={cn(
+                "sm:max-w-md",
+                filterDrag.isDragging && "cursor-grabbing select-none",
+              )}
+            >
               <DialogTitle>{t("gabinet.calendar.filters", "Filtry")}</DialogTitle>
               <DialogDescription className="sr-only">
                 {t("gabinet.calendar.filters", "Filtry")}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1548.

Closes #1548

---

## Claude summary

Typecheck passes. The fix for issue #1548 was already committed (`7ac20a7`) on this branch in a prior session — clean working tree, one commit ahead of `origin/main`.

Summary of what was done for #1548:

The Polish request was "make the option to move the window (entire area)" on `/dashboard/gabinet/calendar`. The appointment dialog and preview popover were already drag-from-anywhere (#1281, #1459, #1476), but the smaller centered dialogs that open from the calendar workflow weren't, so users couldn't peek at the calendar behind them.

The commit extracts the existing drag pattern into a reusable hook `src/hooks/use-draggable-dialog.ts` and wires it into the five remaining dialogs:

- Filter dialog — `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx:1523`
- Cancel-visit dialog — `src/components/gabinet/calendar/appointment-preview-content.tsx:1409`
- Settle dialog — `src/components/gabinet/calendar/appointment-preview-content.tsx:1490`
- Change Employee modal — `src/components/gabinet/change-employee-modal.tsx`
- Document Gate dialog — `src/components/documents/document-gate-dialog.tsx`

The hook preserves the same behaviour as the original AppointmentDialog: clamp-to-viewport so a corner stays visible, rAF-throttled pointer events, skip on touch input (mobile dialogs are full-width), skip when the pointer starts on an interactive element, and writes to `el.style.translate` so it composes additively with shadcn's centering classes without resetting on re-render (issue #1424 caveat).

Typecheck passes. Commit is ready to push.