### PR TITLE
Zmiana/Podpinanie funkcji do modułów

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -8,6 +8,8 @@ const TABLE_MAP: Record<string, string> = {
   companies: "companies",
   leads: "leads",
   products: "products",
+  productStockLevels: "product_stock_levels",
+  productStockMovements: "product_stock_movements",
   calls: "calls",
   notes: "notes",
   activities: "activities",

--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -1,0 +1,250 @@
+// Product inventory backend (#1700 PR-A).
+//
+// "Foundation" layer: lets callers read current stock for a product, adjust it
+// manually with a reason + audit row, and page through the movement history.
+// Higher-level integrations (Gabinet visit settle deducting stock, CRM deal
+// close deducting stock) come in later phases and will call `applyMovement`
+// from their own actions instead of going through `adjustStock`.
+
+import { action } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { v } from "convex/values";
+import { createSupabaseDb } from "./_helpers/supabaseDb";
+import type { SupabaseRow } from "./_helpers/supabaseRows";
+
+type StockLevelRow = SupabaseRow<"productStockLevels">;
+type StockMovementRow = SupabaseRow<"productStockMovements">;
+type ProductRow = SupabaseRow<"products">;
+
+const REASON_VALIDATOR = v.union(
+  v.literal("initial"),
+  v.literal("manual_adjust"),
+  v.literal("appointment_use"),
+  v.literal("appointment_return"),
+  v.literal("deal_close"),
+  v.literal("deal_reopen"),
+  v.literal("transfer_in"),
+  v.literal("transfer_out"),
+  v.literal("other"),
+);
+
+export interface ProductStockSummary {
+  productId: string;
+  trackStock: boolean;
+  total: number;
+  byLocation: Array<{ locationId: string | null; quantity: number }>;
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+export const getStockSummary = action({
+  args: {
+    organizationId: v.id("organizations"),
+    productId: v.string(),
+  },
+  handler: async (ctx, args): Promise<ProductStockSummary> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "products", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    return await loadStockSummary(args.productId, args.organizationId);
+  },
+});
+
+export const listMovements = action({
+  args: {
+    organizationId: v.id("organizations"),
+    productId: v.string(),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<StockMovementRow[]> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "products", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    const db = createSupabaseDb();
+    const limit = Math.max(1, Math.min(args.limit ?? 100, 500));
+    return await db
+      .query<StockMovementRow>("productStockMovements")
+      .eq("organizationId", String(args.organizationId))
+      .eq("productId", args.productId)
+      .order("createdAt", false)
+      .take(limit)
+      .collect();
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+export const adjustStock = action({
+  args: {
+    organizationId: v.id("organizations"),
+    productId: v.string(),
+    locationId: v.optional(v.union(v.id("gabinetLocations"), v.null())),
+    delta: v.optional(v.number()),
+    setTo: v.optional(v.number()),
+    reason: v.optional(REASON_VALIDATOR),
+    note: v.optional(v.union(v.string(), v.null())),
+  },
+  handler: async (ctx, args): Promise<{ movementId: string; balanceAfter: number; warning: string | null }> => {
+    const auth = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "products", action: "edit" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    if (args.delta === undefined && args.setTo === undefined) {
+      throw new Error("adjustStock requires either `delta` or `setTo`");
+    }
+    if (args.delta !== undefined && args.setTo !== undefined) {
+      throw new Error("adjustStock accepts only one of `delta` or `setTo`");
+    }
+
+    const result = await applyMovementInternal({
+      organizationId: String(args.organizationId),
+      productId: args.productId,
+      locationId: args.locationId ?? null,
+      delta: args.delta,
+      setTo: args.setTo,
+      reason: args.reason ?? "manual_adjust",
+      note: args.note ?? null,
+      performedBy: String(auth.userId),
+    });
+
+    return result;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Shared helper — also re-exported for later phases (PR-C/D)
+// ---------------------------------------------------------------------------
+
+interface ApplyMovementParams {
+  organizationId: string;
+  productId: string;
+  locationId: string | null;
+  delta?: number;
+  setTo?: number;
+  reason: StockMovementRow["reason"];
+  sourceType?: string | null;
+  sourceId?: string | null;
+  note?: string | null;
+  performedBy: string;
+}
+
+export async function applyMovementInternal(
+  params: ApplyMovementParams,
+): Promise<{ movementId: string; balanceAfter: number; warning: string | null }> {
+  const db = createSupabaseDb();
+
+  const product = await db.get<ProductRow>("products", params.productId);
+  if (!product || String(product.organizationId) !== params.organizationId) {
+    throw new Error("Product not found");
+  }
+
+  const existing = await db
+    .query<StockLevelRow>("productStockLevels")
+    .eq("productId", params.productId)
+    .collect();
+  const matchKey = (row: StockLevelRow) =>
+    (row.locationId ?? null) === (params.locationId ?? null);
+  const level = existing.find(matchKey);
+
+  const trackStock = !!product.trackStock;
+  const previousBalance = level ? Number(level.quantity) : 0;
+  let resolvedDelta: number;
+  let newBalance: number;
+  if (params.setTo !== undefined) {
+    newBalance = params.setTo;
+    resolvedDelta = newBalance - previousBalance;
+  } else {
+    resolvedDelta = params.delta ?? 0;
+    newBalance = previousBalance + resolvedDelta;
+  }
+
+  let warning: string | null = null;
+  if (trackStock && newBalance < 0) {
+    // Warn-and-allow (#1700): negative stock is permitted but the caller is
+    // expected to surface this in the UI so staff can correct it.
+    warning = "negative_stock";
+  }
+
+  const now = Date.now();
+
+  if (trackStock) {
+    if (level) {
+      await db.patch("productStockLevels", String(level._id), {
+        quantity: newBalance,
+        updatedAt: now,
+      });
+    } else {
+      await db.insert("productStockLevels", {
+        organizationId: params.organizationId,
+        productId: params.productId,
+        locationId: params.locationId,
+        quantity: newBalance,
+        updatedAt: now,
+      });
+    }
+  }
+
+  const movementId = await db.insert("productStockMovements", {
+    organizationId: params.organizationId,
+    productId: params.productId,
+    locationId: params.locationId,
+    delta: resolvedDelta,
+    balanceAfter: trackStock ? newBalance : null,
+    reason: params.reason,
+    sourceType: params.sourceType ?? null,
+    sourceId: params.sourceId ?? null,
+    note: params.note ?? null,
+    performedBy: params.performedBy,
+    createdAt: now,
+  });
+
+  return { movementId, balanceAfter: newBalance, warning };
+}
+
+async function loadStockSummary(
+  productId: string,
+  organizationId: string,
+): Promise<ProductStockSummary> {
+  const db = createSupabaseDb();
+  const product = await db.get<ProductRow>("products", productId);
+  if (!product || String(product.organizationId) !== organizationId) {
+    throw new Error("Product not found");
+  }
+  const levels = await db
+    .query<StockLevelRow>("productStockLevels")
+    .eq("productId", productId)
+    .collect();
+  const byLocation = levels.map((row) => ({
+    locationId: row.locationId ? String(row.locationId) : null,
+    quantity: Number(row.quantity),
+  }));
+  const total = byLocation.reduce((sum, row) => sum + row.quantity, 0);
+  return {
+    productId,
+    trackStock: !!product.trackStock,
+    total,
+    byLocation,
+  };
+}

--- a/convex/products.ts
+++ b/convex/products.ts
@@ -8,6 +8,7 @@ import { logActivity } from "./_helpers/activities";
 import { checkPermission } from "./_helpers/permissions";
 import { Id } from "./_generated/dataModel";
 import type { SupabaseRow } from "./_helpers/supabaseRows";
+import { applyMovementInternal } from "./inventory";
 
 type DealProductRow = SupabaseRow<"dealProducts">;
 type ProductRow = SupabaseRow<"products">;
@@ -74,6 +75,9 @@ export const create = action({
     description: v.optional(v.union(v.string(), v.null())),
     tagIds: v.optional(v.union(v.array(v.string()), v.null())),
     categoryId: v.optional(v.union(v.string(), v.null())),
+    trackStock: v.optional(v.union(v.boolean(), v.null())),
+    stockUnit: v.optional(v.union(v.string(), v.null())),
+    initialStock: v.optional(v.union(v.number(), v.null())),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(
@@ -89,6 +93,7 @@ export const create = action({
     const now = Date.now();
     const db = createSupabaseDb();
 
+    const trackStock = args.trackStock ?? false;
     const productId = await db.insert("products", {
       organizationId: String(args.organizationId),
       name: args.name,
@@ -100,10 +105,31 @@ export const create = action({
       description: args.description ?? null,
       tagIds: args.tagIds ?? null,
       categoryId: args.categoryId ?? null,
+      trackStock,
+      stockUnit: args.stockUnit ?? null,
       createdBy: String(authResult.userId),
       createdAt: now,
       updatedAt: now,
     });
+
+    // Seed an initial stock movement when the product opts into tracking with
+    // a non-zero starting balance. We do this even if trackStock=false but the
+    // user provided an initial number, so the history reflects the intent.
+    const initial = args.initialStock ?? null;
+    if (initial !== null && initial !== 0) {
+      try {
+        await applyMovementInternal({
+          organizationId: String(args.organizationId),
+          productId,
+          locationId: null,
+          delta: initial,
+          reason: "initial",
+          performedBy: String(authResult.userId),
+        });
+      } catch (e) {
+        console.error("[products.create] initial stock seed FAILED:", e);
+      }
+    }
 
     try {
       await ctx.runMutation(internal.products._createSideEffects, {
@@ -151,6 +177,8 @@ export const update = action({
     description: v.optional(v.union(v.string(), v.null())),
     tagIds: v.optional(v.union(v.array(v.string()), v.null())),
     categoryId: v.optional(v.union(v.string(), v.null())),
+    trackStock: v.optional(v.union(v.boolean(), v.null())),
+    stockUnit: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -305,12 +305,65 @@ export function createCrmTables({
     description: v.optional(v.string()),
     tagIds: v.optional(v.array(v.id("tagDefinitions"))),
     categoryId: v.optional(v.id("categoryDefinitions")),
+    // Inventory foundation (#1700 PR-A). When trackStock=true, the product has
+    // managed quantity-on-hand stored in productStockLevels (optionally
+    // per-location for Gabinet) and every change writes a productStockMovements
+    // audit row. When trackStock=false, callers may still log movements for
+    // history but no balance is maintained.
+    trackStock: v.optional(v.boolean()),
+    stockUnit: v.optional(v.string()),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),
   })
     .index("by_org", ["organizationId"])
     .index("by_orgAndSku", ["organizationId", "sku"]),
+
+  // Inventory foundation (#1700 PR-A): current quantity-on-hand per
+  // (product, location). locationId is optional so CRM-only orgs (no
+  // gabinetLocations) can keep a single null-location row per product.
+  productStockLevels: defineTable({
+    organizationId: v.id("organizations"),
+    productId: v.id("products"),
+    locationId: v.optional(v.id("gabinetLocations")),
+    quantity: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_org", ["organizationId"])
+    .index("by_product", ["productId"])
+    .index("by_productAndLocation", ["productId", "locationId"]),
+
+  // Inventory foundation (#1700 PR-A): append-only audit trail for every stock
+  // change. `delta` is positive for receipts (purchase/manual add) and negative
+  // for issues (appointment use, sale, manual remove). `balanceAfter` snapshots
+  // the per-(product, location) running balance after this movement so we can
+  // render history without recomputing.
+  productStockMovements: defineTable({
+    organizationId: v.id("organizations"),
+    productId: v.id("products"),
+    locationId: v.optional(v.id("gabinetLocations")),
+    delta: v.number(),
+    balanceAfter: v.optional(v.number()),
+    reason: v.union(
+      v.literal("initial"),
+      v.literal("manual_adjust"),
+      v.literal("appointment_use"),
+      v.literal("appointment_return"),
+      v.literal("deal_close"),
+      v.literal("deal_reopen"),
+      v.literal("transfer_in"),
+      v.literal("transfer_out"),
+      v.literal("other"),
+    ),
+    sourceType: v.optional(v.string()),
+    sourceId: v.optional(v.string()),
+    note: v.optional(v.string()),
+    performedBy: v.id("users"),
+    createdAt: v.number(),
+  })
+    .index("by_org", ["organizationId", "createdAt"])
+    .index("by_product", ["productId", "createdAt"])
+    .index("by_source", ["sourceType", "sourceId"]),
 
   dealProducts: defineTable({
     organizationId: v.id("organizations"),

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -760,6 +760,14 @@
     },
     "errors": {
       "saveFailed": "Could not save the product."
+    },
+    "stock": {
+      "column": "Stock",
+      "trackToggle": "Track stock",
+      "trackHelp": "Every stock change is recorded in the movement history. When disabled, history can still be kept manually, but the running balance is not enforced.",
+      "unitLabel": "Unit",
+      "unitPlaceholder": "pcs, ml, g…",
+      "initialLabel": "Initial stock"
     }
   },
   "calls": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -774,6 +774,14 @@
     },
     "errors": {
       "saveFailed": "Nie udało się zapisać produktu."
+    },
+    "stock": {
+      "column": "Stan",
+      "trackToggle": "Śledź stan magazynowy",
+      "trackHelp": "Każda zmiana stanu zapisuje się w historii ruchów. Jeśli wyłączone, historia może być nadal prowadzona ręcznie, ale stan nie jest pilnowany.",
+      "unitLabel": "Jednostka",
+      "unitPlaceholder": "szt., ml, g…",
+      "initialLabel": "Stan początkowy"
     }
   },
   "calls": {

--- a/session_state.json
+++ b/session_state.json
@@ -1,19 +1,18 @@
 {
-  "session_id": "S0102",
-  "started_at": "2026-04-15T10:00:00Z",
-  "last_updated": "2026-04-15T10:25:00Z",
-  "status": "paused",
-  "focus": "Phase 1: Convert gabinet appointments.create from mutation to action with Supabase-primary write",
+  "session_id": "S0103",
+  "started_at": "2026-06-12T16:00:00Z",
+  "last_updated": "2026-06-12T16:30:00Z",
+  "status": "active",
+  "focus": "Issue #1700 PR-A: Product inventory foundation (track_stock, stock_levels, stock_movements)",
   "tasks_snapshot": {
-    "total": 36,
+    "total": 1,
     "not_started": 0,
-    "in_progress": 1,
-    "passing": 27,
+    "in_progress": 0,
+    "passing": 1,
     "failing": 0,
-    "blocked": 1,
-    "stale": 6
+    "blocked": 0
   },
-  "active_task_ids": ["SUP-01"],
-  "blockers": ["Frontend callers use useMutation(api.gabinet.appointments.create) which will not work with an action. Must switch to useAction in appointment-dialog.tsx and _layout.tsx before the change is testable end-to-end."],
-  "notes": "S0102: Backend conversion complete. create is now an action writing to Supabase directly. Side effects in _createSideEffects internalMutation. Internal queries created for conflict check, org settings, qualification, location. Auto-package usage wrapped in internalMutation. Frontend MUST be updated to useAction before runtime testing."
+  "active_task_ids": ["INV-A"],
+  "blockers": [],
+  "notes": "S0103: Reviewed and shipped PR-A from an in-progress worktree state. Schema adds trackStock/stockUnit to products plus productStockLevels and productStockMovements tables (location-aware via gabinetLocations FK). Convex action `inventory.adjustStock` writes movements + level updates and returns negative_stock warning. Products list shows Stan column, create form has track-stock toggle + initial stock seed. PR-B (module feature flags) and PR-C/D (treatment defaults + visit settle + dealProducts stock deduction) are still ahead."
 }

--- a/src/hooks/use-supabase-products.ts
+++ b/src/hooks/use-supabase-products.ts
@@ -2,6 +2,7 @@
  * React Query hooks for fetching products from Supabase (PostgreSQL).
  */
 
+import { useMemo } from "react";
 import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
 import { useSupabase } from "@/components/supabase-provider";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
@@ -88,4 +89,64 @@ export function useSupabaseUsedProductIds(
     },
     enabled: enabled && isReady && !!organizationId,
   } satisfies UseQueryOptions<Set<string>, Error>);
+}
+
+// ---------------------------------------------------------------------------
+// Product Stock Totals (#1700 PR-A)
+//
+// Loads every product_stock_levels row for the org and returns a Map from
+// productId → { total, byLocation }. The product list page consumes the
+// total so it can render a Stock column next to each row without an
+// N+1 lookup. Locations are surfaced too for the per-product detail panel.
+// ---------------------------------------------------------------------------
+
+export interface ProductStockTotal {
+  total: number;
+  byLocation: Array<{ locationId: string | null; quantity: number }>;
+}
+
+export function useSupabaseProductStockTotals(
+  organizationId: string,
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  const query = useQuery<
+    Array<{ product_id: string; location_id: string | null; quantity: number }>,
+    Error
+  >({
+    queryKey: supabaseKeys.productStockLevels.list(organizationId),
+    queryFn: async () => {
+      if (!client) throw new Error("Supabase client not ready");
+      const { data, error } = await client
+        .from("product_stock_levels")
+        .select("product_id, location_id, quantity")
+        .eq("organization_id", organizationId);
+      if (error) throw error;
+      return (data ?? []) as Array<{
+        product_id: string;
+        location_id: string | null;
+        quantity: number;
+      }>;
+    },
+    enabled: enabled && isReady && !!organizationId,
+  });
+
+  const totalsByProductId = useMemo(() => {
+    const map = new Map<string, ProductStockTotal>();
+    for (const row of query.data ?? []) {
+      const existing = map.get(row.product_id) ?? { total: 0, byLocation: [] };
+      const qty = Number(row.quantity ?? 0);
+      existing.total += qty;
+      existing.byLocation.push({
+        locationId: row.location_id,
+        quantity: qty,
+      });
+      map.set(row.product_id, existing);
+    }
+    return map;
+  }, [query.data]);
+
+  return { ...query, totalsByProductId };
 }

--- a/src/lib/supabase/database.columns.ts
+++ b/src/lib/supabase/database.columns.ts
@@ -17,6 +17,7 @@
  *   • 00010_gabinet_treatment_package_link.sql
  *   • 00011_entity_type_gabinet_event.sql
  *   • 00012_app_schema_version_rpc.sql
+ *   • 00013_product_inventory_foundation.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  */
@@ -113,7 +114,9 @@ export type TableName =
   | "automation_rules"
   | "automation_runs"
   | "automation_run_steps"
-  | "document_components";
+  | "document_components"
+  | "product_stock_levels"
+  | "product_stock_movements";
 
 /**
  * Column names per table, as a runtime-checkable Set.
@@ -153,7 +156,7 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   object_relationships: new Set(["id", "organization_id", "source_type", "source_id", "target_type", "target_id", "relationship_type", "created_by", "created_at"]),
   activities: new Set(["id", "organization_id", "entity_type", "entity_id", "action", "description", "metadata", "performed_by", "created_at"]),
   notes: new Set(["id", "organization_id", "entity_type", "entity_id", "content", "created_by", "is_pinned", "parent_note_id", "created_at", "updated_at"]),
-  products: new Set(["id", "organization_id", "name", "sku", "unit_price", "tax_rate", "is_active", "description", "tag_ids", "category_id", "created_by", "created_at", "updated_at", "tax_exempt"]),
+  products: new Set(["id", "organization_id", "name", "sku", "unit_price", "tax_rate", "is_active", "description", "tag_ids", "category_id", "created_by", "created_at", "updated_at", "tax_exempt", "track_stock", "stock_unit"]),
   deal_products: new Set(["id", "organization_id", "deal_id", "product_id", "quantity", "unit_price", "discount", "created_at"]),
   calls: new Set(["id", "organization_id", "outcome", "call_date", "note", "duration", "tag_ids", "category_id", "created_by", "created_at", "updated_at"]),
   lost_reasons: new Set(["id", "organization_id", "label", "order", "is_active", "created_by", "created_at", "updated_at"]),
@@ -211,4 +214,6 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   automation_runs: new Set(["id", "organization_id", "rule_id", "module", "event_type", "entity_type", "entity_id", "event_idempotency_key", "correlation_key", "payload_snapshot", "actor_user_id", "status", "error_message", "occurred_at", "processed_at", "created_at", "updated_at"]),
   automation_run_steps: new Set(["id", "organization_id", "run_id", "rule_id", "action_index", "action_type", "idempotency_key", "status", "recipient", "recipient_name", "linked_entity_type", "linked_entity_id", "rendered_subject", "rendered_body", "metadata_snapshot", "error_message", "email_event_log_id", "appointment_sms_event_id", "processed_at", "created_at", "updated_at"]),
   document_components: new Set(["id", "organization_id", "scope", "created_by", "name", "description", "category", "content_json", "protected", "position_constraint", "version", "is_active", "created_at", "updated_at"]),
+  product_stock_levels: new Set(["id", "organization_id", "product_id", "location_id", "quantity", "updated_at"]),
+  product_stock_movements: new Set(["id", "organization_id", "product_id", "location_id", "delta", "balance_after", "reason", "source_type", "source_id", "note", "performed_by", "created_at"]),
 };

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -17,6 +17,7 @@
  *   • 00010_gabinet_treatment_package_link.sql
  *   • 00011_entity_type_gabinet_event.sql
  *   • 00012_app_schema_version_rpc.sql
+ *   • 00013_product_inventory_foundation.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -1346,6 +1347,8 @@ export interface Database {
           created_at: number;
           updated_at: number;
           tax_exempt: boolean | null;
+          track_stock: boolean | null;
+          stock_unit: string | null;
         };
         Insert: {
           id?: string;
@@ -1362,6 +1365,8 @@ export interface Database {
           created_at: number;
           updated_at: number;
           tax_exempt?: boolean | null;
+          track_stock?: boolean | null;
+          stock_unit?: string | null;
         };
         Update: {
           id?: string;
@@ -1378,6 +1383,8 @@ export interface Database {
           created_at?: number;
           updated_at?: number;
           tax_exempt?: boolean | null;
+          track_stock?: boolean | null;
+          stock_unit?: string | null;
         };
       };
       deal_products: {
@@ -4528,6 +4535,76 @@ export interface Database {
           is_active?: boolean;
           created_at?: number;
           updated_at?: number;
+        };
+      };
+      product_stock_levels: {
+        Row: {
+          id: string;
+          organization_id: string;
+          product_id: string;
+          location_id: string | null;
+          quantity: number;
+          updated_at: number;
+        };
+        Insert: {
+          id?: string;
+          organization_id: string;
+          product_id: string;
+          location_id?: string | null;
+          quantity?: number;
+          updated_at: number;
+        };
+        Update: {
+          id?: string;
+          organization_id?: string;
+          product_id?: string;
+          location_id?: string | null;
+          quantity?: number;
+          updated_at?: number;
+        };
+      };
+      product_stock_movements: {
+        Row: {
+          id: string;
+          organization_id: string;
+          product_id: string;
+          location_id: string | null;
+          delta: number;
+          balance_after: number | null;
+          reason: string;
+          source_type: string | null;
+          source_id: string | null;
+          note: string | null;
+          performed_by: string;
+          created_at: number;
+        };
+        Insert: {
+          id?: string;
+          organization_id: string;
+          product_id: string;
+          location_id?: string | null;
+          delta: number;
+          balance_after?: number | null;
+          reason: string;
+          source_type?: string | null;
+          source_id?: string | null;
+          note?: string | null;
+          performed_by: string;
+          created_at: number;
+        };
+        Update: {
+          id?: string;
+          organization_id?: string;
+          product_id?: string;
+          location_id?: string | null;
+          delta?: number;
+          balance_after?: number | null;
+          reason?: string;
+          source_type?: string | null;
+          source_id?: string | null;
+          note?: string | null;
+          performed_by?: string;
+          created_at?: number;
         };
       };
     };

--- a/src/lib/supabase/mappers/products.ts
+++ b/src/lib/supabase/mappers/products.ts
@@ -18,6 +18,8 @@ export interface MappedProduct {
   description?: string;
   tagIds?: string[];
   categoryId?: string;
+  trackStock?: boolean;
+  stockUnit?: string;
   createdBy: string;
   createdAt: number;
   updatedAt: number;

--- a/src/lib/supabase/query-keys.ts
+++ b/src/lib/supabase/query-keys.ts
@@ -45,6 +45,8 @@ export const supabaseKeys = {
   pipelineStages: entityKeys("pipelineStages"),
   pipelineStageActions: entityKeys("pipelineStageActions"),
   dealProducts: entityKeys("dealProducts"),
+  productStockLevels: entityKeys("productStockLevels"),
+  productStockMovements: entityKeys("productStockMovements"),
   scheduledActivities: entityKeys("scheduledActivities"),
   formDocuments: entityKeys("formDocuments"),
 

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -7,6 +7,7 @@ import { api } from "@cvx/_generated/api";
 import {
   useSupabaseProductsList,
   useSupabaseUsedProductIds,
+  useSupabaseProductStockTotals,
 } from "@/hooks/use-supabase-products";
 import { useOrganization } from "@/components/org-context";
 import { PageHeader } from "@/components/layout/page-header";
@@ -156,11 +157,16 @@ function ProductsPage() {
   const [description, setDescription] = useState("");
   const [tagIds, setTagIds] = useState<Id<"tagDefinitions">[]>([]);
   const [categoryId, setCategoryId] = useState<Id<"categoryDefinitions"> | undefined>(undefined);
+  // Inventory (#1700 PR-A)
+  const [trackStock, setTrackStock] = useState(false);
+  const [stockUnit, setStockUnit] = useState("");
+  const [initialStock, setInitialStock] = useState("");
 
   const { data: allProducts = [], isLoading } = useSupabaseProductsList(organizationId);
   const { data: usedProductIds } = useSupabaseUsedProductIds(organizationId, {
     enabled: nudgeFilter === "unused",
   });
+  const { totalsByProductId } = useSupabaseProductStockTotals(organizationId);
 
   const products = useMemo(() => {
     let data = allProducts;
@@ -196,6 +202,9 @@ function ProductsPage() {
     setDescription("");
     setTagIds([]);
     setCategoryId(undefined);
+    setTrackStock(false);
+    setStockUnit("");
+    setInitialStock("");
     setEditingProduct(null);
   };
 
@@ -214,6 +223,9 @@ function ProductsPage() {
     setDescription(product.description ?? "");
     setTagIds((product.tagIds as Id<"tagDefinitions">[]) ?? []);
     setCategoryId(product.categoryId as Id<"categoryDefinitions"> | undefined);
+    setTrackStock(!!product.trackStock);
+    setStockUnit(product.stockUnit ?? "");
+    setInitialStock("");
     setPanelOpen(true);
   };
 
@@ -229,6 +241,12 @@ function ProductsPage() {
         : null
       : null;
     const normalizedUnitPrice = unitPrice.replace(",", ".");
+    const normalizedStockUnit = stockUnit.trim() || null;
+    const normalizedInitialStock = (() => {
+      if (!initialStock.trim()) return null;
+      const parsed = parseFloat(initialStock.replace(",", "."));
+      return Number.isFinite(parsed) ? parsed : null;
+    })();
     try {
       if (editingProduct) {
         await updateProduct({
@@ -242,6 +260,8 @@ function ProductsPage() {
           description: description.trim() || null,
           tagIds,
           categoryId: categoryId ?? null,
+          trackStock,
+          stockUnit: normalizedStockUnit,
         });
       } else {
         await createProduct({
@@ -255,6 +275,9 @@ function ProductsPage() {
           description: description.trim() || null,
           tagIds,
           categoryId: categoryId ?? null,
+          trackStock,
+          stockUnit: normalizedStockUnit,
+          initialStock: normalizedInitialStock,
         });
       }
       setPanelOpen(false);
@@ -300,6 +323,28 @@ function ProductsPage() {
         if (item.taxRate == null) return "\u2014";
         return `${item.taxRate}%`;
       },
+    },
+    {
+      id: "stock",
+      label: t('products.stock.column', { defaultValue: "Stan" }),
+      render: (item) => {
+        if (!item.trackStock) return "\u2014";
+        const summary = totalsByProductId.get(item._id);
+        const total = summary?.total ?? 0;
+        const unit = item.stockUnit?.trim();
+        const negative = total < 0;
+        return (
+          <span className={negative ? "text-destructive font-medium" : undefined}>
+            {total}
+            {unit ? ` ${unit}` : ""}
+          </span>
+        );
+      },
+      getSortValue: (item) => {
+        if (!item.trackStock) return -Infinity;
+        return totalsByProductId.get(item._id)?.total ?? 0;
+      },
+      sortable: true,
     },
     {
       id: "isActive",
@@ -493,6 +538,68 @@ function ProductsPage() {
               <Label className="cursor-pointer">{t('common.active')}</Label>
             </div>
           )}
+
+          <div className="space-y-3 rounded-md border bg-muted/30 px-3 py-3">
+            <div className="flex items-start gap-2">
+              <Checkbox
+                id="product-track-stock"
+                checked={trackStock}
+                onCheckedChange={(checked) => setTrackStock(!!checked)}
+                className="mt-0.5"
+              />
+              <div className="space-y-1">
+                <Label htmlFor="product-track-stock" className="cursor-pointer">
+                  {t("products.stock.trackToggle", {
+                    defaultValue: "Śledź stan magazynowy",
+                  })}
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  {t("products.stock.trackHelp", {
+                    defaultValue:
+                      "Każda zmiana stanu zapisuje się w historii ruchów. Jeśli wyłączone, historia może być nadal prowadzona ręcznie, ale stan nie jest pilnowany.",
+                  })}
+                </p>
+              </div>
+            </div>
+
+            {trackStock && (
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label>
+                    {t("products.stock.unitLabel", { defaultValue: "Jednostka" })}
+                  </Label>
+                  <Input
+                    value={stockUnit}
+                    onChange={(e) => setStockUnit(e.target.value)}
+                    placeholder={t("products.stock.unitPlaceholder", {
+                      defaultValue: "szt., ml, g…",
+                    })}
+                  />
+                </div>
+                {!editingProduct && (
+                  <div className="space-y-1.5">
+                    <Label>
+                      {t("products.stock.initialLabel", {
+                        defaultValue: "Stan początkowy",
+                      })}
+                    </Label>
+                    <Input
+                      type="text"
+                      inputMode="decimal"
+                      value={initialStock}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        if (v === "" || /^-?[0-9]*[.,]?[0-9]*$/.test(v)) {
+                          setInitialStock(v);
+                        }
+                      }}
+                      placeholder="0"
+                    />
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
 
           <div className="space-y-1.5">
             <Label>{t('common.description')}</Label>

--- a/supabase/migrations/00013_product_inventory_foundation.sql
+++ b/supabase/migrations/00013_product_inventory_foundation.sql
@@ -1,0 +1,101 @@
+-- Product inventory foundation (#1700 PR-A).
+--
+-- Extends the CRM products table with optional stock-tracking flags and
+-- adds two new tables that form the inventory audit trail:
+--
+--   • product_stock_levels — current quantity-on-hand per (product, location).
+--     location_id is nullable so CRM-only organizations (without any
+--     gabinet_locations rows) keep one row per product with location_id = NULL.
+--     Gabinet organizations may keep multiple rows per product, one per
+--     gabinet_location they actually stock the product in.
+--
+--   • product_stock_movements — append-only history. Every stock change writes
+--     one row with `delta` (positive for receipts, negative for issues) and a
+--     snapshot of the per-(product, location) running balance after the change
+--     in `balance_after`. `reason` is a small enum-shaped string; `source_type`
+--     / `source_id` link the movement back to the originating record (e.g. a
+--     gabinet appointment or CRM deal) once later phases wire them up.
+--
+-- This migration is intentionally additive: existing products keep working
+-- with track_stock = NULL/FALSE and no stock_levels rows. The follow-up
+-- module-feature-flag PR (PR-B) will let an organization explicitly opt in
+-- to inventory.
+
+-- ---------------------------------------------------------------------------
+-- products: stock-tracking columns
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE products
+  ADD COLUMN IF NOT EXISTS track_stock BOOLEAN;
+
+ALTER TABLE products
+  ADD COLUMN IF NOT EXISTS stock_unit TEXT;
+
+-- ---------------------------------------------------------------------------
+-- product_stock_levels: current per-(product, location) quantity-on-hand
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS product_stock_levels (
+  id              TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  product_id      TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  location_id     TEXT REFERENCES gabinet_locations(id) ON DELETE CASCADE,
+  quantity        NUMERIC NOT NULL DEFAULT 0,
+  updated_at      BIGINT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS product_stock_levels_org_idx
+  ON product_stock_levels (organization_id);
+
+CREATE INDEX IF NOT EXISTS product_stock_levels_product_idx
+  ON product_stock_levels (product_id);
+
+-- One row per (product, location). Partial unique indexes are required
+-- because PostgreSQL treats NULLs as distinct in regular UNIQUE indexes.
+CREATE UNIQUE INDEX IF NOT EXISTS product_stock_levels_product_location_idx
+  ON product_stock_levels (product_id, location_id)
+  WHERE location_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS product_stock_levels_product_no_location_idx
+  ON product_stock_levels (product_id)
+  WHERE location_id IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- product_stock_movements: append-only audit trail
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS product_stock_movements (
+  id              TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  product_id      TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  location_id     TEXT REFERENCES gabinet_locations(id) ON DELETE SET NULL,
+  delta           NUMERIC NOT NULL,
+  balance_after   NUMERIC,
+  reason          TEXT NOT NULL,
+  source_type     TEXT,
+  source_id       TEXT,
+  note            TEXT,
+  performed_by    TEXT NOT NULL REFERENCES users(id),
+  created_at      BIGINT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS product_stock_movements_org_created_idx
+  ON product_stock_movements (organization_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS product_stock_movements_product_created_idx
+  ON product_stock_movements (product_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS product_stock_movements_source_idx
+  ON product_stock_movements (source_type, source_id);
+
+-- ---------------------------------------------------------------------------
+-- RLS: org-scoped access, same pattern as existing CRM tables.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE product_stock_levels ENABLE ROW LEVEL SECURITY;
+CREATE POLICY org_isolation ON product_stock_levels
+  USING (organization_id = current_org_id());
+
+ALTER TABLE product_stock_movements ENABLE ROW LEVEL SECURITY;
+CREATE POLICY org_isolation ON product_stock_movements
+  USING (organization_id = current_org_id());

--- a/tasks_progress.json
+++ b/tasks_progress.json
@@ -1,7 +1,7 @@
 {
-  "session_id": "S0101",
+  "session_id": "S0103",
   "session_uuid": "d8e3f5g2-9c4e-5b0f-c6d7-3e2f1g4b5c6d",
-  "date": "2026-04-15",
+  "date": "2026-06-12",
   "tasks": [
     {
       "id": "SMS-01",
@@ -10,7 +10,11 @@
       "created_session": "S0061",
       "last_updated_session": "S0061",
       "description": "Add durable appointment SMS event/correlation storage with indexes for appointment, organization+phone, provider message id, correlation key, and processing status.",
-      "files": ["convex/schema.ts", "convex/gabinet/appointmentSms.ts", "convex/sms.ts"],
+      "files": [
+        "convex/schema.ts",
+        "convex/gabinet/appointmentSms.ts",
+        "convex/sms.ts"
+      ],
       "depends_on": []
     },
     {
@@ -20,8 +24,15 @@
       "created_session": "S0061",
       "last_updated_session": "S0061",
       "description": "Send dedicated confirmation SMS for appointments through existing provider abstraction, persist outbound event records, and reuse reminder timing/settings where appropriate.",
-      "files": ["convex/gabinet/appointments.ts", "convex/gabinet/appointmentReminders.ts", "convex/sms.ts", "convex/gabinet/appointmentSms.ts"],
-      "depends_on": ["SMS-01"]
+      "files": [
+        "convex/gabinet/appointments.ts",
+        "convex/gabinet/appointmentReminders.ts",
+        "convex/sms.ts",
+        "convex/gabinet/appointmentSms.ts"
+      ],
+      "depends_on": [
+        "SMS-01"
+      ]
     },
     {
       "id": "SMS-03",
@@ -30,8 +41,14 @@
       "created_session": "S0061",
       "last_updated_session": "S0061",
       "description": "Add inbound SMS HTTP route, provider-aware parsing, normalization, signature verification where supported, and idempotent correlation lookup for TAK/NIE replies.",
-      "files": ["convex/http.ts", "convex/gabinet/appointmentSms.ts", "convex/sms.ts"],
-      "depends_on": ["SMS-01"]
+      "files": [
+        "convex/http.ts",
+        "convex/gabinet/appointmentSms.ts",
+        "convex/sms.ts"
+      ],
+      "depends_on": [
+        "SMS-01"
+      ]
     },
     {
       "id": "SMS-04",
@@ -40,8 +57,13 @@
       "created_session": "S0061",
       "last_updated_session": "S0061",
       "description": "Centralize SMS-driven appointment confirm/cancel transitions in appointment domain logic with audit log, activity log, notification, reminder cancellation, and terminal-state guards.",
-      "files": ["convex/gabinet/appointments.ts", "convex/gabinet/appointmentSms.ts"],
-      "depends_on": ["SMS-03"]
+      "files": [
+        "convex/gabinet/appointments.ts",
+        "convex/gabinet/appointmentSms.ts"
+      ],
+      "depends_on": [
+        "SMS-03"
+      ]
     },
     {
       "id": "SMS-05",
@@ -50,8 +72,16 @@
       "created_session": "S0061",
       "last_updated_session": "S0061",
       "description": "Expose SMS confirmation state and compact timeline in appointment detail surfaces, align pending_confirmation UI with backend transitions, and optionally add read-only operational controls.",
-      "files": ["src/components/gabinet/calendar/appointment-detail-dialog.tsx", "src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx", "public/locales/pl/translation.json", "public/locales/en/translation.json"],
-      "depends_on": ["SMS-02", "SMS-04"]
+      "files": [
+        "src/components/gabinet/calendar/appointment-detail-dialog.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx",
+        "public/locales/pl/translation.json",
+        "public/locales/en/translation.json"
+      ],
+      "depends_on": [
+        "SMS-02",
+        "SMS-04"
+      ]
     },
     {
       "id": "SMS-06",
@@ -60,8 +90,73 @@
       "created_session": "S0061",
       "last_updated_session": "S0061",
       "description": "Add focused tests, deterministic inbound fixtures, failure markers, and repo-local WORKFLOW.md for the Symphony pilot lane with manual stop at Human Review.",
-      "files": ["WORKFLOW.md", "ARCHITECTURE.md", "docs/automation/README.md", "docs/automation/rules/00-rule-loading.md", "docs/automation/rules/convex-backend.md", "docs/automation/rules/gabinet-ui.md", "docs/automation/rules/testing-and-evidence.md", "docs/automation/rules/module-boundaries.md", "docs/automation/rules/harness/index.md", "docs/automation/rules/harness/loading-order.md", "docs/automation/rules/harness/rule-selection.md", "docs/automation/rules/harness/rule-promotion.md", "docs/automation/rules/harness/human-review-bias.md", "docs/automation/rules/backend/index.md", "docs/automation/rules/backend/domain-ownership.md", "docs/automation/rules/backend/side-effects.md", "docs/automation/rules/backend/inbound-integrations.md", "docs/automation/rules/backend/correlation-and-idempotency.md", "docs/automation/rules/backend/read-vs-write.md", "docs/automation/rules/backend/provider-routing.md", "docs/automation/rules/backend/audit-attribution.md", "docs/automation/rules/backend/incremental-validation.md", "docs/automation/rules/ui/index.md", "docs/automation/rules/ui/gabinet-surfaces.md", "docs/automation/rules/ui/status-model-alignment.md", "docs/automation/rules/ui/i18n.md", "docs/automation/rules/ui/operator-clarity.md", "docs/automation/rules/ui/evidence-first-ui.md", "docs/automation/rules/testing/index.md", "docs/automation/rules/testing/validation-levels.md", "docs/automation/rules/testing/evidence-bundle.md", "docs/automation/rules/testing/artifact-placement.md", "docs/automation/rules/testing/review-note-quality.md", "docs/automation/rules/architecture/index.md", "docs/automation/rules/architecture/module-boundaries.md", "docs/automation/retrospectives/2026-03-11-sms-backend-retrospective.md", "docs/DESIGN.md", "docs/FRONTEND.md", "docs/PLANS.md", "docs/PRODUCT_SENSE.md", "docs/QUALITY_SCORE.md", "docs/RELIABILITY.md", "docs/SECURITY.md", "docs/design-docs/index.md", "docs/design-docs/core-beliefs.md", "docs/product-specs/index.md", "docs/product-specs/sms-appointment-confirmation-pilot.md", "docs/exec-plans/active/sms-appointment-confirmation-pilot.md", "docs/exec-plans/tech-debt-tracker.md", "docs/generated/db-schema.md", "docs/references/repo-structure-llms.txt", "docs/references/design-system-reference-llms.txt", "docs/references/nixpacks-llms.txt", "docs/references/uv-llms.txt", "convex/tests/appointmentStateMachine.test.ts", "convex/tests/appointmentSms.test.ts", "e2e/gabinet/appointments.spec.ts", "e2e/gabinet/appointment-lifecycle.spec.ts"],
-      "depends_on": ["SMS-01", "SMS-02", "SMS-03", "SMS-04", "SMS-05"]
+      "files": [
+        "WORKFLOW.md",
+        "ARCHITECTURE.md",
+        "docs/automation/README.md",
+        "docs/automation/rules/00-rule-loading.md",
+        "docs/automation/rules/convex-backend.md",
+        "docs/automation/rules/gabinet-ui.md",
+        "docs/automation/rules/testing-and-evidence.md",
+        "docs/automation/rules/module-boundaries.md",
+        "docs/automation/rules/harness/index.md",
+        "docs/automation/rules/harness/loading-order.md",
+        "docs/automation/rules/harness/rule-selection.md",
+        "docs/automation/rules/harness/rule-promotion.md",
+        "docs/automation/rules/harness/human-review-bias.md",
+        "docs/automation/rules/backend/index.md",
+        "docs/automation/rules/backend/domain-ownership.md",
+        "docs/automation/rules/backend/side-effects.md",
+        "docs/automation/rules/backend/inbound-integrations.md",
+        "docs/automation/rules/backend/correlation-and-idempotency.md",
+        "docs/automation/rules/backend/read-vs-write.md",
+        "docs/automation/rules/backend/provider-routing.md",
+        "docs/automation/rules/backend/audit-attribution.md",
+        "docs/automation/rules/backend/incremental-validation.md",
+        "docs/automation/rules/ui/index.md",
+        "docs/automation/rules/ui/gabinet-surfaces.md",
+        "docs/automation/rules/ui/status-model-alignment.md",
+        "docs/automation/rules/ui/i18n.md",
+        "docs/automation/rules/ui/operator-clarity.md",
+        "docs/automation/rules/ui/evidence-first-ui.md",
+        "docs/automation/rules/testing/index.md",
+        "docs/automation/rules/testing/validation-levels.md",
+        "docs/automation/rules/testing/evidence-bundle.md",
+        "docs/automation/rules/testing/artifact-placement.md",
+        "docs/automation/rules/testing/review-note-quality.md",
+        "docs/automation/rules/architecture/index.md",
+        "docs/automation/rules/architecture/module-boundaries.md",
+        "docs/automation/retrospectives/2026-03-11-sms-backend-retrospective.md",
+        "docs/DESIGN.md",
+        "docs/FRONTEND.md",
+        "docs/PLANS.md",
+        "docs/PRODUCT_SENSE.md",
+        "docs/QUALITY_SCORE.md",
+        "docs/RELIABILITY.md",
+        "docs/SECURITY.md",
+        "docs/design-docs/index.md",
+        "docs/design-docs/core-beliefs.md",
+        "docs/product-specs/index.md",
+        "docs/product-specs/sms-appointment-confirmation-pilot.md",
+        "docs/exec-plans/active/sms-appointment-confirmation-pilot.md",
+        "docs/exec-plans/tech-debt-tracker.md",
+        "docs/generated/db-schema.md",
+        "docs/references/repo-structure-llms.txt",
+        "docs/references/design-system-reference-llms.txt",
+        "docs/references/nixpacks-llms.txt",
+        "docs/references/uv-llms.txt",
+        "convex/tests/appointmentStateMachine.test.ts",
+        "convex/tests/appointmentSms.test.ts",
+        "e2e/gabinet/appointments.spec.ts",
+        "e2e/gabinet/appointment-lifecycle.spec.ts"
+      ],
+      "depends_on": [
+        "SMS-01",
+        "SMS-02",
+        "SMS-03",
+        "SMS-04",
+        "SMS-05"
+      ]
     },
     {
       "id": "SMS-07",
@@ -70,8 +165,23 @@
       "created_session": "S0061",
       "last_updated_session": "S0061",
       "description": "Propagate durable outbound and inbound appointment SMS events into the shared activity system for appointment, patient, and linked CRM contact timelines using explicit sms_sent and sms_received actions, while keeping lead propagation out of scope.",
-      "files": ["convex/schema.ts", "convex/gabinet/appointmentSms.ts", "src/components/activity-timeline/activity-item.tsx", "src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx", "convex/tests/appointmentSms.test.ts", "convex/tests/appointmentStateMachine.test.ts", "e2e/gabinet/appointments.spec.ts"],
-      "depends_on": ["SMS-01", "SMS-02", "SMS-03", "SMS-04", "SMS-05", "SMS-06"]
+      "files": [
+        "convex/schema.ts",
+        "convex/gabinet/appointmentSms.ts",
+        "src/components/activity-timeline/activity-item.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx",
+        "convex/tests/appointmentSms.test.ts",
+        "convex/tests/appointmentStateMachine.test.ts",
+        "e2e/gabinet/appointments.spec.ts"
+      ],
+      "depends_on": [
+        "SMS-01",
+        "SMS-02",
+        "SMS-03",
+        "SMS-04",
+        "SMS-05",
+        "SMS-06"
+      ]
     },
     {
       "id": "SMS-08",
@@ -80,8 +190,18 @@
       "created_session": "S0061",
       "last_updated_session": "S0061",
       "description": "Localize the shared automations settings surface, settings sidebar labels, shared activity relative time, and appointment history metadata/descriptions so touched UI no longer leaks object-fallback or mixed-language strings.",
-      "files": ["src/components/layout/app-sidebar.tsx", "src/routes/_app/_auth/dashboard/_layout.settings.automations.tsx", "src/components/activity-timeline/activity-item.tsx", "src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx", "public/locales/en/translation.json", "public/locales/pl/translation.json", "session_state.json"],
-      "depends_on": ["SMS-07"]
+      "files": [
+        "src/components/layout/app-sidebar.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.settings.automations.tsx",
+        "src/components/activity-timeline/activity-item.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx",
+        "public/locales/en/translation.json",
+        "public/locales/pl/translation.json",
+        "session_state.json"
+      ],
+      "depends_on": [
+        "SMS-07"
+      ]
     },
     {
       "id": "AUT-05",
@@ -90,8 +210,22 @@
       "created_session": "S0061",
       "last_updated_session": "S0061",
       "description": "Move automation create/edit flows from the settings modal into dedicated full-page routes while preserving the overview page, shared graph builder, backend payload compatibility, and focused verification.",
-      "files": ["src/routes/_app/_auth/dashboard/_layout.settings.automations.tsx", "src/routes/_app/_auth/dashboard/_layout.settings.automations.new.tsx", "src/routes/_app/_auth/dashboard/_layout.settings.automations.$ruleId.tsx", "src/components/settings/automation-builder/automation-graph-builder.tsx", "e2e/gabinet/appointments.spec.ts", "public/locales/en/translation.json", "public/locales/pl/translation.json", "session_state.json"],
-      "depends_on": ["AUT-01", "AUT-02", "AUT-03", "AUT-04"]
+      "files": [
+        "src/routes/_app/_auth/dashboard/_layout.settings.automations.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.settings.automations.new.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.settings.automations.$ruleId.tsx",
+        "src/components/settings/automation-builder/automation-graph-builder.tsx",
+        "e2e/gabinet/appointments.spec.ts",
+        "public/locales/en/translation.json",
+        "public/locales/pl/translation.json",
+        "session_state.json"
+      ],
+      "depends_on": [
+        "AUT-01",
+        "AUT-02",
+        "AUT-03",
+        "AUT-04"
+      ]
     },
     {
       "id": "AUT-06",
@@ -100,8 +234,21 @@
       "created_session": "S0061",
       "last_updated_session": "S0061",
       "description": "Default automation new/edit routes to a business-friendly simple-mode wizard backed by a frontend Gabinet preset catalog, classify supported existing rules back into simple mode on edit, preserve the backend payload contract, and keep the graph builder as an explicit advanced-mode fallback.",
-      "files": ["src/routes/_app/_auth/dashboard/_layout.settings.automations.index.tsx", "src/routes/_app/_auth/dashboard/_layout.settings.automations.new.tsx", "src/routes/_app/_auth/dashboard/_layout.settings.automations.$ruleId.tsx", "src/components/settings/automation-builder/automation-graph-builder.tsx", "src/components/settings/automation-builder/automation-simple-mode.tsx", "src/components/settings/automation-builder/automation-simple-presets.ts", "public/locales/en/translation.json", "public/locales/pl/translation.json", "e2e/gabinet/appointments.spec.ts", "convex/tests/automation.test.ts"],
-      "depends_on": ["AUT-05"]
+      "files": [
+        "src/routes/_app/_auth/dashboard/_layout.settings.automations.index.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.settings.automations.new.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.settings.automations.$ruleId.tsx",
+        "src/components/settings/automation-builder/automation-graph-builder.tsx",
+        "src/components/settings/automation-builder/automation-simple-mode.tsx",
+        "src/components/settings/automation-builder/automation-simple-presets.ts",
+        "public/locales/en/translation.json",
+        "public/locales/pl/translation.json",
+        "e2e/gabinet/appointments.spec.ts",
+        "convex/tests/automation.test.ts"
+      ],
+      "depends_on": [
+        "AUT-05"
+      ]
     },
     {
       "id": "AUT-07",
@@ -110,8 +257,23 @@
       "created_session": "S0061",
       "last_updated_session": "S0061",
       "description": "Expand the automation backend contract and Gabinet-first business editor to support structured action capabilities, multi-action rules, SMS reply triggers, business recipient mapping, variable insertion, email template/manual composition, and safe permission-aware field updates while preserving backward-compatible execution and strict unsupported-rule fallback.",
-      "files": ["convex/automation.ts", "convex/schema.ts", "src/components/settings/automation-builder/automation-simple-mode.tsx", "src/components/settings/automation-builder/automation-simple-presets.ts", "src/routes/_app/_auth/dashboard/_layout.settings.automations.index.tsx", "src/routes/_app/_auth/dashboard/_layout.settings.automations.new.tsx", "src/routes/_app/_auth/dashboard/_layout.settings.automations.$ruleId.tsx", "public/locales/en/translation.json", "public/locales/pl/translation.json", "convex/tests/automation.test.ts", "e2e/gabinet/appointments.spec.ts"],
-      "depends_on": ["AUT-06", "SMS-07"]
+      "files": [
+        "convex/automation.ts",
+        "convex/schema.ts",
+        "src/components/settings/automation-builder/automation-simple-mode.tsx",
+        "src/components/settings/automation-builder/automation-simple-presets.ts",
+        "src/routes/_app/_auth/dashboard/_layout.settings.automations.index.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.settings.automations.new.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.settings.automations.$ruleId.tsx",
+        "public/locales/en/translation.json",
+        "public/locales/pl/translation.json",
+        "convex/tests/automation.test.ts",
+        "e2e/gabinet/appointments.spec.ts"
+      ],
+      "depends_on": [
+        "AUT-06",
+        "SMS-07"
+      ]
     },
     {
       "id": "SIDEBAR-01",
@@ -120,7 +282,13 @@
       "created_session": "S0063",
       "last_updated_session": "S0063",
       "description": "Run focused app and convex typechecks plus the recentlyViewed test to verify the touched sidebar widget slice after fixes.",
-      "files": ["convex/tests/recentlyViewed.test.ts", "src/components/sidebar-widgets/smart-agenda.tsx", "convex/gabinet/nudges.ts", "public/locales/en/translation.json", "public/locales/pl/translation.json"],
+      "files": [
+        "convex/tests/recentlyViewed.test.ts",
+        "src/components/sidebar-widgets/smart-agenda.tsx",
+        "convex/gabinet/nudges.ts",
+        "public/locales/en/translation.json",
+        "public/locales/pl/translation.json"
+      ],
       "depends_on": []
     },
     {
@@ -130,8 +298,19 @@
       "created_session": "S0063",
       "last_updated_session": "S0063",
       "description": "Verify the sidebar widget enrichment slice across frontend wiring and gabinet backend nudges, fix concrete i18n and logic mismatches, and leave the slice green.",
-      "files": ["src/components/sidebar-widgets/smart-agenda.tsx", "convex/gabinet/nudges.ts", "public/locales/en/translation.json", "public/locales/pl/translation.json", "convex/tests/recentlyViewed.test.ts", "session_state.json", "tasks_progress.json", "tasks_progress_verbose.txt"],
-      "depends_on": ["SIDEBAR-01"]
+      "files": [
+        "src/components/sidebar-widgets/smart-agenda.tsx",
+        "convex/gabinet/nudges.ts",
+        "public/locales/en/translation.json",
+        "public/locales/pl/translation.json",
+        "convex/tests/recentlyViewed.test.ts",
+        "session_state.json",
+        "tasks_progress.json",
+        "tasks_progress_verbose.txt"
+      ],
+      "depends_on": [
+        "SIDEBAR-01"
+      ]
     },
     {
       "id": "SIDEBAR-03",
@@ -140,8 +319,37 @@
       "created_session": "S0064",
       "last_updated_session": "S0064",
       "description": "Replace backend-generated sidebar nudge copy with translation keys plus interpolation values, add matching EN/PL locale entries, and verify the nudge contract remains green.",
-      "files": ["convex/nudges.ts", "convex/gabinet/nudges.ts", "src/components/sidebar-widgets/nudge-card.tsx", "src/components/sidebar-widgets/crm/contacts-widgets.tsx", "src/components/sidebar-widgets/crm/deals-widgets.tsx", "src/components/sidebar-widgets/crm/activities-widgets.tsx", "src/components/sidebar-widgets/crm/calendar-widgets.tsx", "src/components/sidebar-widgets/crm/companies-widgets.tsx", "src/components/sidebar-widgets/crm/insights-widgets.tsx", "src/components/sidebar-widgets/crm/inbox-widgets.tsx", "src/components/sidebar-widgets/crm/calls-widgets.tsx", "src/components/sidebar-widgets/crm/products-widgets.tsx", "src/components/sidebar-widgets/crm/documents-widgets.tsx", "src/components/sidebar-widgets/gabinet/patients-widgets.tsx", "src/components/sidebar-widgets/gabinet/employees-widgets.tsx", "src/components/sidebar-widgets/gabinet/packages-widgets.tsx", "src/components/sidebar-widgets/gabinet/treatments-widgets.tsx", "src/components/sidebar-widgets/gabinet/documents-widgets.tsx", "src/components/sidebar-widgets/gabinet/calendar-widgets.tsx", "src/components/sidebar-widgets/gabinet/dashboard-widgets.tsx", "public/locales/en/translation.json", "public/locales/pl/translation.json", "session_state.json", "tasks_progress.json", "tasks_progress_verbose.txt"],
-      "depends_on": ["SIDEBAR-01", "SIDEBAR-02"]
+      "files": [
+        "convex/nudges.ts",
+        "convex/gabinet/nudges.ts",
+        "src/components/sidebar-widgets/nudge-card.tsx",
+        "src/components/sidebar-widgets/crm/contacts-widgets.tsx",
+        "src/components/sidebar-widgets/crm/deals-widgets.tsx",
+        "src/components/sidebar-widgets/crm/activities-widgets.tsx",
+        "src/components/sidebar-widgets/crm/calendar-widgets.tsx",
+        "src/components/sidebar-widgets/crm/companies-widgets.tsx",
+        "src/components/sidebar-widgets/crm/insights-widgets.tsx",
+        "src/components/sidebar-widgets/crm/inbox-widgets.tsx",
+        "src/components/sidebar-widgets/crm/calls-widgets.tsx",
+        "src/components/sidebar-widgets/crm/products-widgets.tsx",
+        "src/components/sidebar-widgets/crm/documents-widgets.tsx",
+        "src/components/sidebar-widgets/gabinet/patients-widgets.tsx",
+        "src/components/sidebar-widgets/gabinet/employees-widgets.tsx",
+        "src/components/sidebar-widgets/gabinet/packages-widgets.tsx",
+        "src/components/sidebar-widgets/gabinet/treatments-widgets.tsx",
+        "src/components/sidebar-widgets/gabinet/documents-widgets.tsx",
+        "src/components/sidebar-widgets/gabinet/calendar-widgets.tsx",
+        "src/components/sidebar-widgets/gabinet/dashboard-widgets.tsx",
+        "public/locales/en/translation.json",
+        "public/locales/pl/translation.json",
+        "session_state.json",
+        "tasks_progress.json",
+        "tasks_progress_verbose.txt"
+      ],
+      "depends_on": [
+        "SIDEBAR-01",
+        "SIDEBAR-02"
+      ]
     },
     {
       "id": "DOC-01",
@@ -150,7 +358,14 @@
       "created_session": "S0070",
       "last_updated_session": "S0070",
       "description": "Create a dedicated `docs/modules/magazyn.md` blueprint that turns the onboarding example into a reusable module reference covering ownership, shell identity, permissions, product activation, cross-module integrations, automation events, and verification expectations.",
-      "files": ["docs/modules/magazyn.md", "docs/modules/module-onboarding.md", "ARCHITECTURE.md", "session_state.json", "tasks_progress.json", "tasks_progress_verbose.txt"],
+      "files": [
+        "docs/modules/magazyn.md",
+        "docs/modules/module-onboarding.md",
+        "ARCHITECTURE.md",
+        "session_state.json",
+        "tasks_progress.json",
+        "tasks_progress_verbose.txt"
+      ],
       "depends_on": []
     },
     {
@@ -160,7 +375,13 @@
       "created_session": "S0071",
       "last_updated_session": "S0071",
       "description": "Add treatment variants to gabinet treatments system with schema, backend CRUD with inheritance resolution, frontend Variants tab with create/edit dialog, override toggles, and full EN/PL i18n.",
-      "files": ["convex/schema/gabinet.ts", "convex/gabinet/treatments.ts", "src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx", "public/locales/en/translation.json", "public/locales/pl/translation.json"],
+      "files": [
+        "convex/schema/gabinet.ts",
+        "convex/gabinet/treatments.ts",
+        "src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx",
+        "public/locales/en/translation.json",
+        "public/locales/pl/translation.json"
+      ],
       "depends_on": []
     },
     {
@@ -170,7 +391,21 @@
       "created_session": "S0072",
       "last_updated_session": "S0100",
       "description": "Design the requested follow-up after the automation RBAC review: align shared activity records and timeline presentation across touched modules, clarify scope for package assignment, notes, and client email events, and define the RBAC remediation path before implementation. [STALE - Design completed in S0072 but never implemented. Blocked since March 2026. Re-evaluate priority before implementation.]",
-      "files": ["convex/automation.ts", "convex/activities.ts", "convex/_helpers/activities.ts", "src/components/activity-timeline/activity-item.tsx", "src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx", "src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx", "src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx", "src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx", "src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx", "src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx", "session_state.json", "tasks_progress.json", "tasks_progress_verbose.txt"],
+      "files": [
+        "convex/automation.ts",
+        "convex/activities.ts",
+        "convex/_helpers/activities.ts",
+        "src/components/activity-timeline/activity-item.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx",
+        "session_state.json",
+        "tasks_progress.json",
+        "tasks_progress_verbose.txt"
+      ],
       "depends_on": []
     },
     {
@@ -180,7 +415,11 @@
       "created_session": "S0092",
       "last_updated_session": "S0092",
       "description": "Refresh session_state/tasks_progress/tasks_progress_verbose so the current session tracks the approved route-owned sidebar rollout instead of the earlier lead-product verification slice.",
-      "files": ["session_state.json", "tasks_progress.json", "tasks_progress_verbose.txt"],
+      "files": [
+        "session_state.json",
+        "tasks_progress.json",
+        "tasks_progress_verbose.txt"
+      ],
       "depends_on": []
     },
     {
@@ -190,8 +429,15 @@
       "created_session": "S0092",
       "last_updated_session": "S0092",
       "description": "Move Gabinet patient and employee detail routes from EntityDetailLayout variant=sidebar-slot to variant=default, preserve the route-owned left panel, and enable shellSidebarMode icon-only on mount/unmount once the route owns the sidebar content.",
-      "files": ["src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx", "src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx", "src/components/crm/entity-detail-layout.tsx", "src/components/layout/app-sidebar.tsx"],
-      "depends_on": [36]
+      "files": [
+        "src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx",
+        "src/components/crm/entity-detail-layout.tsx",
+        "src/components/layout/app-sidebar.tsx"
+      ],
+      "depends_on": [
+        36
+      ]
     },
     {
       "id": 35,
@@ -200,8 +446,15 @@
       "created_session": "S0092",
       "last_updated_session": "S0092",
       "description": "Capture exact pass/fail evidence for the focused sidebar migration checks and keep session tracking aligned with the currently verified Gabinet routes.",
-      "files": ["session_state.json", "tasks_progress.json", "tasks_progress_verbose.txt"],
-      "depends_on": [31, 36]
+      "files": [
+        "session_state.json",
+        "tasks_progress.json",
+        "tasks_progress_verbose.txt"
+      ],
+      "depends_on": [
+        31,
+        36
+      ]
     },
     {
       "id": 36,
@@ -210,8 +463,13 @@
       "created_session": "S0092",
       "last_updated_session": "S0092",
       "description": "Run and verify focused Playwright regressions for Gabinet patient and employee detail fresh reload behavior so the wide shell sidebar stays hidden once the routes own their left panels.",
-      "files": ["e2e/gabinet/patients.spec.ts", "e2e/gabinet/employees.spec.ts"],
-      "depends_on": [30]
+      "files": [
+        "e2e/gabinet/patients.spec.ts",
+        "e2e/gabinet/employees.spec.ts"
+      ],
+      "depends_on": [
+        30
+      ]
     },
     {
       "id": 33,
@@ -220,8 +478,13 @@
       "created_session": "S0092",
       "last_updated_session": "S0092",
       "description": "Add focused Playwright regressions for contact/company fresh reload sidebar behavior, run the red checks first in background, and rerun focused verification after the route migration.",
-      "files": ["e2e/crm/contacts.spec.ts", "e2e/crm/companies.spec.ts"],
-      "depends_on": [30]
+      "files": [
+        "e2e/crm/contacts.spec.ts",
+        "e2e/crm/companies.spec.ts"
+      ],
+      "depends_on": [
+        30
+      ]
     },
     {
       "id": 34,
@@ -230,36 +493,347 @@
       "created_session": "S0092",
       "last_updated_session": "S0092",
       "description": "Move contact and company detail routes from EntityDetailLayout variant=sidebar-slot to variant=default, preserve sidebar parity inside the route, then enable shellSidebarMode icon-only on mount/unmount.",
-      "files": ["src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx", "src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx", "src/components/crm/entity-detail-layout.tsx", "src/components/layout/app-sidebar.tsx"],
-      "depends_on": [33]
+      "files": [
+        "src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx",
+        "src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx",
+        "src/components/crm/entity-detail-layout.tsx",
+        "src/components/layout/app-sidebar.tsx"
+      ],
+      "depends_on": [
+        33
+      ]
+    },
+    {
+      "id": "INV-A",
+      "name": "product_inventory_foundation",
+      "status": "passing",
+      "created_session": "S0103",
+      "last_updated_session": "S0103",
+      "description": "PR-A of #1700: track_stock flag + product_stock_levels (per gabinet location) + append-only product_stock_movements audit, surfaced as a Stan column on the products list and an initial-stock seed on create. Backend adjustStock returns negative_stock warning (warn-and-allow).",
+      "files": [
+        "convex/schema/crm.ts",
+        "convex/inventory.ts",
+        "convex/products.ts",
+        "convex/_helpers/supabaseDb.ts",
+        "supabase/migrations/00013_product_inventory_foundation.sql",
+        "src/lib/supabase/database.columns.ts",
+        "src/lib/supabase/database.types.ts",
+        "src/lib/supabase/mappers/products.ts",
+        "src/lib/supabase/query-keys.ts",
+        "src/hooks/use-supabase-products.ts",
+        "src/routes/_app/_auth/dashboard/_layout.products.index.tsx",
+        "public/locales/en/translation.json",
+        "public/locales/pl/translation.json"
+      ],
+      "depends_on": []
     }
   ],
-  "reason": "S0101: User correctly identified ACT-01 as stale task from March 2026. Updated task tracking to reflect actual project state: all major features completed (SMS confirmation, automation system, sidebar widgets, route-owned sidebar migration), repository is clean, no active development work. ACT-01 marked as blocked/stale for re-evaluation.",
-  "thinking_process": "Project is in stable, production-ready state. All major feature tracks completed and verified. ACT-01 (activity format unification + RBAC follow-up) was designed in March 2026 (S0072) but never implemented. After 6+ months of other work (sidebar overhaul, document components, entity detail improvements), this task is stale and should be re-evaluated for relevance before any implementation. The codebase may have evolved beyond the original design assumptions.",  "connected_tasks": ["SIDEBAR-01", "SIDEBAR-02", "SIDEBAR-03", "SMS-01", "SMS-02", "SMS-03", "SMS-04", "SMS-05", "SMS-06", "SMS-07", "AUT-01", "AUT-02", "AUT-03", "AUT-04", "AUT-05", "AUT-06", "AUT-07", 17, 18, 19, "VAR-01", "ACT-01", 30, 31, 33, 34, 35, 36],
+  "reason": "Added INV-A task for #1700 PR-A inventory foundation",
+  "thinking_process": "PR-A ships product trackStock + per-location stock levels + append-only movement audit. See verbose log S0103 entries for typecheck evidence.",
+  "connected_tasks": [
+    "SIDEBAR-01",
+    "SIDEBAR-02",
+    "SIDEBAR-03",
+    "SMS-01",
+    "SMS-02",
+    "SMS-03",
+    "SMS-04",
+    "SMS-05",
+    "SMS-06",
+    "SMS-07",
+    "AUT-01",
+    "AUT-02",
+    "AUT-03",
+    "AUT-04",
+    "AUT-05",
+    "AUT-06",
+    "AUT-07",
+    17,
+    18,
+    19,
+    "VAR-01",
+    "ACT-01",
+    30,
+    31,
+    33,
+    34,
+    35,
+    36
+  ],
   "how_to_test": [
-    {"id": 1, "name": "Outbound confirmation send persists correlation/event record for appointment SMS", "status": "done", "is_ok": true, "data_for_next_step": ["convex/tests/appointmentSms.test.ts covers queueConfirmationRequest persistence", "Outbound event assertions include normalized phone, provider, correlation key, and reply contract copy"], "session_id": "S0061"},
-    {"id": 2, "name": "Inbound TAK reply confirms appointment exactly once under duplicate webhook retries", "status": "done", "is_ok": true, "data_for_next_step": ["convex/tests/appointmentSms.test.ts covers duplicate idempotency key handling", "Test now also verifies exactly one sms_received activity row on appointment, patient, and linked contact"], "session_id": "S0061"},
-    {"id": 3, "name": "Inbound NIE reply cancels appointment and preserves audit/notification side effects", "status": "done", "is_ok": true, "data_for_next_step": ["convex/tests/appointmentSms.test.ts covers cancellation path", "Test asserts cancellationReason, audit action status_changed_via_sms, and notification emission for a non-actor creator"], "session_id": "S0061"},
-    {"id": 4, "name": "Late or terminal-state replies are recorded but do not mutate appointment state", "status": "done", "is_ok": true, "data_for_next_step": ["convex/tests/appointmentSms.test.ts covers completed appointment reply handling", "Ignored inbound event preserves appointment terminal state and stores processingError reason"], "session_id": "S0061"},
-    {"id": 5, "name": "Appointment detail UI shows pending confirmation and SMS timeline/status information", "status": "done", "is_ok": true, "data_for_next_step": ["Dialog and full appointment route render SMS summary/history surfaces", "pending_confirmation remains in the UI status maps", "ActivityTimeline now renders distinct SMS iconography"], "session_id": "S0061"},
-    {"id": 6, "name": "Repo preflight passes: lint, typecheck, focused unit/integration tests, focused Playwright smoke", "status": "done", "is_ok": true, "data_for_next_step": ["Focused Convex tests pass: appointmentSms.test.ts + appointmentStateMachine.test.ts (17/17)", "Focused Playwright appointment SMS smoke passes", "Typecheck passes for convex/tsconfig.json and tsconfig.app.json"], "session_id": "S0061"},
-    {"id": 7, "name": "WORKFLOW.md encodes Linear pilot states, bounded concurrency, isolated workspaces, and Human Review stop", "status": "done", "is_ok": true, "data_for_next_step": ["Linear project created: Symphony Pilot — SMS Appointment Confirmation (slugId a0ef8a4e051b)", "Workflow states added: Human Review, Rework, Merging", "Issues created: CRM-1..CRM-6 with blocker graph matching the pilot slices"], "session_id": "S0061"},
-    {"id": 8, "name": "Outbound and inbound SMS events fan out shared activities to appointment, patient, and linked contact without duplicate inbound activity rows", "status": "done", "is_ok": true, "data_for_next_step": ["Outbound sms_sent fan-out verified for appointment, patient, and linked contact", "Inbound sms_received fan-out verified for appointment, patient, and linked contact with duplicate retries still producing one inbound activity row per entity"], "session_id": "S0061"},
-    {"id": 9, "name": "Shared history surfaces render dedicated SMS actions while lead history stays unchanged", "status": "done", "is_ok": true, "data_for_next_step": ["ActivityTimeline has dedicated SMS icon/color mappings", "A seeded lead receives no inferred SMS activity rows in focused backend verification"], "session_id": "S0061"},
-    {"id": 10, "name": "Shared automation/settings i18n cleanup removes fallback sidebar labels and mixed-language appointment history copy", "status": "done", "is_ok": true, "data_for_next_step": ["`npx tsc -p tsconfig.app.json --pretty false` passes after the i18n updates", "Browser check on `/dashboard/settings/automations` shows no object-fallback text and no raw English Enabled/Disabled/actions labels", "Browser check on the verified appointment route History tab shows no targeted English Module/Correlation/workflow/automation labels; unrelated `nav.gabinet.*` labels remain outside this task scope"], "session_id": "S0061"},
-    {"id": 11, "name": "Automation full-page route migration keeps overview on index route and verifies dedicated create/edit pages", "status": "done", "is_ok": true, "data_for_next_step": ["`src/routes/_app/_auth/dashboard/_layout.settings.automations.tsx` now renders `<Outlet />` only", "Overview lives in `_layout.settings.automations.index.tsx` while `new` and `$ruleId` reuse `AutomationGraphBuilder`", "Focused verification passed: app typecheck, convex/tests/automation.test.ts (9/9), Playwright automation lifecycle (1/1)"], "session_id": "S0061"},
-    {"id": 12, "name": "Simple automation wizard creates common Gabinet rule without technical fields and review step explains the rule in plain language", "status": "done", "is_ok": true, "data_for_next_step": ["Preset-backed 3-step wizard now powers the default create/edit flow for supported Gabinet automations", "Focused browser coverage verifies plain-language review copy and successful save back to the overview"], "session_id": "S0061"},
-    {"id": 13, "name": "Edit route opens supported rules in Simple mode with prefilled values and unsupported rules in Advanced mode with safe explanation", "status": "done", "is_ok": true, "data_for_next_step": ["Supported preset-backed rules classify back into Simple mode with prefilled values", "Unsupported advanced-only rules fall back safely to Advanced mode with explanatory UI"], "session_id": "S0061"},
-    {"id": 14, "name": "Focused verification covers overview, simple create/edit, advanced fallback, toggle/delete, backend contract compatibility, and visible automation runs", "status": "done", "is_ok": true, "data_for_next_step": ["App typecheck passes: `npx tsc -p tsconfig.app.json --pretty false`", "Focused backend verification passes: `cd convex && npx vitest run tests/automation.test.ts --reporter=verbose` (9/9)", "Focused browser verification passes: `npx playwright test e2e/gabinet/appointments.spec.ts -g \"automation rule lifecycle triggers visible run\"` (1/1)"], "session_id": "S0061"},
-    {"id": 15, "name": "Richer automation editor verification covers always-visible SMS/email capabilities, reply-SMS trigger/action, multi-action composition, email template/manual authoring, variable insertion, safe field updates, strict edit hydration, and recent runs", "status": "done", "is_ok": true, "data_for_next_step": ["App typecheck passes: `npx tsc -p tsconfig.app.json --pretty false` after overview/i18n cleanup and the `smsRequestMessage` locale default fix", "Focused backend verification passes: `cd convex && npx vitest run tests/automation.test.ts --reporter=verbose` (12/12)", "Focused browser verification passes: `npx playwright test e2e/gabinet/appointments.spec.ts -g \"automation rule lifecycle triggers visible run\"` (1/1) with action-card scoping and a truly unsupported legacy fallback fixture"], "session_id": "S0061"},
-    {"id": 16, "name": "Sidebar widget follow-up verification fixes SmartAgenda i18n, gabinet nudge edge cases, and convex test typing without regressions", "status": "done", "is_ok": true, "data_for_next_step": ["App typecheck passes: `npx tsc -p tsconfig.app.json --pretty false`", "Convex typecheck passes: `npx tsc -p convex/tsconfig.json --pretty false` after typing `import.meta.glob` in `convex/tests/recentlyViewed.test.ts`", "Focused backend verification passes: `cd convex && npx vitest run tests/recentlyViewed.test.ts --reporter=verbose` (5/5)", "SmartAgenda now has EN/PL agenda-specific locale keys and locale-aware date/time formatting", "Gabinet package nudges now exclude already-expired active usages from the expiring-soon count and only treat active usages as package usage"], "session_id": "S0063"},
-    {"id": 17, "name": "Sidebar nudge internationalization adds full EN/PL locale coverage for the translation-key nudge contract", "status": "done", "is_ok": true, "data_for_next_step": ["App typecheck passes: `npx tsc -p tsconfig.app.json --pretty false`", "Convex typecheck passes: `npx tsc -p convex/tsconfig.json --pretty false`", "All 20 sidebar nudge keys resolve in both locale files via focused JSON validation", "NudgeCard resolves translation keys with `messageValues` and touched widgets pass `messageValues` through"], "session_id": "S0064"},
-    {"id": 18, "name": "Treatment variants: schema, backend, frontend, i18n all pass typecheck", "status": "done", "is_ok": true, "data_for_next_step": ["App typecheck passes: `npx tsc -p tsconfig.app.json --noEmit`", "Convex typecheck passes: `npx tsc -p convex/tsconfig.json --noEmit`", "gabinetTreatmentVariants table added with by_treatment and by_org indexes", "5 backend functions: listVariants, getVariant, createVariant, updateVariant, deleteVariant", "Variants tab with list view and create/edit dialog with override toggles", "Full EN/PL locale coverage under gabinet.treatmentDetail.variants.*"], "session_id": "S0071"},
-    {"id": 19, "name": "Contact detail fresh reload regression fails before route-owned migration", "status": "not_started", "is_ok": null, "data_for_next_step": ["Add Playwright assertion that detail content remains visible after reload while the workspace-switcher shell button with CRM label is hidden"], "session_id": "S0092"},
-    {"id": 20, "name": "Company detail fresh reload regression fails before route-owned migration", "status": "not_started", "is_ok": null, "data_for_next_step": ["Mirror the lead-detail reload/sidebar-hide check for company detail and run it before production edits"], "session_id": "S0092"},
-    {"id": 21, "name": "Focused app verification passes after contact/company route migration", "status": "not_started", "is_ok": null, "data_for_next_step": ["Rerun focused Playwright checks for contacts/companies plus app typecheck in background after the route-owned migration lands"], "session_id": "S0092"},
-    {"id": 22, "name": "Patient detail fresh reload regression fails before route-owned migration and passes after the fix", "status": "in_progress", "is_ok": null, "data_for_next_step": ["Read the focused Playwright output for `e2e/gabinet/patients.spec.ts -g \"patient detail hides the wide shell sidebar after a fresh reload\"` and record whether the shell workspace button is gone after reload. The latest sampled output still shows earlier patient tests executing, so this verification is not finished yet."], "session_id": "S0092"},
-    {"id": 23, "name": "Employee detail fresh reload regression fails before route-owned migration and passes after the fix", "status": "done", "is_ok": true, "data_for_next_step": ["Focused Playwright evidence recorded from `/private/tmp/claude-501/-Users-alfred-projects-crm-new/15fc707a-d496-4605-b71f-d1da8192d8e9/tasks/bwr2ispw5.output`: 1 passed and 1 skipped, including `employee detail hides the wide shell sidebar after a fresh reload`."], "session_id": "S0092"},
-    {"id": 24, "name": "App typecheck stays green after Gabinet sidebar route migration", "status": "done", "is_ok": true, "data_for_next_step": ["Background `npx tsc -p tsconfig.app.json --pretty false` completed with exit code 0 (`bk4cgovqx` notification)."], "session_id": "S0092"}
+    {
+      "id": 1,
+      "name": "Outbound confirmation send persists correlation/event record for appointment SMS",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "convex/tests/appointmentSms.test.ts covers queueConfirmationRequest persistence",
+        "Outbound event assertions include normalized phone, provider, correlation key, and reply contract copy"
+      ],
+      "session_id": "S0061"
+    },
+    {
+      "id": 2,
+      "name": "Inbound TAK reply confirms appointment exactly once under duplicate webhook retries",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "convex/tests/appointmentSms.test.ts covers duplicate idempotency key handling",
+        "Test now also verifies exactly one sms_received activity row on appointment, patient, and linked contact"
+      ],
+      "session_id": "S0061"
+    },
+    {
+      "id": 3,
+      "name": "Inbound NIE reply cancels appointment and preserves audit/notification side effects",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "convex/tests/appointmentSms.test.ts covers cancellation path",
+        "Test asserts cancellationReason, audit action status_changed_via_sms, and notification emission for a non-actor creator"
+      ],
+      "session_id": "S0061"
+    },
+    {
+      "id": 4,
+      "name": "Late or terminal-state replies are recorded but do not mutate appointment state",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "convex/tests/appointmentSms.test.ts covers completed appointment reply handling",
+        "Ignored inbound event preserves appointment terminal state and stores processingError reason"
+      ],
+      "session_id": "S0061"
+    },
+    {
+      "id": 5,
+      "name": "Appointment detail UI shows pending confirmation and SMS timeline/status information",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "Dialog and full appointment route render SMS summary/history surfaces",
+        "pending_confirmation remains in the UI status maps",
+        "ActivityTimeline now renders distinct SMS iconography"
+      ],
+      "session_id": "S0061"
+    },
+    {
+      "id": 6,
+      "name": "Repo preflight passes: lint, typecheck, focused unit/integration tests, focused Playwright smoke",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "Focused Convex tests pass: appointmentSms.test.ts + appointmentStateMachine.test.ts (17/17)",
+        "Focused Playwright appointment SMS smoke passes",
+        "Typecheck passes for convex/tsconfig.json and tsconfig.app.json"
+      ],
+      "session_id": "S0061"
+    },
+    {
+      "id": 7,
+      "name": "WORKFLOW.md encodes Linear pilot states, bounded concurrency, isolated workspaces, and Human Review stop",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "Linear project created: Symphony Pilot \u2014 SMS Appointment Confirmation (slugId a0ef8a4e051b)",
+        "Workflow states added: Human Review, Rework, Merging",
+        "Issues created: CRM-1..CRM-6 with blocker graph matching the pilot slices"
+      ],
+      "session_id": "S0061"
+    },
+    {
+      "id": 8,
+      "name": "Outbound and inbound SMS events fan out shared activities to appointment, patient, and linked contact without duplicate inbound activity rows",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "Outbound sms_sent fan-out verified for appointment, patient, and linked contact",
+        "Inbound sms_received fan-out verified for appointment, patient, and linked contact with duplicate retries still producing one inbound activity row per entity"
+      ],
+      "session_id": "S0061"
+    },
+    {
+      "id": 9,
+      "name": "Shared history surfaces render dedicated SMS actions while lead history stays unchanged",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "ActivityTimeline has dedicated SMS icon/color mappings",
+        "A seeded lead receives no inferred SMS activity rows in focused backend verification"
+      ],
+      "session_id": "S0061"
+    },
+    {
+      "id": 10,
+      "name": "Shared automation/settings i18n cleanup removes fallback sidebar labels and mixed-language appointment history copy",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "`npx tsc -p tsconfig.app.json --pretty false` passes after the i18n updates",
+        "Browser check on `/dashboard/settings/automations` shows no object-fallback text and no raw English Enabled/Disabled/actions labels",
+        "Browser check on the verified appointment route History tab shows no targeted English Module/Correlation/workflow/automation labels; unrelated `nav.gabinet.*` labels remain outside this task scope"
+      ],
+      "session_id": "S0061"
+    },
+    {
+      "id": 11,
+      "name": "Automation full-page route migration keeps overview on index route and verifies dedicated create/edit pages",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "`src/routes/_app/_auth/dashboard/_layout.settings.automations.tsx` now renders `<Outlet />` only",
+        "Overview lives in `_layout.settings.automations.index.tsx` while `new` and `$ruleId` reuse `AutomationGraphBuilder`",
+        "Focused verification passed: app typecheck, convex/tests/automation.test.ts (9/9), Playwright automation lifecycle (1/1)"
+      ],
+      "session_id": "S0061"
+    },
+    {
+      "id": 12,
+      "name": "Simple automation wizard creates common Gabinet rule without technical fields and review step explains the rule in plain language",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "Preset-backed 3-step wizard now powers the default create/edit flow for supported Gabinet automations",
+        "Focused browser coverage verifies plain-language review copy and successful save back to the overview"
+      ],
+      "session_id": "S0061"
+    },
+    {
+      "id": 13,
+      "name": "Edit route opens supported rules in Simple mode with prefilled values and unsupported rules in Advanced mode with safe explanation",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "Supported preset-backed rules classify back into Simple mode with prefilled values",
+        "Unsupported advanced-only rules fall back safely to Advanced mode with explanatory UI"
+      ],
+      "session_id": "S0061"
+    },
+    {
+      "id": 14,
+      "name": "Focused verification covers overview, simple create/edit, advanced fallback, toggle/delete, backend contract compatibility, and visible automation runs",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "App typecheck passes: `npx tsc -p tsconfig.app.json --pretty false`",
+        "Focused backend verification passes: `cd convex && npx vitest run tests/automation.test.ts --reporter=verbose` (9/9)",
+        "Focused browser verification passes: `npx playwright test e2e/gabinet/appointments.spec.ts -g \"automation rule lifecycle triggers visible run\"` (1/1)"
+      ],
+      "session_id": "S0061"
+    },
+    {
+      "id": 15,
+      "name": "Richer automation editor verification covers always-visible SMS/email capabilities, reply-SMS trigger/action, multi-action composition, email template/manual authoring, variable insertion, safe field updates, strict edit hydration, and recent runs",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "App typecheck passes: `npx tsc -p tsconfig.app.json --pretty false` after overview/i18n cleanup and the `smsRequestMessage` locale default fix",
+        "Focused backend verification passes: `cd convex && npx vitest run tests/automation.test.ts --reporter=verbose` (12/12)",
+        "Focused browser verification passes: `npx playwright test e2e/gabinet/appointments.spec.ts -g \"automation rule lifecycle triggers visible run\"` (1/1) with action-card scoping and a truly unsupported legacy fallback fixture"
+      ],
+      "session_id": "S0061"
+    },
+    {
+      "id": 16,
+      "name": "Sidebar widget follow-up verification fixes SmartAgenda i18n, gabinet nudge edge cases, and convex test typing without regressions",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "App typecheck passes: `npx tsc -p tsconfig.app.json --pretty false`",
+        "Convex typecheck passes: `npx tsc -p convex/tsconfig.json --pretty false` after typing `import.meta.glob` in `convex/tests/recentlyViewed.test.ts`",
+        "Focused backend verification passes: `cd convex && npx vitest run tests/recentlyViewed.test.ts --reporter=verbose` (5/5)",
+        "SmartAgenda now has EN/PL agenda-specific locale keys and locale-aware date/time formatting",
+        "Gabinet package nudges now exclude already-expired active usages from the expiring-soon count and only treat active usages as package usage"
+      ],
+      "session_id": "S0063"
+    },
+    {
+      "id": 17,
+      "name": "Sidebar nudge internationalization adds full EN/PL locale coverage for the translation-key nudge contract",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "App typecheck passes: `npx tsc -p tsconfig.app.json --pretty false`",
+        "Convex typecheck passes: `npx tsc -p convex/tsconfig.json --pretty false`",
+        "All 20 sidebar nudge keys resolve in both locale files via focused JSON validation",
+        "NudgeCard resolves translation keys with `messageValues` and touched widgets pass `messageValues` through"
+      ],
+      "session_id": "S0064"
+    },
+    {
+      "id": 18,
+      "name": "Treatment variants: schema, backend, frontend, i18n all pass typecheck",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "App typecheck passes: `npx tsc -p tsconfig.app.json --noEmit`",
+        "Convex typecheck passes: `npx tsc -p convex/tsconfig.json --noEmit`",
+        "gabinetTreatmentVariants table added with by_treatment and by_org indexes",
+        "5 backend functions: listVariants, getVariant, createVariant, updateVariant, deleteVariant",
+        "Variants tab with list view and create/edit dialog with override toggles",
+        "Full EN/PL locale coverage under gabinet.treatmentDetail.variants.*"
+      ],
+      "session_id": "S0071"
+    },
+    {
+      "id": 19,
+      "name": "Contact detail fresh reload regression fails before route-owned migration",
+      "status": "not_started",
+      "is_ok": null,
+      "data_for_next_step": [
+        "Add Playwright assertion that detail content remains visible after reload while the workspace-switcher shell button with CRM label is hidden"
+      ],
+      "session_id": "S0092"
+    },
+    {
+      "id": 20,
+      "name": "Company detail fresh reload regression fails before route-owned migration",
+      "status": "not_started",
+      "is_ok": null,
+      "data_for_next_step": [
+        "Mirror the lead-detail reload/sidebar-hide check for company detail and run it before production edits"
+      ],
+      "session_id": "S0092"
+    },
+    {
+      "id": 21,
+      "name": "Focused app verification passes after contact/company route migration",
+      "status": "not_started",
+      "is_ok": null,
+      "data_for_next_step": [
+        "Rerun focused Playwright checks for contacts/companies plus app typecheck in background after the route-owned migration lands"
+      ],
+      "session_id": "S0092"
+    },
+    {
+      "id": 22,
+      "name": "Patient detail fresh reload regression fails before route-owned migration and passes after the fix",
+      "status": "in_progress",
+      "is_ok": null,
+      "data_for_next_step": [
+        "Read the focused Playwright output for `e2e/gabinet/patients.spec.ts -g \"patient detail hides the wide shell sidebar after a fresh reload\"` and record whether the shell workspace button is gone after reload. The latest sampled output still shows earlier patient tests executing, so this verification is not finished yet."
+      ],
+      "session_id": "S0092"
+    },
+    {
+      "id": 23,
+      "name": "Employee detail fresh reload regression fails before route-owned migration and passes after the fix",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "Focused Playwright evidence recorded from `/private/tmp/claude-501/-Users-alfred-projects-crm-new/15fc707a-d496-4605-b71f-d1da8192d8e9/tasks/bwr2ispw5.output`: 1 passed and 1 skipped, including `employee detail hides the wide shell sidebar after a fresh reload`."
+      ],
+      "session_id": "S0092"
+    },
+    {
+      "id": 24,
+      "name": "App typecheck stays green after Gabinet sidebar route migration",
+      "status": "done",
+      "is_ok": true,
+      "data_for_next_step": [
+        "Background `npx tsc -p tsconfig.app.json --pretty false` completed with exit code 0 (`bk4cgovqx` notification)."
+      ],
+      "session_id": "S0092"
+    }
   ]
 }

--- a/tasks_progress_verbose.txt
+++ b/tasks_progress_verbose.txt
@@ -1080,3 +1080,51 @@ Immediate next action: Await new feature requirements
 Open questions: Should ACT-01 be re-evaluated or archived?
 Warnings: ACT-01 design assumptions may be outdated after 6+ months of evolution
 Files modified: session_state.json, tasks_progress.json, tasks_progress_verbose.txt
+
+=== SESSION S0103 START === 2026-06-12T16:00:00Z
+Focus: Issue #1700 PR-A — Product inventory foundation
+Continuing from: S0102 (paused, unrelated gabinet appointments work)
+
+---
+
+S0103. PR-A scope review (issue #1700):
+- User clarified plan in issue comments: ship incrementally (PR-A → PR-B → PR-C → PR-D).
+- Gabinet HAS locations (confirmed by user, verified gabinet_locations in schema/00001 and gabinetLocations in convex/schema/gabinet.ts:864).
+- No-stock products: still allow movement history rows but do not maintain balance.
+- Negative stock: warn-and-allow (matches double-booking pattern from #1526).
+- CRM dealProducts: should also deduct stock on deal close (deferred to a later PR).
+
+S0103. Working tree state on entry:
+- An earlier session had already drafted PR-A scaffolding (uncommitted).
+- Modified: convex/products.ts, convex/schema/crm.ts, convex/_helpers/supabaseDb.ts,
+  src/hooks/use-supabase-products.ts, src/lib/supabase/database.{columns,types}.ts,
+  src/lib/supabase/mappers/products.ts, src/lib/supabase/query-keys.ts,
+  src/routes/_app/_auth/dashboard/_layout.products.index.tsx,
+  public/locales/{en,pl}/translation.json
+- New: convex/inventory.ts, supabase/migrations/00013_product_inventory_foundation.sql
+- Verified migration matches schema (track_stock/stock_unit on products; product_stock_levels has
+  unique-by-product partial indexes for nullable location_id; product_stock_movements is append-only
+  with delta + balance_after + reason + source_type/source_id).
+
+S0103. Typecheck:
+- App typecheck (npx tsc -p tsconfig.app.json --pretty false): only 2 pre-existing errors in
+  convex/gabinet/_availability_supabase.ts (introduced by #1526 / commit 64e351a — not in scope).
+- Initial TS2589 in convex/products.ts on internal._helpers.authAction.verifyOrgAccess was a stale
+  tsconfig.app.tsbuildinfo artefact; cleared and re-ran clean.
+- Convex typecheck (npx tsc -p convex/tsconfig.json --pretty false): same 2 pre-existing errors only.
+
+S0103. PR-A acceptance criteria for this commit:
+- Schema source-of-truth (convex/schema/crm.ts) and Supabase migration aligned.
+- Backend inventory.ts exposes adjustStock + getStockSummary + listMovements actions and re-exports
+  applyMovementInternal for higher-level callers (PR-C/D will call it from settle-visit + deal-close).
+- Products create form takes optional initial stock that seeds an "initial" movement.
+- Products list surfaces a "Stan" column for tracked products with negative-value styling.
+- No Gabinet code touched; no module-feature-flag yet (that is PR-B).
+
+S0103. Deferred until later PRs (explicitly out of scope for PR-A):
+- Manual "Receive / issue stock" dialog in UI (we have the action; no UI button yet).
+- Module feature flag system (PR-B).
+- Treatment ↔ products join table with default quantities (PR-C).
+- Appointment ↔ products + settle-visit stock deduction (PR-D).
+- CRM dealProducts stock deduction on deal close.
+


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1700.

Closes #1700

---

## Claude summary

PR-A shipped as commit `1320b37` on branch `claude/issue-1700`.

## What landed (PR-A: Inventory Foundation)

Schema and migration — `convex/schema/crm.ts` + `supabase/migrations/00013_product_inventory_foundation.sql`:
- `products.track_stock` + `products.stock_unit` (both optional, additive).
- `product_stock_levels` — current quantity-on-hand per `(product_id, location_id)`. `location_id` is nullable so CRM-only orgs keep a single null-location row per product; Gabinet orgs (which confirmed yes, do have `gabinetLocations` — `convex/schema/gabinet.ts:864`) can keep one row per location. Partial-unique indexes enforce one row per slot.
- `product_stock_movements` — append-only audit with `delta`, `balance_after`, `reason` (`initial`/`manual_adjust`/`appointment_use`/…), `source_type`+`source_id` for later wiring to appointments/deals, `performed_by`.

Backend — `convex/inventory.ts`:
- `adjustStock` action: takes `delta` or `setTo`, writes a movement row + updates the level row when `trackStock=true`. Returns `{ movementId, balanceAfter, warning }` where `warning` is `"negative_stock"` if the new balance is below zero (warn-and-allow per your spec, matching #1526's double-booking pattern). When `trackStock=false`, we still write the movement row but skip level maintenance — that's what "bez stock zapisujemy historię ruchów ale nie zarządzamy stanem" means in code.
- `getStockSummary`, `listMovements` read actions.
- `applyMovementInternal` exported helper that PR-D's settle-visit and the CRM deal-close path (per your "Tak, dokładnie tak") will call.

Frontend:
- Products list (`_layout.products.index.tsx`) shows a `Stan` column for tracked products with red styling when negative. Untracked products show `—`.
- Create form has a `Śledź stan magazynowy` checkbox + `Jednostka` (szt./ml/g…) + `Stan początkowy` field that seeds a single `"initial"` movement when non-zero.
- New `useSupabaseProductStockTotals` hook aggregates totals by product for the list view.

Typecheck on both `tsconfig.app.json` and `convex/tsconfig.json` shows only two pre-existing errors in `convex/gabinet/_availability_supabase.ts` from #1526 — not in scope here.

## Next up

I'll come back and ship PR-B (`moduleFeatures` table + `useModuleFeature` hook + the "co ma ten moduł" toggle in Settings → Subscriptions) in a separate commit when you give the go-ahead, then PR-C (`gabinetTreatmentProducts` join + UI on treatment edit), then PR-D (visit settle deducts stock + CRM deal-close deducts stock). Each is independently mergeable.

## Follow-ups
- Add manual "Receive / issue stock" dialog on the products table: backend `adjustStock` action exists but no UI calls it yet outside the create-form initial seed.
- Fix pre-existing TS errors in convex/gabinet/_availability_supabase.ts: `roomAppointments` unused (line 449) and reference to `appointments` (line 456) introduced by #1526 / commit 64e351a.