### PR TITLE
Apply the same fix to other CrmDataTable callers that set both `enableBulkSelect

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
@@ -475,7 +475,6 @@ function CompaniesIndex() {
         ]}
         onBulkAction={handleBulkAction}
         rowActions={rowActions}
-        onRowAction={(id) => navigate({ to: '/dashboard/companies/$companyId', params: { companyId: id } })}
         emptyTitle={t('companies.emptyTitle')}
         emptyDescription={t('companies.emptyDescription')}
       />

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
@@ -448,7 +448,6 @@ function ContactsIndex() {
         ]}
         onBulkAction={handleBulkAction}
         rowActions={rowActions}
-        onRowAction={(id) => navigate({ to: '/dashboard/contacts/$contactId', params: { contactId: id } })}
         emptyTitle={t('contacts.emptyTitle')}
         emptyDescription={t('contacts.emptyDescription')}
       />

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -346,7 +346,6 @@ function EmployeesIndex() {
         ]}
         onBulkAction={handleBulkAction}
         rowActions={rowActions}
-        onRowAction={(id) => navigate({ to: '/dashboard/gabinet/employees/$employeeId', params: { employeeId: id } })}
       />
 
       <TagsManagerSlideout

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -585,7 +585,6 @@ function TreatmentsIndex() {
         ]}
         onBulkAction={handleBulkAction}
         rowActions={rowActions}
-        onRowAction={(id) => navigate({ to: '/dashboard/gabinet/treatments/$treatmentId', params: { treatmentId: id } })}
         emptyTitle={t("gabinet.treatments.emptyTitle")}
         emptyDescription={t("gabinet.treatments.emptyDescription")}
       />

--- a/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
@@ -697,7 +697,6 @@ function LeadsIndex() {
             onClick: handleDelete,
           },
         ]}
-        onRowAction={(id) => navigate({ to: '/dashboard/leads/$leadId', params: { leadId: id } })}
         emptyTitle={t("deals.emptyTitle")}
         emptyDescription={t("deals.emptyDescription")}
       />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1583.

Closes #1583

---

## Claude summary

Applied the same patients fix (#1582) to the five remaining CrmDataTable callers that combined `enableBulkSelect` with a row-wide `onRowAction`: contacts, companies, leads, gabinet treatments, and gabinet employees. Each page already has an explicit `<Link>` in its row-header cell plus a kebab "Edit" action that navigates, so dropping `onRowAction` frees the row body for the selection checkbox without breaking navigation. Committed as `1f538f5`.