### PR TITLE
Audit other handleCreate/handleSubmit handlers for silent try/finally

### DIFF
--- a/src/components/crm/entity-association-panel.tsx
+++ b/src/components/crm/entity-association-panel.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useCallback, useMemo, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Search, Plus } from "@/lib/ez-icons";
@@ -15,6 +16,7 @@ import {
   type EntityLinkResult,
   type EntityTypeConfig,
 } from "@/components/crm/entity-link-modal";
+import { formatActionError } from "@/lib/format-action-error";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -99,11 +101,18 @@ export function EntityAssociationPanel({
       setIsLinking(true);
       try {
         await onLink?.({ id: result.id, label: result.label, sublabel: result.sublabel });
+      } catch (e) {
+        toast.error(
+          formatActionError(e, t, {
+            key: "associations.errors.linkFailed",
+            defaultValue: "Nie udało się powiązać rekordów.",
+          }),
+        );
       } finally {
         setIsLinking(false);
       }
     },
-    [onLink],
+    [onLink, t],
   );
 
   // Convert search results to EntityLinkResult format

--- a/src/components/crm/global-search.tsx
+++ b/src/components/crm/global-search.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 import {
   CommandDialog,
   CommandEmpty,
@@ -98,11 +100,18 @@ export function GlobalSearch({
       try {
         const searchResults = await onSearch(value);
         setResults(searchResults);
+      } catch (e) {
+        toast.error(
+          formatActionError(e, t, {
+            key: "search.errors.searchFailed",
+            defaultValue: "Nie udało się wyszukać.",
+          }),
+        );
       } finally {
         setIsLoading(false);
       }
     },
-    [onSearch]
+    [onSearch, t]
   );
 
   function handleSelect(result: SearchResult) {

--- a/src/components/csv/csv-export-button.tsx
+++ b/src/components/csv/csv-export-button.tsx
@@ -4,9 +4,11 @@ import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Download } from "@/lib/ez-icons";
 import Papa from "papaparse";
+import { formatActionError } from "@/lib/format-action-error";
 
 type EntityType = "contacts" | "companies" | "leads" | "products" | "patients";
 
@@ -23,6 +25,7 @@ export function useCsvExport(
   entityType: EntityType,
   fileNamePrefix?: string,
 ) {
+  const { t } = useTranslation();
   const [isExporting, setIsExporting] = useState(false);
 
   const { refetch } = useQuery({
@@ -48,10 +51,17 @@ export function useCsvExport(
       link.click();
       document.body.removeChild(link);
       URL.revokeObjectURL(url);
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "csv.errors.exportFailed",
+          defaultValue: "Nie udało się wyeksportować danych do CSV.",
+        }),
+      );
     } finally {
       setIsExporting(false);
     }
-  }, [refetch, entityType, fileNamePrefix]);
+  }, [refetch, entityType, fileNamePrefix, t]);
 
   return { handleExport, isExporting };
 }

--- a/src/components/documents/pdf-export.tsx
+++ b/src/components/documents/pdf-export.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Download } from "@/lib/ez-icons";
 import { cn } from "@/lib/utils";
+import { formatActionError } from "@/lib/format-action-error";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -231,6 +233,13 @@ export function PdfExportButton({
           signatureAlt: t("documents.signature"),
         },
       });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "documents.errors.pdfExportFailed",
+          defaultValue: "Nie udało się wygenerować pliku PDF.",
+        }),
+      );
     } finally {
       setIsPrinting(false);
     }

--- a/src/components/email/compose-dialog.tsx
+++ b/src/components/email/compose-dialog.tsx
@@ -5,8 +5,10 @@ import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { useSupabaseEmailTemplatesList } from "@/hooks/use-supabase-email-templates";
 import { useSupabaseMailProvidersList } from "@/hooks/use-supabase-mail-providers";
+import { formatActionError } from "@/lib/format-action-error";
 import {
   Dialog,
   DialogContent,
@@ -195,6 +197,13 @@ export function ComposeDialog({
       setSelectedProviderId(defaultProviderId ?? "");
       lastAppliedTemplateRef.current = null;
       onOpenChange(false);
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "email.errors.sendFailed",
+          defaultValue: "Nie udało się wysłać wiadomości.",
+        }),
+      );
     } finally {
       setIsSending(false);
     }

