### PR TITLE
Fix close-after-merge race

### DIFF
--- a/src/components/gabinet/merge-patients-dialog.tsx
+++ b/src/components/gabinet/merge-patients-dialog.tsx
@@ -154,6 +154,26 @@ export function MergePatientsDialog({
     if (open) setTargetId(preselectedTargetId ?? null);
   }, [open, preselectedTargetId, sourcePatient?._id]);
 
+  // Watchdog: if the merge action's promise never settles (e.g. WebSocket
+  // reconnect leaves it hanging, or a state-update flush is dropped), the
+  // `finally` in handleMerge never runs and the dialog becomes uncloseable —
+  // both the close handler and Cancel button gate on `isMerging`. After the
+  // timeout, force-clear the flag so the user can always close the dialog.
+  // The action will continue server-side; results show up on the next refresh.
+  useEffect(() => {
+    if (!isMerging) return;
+    const id = window.setTimeout(() => {
+      setIsMerging(false);
+      toast.warning(
+        t("gabinet.patients.merge.timeout", {
+          defaultValue:
+            "Scalanie trwa dłużej niż zwykle. Możesz zamknąć okno — wynik pojawi się po odświeżeniu listy.",
+        }),
+      );
+    }, 60_000);
+    return () => window.clearTimeout(id);
+  }, [isMerging, t]);
+
   const sourceEmail = normalizeEmail(sourcePatient?.email);
   const sourcePhone = normalizePhone(sourcePatient?.phone);
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1660.

Closes #1660

---

## Claude summary

Fix committed. Summary:

The merge-patients dialog (`src/components/gabinet/merge-patients-dialog.tsx`) had a real lockout bug: `handleClose` early-returns when `isMerging` is true (line 252) and the Cancel button is `disabled={isMerging}` (line 541). If `await mergePatients()` never settles — the scenario the issue describes, where the action's promise hangs after a WebSocket reconnect — the `finally`'s `setIsMerging(false)` never runs, leaving the dialog uncloseable with no way out (Escape/click-outside go through `handleClose` too).

Fix: added a `useEffect` watchdog that fires `setTimeout` for 60s whenever `isMerging` flips true. If it fires, it force-clears `isMerging` and toasts a warning telling the user to refresh to see the result. On normal success/failure the cleanup clears the timer.