### PR TITLE
Add migration-applied health check on app boot

### DIFF
--- a/src/components/migration-health-banner.tsx
+++ b/src/components/migration-health-banner.tsx
@@ -1,0 +1,113 @@
+/**
+ * MigrationHealthBanner
+ *
+ * One-shot boot health check that compares the running Supabase schema
+ * (latest row in `supabase_migrations.schema_migrations`, exposed via the
+ * `public.app_schema_version` RPC) with the version the build was cut for
+ * (`__EXPECTED_SCHEMA_VERSION__`, injected by vite.config.ts).
+ *
+ * When the database is behind, render a single warning banner instead of
+ * letting every feature fail individually with PGRST204 toasts (#1576).
+ *
+ * Mounts inside <SupabaseProvider> so the authenticated client is available.
+ */
+
+import { useEffect, useState } from "react";
+import { useSupabase } from "@/components/supabase-provider";
+
+type CheckState =
+  | { kind: "checking" }
+  | { kind: "ok" }
+  | { kind: "stale"; applied: string | null; expected: string }
+  | { kind: "rpc-missing"; expected: string };
+
+const DISMISS_KEY = "quera-migration-banner-dismissed";
+
+export function MigrationHealthBanner() {
+  const { client, isReady } = useSupabase();
+  const [state, setState] = useState<CheckState>({ kind: "checking" });
+  const [dismissed, setDismissed] = useState(
+    () => typeof window !== "undefined" && sessionStorage.getItem(DISMISS_KEY) === "1",
+  );
+
+  useEffect(() => {
+    if (!isReady || !client) return;
+
+    const expected = __EXPECTED_SCHEMA_VERSION__;
+    if (!expected) {
+      // Vite couldn't read supabase/migrations at build time. Skip the check
+      // rather than render a false-positive banner.
+      setState({ kind: "ok" });
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      // The RPC is untyped (not in database.types.ts Functions); cast at the
+      // call site rather than polluting the generated types file.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error } = await (client as any).rpc("app_schema_version");
+      if (cancelled) return;
+
+      if (error) {
+        // 42883 = undefined_function. Any other error (network, auth) we
+        // treat as inconclusive and stay silent — failing loudly on transient
+        // hiccups would defeat the purpose.
+        if (error.code === "42883" || /function .* does not exist/i.test(error.message ?? "")) {
+          setState({ kind: "rpc-missing", expected });
+        } else {
+          setState({ kind: "ok" });
+          if (import.meta.env.DEV) {
+            console.warn("[MigrationHealthBanner] schema check inconclusive:", error);
+          }
+        }
+        return;
+      }
+
+      const applied = typeof data === "string" ? data : null;
+      if (applied !== null && applied >= expected) {
+        setState({ kind: "ok" });
+      } else {
+        setState({ kind: "stale", applied, expected });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [client, isReady]);
+
+  if (dismissed) return null;
+  if (state.kind === "checking" || state.kind === "ok") return null;
+
+  const expected = state.expected;
+  const applied = state.kind === "stale" ? state.applied : null;
+
+  return (
+    <div
+      role="alert"
+      className="relative z-40 flex shrink-0 items-center justify-between gap-3 border-b border-amber-300 bg-amber-100 px-4 py-2 text-xs font-medium text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100"
+    >
+      <span>
+        Baza danych nie jest zaktualizowana do wersji aplikacji
+        {" "}
+        (oczekiwano <code className="font-mono">{expected}</code>
+        {applied ? <>, znaleziono <code className="font-mono">{applied}</code></> : null}
+        ). Niektóre funkcje mogą zwracać błędy, dopóki administrator nie zastosuje brakujących migracji
+        {" "}(<code className="font-mono">npm run migrations:apply</code>).
+      </span>
+      <button
+        type="button"
+        onClick={() => {
+          sessionStorage.setItem(DISMISS_KEY, "1");
+          setDismissed(true);
+        }}
+        className="shrink-0 rounded px-2 py-0.5 underline-offset-2 hover:underline"
+        aria-label="Ukryj ostrzeżenie"
+      >
+        Ukryj
+      </button>
+    </div>
+  );
+}

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -72,6 +72,7 @@ import { HeaderSlotProvider, HeaderBackButton } from "@/components/layout/header
 import { getVisibleModules, moduleRegistry } from "@/modules/registry";
 import { useMatchRoute } from "@tanstack/react-router";
 import { useOrganization } from "@/components/org-context";
+import { MigrationHealthBanner } from "@/components/migration-health-banner";
 import { ContactForm } from "@/components/forms/contact-form";
 import { CompanyForm } from "@/components/forms/company-form";
 import { LeadForm } from "@/components/forms/lead-form";
@@ -725,6 +726,7 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
             </button>
           </span>
         </div>
+        <MigrationHealthBanner />
         <DevInfoDialog open={devInfoOpen} onOpenChange={handleDevInfoClose} />
 
         <div className="flex min-h-0 min-w-0 flex-1">

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,9 @@
 /// <reference types="vite/client" />
 
+// Latest committed Supabase migration version, injected by vite.config.ts at
+// build time. Used by the boot health check banner (#1576).
+declare const __EXPECTED_SCHEMA_VERSION__: string;
+
 declare namespace JSX {
   interface IntrinsicElements {
     "easier-icon": React.DetailedHTMLProps<

--- a/supabase/migrations/00012_app_schema_version_rpc.sql
+++ b/supabase/migrations/00012_app_schema_version_rpc.sql
@@ -1,0 +1,33 @@
+-- Expose the latest applied migration version to the browser (issue #1576).
+--
+-- The frontend boots a single health check that calls this RPC and compares
+-- the returned version with the build-time expected version. If the schema
+-- is behind, the app shows one warning banner instead of letting every
+-- feature fail individually with PGRST204 toasts.
+--
+-- `supabase_migrations.schema_migrations` is the same tracking table our
+-- `scripts/supabase-migrations.mjs` writes to and the Supabase CLI uses.
+-- It lives outside the `public` schema, so PostgREST cannot read it
+-- directly; this SECURITY DEFINER function bridges that gap with a
+-- minimal, read-only surface.
+
+CREATE OR REPLACE FUNCTION public.app_schema_version()
+RETURNS TEXT
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = supabase_migrations, pg_temp
+AS $$
+  SELECT version
+  FROM supabase_migrations.schema_migrations
+  ORDER BY version DESC
+  LIMIT 1;
+$$;
+
+REVOKE ALL ON FUNCTION public.app_schema_version() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.app_schema_version() TO authenticated, anon, service_role;
+
+COMMENT ON FUNCTION public.app_schema_version() IS
+  'Returns the version prefix (e.g. ''00012'') of the latest applied migration ' ||
+  'tracked in supabase_migrations.schema_migrations. Used by the frontend boot ' ||
+  'health check (issue #1576) to detect a stale schema.';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,24 @@ import tailwindcss from "@tailwindcss/vite";
 import viteReact from "@vitejs/plugin-react";
 import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
 import path from "path";
+import { readdirSync } from "node:fs";
+
+// Latest committed migration version (e.g. "00012"), read from supabase/migrations/
+// at config load time. The frontend boot health check (#1576) compares this against
+// the version returned by public.app_schema_version() to detect a stale schema.
+function latestMigrationVersion(): string {
+  const dir = path.resolve(__dirname, "./supabase/migrations");
+  const versions = readdirSync(dir)
+    .map((f) => /^(\d+)_.+\.sql$/.exec(f)?.[1])
+    .filter((v): v is string => !!v)
+    .sort();
+  return versions.at(-1) ?? "";
+}
 
 export default defineConfig({
+  define: {
+    __EXPECTED_SCHEMA_VERSION__: JSON.stringify(latestMigrationVersion()),
+  },
   plugins: [tailwindcss(), TanStackRouterVite(), viteReact()],
   server: {
     host: true,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1576.

Closes #1576

---

## Claude summary

Committed as `1af2583`.

Summary of the change:

- New migration `supabase/migrations/00012_app_schema_version_rpc.sql` creates `public.app_schema_version()`, a SECURITY DEFINER function that returns the latest applied migration version from `supabase_migrations.schema_migrations` (the same table `scripts/supabase-migrations.mjs` writes to).
- `vite.config.ts` reads `supabase/migrations/` at config load and exposes the latest filename version as `__EXPECTED_SCHEMA_VERSION__` via Vite's `define`.
- `src/components/migration-health-banner.tsx` runs once on boot: calls the RPC, compares the returned version with the build-time expected version, and renders a single amber warning banner if the schema is behind or the RPC itself isn't present. Inconclusive errors (network, auth) stay silent rather than false-positive. Dismissible per session.
- `src/routes/_app/_auth/dashboard/_layout.tsx` mounts `<MigrationHealthBanner />` under the beta strip, inside the SupabaseProvider so the authenticated client is available.

Typecheck passes. Lint passes on the new files.

## Follow-ups
- Wire `public.app_schema_version` into generated DB types: regenerate `src/lib/supabase/database.types.ts` via `scripts/gen-db-types.mjs` so the RPC isn't cast to `any` at the call site.
- Run schema check from automation/worker too: the boot banner only fires in the browser; backfill the same check into `scripts/agents/*` or the deploy healthcheck so CI fails before users see the banner.