### PR TITLE
Dodaj zdarzenie 

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -105,6 +105,11 @@ interface AppointmentDialogProps {
   /** Pre-select an employee when opening — used by the day-by-employee
    *  calendar view so clicking inside a column carries the column owner. */
   defaultEmployeeId?: string;
+  /** Optional handler to switch from creating a patient appointment to
+   *  creating a non-patient calendar event (meeting / training that blocks
+   *  time without booking a wizyta). When provided, a "Utwórz zdarzenie"
+   *  link is rendered at the top of the dialog. Issue #1598. */
+  onSwitchToEvent?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -199,6 +204,7 @@ export function AppointmentDialog({
   defaultTime,
   defaultEndTime,
   defaultEmployeeId,
+  onSwitchToEvent,
 }: AppointmentDialogProps) {
   const { t, i18n } = useTranslation();
   const dateFnsLocale = i18n.resolvedLanguage === "pl" ? pl : undefined;
@@ -1012,6 +1018,29 @@ export function AppointmentDialog({
           <GripHorizontal className="size-4" />
           <span>{t("gabinet.appointments.dragToMove", "Przeciągnij, aby przesunąć")}</span>
         </div>
+
+        {/* "Utwórz zdarzenie zamiast wizyty" — lets the user pivot from the
+            appointment form to the EventDialog when the calendar slot is for
+            a non-patient block (meeting / training). The toolbar already
+            exposes both options, but users who jumped straight into the
+            appointment dialog by tapping a slot had no way to switch without
+            cancelling first (issue #1598). Carries over the date/time/employee
+            defaults via the parent handler. */}
+        {onSwitchToEvent && (
+          <div className="flex items-center justify-center border-b bg-background px-4 py-2 text-xs">
+            <button
+              type="button"
+              onClick={onSwitchToEvent}
+              className="font-medium text-primary hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring rounded"
+              data-testid="appointment-switch-to-event-button"
+            >
+              {t(
+                "gabinet.appointments.createEventInstead",
+                "Utwórz zdarzenie (zebranie, szkolenie)",
+              )}
+            </button>
+          </div>
+        )}
 
         {/* 3-panel layout: stacks vertically on mobile */}
         <div className="relative flex flex-col md:flex-row md:h-[600px]">

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -1832,6 +1832,14 @@ function GabinetCalendarPage() {
           defaultTime={createDefaultTime}
           defaultEndTime={createDefaultEndTime}
           defaultEmployeeId={createDefaultEmployeeId}
+          onSwitchToEvent={() => {
+            // Pivot to the EventDialog while preserving the date/time/employee
+            // the user already picked by clicking a calendar slot. The shared
+            // createDefault* state means the EventDialog will re-seed with the
+            // same values when it opens (issue #1598).
+            setCreateDialogOpen(false);
+            setEventDialogOpen(true);
+          }}
         />
 
         {/* Create event dialog (non-patient calendar block — issue #1555) */}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1598.

Closes #1598

---

## Claude summary

Summary: when a user taps a calendar slot, the AppointmentDialog opens directly into the patient/treatment form — the toolbar's two-option dropdown ("Nowa wizyta" / "Nowe zdarzenie") is hidden once the dialog is up. Added a small "Utwórz zdarzenie (zebranie, szkolenie)" link right under the drag bar (where the user pointed in the screenshot) that closes the appointment dialog and opens the existing `EventDialog` with the same date / time / employee defaults the user already picked. The event flow itself was already implemented from #1555; this just makes it reachable from inside the appointment dialog on mobile.