### PR TITLE
EntityDetailLayout hardcodes label `"Edit"` for the `onEdit`-derived action

### DIFF
--- a/src/components/crm/entity-detail-layout.tsx
+++ b/src/components/crm/entity-detail-layout.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { ChevronDown, ChevronUp, Plus } from "@/lib/ez-icons";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -151,11 +152,13 @@ function buildDetailActions({
   primaryAction,
   secondaryActions,
   onEdit,
+  editLabel,
   quickActionItems,
 }: {
   primaryAction?: { label: string; onClick: () => void };
   secondaryActions?: { label: string; onClick: () => void; variant?: "default" | "outline" | "destructive" }[];
   onEdit?: () => void;
+  editLabel: string;
   quickActionItems?: { key: string; label: string; icon?: React.ReactNode; onClick: () => void }[];
 }) {
   const allActions: { label: string; icon?: React.ReactNode; onClick: () => void; variant?: string }[] = [];
@@ -165,7 +168,7 @@ function buildDetailActions({
   }
 
   if (onEdit) {
-    allActions.push({ label: "Edit", onClick: onEdit });
+    allActions.push({ label: editLabel, onClick: onEdit });
   }
 
   if (secondaryActions) {
@@ -256,6 +259,7 @@ export function EntityDetailLayout({
   sidebarExtra,
   quickActionItems,
 }: EntityDetailLayoutProps) {
+  const { t } = useTranslation();
   const [showAllFields, setShowAllFields] = useState(false);
 
   // Resizable sidebar width (hooks must be before early returns)
@@ -321,6 +325,7 @@ export function EntityDetailLayout({
     primaryAction,
     secondaryActions,
     onEdit,
+    editLabel: t("common.edit"),
     quickActionItems,
   });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1693.

Closes #1693

---

## Claude summary

Fixed and committed. The `onEdit`-derived action in `EntityDetailLayout` now uses `t("common.edit")` (resolves to "Edytuj" in PL, "Edit" in EN) instead of the hardcoded `"Edit"`. The translation key already exists in both `public/locales/{pl,en}/translation.json`. Typecheck passes.

## Follow-ups
- Translate hardcoded "Akcje" trigger and "Details"/"Attachments" headings in entity-detail-layout.tsx: src/components/crm/entity-detail-layout.tsx:404, :427, :491, :575, :596, :653 still hardcode Polish/English strings instead of using i18n
- Translate hardcoded strings in EntityDetailNotFound: src/components/crm/entity-detail-layout.tsx:136-143 ("Not found", description, "Go back") are English-only