### PR TITLE
Wizyta rozliczenie ponowne

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2899,6 +2899,7 @@
       "close": "Close",
       "saveChanges": "Save changes",
       "closeAndSettle": "Settle visit",
+      "settled": "Settled",
       "performTreatment": "Perform treatment",
       "settleDesc": "Record payment and optionally close the appointment as completed.",
       "settleMarkCompleted": "Mark appointment as completed",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2930,6 +2930,7 @@
       "close": "Zamknij",
       "saveChanges": "Zapisz zmiany",
       "closeAndSettle": "Rozlicz wizytę",
+      "settled": "Rozliczono",
       "performTreatment": "Przeprowadź zabieg",
       "settleDesc": "Zarejestruj płatność i opcjonalnie zamknij wizytę jako zakończoną.",
       "settleMarkCompleted": "Oznacz wizytę jako zakończoną",

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -623,6 +623,13 @@ export function AppointmentPreviewContent({
     .filter((p) => p.status === "completed")
     .reduce((sum, p) => sum + (p.amount ?? 0), 0);
 
+  // Drives the "already settled" affordance on the Rozlicz button (issue #1688).
+  // Settle = visit closed AND nothing left to pay; otherwise the primary button
+  // stays blue so staff can finish the workflow.
+  const isSettled =
+    appointment.status === "completed" &&
+    (treatmentPrice === 0 || completedPaid >= treatmentPrice);
+
   const patientCreditBalance = (detail.patientCreditBalance ?? 0) as number;
 
   // Compact indicator pills mirroring the calendar card surface (issue #730).
@@ -1392,13 +1399,21 @@ export function AppointmentPreviewContent({
         </Button>
         <Button
           size="sm"
+          variant={isSettled ? "outline" : "default"}
           className="h-8 text-xs"
           onClick={handleOpenSettleDialog}
-          disabled={saving || settleSubmitting}
+          disabled={saving || settleSubmitting || isSettled}
         >
-          {saving
-            ? t("common.saving")
-            : t("gabinet.appointmentDetail.closeAndSettle", "Rozlicz wizytę")}
+          {saving ? (
+            t("common.saving")
+          ) : isSettled ? (
+            <>
+              <CircleCheck className="mr-1 size-3" />
+              {t("gabinet.appointmentDetail.settled", "Rozliczono")}
+            </>
+          ) : (
+            t("gabinet.appointmentDetail.closeAndSettle", "Rozlicz wizytę")
+          )}
         </Button>
       </div>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1688.

Closes #1688

---

## Claude summary

Fixed and committed. In the calendar preview popover (`src/components/gabinet/calendar/appointment-preview-content.tsx`), the "Rozlicz wizytę" button now detects when the appointment is already settled (status `completed` AND no outstanding balance) and switches from the default blue/primary variant to an outline variant, disables itself, and shows "Rozliczono" with a checkmark icon. PL/EN translation keys (`gabinet.appointmentDetail.settled`) added.