### PR TITLE
większy odstęp

### DIFF
--- a/src/components/application/table/table.tsx
+++ b/src/components/application/table/table.tsx
@@ -147,7 +147,7 @@ const TableHeader = <T extends object>({ columns, children, bordered = true, cla
             }
         >
             {selectionBehavior === "toggle" && (
-                <AriaColumn className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-20 md:pl-5" : "w-24 md:pl-6")}>
+                <AriaColumn className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-24 md:pl-5" : "w-28 md:pl-6")}>
                     {selectionMode === "multiple" && (
                         <Checkbox
                             slot="selection"
@@ -241,7 +241,7 @@ const TableRow = <T extends object>({ columns, children, className, highlightSel
             }
         >
             {selectionBehavior === "toggle" && (
-                <AriaCell className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-20 md:pl-5" : "w-24 md:pl-6")}>
+                <AriaCell className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-24 md:pl-5" : "w-28 md:pl-6")}>
                     <Checkbox
                         slot="selection"
                         size="md"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1635.

Closes #1635

---

## Claude summary

Committed. Summary:

The issue (a recurring complaint from testers across #1539, #1541, #1564, #1572, #1531) is that the bulk-select column on the gabinet patients list — and every other CrmDataTable list — visually crowds the next column's avatar. The last bump (earlier today, #1531) raised it to w-20/w-24 but the tester still finds it tight.

Change: `src/components/application/table/table.tsx:150,244` — selection column width goes from w-20 → w-24 (96px) for sm and w-24 → w-28 (112px) for md. The checkbox stays anchored to the left via the existing `absolute inset-0` + `pl-4 md:pl-5/6`, so the 16px extra width turns into right-side breathing room before the avatar in the next cell.

Affects every list using `CrmDataTable`: patients, treatments, employees, companies, contacts, leads, activities, documents.

## Follow-ups
- Consider stopping the iterative width bumps and redesign the row-select interaction: testers have filed five separate "too tight / hard to hit" reports (#1539, #1541, #1564, #1516, #1635) over the bulk-select column in a short window. A more durable fix might be a dedicated `cursor-pointer` left rail with a separator, an explicit border between selection and first column, or rendering the checkbox + avatar inside the same cell so spacing is controlled in one place instead of two adjacent cells.