### PR TITLE
Show the latest refund request in admin notifications with an inline approve/rej

### DIFF
--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -99,6 +99,7 @@ export const _createNotification = internalMutation({
     title: v.string(),
     message: v.string(),
     link: v.optional(v.string()),
+    metadata: v.optional(v.any()),
   },
   handler: async (ctx, args) => {
     await ctx.db.insert("notifications", {
@@ -118,6 +119,7 @@ export async function createNotificationDirect(
     title: string;
     message: string;
     link?: string;
+    metadata?: unknown;
   }
 ) {
   // Still write to Convex DB for real-time subscriptions

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -1,5 +1,11 @@
-import { action, internalAction, internalMutation } from "./_generated/server";
+import {
+  action,
+  internalAction,
+  internalMutation,
+  internalQuery,
+} from "./_generated/server";
 import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
@@ -920,6 +926,20 @@ export const _requestRefundAuthSideEffects = internalMutation({
     const message = `${args.requesterName} prosi o autoryzację zwrotu ${args.amount.toFixed(2)} zł z salda klienta ${args.patientLabel}${args.notes ? ` (${args.notes})` : ""}.`;
     const link = `/dashboard/gabinet/patients/${args.patientId}?tab=payments`;
 
+    // Shared requestId so approve/reject can find sibling notifications across
+    // every admin and resolve them together (#1722).
+    const requestId = `rar_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+    const metadata = {
+      requestId,
+      patientId: args.patientId,
+      patientLabel: args.patientLabel,
+      amount: args.amount,
+      notes: args.notes ?? null,
+      requesterId: String(args.requesterId),
+      requesterName: args.requesterName,
+      status: "pending" as const,
+    };
+
     const adminContacts: Array<{ userId: string; email: string; name: string | null }> = [];
 
     for (const m of admins) {
@@ -930,6 +950,7 @@ export const _requestRefundAuthSideEffects = internalMutation({
         title: "Prośba o autoryzację zwrotu",
         message,
         link,
+        metadata,
       });
       const user = await ctx.db.get(m.userId);
       if (user?.email) {
@@ -1057,6 +1078,275 @@ function escapeHtml(s: string): string {
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
 }
+
+/**
+ * Inline approve/reject for refund-authorization notifications (#1722).
+ *
+ * Each refund request fans out one notification per owner/admin with a
+ * shared `metadata.requestId`. The notification bell calls these actions to
+ * resolve a request without round-tripping to the patient page. Resolving
+ * one admin's notification marks every sibling resolved too, so the others
+ * stop seeing the pending CTA the moment the request is handled.
+ */
+
+type RefundAuthMetadata = {
+  requestId: string;
+  patientId: string;
+  patientLabel: string;
+  amount: number;
+  notes: string | null;
+  requesterId: string;
+  requesterName: string;
+  status: "pending" | "approved" | "rejected";
+};
+
+export const _loadRefundAuthNotification = internalQuery({
+  args: { notificationId: v.id("notifications") },
+  handler: async (ctx, args) => {
+    const notification = await ctx.db.get(args.notificationId);
+    if (!notification) return null;
+    return {
+      notificationId: notification._id,
+      organizationId: notification.organizationId,
+      userId: notification.userId,
+      type: notification.type,
+      metadata: (notification.metadata ?? null) as RefundAuthMetadata | null,
+    };
+  },
+});
+
+export const approveRefundAuth = action({
+  args: {
+    organizationId: v.id("organizations"),
+    notificationId: v.id("notifications"),
+    paymentMethod: v.optional(paymentMethodValidator),
+  },
+  handler: async (ctx, args) => {
+    const authResult = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      {
+        organizationId: args.organizationId,
+        feature: "gabinet_payments",
+        action: "refund",
+      },
+    );
+    if (!perm.allowed) {
+      throw new Error(
+        "REFUND_NOT_AUTHORIZED: requires gabinet_payments.refund",
+      );
+    }
+
+    const loaded = await ctx.runQuery(
+      internal.payments._loadRefundAuthNotification,
+      { notificationId: args.notificationId },
+    );
+    if (!loaded) throw new Error("Notification not found");
+    if (loaded.organizationId !== args.organizationId) {
+      throw new Error("Notification belongs to a different organization");
+    }
+    if (loaded.userId !== authResult.userId) {
+      throw new Error("Notification belongs to another user");
+    }
+    if (loaded.type !== "refund_authorization_requested" || !loaded.metadata) {
+      throw new Error("Not a refund authorization notification");
+    }
+    if (loaded.metadata.status !== "pending") {
+      throw new Error("Refund request already resolved");
+    }
+
+    const meta = loaded.metadata;
+    const db = createSupabaseDb();
+    const balance = await computePatientCreditBalance(
+      db,
+      String(args.organizationId),
+      meta.patientId,
+    );
+    if (meta.amount > balance + 0.005) {
+      throw new Error(
+        `Refund amount ${meta.amount} exceeds available credit ${balance}`,
+      );
+    }
+
+    const paymentMethod = args.paymentMethod ?? "cash";
+    const now = Date.now();
+    const paymentId = await db.insert("payments", {
+      organizationId: String(args.organizationId),
+      patientId: meta.patientId,
+      appointmentId: null,
+      packageUsageId: null,
+      amount: meta.amount,
+      currency: "PLN",
+      paymentMethod,
+      status: "completed",
+      paidAt: now,
+      notes: meta.notes ?? null,
+      creditEarned: -meta.amount,
+      creditApplied: null,
+      kind: "credit_refund",
+      createdBy: String(authResult.userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await ctx.runMutation(internal.payments._resolveRefundAuthSideEffects, {
+      organizationId: args.organizationId,
+      approverId: authResult.userId,
+      approverName:
+        authResult.userName ?? authResult.userEmail ?? "Administrator",
+      requestId: meta.requestId,
+      requesterId: meta.requesterId,
+      patientId: meta.patientId,
+      patientLabel: meta.patientLabel,
+      amount: meta.amount,
+      decision: "approved",
+      paymentId,
+    });
+
+    return { paymentId };
+  },
+});
+
+export const rejectRefundAuth = action({
+  args: {
+    organizationId: v.id("organizations"),
+    notificationId: v.id("notifications"),
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const authResult = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    // Reject is allowed for any owner/admin who received the notification.
+    // We don't gate by gabinet_payments.refund — refusing a request is not
+    // the same as authorizing one.
+    if (authResult.role !== "owner" && authResult.role !== "admin") {
+      throw new Error("Only owners or admins can reject refund requests");
+    }
+
+    const loaded = await ctx.runQuery(
+      internal.payments._loadRefundAuthNotification,
+      { notificationId: args.notificationId },
+    );
+    if (!loaded) throw new Error("Notification not found");
+    if (loaded.organizationId !== args.organizationId) {
+      throw new Error("Notification belongs to a different organization");
+    }
+    if (loaded.userId !== authResult.userId) {
+      throw new Error("Notification belongs to another user");
+    }
+    if (loaded.type !== "refund_authorization_requested" || !loaded.metadata) {
+      throw new Error("Not a refund authorization notification");
+    }
+    if (loaded.metadata.status !== "pending") {
+      throw new Error("Refund request already resolved");
+    }
+
+    const meta = loaded.metadata;
+    await ctx.runMutation(internal.payments._resolveRefundAuthSideEffects, {
+      organizationId: args.organizationId,
+      approverId: authResult.userId,
+      approverName:
+        authResult.userName ?? authResult.userEmail ?? "Administrator",
+      requestId: meta.requestId,
+      requesterId: meta.requesterId,
+      patientId: meta.patientId,
+      patientLabel: meta.patientLabel,
+      amount: meta.amount,
+      decision: "rejected",
+      reason: args.reason,
+    });
+
+    return { ok: true };
+  },
+});
+
+export const _resolveRefundAuthSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    approverId: v.id("users"),
+    approverName: v.string(),
+    requestId: v.string(),
+    requesterId: v.string(),
+    patientId: v.string(),
+    patientLabel: v.string(),
+    amount: v.number(),
+    decision: v.union(v.literal("approved"), v.literal("rejected")),
+    paymentId: v.optional(v.string()),
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    // Resolve every sibling notification carrying the same requestId so
+    // other admins immediately see the request has been handled.
+    const siblings = await ctx.db
+      .query("notifications")
+      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+      .filter((q) => q.eq(q.field("type"), "refund_authorization_requested"))
+      .collect();
+
+    for (const n of siblings) {
+      const meta = n.metadata as RefundAuthMetadata | undefined;
+      if (!meta || meta.requestId !== args.requestId) continue;
+      if (meta.status !== "pending") continue;
+      await ctx.db.patch(n._id, {
+        isRead: true,
+        metadata: {
+          ...meta,
+          status: args.decision,
+        },
+      });
+    }
+
+    // Tell the requester what happened so they don't keep refreshing the
+    // patient page wondering whether their request landed.
+    const requesterUserId = args.requesterId as Id<"users">;
+    const amountLabel = `${args.amount.toFixed(2)} zł`;
+    const title =
+      args.decision === "approved"
+        ? "Zwrot zatwierdzony"
+        : "Zwrot odrzucony";
+    const baseMessage =
+      args.decision === "approved"
+        ? `${args.approverName} zatwierdził(a) zwrot ${amountLabel} dla klienta ${args.patientLabel}.`
+        : `${args.approverName} odrzucił(a) prośbę o zwrot ${amountLabel} dla klienta ${args.patientLabel}.`;
+    const message = args.reason
+      ? `${baseMessage} (${args.reason})`
+      : baseMessage;
+    await createNotificationDirect(ctx, {
+      organizationId: args.organizationId,
+      userId: requesterUserId,
+      type:
+        args.decision === "approved"
+          ? "refund_authorization_approved"
+          : "refund_authorization_rejected",
+      title,
+      message,
+      link: `/dashboard/gabinet/patients/${args.patientId}?tab=payments`,
+    });
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: args.approverId,
+      action:
+        args.decision === "approved"
+          ? "refund_authorization_approved"
+          : "refund_authorization_rejected",
+      entityType: "payment",
+      entityId: (args.paymentId ?? args.patientId) as any,
+      details: JSON.stringify({
+        requestId: args.requestId,
+        patientId: args.patientId,
+        amount: args.amount,
+        paymentId: args.paymentId ?? null,
+        reason: args.reason ?? null,
+      }),
+    });
+  },
+});
 
 /** Revenue summary for a time range */
 export const getRevenueSummary = action({

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -656,6 +656,11 @@ export function createCrmTables({
     link: v.optional(v.string()),
     isRead: v.boolean(),
     createdAt: v.number(),
+    // Optional JSON payload carrying type-specific data for inline actions.
+    // For type="refund_authorization_requested" it holds the shared
+    // requestId plus patientId/amount/notes so the bell can approve/reject
+    // without round-tripping to the patient page (#1722).
+    metadata: v.optional(v.any()),
   })
     .index("by_user", ["userId", "createdAt"])
     .index("by_userAndRead", ["userId", "isRead", "createdAt"])

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -206,6 +206,17 @@
       "appointmentCancelledTitle": "Appointment cancelled",
       "appointmentCancelledMessage": "An appointment has been cancelled",
       "appointmentCancelledMessageWithReason": "An appointment has been cancelled: {{reason}}"
+    },
+    "refundAuth": {
+      "approve": "Approve",
+      "reject": "Reject",
+      "approving": "Approving…",
+      "rejecting": "Rejecting…",
+      "approved": "Refund approved",
+      "rejected": "Request rejected",
+      "resolved": "Request already resolved",
+      "approveError": "Could not approve refund",
+      "rejectError": "Could not reject request"
     }
   },
   "sidebar": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -219,6 +219,17 @@
       "appointmentCancelledTitle": "Wizyta odwołana",
       "appointmentCancelledMessage": "Wizyta została odwołana",
       "appointmentCancelledMessageWithReason": "Wizyta została odwołana: {{reason}}"
+    },
+    "refundAuth": {
+      "approve": "Zatwierdź",
+      "reject": "Odrzuć",
+      "approving": "Zatwierdzam…",
+      "rejecting": "Odrzucam…",
+      "approved": "Zwrot zatwierdzony",
+      "rejected": "Prośba odrzucona",
+      "resolved": "Prośba została rozstrzygnięta",
+      "approveError": "Nie udało się zatwierdzić zwrotu",
+      "rejectError": "Nie udało się odrzucić prośby"
     }
   },
   "sidebar": {

--- a/src/components/notifications/notification-bell.tsx
+++ b/src/components/notifications/notification-bell.tsx
@@ -1,10 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
+import { useState } from "react";
+import { toast } from "sonner";
 import { Bell, Mail, TrendingUp, Users, Calendar, FileText, Info } from "@/lib/ez-icons";
 import { Button } from "@/components/ui/button";
 import {
@@ -17,6 +19,26 @@ import {
   translateNotificationTitle,
 } from "@/components/notifications/translate-notification";
 import type { Id } from "@cvx/_generated/dataModel";
+
+type RefundAuthMetadata = {
+  requestId: string;
+  patientId: string;
+  patientLabel: string;
+  amount: number;
+  notes: string | null;
+  requesterId: string;
+  requesterName: string;
+  status: "pending" | "approved" | "rejected";
+};
+
+function isPendingRefundAuth(notification: {
+  type?: string;
+  metadata?: unknown;
+}): notification is { type: string; metadata: RefundAuthMetadata } {
+  if (notification.type !== "refund_authorization_requested") return false;
+  const m = notification.metadata as RefundAuthMetadata | null | undefined;
+  return !!m && m.status === "pending";
+}
 
 function useFormatRelativeTime() {
   const { t, i18n } = useTranslation();
@@ -77,6 +99,13 @@ export function NotificationBell() {
 
   const markAsRead = useAction(api.notifications.markAsRead);
   const markAllRead = useAction(api.notifications.markAllRead);
+  const approveRefundAuth = useAction(api.payments.approveRefundAuth);
+  const rejectRefundAuth = useAction(api.payments.rejectRefundAuth);
+  const queryClient = useQueryClient();
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<"approve" | "reject" | null>(
+    null,
+  );
 
   const handleNotificationClick = async (notification: {
     _id: Id<"notifications">;
@@ -93,6 +122,62 @@ export function NotificationBell() {
 
   const handleMarkAllRead = async () => {
     await markAllRead({ organizationId });
+  };
+
+  const refreshNotifications = () => {
+    void queryClient.invalidateQueries({
+      queryKey: convexQuery(api.notifications.list, {
+        organizationId,
+        limit: 20,
+      }).queryKey,
+    });
+    void queryClient.invalidateQueries({
+      queryKey: convexQuery(api.notifications.getUnreadCount, {
+        organizationId,
+      }).queryKey,
+    });
+  };
+
+  const handleApproveRefund = async (
+    notificationId: Id<"notifications">,
+  ) => {
+    setPendingId(notificationId);
+    setPendingAction("approve");
+    try {
+      await approveRefundAuth({ organizationId, notificationId });
+      toast.success(t("notifications.refundAuth.approved"));
+      refreshNotifications();
+    } catch (e) {
+      toast.error(
+        e instanceof Error
+          ? e.message
+          : t("notifications.refundAuth.approveError"),
+      );
+    } finally {
+      setPendingId(null);
+      setPendingAction(null);
+    }
+  };
+
+  const handleRejectRefund = async (
+    notificationId: Id<"notifications">,
+  ) => {
+    setPendingId(notificationId);
+    setPendingAction("reject");
+    try {
+      await rejectRefundAuth({ organizationId, notificationId });
+      toast.success(t("notifications.refundAuth.rejected"));
+      refreshNotifications();
+    } catch (e) {
+      toast.error(
+        e instanceof Error
+          ? e.message
+          : t("notifications.refundAuth.rejectError"),
+      );
+    } finally {
+      setPendingId(null);
+      setPendingAction(null);
+    }
   };
 
   const count = unreadCount?.count ?? 0;
@@ -132,41 +217,89 @@ export function NotificationBell() {
               {t("notifications.empty", "No notifications")}
             </div>
           ) : (
-            notifications.map((notification) => (
-              <button
-                key={notification._id}
-                type="button"
-                className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/50"
-                onClick={() => handleNotificationClick(notification)}
-              >
-                {!notification.isRead && (
-                  <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-primary" />
-                )}
-                {notification.isRead && <span className="w-2 shrink-0" />}
-                <div className="mt-0.5 shrink-0 text-muted-foreground">
-                  {getNotificationIcon(notification.type)}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <p
-                    className={
-                      notification.isRead
-                        ? "truncate text-sm text-foreground"
-                        : "truncate text-sm font-medium text-foreground"
-                    }
+            notifications.map((notification) => {
+              const showRefundActions = isPendingRefundAuth(notification);
+              const isThisRowBusy = pendingId === notification._id;
+              return (
+                <div
+                  key={notification._id}
+                  className="border-b last:border-b-0"
+                >
+                  <button
+                    type="button"
+                    className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/50"
+                    onClick={() => handleNotificationClick(notification)}
                   >
-                    {translateNotificationTitle(notification.title, t)}
-                  </p>
-                  {notification.message && (
-                    <p className="truncate text-xs text-muted-foreground">
-                      {translateNotificationMessage(notification.message, t)}
-                    </p>
+                    {!notification.isRead && (
+                      <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-primary" />
+                    )}
+                    {notification.isRead && <span className="w-2 shrink-0" />}
+                    <div className="mt-0.5 shrink-0 text-muted-foreground">
+                      {getNotificationIcon(notification.type)}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p
+                        className={
+                          notification.isRead
+                            ? "truncate text-sm text-foreground"
+                            : "truncate text-sm font-medium text-foreground"
+                        }
+                      >
+                        {translateNotificationTitle(notification.title, t)}
+                      </p>
+                      {notification.message && (
+                        <p
+                          className={
+                            showRefundActions
+                              ? "text-xs text-muted-foreground"
+                              : "truncate text-xs text-muted-foreground"
+                          }
+                        >
+                          {translateNotificationMessage(
+                            notification.message,
+                            t,
+                          )}
+                        </p>
+                      )}
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        {formatRelativeTime(notification._creationTime)}
+                      </p>
+                    </div>
+                  </button>
+                  {showRefundActions && (
+                    <div className="flex items-center gap-2 px-4 pb-3 pl-[3.25rem]">
+                      <Button
+                        size="sm"
+                        className="h-7 px-3 text-xs"
+                        disabled={pendingId !== null}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void handleApproveRefund(notification._id);
+                        }}
+                      >
+                        {isThisRowBusy && pendingAction === "approve"
+                          ? t("notifications.refundAuth.approving")
+                          : t("notifications.refundAuth.approve")}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7 px-3 text-xs"
+                        disabled={pendingId !== null}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void handleRejectRefund(notification._id);
+                        }}
+                      >
+                        {isThisRowBusy && pendingAction === "reject"
+                          ? t("notifications.refundAuth.rejecting")
+                          : t("notifications.refundAuth.reject")}
+                      </Button>
+                    </div>
                   )}
-                  <p className="mt-0.5 text-xs text-muted-foreground">
-                    {formatRelativeTime(notification._creationTime)}
-                  </p>
                 </div>
-              </button>
-            ))
+              );
+            })
           )}
         </div>
       </PopoverContent>

--- a/supabase/migrations/00014_notifications_metadata.sql
+++ b/supabase/migrations/00014_notifications_metadata.sql
@@ -1,0 +1,6 @@
+-- Add an optional metadata JSONB column to notifications so type-specific
+-- payloads (e.g. refund authorization requests) can carry the data the bell
+-- needs for inline approve/reject actions (#1722).
+
+ALTER TABLE notifications
+  ADD COLUMN IF NOT EXISTS metadata JSONB;

--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { api } from "../../convex/_generated/api";
-import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import {
+  createTestCtx,
+  seedSecondUser,
+  seedTestUser,
+} from "../../convex/_test_helpers";
 
 afterEach(async () => {
   // Let any pending setTimeout(0) side-effect callbacks from the test fire
@@ -507,5 +511,206 @@ describe("payments", () => {
     });
 
     expect(result.page[0].paymentMethod).toBe("card");
+  });
+
+  // Inline approve/reject for refund authorization requests (#1722) ---------
+
+  describe("refund authorization inline actions", () => {
+    test("approveRefundAuth executes the refund and resolves siblings", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity: ownerIdentity, userId: ownerUserId } =
+        await seedTestUser(t);
+      const { identity: memberIdentity } = await seedSecondUser(
+        t,
+        organizationId,
+        { role: "member" },
+      );
+      const patientId = TEST_PATIENT_ID;
+
+      // Seed 500 credit for the patient.
+      await t.withIdentity(ownerIdentity).action(api.payments.create, {
+        organizationId,
+        patientId,
+        amount: 500,
+        currency: "PLN",
+        paymentMethod: "cash",
+        creditEarned: 500,
+      });
+
+      // Member (no refund permission) asks for authorization.
+      await t
+        .withIdentity(memberIdentity)
+        .action(api.payments.requestRefundAuthorization, {
+          organizationId,
+          patientId,
+          amount: 200,
+          notes: "Patient changed mind",
+        });
+
+      // The owner should now have a pending refund_authorization_requested
+      // notification carrying the metadata we need to approve inline.
+      const ownerNotifications = await t.run(async (ctx) => {
+        return await ctx.db
+          .query("notifications")
+          .withIndex("by_user", (q) => q.eq("userId", ownerUserId))
+          .collect();
+      });
+      const refundNotification = ownerNotifications.find(
+        (n) => n.type === "refund_authorization_requested",
+      );
+      expect(refundNotification).toBeTruthy();
+      expect(refundNotification!.metadata).toMatchObject({
+        patientId,
+        amount: 200,
+        status: "pending",
+      });
+
+      // Approve via the inline action.
+      await t
+        .withIdentity(ownerIdentity)
+        .action(api.payments.approveRefundAuth, {
+          organizationId,
+          notificationId: refundNotification!._id,
+        });
+
+      // Patient credit balance should have dropped by the refund amount.
+      const credit = await t
+        .withIdentity(ownerIdentity)
+        .action(api.payments.getPatientCredit, {
+          organizationId,
+          patientId,
+        });
+      expect(credit.balance).toBe(300);
+
+      // The original notification is now marked read and its metadata
+      // status flipped so the bell will hide the inline buttons.
+      const resolved = await t.run(async (ctx) =>
+        ctx.db.get(refundNotification!._id),
+      );
+      expect(resolved?.isRead).toBe(true);
+      expect((resolved?.metadata as { status: string }).status).toBe(
+        "approved",
+      );
+    });
+
+    test("rejectRefundAuth resolves the request without refunding", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity: ownerIdentity, userId: ownerUserId } =
+        await seedTestUser(t);
+      const { identity: memberIdentity } = await seedSecondUser(
+        t,
+        organizationId,
+        { role: "member" },
+      );
+      const patientId = TEST_PATIENT_ID;
+
+      await t.withIdentity(ownerIdentity).action(api.payments.create, {
+        organizationId,
+        patientId,
+        amount: 500,
+        currency: "PLN",
+        paymentMethod: "cash",
+        creditEarned: 500,
+      });
+
+      await t
+        .withIdentity(memberIdentity)
+        .action(api.payments.requestRefundAuthorization, {
+          organizationId,
+          patientId,
+          amount: 100,
+        });
+
+      const ownerNotifications = await t.run(async (ctx) =>
+        ctx.db
+          .query("notifications")
+          .withIndex("by_user", (q) => q.eq("userId", ownerUserId))
+          .collect(),
+      );
+      const refundNotification = ownerNotifications.find(
+        (n) => n.type === "refund_authorization_requested",
+      )!;
+
+      await t
+        .withIdentity(ownerIdentity)
+        .action(api.payments.rejectRefundAuth, {
+          organizationId,
+          notificationId: refundNotification._id,
+          reason: "Already refunded offline",
+        });
+
+      // Balance unchanged.
+      const credit = await t
+        .withIdentity(ownerIdentity)
+        .action(api.payments.getPatientCredit, {
+          organizationId,
+          patientId,
+        });
+      expect(credit.balance).toBe(500);
+
+      // Notification flipped to rejected + read.
+      const resolved = await t.run(async (ctx) =>
+        ctx.db.get(refundNotification._id),
+      );
+      expect(resolved?.isRead).toBe(true);
+      expect((resolved?.metadata as { status: string }).status).toBe(
+        "rejected",
+      );
+    });
+
+    test("approveRefundAuth twice is rejected (already resolved)", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity: ownerIdentity, userId: ownerUserId } =
+        await seedTestUser(t);
+      const { identity: memberIdentity } = await seedSecondUser(
+        t,
+        organizationId,
+        { role: "member" },
+      );
+      const patientId = TEST_PATIENT_ID;
+
+      await t.withIdentity(ownerIdentity).action(api.payments.create, {
+        organizationId,
+        patientId,
+        amount: 500,
+        currency: "PLN",
+        paymentMethod: "cash",
+        creditEarned: 500,
+      });
+
+      await t
+        .withIdentity(memberIdentity)
+        .action(api.payments.requestRefundAuthorization, {
+          organizationId,
+          patientId,
+          amount: 100,
+        });
+
+      const ownerNotifications = await t.run(async (ctx) =>
+        ctx.db
+          .query("notifications")
+          .withIndex("by_user", (q) => q.eq("userId", ownerUserId))
+          .collect(),
+      );
+      const refundNotification = ownerNotifications.find(
+        (n) => n.type === "refund_authorization_requested",
+      )!;
+
+      await t
+        .withIdentity(ownerIdentity)
+        .action(api.payments.approveRefundAuth, {
+          organizationId,
+          notificationId: refundNotification._id,
+        });
+
+      await expect(
+        t
+          .withIdentity(ownerIdentity)
+          .action(api.payments.approveRefundAuth, {
+            organizationId,
+            notificationId: refundNotification._id,
+          }),
+      ).rejects.toThrow(/already resolved/i);
+    });
   });
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1722.

Closes #1722

---

## Claude summary

Committed. Here's a summary of what shipped for issue #1722:

The admin notification bell now resolves refund authorization requests inline. When a member without `gabinet_payments.refund` calls `requestRefundAuthorization`, the fan-out mutation tags every owner/admin notification with a shared `metadata` payload (`requestId`, `patientId`, `amount`, `notes`, requester info, `status: "pending"`).

Two new Convex actions — `approveRefundAuth` and `rejectRefundAuth` — re-check RBAC, load the notification, run the refund through Supabase (approve) or skip it (reject), and call `_resolveRefundAuthSideEffects` which patches every sibling notification carrying the same `requestId`. That last step means as soon as one admin acts, the other admins' bells stop showing the pending CTA. The original requester also gets a follow-up notification with the decision (and optional rejection reason).

On the frontend, `notification-bell.tsx` renders Approve/Reject buttons only while `metadata.status === "pending"`, with toast feedback and react-query invalidation so the bell refreshes immediately after the action resolves. Three new tests in `payments.test.ts` cover approve, reject, and the "already resolved" guard; all 155 convex tests pass.

The pre-existing TypeScript errors in `convex/gabinet/_availability_supabase.ts` exist on `main` and are unrelated.

## Follow-ups
- Add optimistic-concurrency guard on refund authorization approve: two admins clicking Approve simultaneously can both pass the JS-level `status === "pending"` check and create two refund payments before either patches the notification; should gate on a DB-level claim of the request.