### PR TITLE
Minuty grafiku

### DIFF
--- a/src/components/gabinet/flexible-schedule-editor.tsx
+++ b/src/components/gabinet/flexible-schedule-editor.tsx
@@ -640,7 +640,7 @@ export function FlexibleScheduleEditor({
                     />
                     <Input
                       type="time"
-                      step={300}
+                      step={900}
                       className="h-7 w-22"
                       value={h.startTime}
                       onChange={(e) =>
@@ -650,7 +650,7 @@ export function FlexibleScheduleEditor({
                     />
                     <Input
                       type="time"
-                      step={300}
+                      step={900}
                       className="h-7 w-22"
                       value={h.endTime}
                       onChange={(e) =>
@@ -662,7 +662,7 @@ export function FlexibleScheduleEditor({
                       <div className="flex items-center gap-1">
                         <Input
                           type="time"
-                          step={300}
+                          step={900}
                           className="h-7 w-22"
                           value={h.breakStart}
                           onChange={(e) =>
@@ -677,7 +677,7 @@ export function FlexibleScheduleEditor({
                         <span className="text-xs text-muted-foreground">–</span>
                         <Input
                           type="time"
-                          step={300}
+                          step={900}
                           className="h-7 w-22"
                           value={h.breakEnd}
                           onChange={(e) =>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1666.

Closes #1666

---

## Claude summary

Changed `step={300}` (5 min) to `step={900}` (15 min) on all four time inputs (start, end, break start, break end) in `src/components/gabinet/flexible-schedule-editor.tsx:643,653,665,680` — the editor used on `/dashboard/gabinet/employees/<id>`. The browser's time spinner now snaps to :00, :15, :30, :45 as requested. Other `type="time"` inputs (appointments, activities, leaves, clinic settings) were intentionally left alone — the issue is specifically about employee schedules.

Note: HTML `step` controls the spinner increments but doesn't strictly block typed-in values in every browser. If the user reports they can still paste/type 10:05, a follow-up would add validation; the issue text describes the spinner behavior so this should be enough.

## Follow-ups
- Delete unused `employee-schedule-manager.tsx`: dead code with `@ts-nocheck`, no callers, duplicates `FlexibleScheduleEditor` functionality and will drift out of sync