### PR TITLE
wybór klienta

### DIFF
--- a/src/components/crm/enhanced-data-table.tsx
+++ b/src/components/crm/enhanced-data-table.tsx
@@ -162,16 +162,16 @@ export function CrmDataTable<TData>({
 
   // React Aria's Table treats row clicks as selection toggles in multi-select
   // mode UNLESS `onRowAction` is set, in which case row clicks fire the action
-  // and only checkbox clicks toggle selection. We always provide an action when
-  // bulk-select is on so checkbox-only selection is the native behavior — if
-  // the caller didn't ask for navigation, the action is a no-op. This avoids
-  // the document-level click listener / target-sniffing workaround that used
-  // to fight with the cell-wide navigation div.
+  // and only checkbox clicks toggle selection. Letting React Aria default to
+  // row-click → toggle when no `onRowAction` is provided gives the user the
+  // entire row as a hit target for selection (issue #1594 — tiny checkbox is
+  // hard to hit on mobile). Focusable children like the patient-name Link or
+  // the kebab button still take priority — React Aria skips the row action
+  // when the press lands on a focusable descendant.
   const tableRowAction = useMemo(() => {
     if (onRowAction) return (key: Key) => onRowAction(String(key));
-    if (enableBulkSelect) return () => {};
     return undefined;
-  }, [onRowAction, enableBulkSelect]);
+  }, [onRowAction]);
 
   // --- Derived data ---
   const sorted = useMemo(() => sortItems(data, sort, columns), [data, sort, columns]);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1594.

Closes #1594

---

## Claude summary

Fixed and committed. The root cause was the explicit no-op `onRowAction = () => {}` in `src/components/crm/enhanced-data-table.tsx:172` that turned every cell outside the small checkbox into a dead zone — so on iOS, a near-miss on the ~16px checkbox would either land on the next cell's padding (no action) or worse, on the `<Link>` wrapping the avatar/name (navigation → patient card opens).

The fix: drop the no-op. React Aria's native multi-select then makes the whole row a selection target while React Aria's `useSelectableItem` still defers to focusable descendants (the `<Link>` on the patient name, the kebab button, the checkbox itself). Net effect:

- Tap anywhere on a row body → toggle selection (the bigger area the user asked for)
- Tap the patient-name `<Link>` → still navigates to the patient card
- Tap the kebab → still opens the row-actions dropdown

Applies to every list using `CrmDataTable` with `enableBulkSelect` (patients, contacts, companies, leads, activities, treatments, employees, documents — CRM and gabinet).