### PR TITLE
Wywiad mail

### DIFF
--- a/src/routes/sign.$token.tsx
+++ b/src/routes/sign.$token.tsx
@@ -65,8 +65,11 @@ function SigningPage() {
 // ---------------------------------------------------------------------------
 
 function PageShell({ children }: { children: React.ReactNode }) {
+  // body has `overflow: hidden; height: 100dvh` globally, so this shell must
+  // be the scroll container — otherwise long documents overflow with no
+  // way to scroll. See #1687.
   return (
-    <div className="min-h-screen bg-muted/30">
+    <div className="h-dvh overflow-y-auto bg-muted/30">
       <div className="mx-auto max-w-3xl px-4 py-8">{children}</div>
     </div>
   );

--- a/src/routes/sign.form.$token.tsx
+++ b/src/routes/sign.form.$token.tsx
@@ -92,8 +92,11 @@ function FormSigningPage() {
 // ---------------------------------------------------------------------------
 
 function PageShell({ children }: { children: React.ReactNode }) {
+  // body has `overflow: hidden; height: 100dvh` globally, so this shell must
+  // be the scroll container — otherwise long forms (e.g. medical interview)
+  // overflow without any way to scroll. See #1687.
   return (
-    <div className="min-h-screen bg-muted/30">
+    <div className="h-dvh overflow-y-auto bg-muted/30">
       <div className="mx-auto max-w-2xl px-4 py-8 sm:py-12">{children}</div>
     </div>
   );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1687.

Closes #1687

---

## Claude summary

Fix committed as `80eec2b`.

The bug: the global stylesheet sets `html, body { overflow: hidden; height: 100dvh }` (src/index.css:331) so the dashboard's `<main>` is the scroll container. But the public signing routes don't use the dashboard layout — their `PageShell` was just `min-h-screen bg-muted/30`, which silently overflows a locked-overflow body. On the medical-interview form (`/sign/form/$token`), the form is long enough to push the submit button below the viewport with no way to reach it.

The fix: make `PageShell` itself the scroll container by switching to `h-dvh overflow-y-auto`. Applied to both `sign.form.$token.tsx` (the route in the report) and `sign.$token.tsx` (same pattern, same latent bug).