### PR TITLE
Przeprowadź wizytę 

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2896,6 +2896,7 @@
       "close": "Close",
       "saveChanges": "Save changes",
       "closeAndSettle": "Settle visit",
+      "performTreatment": "Perform treatment",
       "settleDesc": "Record payment and optionally close the appointment as completed.",
       "settleMarkCompleted": "Mark appointment as completed",
       "settleNothingToDo": "Enter an amount or check the close option.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2927,6 +2927,7 @@
       "close": "Zamknij",
       "saveChanges": "Zapisz zmiany",
       "closeAndSettle": "Rozlicz wizytę",
+      "performTreatment": "Przeprowadź zabieg",
       "settleDesc": "Zarejestruj płatność i opcjonalnie zamknij wizytę jako zakończoną.",
       "settleMarkCompleted": "Oznacz wizytę jako zakończoną",
       "settleNothingToDo": "Wpisz kwotę lub zaznacz zamknięcie wizyty.",

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -70,6 +70,7 @@ import {
   OctagonX,
   Phone,
   PlayCircle,
+  Sparkles,
   Stethoscope,
   User,
   XCircle,
@@ -1400,6 +1401,26 @@ export function AppointmentPreviewContent({
             : t("gabinet.appointmentDetail.closeAndSettle", "Rozlicz wizytę")}
         </Button>
       </div>
+
+      {/* Perform treatment shortcut — issue #1629. Sends staff straight to the
+          Dokumentacja tab where they can attach before/after photos, fill the
+          treatment card, and complete the per-appointment paperwork. */}
+      <Button
+        asChild
+        size="sm"
+        variant="outline"
+        className="h-9 w-full text-xs"
+      >
+        <Link
+          to="/dashboard/gabinet/appointments/$appointmentId"
+          params={{ appointmentId: appointment._id }}
+          search={{ tab: "documentation" }}
+          onClick={onClose}
+        >
+          <Sparkles className="mr-1.5 size-3.5" />
+          {t("gabinet.appointmentDetail.performTreatment", "Przeprowadź zabieg")}
+        </Link>
+      </Button>
     </div>
 
     <Dialog

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -2697,7 +2697,11 @@ function AppointmentDetail() {
         sidebarExtra={sidebarExtra}
         tabs={tabs}
         defaultTab={
-          tabSearch === "payments" ? t("gabinet.payments.payments") : undefined
+          tabSearch === "payments"
+            ? t("gabinet.payments.payments")
+            : tabSearch === "documentation"
+              ? t("gabinet.appointments.tabs.documentation", "Dokumentacja")
+              : undefined
         }
       />
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.tsx
@@ -1,13 +1,18 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 type AppointmentSearch = {
-  tab?: "payments";
+  tab?: "payments" | "documentation";
 };
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/appointments/$appointmentId"
 )({
   validateSearch: (search: Record<string, unknown>): AppointmentSearch => ({
-    tab: search.tab === "payments" ? "payments" : undefined,
+    tab:
+      search.tab === "payments"
+        ? "payments"
+        : search.tab === "documentation"
+          ? "documentation"
+          : undefined,
   }),
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1629.

Closes #1629

---

## Claude summary

Committed. Summary of the change:

The calendar appointment preview popover now has a full-width "Przeprowadź zabieg" button below the existing Edytuj / Zapisz / Rozlicz action row. It deep-links to `/dashboard/gabinet/appointments/$appointmentId?tab=documentation`, which lands the user on the existing Dokumentacja tab where they can attach before/after photos, fill the treatment card, and add supporting documents — the exact workflow the issue describes.

Visibility is implicitly employee-only: the preview is only used inside `_app/_auth/dashboard/_layout.gabinet.calendar.*`. Patients use a separate portal flow (`_app/patient/...`) that never reaches this component, so no extra role check was needed.

Files changed:
- `src/components/gabinet/calendar/appointment-preview-content.tsx` — new button + Sparkles icon import
- `src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.tsx` — accept `tab=documentation` in `validateSearch`
- `src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx` — honor `tab=documentation` in `defaultTab`
- `public/locales/{pl,en}/translation.json` — new `performTreatment` string