### PR TITLE
Add a detail/edit shortcut from products, activities, and calls tables

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.activities.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.activities.index.tsx
@@ -448,6 +448,10 @@ function ActivitiesPage() {
         rowActions={rowActions}
         enableBulkSelect
         isLoading={isLoading}
+        onRowAction={(activityId) => {
+          const activity = tableData.find((a) => a._id === activityId);
+          if (activity) openEditPanel(activity);
+        }}
       />
 
       <SidePanel

--- a/src/routes/_app/_auth/dashboard/_layout.calls.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calls.index.tsx
@@ -420,6 +420,10 @@ function CallsPage() {
         data={calls}
         rowActions={rowActions}
         isLoading={isLoading}
+        onRowAction={(callId) => {
+          const call = calls.find((c) => c._id === callId);
+          if (call) openEditPanel(call);
+        }}
       />
 
       <SidePanel

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -400,6 +400,10 @@ function ProductsPage() {
         data={products}
         rowActions={rowActions}
         isLoading={isLoading}
+        onRowAction={(productId) => {
+          const product = products.find((p) => p._id === productId);
+          if (product) openEditPanel(product);
+        }}
       />
 
       <CsvImportDialog


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1699.

Closes #1699

---

## Claude summary

Wired `onRowAction` on the products, activities, and calls CrmDataTables to open each page's existing edit SidePanel — clicking a row now opens it for editing, matching the row-click pattern in contacts/companies/leads (which navigate to detail routes). React Aria's table already skips this action when the click lands on the kebab-menu button, so existing row actions still work.