--- a/src/components/settings/google-integration-card.tsx
+++ b/src/components/settings/google-integration-card.tsx
@@ -8,6 +8,8 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Mail, Calendar, Unplug, ExternalLink } from "@/lib/ez-icons";
 import { useState } from "react";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 interface GoogleIntegrationCardProps {
   organizationId: Id<"organizations">;
@@ -42,6 +44,13 @@ export function GoogleIntegrationCard({
     setDisconnecting(true);
     try {
       await revokeAndDeactivate({ organizationId, connectionId: connection._id });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "integrations.errors.disconnectFailed",
+          defaultValue: "Nie udało się odłączyć integracji.",
+        }),
+      );
     } finally {
       setDisconnecting(false);
     }

--- a/src/components/settings/mail-provider-form.tsx
+++ b/src/components/settings/mail-provider-form.tsx
@@ -22,6 +22,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ExternalLink } from "@/lib/ez-icons";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 type ProviderType = "google" | "microsoft" | "mailgun" | "resend";
 
@@ -147,6 +149,17 @@ export function MailProviderForm({
         await createProvider(payload);
       }
       onOpenChange(false);
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: isEdit
+            ? "mailProviders.errors.updateFailed"
+            : "mailProviders.errors.createFailed",
+          defaultValue: isEdit
+            ? "Nie udało się zapisać dostawcy poczty."
+            : "Nie udało się dodać dostawcy poczty.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.activities.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.activities.index.tsx
@@ -53,6 +53,8 @@ import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-s
 import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 type ActivityNudgeFilter = "overdue";
 
@@ -277,6 +279,17 @@ function ActivitiesPage() {
       await saveCfValues(activityId);
       setPanelOpen(false);
       resetForm();
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: editingActivity
+            ? "activities.errors.updateFailed"
+            : "activities.errors.createFailed",
+          defaultValue: editingActivity
+            ? "Nie udało się zapisać aktywności."
+            : "Nie udało się dodać aktywności.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.calls.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calls.index.tsx
@@ -39,6 +39,8 @@ import { CategoriesManagerSlideout } from "@/components/categories-tags/categori
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { AvatarLabelGroup } from "@untitled/base/avatar/avatar-label-group";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 type CallsNudgeFilter = "no-outcome";
 
@@ -213,6 +215,17 @@ function CallsPage() {
       }
       setPanelOpen(false);
       resetForm();
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: editingCall
+            ? "calls.errors.updateFailed"
+            : "calls.errors.createFailed",
+          defaultValue: editingCall
+            ? "Nie udało się zapisać rozmowy."
+            : "Nie udało się dodać rozmowy.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx
@@ -58,6 +58,8 @@ import { EntityAssociationPanel } from "@/components/crm/entity-association-pane
 import type { SearchResultItem } from "@/components/crm/entity-association-panel";
 import { CompanyOverviewTab } from "@/components/crm/company-overview-tab";
 import { useSidebarSlot } from "@/components/layout/sidebar-slot-context";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/companies/$companyId"
@@ -319,6 +321,13 @@ function CompanyDetail() {
       }
       setEditDrawerOpen(false);
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.companies.all });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "companies.errors.updateFailed",
+          defaultValue: "Nie udało się zapisać firmy.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -491,6 +500,13 @@ function CompanyDetail() {
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.objectRelationships.list(organizationId) });
       setCreateContactDrawerOpen(false);
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "contacts.errors.createFailed",
+          defaultValue: "Nie udało się dodać kontaktu.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -508,6 +524,13 @@ function CompanyDetail() {
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.notes.list(organizationId) });
       setNewNote("");
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "notes.errors.createFailed",
+          defaultValue: "Nie udało się dodać notatki.",
+        }),
+      );
     } finally {
       setIsAddingNote(false);
     }
@@ -540,6 +563,13 @@ function CompanyDetail() {
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.objectRelationships.list(organizationId) });
       setCreateLeadDrawerOpen(false);
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "leads.errors.createFailed",
+          defaultValue: "Nie udało się dodać szansy sprzedaży.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
@@ -34,6 +34,8 @@ import { CategoriesManagerSlideout } from "@/components/categories-tags/categori
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 type CompanyNudgeFilter = "no-contacts" | "no-industry";
 
