### PR TITLE
Hide MigrationHealthBanner from non-admin users

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -812,7 +812,9 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
             </button>
           </span>
         </div>
-        <MigrationHealthBanner />
+        {(firstOrg?.role === "owner" || firstOrg?.role === "admin") && (
+          <MigrationHealthBanner />
+        )}
         <DevInfoDialog open={devInfoOpen} onOpenChange={handleDevInfoClose} />
 
         <div className="flex min-h-0 min-w-0 flex-1">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1672.

Closes #1672

---

## Claude summary

Gated `MigrationHealthBanner` to render only when `firstOrg.role` is `"owner"` or `"admin"`. The role is already attached to `firstOrg` by `getMyOrganizations` (convex/organizations.ts:134), so this is a single render-site conditional in `src/routes/_app/_auth/dashboard/_layout.tsx:815` with no additional queries. Non-admins now see degraded behavior only through the existing per-feature error toasts, not the alarming banner with `npm run migrations:apply`.