### PR TITLE
do zakładki klienci

### DIFF
--- a/src/components/application/table/table.tsx
+++ b/src/components/application/table/table.tsx
@@ -147,7 +147,7 @@ const TableHeader = <T extends object>({ columns, children, bordered = true, cla
             }
         >
             {selectionBehavior === "toggle" && (
-                <AriaColumn className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-12 md:pl-5" : "w-14 md:pl-6")}>
+                <AriaColumn className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-16 md:pl-5" : "w-18 md:pl-6")}>
                     {selectionMode === "multiple" && (
                         <Checkbox
                             slot="selection"
@@ -241,7 +241,7 @@ const TableRow = <T extends object>({ columns, children, className, highlightSel
             }
         >
             {selectionBehavior === "toggle" && (
-                <AriaCell className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-12 md:pl-5" : "w-14 md:pl-6")}>
+                <AriaCell className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-16 md:pl-5" : "w-18 md:pl-6")}>
                     <Checkbox
                         slot="selection"
                         size="md"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1564.

Closes #1564

---

## Claude summary

Triage. The reporter (Gabrysia) keeps hitting the same accidental-navigation issue when aiming at the row checkbox on the gabinet "Klienci" (patients) list — same theme as #1516 and #1549. The owner's comment "@claude #1516 tu jest dobrze zrób tak" directs me to continue that fix line.

Root cause for why the previous fix wasn't enough: PR #1561 (titled "przesuń bardziej" / "shift more") had a PR description claiming it widened the selection cell to `w-16` in `src/components/application/table/table.tsx:150,244`, but the commit was a duplicate cherry-pick of #1554 (`git rev-parse e2c630e^{tree} 69975e8^{tree}` returns the same hash). So no widening actually landed — the column stayed at `w-12`/`w-14`.

Fix: bumped the selection cell in `src/components/application/table/table.tsx` to `w-16` (sm) / `w-18` (md) — the change #1561's description described but never committed. Combined with the existing buffer in the first content cell from #1554, the comfortable zone between row edge and the navigation hit area is now ~84–96px. Applies to every bulk-select list via the shared UTUI table (patients, treatments, employees, companies, contacts, leads, activities, documents). Committed as d638810.

## Follow-ups
- Audit duplicate-tree PR merges: PR #1561's description claimed code changes that its actual commit (identical tree to #1554) did not include — automation may be generating optimistic descriptions before the diff is final.