### PR TITLE
Pominięcie lub możliwość dodania z tej pozycji pracownika

### DIFF
--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -1,9 +1,9 @@
 import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { convexQuery } from "@convex-dev/react-query";
 import { useAction } from "convex/react";
-import { Link } from "@tanstack/react-router";
+import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
@@ -18,8 +18,20 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
+import {
+  UserInvitationForm,
+  type UserInvitationFormData,
+} from "@/components/forms/user-invitation-form";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { Search } from "@/lib/ez-icons";
 
 const ROLES = ["doctor", "nurse", "therapist", "receptionist", "admin", "other"] as const;
@@ -112,6 +124,11 @@ export function EmployeeForm({
       .map((m) => ({ _id: m.userId, name: m.user!.name, email: m.user!.email }));
   }, [members, employees]);
 
+  const queryClient = useQueryClient();
+  const createInvitation = useAction(api.invitations.create);
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [isSendingInvite, setIsSendingInvite] = useState(false);
+
   const [userId, setUserId] = useState<string>(initialData?.userId ?? "");
   const [firstName, setFirstName] = useState(initialData?.firstName ?? "");
   const [lastName, setLastName] = useState(initialData?.lastName ?? "");
@@ -188,18 +205,61 @@ export function EmployeeForm({
               )}
             </SelectContent>
           </Select>
-          {availableUsers.length === 0 && (
-            <p className="text-xs text-muted-foreground">
-              {t("gabinet.employees.allUsersRegistered")}{" "}
-              <Link
-                to="/dashboard/settings/team"
-                className="text-brand-secondary underline hover:no-underline"
-              >
-                {t("gabinet.employees.inviteTeamMember", { defaultValue: "Zaproś nowego członka zespołu" })}
-              </Link>
-            </p>
-          )}
+          <p className="text-xs text-muted-foreground">
+            {availableUsers.length === 0 && (
+              <>{t("gabinet.employees.allUsersRegistered")}{" "}</>
+            )}
+            <button
+              type="button"
+              onClick={() => setInviteOpen(true)}
+              className="text-brand-secondary underline hover:no-underline"
+            >
+              {t("gabinet.employees.inviteTeamMember", { defaultValue: "Zaproś nowego członka zespołu" })}
+            </button>
+          </p>
         </div>
+      )}
+
+      {requireUserSelection && (
+        <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
+          <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle>{t("team.inviteDialog.title")}</DialogTitle>
+              <DialogDescription>
+                {t("team.inviteDialog.description")}
+              </DialogDescription>
+            </DialogHeader>
+            <UserInvitationForm
+              defaultModule="gabinet"
+              isSubmitting={isSendingInvite}
+              onCancel={() => setInviteOpen(false)}
+              onSubmit={async (data: UserInvitationFormData) => {
+                setIsSendingInvite(true);
+                try {
+                  await createInvitation({
+                    organizationId,
+                    email: data.email,
+                    role: data.role as "admin" | "member" | "viewer" | "owner",
+                    module: data.module,
+                    moduleData: data.moduleData,
+                  });
+                  toast.success(t("team.invitationSent"));
+                  void queryClient.invalidateQueries({
+                    queryKey: supabaseKeys.invitations.list(organizationId),
+                  });
+                  void queryClient.invalidateQueries({
+                    queryKey: supabaseKeys.teamMemberships.list(organizationId),
+                  });
+                  setInviteOpen(false);
+                } catch (e) {
+                  toast.error(e instanceof Error ? e.message : String(e));
+                } finally {
+                  setIsSendingInvite(false);
+                }
+              }}
+            />
+          </DialogContent>
+        </Dialog>
       )}
 
       {/* Name fields */}

--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -82,12 +82,14 @@ interface UserInvitationFormProps {
   onSubmit: (data: UserInvitationFormData) => void;
   onCancel: () => void;
   isSubmitting?: boolean;
+  defaultModule?: InviteModule;
 }
 
 export function UserInvitationForm({
   onSubmit,
   onCancel,
   isSubmitting = false,
+  defaultModule = "none",
 }: UserInvitationFormProps) {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
@@ -103,7 +105,7 @@ export function UserInvitationForm({
   );
 
   // Gabinet-specific data sources — only fetched lazily once Gabinet is picked.
-  const [module, setModule] = useState<InviteModule>("none");
+  const [module, setModule] = useState<InviteModule>(defaultModule);
 
   const listActiveTreatments = useAction(api.gabinet.treatments.listActive);
   const { data: treatments } = useQuery({


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1624.

Closes #1624

---

## Claude summary

Committed.

Summary of the fix for #1624: in the gabinet "Dodaj pracownika" sheet, the "Zaproś nowego członka zespołu" link previously navigated the user to `/dashboard/settings/team`, forcing them out of the gabinet flow. I replaced that link with an inline button that opens a Dialog containing the existing `UserInvitationForm` (now accepting a `defaultModule` prop, pre-set to `"gabinet"` so the invitee becomes a gabinet employee automatically on accept). The invite link is now always shown — not only when all members are already employees — so the user can invite from this position whenever needed. On success the invitation is sent, a toast appears, and the dialog closes; the gabinet employee sheet stays open. Typecheck passes (`tsc -p tsconfig.app.json`).

Files changed: `src/components/forms/employee-form.tsx` (inline invite dialog), `src/components/forms/user-invitation-form.tsx` (new `defaultModule` prop).