### PR TITLE
Zegar

### DIFF
--- a/src/components/crm/activity-detail-drawer.tsx
+++ b/src/components/crm/activity-detail-drawer.tsx
@@ -274,6 +274,7 @@ export function ActivityDetailDrawer({
                   />
                   <Input
                     type="time"
+                    step={300}
                     className="w-auto"
                     value={editDueTime}
                     onChange={(e) => setEditDueTime(e.target.value)}
@@ -292,6 +293,7 @@ export function ActivityDetailDrawer({
                   />
                   <Input
                     type="time"
+                    step={300}
                     className="w-auto"
                     value={editEndTime}
                     onChange={(e) => setEditEndTime(e.target.value)}

--- a/src/components/crm/activity-form.tsx
+++ b/src/components/crm/activity-form.tsx
@@ -310,6 +310,7 @@ export function ActivityForm({
           <div className="relative flex items-center">
             <Input
               type="time"
+              step={300}
               className="w-auto pr-8"
               value={startTime}
               onChange={(e) => setStartTime(e.target.value)}

--- a/src/components/data-table/editable-cell.tsx
+++ b/src/components/data-table/editable-cell.tsx
@@ -189,7 +189,7 @@ export function EditableCell({
         );
       case "time":
         return (
-          <Input ref={inputRef} type="time" value={editValue ?? ""} onChange={(e) => setEditValue(e.target.value)} {...inputProps} />
+          <Input ref={inputRef} type="time" step={300} value={editValue ?? ""} onChange={(e) => setEditValue(e.target.value)} {...inputProps} />
         );
       case "datetime":
         return (

--- a/src/components/forms/leave-form.tsx
+++ b/src/components/forms/leave-form.tsx
@@ -227,6 +227,7 @@ export function LeaveForm({
             <Label>{t("schedule.startTime")}</Label>
             <Input
               type="time"
+              step={300}
               value={startTime}
               onChange={(e) => setStartTime(e.target.value)}
             />
@@ -236,6 +237,7 @@ export function LeaveForm({
             <Label>{t("schedule.endTime")}</Label>
             <Input
               type="time"
+              step={300}
               value={endTime}
               onChange={(e) => setEndTime(e.target.value)}
             />

--- a/src/components/gabinet/employee-schedule-manager.tsx
+++ b/src/components/gabinet/employee-schedule-manager.tsx
@@ -204,6 +204,7 @@ export function EmployeeScheduleManager({ employeeId }: EmployeeScheduleManagerP
                         <Label>{t("gabinet.schedules.startTime")}</Label>
                         <Input
                           type="time"
+                          step={300}
                           value={formData.startTime ?? ""}
                           onChange={(e) => setFormData((prev) => ({ ...prev, startTime: e.target.value }))}
                         />
@@ -212,6 +213,7 @@ export function EmployeeScheduleManager({ employeeId }: EmployeeScheduleManagerP
                         <Label>{t("gabinet.schedules.endTime")}</Label>
                         <Input
                           type="time"
+                          step={300}
                           value={formData.endTime ?? ""}
                           onChange={(e) => setFormData((prev) => ({ ...prev, endTime: e.target.value }))}
                         />
@@ -223,6 +225,7 @@ export function EmployeeScheduleManager({ employeeId }: EmployeeScheduleManagerP
                         <Label>{t("gabinet.schedules.breakStart")}</Label>
                         <Input
                           type="time"
+                          step={300}
                           value={formData.breakStartTime ?? ""}
                           onChange={(e) => setFormData((prev) => ({ ...prev, breakStartTime: e.target.value || undefined }))}
                         />
@@ -231,6 +234,7 @@ export function EmployeeScheduleManager({ employeeId }: EmployeeScheduleManagerP
                         <Label>{t("gabinet.schedules.breakEnd")}</Label>
                         <Input
                           type="time"
+                          step={300}
                           value={formData.breakEndTime ?? ""}
                           onChange={(e) => setFormData((prev) => ({ ...prev, breakEndTime: e.target.value || undefined }))}
                         />

--- a/src/components/gabinet/flexible-schedule-editor.tsx
+++ b/src/components/gabinet/flexible-schedule-editor.tsx
@@ -640,6 +640,7 @@ export function FlexibleScheduleEditor({
                     />
                     <Input
                       type="time"
+                      step={300}
                       className="h-7 w-22"
                       value={h.startTime}
                       onChange={(e) =>
@@ -649,6 +650,7 @@ export function FlexibleScheduleEditor({
                     />
                     <Input
                       type="time"
+                      step={300}
                       className="h-7 w-22"
                       value={h.endTime}
                       onChange={(e) =>
@@ -660,6 +662,7 @@ export function FlexibleScheduleEditor({
                       <div className="flex items-center gap-1">
                         <Input
                           type="time"
+                          step={300}
                           className="h-7 w-22"
                           value={h.breakStart}
                           onChange={(e) =>
@@ -674,6 +677,7 @@ export function FlexibleScheduleEditor({
                         <span className="text-xs text-muted-foreground">–</span>
                         <Input
                           type="time"
+                          step={300}
                           className="h-7 w-22"
                           value={h.breakEnd}
                           onChange={(e) =>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
@@ -175,6 +175,7 @@ function SchedulingSettings() {
             />
             <Input
               type="time"
+              step={300}
               className="h-8 w-24"
               value={h.startTime}
               onChange={(e) => updateDay(h.dayOfWeek, "startTime", e.target.value)}
@@ -182,6 +183,7 @@ function SchedulingSettings() {
             />
             <Input
               type="time"
+              step={300}
               className="h-8 w-24"
               value={h.endTime}
               onChange={(e) => updateDay(h.dayOfWeek, "endTime", e.target.value)}
@@ -191,6 +193,7 @@ function SchedulingSettings() {
               <div className="flex items-center gap-1">
                 <Input
                   type="time"
+                  step={300}
                   className="h-8 w-24"
                   value={h.breakStart}
                   onChange={(e) => updateDay(h.dayOfWeek, "breakStart", e.target.value)}
@@ -199,6 +202,7 @@ function SchedulingSettings() {
                 <span className="text-xs text-muted-foreground">–</span>
                 <Input
                   type="time"
+                  step={300}
                   className="h-8 w-24"
                   value={h.breakEnd}
                   onChange={(e) => updateDay(h.dayOfWeek, "breakEnd", e.target.value)}

--- a/src/routes/_app/_auth/dashboard/_layout.setup.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.setup.tsx
@@ -341,6 +341,7 @@ function SetupWizard() {
                     <>
                       <Input
                         type="time"
+                        step={300}
                         value={schedule[day]?.start || ""}
                         onChange={(e) => updateSchedule(day, "start", e.target.value)}
                         className="w-32"
@@ -348,6 +349,7 @@ function SetupWizard() {
                       <span className="text-muted-foreground">-</span>
                       <Input
                         type="time"
+                        step={300}
                         value={schedule[day]?.end || ""}
                         onChange={(e) => updateSchedule(day, "end", e.target.value)}
                         className="w-32"

--- a/src/routes/_app/patient/_layout.appointments.tsx
+++ b/src/routes/_app/patient/_layout.appointments.tsx
@@ -259,6 +259,7 @@ function PatientAppointments() {
                 <Input
                   id="reschedule-time"
                   type="time"
+                  step={300}
                   value={requestedTime}
                   onChange={(e) => setRequestedTime(e.target.value)}
                 />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1610.

Closes #1610

---

## Claude summary

Committed. Summary:

Added `step={300}` (5 minutes) to all `<Input type="time">` fields across the app that previously had no `step` attribute, so the native time picker advances in 5-minute increments instead of one minute at a time. Affected areas: CRM activity form/detail drawer, generic editable-cell, gabinet employee schedule manager, flexible schedule editor, scheduling settings, onboarding setup, patient portal reschedule, and leave form.

The appointment dialogs (`appointment-dialog.tsx`, `appointment-preview-content.tsx`, `appointments.$appointmentId.lazy.tsx`) already use `step={900}` with explicit 15-minute snap logic (`snapTimeTo15Min`), so they remain at 15-min slots — they don't have the "every minute" issue the user reported. The event-dialog was already `step={300}`.