### PR TITLE
znaczek do zaznaczania klientów

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -598,7 +598,6 @@ function PatientsIndex() {
         ]}
         onBulkAction={handleBulkAction}
         rowActions={rowActions}
-        onRowAction={(id) => navigate({ to: '/dashboard/gabinet/patients/$patientId', params: { patientId: id } })}
         emptyTitle={t("gabinet.patients.emptyTitle")}
         emptyDescription={t("gabinet.patients.emptyDescription")}
       />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1570.

Closes #1570

---

## Claude summary

Committed.

Summary: The Jam recording showed the user repeatedly clicking on the patient firstName cell, getting navigated to the patient detail page each time, when she actually wanted to mark/select patients via the checkboxes (for bulk merge/delete). The `onRowAction` prop on the `CrmDataTable` made every cell wrap its content in a clickable navigation div, hijacking clicks before they could reach the row checkbox.

The fix removes that single prop on the patients table. Navigation is preserved through the explicit `<Link>` around the avatar+name in the firstName cell and through the kebab row-action menu. The row body and the checkbox in the selection column now behave like normal selection controls.

## Follow-ups
- Apply the same fix to other CrmDataTable callers that set both `enableBulkSelect` and `onRowAction`: contacts, companies, leads, treatments, employees, etc. all share the navigation-hijacks-selection pattern.
- Rework CrmDataTable's row-click model so bulk-select and row-action navigation can coexist cleanly: today the lastClickTargetRef workaround and the cell-wide navigation div fight each other.