### PR TITLE
wybór klienta 

### DIFF
--- a/src/components/application/table/table.tsx
+++ b/src/components/application/table/table.tsx
@@ -147,7 +147,7 @@ const TableHeader = <T extends object>({ columns, children, bordered = true, cla
             }
         >
             {selectionBehavior === "toggle" && (
-                <AriaColumn className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-16 md:pl-5" : "w-18 md:pl-6")}>
+                <AriaColumn className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-20 md:pl-5" : "w-24 md:pl-6")}>
                     {selectionMode === "multiple" && (
                         <Checkbox
                             slot="selection"
@@ -241,7 +241,7 @@ const TableRow = <T extends object>({ columns, children, className, highlightSel
             }
         >
             {selectionBehavior === "toggle" && (
-                <AriaCell className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-16 md:pl-5" : "w-18 md:pl-6")}>
+                <AriaCell className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-20 md:pl-5" : "w-24 md:pl-6")}>
                     <Checkbox
                         slot="selection"
                         size="md"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1516.

Closes #1516

---

## Claude summary

NOT_A_BUG: this issue is already resolved and merged. PR #1531 ("obszar") was squash-merged to `main` at 2026-06-12T08:54:55Z. The branch `claude/issue-1516` already contains the fix at commit `0553144`. 

The bulk-select column in `src/components/application/table/table.tsx:150,244` has been widened from `w-16`/`w-18` (64/72px) to `w-20`/`w-24` (80/96px) for both the header `<AriaColumn>` and body `<AriaCell>`. Combined with the row-click→toggle behavior added in #1604 (commit `519c108`), the buffer between the row edge and the patient-card `<Link>` is now ~100–120px, which absorbs the misclicks @aslocka reported.

Nothing further to commit on this branch — working tree is clean and matches `main` HEAD.