### PR TITLE
przesuń bardziej

### DIFF
--- a/src/components/crm/enhanced-data-table.tsx
+++ b/src/components/crm/enhanced-data-table.tsx
@@ -271,11 +271,20 @@ export function CrmDataTable<TData>({
               const rowId = getRowId(item, (page - 1) * pageSize + index);
               return (
                 <Table.Row key={rowId} id={rowId}>
-                  {visibleColumns.map((col) => (
+                  {visibleColumns.map((col, colIndex) => (
                     <Table.Cell key={col.id} className={col.className}>
                       {onRowAction && !col.interactive ? (
                         <div
-                          className="cursor-pointer -mx-5 -my-3 px-5 py-3"
+                          // First data column next to the selection checkbox
+                          // drops the negative left margin so the navigation
+                          // hit area starts after the cell's left padding —
+                          // leaves a buffer zone next to the checkbox so users
+                          // aiming at the checkbox don't accidentally navigate.
+                          className={
+                            enableBulkSelect && colIndex === 0
+                              ? "cursor-pointer -mr-5 -my-3 pr-5 py-3"
+                              : "cursor-pointer -mx-5 -my-3 px-5 py-3"
+                          }
                           onClick={(e) => {
                             e.stopPropagation();
                             onRowAction(rowId);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1549.

Closes #1549

---

## Claude summary

Committed.

Summary of what changed: the Jam recording shows the user clicking near the checkbox but the event lands on the `cursor-pointer -mx-5 -my-3 px-5 py-3` wrapper that fires navigation. The `-mx-5` makes the navigation hit area extend to the cell's left edge — which sits flush against the checkbox column. So even after the recent visual-gap fixes (#1539/#1541/#1543), the nav-click trap was still right next to the checkbox.

The fix in `src/components/crm/enhanced-data-table.tsx:274-294` keeps the existing layout for all but the first data column when bulk-select is on; that column now uses `-mr-5 pr-5` only, so the navigation hit area begins after the cell's natural left padding. That creates a ~20px buffer next to the checkbox column. The inner `<Link>` around the avatar/name still navigates normally, and the rest of the cell still clicks through to the patient page.