@@ -346,11 +348,18 @@ function CompaniesIndex() {
         setPanelOpen(false);
         setTagIds([]);
         setCategoryId(undefined);
+      } catch (e) {
+        toast.error(
+          formatActionError(e, t, {
+            key: "companies.errors.createFailed",
+            defaultValue: "Nie udało się dodać firmy.",
+          }),
+        );
       } finally {
         setIsCreating(false);
       }
     },
-    [createCompany, organizationId, cfDefs, setCustomFieldValues, tagIds, categoryId]
+    [createCompany, organizationId, cfDefs, setCustomFieldValues, tagIds, categoryId, t]
   );
 
   const handleBulkAction = useCallback(

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
@@ -57,6 +57,8 @@ import { EntityAssociationPanel } from "@/components/crm/entity-association-pane
 import type { SearchResultItem } from "@/components/crm/entity-association-panel";
 import { EntityDocumentsTab } from "@/components/documents/entity-documents-tab";
 import { useSidebarSlot } from "@/components/layout/sidebar-slot-context";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createLazyFileRoute(
   "/_app/_auth/dashboard/_layout/contacts/$contactId"
@@ -321,6 +323,13 @@ function ContactDetail() {
         }
       }
       setEditDrawerOpen(false);
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "contacts.errors.updateFailed",
+          defaultValue: "Nie udało się zapisać kontaktu.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -495,6 +504,13 @@ function ContactDetail() {
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.objectRelationships.list(organizationId) });
       setCreateCompanyDrawerOpen(false);
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "companies.errors.createFailed",
+          defaultValue: "Nie udało się dodać firmy.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -512,6 +528,13 @@ function ContactDetail() {
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.notes.list(organizationId) });
       setNewNote("");
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "notes.errors.createFailed",
+          defaultValue: "Nie udało się dodać notatki.",
+        }),
+      );
     } finally {
       setIsAddingNote(false);
     }
@@ -544,6 +567,13 @@ function ContactDetail() {
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.objectRelationships.list(organizationId) });
       setCreateLeadDrawerOpen(false);
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "leads.errors.createFailed",
+          defaultValue: "Nie udało się dodać szansy sprzedaży.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
@@ -28,6 +28,8 @@ import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
 import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
 import { formatPhoneNumber } from "@/lib/phone";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 type ContactNudgeFilter = "unlinked-company";
 
@@ -321,11 +323,18 @@ function ContactsIndex() {
           }
         }
         setPanelOpen(false);
+      } catch (e) {
+        toast.error(
+          formatActionError(e, t, {
+            key: "contacts.errors.createFailed",
+            defaultValue: "Nie udało się dodać kontaktu.",
+          }),
+        );
       } finally {
         setIsCreating(false);
       }
     },
-    [createContact, organizationId, cfDefs, setCustomFieldValues]
+    [createContact, organizationId, cfDefs, setCustomFieldValues, t]
   );
 
   const handleBulkAction = useCallback(

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -549,6 +549,17 @@ function TreatmentDetail() {
       setVariantDialogOpen(false);
       resetVariantForm();
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatmentVariants.list(organizationId) });
+    } catch (e) {
+      toast.error(
+        formatTreatmentError(e, t, {
+          key: editingVariant
+            ? "gabinet.treatmentDetail.variants.errors.updateFailed"
+            : "gabinet.treatmentDetail.variants.errors.createFailed",
+          defaultValue: editingVariant
+            ? "Nie udało się zapisać wariantu zabiegu."
+            : "Nie udało się dodać wariantu zabiegu.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
@@ -84,6 +84,8 @@ import { cn } from "@/lib/utils";
 import { useCustomFieldForm } from "@/hooks/use-custom-field-form";
 import { EmailEntityTab } from "@/components/email/email-entity-tab";
 import { EntityDocumentsTab } from "@/components/documents/entity-documents-tab";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createLazyFileRoute(
   "/_app/_auth/dashboard/_layout/leads/$leadId"
@@ -538,6 +540,13 @@ function LeadDetail() {
       setEditDrawerOpen(false);
       queryClient.invalidateQueries({ queryKey: supabaseKeys.leads.all });
       queryClient.invalidateQueries({ queryKey: supabaseKeys.pipelineStages.all });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "leads.errors.updateFailed",
+          defaultValue: "Nie udało się zapisać szansy sprzedaży.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -740,6 +749,13 @@ function LeadDetail() {
       });
       setCreateContactDrawerOpen(false);
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.objectRelationships.all });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "contacts.errors.createFailed",
+          defaultValue: "Nie udało się dodać kontaktu.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -770,6 +786,13 @@ function LeadDetail() {
       });
       setCreateCompanyDrawerOpen(false);
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.objectRelationships.all });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "companies.errors.createFailed",
+          defaultValue: "Nie udało się dodać firmy.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -787,6 +810,13 @@ function LeadDetail() {
       });
       setNewNote("");
       queryClient.invalidateQueries({ queryKey: supabaseKeys.notes.all });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "notes.errors.createFailed",
