### PR TITLE
Pogląd telefon 

### DIFF
--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -5,6 +5,7 @@ import {
   PopoverAnchor,
   PopoverContent,
 } from "@/components/ui/popover";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 import {
   AppointmentCard,
@@ -71,6 +72,7 @@ export function DraggableAppointment({
 
   const [previewEndTime, setPreviewEndTime] = useState<string | null>(null);
   const [popoverOpen, setPopoverOpen] = useState(false);
+  const isMobile = useIsMobile();
   // Suppress popover open when the click follows a drag — useDraggable triggers
   // onClick after a successful drop, which would otherwise pop the preview.
   const isPopoverDisabled = status === "blocked";
@@ -286,8 +288,12 @@ export function DraggableAppointment({
           "w-[553px] max-w-[calc(100vw-24px)] max-h-[calc(100dvh-24px)] overflow-y-auto p-4",
           isPreviewDragging && "cursor-grabbing select-none",
         )}
-        align="start"
-        side="right"
+        // On mobile the appointment can sit on either side of the screen, and a
+        // 378px popover does not fit beside it. Anchor it to the bottom of the
+        // card and center horizontally so the whole preview stays on-screen;
+        // Radix will flip to "top" if there is no room below (issue #1566).
+        align={isMobile ? "center" : "start"}
+        side={isMobile ? "bottom" : "right"}
         sideOffset={8}
         collisionPadding={12}
         onOpenAutoFocus={(e) => e.preventDefault()}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1566.

Closes #1566

---

## Claude summary

Committed. Here's what I changed and why:

The Gabinet calendar appointment-preview popover (`src/components/gabinet/calendar/draggable-appointment.tsx`) uses `side="right"` + `align="start"` with a 553px width capped at `calc(100vw-24px)`. On a 402px iPhone viewport, that cap resolves to 378px — wider than the space either side of the appointment card. Radix's collision detection flipped from right to left as expected, but the popover still overflowed the left edge of the screen, hiding the patient name, treatment selector, and the start of the form (matching the screenshot the user posted).

The fix uses the existing `useIsMobile()` hook to switch to `side="bottom"` + `align="center"` on viewports under 768px, so the preview drops below the card and stays horizontally centered (with Radix flipping to "top" if there's no room below). Desktop keeps the existing side-by-side layout. Typecheck passes for the app project.