### PR TITLE
Rename `defaultEmployeeId` in EventDialog to `defaultUserId`

### DIFF
--- a/src/components/gabinet/calendar/event-dialog.tsx
+++ b/src/components/gabinet/calendar/event-dialog.tsx
@@ -39,13 +39,13 @@ interface EventDialogProps {
   defaultDate?: string;
   defaultTime?: string;
   defaultEndTime?: string;
-  defaultEmployeeId?: string;
+  defaultUserId?: string;
   /**
    * Pre-select multiple employees by userId (e.g. when opened from a bulk
    * action on the employees list — issue #1614). Takes precedence over
-   * defaultEmployeeId when provided and non-empty.
+   * defaultUserId when provided and non-empty.
    */
-  defaultEmployeeIds?: string[];
+  defaultUserIds?: string[];
   onManageEventTypes?: () => void;
 }
 
@@ -69,8 +69,8 @@ export function EventDialog({
   defaultDate,
   defaultTime,
   defaultEndTime,
-  defaultEmployeeId,
-  defaultEmployeeIds,
+  defaultUserId,
+  defaultUserIds,
   onManageEventTypes,
 }: EventDialogProps) {
   const { t } = useTranslation();
@@ -100,10 +100,10 @@ export function EventDialog({
   // Multiple selections create one scheduled activity per employee so the
   // event renders in every selected employee's calendar column (issue #1608).
   const [employeeIds, setEmployeeIds] = useState<string[]>(
-    defaultEmployeeIds && defaultEmployeeIds.length > 0
-      ? defaultEmployeeIds
-      : defaultEmployeeId
-      ? [defaultEmployeeId]
+    defaultUserIds && defaultUserIds.length > 0
+      ? defaultUserIds
+      : defaultUserId
+      ? [defaultUserId]
       : [],
   );
   const [employeePickerOpen, setEmployeePickerOpen] = useState(false);
@@ -123,15 +123,15 @@ export function EventDialog({
       defaultEndTime ?? computeEndTime(defaultTime ?? "09:00", 60),
     );
     setEmployeeIds(
-      defaultEmployeeIds && defaultEmployeeIds.length > 0
-        ? defaultEmployeeIds
-        : defaultEmployeeId
-        ? [defaultEmployeeId]
+      defaultUserIds && defaultUserIds.length > 0
+        ? defaultUserIds
+        : defaultUserId
+        ? [defaultUserId]
         : [],
     );
     setCategoryId(undefined);
     setNotes("");
-  }, [open, defaultDate, defaultTime, defaultEndTime, defaultEmployeeId, defaultEmployeeIds]);
+  }, [open, defaultDate, defaultTime, defaultEndTime, defaultUserId, defaultUserIds]);
 
   // Keep endTime ≥ startTime as user edits start
   const handleStartTimeChange = useCallback(

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -1850,7 +1850,7 @@ function GabinetCalendarPage() {
           defaultDate={createDefaultDate}
           defaultTime={createDefaultTime}
           defaultEndTime={createDefaultEndTime}
-          defaultEmployeeId={createDefaultEmployeeId}
+          defaultUserId={createDefaultEmployeeId}
           onManageEventTypes={() => setEventTypesSlideoutOpen(true)}
         />
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -384,7 +384,7 @@ function EmployeesIndex() {
         organizationId={organizationId}
         open={eventDialogOpen}
         onOpenChange={setEventDialogOpen}
-        defaultEmployeeIds={eventDefaultEmployeeIds}
+        defaultUserIds={eventDefaultEmployeeIds}
       />
     </div>
   );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1617.

Closes #1617

---

## Claude summary

Renamed `EventDialog`'s `defaultEmployeeId`/`defaultEmployeeIds` props to `defaultUserId`/`defaultUserIds` (they hold userIds, not `gabinetEmployees._id`), and updated the two call sites in the calendar and employees routes. `AppointmentDialog` was intentionally left alone — out of scope for this issue. Typecheck clean for the touched files; the two failures the portable typecheck surfaces are pre-existing in unrelated files.

## Follow-ups
- Rename AppointmentDialog defaultEmployeeId to defaultUserId: same userId-vs-employeeId confusion as #1617 lives on `src/components/gabinet/calendar/appointment-dialog.tsx:107` and is shared with the same `createDefaultEmployeeId` state in the calendar route.
- Rename calendar route state `createDefaultEmployeeId` to `createDefaultUserId`: `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx:181` holds a userId; aligning the local name with the prop rename keeps the codebase coherent.
- Rename employees route state `eventDefaultEmployeeIds` to `eventDefaultUserIds`: `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx:67` is also userIds; rename for consistency with the new EventDialog prop.
- Fix pre-existing typecheck error in migration-health-banner: `src/components/migration-health-banner.tsx:66` `Operator '>=' cannot be applied to types 'never' and 'string'`.
- Fix pre-existing typecheck error in patient appointments route: `src/routes/_app/patient/_layout.appointments.tsx:48` `Type instantiation is excessively deep and possibly infinite`.