### PR TITLE
Opcja przesuwania zdjęć przed i po

### DIFF
--- a/src/components/gabinet/documentation-tab.tsx
+++ b/src/components/gabinet/documentation-tab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useMutation, useAction } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
@@ -35,7 +35,7 @@ import {
   ChevronLeft,
   ChevronRight,
 } from "@/lib/ez-icons";
-import { XIcon } from "lucide-react";
+import { XIcon, ColumnsIcon, ImageOffIcon } from "lucide-react";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
 import { formatBytes } from "@/hooks/use-file-upload";
@@ -492,44 +492,15 @@ export function DocumentationTab({
       </Card>
 
       {/* Before/After Photos */}
-      <Card>
-        <CardHeader className="px-6 py-3 border-b">
-          <CardTitle className="text-sm flex items-center gap-2">
-            <Eye className="h-4 w-4" variant="stroke" />
-            {t("gabinet.documentation.photos", "Zdjęcia przed / po")}
-          </CardTitle>
-          <CardDescription className="text-xs">
-            {t(
-              "gabinet.documentation.photosDesc",
-              "Dodaj zdjęcia dokumentujące stan przed i po zabiegu.",
-            )}
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="px-6 py-4">
-          <div className="grid grid-cols-2 gap-4">
-            <PhotoColumn
-              type="before"
-              label={t("gabinet.documentation.before", "Przed")}
-              photos={beforePhotos}
-              urlMap={urlMap}
-              onRemove={handleRemovePhoto}
-              uploadFile={uploadFile}
-              uploadingFiles={uploadingFiles}
-              t={t as (key: string, fallback?: string) => string}
-            />
-            <PhotoColumn
-              type="after"
-              label={t("gabinet.documentation.after", "Po")}
-              photos={afterPhotos}
-              urlMap={urlMap}
-              onRemove={handleRemovePhoto}
-              uploadFile={uploadFile}
-              uploadingFiles={uploadingFiles}
-              t={t as (key: string, fallback?: string) => string}
-            />
-          </div>
-        </CardContent>
-      </Card>
+      <PhotosSection
+        beforePhotos={beforePhotos}
+        afterPhotos={afterPhotos}
+        urlMap={urlMap}
+        onRemove={handleRemovePhoto}
+        uploadFile={uploadFile}
+        uploadingFiles={uploadingFiles}
+        t={t as (key: string, fallback?: string) => string}
+      />
 
       {/* Clinical Remarks */}
       <Card>
@@ -570,6 +541,100 @@ export function DocumentationTab({
 }
 
 // ---------------------------------------------------------------------------
+// PhotosSection — combined card with shared lightbox state for before+after
+// ---------------------------------------------------------------------------
+
+function PhotosSection({
+  beforePhotos,
+  afterPhotos,
+  urlMap,
+  onRemove,
+  uploadFile,
+  uploadingFiles,
+  t,
+}: {
+  beforePhotos: Photo[];
+  afterPhotos: Photo[];
+  urlMap: Map<string, string | null>;
+  onRemove: (storageId: Id<"_storage">) => void;
+  uploadFile: (file: File, type: "before" | "after") => void;
+  uploadingFiles: UploadingFile[];
+  t: (key: string, fallback?: string) => string;
+}) {
+  const orderedPhotos = useMemo(
+    () => [...beforePhotos, ...afterPhotos],
+    [beforePhotos, afterPhotos],
+  );
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+  const [compareMode, setCompareMode] = useState(false);
+
+  const closePreview = useCallback(() => {
+    setPreviewIndex(null);
+    setCompareMode(false);
+  }, []);
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="px-6 py-3 border-b">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Eye className="h-4 w-4" variant="stroke" />
+            {t("gabinet.documentation.photos", "Zdjęcia przed / po")}
+          </CardTitle>
+          <CardDescription className="text-xs">
+            {t(
+              "gabinet.documentation.photosDesc",
+              "Dodaj zdjęcia dokumentujące stan przed i po zabiegu.",
+            )}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="px-6 py-4">
+          <div className="grid grid-cols-2 gap-4">
+            <PhotoColumn
+              type="before"
+              label={t("gabinet.documentation.before", "Przed")}
+              photos={beforePhotos}
+              baseIndex={0}
+              urlMap={urlMap}
+              onRemove={onRemove}
+              onPreview={setPreviewIndex}
+              uploadFile={uploadFile}
+              uploadingFiles={uploadingFiles}
+              t={t}
+            />
+            <PhotoColumn
+              type="after"
+              label={t("gabinet.documentation.after", "Po")}
+              photos={afterPhotos}
+              baseIndex={beforePhotos.length}
+              urlMap={urlMap}
+              onRemove={onRemove}
+              onPreview={setPreviewIndex}
+              uploadFile={uploadFile}
+              uploadingFiles={uploadingFiles}
+              t={t}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <PhotoPreviewDialog
+        photos={orderedPhotos}
+        beforeCount={beforePhotos.length}
+        afterCount={afterPhotos.length}
+        urlMap={urlMap}
+        index={previewIndex}
+        onChangeIndex={setPreviewIndex}
+        compareMode={compareMode}
+        onToggleCompare={setCompareMode}
+        onClose={closePreview}
+        t={t}
+      />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // PhotoColumn — drag & drop upload zone with progress (file-upload-06 style)
 // ---------------------------------------------------------------------------
 
@@ -577,8 +642,10 @@ function PhotoColumn({
   type,
   label,
   photos,
+  baseIndex,
   urlMap,
   onRemove,
+  onPreview,
   uploadFile,
   uploadingFiles,
   t,
@@ -586,8 +653,10 @@ function PhotoColumn({
   type: "before" | "after";
   label: string;
   photos: Photo[];
+  baseIndex: number;
   urlMap: Map<string, string | null>;
   onRemove: (storageId: Id<"_storage">) => void;
+  onPreview: (globalIndex: number) => void;
   uploadFile: (file: File, type: "before" | "after") => void;
   uploadingFiles: UploadingFile[];
   t: (key: string, fallback?: string) => string;
@@ -607,7 +676,13 @@ function PhotoColumn({
       <p className="text-sm font-medium">{label}</p>
 
       {/* Already-uploaded photos */}
-      <PhotoGrid photos={photos} urlMap={urlMap} onRemove={onRemove} />
+      <PhotoGrid
+        photos={photos}
+        baseIndex={baseIndex}
+        urlMap={urlMap}
+        onRemove={onRemove}
+        onPreview={onPreview}
+      />
 
       {/* Uploading files with real progress */}
       {myUploads.map((upload) => (
@@ -701,74 +776,66 @@ function PhotoColumn({
 
 function PhotoGrid({
   photos,
+  baseIndex,
   urlMap,
   onRemove,
+  onPreview,
 }: {
   photos: Photo[];
+  baseIndex: number;
   urlMap: Map<string, string | null>;
   onRemove: (storageId: Id<"_storage">) => void;
+  onPreview: (globalIndex: number) => void;
 }) {
-  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
-
   if (photos.length === 0) return null;
 
   return (
-    <>
-      <div className="grid grid-cols-3 gap-2">
-        {photos.map((photo, idx) => {
-          const url = urlMap.get(photo.storageId);
-          return (
-            <div
-              key={photo.storageId}
-              className="group bg-muted relative aspect-square overflow-hidden rounded-lg"
-            >
-              {url ? (
-                <button
-                  type="button"
-                  onClick={() => setPreviewIndex(idx)}
-                  className="block h-full w-full cursor-zoom-in focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                  aria-label="Preview photo"
-                >
-                  <img
-                    src={url}
-                    alt=""
-                    className="h-full w-full object-cover transition-transform group-hover:scale-105"
-                  />
-                </button>
-              ) : (
-                <div className="flex h-full w-full items-center justify-center">
-                  <Loader2
-                    size={16}
-                    variant="stroke"
-                    className="animate-spin text-muted-foreground"
-                  />
-                </div>
-              )}
-              <Button
-                variant="secondary"
-                size="icon"
-                className="absolute right-1 top-1 size-6 opacity-0 shadow-sm transition-opacity group-hover:opacity-100"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onRemove(photo.storageId);
-                }}
-                aria-label="Remove"
+    <div className="grid grid-cols-3 gap-2">
+      {photos.map((photo, idx) => {
+        const url = urlMap.get(photo.storageId);
+        return (
+          <div
+            key={photo.storageId}
+            className="group bg-muted relative aspect-square overflow-hidden rounded-lg"
+          >
+            {url ? (
+              <button
+                type="button"
+                onClick={() => onPreview(baseIndex + idx)}
+                className="block h-full w-full cursor-zoom-in focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                aria-label="Preview photo"
               >
-                <XIcon className="size-3.5" />
-              </Button>
-            </div>
-          );
-        })}
-      </div>
-
-      <PhotoPreviewDialog
-        photos={photos}
-        urlMap={urlMap}
-        index={previewIndex}
-        onChangeIndex={setPreviewIndex}
-        onClose={() => setPreviewIndex(null)}
-      />
-    </>
+                <img
+                  src={url}
+                  alt=""
+                  className="h-full w-full object-cover transition-transform group-hover:scale-105"
+                />
+              </button>
+            ) : (
+              <div className="flex h-full w-full items-center justify-center">
+                <Loader2
+                  size={16}
+                  variant="stroke"
+                  className="animate-spin text-muted-foreground"
+                />
+              </div>
+            )}
+            <Button
+              variant="secondary"
+              size="icon"
+              className="absolute right-1 top-1 size-6 opacity-0 shadow-sm transition-opacity group-hover:opacity-100"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove(photo.storageId);
+              }}
+              aria-label="Remove"
+            >
+              <XIcon className="size-3.5" />
+            </Button>
+          </div>
+        );
+      })}
+    </div>
   );
 }
 
@@ -778,30 +845,79 @@ function PhotoGrid({
 
 function PhotoPreviewDialog({
   photos,
+  beforeCount,
+  afterCount,
   urlMap,
   index,
   onChangeIndex,
+  compareMode,
+  onToggleCompare,
   onClose,
+  t,
 }: {
   photos: Photo[];
+  beforeCount: number;
+  afterCount: number;
   urlMap: Map<string, string | null>;
   index: number | null;
   onChangeIndex: (index: number) => void;
+  compareMode: boolean;
+  onToggleCompare: (next: boolean) => void;
   onClose: () => void;
+  t: (key: string, fallback?: string) => string;
 }) {
   const open = index !== null;
   const photo = index !== null ? photos[index] : undefined;
   const url = photo ? urlMap.get(photo.storageId) : undefined;
 
+  // Pair index for compare mode: derived from the single-mode index so that
+  // toggling between modes keeps the user roughly where they were.
+  const pairCount = Math.max(beforeCount, afterCount);
+  const canCompare = beforeCount > 0 && afterCount > 0;
+  const pairIndex =
+    index === null
+      ? 0
+      : index < beforeCount
+        ? Math.min(index, pairCount - 1)
+        : Math.min(index - beforeCount, pairCount - 1);
+
+  const beforePair = beforeCount > 0 ? photos[Math.min(pairIndex, beforeCount - 1)] : undefined;
+  const afterPair =
+    afterCount > 0 ? photos[beforeCount + Math.min(pairIndex, afterCount - 1)] : undefined;
+  const beforePairUrl = beforePair ? urlMap.get(beforePair.storageId) : undefined;
+  const afterPairUrl = afterPair ? urlMap.get(afterPair.storageId) : undefined;
+
   const goPrev = useCallback(() => {
     if (index === null || photos.length === 0) return;
-    onChangeIndex((index - 1 + photos.length) % photos.length);
-  }, [index, photos.length, onChangeIndex]);
+    if (compareMode) {
+      if (pairCount === 0) return;
+      const nextPair = (pairIndex - 1 + pairCount) % pairCount;
+      // Anchor preview index to the "before" side of the new pair when possible
+      // so toggling out of compare mode lands on a sensible photo.
+      onChangeIndex(
+        beforeCount > 0
+          ? Math.min(nextPair, beforeCount - 1)
+          : beforeCount + Math.min(nextPair, afterCount - 1),
+      );
+    } else {
+      onChangeIndex((index - 1 + photos.length) % photos.length);
+    }
+  }, [index, photos.length, onChangeIndex, compareMode, pairIndex, pairCount, beforeCount, afterCount]);
 
   const goNext = useCallback(() => {
     if (index === null || photos.length === 0) return;
-    onChangeIndex((index + 1) % photos.length);
-  }, [index, photos.length, onChangeIndex]);
+    if (compareMode) {
+      if (pairCount === 0) return;
+      const nextPair = (pairIndex + 1) % pairCount;
+      onChangeIndex(
+        beforeCount > 0
+          ? Math.min(nextPair, beforeCount - 1)
+          : beforeCount + Math.min(nextPair, afterCount - 1),
+      );
+    } else {
+      onChangeIndex((index + 1) % photos.length);
+    }
+  }, [index, photos.length, onChangeIndex, compareMode, pairIndex, pairCount, beforeCount, afterCount]);
 
   useEffect(() => {
     if (!open) return;
@@ -818,14 +934,57 @@ function PhotoPreviewDialog({
     return () => window.removeEventListener("keydown", handler);
   }, [open, goPrev, goNext]);
 
+  // If photos disappear (e.g. removed), close compare mode automatically.
+  useEffect(() => {
+    if (!canCompare && compareMode) onToggleCompare(false);
+  }, [canCompare, compareMode, onToggleCompare]);
+
   if (!photo) return null;
+
+  const beforeLabel = t("gabinet.documentation.before", "Przed");
+  const afterLabel = t("gabinet.documentation.after", "Po");
+  const compareLabel = t("gabinet.documentation.compare", "Porównaj");
+  const exitCompareLabel = t("gabinet.documentation.exitCompare", "Zamknij porównanie");
+  const showNav = compareMode ? pairCount > 1 : photos.length > 1;
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="flex max-h-[95dvh] w-[95vw] max-w-[95vw] flex-col gap-3 bg-background p-4 sm:max-w-4xl">
+      <DialogContent
+        className={`flex max-h-[95dvh] w-[95vw] flex-col gap-3 bg-background p-4 ${
+          compareMode ? "max-w-[95vw] sm:max-w-6xl" : "max-w-[95vw] sm:max-w-4xl"
+        }`}
+      >
         <DialogTitle className="sr-only">Photo preview</DialogTitle>
+        <div className="flex items-center justify-end gap-2">
+          {canCompare && (
+            <Button
+              variant={compareMode ? "default" : "secondary"}
+              size="sm"
+              onClick={() => onToggleCompare(!compareMode)}
+              aria-pressed={compareMode}
+            >
+              <ColumnsIcon className="mr-1.5 size-4" />
+              {compareMode ? exitCompareLabel : compareLabel}
+            </Button>
+          )}
+        </div>
         <div className="relative flex min-h-0 flex-1 items-center justify-center">
-          {url ? (
+          {compareMode ? (
+            <div className="grid w-full grid-cols-2 gap-3">
+              <ComparePane
+                label={beforeLabel}
+                url={beforePairUrl}
+                photo={beforePair}
+                t={t}
+              />
+              <ComparePane
+                label={afterLabel}
+                url={afterPairUrl}
+                photo={afterPair}
+                t={t}
+              />
+            </div>
+          ) : url ? (
             <img
               src={url}
               alt=""
@@ -838,7 +997,7 @@ function PhotoPreviewDialog({
               className="animate-spin text-muted-foreground"
             />
           )}
-          {photos.length > 1 && (
+          {showNav && (
             <>
               <Button
                 variant="secondary"
@@ -861,15 +1020,81 @@ function PhotoPreviewDialog({
             </>
           )}
         </div>
-        <div className="flex items-center justify-between text-xs text-muted-foreground">
-          <span>{new Date(photo.uploadedAt).toLocaleString()}</span>
-          {photos.length > 1 && (
-            <span>
-              {(index ?? 0) + 1} / {photos.length}
-            </span>
+        <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+          {compareMode ? (
+            <>
+              <span>
+                {beforePair
+                  ? new Date(beforePair.uploadedAt).toLocaleString()
+                  : "—"}
+                {" · "}
+                {afterPair
+                  ? new Date(afterPair.uploadedAt).toLocaleString()
+                  : "—"}
+              </span>
+              {pairCount > 1 && (
+                <span>
+                  {pairIndex + 1} / {pairCount}
+                </span>
+              )}
+            </>
+          ) : (
+            <>
+              <span className="flex items-center gap-2">
+                <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide">
+                  {photo.type === "before" ? beforeLabel : afterLabel}
+                </span>
+                {new Date(photo.uploadedAt).toLocaleString()}
+              </span>
+              {photos.length > 1 && (
+                <span>
+                  {(index ?? 0) + 1} / {photos.length}
+                </span>
+              )}
+            </>
           )}
         </div>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function ComparePane({
+  label,
+  url,
+  photo,
+  t,
+}: {
+  label: string;
+  url: string | null | undefined;
+  photo: Photo | undefined;
+  t: (key: string, fallback?: string) => string;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <div className="bg-muted flex aspect-square w-full items-center justify-center overflow-hidden rounded-md">
+        {photo && url ? (
+          <img
+            src={url}
+            alt=""
+            className="max-h-[70dvh] w-full object-contain"
+          />
+        ) : photo ? (
+          <Loader2
+            size={24}
+            variant="stroke"
+            className="animate-spin text-muted-foreground"
+          />
+        ) : (
+          <div className="flex flex-col items-center gap-1 text-xs text-muted-foreground">
+            <ImageOffIcon className="size-6" />
+            <span>{t("gabinet.documentation.noPhoto", "Brak zdjęcia")}</span>
+          </div>
+        )}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1644.

Closes #1644

---

## Claude summary

Done. In `src/components/gabinet/documentation-tab.tsx` I lifted the photo-preview state out of the per-column `PhotoGrid` into a new shared `PhotosSection`, so:

- Clicking any photo opens a single lightbox whose prev/next (buttons + ←/→ keys) navigates the full ordered list — before photos first, then after photos — letting the user flow directly from "Przed" to "Po" without closing the modal.
- The lightbox shows a small "Przed" / "Po" badge next to the timestamp so the user always knows which side they're looking at.
- A new "Porównaj" toggle (only visible when both sides have at least one photo) splits the dialog into two panes — left "Przed", right "Po" — paired by index, with prev/next moving through pairs. Missing counterparts render a "Brak zdjęcia" placeholder.

Typecheck passes; the only lint output is a pre-existing `any` warning unrelated to this change. Committed as 3286c90.