### PR TITLE
Dodawanie zdarzenia 

### DIFF
--- a/src/components/categories-tags/category-picker.tsx
+++ b/src/components/categories-tags/category-picker.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useAction } from "convex/react";
 import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { LayersTwo02, XClose, ChevronRight, Plus } from "@untitledui/icons";
 import { Button, styles as buttonStyles } from "@untitled/base/buttons/button";
 import { Input } from "@untitled/base/input/input";
@@ -12,6 +13,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cx } from "@/lib/utils/cx";
+import { formatActionError } from "@/lib/format-action-error";
 import { api } from "@cvx/_generated/api";
 import { Id } from "@cvx/_generated/dataModel";
 import type { EntityType } from "@cvx/schema";
@@ -122,6 +124,16 @@ export function CategoryPicker({
       onChange(newId);
       resetAddForm();
       setOpen(false);
+    } catch (e) {
+      // Without this, action failures (missing permission, missing
+      // entity_type_enum value, network error) leave the user staring at
+      // a "Dodaj" button that appears to do nothing — issue #1653.
+      toast.error(
+        formatActionError(e, t, {
+          key: "categories.errors.createFailed",
+          defaultValue: "Nie udało się dodać kategorii.",
+        }),
+      );
     } finally {
       setIsCreating(false);
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1653.

Closes #1653

---

## Claude summary

Fixed. The root cause was a silent error: `CategoryPicker.handleCreate` (src/components/categories-tags/category-picker.tsx:109) used `try/finally` with no `catch`. When `categoryDefinitions.create` failed for any reason — including the missing `gabinetEvent` value in `entity_type_enum` that the maintainer manually patched — the promise rejection was dropped on the floor and the user saw the "Dodaj" button do absolutely nothing.

The sibling component `categories-manager-slideout.tsx:114-121` already handled this correctly with `formatActionError` + `toast.error`. I mirrored that pattern. Now any future failure (perm denial, network drop, new entity_type added to the validator but not the Postgres enum) will surface a Polish toast instead of looking like a dead button.

Even though the maintainer already patched migration 00011 manually on quera-dev, this fix is still load-bearing: the silent-error UX would re-appear the next time anything in the create path fails.

## Follow-ups
- Audit other handleCreate/handleSubmit handlers for silent try/finally: same anti-pattern likely exists elsewhere (grep `} finally {` near action calls). Each instance turns a backend error into a "button does nothing" report.
- Restore auto-apply for supabase-migrations workflow: maintainer comment notes the workflow is broken without `SUPABASE_DB_URL` secret and migrations 00009–00012 had to be applied manually to quera-dev; recurrence of #1653-class issues is likely until this is fixed.