### PR TITLE
fix(supabase): drop setTimeout-based FK retry backoff (was breaking mutations)

### DIFF
--- a/convex/supabase/client.ts
+++ b/convex/supabase/client.ts
@@ -41,7 +41,9 @@ export async function upsertWithFkRetry(
   table: string,
   row: Record<string, unknown>,
   maxRetries = 3,
-  delayMs = 2000,
+  // Kept for back-compat; ignored after we dropped the setTimeout-based
+  // backoff. See comment inside the loop.
+  _delayMs = 2000,
 ): Promise<{ id: string }> {
   let lastError: { message: string; code: string } | null = null;
 
@@ -60,9 +62,15 @@ export async function upsertWithFkRetry(
 
     if (error?.code === "23503" && attempt < maxRetries - 1) {
       console.warn(
-        `[${table}] FK violation attempt ${attempt + 1}/${maxRetries}, retrying in ${delayMs}ms: ${error.message}`,
+        `[${table}] FK violation attempt ${attempt + 1}/${maxRetries}, retrying: ${error.message}`,
       );
-      await new Promise((r) => setTimeout(r, delayMs));
+      // Previously this awaited a setTimeout-based delay so concurrent
+      // writes had a chance to settle. setTimeout is forbidden in Convex
+      // queries/mutations — `_createSideEffects` was logging
+      // "Can't use setTimeout in queries and mutations" on every
+      // appointment create (dev 2026-06-12 14:36 UTC). Inside a mutation
+      // the FK target either exists in the snapshot or doesn't, so the
+      // pause couldn't help anyway. In actions the tighter retry is cheap.
       continue;
     }
 


### PR DESCRIPTION
Found via `npx convex logs --deployment helpful-mule-867 --history` while investigating Convex error patterns:

```
12.06.2026, 14:36:29 [CONVEX M(gabinet/appointments:_createSideEffects)]
Uncaught Error: Can't use setTimeout in queries and mutations.
```

`upsertWithFkRetry` awaited a `setTimeout`-based backoff between FK-violation (23503) retries. Convex mutations forbid setTimeout, so any appointment create that hit FK retry failed all downstream side effects (automation events, document auto-gen, activity log, reminder scheduling) — the visit row landed via the action, but nothing else fired.

## Fix
Drop the pause and just retry immediately. In a mutation the FK target is fixed in the snapshot — waiting can't help. In actions a tight retry is cheap. `delayMs` parameter renamed to `_delayMs` for back-compat.