### PR TITLE
Generowany dokument z szablonu - domyślna wartość dla brakujących zmiennych

### DIFF
--- a/src/components/documents/document-renderer.tsx
+++ b/src/components/documents/document-renderer.tsx
@@ -153,7 +153,7 @@ export function renderDocument(
         span.setAttribute("data-missing-var", path);
         el.replaceWith(span);
       } else {
-        el.replaceWith(document.createTextNode(`[${path}]`));
+        el.replaceWith(document.createTextNode(""));
       }
     }
   });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1684.

Closes #1684

---

## Claude summary

Fixed and committed.

The bug was in `src/components/documents/document-renderer.tsx:156`. When a `[data-variable]` node had no resolved value and `highlightMissing` was off (the default for client-facing renders in `generate-document-dialog.tsx`, `entity-documents-tab.tsx`, `after-completion-documents-dialog.tsx`, `appointment-document-checklist.tsx`, and the public `sign.form.$token.tsx` route), the renderer substituted `` `[${path}]` `` — so a missing patient first name showed as `[patient.firstName]` in the document the client receives.

The fix swaps that text node for an empty string. The internal template preview (`template-preview-sheet.tsx:409`) keeps its `highlightMissing: true` opt-in, so staff still see flagged gaps when editing/previewing templates.