### PR TITLE
Problem z pakietami i rozliczaniem skladowych

### DIFF
--- a/src/lib/supabase/mappers/gabinet/package-usage.ts
+++ b/src/lib/supabase/mappers/gabinet/package-usage.ts
@@ -13,7 +13,7 @@ export interface PackageTreatmentUsageEntry {
   treatmentId: string;
   variantId?: string;
   usedCount: number;
-  totalAllowed: number;
+  totalCount: number;
 }
 
 export interface MappedGabinetPackageUsage {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -109,7 +109,7 @@ function buildActiveUsageDetails(
         byPackage[u.packageId].treatmentProgress[key] = { usedCount: 0, totalCount: 0 };
       }
       byPackage[u.packageId].treatmentProgress[key].usedCount += t.usedCount;
-      byPackage[u.packageId].treatmentProgress[key].totalCount += t.totalAllowed;
+      byPackage[u.packageId].treatmentProgress[key].totalCount += t.totalCount;
     }
   }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1695.

Closes #1695

---

## Claude summary

Fixed and committed.

Root cause: in `src/lib/supabase/mappers/gabinet/package-usage.ts:16` the `PackageTreatmentUsageEntry` interface declared `totalAllowed: number`, and the packages page client-side aggregation at `src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx:112` summed `t.totalAllowed`. But the backend (`convex/gabinet/packages.ts` writes), the Convex schema (`convex/schema/gabinet.ts:453`), the Supabase migration comment (`supabase/migrations/00001_initial_schema.sql:1738`), and every other consumer in `src/` all use `totalCount`. So `t.totalAllowed` was always `undefined`, and `0 + undefined = NaN` propagated into the per-treatment progress total. That rendered as "0 / NaN" in the text `{usedCount} / {totalCount}` on the package cards.

Blast radius: only the cards in `/dashboard/gabinet/packages`. The per-treatment progress bars (`<div style={{ width: ${percent}% }}/>`) and the overall progress bar stayed at 0% because `NaN > 0` is false, so the bar gradient wasn't broken — only the numeric labels showed NaN. KPI counters (totalPackages / activePackages / expiringPackages) are unaffected because they don't read `totalAllowed`/`totalCount`. Other surfaces that show treatment progress (`patient-packages-card.tsx`, `patient-treatments-card.tsx`, `package-usage-selector.tsx`, patient portal packages page, appointment detail) already used `totalCount` directly and were never affected.

Fix: rename `totalAllowed` → `totalCount` in the mapper interface and the aggregation call site. The hook `use-supabase-gabinet-appointments.ts:335` already had a defensive `totalCount ?? totalAllowed` fallback, so legacy historical rows (if any) keep working there.