### PR TITLE
nie ten odstęp

### DIFF
--- a/src/components/application/table/table.tsx
+++ b/src/components/application/table/table.tsx
@@ -153,7 +153,7 @@ const TableHeader = <T extends object>({ columns, children, bordered = true, cla
                         // Right separator via ::before so we don't clash with the parent's
                         // [&>tr>th]:after rule that draws the header bottom border.
                         "before:pointer-events-none before:absolute before:inset-y-0 before:right-0 before:w-px before:bg-border-secondary before:content-['']",
-                        size === "sm" ? "w-16 md:pl-5" : "w-20 md:pl-6",
+                        size === "sm" ? "w-24 md:pl-5" : "w-28 md:pl-6",
                     )}
                 >
                     {selectionMode === "multiple" && (
@@ -255,7 +255,7 @@ const TableRow = <T extends object>({ columns, children, className, highlightSel
                         // Right separator via ::before so we don't clash with the parent's
                         // [&>td]:after rule that draws the row bottom border.
                         "before:pointer-events-none before:absolute before:inset-y-0 before:right-0 before:w-px before:bg-border-secondary before:content-['']",
-                        size === "sm" ? "w-16 md:pl-5" : "w-20 md:pl-6",
+                        size === "sm" ? "w-24 md:pl-5" : "w-28 md:pl-6",
                     )}
                 >
                     <Checkbox


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1639.

Closes #1639

---

## Claude summary

Committed.

Restored the bulk-select column width from `w-16/w-20` back to `w-24/w-28` in `src/components/application/table/table.tsx:156` (header) and `:258` (row), keeping the left padding (`pl-4 md:pl-5/pl-6`) and the `::before` separator rail from #1637 unchanged. This brings back the wider gap between the checkbox and the avatar/graphic the user asked to restore, without touching the left margin.