### PR TITLE
Rename AppointmentDialog defaultEmployeeId to defaultUserId

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -103,8 +103,9 @@ interface AppointmentDialogProps {
   defaultTime?: string;
   defaultEndTime?: string;
   /** Pre-select an employee when opening — used by the day-by-employee
-   *  calendar view so clicking inside a column carries the column owner. */
-  defaultEmployeeId?: string;
+   *  calendar view so clicking inside a column carries the column owner.
+   *  Holds a userId (gabinetAppointments.employeeId is a users._id). */
+  defaultUserId?: string;
   /** Optional handler to switch from creating a patient appointment to
    *  creating a non-patient calendar event (meeting / training that blocks
    *  time without booking a wizyta). When provided, a "Utwórz zdarzenie"
@@ -203,7 +204,7 @@ export function AppointmentDialog({
   defaultDate,
   defaultTime,
   defaultEndTime,
-  defaultEmployeeId,
+  defaultUserId,
   onSwitchToEvent,
 }: AppointmentDialogProps) {
   const { t, i18n } = useTranslation();
@@ -266,7 +267,7 @@ export function AppointmentDialog({
   // -------------------------------------------------------------------------
 
   const [treatmentId, setTreatmentId] = useState("");
-  const [employeeId, setEmployeeId] = useState(defaultEmployeeId ?? "");
+  const [employeeId, setEmployeeId] = useState(defaultUserId ?? "");
   const [patientId, setPatientId] = useState("");
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(
     defaultDate ? new Date(defaultDate + "T00:00:00") : undefined,
@@ -937,12 +938,12 @@ export function AppointmentDialog({
       // Seed employee from prop when opening so the day-by-employee view's
       // column selection survives even though the auto-select effect below
       // would otherwise overwrite it once treatments load.
-      if (defaultEmployeeId) {
-        setEmployeeId(defaultEmployeeId);
+      if (defaultUserId) {
+        setEmployeeId(defaultUserId);
       }
     } else {
       setTreatmentId("");
-      setEmployeeId(defaultEmployeeId ?? "");
+      setEmployeeId(defaultUserId ?? "");
       setPatientId("");
       setSelectedDate(
         defaultDate ? new Date(defaultDate + "T00:00:00") : undefined,
@@ -964,7 +965,7 @@ export function AppointmentDialog({
       setPendingPatientLabel(null);
       setRecordWalkIn(false);
     }
-  }, [open, defaultDate, defaultTime, defaultEndTime, defaultEmployeeId]);
+  }, [open, defaultDate, defaultTime, defaultEndTime, defaultUserId]);
 
   // -------------------------------------------------------------------------
   // Determine which panels are active

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -1831,7 +1831,7 @@ function GabinetCalendarPage() {
           defaultDate={createDefaultDate}
           defaultTime={createDefaultTime}
           defaultEndTime={createDefaultEndTime}
-          defaultEmployeeId={createDefaultEmployeeId}
+          defaultUserId={createDefaultEmployeeId}
           onSwitchToEvent={() => {
             // Pivot to the EventDialog while preserving the date/time/employee
             // the user already picked by clicking a calendar slot. The shared


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1619.

Closes #1619

---

## Claude summary

Renamed `AppointmentDialog`'s `defaultEmployeeId` prop to `defaultUserId` in `src/components/gabinet/calendar/appointment-dialog.tsx` (interface, destructure, two `useEffect` branches, the `useState` seed, and the dep array) plus the lone call site in `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx:1834`. Verified the prop is a userId — internal logic looks it up via `emp.userId === employeeId` (line 483), passes it as `userId` to the availability query (line 560), and casts it to `Id<"users">` when calling the create action (line 864). Mirrors the #1617 rename for `EventDialog`. The local `employeeId` state name is unchanged (out of scope, and matches the underlying `gabinetAppointments.employeeId` column, which is itself a `users._id`). Committed as `4a5cd27`.