### PR TITLE
Dodawanie zabiegu

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -74,6 +74,7 @@
     "errors": {
       "permissionDenied": "You don't have permission to perform this action.",
       "invalidArguments": "Invalid data. Please check the form and try again.",
+      "invalidField": "Invalid data: {{field}} — {{reason}}.",
       "schemaCache": "Database schema is missing a column — a migration likely wasn't applied. Run `npm run migrations:apply` and refresh.",
       "storage": "Storage error. Please try again."
     },
@@ -2356,6 +2357,7 @@
         "variantNotFound": "Treatment variant not found.",
         "permissionDenied": "You don't have permission for this treatment action.",
         "invalidArguments": "Could not save the treatment — invalid data.",
+        "invalidField": "Could not save the treatment: {{field}} — {{reason}}.",
         "schemaCache": "Database schema is missing a column — a migration likely wasn't applied. Run `npm run migrations:apply` and refresh.",
         "storage": "Could not save the treatment — storage error. Please try again.",
         "purchaseFailed": "Could not sell the treatment."

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -74,6 +74,7 @@
     "errors": {
       "permissionDenied": "Brak uprawnień do tej operacji.",
       "invalidArguments": "Nieprawidłowe dane. Sprawdź formularz i spróbuj ponownie.",
+      "invalidField": "Nieprawidłowe dane: {{field}} — {{reason}}.",
       "schemaCache": "Brak kolumny w schemacie bazy — najpewniej nie zastosowano migracji. Uruchom `npm run migrations:apply` i odśwież stronę.",
       "storage": "Błąd magazynu danych. Spróbuj ponownie."
     },
@@ -2384,6 +2385,7 @@
         "variantNotFound": "Nie znaleziono wariantu zabiegu.",
         "permissionDenied": "Brak uprawnień do tej operacji na zabiegu.",
         "invalidArguments": "Nie udało się zapisać zabiegu — nieprawidłowe dane.",
+        "invalidField": "Nie udało się zapisać zabiegu: {{field}} — {{reason}}.",
         "schemaCache": "Brak kolumny w schemacie bazy — najpewniej nie zastosowano migracji. Uruchom `npm run migrations:apply` i odśwież stronę.",
         "storage": "Nie udało się zapisać zabiegu — błąd magazynu danych. Spróbuj ponownie.",
         "purchaseFailed": "Nie udało się sprzedać zabiegu."

--- a/src/lib/format-action-error.test.ts
+++ b/src/lib/format-action-error.test.ts
@@ -1,0 +1,91 @@
+import type { TFunction } from "i18next";
+import { describe, expect, it } from "vitest";
+import {
+  extractFieldValidationDetail,
+  formatTreatmentError,
+} from "./format-action-error";
+
+// Minimal i18next-like translator that interpolates `{{param}}` placeholders
+// in `defaultValue`. Cast to TFunction so the call sites don't fight
+// i18next's branded generic signature in unit tests.
+const t = ((
+  key: string,
+  arg?: { defaultValue?: string; [k: string]: unknown },
+): string => {
+  const tpl = (arg?.defaultValue as string) ?? key;
+  return tpl.replace(/\{\{(\w+)\}\}/g, (_, name) => String(arg?.[name] ?? ""));
+}) as unknown as TFunction;
+
+describe("extractFieldValidationDetail", () => {
+  it("extracts column name from Postgres null-violation", () => {
+    const detail = extractFieldValidationDetail(
+      'null value in column "duration" of relation "gabinet_treatments" violates not-null constraint',
+    );
+    expect(detail).toEqual({
+      rawField: "duration",
+      fieldLabel: "Czas trwania",
+      reason: "to pole jest wymagane",
+    });
+  });
+
+  it("extracts column name from missing-column error", () => {
+    const detail = extractFieldValidationDetail(
+      'column "package_id" of relation "gabinet_treatments" does not exist',
+    );
+    expect(detail?.fieldLabel).toBe("Powiązany pakiet");
+    expect(detail?.reason).toBe("kolumna nie istnieje w bazie");
+  });
+
+  it("extracts type from invalid input syntax", () => {
+    const detail = extractFieldValidationDetail(
+      'invalid input syntax for type integer: "abc"',
+    );
+    expect(detail?.rawField).toBe("integer");
+    expect(detail?.fieldLabel).toBe('wartość "abc"');
+    expect(detail?.reason).toContain("integer");
+  });
+
+  it("extracts argument name from Convex validator error", () => {
+    const detail = extractFieldValidationDetail(
+      "ArgumentValidationError: Value 'foo' for argument 'price' is not a valid value",
+    );
+    expect(detail?.rawField).toBe("price");
+    expect(detail?.fieldLabel).toBe("Cena");
+  });
+
+  it("returns null for unrelated messages", () => {
+    expect(extractFieldValidationDetail("Some other error")).toBeNull();
+  });
+});
+
+describe("formatTreatmentError", () => {
+  it("surfaces field name when Postgres reports a NOT NULL violation", () => {
+    const err = new Error(
+      'supabaseDb.patch(gabinetTreatments, abc): null value in column "name" of relation "gabinet_treatments" violates not-null constraint',
+    );
+    const msg = formatTreatmentError(err, t, {
+      key: "gabinet.treatments.errors.createFailed",
+      defaultValue: "Nie udało się utworzyć zabiegu.",
+    });
+    expect(msg).toContain("Nazwa");
+    expect(msg).toContain("to pole jest wymagane");
+  });
+
+  it("falls back to generic message when error has no extractable field", () => {
+    const err = new Error("Permission denied");
+    const msg = formatTreatmentError(err, t, {
+      key: "gabinet.treatments.errors.createFailed",
+      defaultValue: "Nie udało się utworzyć zabiegu.",
+    });
+    expect(msg).toBe("Brak uprawnień do tej operacji na zabiegu.");
+  });
+
+  it("falls back to caller's default when nothing matches", () => {
+    const err = new Error("Something totally unexpected");
+    const msg = formatTreatmentError(err, t, {
+      key: "gabinet.treatments.errors.createFailed",
+      defaultValue: "Nie udało się utworzyć zabiegu.",
+    });
+    expect(msg).toBe("Nie udało się utworzyć zabiegu.");
+  });
+});

