### PR TITLE
dodaj tu 

### DIFF
--- a/src/components/gabinet/calendar/event-dialog.tsx
+++ b/src/components/gabinet/calendar/event-dialog.tsx
@@ -40,6 +40,12 @@ interface EventDialogProps {
   defaultTime?: string;
   defaultEndTime?: string;
   defaultEmployeeId?: string;
+  /**
+   * Pre-select multiple employees by userId (e.g. when opened from a bulk
+   * action on the employees list — issue #1614). Takes precedence over
+   * defaultEmployeeId when provided and non-empty.
+   */
+  defaultEmployeeIds?: string[];
   onManageEventTypes?: () => void;
 }
 
@@ -64,6 +70,7 @@ export function EventDialog({
   defaultTime,
   defaultEndTime,
   defaultEmployeeId,
+  defaultEmployeeIds,
   onManageEventTypes,
 }: EventDialogProps) {
   const { t } = useTranslation();
@@ -93,7 +100,11 @@ export function EventDialog({
   // Multiple selections create one scheduled activity per employee so the
   // event renders in every selected employee's calendar column (issue #1608).
   const [employeeIds, setEmployeeIds] = useState<string[]>(
-    defaultEmployeeId ? [defaultEmployeeId] : [],
+    defaultEmployeeIds && defaultEmployeeIds.length > 0
+      ? defaultEmployeeIds
+      : defaultEmployeeId
+      ? [defaultEmployeeId]
+      : [],
   );
   const [employeePickerOpen, setEmployeePickerOpen] = useState(false);
   const [categoryId, setCategoryId] = useState<
@@ -111,10 +122,16 @@ export function EventDialog({
     setEndTime(
       defaultEndTime ?? computeEndTime(defaultTime ?? "09:00", 60),
     );
-    setEmployeeIds(defaultEmployeeId ? [defaultEmployeeId] : []);
+    setEmployeeIds(
+      defaultEmployeeIds && defaultEmployeeIds.length > 0
+        ? defaultEmployeeIds
+        : defaultEmployeeId
+        ? [defaultEmployeeId]
+        : [],
+    );
     setCategoryId(undefined);
     setNotes("");
-  }, [open, defaultDate, defaultTime, defaultEndTime, defaultEmployeeId]);
+  }, [open, defaultDate, defaultTime, defaultEndTime, defaultEmployeeId, defaultEmployeeIds]);
 
   // Keep endTime ≥ startTime as user edits start
   const handleStartTimeChange = useCallback(

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -30,6 +30,7 @@ import { applyFilterConditions } from "@/hooks/use-saved-views";
 import { PlateText } from "@/components/plate-text";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { EmployeeForm } from "@/components/forms/employee-form";
+import { EventDialog } from "@/components/gabinet/calendar/event-dialog";
 
 // shadcn/studio statistics blocks
 import StatisticsOrderCard from "@/components/shadcn-studio/blocks/statistics-order-card";
@@ -62,6 +63,8 @@ function EmployeesIndex() {
   const [showCreate, setShowCreate] = useState(false);
   const [searchValue, setSearchValue] = useState("");
   const [activeFilters, setActiveFilters] = useState<FilterCondition[]>([]);
+  const [eventDialogOpen, setEventDialogOpen] = useState(false);
+  const [eventDefaultEmployeeIds, setEventDefaultEmployeeIds] = useState<string[]>([]);
 
   const filterableFields = useMemo((): FieldDef[] => [
     { id: "firstName", label: t("gabinet.employees.firstName"), type: "text" },
@@ -264,6 +267,12 @@ function EmployeesIndex() {
         for (const row of selectedRows) {
           await removeEmployee({ organizationId, employeeId: row._id as Id<"gabinetEmployees"> });
         }
+      } else if (action === "addEvent") {
+        // EventDialog identifies employees by userId (it creates one
+        // scheduledActivity per resourceId=userId so the block lands in each
+        // selected employee's calendar column).
+        setEventDefaultEmployeeIds(selectedRows.map((row) => row.userId));
+        setEventDialogOpen(true);
       }
     },
     [removeEmployee, organizationId]
@@ -342,6 +351,7 @@ function EmployeesIndex() {
         enableBulkSelect
         hiddenColumnIds={hiddenColumnIds}
         bulkActions={[
+          { label: t("gabinet.events.create", { defaultValue: "Nowe zdarzenie" }), value: "addEvent" },
           { label: t("common.delete"), value: "delete", variant: "destructive" },
         ]}
         onBulkAction={handleBulkAction}
@@ -368,6 +378,13 @@ function EmployeesIndex() {
         organizationId={organizationId}
         tagDefinitions={tags}
         categoryDefinitions={categories}
+      />
+
+      <EventDialog
+        organizationId={organizationId}
+        open={eventDialogOpen}
+        onOpenChange={setEventDialogOpen}
+        defaultEmployeeIds={eventDefaultEmployeeIds}
       />
     </div>
   );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1614.

Closes #1614

---

## Claude summary

Committed.

The screenshot showed the bulk-actions dropdown on the Gabinet employees list (`/dashboard/gabinet/employees`) with only "Usuń" (Delete), and the author asked to add a way to create an event from there. Now the dropdown also contains "Nowe zdarzenie" (New event), which opens the existing `EventDialog` with the selected employees pre-filled — one `scheduledActivity` per employee, so the block appears in each of their calendar columns (matching the multi-employee behavior introduced in #1608).

Changes:
- `src/components/gabinet/calendar/event-dialog.tsx:43-47,73,103-107,125-131` — added optional `defaultEmployeeIds: string[]` prop that takes precedence over the singular `defaultEmployeeId`.
- `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx:33,66-67,270-275,354,382-387` — new "addEvent" bulk action, state, and dialog render.

## Follow-ups
- Rename `defaultEmployeeId` in EventDialog to `defaultUserId`: the prop is a userId, not a `gabinetEmployees._id`, which is confusing across call sites.