### PR TITLE
miejsce na sekcję "odstęp"

### DIFF
--- a/src/components/application/table/table.tsx
+++ b/src/components/application/table/table.tsx
@@ -149,11 +149,11 @@ const TableHeader = <T extends object>({ columns, children, bordered = true, cla
             {selectionBehavior === "toggle" && (
                 <AriaColumn
                     className={cx(
-                        "relative py-2 pr-0 pl-4",
+                        "relative py-2 pr-0 pl-2",
                         // Right separator via ::before so we don't clash with the parent's
                         // [&>tr>th]:after rule that draws the header bottom border.
                         "before:pointer-events-none before:absolute before:inset-y-0 before:right-0 before:w-px before:bg-border-secondary before:content-['']",
-                        size === "sm" ? "w-24 md:pl-5" : "w-28 md:pl-6",
+                        size === "sm" ? "w-24 md:pl-3" : "w-28 md:pl-4",
                     )}
                 >
                     {selectionMode === "multiple" && (
@@ -161,8 +161,8 @@ const TableHeader = <T extends object>({ columns, children, bordered = true, cla
                             slot="selection"
                             size="md"
                             className={cx(
-                                "absolute inset-0 !flex !items-center cursor-pointer pl-4",
-                                size === "sm" ? "md:pl-5" : "md:pl-6",
+                                "absolute inset-0 !flex !items-center cursor-pointer pl-2",
+                                size === "sm" ? "md:pl-3" : "md:pl-4",
                             )}
                         />
                     )}
@@ -251,19 +251,19 @@ const TableRow = <T extends object>({ columns, children, className, highlightSel
             {selectionBehavior === "toggle" && (
                 <AriaCell
                     className={cx(
-                        "relative py-2 pr-0 pl-4",
+                        "relative py-2 pr-0 pl-2",
                         // Right separator via ::before so we don't clash with the parent's
                         // [&>td]:after rule that draws the row bottom border.
                         "before:pointer-events-none before:absolute before:inset-y-0 before:right-0 before:w-px before:bg-border-secondary before:content-['']",
-                        size === "sm" ? "w-24 md:pl-5" : "w-28 md:pl-6",
+                        size === "sm" ? "w-24 md:pl-3" : "w-28 md:pl-4",
                     )}
                 >
                     <Checkbox
                         slot="selection"
                         size="md"
                         className={cx(
-                            "absolute inset-0 !flex !items-center cursor-pointer pl-4",
-                            size === "sm" ? "md:pl-5" : "md:pl-6",
+                            "absolute inset-0 !flex !items-center cursor-pointer pl-2",
+                            size === "sm" ? "md:pl-3" : "md:pl-4",
                         )}
                     />
                 </AriaCell>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1641.

Closes #1641

---

## Claude summary

Committed. Summary:

Issue #1641 reports that on the patients table at `/dashboard/gabinet/patients`, the bulk-select column has too much empty padding on the left (area 1) and the checkbox click area itself feels too small (area 2). The user wants it easier to click the checkbox.

Fix: in `src/components/application/table/table.tsx`, halved the left padding on the bulk-select header cell, row cell, and the inner `<Checkbox>` label — `pl-4 md:pl-5/pl-6` → `pl-2 md:pl-3/pl-4`. The cell width (`w-24/w-28`) and the `::before` separator rail from #1637 are untouched, so the total click target stays the same size; the checkbox graphic just shifts ~12px closer to the left edge, shrinking the perceived "wasted" left gutter (area 1) and giving more visible breathing room to the right of the checkbox that reads as part of the click target (area 2). Affects every `CrmDataTable` with `enableBulkSelect`.