### PR TITLE
Stop stringifying Plate JSON in merge dialog

### DIFF
--- a/src/components/gabinet/merge-patients-dialog.tsx
+++ b/src/components/gabinet/merge-patients-dialog.tsx
@@ -24,6 +24,7 @@ import { Loader2, ArrowRight, AlertCircle } from "@/lib/ez-icons";
 import type { MappedGabinetPatient } from "@/lib/supabase/mappers/gabinet/patients";
 import { formatPhoneNumber } from "@/lib/phone";
 import { formatActionError } from "@/lib/format-action-error";
+import { plateJsonToText } from "@/components/plate-text";
 import { cn } from "@/lib/utils";
 
 interface MergePatientsDialogProps {
@@ -108,8 +109,11 @@ function readFieldRaw(p: MappedGabinetPatient, key: MergeFieldKey): string | nul
   }
   const v = p[key as ScalarFieldKey];
   if (v == null) return null;
-  const s = String(v);
-  return s.trim() === "" ? null : s;
+  // Defensive: schema declares these as strings, but if a row somehow holds a
+  // non-string (legacy data, bad migration), skip rather than stringify into
+  // garbage like "[object Object]".
+  if (typeof v !== "string") return null;
+  return v.trim() === "" ? null : v;
 }
 
 function displayValue(
@@ -120,6 +124,13 @@ function displayValue(
   const raw = readFieldRaw(p, key);
   if (raw === null) return emptyPlaceholder;
   if (key === "phone" || key === "emergencyContactPhone") return formatPhoneNumber(raw);
+  // medicalNotes is written by the Plate rich-text editor and stored as a JSON
+  // string. Extract plain text so the comparison rows are readable rather than
+  // showing raw `[{"type":"p",...}]` payloads.
+  if (key === "medicalNotes") {
+    const text = plateJsonToText(raw).trim();
+    return text === "" ? emptyPlaceholder : text;
+  }
   return raw;
 }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1659.

Closes #1659

---

## Claude summary

Committed. Summary:

The original issue's `[object Object]` claim was inaccurate — `medicalNotes` is typed as `string` and stored in a `TEXT` column, so `String(v)` always returns the original string. The real problem is that the Plate rich-text editor stores its value as a JSON-stringified array, so the merge comparison row was displaying raw `[{"type":"p","children":[...]}]` payloads to the user.

Changes in `src/components/gabinet/merge-patients-dialog.tsx`:
- `displayValue` now runs `plateJsonToText()` on `medicalNotes`, falling back to the empty placeholder if the extracted text is blank
- `readFieldRaw` defensively returns `null` for non-string scalar values instead of stringifying them (matches the issue's "hide if non-string" guidance)
- The stored value passed to the merge action is unchanged — the underlying JSON string is still preserved when the user picks "source"