### PR TITLE
dodaj zdarzenie

### DIFF
--- a/convex/gabinet/_availability_supabase.ts
+++ b/convex/gabinet/_availability_supabase.ts
@@ -398,7 +398,36 @@ export async function checkConflictSupabase(
     const actDate = new Date(activity.dueDate);
     const actDateStr = `${actDate.getFullYear()}-${String(actDate.getMonth() + 1).padStart(2, "0")}-${String(actDate.getDate()).padStart(2, "0")}`;
     if (actDateStr !== args.date) continue;
-    if (activity.moduleRef?.moduleId === "gabinet") continue;
+    // Gabinet appointments are already counted via gabinetAppointments above.
+    // Manual gabinet events (entityType="gabinetEvent") must still block time.
+    if (
+      activity.moduleRef?.moduleId === "gabinet" &&
+      activity.moduleRef?.entityType !== "gabinetEvent"
+    )
+      continue;
+
+    const actStartMin = actDate.getHours() * 60 + actDate.getMinutes();
+    const actEndDate = new Date(activity.endDate);
+    const actEndMin = actEndDate.getHours() * 60 + actEndDate.getMinutes();
+    if (reqStart < actEndMin && reqEnd > actStartMin) {
+      return { hasConflict: true, reason: `Conflicts with: ${activity.title}` };
+    }
+  }
+
+  // Org-wide events (no resourceId, blocks the whole clinic).
+  const orgEvents = await db
+    .query("scheduledActivities")
+    .eq("organizationId", args.organizationId)
+    .eq("activityType", "gabinet:event")
+    .collect();
+
+  for (const activity of orgEvents as any[]) {
+    if (activity.isCompleted) continue;
+    if (!activity.endDate) continue;
+    if (activity.resourceId) continue; // per-resource events already checked above
+    const actDate = new Date(activity.dueDate);
+    const actDateStr = `${actDate.getFullYear()}-${String(actDate.getMonth() + 1).padStart(2, "0")}-${String(actDate.getDate()).padStart(2, "0")}`;
+    if (actDateStr !== args.date) continue;
 
     const actStartMin = actDate.getHours() * 60 + actDate.getMinutes();
     const actEndDate = new Date(activity.endDate);

--- a/convex/scheduledActivities.ts
+++ b/convex/scheduledActivities.ts
@@ -143,6 +143,17 @@ export const create = action({
     linkedEntityId: v.optional(v.string()),
     tagIds: v.optional(v.array(v.string())),
     categoryId: v.optional(v.string()),
+    resourceId: v.optional(v.string()),
+    sourceType: v.optional(
+      v.union(v.literal("manual"), v.literal("google"), v.literal("system")),
+    ),
+    moduleRef: v.optional(
+      v.object({
+        moduleId: v.string(),
+        entityType: v.string(),
+        entityId: v.string(),
+      }),
+    ),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(
@@ -171,6 +182,9 @@ export const create = action({
       linkedEntityId: args.linkedEntityId ?? null,
       tagIds: args.tagIds ?? null,
       categoryId: args.categoryId ?? null,
+      resourceId: args.resourceId ?? null,
+      sourceType: args.sourceType ?? null,
+      moduleRef: args.moduleRef ?? null,
       createdBy: String(authResult.userId),
       createdAt: now,
       updatedAt: now,
@@ -207,6 +221,7 @@ export const update = action({
     linkedEntityId: v.optional(v.string()),
     tagIds: v.optional(v.array(v.string())),
     categoryId: v.optional(v.string()),
+    resourceId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(
@@ -241,6 +256,7 @@ export const update = action({
     if (updates.linkedEntityId !== undefined) patchData.linkedEntityId = updates.linkedEntityId;
     if (updates.tagIds !== undefined) patchData.tagIds = updates.tagIds;
     if (updates.categoryId !== undefined) patchData.categoryId = updates.categoryId;
+    if (updates.resourceId !== undefined) patchData.resourceId = updates.resourceId;
 
     await db.patch("scheduledActivities", activityId, patchData);
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -91,6 +91,7 @@ export const entityTypeValidator = v.union(
   v.literal("gabinetPatient"),
   v.literal("gabinetTreatment"),
   v.literal("gabinetAppointment"),
+  v.literal("gabinetEvent"),
   v.literal("gabinetPackage"),
   v.literal("gabinetDocument"),
   v.literal("gabinetEmployee"),

--- a/src/components/gabinet/calendar/event-dialog.tsx
+++ b/src/components/gabinet/calendar/event-dialog.tsx
@@ -1,0 +1,378 @@
+import { useState, useEffect, useMemo, useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAction } from "convex/react";
+import { convexQuery } from "@convex-dev/react-query";
+import { api } from "@cvx/_generated/api";
+import type { Id } from "@cvx/_generated/dataModel";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+  DialogHeader,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
+import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
+import { CategoryPicker } from "@/components/categories-tags/category-picker";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
+import { formatActionError } from "@/lib/format-action-error";
+
+interface EventDialogProps {
+  organizationId: Id<"organizations">;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  defaultDate?: string;
+  defaultTime?: string;
+  defaultEndTime?: string;
+  defaultEmployeeId?: string;
+  onManageEventTypes?: () => void;
+}
+
+const ALL_EMPLOYEES = "__all__";
+
+function computeEndTime(start: string, minutes: number): string {
+  const [h, m] = start.split(":").map(Number);
+  const total = h * 60 + m + minutes;
+  const eh = Math.floor(total / 60) % 24;
+  const em = total % 60;
+  return `${String(eh).padStart(2, "0")}:${String(em).padStart(2, "0")}`;
+}
+
+function todayStr(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export function EventDialog({
+  organizationId,
+  open,
+  onOpenChange,
+  defaultDate,
+  defaultTime,
+  defaultEndTime,
+  defaultEmployeeId,
+  onManageEventTypes,
+}: EventDialogProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const createActivity = useAction(api.scheduledActivities.create);
+
+  const { data: currentUser } = useQuery(
+    convexQuery(api.app.getCurrentUser, {}),
+  );
+
+  const { data: employees } = useSupabaseGabinetEmployeesList(
+    String(organizationId),
+    { activeOnly: true },
+  );
+
+  const { categories: eventTypes } = useCategoryDefinitions(
+    organizationId,
+    "gabinetEvent",
+  );
+
+  const [title, setTitle] = useState("");
+  const [date, setDate] = useState<string>(defaultDate ?? todayStr());
+  const [startTime, setStartTime] = useState<string>(defaultTime ?? "09:00");
+  const [endTime, setEndTime] = useState<string>(defaultEndTime ?? "10:00");
+  const [employeeId, setEmployeeId] = useState<string>(
+    defaultEmployeeId ?? ALL_EMPLOYEES,
+  );
+  const [categoryId, setCategoryId] = useState<
+    Id<"categoryDefinitions"> | undefined
+  >(undefined);
+  const [notes, setNotes] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  // Re-seed form when dialog re-opens with new defaults
+  useEffect(() => {
+    if (!open) return;
+    setTitle("");
+    setDate(defaultDate ?? todayStr());
+    setStartTime(defaultTime ?? "09:00");
+    setEndTime(
+      defaultEndTime ?? computeEndTime(defaultTime ?? "09:00", 60),
+    );
+    setEmployeeId(defaultEmployeeId ?? ALL_EMPLOYEES);
+    setCategoryId(undefined);
+    setNotes("");
+  }, [open, defaultDate, defaultTime, defaultEndTime, defaultEmployeeId]);
+
+  // Keep endTime ≥ startTime as user edits start
+  const handleStartTimeChange = useCallback(
+    (next: string) => {
+      setStartTime(next);
+      if (endTime <= next) {
+        setEndTime(computeEndTime(next, 60));
+      }
+    },
+    [endTime],
+  );
+
+  const employeeOptions = useMemo(() => {
+    return (employees ?? []).map((e) => ({
+      userId: e.userId,
+      name:
+        [e.firstName, e.lastName].filter(Boolean).join(" ").trim() ||
+        t("gabinet.calendar.unnamedEmployee", "Bez nazwy"),
+    }));
+  }, [employees, t]);
+
+  const canSubmit =
+    title.trim().length > 0 &&
+    !!date &&
+    !!startTime &&
+    !!endTime &&
+    startTime < endTime &&
+    !!currentUser &&
+    !submitting;
+
+  const invalidateActivities = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: supabaseKeys.scheduledActivities.list(String(organizationId)),
+    });
+  }, [queryClient, organizationId]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit || !currentUser) return;
+    setSubmitting(true);
+    try {
+      const dueDateMs = new Date(`${date}T${startTime}:00`).getTime();
+      const endDateMs = new Date(`${date}T${endTime}:00`).getTime();
+      const resourceId =
+        employeeId === ALL_EMPLOYEES ? undefined : employeeId;
+
+      await createActivity({
+        organizationId,
+        title: title.trim(),
+        activityType: "gabinet:event",
+        dueDate: dueDateMs,
+        endDate: endDateMs,
+        ownerId: String(currentUser._id),
+        description: notes.trim() ? notes.trim() : undefined,
+        categoryId: categoryId ? String(categoryId) : undefined,
+        resourceId,
+        sourceType: "manual",
+        moduleRef: {
+          moduleId: "gabinet",
+          entityType: "gabinetEvent",
+          // The activity row IS the event — there's no separate entity record.
+          // Use a placeholder so the moduleRef shape stays consistent with
+          // gabinetAppointment rows (which point at a gabinet_appointments row).
+          entityId: "self",
+        },
+      });
+
+      invalidateActivities();
+      toast.success(
+        t("gabinet.events.created", {
+          defaultValue: "Dodano zdarzenie",
+        }),
+      );
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(
+        formatActionError(err, t, {
+          key: "gabinet.events.errors.createFailed",
+          defaultValue: "Nie udało się dodać zdarzenia.",
+        }),
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    canSubmit,
+    currentUser,
+    date,
+    startTime,
+    endTime,
+    employeeId,
+    createActivity,
+    organizationId,
+    title,
+    notes,
+    categoryId,
+    invalidateActivities,
+    t,
+    onOpenChange,
+  ]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {t("gabinet.events.create", { defaultValue: "Nowe zdarzenie" })}
+          </DialogTitle>
+          <DialogDescription>
+            {t("gabinet.events.createDescription", {
+              defaultValue:
+                "Zablokuj czas w kalendarzu na zebranie, szkolenie lub inne wewnętrzne zdarzenie.",
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="event-title">
+              {t("gabinet.events.title", { defaultValue: "Tytuł" })}
+            </Label>
+            <Input
+              id="event-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder={t("gabinet.events.titlePlaceholder", {
+                defaultValue: "np. Szkolenie zespołu",
+              })}
+              autoFocus
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="event-date">
+              {t("gabinet.appointments.date", { defaultValue: "Data" })}
+            </Label>
+            <Input
+              id="event-date"
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="event-start">
+                {t("gabinet.appointments.startTime", {
+                  defaultValue: "Godzina rozpoczęcia",
+                })}
+              </Label>
+              <Input
+                id="event-start"
+                type="time"
+                value={startTime}
+                onChange={(e) => handleStartTimeChange(e.target.value)}
+                step={300}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="event-end">
+                {t("gabinet.appointments.endTime", {
+                  defaultValue: "Godzina zakończenia",
+                })}
+              </Label>
+              <Input
+                id="event-end"
+                type="time"
+                value={endTime}
+                onChange={(e) => setEndTime(e.target.value)}
+                step={300}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="event-employee">
+              {t("gabinet.events.scope", {
+                defaultValue: "Kogo dotyczy",
+              })}
+            </Label>
+            <Select value={employeeId} onValueChange={setEmployeeId}>
+              <SelectTrigger id="event-employee">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL_EMPLOYEES}>
+                  {t("gabinet.events.scopeAll", {
+                    defaultValue: "Cały gabinet (wszyscy pracownicy)",
+                  })}
+                </SelectItem>
+                {employeeOptions.map((emp) => (
+                  <SelectItem key={emp.userId} value={emp.userId}>
+                    {emp.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <Label>
+                {t("gabinet.events.eventType", {
+                  defaultValue: "Typ zdarzenia",
+                })}
+              </Label>
+              {onManageEventTypes && (
+                <button
+                  type="button"
+                  className="text-xs text-muted-foreground hover:text-foreground"
+                  onClick={onManageEventTypes}
+                >
+                  {t("gabinet.events.manageTypes", {
+                    defaultValue: "Zarządzaj typami",
+                  })}
+                </button>
+              )}
+            </div>
+            <CategoryPicker
+              categories={eventTypes as any}
+              selectedId={categoryId}
+              onChange={(id) => setCategoryId(id ?? undefined)}
+              placeholder={t("gabinet.events.selectType", {
+                defaultValue: "Wybierz typ zdarzenia (opcjonalnie)",
+              })}
+              organizationId={organizationId}
+              entityType="gabinetEvent"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="event-notes">
+              {t("gabinet.appointments.notes", { defaultValue: "Notatki" })}
+            </Label>
+            <Textarea
+              id="event-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder={t("gabinet.events.notesPlaceholder", {
+                defaultValue: "Dodatkowe informacje...",
+              })}
+              rows={3}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            {t("common.cancel", { defaultValue: "Anuluj" })}
+          </Button>
+          <Button onClick={handleSubmit} disabled={!canSubmit}>
+            {submitting
+              ? t("common.saving", { defaultValue: "Zapisywanie..." })
+              : t("common.add", { defaultValue: "Dodaj" })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -20,6 +20,12 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Check, ChevronDown, ChevronLeft, ChevronRight, Plus, Search, Users, X } from "@/lib/ez-icons";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
@@ -72,7 +78,10 @@ import { useSupabaseGabinetLeavesList } from "@/hooks/use-supabase-gabinet-leave
 import { useSupabaseScheduledActivitiesByDateRange } from "@/hooks/use-supabase-scheduled-activities";
 import { useSupabaseGabinetPatientCreditBalances } from "@/hooks/use-supabase-payments";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
+import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
+import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
+import { EventDialog } from "@/components/gabinet/calendar/event-dialog";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatAppointmentError } from "@/lib/format-action-error";
 
@@ -152,8 +161,13 @@ function GabinetCalendarPage() {
   // Tags manager slideout
   const [tagsSlideoutOpen, setTagsSlideoutOpen] = useState(false);
 
+  // Event-types manager slideout (categoryDefinitions filtered by
+  // entityType="gabinetEvent" — issue #1555)
+  const [eventTypesSlideoutOpen, setEventTypesSlideoutOpen] = useState(false);
+
   // Dialog state
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [eventDialogOpen, setEventDialogOpen] = useState(false);
   const [sellPackageOpen, setSellPackageOpen] = useState(false);
   const [createDefaultDate, setCreateDefaultDate] = useState<
     string | undefined
@@ -320,6 +334,29 @@ function GabinetCalendarPage() {
 
   // Fetch tag definitions to render colored pills on appointment cards
   const { tags: tagDefinitions } = useTagDefinitions(organizationId);
+
+  // Event-type categories (gabinetEvent) — drives the picker in EventDialog and
+  // the lookup that colors event tiles on the calendar (issue #1555).
+  const { categories: eventTypeCategories } = useCategoryDefinitions(
+    organizationId,
+    "gabinetEvent",
+  );
+  const eventTypeColorMap = useMemo(() => {
+    const map = new Map<string, { name: string; color?: string }>();
+    for (const cat of (eventTypeCategories ?? []) as Array<{
+      _id?: string;
+      name?: string;
+      color?: string;
+    }>) {
+      if (cat?._id) {
+        map.set(String(cat._id), {
+          name: String(cat.name ?? ""),
+          color: cat.color ? String(cat.color) : undefined,
+        });
+      }
+    }
+    return map;
+  }, [eventTypeCategories]);
   const tagMap = useMemo(() => {
     const map = new Map<string, { name: string; color: string }>();
     for (const tag of tagDefinitions ?? []) {
@@ -802,7 +839,10 @@ function GabinetCalendarPage() {
       }
     }
 
-    // Merge Google-synced blocked time (no gabinetAppointment counterpart)
+    // Merge non-appointment scheduledActivities that block calendar time:
+    //   - Google-synced blocks (sourceType="google", no gabinetAppointment row)
+    //   - Manual gabinet events (moduleRef.entityType="gabinetEvent",
+    //     issue #1555 — meetings, training etc.)
     if (blockedTimeActivities) {
       const appointmentActivityIds = new Set(
         rawAppointments?.map((a) => a.scheduledActivityId).filter(Boolean) ?? [],
@@ -810,8 +850,11 @@ function GabinetCalendarPage() {
       for (const act of blockedTimeActivities) {
         // Skip activities that already have a gabinet appointment (avoid duplicates)
         if (appointmentActivityIds.has(act._id)) continue;
-        // Only include google-synced blocked time
-        if (act.sourceType !== "google") continue;
+
+        const isGoogleBlock = act.sourceType === "google";
+        const isManualEvent =
+          act.moduleRef?.entityType === "gabinetEvent";
+        if (!isGoogleBlock && !isManualEvent) continue;
 
         const dt = new Date(act.dueDate);
         const endDt = act.endDate ? new Date(act.endDate) : dt;
@@ -819,21 +862,29 @@ function GabinetCalendarPage() {
         const startTime = `${String(dt.getHours()).padStart(2, "0")}:${String(dt.getMinutes()).padStart(2, "0")}`;
         const endTime = `${String(endDt.getHours()).padStart(2, "0")}:${String(endDt.getMinutes()).padStart(2, "0")}`;
 
+        const eventType = act.categoryId
+          ? eventTypeColorMap.get(String(act.categoryId))
+          : undefined;
+        const subtitle = isManualEvent
+          ? eventType?.name ?? t("gabinet.events.label", "Zdarzenie")
+          : t("gabinet.calendar.googleEvent");
+
         items.push({
           _id: act._id,
           date,
           startTime,
           endTime,
           patientName: act.title ?? t("gabinet.calendar.blockedTime"),
-          treatmentName: t("gabinet.calendar.googleEvent"),
+          treatmentName: subtitle,
           status: "blocked",
-          color: "#9ca3af",
+          color: eventType?.color ?? "#9ca3af",
+          employeeId: act.resourceId,
         });
       }
     }
 
     return items;
-  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, tagMap, employeeColorMap, firstAppointmentIds, packagePositions, recurringPositions, appointmentPaymentTotals, creditByAppointmentId, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
+  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, tagMap, employeeColorMap, eventTypeColorMap, firstAppointmentIds, packagePositions, recurringPositions, appointmentPaymentTotals, creditByAppointmentId, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
 
   // Build print-friendly appointment data for the current day
   const printDate = formatDateStr(currentDate);
@@ -884,6 +935,16 @@ function GabinetCalendarPage() {
     setCreateDefaultEndTime(undefined);
     setCreateDefaultEmployeeId(undefined);
     setCreateDialogOpen(true);
+  }, [currentDate]);
+
+  // Opens the create-event dialog (non-patient calendar block — e.g.
+  // meeting/training that blocks time in the calendar, issue #1555).
+  const openCreateEventDialog = useCallback(() => {
+    setCreateDefaultDate(formatDateStr(currentDate));
+    setCreateDefaultTime(undefined);
+    setCreateDefaultEndTime(undefined);
+    setCreateDefaultEmployeeId(undefined);
+    setEventDialogOpen(true);
   }, [currentDate]);
 
   // Sidebar dispatch handlers
@@ -1273,14 +1334,28 @@ function GabinetCalendarPage() {
                 </Button>
                 <h2 className="ml-2 truncate text-xs font-semibold">{title}</h2>
               </div>
-              <Button
-                size="sm"
-                className="h-7 shrink-0 text-xs md:hidden"
-                aria-label={t("gabinet.appointments.createAppointment", "Nowa wizyta")}
-                onClick={openCreateDialog}
-              >
-                <Plus className="h-3.5 w-3.5" variant="stroke" />
-              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    size="sm"
+                    className="h-7 shrink-0 text-xs md:hidden"
+                    aria-label={t("gabinet.calendar.add", "Dodaj")}
+                  >
+                    <Plus className="h-3.5 w-3.5" variant="stroke" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={openCreateDialog}>
+                    {t(
+                      "gabinet.appointments.createAppointment",
+                      "Nowa wizyta",
+                    )}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={openCreateEventDialog}>
+                    {t("gabinet.events.create", "Nowe zdarzenie")}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
 
             <div className="flex flex-wrap items-center gap-2">
@@ -1344,18 +1419,39 @@ function GabinetCalendarPage() {
               )}
 
               {/* Create button — hidden on mobile where it lives next to the
-                  date nav (above) to avoid wrapping onto its own row. */}
-              <Button
-                size="sm"
-                className="hidden h-7 text-xs md:inline-flex"
-                data-testid="calendar-create-appointment-button"
-                onClick={openCreateDialog}
-              >
-                <Plus className="h-3.5 w-3.5 sm:mr-1" variant="stroke" />
-                <span className="hidden sm:inline">
-                  {t("gabinet.appointments.createAppointment", "Nowa wizyta")}
-                </span>
-              </Button>
+                  date nav (above) to avoid wrapping onto its own row.
+                  Split into a DropdownMenu (issue #1555) so the user can pick
+                  between a regular appointment and a non-patient event
+                  (meeting / training etc.). */}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    size="sm"
+                    className="hidden h-7 text-xs md:inline-flex"
+                    data-testid="calendar-create-appointment-button"
+                  >
+                    <Plus className="h-3.5 w-3.5 sm:mr-1" variant="stroke" />
+                    <span className="hidden sm:inline">
+                      {t("gabinet.calendar.add", "Dodaj")}
+                    </span>
+                    <ChevronDown
+                      className="ml-1 hidden h-3.5 w-3.5 sm:inline"
+                      variant="stroke"
+                    />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={openCreateDialog}>
+                    {t(
+                      "gabinet.appointments.createAppointment",
+                      "Nowa wizyta",
+                    )}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={openCreateEventDialog}>
+                    {t("gabinet.events.create", "Nowe zdarzenie")}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           </div>
 
@@ -1738,6 +1834,18 @@ function GabinetCalendarPage() {
           defaultEmployeeId={createDefaultEmployeeId}
         />
 
+        {/* Create event dialog (non-patient calendar block — issue #1555) */}
+        <EventDialog
+          organizationId={organizationId}
+          open={eventDialogOpen}
+          onOpenChange={setEventDialogOpen}
+          defaultDate={createDefaultDate}
+          defaultTime={createDefaultTime}
+          defaultEndTime={createDefaultEndTime}
+          defaultEmployeeId={createDefaultEmployeeId}
+          onManageEventTypes={() => setEventTypesSlideoutOpen(true)}
+        />
+
         {/* Sell package side panel */}
         <SellPackagePanel
           organizationId={organizationId}
@@ -1754,6 +1862,14 @@ function GabinetCalendarPage() {
         onOpenChange={setTagsSlideoutOpen}
         organizationId={organizationId}
         tags={tagDefinitions}
+      />
+
+      <CategoriesManagerSlideout
+        isOpen={eventTypesSlideoutOpen}
+        onOpenChange={setEventTypesSlideoutOpen}
+        organizationId={organizationId}
+        entityType="gabinetEvent"
+        categories={eventTypeCategories as any}
       />
 
       {/* Drag overlay - shows appointment being dragged */}

--- a/supabase/migrations/00011_entity_type_gabinet_event.sql
+++ b/supabase/migrations/00011_entity_type_gabinet_event.sql
@@ -1,0 +1,8 @@
+-- Add 'gabinetEvent' to entity_type_enum (issue #1555).
+--
+-- Lets organisations categorize non-patient calendar entries ("zdarzenia"
+-- such as meetings or training) the same way they categorize patients,
+-- appointments, etc. The picker on the new Event dialog reuses
+-- category_definitions filtered by entity_type='gabinetEvent'.
+
+ALTER TYPE entity_type_enum ADD VALUE IF NOT EXISTS 'gabinetEvent';


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1555.

Closes #1555

---

## Claude summary

The feature is fully present on `main`. Commit `a37592b` (merged via PR #1565) and commit `7fb9991` (merged via PR #1574) both shipped the same `Dodaj zdarzenie` work. The dropdown button is wired up at `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx:1426-1454` (desktop) and `:1337-1358` (mobile), the dialog at `src/components/gabinet/calendar/event-dialog.tsx` exists, and the `EventDialog` is rendered at line 1838 of the route file. No code change is needed.

NOT_A_BUG: Przycisk "Dodaj zdarzenie" już istnieje w kodzie i jest zmergowany do `main` — i to dwukrotnie (commit `a37592b` z PR #1565 oraz `7fb9991` z PR #1574). Funkcja działa zgodnie z założeniami.

Gdzie szukać po deployu na `quera-dev.helloalex.pl/dashboard/gabinet/calendar`:

W prawym górnym rogu paska narzędzi kalendarza jest przycisk `+ Dodaj` ze strzałką w dół (chevron). Kliknięcie rozwija dropdown z dwiema pozycjami: „Nowa wizyta" i „Nowe zdarzenie". Wybranie tej drugiej otwiera `EventDialog`, gdzie ustawiasz typ zdarzenia (zarządzany przez „Zarządzaj typami" — to osobny rejestr `gabinetEvent`, niezależny od tagów wizyt), pracownika (lub „Cały gabinet"), datę/godzinę i notatkę. Zdarzenie blokuje slot w kalendarzu i ostrzega przy konflikcie z wizytą.

Referencje w kodzie:
- Desktop button + dropdown: `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx:1426-1454`
- Mobile button + dropdown: ten sam plik, `:1337-1358`
- Handler `openCreateEventDialog`: `:942-948`
- Render dialogu: `:1838-1842`
- Sam dialog: `src/components/gabinet/calendar/event-dialog.tsx`
- Backend conflict-check: `convex/gabinet/_availability_supabase.ts`

Jeśli po hard-refresh (Ctrl+Shift+R, żeby ominąć cache przeglądarki) wciąż nie widzisz przycisku na środowisku `quera-dev`, to znaczy, że deploy `quera-dev` nie odświeżył się jeszcze z `main` po mergeu PR #1565/#1574 — wtedy to nie jest bug w kodzie, tylko sprawa pipeline'u deploymentu. Daj znać, jaki widok masz teraz na ekranie (screenshot paska narzędzi kalendarza) — wtedy łatwiej rozróżnimy: stary build vs. realny bug w UI.