--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -1,5 +1,147 @@
 import type { TFunction } from "i18next";
 
+// Snake_case Postgres column name → Polish form label. Used to turn raw
+// backend errors like `null value in column "duration"` into something the
+// end-user can act on (#1647 — generic "nieprawidłowe dane" toast hid which
+// field was wrong). Treatment-specific entries are listed first; the map is
+// shared across domains since column names rarely collide.
+const COLUMN_LABEL_MAP: Record<string, string> = {
+  name: "Nazwa",
+  duration: "Czas trwania",
+  price: "Cena",
+  currency: "Waluta",
+  tax_rate: "Stawka VAT",
+  tax_exempt: "Zwolnienie z VAT",
+  color: "Kolor",
+  category: "Kategoria",
+  category_id: "Kategoria",
+  tag_ids: "Tagi",
+  description: "Opis",
+  contraindications: "Przeciwwskazania",
+  preparation_instructions: "Instrukcje przygotowania",
+  aftercare_instructions: "Zalecenia po zabiegu",
+  required_equipment: "Wymagany sprzęt",
+  required_equipment_ids: "Wymagany sprzęt",
+  requires_approval: "Wymaga zatwierdzenia",
+  treatment_count: "Liczba zabiegów w pakiecie",
+  package_id: "Powiązany pakiet",
+  organization_id: "Organizacja",
+  created_by: "Utworzone przez",
+};
+
+function humanFieldLabel(rawField: string): string {
+  const snake = rawField
+    .replace(/([A-Z])/g, "_$1")
+    .toLowerCase()
+    .replace(/^_/, "");
+  return COLUMN_LABEL_MAP[snake] ?? COLUMN_LABEL_MAP[rawField] ?? rawField;
+}
+
+// Best-effort extraction of "which field" and "why" from raw Postgres /
+// Convex validator error messages. Returns `null` when we cannot identify a
+// specific field — callers fall back to the generic invalidArguments toast.
+export interface FieldValidationDetail {
+  /** Human-readable Polish label for the offending field. */
+  fieldLabel: string;
+  /** Raw column or argument name as it appeared in the backend message. */
+  rawField: string;
+  /** Short Polish reason suitable for inclusion in a toast. */
+  reason: string;
+}
+
+export function extractFieldValidationDetail(
+  msg: string,
+): FieldValidationDetail | null {
+  // Postgres: null value in column "X" of relation "..." violates not-null
+  const nullCol = msg.match(/null value in column "([^"]+)"/i);
+  if (nullCol) {
+    return {
+      rawField: nullCol[1],
+      fieldLabel: humanFieldLabel(nullCol[1]),
+      reason: "to pole jest wymagane",
+    };
+  }
+
+  // Postgres: column "X" of relation "..." does not exist (also raw column
+  // missing — PGRST204 is caught separately by the schemaCache matcher).
+  const missingCol = msg.match(/column "([^"]+)" (?:of relation [^ ]+ )?does not exist/i);
+  if (missingCol) {
+    return {
+      rawField: missingCol[1],
+      fieldLabel: humanFieldLabel(missingCol[1]),
+      reason: "kolumna nie istnieje w bazie",
+    };
+  }
+
+  // Postgres: invalid input syntax for type X: "Y"  (no column in message,
+  // so we can only report the type).
+  const invalidSyntax = msg.match(/invalid input syntax for type (\w+)(?:: "([^"]*)")?/i);
+  if (invalidSyntax) {
+    return {
+      rawField: invalidSyntax[1],
+      fieldLabel: invalidSyntax[2]
+        ? `wartość "${invalidSyntax[2]}"`
+        : invalidSyntax[1],
+      reason: `nieprawidłowy format (oczekiwano: ${invalidSyntax[1]})`,
+    };
+  }
+
+  // Postgres: numeric field overflow
+  const overflow = msg.match(/numeric field overflow/i);
+  if (overflow) {
+    return {
+      rawField: "numeric",
+      fieldLabel: "Wartość liczbowa",
+      reason: "liczba jest za duża",
+    };
+  }
+
+  // Postgres: value too long for type character varying(N)
+  const tooLong = msg.match(/value too long for type [^,]+/i);
+  if (tooLong) {
+    return {
+      rawField: "string",
+      fieldLabel: "Tekst",
+      reason: "wartość jest za długa",
+    };
+  }
+
+  // Postgres: violates check constraint "X" — extract constraint name.
+  const checkCon = msg.match(/violates check constraint "([^"]+)"/i);
+  if (checkCon) {
+    return {
+      rawField: checkCon[1],
+      fieldLabel: humanFieldLabel(checkCon[1]),
+      reason: "wartość nie spełnia ograniczenia",
+    };
+  }
+
+  // Postgres: violates foreign key constraint "X" — happens when a referenced
+  // row (e.g. selected package, category) no longer exists.
+  const fkCon = msg.match(/violates foreign key constraint "([^"]+)"/i);
+  if (fkCon) {
+    return {
+      rawField: fkCon[1],
+      fieldLabel: humanFieldLabel(fkCon[1]),
+      reason: "powiązany rekord nie istnieje",
+    };
+  }
+
+  // Convex: Value '...' for argument 'X' is not a valid value
+  // (also matches "Value ... does not match validator").
+  const convexArg = msg.match(/(?:for argument|argument) ['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?/i);
+  if (convexArg) {
+    const rawField = convexArg[1];
+    return {
+      rawField,
+      fieldLabel: humanFieldLabel(rawField),
+      reason: "nieprawidłowa wartość",
+    };
+  }
+
+  return null;
+}
+
 // Convex Action errors arrive on the client as plain `Error` instances whose
 // `.message` is wrapped with the framework's diagnostic prefix, e.g.:
 //
@@ -185,6 +327,16 @@ export function formatTreatmentError(
   const inner = extractActionErrorMessage(err);
   for (const entry of TREATMENT_ERROR_MAP) {
     if (entry.test(inner)) {
+      if (entry.key === "gabinet.treatments.errors.invalidArguments") {
+        const detail = extractFieldValidationDetail(inner);
+        if (detail) {
+          return t("gabinet.treatments.errors.invalidField", {
+            field: detail.fieldLabel,
+            reason: detail.reason,
+            defaultValue: `Nieprawidłowe dane: ${detail.fieldLabel} — ${detail.reason}.`,
+          });
+        }
+      }
       return t(entry.key, { defaultValue: entry.fallback });
     }
   }
@@ -234,6 +386,16 @@ export function formatActionError(
   const inner = extractActionErrorMessage(err);
   for (const entry of GENERIC_ERROR_MAP) {
     if (entry.test(inner)) {
+      if (entry.key === "common.errors.invalidArguments") {
+        const detail = extractFieldValidationDetail(inner);
+        if (detail) {
+          return t("common.errors.invalidField", {
+            field: detail.fieldLabel,
+            reason: detail.reason,
+            defaultValue: `Nieprawidłowe dane: ${detail.fieldLabel} — ${detail.reason}.`,
+          });
+        }
+      }
       return t(entry.key, { defaultValue: entry.fallback });
     }
   }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1647.

Closes #1647

---

## Claude summary

Committed as `3cc76ec`.

Summary: the toast now extracts the failing field from the raw backend error and shows e.g. `Nie udało się zapisać zabiegu: Cena — to pole jest wymagane.` instead of the opaque "nieprawidłowe dane". A new `extractFieldValidationDetail` helper in `src/lib/format-action-error.ts` recognises Postgres NOT NULL violations (`null value in column "X"`), missing columns, invalid input syntax, FK / check-constraint violations, numeric overflow, value-too-long, and Convex argument-validator errors, then maps the column name through a Polish label map (Nazwa, Czas trwania, Cena, Waluta, Stawka VAT, Powiązany pakiet, etc.). Hooked into both `formatTreatmentError` (used by the treatments form at `_layout.gabinet.treatments.index.tsx:417`) and the generic `formatActionError`. Added 8 unit tests in `src/lib/format-action-error.test.ts`; full frontend suite (28 tests) and `tsc -p tsconfig.app.json` both pass.