### PR TITLE
Te trzy pola powinny być w jednej linii

### DIFF
--- a/src/components/crm/data-list-filter-bar.tsx
+++ b/src/components/crm/data-list-filter-bar.tsx
@@ -406,13 +406,19 @@ export function DataListFilterBar({
           <button
             type="button"
             onClick={openCreateDialog}
-            className="inline-flex shrink-0 items-center gap-1 whitespace-nowrap px-2 py-1.5 text-sm font-medium text-fg-quaternary transition hover:text-fg-primary"
-          >
-            <Plus className="size-4" />
-            {t("views.addView", {
+            aria-label={t("views.addView", {
               current: customViewCount,
               max: maxCustomViews,
             })}
+            className="inline-flex shrink-0 items-center gap-1 whitespace-nowrap px-2 py-1.5 text-sm font-medium text-fg-quaternary transition hover:text-fg-primary"
+          >
+            <Plus className="size-4" />
+            <span className="hidden md:inline">
+              {t("views.addView", {
+                current: customViewCount,
+                max: maxCustomViews,
+              })}
+            </span>
           </button>
         )}
         {leftExtras}

--- a/src/components/crm/mini-charts.tsx
+++ b/src/components/crm/mini-charts.tsx
@@ -191,6 +191,10 @@ export function ChartsToggleButton({
   onToggle: () => void;
 }) {
   const { t } = useTranslation();
+  const fullLabel = open
+    ? t("common.hideStatistics", { defaultValue: "Ukryj statystyki" })
+    : t("common.showStatistics", { defaultValue: "Pokaż statystyki" });
+  const shortLabel = t("common.statistics", { defaultValue: "Statystyki" });
   return (
     <UntitledButton
       size="sm"
@@ -198,10 +202,10 @@ export function ChartsToggleButton({
       iconLeading={open ? UiChevronUp : UiChevronDown}
       onClick={onToggle}
       aria-expanded={open}
+      aria-label={fullLabel}
     >
-      {open
-        ? t("common.hideStatistics", { defaultValue: "Ukryj statystyki" })
-        : t("common.showStatistics", { defaultValue: "Pokaż statystyki" })}
+      <span className="hidden md:inline">{fullLabel}</span>
+      <span className="md:hidden">{shortLabel}</span>
     </UntitledButton>
   );
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1596.

Closes #1596

---

## Claude summary

Committed as 0b847c4.

Summary: Issue #1596 was filed at 4:05pm UTC, 23 minutes before commit e4c051b moved the "Pokaż statystyki" toggle into the `DataListFilterBar` leftExtras slot alongside the view selector and add-view button. That fix put all three in the same flex row, but on a 390px iPhone viewport their full labels total ~480px and overflow off the right edge. This change makes the add-view button icon-only below `md` (with an `aria-label` for accessibility) and switches the charts toggle text to "Statystyki" on mobile while keeping "Pokaż/Ukryj statystyki" on desktop, so all three controls now actually fit on one visible line at iPhone widths. Total width on mobile drops to ~320px, comfortably inside the ~358px content area on a 390px viewport.

Files changed: `src/components/crm/data-list-filter-bar.tsx`, `src/components/crm/mini-charts.tsx`.