### PR TITLE
Fix pre-existing typecheck error in migration-health-banner

### DIFF
--- a/src/components/migration-health-banner.tsx
+++ b/src/components/migration-health-banner.tsx
@@ -62,7 +62,10 @@ export function MigrationHealthBanner() {
         return;
       }
 
-      const applied = typeof data === "string" ? data : null;
+      // supabase-js types `data` from a primitive-return RPC as `null` even on
+      // success, so narrow via `unknown` to preserve the runtime guard.
+      const raw: unknown = data;
+      const applied = typeof raw === "string" ? raw : null;
       if (applied !== null && applied >= expected) {
         setState({ kind: "ok" });
       } else {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1622.

Closes #1622

---

## Claude summary

Fixed and committed.

The error was at `src/components/migration-health-banner.tsx:66`. Root cause: supabase-js's RPC type inference resolves `data` from a primitive-return RPC (`app_schema_version`, declared `Returns: string`) as `null` rather than `string | null`. As a result, `typeof data === "string"` narrows the true branch to `never`, the ternary yields `null`, and `applied !== null` narrows further to `never` — which is why `applied >= expected` errored with "Operator '>=' cannot be applied to types 'never' and 'string'".

The fix re-binds `data` to a local `unknown` variable, so the `typeof === "string"` guard narrows cleanly to `string` and the runtime check is preserved. `npm run typecheck` now passes with no errors.