### PR TITLE
fix(ci): pass VITE_CONVEX_URL to the playwright test step

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,6 +52,10 @@ jobs:
           CI: true
           E2E_USER_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
           E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
+          # Some specs (e.g. e2e/gabinet/appointments.spec.ts) build a
+          # ConvexHttpClient at module load and look up VITE_CONVEX_URL.
+          # Without this the test discovery throws before any test runs.
+          VITE_CONVEX_URL: ${{ secrets.VITE_CONVEX_URL }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
E2E has been failing since #1436 because the playwright step doesn't have VITE_CONVEX_URL in its env, even though `Start preview server` does. The replacement reads from `process.env.VITE_CONVEX_URL` and throws "Missing VITE_CONVEX_URL" before any test runs.