+          defaultValue: "Nie udało się dodać notatki.",
+        }),
+      );
     } finally {
       setIsAddingNote(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
@@ -58,6 +58,8 @@ import { CategoriesManagerSlideout } from "@/components/categories-tags/categori
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 type LeadNudgeFilter = "stale" | "closing-this-week";
 
@@ -772,6 +774,13 @@ function LeadsIndex() {
                 categoryId,
               });
               setCreateOpen(false);
+            } catch (e) {
+              toast.error(
+                formatActionError(e, t, {
+                  key: "leads.errors.createFailed",
+                  defaultValue: "Nie udało się dodać szansy sprzedaży.",
+                }),
+              );
             } finally {
               setIsSubmitting(false);
             }

--- a/src/routes/_app/_auth/dashboard/_layout.settings.activity-types.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.activity-types.tsx
@@ -20,6 +20,8 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { Plus, Pencil, Trash2 } from "@/lib/ez-icons";
 import { getActivityIcon } from "@/lib/activity-icon-registry";
 import { Id } from "@cvx/_generated/dataModel";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/settings/activity-types"
@@ -91,6 +93,13 @@ function ActivityTypesSettings() {
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.activityTypes.list(organizationId) });
       setShowCreateForm(false);
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "activityTypes.errors.createFailed",
+          defaultValue: "Nie udało się dodać typu aktywności.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -111,6 +120,13 @@ function ActivityTypesSettings() {
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.activityTypes.list(organizationId) });
       setEditingId(null);
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "activityTypes.errors.updateFailed",
+          defaultValue: "Nie udało się zapisać typu aktywności.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.settings.email-templates.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.email-templates.tsx
@@ -40,6 +40,8 @@ import { Plus, Pencil, Trash2 } from "@/lib/ez-icons";
 import { Id } from "@cvx/_generated/dataModel";
 import { EmailTemplateEditor } from "@/components/email/template-editor";
 import type { EmailTemplateEditorHandle } from "@/components/email/template-editor";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/settings/email-templates",
@@ -160,6 +162,17 @@ function EmailTemplatesSettings() {
       setDialogOpen(false);
       setForm(emptyForm);
       setEditingId(null);
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: editingId
+            ? "emailTemplates.errors.updateFailed"
+            : "emailTemplates.errors.createFailed",
+          defaultValue: editingId
+            ? "Nie udało się zapisać szablonu."
+            : "Nie udało się dodać szablonu.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.settings.lost-reasons.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.lost-reasons.tsx
@@ -18,6 +18,8 @@ import { Switch } from "@/components/ui/switch";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { Plus, Pencil, Trash2 } from "@/lib/ez-icons";
 import { Id } from "@cvx/_generated/dataModel";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/settings/lost-reasons"
@@ -57,6 +59,13 @@ function LostReasonsSettings() {
       setNewLabel("");
       setShowCreateForm(false);
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.lostReasons.list(organizationId) });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "lostReasons.errors.createFailed",
+          defaultValue: "Nie udało się dodać powodu utraty.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -73,6 +82,13 @@ function LostReasonsSettings() {
       });
       setEditingId(null);
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.lostReasons.list(organizationId) });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "lostReasons.errors.updateFailed",
+          defaultValue: "Nie udało się zapisać powodu utraty.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.settings.organization.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.organization.tsx
@@ -29,6 +29,8 @@ import {
   Package,
   Mail,
 } from "@/lib/ez-icons";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/settings/organization"
