### PR TITLE
Podglad wygenerowanego dokumentu - pola do uzupełnienia

### DIFF
--- a/src/components/documents/form-field-node.tsx
+++ b/src/components/documents/form-field-node.tsx
@@ -262,9 +262,12 @@ export const FormFieldNode = Node.create({
         "data-form-field": HTMLAttributes.fieldId,
         "data-field-type": HTMLAttributes.fieldType,
         "data-filled-by": HTMLAttributes.filledBy || "employee",
+        // No dark: variants — this HTML is always rendered inside a
+        // white-paper document container (bg-white + [&_*]:!text-gray-900),
+        // where dark-mode backgrounds would clash with the forced dark text.
         class: isClient
-          ? "inline-flex items-center rounded border border-dashed border-blue-300 bg-blue-50 px-2 py-0.5 text-xs text-blue-700 dark:border-blue-600 dark:bg-blue-950 dark:text-blue-300"
-          : "inline-flex items-center rounded border border-dashed border-orange-300 bg-orange-50 px-2 py-0.5 text-xs text-orange-700 dark:border-orange-600 dark:bg-orange-950 dark:text-orange-300",
+          ? "inline-flex items-center rounded border border-dashed border-blue-300 bg-blue-50 px-2 py-0.5 text-xs text-blue-700"
+          : "inline-flex items-center rounded border border-dashed border-orange-300 bg-orange-50 px-2 py-0.5 text-xs text-orange-700",
         contenteditable: "false",
       }),
       `[${HTMLAttributes.label || HTMLAttributes.fieldId || "Field"}]`,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1685.

Closes #1685

---

## Claude summary

Fix committed. Summary:

The issue is that unresolved client form-field placeholders (e.g. `[Akceptuję wybrany kolor barwnika...]`) rendered with `dark:bg-blue-950` / `dark:bg-orange-950` Tailwind classes in `form-field-node.tsx` (the TipTap node's `renderHTML`). However, every place that calls `renderDocument()` wraps the output in a white-paper container with `bg-white p-6 ... [&_*]:!text-gray-900` — that `!important` forces every descendant's text color to near-black. In dark mode the dark-navy/dark-orange backgrounds applied (since `<html class="dark">`), but the text was forced gray-900 → dark text on dark background, exactly as the screenshot shows (`#1a2566` pills with invisible text).

Blast radius for the same bug: the same `renderDocument` output container is used in seven places (`DocumentViewer`, `GenerateDocumentDialog` preview, `TemplatePreviewSheet`, `EntityDocumentsTab`, `AppointmentDocumentChecklist`, `AfterCompletionDocumentsDialog`, the document list page, and the public `sign.form.$token` route). All of them inherit the fix automatically since the source is a single TipTap node `renderHTML`.

The fix removes the `dark:` variants from `renderHTML` in `src/components/documents/form-field-node.tsx:268-270`. The editor's React `NodeView` was already light-only and renders inside a white editor canvas, so it's unaffected.