### PR TITLE
Poprawa wyświetlania eventu dotyczącego więcej niż jednego pracownika

### DIFF
--- a/src/components/gabinet/calendar/appointment-card.tsx
+++ b/src/components/gabinet/calendar/appointment-card.tsx
@@ -1,3 +1,4 @@
+import { Users } from "lucide-react";
 import {
   appointmentEmployeeStyle,
   appointmentStatusBadgeClass,
@@ -24,6 +25,14 @@ interface AppointmentCardProps {
   color?: string;
   tags?: AppointmentTag[];
   indicators?: AppointmentIndicator[];
+  /**
+   * When > 1 the same event covers multiple employees. The card collapses
+   * those duplicate scheduled-activity rows into one tile and shows a
+   * "👥 N" badge. The full list of employee names goes into the button's
+   * title so the user can see who the event covers on hover (issue #1694).
+   */
+  employeeCount?: number;
+  employeeNames?: string[];
   onClick?: () => void;
 }
 
@@ -36,6 +45,8 @@ export function AppointmentCard({
   color,
   tags,
   indicators,
+  employeeCount,
+  employeeNames,
   onClick,
 }: AppointmentCardProps) {
   // When a base color is provided (employee color, treatment color, or an
@@ -48,10 +59,20 @@ export function AppointmentCard({
     ? ""
     : appointmentStatusBadgeClass(status);
   const strike = status === "cancelled" ? " line-through" : "";
+  const showEmployeeCount = (employeeCount ?? 0) > 1;
+  const employeeListTitle =
+    showEmployeeCount && employeeNames && employeeNames.length > 0
+      ? employeeNames.join(", ")
+      : undefined;
+  const hasHeaderBadges =
+    (tags && tags.length > 0) ||
+    (indicators && indicators.length > 0) ||
+    showEmployeeCount;
 
   return (
     <button
       onClick={onClick}
+      title={employeeListTitle}
       className={`flex w-full h-full flex-col overflow-hidden rounded border-l-4 text-left text-xs transition-opacity hover:opacity-80 ${employeeStyle ? "gabinet-tile-tint" : ""} ${fallbackCls}${strike}`}
       style={
         employeeStyle
@@ -70,7 +91,7 @@ export function AppointmentCard({
         style={employeeStyle ? employeeStyle.headerStyle : undefined}
       >
         <span className="truncate">{startTime}–{endTime}</span>
-        {((tags && tags.length > 0) || (indicators && indicators.length > 0)) && (
+        {hasHeaderBadges && (
           <div className="flex shrink-0 items-center gap-0.5">
             {tags?.map((tag, i) => (
               <span
@@ -86,6 +107,16 @@ export function AppointmentCard({
                 indicator={ind}
               />
             ))}
+            {showEmployeeCount && (
+              <span
+                className="inline-flex items-center gap-0.5 rounded-sm bg-white/25 px-1 text-[10px] font-semibold leading-none dark:bg-white/15"
+                title={employeeListTitle}
+                aria-label={employeeListTitle}
+              >
+                <Users className="size-2.5" />
+                {employeeCount}
+              </span>
+            )}
           </div>
         )}
       </div>

--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -16,6 +16,8 @@ interface Appointment {
   color?: string;
   tags?: Array<{ name: string; color: string }>;
   indicators?: AppointmentIndicator[];
+  employeeCount?: number;
+  employeeNames?: string[];
 }
 
 interface CalendarDayViewProps {

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -19,6 +19,8 @@ interface Appointment {
   color?: string;
   tags?: Array<{ name: string; color: string }>;
   indicators?: AppointmentIndicator[];
+  employeeCount?: number;
+  employeeNames?: string[];
 }
 
 interface CalendarWeekViewProps {

--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -27,6 +27,8 @@ interface Appointment {
   color?: string;
   tags?: AppointmentTag[];
   indicators?: AppointmentIndicator[];
+  employeeCount?: number;
+  employeeNames?: string[];
 }
 
 interface DraggableAppointmentProps extends Appointment {
@@ -57,6 +59,8 @@ export function DraggableAppointment({
   color,
   tags,
   indicators,
+  employeeCount,
+  employeeNames,
   onResize,
   hourHeight = 60,
   snapMinutes = 15,
@@ -308,6 +312,8 @@ export function DraggableAppointment({
         color={color}
         tags={tags}
         indicators={indicators}
+        employeeCount={employeeCount}
+        employeeNames={employeeNames}
         onClick={handleCardClick}
       />
       {onResize && status !== "blocked" && (

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -673,6 +673,8 @@ function GabinetCalendarPage() {
       employeeId?: string;
       tags?: Array<{ name: string; color: string }>;
       indicators?: Indicator[];
+      employeeCount?: number;
+      employeeNames?: string[];
     }> = [];
 
     if (rawAppointments) {
@@ -885,6 +887,47 @@ function GabinetCalendarPage() {
 
     return items;
   }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, tagMap, employeeColorMap, eventTypeColorMap, firstAppointmentIds, packagePositions, recurringPositions, appointmentPaymentTotals, creditByAppointmentId, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
+
+  // Collapse blocked-time events that target multiple employees into a single
+  // tile for views that don't break the day into per-employee columns
+  // (week, day-all-employees, month). The EventDialog writes one
+  // scheduledActivity per selected employee — correct for the day-by-employee
+  // view, but in the other views the same event appears as N stacked
+  // duplicates. We group by date+time+title+subtitle+color and keep the first
+  // _id as the canonical row so drag/resize handlers still resolve to a real
+  // activity. The badge + tooltip show "N pracowników" with the full name list
+  // (issue #1694).
+  const aggregatedAppointments = useMemo(() => {
+    const out: typeof viewAppointments = [];
+    const groups = new Map<string, number>(); // key -> index in `out`
+    for (const a of viewAppointments) {
+      if (a.status !== "blocked") {
+        out.push(a);
+        continue;
+      }
+      const key = `${a.date}|${a.startTime}|${a.endTime}|${a.patientName}|${a.treatmentName}|${a.color ?? ""}`;
+      const existingIdx = groups.get(key);
+      const employeeName = a.employeeId ? userMap.get(a.employeeId) : undefined;
+      if (existingIdx === undefined) {
+        out.push({
+          ...a,
+          employeeCount: 1,
+          employeeNames: employeeName ? [employeeName] : [],
+        });
+        groups.set(key, out.length - 1);
+      } else {
+        const existing = out[existingIdx];
+        existing.employeeCount = (existing.employeeCount ?? 1) + 1;
+        if (employeeName) {
+          existing.employeeNames = [
+            ...(existing.employeeNames ?? []),
+            employeeName,
+          ];
+        }
+      }
+    }
+    return out;
+  }, [viewAppointments, userMap]);
 
   // Build print-friendly appointment data for the current day
   const printDate = formatDateStr(currentDate);
@@ -1784,7 +1827,7 @@ function GabinetCalendarPage() {
           {viewMode === "day" && !isDayByEmployeeView && (
             <CalendarDayView
               date={formatDateStr(currentDate)}
-              appointments={viewAppointments}
+              appointments={aggregatedAppointments}
               onSlotClick={(time) =>
                 handleSlotClick(formatDateStr(currentDate), time)
               }
@@ -1798,7 +1841,7 @@ function GabinetCalendarPage() {
           {viewMode === "week" && (
             <CalendarWeekView
               weekStart={formatDateStr(getMonday(currentDate))}
-              appointments={viewAppointments}
+              appointments={aggregatedAppointments}
               onSlotClick={handleSlotClick}
               onSlotDragSelect={handleSlotDragSelect}
               onAppointmentResize={handleAppointmentResize}
@@ -1813,7 +1856,7 @@ function GabinetCalendarPage() {
             <CalendarMonthView
               year={currentDate.getFullYear()}
               month={currentDate.getMonth()}
-              appointments={viewAppointments}
+              appointments={aggregatedAppointments}
               onDayClick={handleDayClick}
               selectedDate={formatDateStr(currentDate)}
               leaveDates={leaveDates}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1694.

Closes #1694

---

## Claude summary

Committed. Summary of the fix:

The `EventDialog` creates one `scheduledActivity` row per selected employee (so the block appears in each employee's column in the day-by-employee view). In the week, month, and day-all-employees views — which don't split by employee — those rows stacked as N visually-identical tiles.

Added an `aggregatedAppointments` memo in `_layout.gabinet.calendar.index.lazy.tsx:891` that groups blocked-time items by date+time+title+subtitle+color, keeping the first `_id` as the canonical row and tracking `employeeCount`/`employeeNames`. The week, day (non-by-employee), and month views now consume the aggregated list; the day-by-employee view still uses the original per-employee list so each column gets its tile.

`AppointmentCard` (`appointment-card.tsx`) renders a `👥 N` badge when `employeeCount > 1` and sets the comma-separated names as the button's `title` attribute, so hover shows which employees the event covers. Typecheck passes; lint warnings are pre-existing in other files.