### PR TITLE
feat(gabinet): allow double-booking appointments with a warning (closes #1526)

### DIFF
--- a/convex/gabinet/_availability_supabase.ts
+++ b/convex/gabinet/_availability_supabase.ts
@@ -306,6 +306,12 @@ export async function checkConflictSupabase(
     endTime: string;
     excludeAppointmentId?: string;
     roomId?: string;
+    // When true, soft "booking" conflicts (overlapping appointment, overlapping
+    // calendar activity, occupied room) are ignored so the caller can
+    // double-book on purpose with a warning surfaced in the UI. Hard
+    // constraints (working hours, approved leave, clinic closed) still apply.
+    // Issue #1526.
+    allowBookingConflict?: boolean;
   },
 ): Promise<{ hasConflict: boolean; reason?: string }> {
   const dayOfWeek = new Date(args.date + "T00:00:00").getDay();
@@ -369,71 +375,73 @@ export async function checkConflictSupabase(
     }
   }
 
-  const appointments = await db
-    .query("gabinetAppointments")
-    .eq("organizationId", args.organizationId)
-    .eq("employeeId", args.userId)
-    .eq("date", args.date)
-    .collect();
+  if (!args.allowBookingConflict) {
+    const appointments = await db
+      .query("gabinetAppointments")
+      .eq("organizationId", args.organizationId)
+      .eq("employeeId", args.userId)
+      .eq("date", args.date)
+      .collect();
 
-  for (const appt of appointments as any[]) {
-    if (args.excludeAppointmentId && String(appt.id ?? appt._id) === args.excludeAppointmentId) continue;
-    if (appt.status === "cancelled" || appt.status === "no_show") continue;
-    const apptStart = timeToMinutes(String(appt.startTime));
-    const apptEnd = timeToMinutes(String(appt.endTime));
-    if (reqStart < apptEnd && reqEnd > apptStart) {
-      return { hasConflict: true, reason: "Conflicts with existing appointment" };
+    for (const appt of appointments as any[]) {
+      if (args.excludeAppointmentId && String(appt.id ?? appt._id) === args.excludeAppointmentId) continue;
+      if (appt.status === "cancelled" || appt.status === "no_show") continue;
+      const apptStart = timeToMinutes(String(appt.startTime));
+      const apptEnd = timeToMinutes(String(appt.endTime));
+      if (reqStart < apptEnd && reqEnd > apptStart) {
+        return { hasConflict: true, reason: "Conflicts with existing appointment" };
+      }
     }
-  }
 
-  const resourceActivities = await db
-    .query("scheduledActivities")
-    .eq("organizationId", args.organizationId)
-    .eq("resourceId", args.userId)
-    .collect();
+    const resourceActivities = await db
+      .query("scheduledActivities")
+      .eq("organizationId", args.organizationId)
+      .eq("resourceId", args.userId)
+      .collect();
 
-  for (const activity of resourceActivities as any[]) {
-    if (activity.isCompleted) continue;
-    if (!activity.endDate) continue;
-    const actDate = new Date(activity.dueDate);
-    const actDateStr = `${actDate.getFullYear()}-${String(actDate.getMonth() + 1).padStart(2, "0")}-${String(actDate.getDate()).padStart(2, "0")}`;
-    if (actDateStr !== args.date) continue;
-    // Gabinet appointments are already counted via gabinetAppointments above.
-    // Manual gabinet events (entityType="gabinetEvent") must still block time.
-    if (
-      activity.moduleRef?.moduleId === "gabinet" &&
-      activity.moduleRef?.entityType !== "gabinetEvent"
-    )
-      continue;
+    for (const activity of resourceActivities as any[]) {
+      if (activity.isCompleted) continue;
+      if (!activity.endDate) continue;
+      const actDate = new Date(activity.dueDate);
+      const actDateStr = `${actDate.getFullYear()}-${String(actDate.getMonth() + 1).padStart(2, "0")}-${String(actDate.getDate()).padStart(2, "0")}`;
+      if (actDateStr !== args.date) continue;
+      // Gabinet appointments are already counted via gabinetAppointments above.
+      // Manual gabinet events (entityType="gabinetEvent") must still block time.
+      if (
+        activity.moduleRef?.moduleId === "gabinet" &&
+        activity.moduleRef?.entityType !== "gabinetEvent"
+      )
+        continue;
 
-    const actStartMin = actDate.getHours() * 60 + actDate.getMinutes();
-    const actEndDate = new Date(activity.endDate);
-    const actEndMin = actEndDate.getHours() * 60 + actEndDate.getMinutes();
-    if (reqStart < actEndMin && reqEnd > actStartMin) {
-      return { hasConflict: true, reason: `Conflicts with: ${activity.title}` };
+      const actStartMin = actDate.getHours() * 60 + actDate.getMinutes();
+      const actEndDate = new Date(activity.endDate);
+      const actEndMin = actEndDate.getHours() * 60 + actEndDate.getMinutes();
+      if (reqStart < actEndMin && reqEnd > actStartMin) {
+        return { hasConflict: true, reason: `Conflicts with: ${activity.title}` };
+      }
     }
-  }
 
-  // Org-wide events (no resourceId, blocks the whole clinic).
-  const orgEvents = await db
-    .query("scheduledActivities")
-    .eq("organizationId", args.organizationId)
-    .eq("activityType", "gabinet:event")
-    .collect();
+    // Org-wide events (no resourceId, blocks the whole clinic).
+    const orgEvents = await db
+      .query("scheduledActivities")
+      .eq("organizationId", args.organizationId)
+      .eq("activityType", "gabinet:event")
+      .collect();
 
-  for (const activity of orgEvents as any[]) {
-    if (activity.isCompleted) continue;
-    if (!activity.endDate) continue;
-    if (activity.resourceId) continue; // per-resource events already checked above
-    const actDate = new Date(activity.dueDate);
-    const actDateStr = `${actDate.getFullYear()}-${String(actDate.getMonth() + 1).padStart(2, "0")}-${String(actDate.getDate()).padStart(2, "0")}`;
-    if (actDateStr !== args.date) continue;
+    for (const activity of orgEvents as any[]) {
+      if (activity.isCompleted) continue;
+      if (!activity.endDate) continue;
+      if (activity.resourceId) continue; // per-resource events already checked above
+      const actDate = new Date(activity.dueDate);
+      const actDateStr = `${actDate.getFullYear()}-${String(actDate.getMonth() + 1).padStart(2, "0")}-${String(actDate.getDate()).padStart(2, "0")}`;
+      if (actDateStr !== args.date) continue;
 
-    const actStartMin = actDate.getHours() * 60 + actDate.getMinutes();
-    const actEndDate = new Date(activity.endDate);
-    const actEndMin = actEndDate.getHours() * 60 + actEndDate.getMinutes();
-    if (reqStart < actEndMin && reqEnd > actStartMin) {
-      return { hasConflict: true, reason: `Conflicts with: ${activity.title}` };
+      const actStartMin = actDate.getHours() * 60 + actDate.getMinutes();
+      const actEndDate = new Date(activity.endDate);
+      const actEndMin = actEndDate.getHours() * 60 + actEndDate.getMinutes();
+      if (reqStart < actEndMin && reqEnd > actStartMin) {
+        return { hasConflict: true, reason: `Conflicts with: ${activity.title}` };
+      }
     }
   }
 
@@ -441,18 +449,59 @@ export async function checkConflictSupabase(
     const roomAppointments = await db
       .query("gabinetAppointments")
       .eq("organizationId", args.organizationId)
-      .eq("roomId", args.roomId)
+      .eq("employeeId", args.userId)
       .eq("date", args.date)
       .collect();
 
-    for (const appt of roomAppointments as any[]) {
+    for (const appt of appointments as any[]) {
       if (args.excludeAppointmentId && String(appt.id ?? appt._id) === args.excludeAppointmentId) continue;
       if (appt.status === "cancelled" || appt.status === "no_show") continue;
-      if (
-        String(appt.startTime) < args.endTime &&
-        String(appt.endTime) > args.startTime
-      ) {
-        return { hasConflict: true, reason: "Room is occupied at this time" };
+      const apptStart = timeToMinutes(String(appt.startTime));
+      const apptEnd = timeToMinutes(String(appt.endTime));
+      if (reqStart < apptEnd && reqEnd > apptStart) {
+        return { hasConflict: true, reason: "Conflicts with existing appointment" };
+      }
+    }
+
+    const resourceActivities = await db
+      .query("scheduledActivities")
+      .eq("organizationId", args.organizationId)
+      .eq("resourceId", args.userId)
+      .collect();
+
+    for (const activity of resourceActivities as any[]) {
+      if (activity.isCompleted) continue;
+      if (!activity.endDate) continue;
+      const actDate = new Date(activity.dueDate);
+      const actDateStr = `${actDate.getFullYear()}-${String(actDate.getMonth() + 1).padStart(2, "0")}-${String(actDate.getDate()).padStart(2, "0")}`;
+      if (actDateStr !== args.date) continue;
+      if (activity.moduleRef?.moduleId === "gabinet") continue;
+
+      const actStartMin = actDate.getHours() * 60 + actDate.getMinutes();
+      const actEndDate = new Date(activity.endDate);
+      const actEndMin = actEndDate.getHours() * 60 + actEndDate.getMinutes();
+      if (reqStart < actEndMin && reqEnd > actStartMin) {
+        return { hasConflict: true, reason: `Conflicts with: ${activity.title}` };
+      }
+    }
+
+    if (args.roomId) {
+      const roomAppointments = await db
+        .query("gabinetAppointments")
+        .eq("organizationId", args.organizationId)
+        .eq("roomId", args.roomId)
+        .eq("date", args.date)
+        .collect();
+
+      for (const appt of roomAppointments as any[]) {
+        if (args.excludeAppointmentId && String(appt.id ?? appt._id) === args.excludeAppointmentId) continue;
+        if (appt.status === "cancelled" || appt.status === "no_show") continue;
+        if (
+          String(appt.startTime) < args.endTime &&
+          String(appt.endTime) > args.startTime
+        ) {
+          return { hasConflict: true, reason: "Room is occupied at this time" };
+        }
       }
     }
   }

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1046,6 +1046,11 @@ export const create = action({
     // or crafted API call cannot silently create a past appointment. Issue
     // #1414.
     allowPast: v.optional(v.boolean()),
+    // When true, allow saving even if the slot overlaps with another
+    // appointment, calendar activity, or occupied room. The UI shows an
+    // explicit warning before the user opts in. Hard constraints (working
+    // hours, approved leave, clinic closed) still block creation. Issue #1526.
+    allowConflict: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     // --- Auth + permissions (via internal queries) ---
@@ -1102,6 +1107,7 @@ export const create = action({
       startTime: args.startTime,
       endTime: args.endTime,
       roomId: args.roomId ?? undefined,
+      allowBookingConflict: args.allowConflict ?? false,
     });
     if (conflict.hasConflict) {
       throw new Error(conflict.reason ?? "Time slot conflict");

--- a/src/components/gabinet/appointment-shared/warnings.tsx
+++ b/src/components/gabinet/appointment-shared/warnings.tsx
@@ -76,3 +76,42 @@ export function EquipmentWarning({
     </div>
   );
 }
+
+interface ConflictWarningProps {
+  className?: string;
+  size?: "sm" | "compact";
+}
+
+// Surfaced in the appointment dialog when the selected slot overlaps with an
+// existing appointment for the same employee. Lets staff opt in to
+// double-booking with eyes open (issue #1526) — submission still works because
+// the backend skips the soft conflict check when the dialog forwards
+// `allowConflict: true`.
+export function ConflictWarning({
+  className,
+  size = "sm",
+}: ConflictWarningProps) {
+  const { t } = useTranslation();
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200",
+        size === "sm" ? "px-3 py-2 text-sm" : "px-2.5 py-2 text-xs",
+        className,
+      )}
+    >
+      <AlertTriangle
+        className={cn(
+          "mt-0.5 shrink-0",
+          size === "sm" ? "size-4" : "size-3.5",
+        )}
+      />
+      <span>
+        {t("gabinet.appointments.warnings.conflict", {
+          defaultValue: "Kolizja terminów z inną wizytą",
+        })}
+      </span>
+    </div>
+  );
+}

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -79,6 +79,7 @@ import { SidePanel } from "@/components/crm/side-panel";
 import { PatientForm } from "@/components/forms/patient-form";
 import { PackageUsageSelector } from "@/components/gabinet/package-usage-selector";
 import {
+  ConflictWarning,
   EquipmentWarning,
   LeaveWarning,
 } from "@/components/gabinet/appointment-shared/warnings";
@@ -89,6 +90,7 @@ import {
 import { SlotPicker } from "@/components/gabinet/appointment-shared/slot-picker";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
+import { useSupabaseGabinetAppointmentsByDateRange } from "@/hooks/use-supabase-gabinet-appointments";
 import { formatPhoneNumber } from "@/lib/phone";
 
 // ---------------------------------------------------------------------------
@@ -797,6 +799,35 @@ export function AppointmentDialog({
       )
     : "";
 
+  // Existing appointments for the chosen employee + day, used to detect when
+  // the user picks a slot that overlaps with another booking. The dialog
+  // surfaces a warning and lets the user save anyway (`allowConflict` flag on
+  // submit) — issue #1526.
+  const { data: employeeDayAppointments } =
+    useSupabaseGabinetAppointmentsByDateRange(
+      String(organizationId),
+      dateStr,
+      dateStr,
+      {
+        employeeId: employeeId || undefined,
+        enabled: !!organizationId && !!employeeId && !!dateStr,
+      },
+    );
+
+  const conflictingAppointment = useMemo(() => {
+    if (!selectedSlot?.start || !endTime || !employeeDayAppointments) return null;
+    const reqStart = selectedSlot.start;
+    const reqEnd = endTime;
+    return (
+      employeeDayAppointments.find((appt) => {
+        if (appt.status === "cancelled" || appt.status === "no_show") return false;
+        return appt.startTime < reqEnd && appt.endTime > reqStart;
+      }) ?? null
+    );
+  }, [selectedSlot, endTime, employeeDayAppointments]);
+
+  const hasBookingConflict = !!conflictingAppointment;
+
   // Recurring occurrences (date + effective start time). The first entry is
   // the base appointment (tied to calendar selection, read-only). The rest
   // are generated from the cycle, with optional per-index date/time overrides
@@ -876,6 +907,7 @@ export function AppointmentDialog({
         roomId: roomId ? (roomId as Id<"gabinetRooms">) : undefined,
         packageUsageId: packageUsageId ?? undefined,
         allowPast: recordWalkIn || undefined,
+        allowConflict: hasBookingConflict || undefined,
       });
       // Refresh the calendar immediately — Convex actions don't invalidate
       // the Supabase React Query cache automatically.
@@ -914,6 +946,8 @@ export function AppointmentDialog({
     locationId,
     roomId,
     packageUsageId,
+    recordWalkIn,
+    hasBookingConflict,
     onOpenChange,
     queryClient,
     t,
@@ -1701,6 +1735,13 @@ export function AppointmentDialog({
                 {employeeLeaveOnSelectedDate && (
                   <LeaveWarning
                     leave={employeeLeaveOnSelectedDate}
+                    size="compact"
+                    className="mx-3 mb-2"
+                  />
+                )}
+
+                {hasBookingConflict && (
+                  <ConflictWarning
                     size="compact"
                     className="mx-3 mb-2"
                   />


### PR DESCRIPTION
Cherry-picked from stale `claude/issue-1526` (PR #1568 was 1 day behind main, branch couldn't open clean PR). Conflict in `_availability_supabase.ts` resolved: kept HEAD's expanded availability checks (org-wide events + gabinet-event filter on resourceActivities — landed after the original branch was cut) and wrapped the whole soft-conflict region in `if (!args.allowBookingConflict)`. Hard constraints (working hours, leaves, room) still apply.

Closes #1568 (the original stale PR — same commit re-applied on fresh main).