### PR TITLE
przetłumacz

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2831,6 +2831,7 @@
       "equipmentWarning": "Required equipment not at this location — cannot save appointment",
       "warnings": {
         "title": "Warning",
+        "past": "Appointment time is in the past",
         "qualification": "Employee is not qualified for this treatment",
         "leave": "Employee is on leave at this time",
         "leavePartial": "Employee is on leave on this day between {{start}}–{{end}}.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2862,6 +2862,7 @@
       "equipmentWarning": "Brak wymaganego sprzętu w tej lokalizacji — nie można zapisać wizyty",
       "warnings": {
         "title": "Ostrzeżenie",
+        "past": "Termin wizyty jest w przeszłości",
         "qualification": "Pracownik nie ma kwalifikacji do tego zabiegu",
         "leave": "Pracownik jest na urlopie w tym terminie",
         "leavePartial": "Pracownik jest na urlopie w tym dniu w godzinach {{start}}–{{end}}.",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1559.

Closes #1559

---

## Claude summary

Fixed and committed. The appointment preview in the gabinet calendar was showing the raw key `gabinet.appointments.warnings.past` because neither `public/locales/pl/translation.json` nor `public/locales/en/translation.json` had a string for the `past` warning code that the backend emits at `convex/gabinet/appointments.ts:2806`. I added the missing entry to both locale files ("Termin wizyty jest w przeszłości" / "Appointment time is in the past").