### PR TITLE
Nazwa dokumentacja w zabiegu

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -2553,7 +2553,7 @@ function AppointmentDetail() {
       ),
     },
     {
-      label: t("gabinet.appointments.tabs.documentation", "Dokumentacja"),
+      label: t("gabinet.appointments.tabs.documentation", "Notatki z wizyty"),
       content: (
         <DocumentationTab
           organizationId={organizationId}
@@ -2700,7 +2700,7 @@ function AppointmentDetail() {
           tabSearch === "payments"
             ? t("gabinet.payments.payments")
             : tabSearch === "documentation"
-              ? t("gabinet.appointments.tabs.documentation", "Dokumentacja")
+              ? t("gabinet.appointments.tabs.documentation", "Notatki z wizyty")
               : undefined
         }
       />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1658.

Closes #1658

---

## Claude summary

Changed both occurrences of the tab label default from "Dokumentacja" to "Notatki z wizyty" in the appointment detail page (`src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx:2556` and `:2703`). The i18n key `gabinet.appointments.tabs.documentation` isn't defined in either locale file, so both PL and EN render the default — updating the default fully resolves the label everywhere it appears (tab strip and the `?tab=documentation` default-tab selector). Committed on `claude/issue-1658`.