### PR TITLE
Rename employees route state `eventDefaultEmployeeIds` to `eventDefaultUserIds`

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -64,7 +64,7 @@ function EmployeesIndex() {
   const [searchValue, setSearchValue] = useState("");
   const [activeFilters, setActiveFilters] = useState<FilterCondition[]>([]);
   const [eventDialogOpen, setEventDialogOpen] = useState(false);
-  const [eventDefaultEmployeeIds, setEventDefaultEmployeeIds] = useState<string[]>([]);
+  const [eventDefaultUserIds, setEventDefaultUserIds] = useState<string[]>([]);
 
   const filterableFields = useMemo((): FieldDef[] => [
     { id: "firstName", label: t("gabinet.employees.firstName"), type: "text" },
@@ -271,7 +271,7 @@ function EmployeesIndex() {
         // EventDialog identifies employees by userId (it creates one
         // scheduledActivity per resourceId=userId so the block lands in each
         // selected employee's calendar column).
-        setEventDefaultEmployeeIds(selectedRows.map((row) => row.userId));
+        setEventDefaultUserIds(selectedRows.map((row) => row.userId));
         setEventDialogOpen(true);
       }
     },
@@ -384,7 +384,7 @@ function EmployeesIndex() {
         organizationId={organizationId}
         open={eventDialogOpen}
         onOpenChange={setEventDialogOpen}
-        defaultUserIds={eventDefaultEmployeeIds}
+        defaultUserIds={eventDefaultUserIds}
       />
     </div>
   );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1621.

Closes #1621

---

## Claude summary

Renamed `eventDefaultEmployeeIds` → `eventDefaultUserIds` in `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx` (state declaration, setter call in `handleBulkAction`, and the prop binding to `EventDialog.defaultUserIds`). The values were already userIds, so this is a pure naming consistency change matching the EventDialog API renamed in #1617. Typecheck passes; committed as `0da1deb`.