### PR TITLE
Szczegoly kontaktu i pracownika

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
@@ -38,6 +38,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -766,14 +767,6 @@ function ContactDetail() {
       ]
     : [];
 
-  // --- Sidebar content passed as props (no useEffect loop) ---
-  const quickActionItems = [
-    { key: "scheduleActivity", label: t("entityActions.scheduleActivity", { defaultValue: "Zaplanuj aktywność" }), onClick: () => { setActiveTab(t('detail.tabs.activities')); setShowActivityForm(true); } },
-    { key: "sendEmail", label: t("entityActions.sendEmail", { defaultValue: "Wyślij email" }), onClick: () => { setActiveTab(t('detail.tabs.emails')); setAutoComposeCounter(c => c + 1); } },
-    { key: "addNote", label: t("entityActions.addNote", { defaultValue: "Dodaj notatkę" }), onClick: () => { setActiveTab(t('detail.tabs.notes')); setIsAddingNote(true); } },
-    { key: "logCall", label: t("entityActions.logCall", { defaultValue: "Zarejestruj połączenie" }), onClick: () => setActiveTab(t('detail.tabs.calls')) },
-  ];
-
   // --- Actions menu ---
   const actionsMenu = (
     <DropdownMenu>
@@ -784,6 +777,19 @@ function ContactDetail() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => { setActiveTab(t('detail.tabs.activities')); setShowActivityForm(true); }}>
+          {t("entityActions.scheduleActivity", { defaultValue: "Zaplanuj aktywność" })}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => { setActiveTab(t('detail.tabs.emails')); setAutoComposeCounter(c => c + 1); }}>
+          {t("entityActions.sendEmail", { defaultValue: "Wyślij email" })}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => { setActiveTab(t('detail.tabs.notes')); setIsAddingNote(true); }}>
+          {t("entityActions.addNote", { defaultValue: "Dodaj notatkę" })}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setActiveTab(t('detail.tabs.calls'))}>
+          {t("entityActions.logCall", { defaultValue: "Zarejestruj połączenie" })}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
         <DropdownMenuItem onClick={() => setCreateLeadDrawerOpen(true)}>
           <Plus className="mr-2 h-4 w-4" variant="stroke" />
           {t('detail.actions.addLead')}
@@ -1091,7 +1097,6 @@ function ContactDetail() {
           },
         ]}
         attachments={attachmentsContent}
-        quickActionItems={quickActionItems}
         tabs={tabs}
         defaultTab={t('detail.tabs.all')}
         activeTab={activeTab}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -738,7 +738,6 @@ function EmployeeDetail() {
         headerSubtitle={headerSubtitle}
         avatarFallback={avatarFallback}
         actionsMenu={actionsMenu}
-        onEdit={() => setEditDrawerOpen(true)}
         fields={detailFields}
         expandedFieldCount={5}
         sidebarExtra={sidebarExtra}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1671.

Closes #1671

---

## Claude summary

Committed. Summary of the fix:

**Problem.** The employee detail (`/dashboard/gabinet/employees/:id`) and contact detail (`/dashboard/contacts/:id`) pages rendered TWO stacked "Akcje" dropdowns in the sidebar. EntityDetailLayout shows the custom `actionsMenu` prop, and then *also* auto-generates a second "Akcje" button whenever `onEdit` or `quickActionItems` produce entries.

**Fix.**
- Employee page (`_layout.gabinet.employees.$employeeId.tsx:740`): dropped the redundant `onEdit` prop — Edit is already in the custom menu, so the second dropdown no longer renders.
- Contact page (`_layout.contacts.$contactId.lazy.tsx:770`): folded the four `quickActionItems` (Schedule activity, Send email, Add note, Log call) into the custom `actionsMenu` above a `DropdownMenuSeparator` and entity actions (Add lead, Edit, Delete). Removed the `quickActionItems` prop.

Both pages now show a single "Akcje" button.

## Follow-ups
- Same duplicate-Akcje bug on leads and companies detail pages: `src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx:1499-1508` and `src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx:834-888` both pass `actionsMenu` + `onEdit` + `quickActionItems` and render two stacked "Akcje" dropdowns just like #1671 — apply the same merge.
- EntityDetailLayout hardcodes label `"Edit"` for the `onEdit`-derived action: `src/components/crm/entity-detail-layout.tsx:168` pushes `label: "Edit"`, which renders as English even in Polish locale; should use i18n.