@@ -111,6 +113,13 @@ function OrganizationSettings() {
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.organizations.detail(organizationId, organizationId) });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.orgSettings.detail(organizationId, organizationId) });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "organization.errors.saveFailed",
+          defaultValue: "Nie udało się zapisać ustawień organizacji.",
+        }),
+      );
     } finally {
       setIsSaving(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.settings.sources.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.sources.tsx
@@ -16,6 +16,8 @@ import { Switch } from "@/components/ui/switch";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { Plus, Pencil, Trash2 } from "@/lib/ez-icons";
 import { Id } from "@cvx/_generated/dataModel";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/settings/sources"
@@ -52,6 +54,13 @@ function SourcesSettings() {
       setNewName("");
       setShowCreateForm(false);
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.sources.list(organizationId) });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "sources.errors.createFailed",
+          defaultValue: "Nie udało się dodać źródła.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -68,6 +77,13 @@ function SourcesSettings() {
       });
       setEditingId(null);
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.sources.list(organizationId) });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "sources.errors.updateFailed",
+          defaultValue: "Nie udało się zapisać źródła.",
+        }),
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -92,6 +92,8 @@ import { DateRangePicker } from "@/components/crm/date-range-picker";
 import { AgendaStrip } from "@/components/layout/agenda-strip";
 import type { Id } from "@cvx/_generated/dataModel";
 import { NudgesProvider } from "@/contexts/nudges-context";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute("/_app/_auth/dashboard/_layout")({
   errorComponent: ({ error, reset }) => (
@@ -427,6 +429,13 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
                   });
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.contacts.list(orgId) });
                   opts.onSuccess();
+                } catch (e) {
+                  toast.error(
+                    formatActionError(e, t, {
+                      key: "contacts.errors.createFailed",
+                      defaultValue: "Nie udało się dodać kontaktu.",
+                    }),
+                  );
                 } finally {
                   setIsCreating(false);
                 }
@@ -449,6 +458,13 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
                   await createCompany({ organizationId: orgId, ...data });
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.companies.list(orgId) });
                   opts.onSuccess();
+                } catch (e) {
+                  toast.error(
+                    formatActionError(e, t, {
+                      key: "companies.errors.createFailed",
+                      defaultValue: "Nie udało się dodać firmy.",
+                    }),
+                  );
                 } finally {
                   setIsCreating(false);
                 }
@@ -474,6 +490,13 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
                   });
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.leads.list(orgId) });
                   opts.onSuccess();
+                } catch (e) {
+                  toast.error(
+                    formatActionError(e, t, {
+                      key: "leads.errors.createFailed",
+                      defaultValue: "Nie udało się dodać szansy sprzedaży.",
+                    }),
+                  );
                 } finally {
                   setIsCreating(false);
                 }
@@ -491,6 +514,13 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
                   await createPatient({ organizationId: orgId, ...data });
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetPatients.list(orgId) });
                   opts.onSuccess();
+                } catch (e) {
+                  toast.error(
+                    formatActionError(e, t, {
+                      key: "gabinet.patients.errors.createFailed",
+                      defaultValue: "Nie udało się dodać pacjenta.",
+                    }),
+                  );
                 } finally {
                   setIsCreating(false);
                 }
@@ -512,6 +542,13 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
                   await createTreatment({ organizationId: orgId, ...data });
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatments.list(orgId) });
                   opts.onSuccess();
+                } catch (e) {
+                  toast.error(
+                    formatActionError(e, t, {
+                      key: "gabinet.treatments.errors.createFailed",
+                      defaultValue: "Nie udało się dodać zabiegu.",
+                    }),
+                  );
                 } finally {
                   setIsCreating(false);
                 }
@@ -529,6 +566,13 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
                   await createPackage({ organizationId: orgId, ...data });
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatmentPackages.list(orgId) });
                   opts.onSuccess();
+                } catch (e) {
+                  toast.error(
+                    formatActionError(e, t, {
+                      key: "gabinet.packages.errors.createFailed",
+                      defaultValue: "Nie udało się dodać pakietu.",
+                    }),
+                  );
                 } finally {
                   setIsCreating(false);
                 }
@@ -547,6 +591,13 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
                   await createEmployee({ organizationId: orgId, ...data, userId: data.userId });
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetEmployees.list(orgId) });
                   opts.onSuccess();
+                } catch (e) {
+                  toast.error(
+                    formatActionError(e, t, {
+                      key: "gabinet.employees.errors.createFailed",
+                      defaultValue: "Nie udało się dodać pracownika.",
+                    }),
+                  );
                 } finally {
                   setIsCreating(false);
                 }
