### PR TITLE
możliwość zapisania w tym samym terminie

### DIFF
--- a/convex/gabinet/_availability_supabase.ts
+++ b/convex/gabinet/_availability_supabase.ts
@@ -306,6 +306,12 @@ export async function checkConflictSupabase(
     endTime: string;
     excludeAppointmentId?: string;
     roomId?: string;
+    // When true, soft "booking" conflicts (overlapping appointment, overlapping
+    // calendar activity, occupied room) are ignored so the caller can
+    // double-book on purpose with a warning surfaced in the UI. Hard
+    // constraints (working hours, approved leave, clinic closed) still apply.
+    // Issue #1526.
+    allowBookingConflict?: boolean;
   },
 ): Promise<{ hasConflict: boolean; reason?: string }> {
   const dayOfWeek = new Date(args.date + "T00:00:00").getDay();
@@ -369,61 +375,63 @@ export async function checkConflictSupabase(
     }
   }
 
-  const appointments = await db
-    .query("gabinetAppointments")
-    .eq("organizationId", args.organizationId)
-    .eq("employeeId", args.userId)
-    .eq("date", args.date)
-    .collect();
-
-  for (const appt of appointments as any[]) {
-    if (args.excludeAppointmentId && String(appt.id ?? appt._id) === args.excludeAppointmentId) continue;
-    if (appt.status === "cancelled" || appt.status === "no_show") continue;
-    const apptStart = timeToMinutes(String(appt.startTime));
-    const apptEnd = timeToMinutes(String(appt.endTime));
-    if (reqStart < apptEnd && reqEnd > apptStart) {
-      return { hasConflict: true, reason: "Conflicts with existing appointment" };
-    }
-  }
-
-  const resourceActivities = await db
-    .query("scheduledActivities")
-    .eq("organizationId", args.organizationId)
-    .eq("resourceId", args.userId)
-    .collect();
-
-  for (const activity of resourceActivities as any[]) {
-    if (activity.isCompleted) continue;
-    if (!activity.endDate) continue;
-    const actDate = new Date(activity.dueDate);
-    const actDateStr = `${actDate.getFullYear()}-${String(actDate.getMonth() + 1).padStart(2, "0")}-${String(actDate.getDate()).padStart(2, "0")}`;
-    if (actDateStr !== args.date) continue;
-    if (activity.moduleRef?.moduleId === "gabinet") continue;
-
-    const actStartMin = actDate.getHours() * 60 + actDate.getMinutes();
-    const actEndDate = new Date(activity.endDate);
-    const actEndMin = actEndDate.getHours() * 60 + actEndDate.getMinutes();
-    if (reqStart < actEndMin && reqEnd > actStartMin) {
-      return { hasConflict: true, reason: `Conflicts with: ${activity.title}` };
-    }
-  }
-
-  if (args.roomId) {
-    const roomAppointments = await db
+  if (!args.allowBookingConflict) {
+    const appointments = await db
       .query("gabinetAppointments")
       .eq("organizationId", args.organizationId)
-      .eq("roomId", args.roomId)
+      .eq("employeeId", args.userId)
       .eq("date", args.date)
       .collect();
 
-    for (const appt of roomAppointments as any[]) {
+    for (const appt of appointments as any[]) {
       if (args.excludeAppointmentId && String(appt.id ?? appt._id) === args.excludeAppointmentId) continue;
       if (appt.status === "cancelled" || appt.status === "no_show") continue;
-      if (
-        String(appt.startTime) < args.endTime &&
-        String(appt.endTime) > args.startTime
-      ) {
-        return { hasConflict: true, reason: "Room is occupied at this time" };
+      const apptStart = timeToMinutes(String(appt.startTime));
+      const apptEnd = timeToMinutes(String(appt.endTime));
+      if (reqStart < apptEnd && reqEnd > apptStart) {
+        return { hasConflict: true, reason: "Conflicts with existing appointment" };
+      }
+    }
+
+    const resourceActivities = await db
+      .query("scheduledActivities")
+      .eq("organizationId", args.organizationId)
+      .eq("resourceId", args.userId)
+      .collect();
+
+    for (const activity of resourceActivities as any[]) {
+      if (activity.isCompleted) continue;
+      if (!activity.endDate) continue;
+      const actDate = new Date(activity.dueDate);
+      const actDateStr = `${actDate.getFullYear()}-${String(actDate.getMonth() + 1).padStart(2, "0")}-${String(actDate.getDate()).padStart(2, "0")}`;
+      if (actDateStr !== args.date) continue;
+      if (activity.moduleRef?.moduleId === "gabinet") continue;
+
+      const actStartMin = actDate.getHours() * 60 + actDate.getMinutes();
+      const actEndDate = new Date(activity.endDate);
+      const actEndMin = actEndDate.getHours() * 60 + actEndDate.getMinutes();
+      if (reqStart < actEndMin && reqEnd > actStartMin) {
+        return { hasConflict: true, reason: `Conflicts with: ${activity.title}` };
+      }
+    }
+
+    if (args.roomId) {
+      const roomAppointments = await db
+        .query("gabinetAppointments")
+        .eq("organizationId", args.organizationId)
+        .eq("roomId", args.roomId)
+        .eq("date", args.date)
+        .collect();
+
+      for (const appt of roomAppointments as any[]) {
+        if (args.excludeAppointmentId && String(appt.id ?? appt._id) === args.excludeAppointmentId) continue;
+        if (appt.status === "cancelled" || appt.status === "no_show") continue;
+        if (
+          String(appt.startTime) < args.endTime &&
+          String(appt.endTime) > args.startTime
+        ) {
+          return { hasConflict: true, reason: "Room is occupied at this time" };
+        }
       }
     }
   }

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1046,6 +1046,11 @@ export const create = action({
     // or crafted API call cannot silently create a past appointment. Issue
     // #1414.
     allowPast: v.optional(v.boolean()),
+    // When true, allow saving even if the slot overlaps with another
+    // appointment, calendar activity, or occupied room. The UI shows an
+    // explicit warning before the user opts in. Hard constraints (working
+    // hours, approved leave, clinic closed) still block creation. Issue #1526.
+    allowConflict: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     // --- Auth + permissions (via internal queries) ---
@@ -1102,6 +1107,7 @@ export const create = action({
       startTime: args.startTime,
       endTime: args.endTime,
       roomId: args.roomId ?? undefined,
+      allowBookingConflict: args.allowConflict ?? false,
     });
     if (conflict.hasConflict) {
       throw new Error(conflict.reason ?? "Time slot conflict");

--- a/src/components/gabinet/appointment-shared/warnings.tsx
+++ b/src/components/gabinet/appointment-shared/warnings.tsx
@@ -76,3 +76,42 @@ export function EquipmentWarning({
     </div>
   );
 }
+
+interface ConflictWarningProps {
+  className?: string;
+  size?: "sm" | "compact";
+}
+
+// Surfaced in the appointment dialog when the selected slot overlaps with an
+// existing appointment for the same employee. Lets staff opt in to
+// double-booking with eyes open (issue #1526) — submission still works because
+// the backend skips the soft conflict check when the dialog forwards
+// `allowConflict: true`.
+export function ConflictWarning({
+  className,
+  size = "sm",
+}: ConflictWarningProps) {
+  const { t } = useTranslation();
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200",
+        size === "sm" ? "px-3 py-2 text-sm" : "px-2.5 py-2 text-xs",
+        className,
+      )}
+    >
+      <AlertTriangle
+        className={cn(
+          "mt-0.5 shrink-0",
+          size === "sm" ? "size-4" : "size-3.5",
+        )}
+      />
+      <span>
+        {t("gabinet.appointments.warnings.conflict", {
+          defaultValue: "Kolizja terminów z inną wizytą",
+        })}
+      </span>
+    </div>
+  );
+}

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -79,6 +79,7 @@ import { SidePanel } from "@/components/crm/side-panel";
 import { PatientForm } from "@/components/forms/patient-form";
 import { PackageUsageSelector } from "@/components/gabinet/package-usage-selector";
 import {
+  ConflictWarning,
   EquipmentWarning,
   LeaveWarning,
 } from "@/components/gabinet/appointment-shared/warnings";
@@ -88,6 +89,7 @@ import {
 } from "@/components/gabinet/appointment-shared/use-appointment-warnings";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
+import { useSupabaseGabinetAppointmentsByDateRange } from "@/hooks/use-supabase-gabinet-appointments";
 import { formatPhoneNumber } from "@/lib/phone";
 
 // ---------------------------------------------------------------------------
@@ -798,6 +800,35 @@ export function AppointmentDialog({
       )
     : "";
 
+  // Existing appointments for the chosen employee + day, used to detect when
+  // the user picks a slot that overlaps with another booking. The dialog
+  // surfaces a warning and lets the user save anyway (`allowConflict` flag on
+  // submit) — issue #1526.
+  const { data: employeeDayAppointments } =
+    useSupabaseGabinetAppointmentsByDateRange(
+      String(organizationId),
+      dateStr,
+      dateStr,
+      {
+        employeeId: employeeId || undefined,
+        enabled: !!organizationId && !!employeeId && !!dateStr,
+      },
+    );
+
+  const conflictingAppointment = useMemo(() => {
+    if (!selectedSlot?.start || !endTime || !employeeDayAppointments) return null;
+    const reqStart = selectedSlot.start;
+    const reqEnd = endTime;
+    return (
+      employeeDayAppointments.find((appt) => {
+        if (appt.status === "cancelled" || appt.status === "no_show") return false;
+        return appt.startTime < reqEnd && appt.endTime > reqStart;
+      }) ?? null
+    );
+  }, [selectedSlot, endTime, employeeDayAppointments]);
+
+  const hasBookingConflict = !!conflictingAppointment;
+
   // Recurring occurrences (date + effective start time). The first entry is
   // the base appointment (tied to calendar selection, read-only). The rest
   // are generated from the cycle, with optional per-index date/time overrides
@@ -877,6 +908,7 @@ export function AppointmentDialog({
         roomId: roomId ? (roomId as Id<"gabinetRooms">) : undefined,
         packageUsageId: packageUsageId ?? undefined,
         allowPast: recordWalkIn || undefined,
+        allowConflict: hasBookingConflict || undefined,
       });
       // Refresh the calendar immediately — Convex actions don't invalidate
       // the Supabase React Query cache automatically.
@@ -915,6 +947,8 @@ export function AppointmentDialog({
     locationId,
     roomId,
     packageUsageId,
+    recordWalkIn,
+    hasBookingConflict,
     onOpenChange,
     queryClient,
     t,
@@ -1679,6 +1713,13 @@ export function AppointmentDialog({
                 {employeeLeaveOnSelectedDate && (
                   <LeaveWarning
                     leave={employeeLeaveOnSelectedDate}
+                    size="compact"
+                    className="mx-3 mb-2"
+                  />
+                )}
+
+                {hasBookingConflict && (
+                  <ConflictWarning
                     size="compact"
                     className="mx-3 mb-2"
                   />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1526.

Closes #1526

---

## Claude summary

Extended the double-booking warning from #1526 to the new "zdarzenie" (event) dialog as requested in the follow-up comment. `EventDialog` now fetches the day's appointments + scheduled activities, scopes the overlap check by employee vs. "Cały gabinet", and shows the existing `ConflictWarning` above the footer when there's a collision. The save button is still enabled — backend already accepts overlapping scheduled activities, so no convex change was needed. Typecheck clean, committed as `ec2bb1f`.