### PR TITLE
Kliknięcie w wiersz w data table (dowolne) natomiat przyklad jest z tabeli pracownikow

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
@@ -486,6 +486,9 @@ function CompaniesIndex() {
         rowActions={rowActions}
         emptyTitle={t('companies.emptyTitle')}
         emptyDescription={t('companies.emptyDescription')}
+        onRowAction={(companyId) =>
+          navigate({ to: `/dashboard/companies/${companyId}` })
+        }
       />
 
       <CsvImportDialog

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
@@ -459,6 +459,9 @@ function ContactsIndex() {
         rowActions={rowActions}
         emptyTitle={t('contacts.emptyTitle')}
         emptyDescription={t('contacts.emptyDescription')}
+        onRowAction={(contactId) =>
+          navigate({ to: `/dashboard/contacts/${contactId}` })
+        }
       />
 
       <CsvImportDialog

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -356,6 +356,9 @@ function EmployeesIndex() {
         ]}
         onBulkAction={handleBulkAction}
         rowActions={rowActions}
+        onRowAction={(employeeId) =>
+          navigate({ to: `/dashboard/gabinet/employees/${employeeId}` })
+        }
       />
 
       <TagsManagerSlideout

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -603,6 +603,9 @@ function PatientsIndex() {
         rowActions={rowActions}
         emptyTitle={t("gabinet.patients.emptyTitle")}
         emptyDescription={t("gabinet.patients.emptyDescription")}
+        onRowAction={(patientId) =>
+          navigate({ to: `/dashboard/gabinet/patients/${patientId}` })
+        }
       />
 
       <SidePanel

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -587,6 +587,9 @@ function TreatmentsIndex() {
         rowActions={rowActions}
         emptyTitle={t("gabinet.treatments.emptyTitle")}
         emptyDescription={t("gabinet.treatments.emptyDescription")}
+        onRowAction={(treatmentId) =>
+          navigate({ to: `/dashboard/gabinet/treatments/${treatmentId}` })
+        }
       />
 
       <SidePanel

--- a/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
@@ -701,6 +701,9 @@ function LeadsIndex() {
         ]}
         emptyTitle={t("deals.emptyTitle")}
         emptyDescription={t("deals.emptyDescription")}
+        onRowAction={(leadId) =>
+          navigate({ to: `/dashboard/leads/${leadId}` })
+        }
       />
 
       <CsvImportDialog


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1673.

Closes #1673

---

## Claude summary

Wired up `onRowAction` on all six list pages that have detail routes: contacts, companies, leads, gabinet patients, treatments, and employees. The `CrmDataTable` (`src/components/crm/enhanced-data-table.tsx:75`) already supported this prop — React Aria's table treats a row click as a selection toggle by default, but when `onRowAction` is set it fires the action on row clicks while reserving selection toggling to the checkbox cell. The infrastructure was in place, but no consumer was passing it. Other tables (products, activities, calls, documents, gabinet/documents) don't have detail routes, so their behavior is unchanged.

Focusable children inside cells (the existing name `<Link>`, the kebab menu button) continue to take precedence — React Aria skips the row action when the press lands on a focusable descendant — so the existing inline links and row-action menus keep working without double navigation.

## Follow-ups
- Add a detail/edit shortcut from products, activities, and calls tables: these CrmDataTable lists have no detail route, so row-click navigation can't be wired without first introducing a detail page or sheet pattern.