@@ -575,6 +626,13 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.scheduledActivities.list(orgId) });
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.activities.list(orgId) });
                   opts.onSuccess();
+                } catch (e) {
+                  toast.error(
+                    formatActionError(e, t, {
+                      key: "activities.errors.createFailed",
+                      defaultValue: "Nie udało się dodać aktywności.",
+                    }),
+                  );
                 } finally {
                   setIsCreating(false);
                 }
@@ -602,6 +660,13 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
                   });
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetLeaves.list(orgId) });
                   opts.onSuccess();
+                } catch (e) {
+                  toast.error(
+                    formatActionError(e, t, {
+                      key: "gabinet.leaves.errors.createFailed",
+                      defaultValue: "Nie udało się dodać urlopu.",
+                    }),
+                  );
                 } finally {
                   setIsCreating(false);
                 }
@@ -619,6 +684,13 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
                   await createProduct({ organizationId: orgId, ...data });
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.products.list(orgId) });
                   opts.onSuccess();
+                } catch (e) {
+                  toast.error(
+                    formatActionError(e, t, {
+                      key: "products.errors.createFailed",
+                      defaultValue: "Nie udało się dodać produktu.",
+                    }),
+                  );
                 } finally {
                   setIsCreating(false);
                 }
@@ -636,6 +708,13 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
                   await createCall({ organizationId: orgId, ...data });
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.calls.list(orgId) });
                   opts.onSuccess();
+                } catch (e) {
+                  toast.error(
+                    formatActionError(e, t, {
+                      key: "calls.errors.createFailed",
+                      defaultValue: "Nie udało się dodać rozmowy.",
+                    }),
+                  );
                 } finally {
                   setIsCreating(false);
                 }
@@ -659,6 +738,13 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
                   });
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(orgId) });
                   opts.onSuccess();
+                } catch (e) {
+                  toast.error(
+                    formatActionError(e, t, {
+                      key: "invitations.errors.createFailed",
+                      defaultValue: "Nie udało się wysłać zaproszenia.",
+                    }),
+                  );
                 } finally {
                   setIsCreating(false);
                 }
@@ -874,6 +960,13 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
               endDate: data.endDate,
               description: data.description,
             });
+          } catch (e) {
+            toast.error(
+              formatActionError(e, t, {
+                key: "activities.errors.updateFailed",
+                defaultValue: "Nie udało się zapisać aktywności.",
+              }),
+            );
           } finally {
             setActivityDetailSubmitting(false);
           }
@@ -886,6 +979,13 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
               activityId: id as Id<"scheduledActivities">,
             });
             setActivityDetailId(null);
+          } catch (e) {
+            toast.error(
+              formatActionError(e, t, {
+                key: "activities.errors.deleteFailed",
+                defaultValue: "Nie udało się usunąć aktywności.",
+              }),
+            );
           } finally {
             setActivityDetailSubmitting(false);
           }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1669.

Closes #1669

---

## Claude summary

Committed. Here's the summary.

I audited every `} finally {` block in `src/` for the silent try/finally anti-pattern from #1653 (try { await action() } finally { setLoading(false) } with no catch). My audit script found nine remaining files after the prior in-progress work on this branch had touched thirteen route files. I extended the same fix to:

- `src/components/settings/mail-provider-form.tsx` — handleSubmit
- `src/components/settings/google-integration-card.tsx` — handleDisconnect
- `src/components/documents/pdf-export.tsx` — handleExport
- `src/components/email/compose-dialog.tsx` — handleSend
- `src/components/csv/csv-export-button.tsx` — useCsvExport.handleExport
- `src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx` — handleSaveVariant
- `src/routes/_app/_auth/dashboard/_layout.settings.email-templates.tsx` — handleSave
- `src/components/crm/global-search.tsx` — handleSearch
- `src/components/crm/entity-association-panel.tsx` — handleSelect (the parent re-throws after rolling back optimistic updates, so the swallowed error was real)

Each catch toasts via `formatActionError` (or `formatTreatmentError` where already imported), mirroring #1653. `tsc -p tsconfig.app.json --noEmit` passes; lint shows only pre-existing warnings unrelated to this change. A final re-scan confirms no silent try/finally remains in `src/`. Commit: `f3623cc`.