### PR TITLE
Consider stopping the iterative width bumps and redesign the row-select interact

### DIFF
--- a/src/components/application/table/table.tsx
+++ b/src/components/application/table/table.tsx
@@ -147,7 +147,15 @@ const TableHeader = <T extends object>({ columns, children, bordered = true, cla
             }
         >
             {selectionBehavior === "toggle" && (
-                <AriaColumn className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-24 md:pl-5" : "w-28 md:pl-6")}>
+                <AriaColumn
+                    className={cx(
+                        "relative py-2 pr-0 pl-4",
+                        // Right separator via ::before so we don't clash with the parent's
+                        // [&>tr>th]:after rule that draws the header bottom border.
+                        "before:pointer-events-none before:absolute before:inset-y-0 before:right-0 before:w-px before:bg-border-secondary before:content-['']",
+                        size === "sm" ? "w-16 md:pl-5" : "w-20 md:pl-6",
+                    )}
+                >
                     {selectionMode === "multiple" && (
                         <Checkbox
                             slot="selection"
@@ -241,7 +249,15 @@ const TableRow = <T extends object>({ columns, children, className, highlightSel
             }
         >
             {selectionBehavior === "toggle" && (
-                <AriaCell className={cx("relative py-2 pr-0 pl-4", size === "sm" ? "w-24 md:pl-5" : "w-28 md:pl-6")}>
+                <AriaCell
+                    className={cx(
+                        "relative py-2 pr-0 pl-4",
+                        // Right separator via ::before so we don't clash with the parent's
+                        // [&>td]:after rule that draws the row bottom border.
+                        "before:pointer-events-none before:absolute before:inset-y-0 before:right-0 before:w-px before:bg-border-secondary before:content-['']",
+                        size === "sm" ? "w-16 md:pl-5" : "w-20 md:pl-6",
+                    )}
+                >
                     <Checkbox
                         slot="selection"
                         size="md"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1637.

Closes #1637

---

## Claude summary

Committed.

Summary of the change in `src/components/application/table/table.tsx`:

The recurring "too tight / hard to hit" complaints had two distinct halves. The hit-target half was already solved by #1594 (row body clicks toggle selection). The "too tight" half kept resurfacing because empty space in a wide column doesn't read as intentional gap — testers saw the avatar as "hugging" the checkbox even with ~100px of nothing between them.

I added a 1px vertical separator at the right edge of the selection cell (both header column and body cells) via a `::before` pseudo-element. `::before` is used because `::after` is already taken by the parent's `[&>tr>th]:after` / `[&>td]:after` rules that paint the horizontal bottom border. With the separator providing a visible boundary, the column width no longer has to compensate, so I reverted it to `w-16` / `w-20` (64/80px). The cell still gives ≥48px of hit area on top of the whole-row toggle and the avatar in the next column now reads as living in its own column instead of crowding the checkbox.

Affects every `CrmDataTable` with `enableBulkSelect`: patients, treatments, employees, contacts, companies, leads, activities, documents.