### PR TITLE
Pola w zakładce klienci

### DIFF
--- a/src/components/crm/data-list-filter-bar.tsx
+++ b/src/components/crm/data-list-filter-bar.tsx
@@ -110,6 +110,9 @@ export interface DataListFilterBarProps {
   // Tags & Categories management
   onTagsManage?: () => void;
   onCategoriesManage?: () => void;
+
+  // Extra elements rendered on the left side next to the view selector
+  leftExtras?: React.ReactNode;
 }
 
 let filterIdCounter = 0;
@@ -157,6 +160,7 @@ export function DataListFilterBar({
   dropdownActions = [],
   onTagsManage: _onTagsManage,
   onCategoriesManage: _onCategoriesManage,
+  leftExtras,
 }: DataListFilterBarProps) {
   const { t } = useTranslation();
   const [internalFilterSlideoutOpen, setInternalFilterSlideoutOpen] =
@@ -411,6 +415,7 @@ export function DataListFilterBar({
             })}
           </button>
         )}
+        {leftExtras}
       </div>
 
       {/* Right: search + filter trigger (desktop) */}

--- a/src/components/crm/mini-charts.tsx
+++ b/src/components/crm/mini-charts.tsx
@@ -9,7 +9,9 @@ import {
 } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
+import { Button as UntitledButton } from "@untitled/base/buttons/button";
 import { ChevronDown, ChevronUp } from "@/lib/ez-icons";
+import { ChevronDown as UiChevronDown, ChevronUp as UiChevronUp } from "@untitledui/icons";
 import type { TimeRange } from "./types";
 
 export interface MiniChartData {
@@ -154,14 +156,10 @@ export function MiniChartsRow({ leftChart, rightChart, storageKey }: MiniChartsR
   return <CollapsibleCharts storageKey={storageKey}>{charts}</CollapsibleCharts>;
 }
 
-function CollapsibleCharts({
-  storageKey,
-  children,
-}: {
-  storageKey: string;
-  children: React.ReactNode;
-}) {
-  const { t } = useTranslation();
+export function useChartsToggleState(storageKey: string): {
+  open: boolean;
+  toggle: () => void;
+} {
   const lsKey = `mini-charts:${storageKey}`;
   const [open, setOpen] = useState<boolean>(() => {
     try {
@@ -181,6 +179,42 @@ function CollapsibleCharts({
       return next;
     });
   }, [lsKey]);
+
+  return { open, toggle };
+}
+
+export function ChartsToggleButton({
+  open,
+  onToggle,
+}: {
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <UntitledButton
+      size="sm"
+      color="secondary"
+      iconLeading={open ? UiChevronUp : UiChevronDown}
+      onClick={onToggle}
+      aria-expanded={open}
+    >
+      {open
+        ? t("common.hideStatistics", { defaultValue: "Ukryj statystyki" })
+        : t("common.showStatistics", { defaultValue: "Pokaż statystyki" })}
+    </UntitledButton>
+  );
+}
+
+function CollapsibleCharts({
+  storageKey,
+  children,
+}: {
+  storageKey: string;
+  children: React.ReactNode;
+}) {
+  const { t } = useTranslation();
+  const { open, toggle } = useChartsToggleState(storageKey);
 
   return (
     <div className="space-y-3">

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -11,7 +11,7 @@ import { useOrganization } from "@/components/org-context";
 import { PageHeader } from "@/components/layout/page-header";
 import { CrmDataTable, useColumnVisibility, useAllColumns, type CrmColumn } from "@/components/crm/enhanced-data-table";
 import { DataListFilterBar } from "@/components/crm/data-list-filter-bar";
-import { MiniChartsRow } from "@/components/crm/mini-charts";
+import { MiniChartsRow, useChartsToggleState, ChartsToggleButton } from "@/components/crm/mini-charts";
 import { SidePanel } from "@/components/crm/side-panel";
 import { PatientForm } from "@/components/forms/patient-form";
 import { MergePatientsDialog } from "@/components/gabinet/merge-patients-dialog";
@@ -80,6 +80,7 @@ function PatientsIndex() {
   const [mergePreselectedTargetId, setMergePreselectedTargetId] = useState<string | null>(null);
   const [leftTimeRange, setLeftTimeRange] = useState<TimeRange>("last30days");
   const [rightTimeRange, setRightTimeRange] = useState<TimeRange>("all");
+  const { open: chartsOpen, toggle: toggleCharts } = useChartsToggleState("gabinet-patients");
   const [savedViewsDialogOpen, setSavedViewsDialogOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
   const [activeFilters, setActiveFilters] = useState<FilterCondition[]>([]);
@@ -557,25 +558,27 @@ function PatientsIndex() {
         onTagsManage={() => setTagsSlideoutOpen(true)}
         onCategoriesManage={() => setCategoriesSlideoutOpen(true)}
         onFiltersChange={setActiveFilters}
+        leftExtras={<ChartsToggleButton open={chartsOpen} onToggle={toggleCharts} />}
       />
 
-      <MiniChartsRow
-        storageKey="gabinet-patients"
-        leftChart={{
-          title: t("gabinet.patients.byDay"),
-          data: patientsByDay,
-          chartType: "line",
-          timeRange: leftTimeRange,
-          onTimeRangeChange: setLeftTimeRange,
-        }}
-        rightChart={{
-          title: t("gabinet.patients.bySource"),
-          data: patientsBySource,
-          chartType: "bar",
-          timeRange: rightTimeRange,
-          onTimeRangeChange: setRightTimeRange,
-        }}
-      />
+      {chartsOpen && (
+        <MiniChartsRow
+          leftChart={{
+            title: t("gabinet.patients.byDay"),
+            data: patientsByDay,
+            chartType: "line",
+            timeRange: leftTimeRange,
+            onTimeRangeChange: setLeftTimeRange,
+          }}
+          rightChart={{
+            title: t("gabinet.patients.bySource"),
+            data: patientsBySource,
+            chartType: "bar",
+            timeRange: rightTimeRange,
+            onTimeRangeChange: setRightTimeRange,
+          }}
+        />
+      )}
 
       <CrmDataTable
         columns={allColumns}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1588.

Closes #1588

---

## Claude summary

Committed in `e281089`.

Summary: On the Gabinet patients page (`/dashboard/gabinet/patients`, title "Klienci"), the "Pokaż statystyki" toggle previously sat on its own row below the filter bar as a tiny ghost button (`h-7 px-2 text-xs`), while the "Wszyscy klienci" view dropdown was a UTUI Button `size="sm" color="secondary"` on the row above. The two controls now share one line and matching styling:

- `src/components/crm/mini-charts.tsx` — extracted the localStorage-backed open/toggle logic into `useChartsToggleState(storageKey)` and added a `ChartsToggleButton` component that renders the UTUI Button (`size="sm" color="secondary"`, leading chevron) so it visually matches the view selector. `CollapsibleCharts` (still used as the fallback when `storageKey` is passed to `MiniChartsRow`) was refactored to consume the same hook.
- `src/components/crm/data-list-filter-bar.tsx` — added a `leftExtras?: React.ReactNode` prop rendered inside the left-side flex container, next to the view selector / "Add view" button.
- `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx` — wires the hook + button: `leftExtras={<ChartsToggleButton ... />}` on the filter bar, conditional `{chartsOpen && <MiniChartsRow ... />}` for the charts, removed the `storageKey` prop (no longer needed since the toggle lives outside).

Other pages that use `MiniChartsRow` without `storageKey` (contacts, companies, leads, gabinet documents) are unaffected — the `MiniChartsRow` API stayed backwards compatible.