### PR TITLE
refactor(gabinet): extract shared TreatmentPicker (closes #1519)

### DIFF
--- a/src/components/gabinet/appointment-shared/treatment-picker.tsx
+++ b/src/components/gabinet/appointment-shared/treatment-picker.tsx
@@ -1,0 +1,153 @@
+import type { ReactNode } from "react";
+import { ChevronsUpDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+
+export interface TreatmentOption {
+  _id: string;
+  name: string;
+  duration: number;
+  price?: number | null;
+  currency?: string;
+}
+
+interface TreatmentPickerProps {
+  treatments: TreatmentOption[] | undefined;
+  value: string;
+  onSelect: (id: string) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  search: string;
+  onSearchChange: (search: string) => void;
+  /** Format a price for the dropdown row. Different call sites use different
+   *  currency rendering (PLN-only vs. multi-currency). */
+  formatPrice: (price: number | null | undefined, currency?: string) => string;
+  placeholder: string;
+  searchPlaceholder: string;
+  emptyText: string;
+  closeLabel: string;
+  /** Override for the trigger label. Useful when the current selection is not
+   *  present in `treatments` (e.g. an existing appointment whose treatment is
+   *  not in the active list). */
+  selectedLabel?: string;
+  /** Optional icon rendered inside the trigger before the label. */
+  triggerIcon?: ReactNode;
+  triggerClassName?: string;
+  triggerTestId?: string;
+}
+
+export function TreatmentPicker({
+  treatments,
+  value,
+  onSelect,
+  open,
+  onOpenChange,
+  search,
+  onSearchChange,
+  formatPrice,
+  placeholder,
+  searchPlaceholder,
+  emptyText,
+  closeLabel,
+  selectedLabel,
+  triggerIcon,
+  triggerClassName,
+  triggerTestId,
+}: TreatmentPickerProps) {
+  const list = treatments ?? [];
+  const filtered = (() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return list;
+    return list.filter((tr) => (tr.name ?? "").toLowerCase().includes(q));
+  })();
+
+  const fromList = list.find((tr) => tr._id === value)?.name;
+  const triggerLabel = fromList ?? selectedLabel ?? placeholder;
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(o) => {
+        onOpenChange(o);
+        if (!o) onSearchChange("");
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={cn("w-full justify-between font-normal", triggerClassName)}
+          data-testid={triggerTestId}
+        >
+          {triggerIcon ? (
+            <span className="flex items-center gap-2 truncate">
+              {triggerIcon}
+              <span className="truncate">{triggerLabel}</span>
+            </span>
+          ) : (
+            <span className="truncate">{triggerLabel}</span>
+          )}
+          <ChevronsUpDown className="ml-auto size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="p-0"
+        align="start"
+        style={{
+          width: "var(--radix-popover-trigger-width)",
+          maxHeight: "var(--radix-popover-content-available-height)",
+        }}
+      >
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder={searchPlaceholder}
+            value={search}
+            onValueChange={onSearchChange}
+            onClose={() => onOpenChange(false)}
+            closeLabel={closeLabel}
+          />
+          <CommandList className="flex-1 min-h-0">
+            <CommandEmpty>{emptyText}</CommandEmpty>
+            <CommandGroup>
+              {filtered.map((tr) => (
+                <CommandItem
+                  key={tr._id}
+                  value={tr._id}
+                  onSelect={() => onSelect(tr._id)}
+                  className={cn(
+                    "px-3",
+                    value === tr._id &&
+                      "bg-accent font-medium text-accent-foreground",
+                  )}
+                >
+                  <div className="flex flex-col">
+                    <span className="text-sm">{tr.name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {tr.duration} min
+                      {tr.price != null &&
+                        ` · ${formatPrice(tr.price, tr.currency)}`}
+                    </span>
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -88,6 +88,7 @@ import {
   useMissingEquipment,
 } from "@/components/gabinet/appointment-shared/use-appointment-warnings";
 import { SlotPicker } from "@/components/gabinet/appointment-shared/slot-picker";
+import { TreatmentPicker } from "@/components/gabinet/appointment-shared/treatment-picker";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { useSupabaseGabinetAppointmentsByDateRange } from "@/hooks/use-supabase-gabinet-appointments";
@@ -517,14 +518,6 @@ export function AppointmentDialog({
       );
     });
   }, [patients, patientSearch]);
-
-  // Filter treatments by search
-  const filteredTreatments = useMemo(() => {
-    const all = treatments ?? [];
-    if (!treatmentSearch.trim()) return all;
-    const q = treatmentSearch.toLowerCase();
-    return all.filter((tr) => (tr.name ?? "").toLowerCase().includes(q));
-  }, [treatments, treatmentSearch]);
 
   const dateStr = selectedDate
     ? `${selectedDate.getFullYear()}-${String(selectedDate.getMonth() + 1).padStart(2, "0")}-${String(selectedDate.getDate()).padStart(2, "0")}`
@@ -1195,83 +1188,22 @@ export function AppointmentDialog({
                   <Label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
                     {t("gabinet.appointments.treatment")}
                   </Label>
-                  <Popover
+                  <TreatmentPicker
+                    treatments={treatments}
+                    value={treatmentId}
+                    onSelect={handleTreatmentSelect}
                     open={treatmentOpen}
-                    onOpenChange={(o) => {
-                      setTreatmentOpen(o);
-                      if (!o) setTreatmentSearch("");
-                    }}
-                  >
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        role="combobox"
-                        aria-expanded={treatmentOpen}
-                        className="w-full justify-between h-11 font-normal"
-                        data-testid="appointment-treatment-trigger"
-                      >
-                        <span className="truncate">
-                          {selectedTreatment
-                            ? selectedTreatment.name
-                            : t("gabinet.appointments.selectTreatment")}
-                        </span>
-                        <ChevronsUpDown className="ml-auto size-4 shrink-0 opacity-50" />
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent
-                      className="p-0"
-                      align="start"
-                      style={{
-                        width: "var(--radix-popover-trigger-width)",
-                        maxHeight:
-                          "var(--radix-popover-content-available-height)",
-                      }}
-                    >
-                      <Command shouldFilter={false}>
-                        <CommandInput
-                          placeholder={t(
-                            "gabinet.appointments.searchTreatment",
-                          )}
-                          value={treatmentSearch}
-                          onValueChange={setTreatmentSearch}
-                          onClose={() => setTreatmentOpen(false)}
-                          closeLabel={t("common.close")}
-                        />
-                        <CommandList className="flex-1 min-h-0">
-                          <CommandEmpty>
-                            {t("common.noResults")}
-                          </CommandEmpty>
-                          <CommandGroup>
-                            {filteredTreatments.map((tr) => (
-                              <CommandItem
-                                key={tr._id}
-                                value={tr._id}
-                                onSelect={() =>
-                                  handleTreatmentSelect(tr._id)
-                                }
-                                className={cn(
-                                  "px-3",
-                                  treatmentId === tr._id &&
-                                    "bg-accent font-medium text-accent-foreground",
-                                )}
-                              >
-                                <div className="flex flex-col">
-                                  <span className="text-sm">
-                                    {tr.name}
-                                  </span>
-                                  <span className="text-xs text-muted-foreground">
-                                    {tr.duration} min
-                                    {tr.price != null &&
-                                      ` \u00b7 ${formatPrice(tr.price)}`}
-                                  </span>
-                                </div>
-                              </CommandItem>
-                            ))}
-                          </CommandGroup>
-                        </CommandList>
-                      </Command>
-                    </PopoverContent>
-                  </Popover>
+                    onOpenChange={setTreatmentOpen}
+                    search={treatmentSearch}
+                    onSearchChange={setTreatmentSearch}
+                    formatPrice={(price) => formatPrice(price)}
+                    placeholder={t("gabinet.appointments.selectTreatment")}
+                    searchPlaceholder={t("gabinet.appointments.searchTreatment")}
+                    emptyText={t("common.noResults")}
+                    closeLabel={t("common.close")}
+                    triggerClassName="h-11"
+                    triggerTestId="appointment-treatment-trigger"
+                  />
                 </div>
 
                 {/* Treatment info card */}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ChangeEmployeeModal } from "@/components/gabinet/change-employee-modal";
 import { DocumentationTab } from "@/components/gabinet/documentation-tab";
+import { TreatmentPicker } from "@/components/gabinet/appointment-shared/treatment-picker";
 import { RichTextEditor, plateJsonToText } from "@/components/gabinet/rich-text-editor";
 import { Avatar as UntitledAvatar } from "@untitled/base/avatar/avatar";
 import { Input } from "@/components/ui/input";
@@ -55,20 +56,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
-import { cn } from "@/lib/utils";
 import {
   EntityDetailLayout,
   type DetailField,
@@ -112,7 +99,6 @@ import {
   MapPin,
   Building2,
 } from "@/lib/ez-icons";
-import { ChevronsUpDown } from "lucide-react";
 import { Id } from "@cvx/_generated/dataModel";
 import type { AppointmentFullDetailNote } from "@cvx/gabinet/appointments";
 import { useTranslation } from "react-i18next";
@@ -1313,86 +1299,31 @@ function AppointmentDetail() {
                 <Label className="text-xs uppercase tracking-wide text-muted-foreground">
                   {t("common.name")}
                 </Label>
-                <Popover
-                  open={treatmentPickerOpen}
-                  onOpenChange={(o) => {
-                    setTreatmentPickerOpen(o);
-                    if (!o) setTreatmentSearch("");
+                <TreatmentPicker
+                  treatments={treatmentsList}
+                  value={editTreatmentId}
+                  onSelect={(id) => {
+                    setEditTreatmentId(id);
+                    setTreatmentPickerOpen(false);
+                    setTreatmentSearch("");
                   }}
-                >
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="outline"
-                      role="combobox"
-                      aria-expanded={treatmentPickerOpen}
-                      className="w-full justify-between font-normal"
-                    >
-                      <span className="flex items-center gap-2 truncate">
-                        <Stethoscope className="size-4 shrink-0 text-primary" />
-                        <span className="truncate">
-                          {treatmentsList?.find((tr) => tr._id === editTreatmentId)?.name
-                            ?? treatment?.name
-                            ?? t("gabinet.appointments.selectTreatment")}
-                        </span>
-                      </span>
-                      <ChevronsUpDown className="ml-auto size-4 shrink-0 opacity-50" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    className="p-0"
-                    align="start"
-                    style={{
-                      width: "var(--radix-popover-trigger-width)",
-                      maxHeight:
-                        "var(--radix-popover-content-available-height)",
-                    }}
-                  >
-                    <Command shouldFilter={false}>
-                      <CommandInput
-                        placeholder={t("gabinet.appointments.searchTreatment")}
-                        value={treatmentSearch}
-                        onValueChange={setTreatmentSearch}
-                        onClose={() => setTreatmentPickerOpen(false)}
-                        closeLabel={t("common.close")}
-                      />
-                      <CommandList className="flex-1 min-h-0">
-                        <CommandEmpty>{t("common.noResults")}</CommandEmpty>
-                        <CommandGroup>
-                          {(treatmentsList ?? [])
-                            .filter((tr) => {
-                              const q = treatmentSearch.trim().toLowerCase();
-                              if (!q) return true;
-                              return tr.name.toLowerCase().includes(q);
-                            })
-                            .map((tr) => (
-                              <CommandItem
-                                key={tr._id}
-                                value={tr._id}
-                                onSelect={() => {
-                                  setEditTreatmentId(tr._id);
-                                  setTreatmentPickerOpen(false);
-                                  setTreatmentSearch("");
-                                }}
-                                className={cn(
-                                  "px-3",
-                                  editTreatmentId === tr._id &&
-                                    "bg-accent font-medium text-accent-foreground",
-                                )}
-                              >
-                                <div className="flex flex-col">
-                                  <span className="text-sm">{tr.name}</span>
-                                  <span className="text-xs text-muted-foreground">
-                                    {tr.duration} min
-                                    {tr.price != null && ` · ${formatCurrencyPLN(tr.price, tr.currency ?? "PLN")}`}
-                                  </span>
-                                </div>
-                              </CommandItem>
-                            ))}
-                        </CommandGroup>
-                      </CommandList>
-                    </Command>
-                  </PopoverContent>
-                </Popover>
+                  open={treatmentPickerOpen}
+                  onOpenChange={setTreatmentPickerOpen}
+                  search={treatmentSearch}
+                  onSearchChange={setTreatmentSearch}
+                  formatPrice={(price, currency) =>
+                    formatCurrencyPLN(price ?? 0, currency ?? "PLN")
+                  }
+                  placeholder={t("gabinet.appointments.selectTreatment")}
+                  searchPlaceholder={t("gabinet.appointments.searchTreatment")}
+                  emptyText={t("common.noResults")}
+                  closeLabel={t("common.close")}
+                  selectedLabel={treatment?.name}
+                  triggerIcon={
+                    <Stethoscope className="size-4 shrink-0 text-primary" />
+                  }
+                />
+
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">


### PR DESCRIPTION
Cherry-picked from stale `claude/issue-1519` (PR #1680). Conflict was an import-order collision in `appointment-dialog.tsx` — main got `SlotPicker` in the same import block, branch added `TreatmentPicker`. Resolved by keeping both.