### PR TITLE
rozliczenia płatności

### DIFF
--- a/convex/_helpers/gabinetRolePermissions.ts
+++ b/convex/_helpers/gabinetRolePermissions.ts
@@ -45,6 +45,7 @@ function buildGabinet(
     delete: "none",
     approve: "none",
     sign: "none",
+    refund: "none",
   };
   const result = {} as FeaturePermissions;
   // Every feature defaults to all-none, so MAX-merge with org-role is a no-op
@@ -64,6 +65,7 @@ function buildGabinet(
     "gabinet_treatments",
     "gabinet_packages",
     "gabinet_employees",
+    "gabinet_payments",
     "gabinet_settings",
     "settings",
     "team",
@@ -96,6 +98,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_treatments: { view: "all" },
     gabinet_packages: { view: "all" },
     gabinet_employees: { view: "all" },
+    gabinet_payments: { view: "all" },
     gabinet_settings: {},
   }),
   therapist: buildGabinet({
@@ -104,6 +107,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_treatments: { view: "all" },
     gabinet_packages: { view: "all" },
     gabinet_employees: { view: "all" },
+    gabinet_payments: { view: "all" },
     gabinet_settings: {},
   }),
   nurse: buildGabinet({
@@ -112,6 +116,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_treatments: { view: "all" },
     gabinet_packages: { view: "all" },
     gabinet_employees: { view: "all" },
+    gabinet_payments: { view: "all" },
     gabinet_settings: {},
   }),
   receptionist: buildGabinet({
@@ -120,6 +125,9 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_treatments: { view: "all" },
     gabinet_packages: { view: "all" },
     gabinet_employees: { view: "all" },
+    // Recepcja może rejestrować wpłaty i edytować je, ale NIE robi zwrotów —
+    // zwrot wymaga osobnej autoryzacji administratora (issue #1690).
+    gabinet_payments: { view: "all", create: "all", edit: "all" },
     gabinet_settings: {},
   }),
   admin: buildGabinet({
@@ -128,6 +136,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_treatments: { view: "all", create: "all", edit: "all", delete: "all" },
     gabinet_packages: { view: "all", create: "all", edit: "all", delete: "all" },
     gabinet_employees: { view: "all", create: "all", edit: "all", delete: "all" },
+    gabinet_payments: { view: "all", create: "all", edit: "all", delete: "all", refund: "all" },
     gabinet_settings: { view: "all", create: "all", edit: "all", delete: "all" },
   }),
   other: buildGabinet({
@@ -136,6 +145,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_treatments: { view: "all" },
     gabinet_packages: { view: "all" },
     gabinet_employees: { view: "all" },
+    gabinet_payments: { view: "all" },
     gabinet_settings: {},
   }),
 };

--- a/convex/_helpers/permissionTypes.ts
+++ b/convex/_helpers/permissionTypes.ts
@@ -18,6 +18,7 @@ export const FEATURES = [
   "gabinet_treatments",
   "gabinet_packages",
   "gabinet_employees",
+  "gabinet_payments",
   "gabinet_settings",
   "settings",
   "team",
@@ -27,7 +28,7 @@ export const FEATURES = [
   "categoryDefinitions",
 ] as const;
 
-export const ACTIONS = ["view", "create", "edit", "delete", "approve", "sign"] as const;
+export const ACTIONS = ["view", "create", "edit", "delete", "approve", "sign", "refund"] as const;
 
 export const SCOPES = ["none", "own", "all"] as const;
 

--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -27,10 +27,26 @@ function buildDefaults(scope: Record<Action, Scope>): FeaturePermissions {
 }
 
 export const DEFAULT_PERMISSIONS: Record<OrgRole, FeaturePermissions> = {
-  owner: buildDefaults({ view: "all", create: "all", edit: "all", delete: "all", approve: "none", sign: "none" }),
-  admin: buildDefaults({ view: "all", create: "all", edit: "all", delete: "all", approve: "none", sign: "none" }),
-  member: buildDefaults({ view: "all", create: "all", edit: "own", delete: "own", approve: "none", sign: "none" }),
-  viewer: buildDefaults({ view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none" }),
+  owner: buildDefaults({ view: "all", create: "all", edit: "all", delete: "all", approve: "none", sign: "none", refund: "none" }),
+  admin: buildDefaults({ view: "all", create: "all", edit: "all", delete: "all", approve: "none", sign: "none", refund: "none" }),
+  member: buildDefaults({ view: "all", create: "all", edit: "own", delete: "own", approve: "none", sign: "none", refund: "none" }),
+  viewer: buildDefaults({ view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none" }),
+};
+
+// --- Per-feature overrides for gabinet_payments ---
+// owner/admin: full incl. refund; member: view/create/edit (no delete, no
+// refund — recepcja); viewer: view only. Issue #1690.
+DEFAULT_PERMISSIONS.owner.gabinet_payments = {
+  view: "all", create: "all", edit: "all", delete: "all", approve: "none", sign: "none", refund: "all",
+};
+DEFAULT_PERMISSIONS.admin.gabinet_payments = {
+  view: "all", create: "all", edit: "all", delete: "all", approve: "none", sign: "none", refund: "all",
+};
+DEFAULT_PERMISSIONS.member.gabinet_payments = {
+  view: "all", create: "all", edit: "all", delete: "none", approve: "none", sign: "none", refund: "none",
+};
+DEFAULT_PERMISSIONS.viewer.gabinet_payments = {
+  view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
 };
 
 // --- Per-feature overrides for document_templates ---
@@ -38,44 +54,44 @@ export const DEFAULT_PERMISSIONS: Record<OrgRole, FeaturePermissions> = {
 // member: view only (no create/edit/delete)
 // viewer: view only
 DEFAULT_PERMISSIONS.member.document_templates = {
-  view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none",
+  view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
 };
 
 // --- Per-feature overrides for document_instances ---
 // owner/admin: all actions allowed
 DEFAULT_PERMISSIONS.owner.document_instances = {
-  view: "all", create: "all", edit: "all", delete: "all", approve: "all", sign: "all",
+  view: "all", create: "all", edit: "all", delete: "all", approve: "all", sign: "all", refund: "none",
 };
 DEFAULT_PERMISSIONS.admin.document_instances = {
-  view: "all", create: "all", edit: "all", delete: "all", approve: "all", sign: "all",
+  view: "all", create: "all", edit: "all", delete: "all", approve: "all", sign: "all", refund: "none",
 };
 // member: view, create, edit, sign; NO approve or delete
 DEFAULT_PERMISSIONS.member.document_instances = {
-  view: "all", create: "all", edit: "own", delete: "none", approve: "none", sign: "all",
+  view: "all", create: "all", edit: "own", delete: "none", approve: "none", sign: "all", refund: "none",
 };
 // viewer: view only
 DEFAULT_PERMISSIONS.viewer.document_instances = {
-  view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none",
+  view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
 };
 
 // --- Per-feature overrides for tagDefinitions ---
 // member: create only (no edit/delete)
 DEFAULT_PERMISSIONS.member.tagDefinitions = {
-  view: "all", create: "all", edit: "none", delete: "none", approve: "none", sign: "none",
+  view: "all", create: "all", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
 };
 // viewer: no CRUD
 DEFAULT_PERMISSIONS.viewer.tagDefinitions = {
-  view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none",
+  view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
 };
 
 // --- Per-feature overrides for categoryDefinitions ---
 // member: create only (no edit/delete)
 DEFAULT_PERMISSIONS.member.categoryDefinitions = {
-  view: "all", create: "all", edit: "none", delete: "none", approve: "none", sign: "none",
+  view: "all", create: "all", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
 };
 // viewer: no CRUD
 DEFAULT_PERMISSIONS.viewer.categoryDefinitions = {
-  view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none",
+  view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
 };
 
 // --- checkPermission ---

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -5,6 +5,7 @@ import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { logAudit } from "./auditLog";
 import { logActivity } from "./_helpers/activities";
+import { createNotificationDirect } from "./notifications";
 
 const paymentMethodValidator = v.union(
   v.literal("cash"),
@@ -305,8 +306,20 @@ export const refundCredit = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
-    if (authResult.role !== "owner" && authResult.role !== "admin") {
-      throw new Error("Only organization admins can refund patient credit");
+    // Issue #1690: refunds are gated by gabinet_payments.refund (separate slot
+    // so e.g. reception can record payments but not authorize refunds).
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      {
+        organizationId: args.organizationId,
+        feature: "gabinet_payments",
+        action: "refund",
+      },
+    );
+    if (!perm.allowed) {
+      throw new Error(
+        "REFUND_NOT_AUTHORIZED: requires gabinet_payments.refund — use requestRefundAuthorization to ask an admin",
+      );
     }
     if (!Number.isFinite(args.amount) || args.amount <= 0) {
       throw new Error("Refund amount must be positive");
@@ -712,6 +725,205 @@ export const _refundCreditSideEffects = internalMutation({
       entityType: "payment",
       entityId: args.paymentId as any,
       details: JSON.stringify({ amount: args.amount }),
+    });
+  },
+});
+
+/**
+ * Soft-cancel a payment (issue #1690 — "Usuń wpłatę").
+ *
+ * Never hard-deletes the row, so credit-history is preserved. Flips the
+ * status to "cancelled" which drops the row from balance + outstanding
+ * computations (see computePatientCreditBalance which filters on
+ * status="completed"). Already-refunded/cancelled rows are rejected.
+ */
+export const cancel = action({
+  args: {
+    organizationId: v.id("organizations"),
+    paymentId: v.string(),
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const authResult = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      {
+        organizationId: args.organizationId,
+        feature: "gabinet_payments",
+        action: "delete",
+      },
+    );
+    if (!perm.allowed) {
+      throw new Error("Not authorized to cancel payments");
+    }
+
+    const db = createSupabaseDb();
+    const payment = await db.get("payments", args.paymentId);
+    if (!payment || payment.organizationId !== String(args.organizationId)) {
+      throw new Error("Payment not found");
+    }
+    if (payment.status === "refunded" || payment.status === "cancelled") {
+      throw new Error(`Cannot cancel a ${payment.status} payment`);
+    }
+
+    const baseNotes = (payment.notes as string | null) ?? "";
+    const newNotes = args.reason
+      ? `${baseNotes ? baseNotes + "\n" : ""}Cancelled: ${args.reason}`
+      : baseNotes || null;
+
+    await db.patch("payments", args.paymentId, {
+      status: "cancelled",
+      notes: newNotes,
+      updatedAt: Date.now(),
+    });
+
+    try {
+      await ctx.runMutation(internal.payments._cancelPaymentSideEffects, {
+        paymentId: args.paymentId,
+        organizationId: args.organizationId,
+        userId: authResult.userId,
+        amount: payment.amount as number,
+        reason: args.reason,
+      });
+    } catch {
+      // side effects are best-effort
+    }
+
+    return args.paymentId;
+  },
+});
+
+export const _cancelPaymentSideEffects = internalMutation({
+  args: {
+    paymentId: v.string(),
+    organizationId: v.id("organizations"),
+    userId: v.id("users"),
+    amount: v.number(),
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: args.userId,
+      action: "payment_cancelled",
+      entityType: "payment",
+      entityId: args.paymentId as any,
+      details: JSON.stringify({ amount: args.amount, reason: args.reason }),
+    });
+  },
+});
+
+/**
+ * Issue #1690: when a staff member without gabinet_payments.refund permission
+ * tries to issue a refund, they instead call this action. It records the
+ * request in the audit log and notifies every owner/admin in the org with a
+ * link back to the patient. The admin then approves by clicking through and
+ * executing `refundCredit` from the UI.
+ *
+ * Note: email delivery and a single-click email-link approval flow are
+ * tracked as a follow-up. The notification-based flow ships first so refund
+ * gating works end-to-end immediately.
+ */
+export const requestRefundAuthorization = action({
+  args: {
+    organizationId: v.id("organizations"),
+    patientId: v.string(),
+    amount: v.number(),
+    notes: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const authResult = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    if (!Number.isFinite(args.amount) || args.amount <= 0) {
+      throw new Error("Refund amount must be positive");
+    }
+
+    // Sanity-check the patient still has enough credit to refund — saves
+    // admins from approving impossible requests.
+    const db = createSupabaseDb();
+    const balance = await computePatientCreditBalance(
+      db,
+      String(args.organizationId),
+      String(args.patientId),
+    );
+    if (args.amount > balance + 0.005) {
+      throw new Error(
+        `Refund amount ${args.amount} exceeds available credit ${balance}`,
+      );
+    }
+
+    const patient = await db.get("gabinetPatients", args.patientId);
+    const patientLabel = patient
+      ? `${(patient.firstName as string) ?? ""} ${(patient.lastName as string) ?? ""}`.trim() || "Pacjent"
+      : "Pacjent";
+
+    await ctx.runMutation(internal.payments._requestRefundAuthSideEffects, {
+      organizationId: args.organizationId,
+      requesterId: authResult.userId,
+      requesterName: authResult.userName ?? authResult.userEmail ?? "Pracownik",
+      patientId: args.patientId,
+      patientLabel,
+      amount: args.amount,
+      notes: args.notes,
+    });
+
+    return { ok: true };
+  },
+});
+
+export const _requestRefundAuthSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    requesterId: v.id("users"),
+    requesterName: v.string(),
+    patientId: v.string(),
+    patientLabel: v.string(),
+    amount: v.number(),
+    notes: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    // Notify every owner/admin in the org.
+    const memberships = await ctx.db
+      .query("teamMemberships")
+      .withIndex("by_organizationId", (q) =>
+        q.eq("organizationId", args.organizationId),
+      )
+      .collect();
+
+    const adminIds = memberships
+      .filter((m) => m.role === "owner" || m.role === "admin")
+      .map((m) => m.userId);
+
+    const message = `${args.requesterName} prosi o autoryzację zwrotu ${args.amount.toFixed(2)} zł z salda klienta ${args.patientLabel}${args.notes ? ` (${args.notes})` : ""}.`;
+    const link = `/dashboard/gabinet/patients/${args.patientId}?tab=payments`;
+
+    for (const userId of adminIds) {
+      await createNotificationDirect(ctx, {
+        organizationId: args.organizationId,
+        userId,
+        type: "refund_authorization_requested",
+        title: "Prośba o autoryzację zwrotu",
+        message,
+        link,
+      });
+    }
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: args.requesterId,
+      action: "refund_authorization_requested",
+      entityType: "payment",
+      entityId: args.patientId as any,
+      details: JSON.stringify({
+        patientId: args.patientId,
+        amount: args.amount,
+        notes: args.notes,
+      }),
     });
   },
 });

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3358,6 +3358,29 @@
       "creditAmountToApply": "Amount from credit",
       "creditExceedsBalance": "Credit amount exceeds available balance.",
       "overpaymentNote": "Overpayment of {{amount}} will be added to the patient's credit balance and can be used on future visits.",
+      "overpaymentToCredit": "Overpayment of {{amount}} will be added to the patient's credit.",
+      "useBalance": "Use patient balance ({{amount}})",
+      "useBalanceHint": "The unpaid portion will be covered from the patient's credit balance.",
+      "addPaymentPatientDesc": "Record a patient payment. With no appointment selected the full amount goes to the credit balance.",
+      "linkedAppointment": "Linked appointment",
+      "noAppointmentToCredit": "None — add to credit balance",
+      "fullAmountToCreditHint": "The full amount will be added to the patient's credit balance.",
+      "type": "Type",
+      "balanceDelta": "Balance change",
+      "cancelled": "Payment cancelled",
+      "cancelPayment": "Cancel payment",
+      "cancelPaymentDesc": "A cancelled payment is excluded from balance and settlements. The history entry stays for audit.",
+      "cancelReason": "Cancellation reason",
+      "cancelReasonPlaceholder": "E.g. wrong amount, customer withdrawal...",
+      "cancelConfirm": "Cancel payment",
+      "types": {
+        "payment": "Payment",
+        "overpayment": "Overpayment",
+        "creditApplied": "Credit used",
+        "creditRefund": "Credit refund",
+        "cancelled": "Cancelled",
+        "refunded": "Refunded"
+      },
       "credit": {
         "title": "Credit balance",
         "description": "Overpayments are added to the patient's credit and can be applied to future visits.",
@@ -3376,7 +3399,11 @@
         "refundConfirm": "Confirm refund",
         "refundSuccess": "Credit refunded",
         "refundExceeds": "Refund amount exceeds available credit.",
-        "adminOnly": "Only organization owners and admins can refund credit."
+        "adminOnly": "Only organization owners and admins can refund credit.",
+        "requestRefundDialogTitle": "Request refund authorization",
+        "requestRefundDialogDesc": "You don't have permission to refund credit. Your request will be sent to an organization admin.",
+        "requestRefundConfirm": "Send request",
+        "refundRequestSent": "Refund authorization request sent to admin."
       }
     },
     "schedules": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3389,6 +3389,29 @@
       "creditAmountToApply": "Kwota z salda",
       "creditExceedsBalance": "Kwota użytego salda nadpłat przekracza dostępne środki.",
       "overpaymentNote": "Nadpłata {{amount}} zostanie dopisana do salda klienta i można ją wykorzystać przy kolejnych wizytach.",
+      "overpaymentToCredit": "Nadpłata {{amount}} zostanie dopisana do salda klienta.",
+      "useBalance": "Użyj salda klienta ({{amount}})",
+      "useBalanceHint": "Brakująca kwota zostanie pokryta z salda nadpłat klienta.",
+      "addPaymentPatientDesc": "Zarejestruj wpłatę klienta. Bez wybranej wizyty całość trafi do salda.",
+      "linkedAppointment": "Powiązana wizyta",
+      "noAppointmentToCredit": "Brak — wpłata do salda klienta",
+      "fullAmountToCreditHint": "Całość wpłaty zostanie dopisana do salda klienta.",
+      "type": "Typ",
+      "balanceDelta": "Wpływ na saldo",
+      "cancelled": "Płatność anulowana",
+      "cancelPayment": "Anuluj płatność",
+      "cancelPaymentDesc": "Anulowana płatność nie zostanie wliczona do salda ani do rozliczeń. Operacja zachowuje wpis w historii.",
+      "cancelReason": "Powód anulowania",
+      "cancelReasonPlaceholder": "Np. błędna kwota, rezygnacja klienta...",
+      "cancelConfirm": "Anuluj wpłatę",
+      "types": {
+        "payment": "Wpłata",
+        "overpayment": "Nadpłata",
+        "creditApplied": "Użycie salda",
+        "creditRefund": "Zwrot salda",
+        "cancelled": "Anulowana",
+        "refunded": "Zwrócona"
+      },
       "credit": {
         "title": "Saldo nadpłat",
         "description": "Nadpłaty są dopisywane do salda klienta i mogą zostać wykorzystane przy kolejnych wizytach.",
@@ -3407,7 +3430,11 @@
         "refundConfirm": "Potwierdź zwrot",
         "refundSuccess": "Saldo zwrócone",
         "refundExceeds": "Kwota zwrotu przekracza dostępne saldo.",
-        "adminOnly": "Tylko właściciele i administratorzy organizacji mogą zwracać saldo nadpłat."
+        "adminOnly": "Tylko właściciele i administratorzy organizacji mogą zwracać saldo nadpłat.",
+        "requestRefundDialogTitle": "Poproś o autoryzację zwrotu",
+        "requestRefundDialogDesc": "Nie masz uprawnień do bezpośrednich zwrotów. Twoja prośba trafi do administratora organizacji.",
+        "requestRefundConfirm": "Wyślij prośbę",
+        "refundRequestSent": "Prośba o autoryzację zwrotu wysłana do administratora."
       }
     },
     "schedules": {

--- a/src/lib/supabase/mappers/payments.ts
+++ b/src/lib/supabase/mappers/payments.ts
@@ -23,6 +23,9 @@ export interface MappedPayment {
   createdBy: string;
   createdAt: number;
   updatedAt: number;
+  creditEarned?: number;
+  creditApplied?: number;
+  kind?: string;
   _source: "supabase";
 }
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -370,7 +370,11 @@ function AppointmentDetail() {
   const [paymentAmount, setPaymentAmount] = useState("");
   const [paymentMethod, setPaymentMethod] = useState<string>("cash");
   const [paymentNote, setPaymentNote] = useState("");
+  const [paymentUseBalance, setPaymentUseBalance] = useState(false);
   const [isPaymentSubmitting, setIsPaymentSubmitting] = useState(false);
+  const [patientCreditBalance, setPatientCreditBalance] = useState<number | null>(
+    null,
+  );
 
   // Body chart state
   const [bodyChartData, setBodyChartData] = useState<BodyRegion[]>([]);
@@ -422,6 +426,7 @@ function AppointmentDetail() {
   const createPayment = useAction(api.payments.create);
   const markPaymentPaid = useAction(api.payments.markPaid);
   const refundPayment = useAction(api.payments.refund);
+  const getPatientCreditAction = useAction(api.payments.getPatientCredit);
 
   // Note actions (Supabase-primary)
   const createNote = useAction(api.notes.create);
@@ -989,6 +994,26 @@ function AppointmentDetail() {
     }
   };
 
+  // Open the Add Payment dialog and fetch the patient's current credit
+  // balance — needed so the dialog can offer "Użyj salda klienta" with a
+  // correct cap. Best-effort: failure leaves balance at null and hides the
+  // option, the user can still record the payment.
+  const openPaymentDialog = async () => {
+    setPaymentDialogOpen(true);
+    setPaymentUseBalance(false);
+    if (patient?._id) {
+      try {
+        const credit = await getPatientCreditAction({
+          organizationId,
+          patientId: patient._id,
+        });
+        setPatientCreditBalance(credit.balance);
+      } catch {
+        setPatientCreditBalance(null);
+      }
+    }
+  };
+
   // Payment handlers
   const handleCreatePayment = async () => {
     const normalizedAmount = paymentAmount.replace(",", ".");
@@ -997,23 +1022,61 @@ function AppointmentDetail() {
       return;
     }
 
+    const amount = parseFloat(normalizedAmount);
+    // Issue #1690: any portion of `amount` above the visit's outstanding
+    // automatically flows to the patient's credit balance as creditEarned.
+    // Outstanding is treatmentPrice - sum(completed payments) at the moment
+    // of submit, so the math stays consistent with what the user sees in the
+    // summary card.
+    const outstandingNow = Math.max(0, treatmentPrice - totalPaid);
+    const creditEarned =
+      amount > outstandingNow + 0.005
+        ? Math.round((amount - outstandingNow) * 100) / 100
+        : 0;
+    // Issue #1690: when "Użyj salda klienta" is checked, apply available
+    // balance against the visit. We send creditApplied so the backend
+    // deducts from the patient ledger; it does not increase `amount`.
+    const balanceAvailable = patientCreditBalance ?? 0;
+    const creditApplied =
+      paymentUseBalance && balanceAvailable > 0
+        ? Math.round(
+            Math.min(balanceAvailable, Math.max(0, outstandingNow - amount)) *
+              100,
+          ) / 100
+        : 0;
+
     setIsPaymentSubmitting(true);
     try {
       await createPayment({
         organizationId,
         patientId: patient!._id,
         appointmentId: appointment._id,
-        amount: parseFloat(normalizedAmount),
+        amount,
         currency: "PLN",
         paymentMethod: paymentMethod as "cash" | "card" | "transfer" | "package" | "other",
         notes: paymentNote || undefined,
+        creditEarned: creditEarned > 0 ? creditEarned : undefined,
+        creditApplied: creditApplied > 0 ? creditApplied : undefined,
       });
 
       toast.success(t("gabinet.payments.created"));
       setPaymentDialogOpen(false);
       setPaymentAmount("");
       setPaymentNote("");
+      setPaymentUseBalance(false);
       refetch();
+      // Refresh credit balance for any further dialog opens.
+      if (patient?._id) {
+        try {
+          const credit = await getPatientCreditAction({
+            organizationId,
+            patientId: patient._id,
+          });
+          setPatientCreditBalance(credit.balance);
+        } catch {
+          // best-effort; balance will refresh next time the dialog opens
+        }
+      }
     } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
@@ -1834,7 +1897,7 @@ function AppointmentDetail() {
               <Button
                 size="sm"
                 variant="outline"
-                onClick={() => setPaymentDialogOpen(true)}
+                onClick={() => void openPaymentDialog()}
               >
                 <Plus className="mr-2 h-4 w-4" variant="stroke" />
                 {t("gabinet.payments.addPayment")}
@@ -1847,7 +1910,7 @@ function AppointmentDetail() {
                   title={t("gabinet.payments.noPayments")}
                   description={t("gabinet.payments.noPaymentsDesc")}
                   action={
-                    <Button onClick={() => setPaymentDialogOpen(true)}>
+                    <Button onClick={() => void openPaymentDialog()}>
                       <Plus className="mr-2 h-4 w-4" variant="stroke" />
                       {t("gabinet.payments.addFirst")}
                     </Button>
@@ -2811,7 +2874,47 @@ function AppointmentDetail() {
                   {t("gabinet.payments.outstanding")}: {formatCurrencyPLN(outstanding)}
                 </p>
               )}
+              {(() => {
+                // Live preview of overpayment → patient credit (issue #1690).
+                const parsed = parseFloat(paymentAmount.replace(",", "."));
+                const overpay =
+                  Number.isFinite(parsed) && outstanding > 0
+                    ? Math.max(0, parsed - outstanding)
+                    : Number.isFinite(parsed) && outstanding <= 0
+                      ? Math.max(0, parsed)
+                      : 0;
+                if (overpay <= 0) return null;
+                return (
+                  <p className="text-xs text-emerald-600 mt-1">
+                    {t("gabinet.payments.overpaymentToCredit", {
+                      amount: formatCurrencyPLN(overpay),
+                    })}
+                  </p>
+                );
+              })()}
             </div>
+            {patientCreditBalance !== null && patientCreditBalance > 0 && (
+              <div className="rounded-md border bg-emerald-50/50 p-2.5 dark:bg-emerald-950/20">
+                <label className="flex items-start gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="mt-1"
+                    checked={paymentUseBalance}
+                    onChange={(e) => setPaymentUseBalance(e.target.checked)}
+                  />
+                  <div className="flex-1">
+                    <p className="text-sm font-medium">
+                      {t("gabinet.payments.useBalance", {
+                        amount: formatCurrencyPLN(patientCreditBalance),
+                      })}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {t("gabinet.payments.useBalanceHint")}
+                    </p>
+                  </div>
+                </label>
+              </div>
+            )}
             <div>
               <Label>{t("gabinet.payments.method")}</Label>
               <Select value={paymentMethod} onValueChange={setPaymentMethod}>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1017,12 +1017,16 @@ function AppointmentDetail() {
   // Payment handlers
   const handleCreatePayment = async () => {
     const normalizedAmount = paymentAmount.replace(",", ".");
-    if (!paymentAmount || isNaN(parseFloat(normalizedAmount))) {
+    // When the user opts to settle from the patient's balance, an empty
+    // amount means "pay 100% from balance" — treat it as 0 instead of
+    // rejecting the submit.
+    const isBalanceOnly = paymentUseBalance && !paymentAmount;
+    if (!isBalanceOnly && (!paymentAmount || isNaN(parseFloat(normalizedAmount)))) {
       toast.error(t("gabinet.payments.amountRequired"));
       return;
     }
 
-    const amount = parseFloat(normalizedAmount);
+    const amount = isBalanceOnly ? 0 : parseFloat(normalizedAmount);
     // Issue #1690: any portion of `amount` above the visit's outstanding
     // automatically flows to the patient's credit balance as creditEarned.
     // Outstanding is treatmentPrice - sum(completed payments) at the moment
@@ -2915,31 +2919,33 @@ function AppointmentDetail() {
                 </label>
               </div>
             )}
-            <div>
-              <Label>{t("gabinet.payments.method")}</Label>
-              <Select value={paymentMethod} onValueChange={setPaymentMethod}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="cash">
-                    {t("gabinet.payments.methods.cash")}
-                  </SelectItem>
-                  <SelectItem value="card">
-                    {t("gabinet.payments.methods.card")}
-                  </SelectItem>
-                  <SelectItem value="transfer">
-                    {t("gabinet.payments.methods.transfer")}
-                  </SelectItem>
-                  <SelectItem value="package">
-                    {t("gabinet.payments.methods.package")}
-                  </SelectItem>
-                  <SelectItem value="other">
-                    {t("gabinet.payments.methods.other")}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+            {!paymentUseBalance && (
+              <div>
+                <Label>{t("gabinet.payments.method")}</Label>
+                <Select value={paymentMethod} onValueChange={setPaymentMethod}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="cash">
+                      {t("gabinet.payments.methods.cash")}
+                    </SelectItem>
+                    <SelectItem value="card">
+                      {t("gabinet.payments.methods.card")}
+                    </SelectItem>
+                    <SelectItem value="transfer">
+                      {t("gabinet.payments.methods.transfer")}
+                    </SelectItem>
+                    <SelectItem value="package">
+                      {t("gabinet.payments.methods.package")}
+                    </SelectItem>
+                    <SelectItem value="other">
+                      {t("gabinet.payments.methods.other")}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
             <div>
               <Label>{t("common.notes")}</Label>
               <RichTextEditor

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { convexQuery } from "@convex-dev/react-query";
 import { useAction } from "convex/react";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
@@ -72,6 +71,7 @@ import {
 } from "@/lib/ez-icons";
 
 import { useTranslation } from "react-i18next";
+import { usePermission } from "@/hooks/use-permission";
 import { PatientPackagesCard } from "@/components/gabinet/patient-packages-card";
 import { PatientTreatmentsCard } from "@/components/gabinet/patient-treatments-card";
 import { plateJsonToText } from "@/components/gabinet/rich-text-editor";
@@ -97,8 +97,13 @@ function PatientDetail() {
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen for this action
   const removePatient = useAction(api.gabinet.patients.remove);
   const updatePaymentAction = useAction(api.payments.update);
+  const createPaymentAction = useAction(api.payments.create);
+  const cancelPaymentAction = useAction(api.payments.cancel);
   const getPatientCreditAction = useAction(api.payments.getPatientCredit);
   const refundCreditAction = useAction(api.payments.refundCredit);
+  const requestRefundAuthAction = useAction(
+    api.payments.requestRefundAuthorization,
+  );
   const trackView = useAction(api.recentlyViewed.track);
   const listDocumentsByEntity = useAction(api.documents.documents.listByEntity);
   const queryClient = useQueryClient();
@@ -129,6 +134,25 @@ function PatientDetail() {
   >("cash");
   const [refundNotes, setRefundNotes] = useState("");
   const [isRefundSubmitting, setIsRefundSubmitting] = useState(false);
+
+  // Issue #1690: Add Payment from patient page (no appointment required —
+  // funds go straight into the credit balance via creditEarned).
+  const [addPaymentOpen, setAddPaymentOpen] = useState(false);
+  const [addPaymentAmount, setAddPaymentAmount] = useState("");
+  const [addPaymentMethod, setAddPaymentMethod] = useState<
+    "cash" | "card" | "transfer" | "other"
+  >("cash");
+  const [addPaymentNotes, setAddPaymentNotes] = useState("");
+  const [addPaymentAppointmentId, setAddPaymentAppointmentId] =
+    useState<string>("");
+  const [isAddPaymentSubmitting, setIsAddPaymentSubmitting] = useState(false);
+
+  // Cancel-payment confirm state.
+  const [cancellingPaymentId, setCancellingPaymentId] = useState<string | null>(
+    null,
+  );
+  const [cancelReason, setCancelReason] = useState("");
+  const [isCancelSubmitting, setIsCancelSubmitting] = useState(false);
 
   const { data: patient, isLoading } = useSupabaseGabinetPatient(
     organizationId,
@@ -217,15 +241,21 @@ function PatientDetail() {
     enabled: !!organizationId && !!patientId,
   });
 
-  // @ts-ignore — TS2589: deep type instantiation in Convex codegen
-  const { data: myOrgs } = useQuery(
-    convexQuery(api.organizations.getMyOrganizations, {}),
+  // Issue #1690: refund and delete actions are gated by the new
+  // gabinet_payments feature. Members of the org without `refund` permission
+  // get a "request authorization" flow that pings owners/admins instead.
+  const { allowed: canRefundCredit } = usePermission(
+    "gabinet_payments",
+    "refund",
   );
-  const currentOrgRole = (myOrgs ?? []).find(
-    (o: { _id: string; role: string } | null) => o?._id === organizationId,
-  )?.role as "owner" | "admin" | "member" | "viewer" | undefined;
-  const canRefundCredit =
-    currentOrgRole === "owner" || currentOrgRole === "admin";
+  const { allowed: canCancelPayment } = usePermission(
+    "gabinet_payments",
+    "delete",
+  );
+  const { allowed: canCreatePayment } = usePermission(
+    "gabinet_payments",
+    "create",
+  );
 
   const getPaymentForLabel = (payment: {
     appointmentId?: string;
@@ -556,6 +586,142 @@ function PatientDetail() {
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetPatients.list(organizationId) });
       navigate({ to: "/dashboard/gabinet/patients" });
+    }
+  };
+
+  // Issue #1690 — open the "Dodaj wpłatę" dialog from the patient page.
+  const openAddPaymentDialog = () => {
+    setAddPaymentAmount("");
+    setAddPaymentMethod("cash");
+    setAddPaymentNotes("");
+    setAddPaymentAppointmentId("");
+    setAddPaymentOpen(true);
+  };
+
+  const handleAddPayment = async () => {
+    const normalized = addPaymentAmount.replace(",", ".").trim();
+    const amount = parseFloat(normalized);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      toast.error(t("gabinet.payments.amountRequired"));
+      return;
+    }
+    setIsAddPaymentSubmitting(true);
+    try {
+      // No appointment selected → full amount goes to the patient's credit
+      // balance (issue #1690 Q2). With an appointment selected, the backend
+      // still credits any overpayment via creditEarned computed here.
+      let creditEarned = 0;
+      if (!addPaymentAppointmentId) {
+        creditEarned = amount;
+      } else {
+        // Compute outstanding for the chosen appointment from completed
+        // payments visible in patientPayments. Falls back to crediting the
+        // whole amount when we can't price the visit.
+        const apt = (patientAppointments ?? []).find(
+          (a) => a._id === addPaymentAppointmentId,
+        );
+        const treatmentPrice =
+          apt?.treatmentId
+            ? treatmentsData?.find((tr) => tr._id === apt.treatmentId)?.price ??
+              0
+            : 0;
+        const paidForVisit = (patientPayments ?? [])
+          .filter(
+            (p) =>
+              p.appointmentId === addPaymentAppointmentId &&
+              p.status === "completed",
+          )
+          .reduce((sum, p) => sum + (p.amount ?? 0), 0);
+        const outstanding = Math.max(0, treatmentPrice - paidForVisit);
+        if (amount > outstanding + 0.005) {
+          creditEarned = Math.round((amount - outstanding) * 100) / 100;
+        }
+      }
+      await createPaymentAction({
+        organizationId,
+        patientId,
+        appointmentId: addPaymentAppointmentId || undefined,
+        amount,
+        currency: "PLN",
+        paymentMethod: addPaymentMethod,
+        notes: addPaymentNotes.trim() ? addPaymentNotes.trim() : undefined,
+        creditEarned: creditEarned > 0 ? creditEarned : undefined,
+      });
+      toast.success(t("gabinet.payments.created"));
+      setAddPaymentOpen(false);
+      await refetchPatientCredit();
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.payments.all });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "common.error",
+          defaultValue: "Wystąpił błąd.",
+        }),
+      );
+    } finally {
+      setIsAddPaymentSubmitting(false);
+    }
+  };
+
+  const openCancelDialog = (paymentId: string) => {
+    setCancellingPaymentId(paymentId);
+    setCancelReason("");
+  };
+
+  const handleCancelPayment = async () => {
+    if (!cancellingPaymentId) return;
+    setIsCancelSubmitting(true);
+    try {
+      await cancelPaymentAction({
+        organizationId,
+        paymentId: cancellingPaymentId,
+        reason: cancelReason.trim() ? cancelReason.trim() : undefined,
+      });
+      toast.success(t("gabinet.payments.cancelled"));
+      setCancellingPaymentId(null);
+      setCancelReason("");
+      await refetchPatientCredit();
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.payments.all });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "common.error",
+          defaultValue: "Wystąpił błąd.",
+        }),
+      );
+    } finally {
+      setIsCancelSubmitting(false);
+    }
+  };
+
+  // For users without refund permission — sends a request to admins instead
+  // of executing the refund. Same dialog state as the regular refund.
+  const handleRequestRefundAuthorization = async () => {
+    const normalized = refundAmount.replace(",", ".").trim();
+    const amount = parseFloat(normalized);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      toast.error(t("gabinet.payments.amountRequired"));
+      return;
+    }
+    setIsRefundSubmitting(true);
+    try {
+      await requestRefundAuthAction({
+        organizationId,
+        patientId,
+        amount,
+        notes: refundNotes.trim() ? refundNotes.trim() : undefined,
+      });
+      toast.success(t("gabinet.payments.credit.refundRequestSent"));
+      setRefundDialogOpen(false);
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "common.error",
+          defaultValue: "Wystąpił błąd.",
+        }),
+      );
+    } finally {
+      setIsRefundSubmitting(false);
     }
   };
 
@@ -894,11 +1060,13 @@ function PatientDetail() {
       ),
     },
     {
+      // Issue #1690: one merged tab — wpłaty, saldo, naliczenia, zwroty in
+      // a single chronological table with a "Typ" column.
       label: t("gabinet.payments.payments"),
       count: patientPayments?.length ?? 0,
       content: (() => {
         const completedPayments = (patientPayments ?? []).filter(
-          (p) => p.status === "completed",
+          (p) => p.status === "completed" && p.kind !== "credit_refund",
         );
         const totalSpent = completedPayments.reduce(
           (sum, p) => sum + (p.amount ?? 0),
@@ -911,10 +1079,71 @@ function PatientDetail() {
           (sum, p) => sum + (p.amount ?? 0),
           0,
         );
-        const lastPayment = patientPayments?.[0];
+        const balance = patientCredit?.balance ?? 0;
+
+        type PaymentRowType =
+          | "payment"
+          | "overpayment"
+          | "credit_applied"
+          | "credit_refund"
+          | "cancelled"
+          | "refunded";
+
+        const classifyPayment = (p: NonNullable<typeof patientPayments>[number]) => {
+          const earned = p.creditEarned ?? 0;
+          const applied = p.creditApplied ?? 0;
+          if (p.kind === "credit_refund") return "credit_refund" as const;
+          if (p.status === "cancelled") return "cancelled" as const;
+          if (p.status === "refunded") return "refunded" as const;
+          if (earned > 0) return "overpayment" as const;
+          if (applied > 0) return "credit_applied" as const;
+          return "payment" as const;
+        };
+
+        const typeLabelKey: Record<PaymentRowType, string> = {
+          payment: "gabinet.payments.types.payment",
+          overpayment: "gabinet.payments.types.overpayment",
+          credit_applied: "gabinet.payments.types.creditApplied",
+          credit_refund: "gabinet.payments.types.creditRefund",
+          cancelled: "gabinet.payments.types.cancelled",
+          refunded: "gabinet.payments.types.refunded",
+        };
+
+        const typeBadgeClass: Record<PaymentRowType, string> = {
+          payment: "",
+          overpayment:
+            "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-300",
+          credit_applied:
+            "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-300",
+          credit_refund:
+            "border-red-200 bg-red-50 text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300",
+          cancelled:
+            "border-gray-200 bg-gray-50 text-gray-700 dark:border-gray-800/60 dark:bg-gray-950/40 dark:text-gray-300",
+          refunded:
+            "border-red-200 bg-red-50 text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300",
+        };
+
         return (
           <div className="space-y-6">
-            <div className="grid gap-4 sm:grid-cols-3">
+            <div className="grid gap-4 sm:grid-cols-4">
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="flex items-center gap-3">
+                    <WalletIcon
+                      className="h-4 w-4 text-emerald-600"
+                      variant="stroke"
+                    />
+                    <div>
+                      <p className="text-sm text-muted-foreground">
+                        {t("gabinet.payments.credit.available")}
+                      </p>
+                      <p className="text-2xl font-bold tabular-nums">
+                        {formatCurrencyPLN(balance)}
+                      </p>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
               <Card>
                 <CardContent className="pt-6">
                   <div className="flex items-center gap-3">
@@ -953,23 +1182,28 @@ function PatientDetail() {
               </Card>
               <Card>
                 <CardContent className="pt-6">
-                  <div className="flex items-center gap-3">
-                    <Calendar
-                      className="h-4 w-4 text-muted-foreground"
-                      variant="stroke"
-                    />
-                    <div>
-                      <p className="text-sm text-muted-foreground">
-                        {t("gabinet.payments.lastPayment")}
-                      </p>
-                      <p className="font-medium">
-                        {lastPayment
-                          ? new Date(lastPayment.createdAt).toLocaleDateString(
-                              "pl-PL",
-                            )
-                          : "—"}
-                      </p>
-                    </div>
+                  <div className="flex flex-col gap-2">
+                    {canCreatePayment && (
+                      <Button
+                        size="sm"
+                        onClick={openAddPaymentDialog}
+                        className="w-full"
+                      >
+                        <Plus className="mr-1 h-4 w-4" variant="stroke" />
+                        {t("gabinet.payments.addPayment")}
+                      </Button>
+                    )}
+                    {balance > 0 && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={openRefundDialog}
+                        className="w-full"
+                      >
+                        <RefreshCw className="mr-1 h-4 w-4" variant="stroke" />
+                        {t("gabinet.payments.credit.refundCredit")}
+                      </Button>
+                    )}
                   </div>
                 </CardContent>
               </Card>
@@ -997,7 +1231,10 @@ function PatientDetail() {
                       <thead>
                         <tr className="border-b bg-muted/50">
                           <th className="text-left p-3 text-sm font-medium">
-                            {t("gabinet.payments.amount")}
+                            {t("common.date")}
+                          </th>
+                          <th className="text-left p-3 text-sm font-medium">
+                            {t("gabinet.payments.type")}
                           </th>
                           <th className="text-left p-3 text-sm font-medium">
                             {t("gabinet.payments.for")}
@@ -1005,11 +1242,11 @@ function PatientDetail() {
                           <th className="text-left p-3 text-sm font-medium">
                             {t("gabinet.payments.method")}
                           </th>
-                          <th className="text-left p-3 text-sm font-medium">
-                            {t("common.date")}
+                          <th className="text-right p-3 text-sm font-medium">
+                            {t("gabinet.payments.amount")}
                           </th>
-                          <th className="text-left p-3 text-sm font-medium">
-                            {t("common.status")}
+                          <th className="text-right p-3 text-sm font-medium">
+                            {t("gabinet.payments.balanceDelta")}
                           </th>
                           <th className="text-right p-3 text-sm font-medium">
                             {t("common.actions")}
@@ -1017,90 +1254,138 @@ function PatientDetail() {
                         </tr>
                       </thead>
                       <tbody>
-                        {patientPayments.map((payment) => (
-                          <tr
-                            key={payment._id}
-                            className={`border-b last:border-0 hover:bg-muted/30 ${
-                              payment.appointmentId
-                                ? "cursor-pointer"
-                                : ""
-                            }`}
-                            onClick={() => {
-                              if (payment.appointmentId) {
-                                navigate({
-                                  to: "/dashboard/gabinet/appointments/$appointmentId",
-                                  params: {
-                                    appointmentId: payment.appointmentId,
-                                  },
-                                });
-                              }
-                            }}
-                          >
-                            <td className="p-3 font-medium">
-                              {formatCurrencyPLN(
-                                payment.amount,
-                                payment.currency ?? "PLN",
-                              )}
-                            </td>
-                            <td className="p-3 text-sm">
-                              <div
-                                className="max-w-[260px] truncate"
-                                title={getPaymentForLabel(payment)}
-                              >
-                                {getPaymentForLabel(payment)}
-                              </div>
-                            </td>
-                            <td className="p-3">
-                              <Badge variant="outline">
-                                {t(
-                                  `gabinet.payments.methods.${payment.paymentMethod}`,
-                                )}
-                              </Badge>
-                            </td>
-                            <td className="p-3 text-sm text-muted-foreground">
-                              {new Date(
-                                payment.createdAt,
-                              ).toLocaleDateString("pl-PL")}
-                            </td>
-                            <td className="p-3">
-                              <Badge
-                                variant={
-                                  payment.status === "completed"
-                                    ? "default"
-                                    : payment.status === "refunded"
-                                      ? "destructive"
-                                      : "secondary"
-                                }
-                              >
-                                {t(
-                                  `gabinet.payments.status.${payment.status}`,
-                                )}
-                              </Badge>
-                            </td>
-                            <td className="p-3 text-right">
-                              {(payment.status === "completed" ||
-                                payment.status === "pending") && (
-                                <Button
-                                  size="sm"
-                                  variant="ghost"
-                                  aria-label={t("common.edit")}
-                                  title={t("gabinet.payments.editPayment")}
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    openEditPaymentDialog({
-                                      _id: payment._id,
-                                      amount: payment.amount,
-                                      paymentMethod: payment.paymentMethod,
-                                      notes: payment.notes,
+                        {[...patientPayments]
+                          .sort((a, b) => b.createdAt - a.createdAt)
+                          .map((payment) => {
+                            const type = classifyPayment(payment);
+                            const earned = payment.creditEarned ?? 0;
+                            const applied = payment.creditApplied ?? 0;
+                            const balanceDelta = earned - applied;
+                            const isCancellable =
+                              canCancelPayment &&
+                              (payment.status === "completed" ||
+                                payment.status === "pending");
+                            const isEditable =
+                              payment.status === "completed" ||
+                              payment.status === "pending";
+                            return (
+                              <tr
+                                key={payment._id}
+                                className={`border-b last:border-0 hover:bg-muted/30 ${
+                                  payment.appointmentId
+                                    ? "cursor-pointer"
+                                    : ""
+                                }`}
+                                onClick={() => {
+                                  if (payment.appointmentId) {
+                                    navigate({
+                                      to: "/dashboard/gabinet/appointments/$appointmentId",
+                                      params: {
+                                        appointmentId: payment.appointmentId,
+                                      },
                                     });
-                                  }}
+                                  }
+                                }}
+                              >
+                                <td className="p-3 text-sm text-muted-foreground whitespace-nowrap">
+                                  {new Date(
+                                    payment.createdAt,
+                                  ).toLocaleDateString("pl-PL")}
+                                </td>
+                                <td className="p-3">
+                                  <Badge
+                                    variant="outline"
+                                    className={`text-[10px] ${typeBadgeClass[type]}`}
+                                  >
+                                    {t(typeLabelKey[type])}
+                                  </Badge>
+                                </td>
+                                <td className="p-3 text-sm">
+                                  <div
+                                    className="max-w-[220px] truncate"
+                                    title={getPaymentForLabel(payment)}
+                                  >
+                                    {getPaymentForLabel(payment)}
+                                  </div>
+                                </td>
+                                <td className="p-3">
+                                  <Badge variant="outline">
+                                    {t(
+                                      `gabinet.payments.methods.${payment.paymentMethod}`,
+                                    )}
+                                  </Badge>
+                                </td>
+                                <td className="p-3 text-right font-medium tabular-nums">
+                                  {formatCurrencyPLN(
+                                    payment.amount,
+                                    payment.currency ?? "PLN",
+                                  )}
+                                </td>
+                                <td
+                                  className={`p-3 text-right font-semibold tabular-nums ${
+                                    balanceDelta > 0
+                                      ? "text-emerald-600"
+                                      : balanceDelta < 0
+                                        ? "text-red-600"
+                                        : "text-muted-foreground"
+                                  }`}
                                 >
-                                  <Pencil className="h-4 w-4" variant="stroke" />
-                                </Button>
-                              )}
-                            </td>
-                          </tr>
-                        ))}
+                                  {balanceDelta === 0
+                                    ? "—"
+                                    : `${balanceDelta > 0 ? "+" : "−"}${formatCurrencyPLN(Math.abs(balanceDelta))}`}
+                                </td>
+                                <td className="p-3 text-right">
+                                  <div className="flex justify-end gap-1">
+                                    {isEditable && (
+                                      <Button
+                                        size="sm"
+                                        variant="ghost"
+                                        aria-label={t("common.edit")}
+                                        title={t(
+                                          "gabinet.payments.editPayment",
+                                        )}
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          openEditPaymentDialog({
+                                            _id: payment._id,
+                                            amount: payment.amount,
+                                            paymentMethod:
+                                              payment.paymentMethod,
+                                            notes: payment.notes,
+                                          });
+                                        }}
+                                      >
+                                        <Pencil
+                                          className="h-4 w-4"
+                                          variant="stroke"
+                                        />
+                                      </Button>
+                                    )}
+                                    {isCancellable && (
+                                      <Button
+                                        size="sm"
+                                        variant="ghost"
+                                        className="text-destructive"
+                                        aria-label={t("common.cancel")}
+                                        title={t(
+                                          "gabinet.payments.cancelPayment",
+                                        )}
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          openCancelDialog(payment._id);
+                                        }}
+                                      >
+                                        <Minus
+                                          className="h-4 w-4"
+                                          variant="stroke"
+                                        />
+                                      </Button>
+                                    )}
+                                  </div>
+                                </td>
+                              </tr>
+                            );
+                          })}
                       </tbody>
                     </table>
                   </div>
@@ -1281,148 +1566,6 @@ function PatientDetail() {
       ),
     },
     {
-      label: t("gabinet.patients.tabs.credit"),
-      count: patientCredit?.history.length ?? 0,
-      content: (() => {
-        const balance = patientCredit?.balance ?? 0;
-        const history = patientCredit?.history ?? [];
-        return (
-          <div className="space-y-6">
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="flex items-center gap-3">
-                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
-                      <WalletIcon className="h-5 w-5" variant="stroke" />
-                    </div>
-                    <div>
-                      <p className="text-sm text-muted-foreground">
-                        {t("gabinet.payments.credit.available")}
-                      </p>
-                      <p className="text-2xl font-bold tabular-nums">
-                        {formatCurrencyPLN(balance)}
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground max-w-md">
-                        {t("gabinet.payments.credit.description")}
-                      </p>
-                    </div>
-                  </div>
-                  {canRefundCredit && balance > 0 && (
-                    <Button
-                      variant="outline"
-                      onClick={openRefundDialog}
-                      className="sm:self-start"
-                    >
-                      <RefreshCw className="mr-1 h-4 w-4" variant="stroke" />
-                      {t("gabinet.payments.credit.refundCredit")}
-                    </Button>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardContent className="pt-6 space-y-4">
-                <h3 className="text-sm font-semibold flex items-center gap-2">
-                  <WalletIcon
-                    className="h-4 w-4 text-muted-foreground"
-                    variant="stroke"
-                  />
-                  {t("gabinet.payments.credit.history")}
-                </h3>
-                {history.length === 0 ? (
-                  <div className="flex flex-col items-center justify-center py-12 text-center">
-                    <WalletIcon className="h-10 w-10 text-muted-foreground/40 mb-3" />
-                    <p className="text-sm text-muted-foreground">
-                      {t("gabinet.payments.credit.noCredit")}
-                    </p>
-                  </div>
-                ) : (
-                  <div className="overflow-x-auto border rounded-lg">
-                    <table className="w-full">
-                      <thead>
-                        <tr className="border-b bg-muted/50">
-                          <th className="text-left p-3 text-sm font-medium">
-                            {t("common.date")}
-                          </th>
-                          <th className="text-left p-3 text-sm font-medium">
-                            {t("gabinet.payments.for")}
-                          </th>
-                          <th className="text-right p-3 text-sm font-medium">
-                            {t("gabinet.payments.amount")}
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {history.map((entry) => {
-                          const isRefund = entry.kind === "credit_refund";
-                          const isEarned = entry.creditEarned > 0;
-                          const isApplied = entry.creditApplied > 0;
-                          let label: string;
-                          let delta: number;
-                          let deltaClass: string;
-                          if (isRefund) {
-                            label = t("gabinet.payments.credit.refund");
-                            // Refund row stores creditEarned = -amount; show as
-                            // negative delta to balance.
-                            delta = entry.creditEarned;
-                            deltaClass = "text-red-600";
-                          } else if (isEarned) {
-                            label = t("gabinet.payments.credit.earned");
-                            delta = entry.creditEarned;
-                            deltaClass = "text-emerald-600";
-                          } else if (isApplied) {
-                            label = t("gabinet.payments.credit.applied");
-                            delta = -entry.creditApplied;
-                            deltaClass = "text-red-600";
-                          } else {
-                            label = entry.notes ?? "—";
-                            delta = 0;
-                            deltaClass = "text-muted-foreground";
-                          }
-                          return (
-                            <tr
-                              key={entry._id}
-                              className={`border-b last:border-0 hover:bg-muted/30 ${
-                                entry.appointmentId ? "cursor-pointer" : ""
-                              }`}
-                              onClick={() => {
-                                if (entry.appointmentId) {
-                                  navigate({
-                                    to: "/dashboard/gabinet/appointments/$appointmentId",
-                                    params: {
-                                      appointmentId: entry.appointmentId,
-                                    },
-                                  });
-                                }
-                              }}
-                            >
-                              <td className="p-3 text-sm text-muted-foreground">
-                                {new Date(entry.createdAt).toLocaleDateString(
-                                  "pl-PL",
-                                )}
-                              </td>
-                              <td className="p-3 text-sm">{label}</td>
-                              <td
-                                className={`p-3 text-right font-semibold tabular-nums ${deltaClass}`}
-                              >
-                                {delta > 0 ? "+" : delta < 0 ? "−" : ""}
-                                {formatCurrencyPLN(Math.abs(delta))}
-                              </td>
-                            </tr>
-                          );
-                        })}
-                      </tbody>
-                    </table>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          </div>
-        );
-      })(),
-    },
-    {
       label: t("gabinet.patients.tabs.activity"),
       content: (
         <ActivityFeed
@@ -1591,10 +1734,14 @@ function PatientDetail() {
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>
-              {t("gabinet.payments.credit.refundDialogTitle")}
+              {canRefundCredit
+                ? t("gabinet.payments.credit.refundDialogTitle")
+                : t("gabinet.payments.credit.requestRefundDialogTitle")}
             </DialogTitle>
             <DialogDescription>
-              {t("gabinet.payments.credit.refundDialogDesc")}
+              {canRefundCredit
+                ? t("gabinet.payments.credit.refundDialogDesc")
+                : t("gabinet.payments.credit.requestRefundDialogDesc")}
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-2">
@@ -1621,12 +1768,108 @@ function PatientDetail() {
                 placeholder="0.00"
               />
             </div>
+            {canRefundCredit && (
+              <div>
+                <Label>{t("gabinet.payments.credit.refundMethod")}</Label>
+                <Select
+                  value={refundMethod}
+                  onValueChange={(v) =>
+                    setRefundMethod(
+                      v as "cash" | "card" | "transfer" | "other",
+                    )
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="cash">
+                      {t("gabinet.payments.methods.cash")}
+                    </SelectItem>
+                    <SelectItem value="card">
+                      {t("gabinet.payments.methods.card")}
+                    </SelectItem>
+                    <SelectItem value="transfer">
+                      {t("gabinet.payments.methods.transfer")}
+                    </SelectItem>
+                    <SelectItem value="other">
+                      {t("gabinet.payments.methods.other")}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
             <div>
-              <Label>{t("gabinet.payments.credit.refundMethod")}</Label>
+              <Label>{t("gabinet.payments.credit.refundNotes")}</Label>
+              <Input
+                type="text"
+                value={refundNotes}
+                onChange={(e) => setRefundNotes(e.target.value)}
+                placeholder={t("gabinet.payments.notePlaceholder")}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setRefundDialogOpen(false)}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button
+              onClick={
+                canRefundCredit
+                  ? handleRefundCredit
+                  : handleRequestRefundAuthorization
+              }
+              disabled={isRefundSubmitting}
+            >
+              {isRefundSubmitting
+                ? t("common.processing")
+                : canRefundCredit
+                  ? t("gabinet.payments.credit.refundConfirm")
+                  : t("gabinet.payments.credit.requestRefundConfirm")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Issue #1690: Add a free-standing payment from the patient page. */}
+      <Dialog
+        open={addPaymentOpen}
+        onOpenChange={(open) => {
+          if (!open) setAddPaymentOpen(false);
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t("gabinet.payments.addPayment")}</DialogTitle>
+            <DialogDescription>
+              {t("gabinet.payments.addPaymentPatientDesc")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div>
+              <Label>{t("gabinet.payments.amount")}</Label>
+              <Input
+                type="text"
+                inputMode="decimal"
+                value={addPaymentAmount}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                    setAddPaymentAmount(v);
+                  }
+                }}
+                placeholder="0.00"
+              />
+            </div>
+            <div>
+              <Label>{t("gabinet.payments.method")}</Label>
               <Select
-                value={refundMethod}
+                value={addPaymentMethod}
                 onValueChange={(v) =>
-                  setRefundMethod(
+                  setAddPaymentMethod(
                     v as "cash" | "card" | "transfer" | "other",
                   )
                 }
@@ -1651,11 +1894,60 @@ function PatientDetail() {
               </Select>
             </div>
             <div>
-              <Label>{t("gabinet.payments.credit.refundNotes")}</Label>
+              <Label>
+                {t("gabinet.payments.linkedAppointment")}{" "}
+                <span className="text-xs text-muted-foreground">
+                  ({t("common.optional")})
+                </span>
+              </Label>
+              <Select
+                value={addPaymentAppointmentId || "none"}
+                onValueChange={(v) =>
+                  setAddPaymentAppointmentId(v === "none" ? "" : v)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">
+                    {t("gabinet.payments.noAppointmentToCredit")}
+                  </SelectItem>
+                  {(() => {
+                    const today = new Date().toISOString().split("T")[0];
+                    const upcoming = (patientAppointments ?? [])
+                      .filter(
+                        (a) =>
+                          a.date >= today &&
+                          a.status !== "cancelled" &&
+                          a.status !== "no_show",
+                      )
+                      .slice(0, 20);
+                    return upcoming.map((apt) => {
+                      const treatmentName =
+                        treatmentsData?.find((tr) => tr._id === apt.treatmentId)
+                          ?.name ?? t("common.unknown");
+                      return (
+                        <SelectItem key={apt._id} value={apt._id}>
+                          {apt.date} · {apt.startTime} · {treatmentName}
+                        </SelectItem>
+                      );
+                    });
+                  })()}
+                </SelectContent>
+              </Select>
+              {!addPaymentAppointmentId && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t("gabinet.payments.fullAmountToCreditHint")}
+                </p>
+              )}
+            </div>
+            <div>
+              <Label>{t("common.notes")}</Label>
               <Input
                 type="text"
-                value={refundNotes}
-                onChange={(e) => setRefundNotes(e.target.value)}
+                value={addPaymentNotes}
+                onChange={(e) => setAddPaymentNotes(e.target.value)}
                 placeholder={t("gabinet.payments.notePlaceholder")}
               />
             </div>
@@ -1663,22 +1955,77 @@ function PatientDetail() {
           <DialogFooter>
             <Button
               variant="outline"
-              onClick={() => setRefundDialogOpen(false)}
+              onClick={() => setAddPaymentOpen(false)}
             >
               {t("common.cancel")}
             </Button>
             <Button
-              onClick={handleRefundCredit}
-              disabled={isRefundSubmitting}
+              onClick={handleAddPayment}
+              disabled={isAddPaymentSubmitting}
             >
-              {isRefundSubmitting
+              {isAddPaymentSubmitting
                 ? t("common.processing")
-                : t("gabinet.payments.credit.refundConfirm")}
+                : t("gabinet.payments.create")}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
+      {/* Issue #1690: per-row soft-cancel (no hard delete — status flip). */}
+      <Dialog
+        open={cancellingPaymentId !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setCancellingPaymentId(null);
+            setCancelReason("");
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t("gabinet.payments.cancelPayment")}</DialogTitle>
+            <DialogDescription>
+              {t("gabinet.payments.cancelPaymentDesc")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div>
+              <Label>
+                {t("gabinet.payments.cancelReason")}{" "}
+                <span className="text-xs text-muted-foreground">
+                  ({t("common.optional")})
+                </span>
+              </Label>
+              <Input
+                type="text"
+                value={cancelReason}
+                onChange={(e) => setCancelReason(e.target.value)}
+                placeholder={t("gabinet.payments.cancelReasonPlaceholder")}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setCancellingPaymentId(null);
+                setCancelReason("");
+              }}
+            >
+              {t("common.close")}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleCancelPayment}
+              disabled={isCancelSubmitting}
+            >
+              {isCancelSubmitting
+                ? t("common.processing")
+                : t("gabinet.payments.cancelConfirm")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -424,7 +424,7 @@ describe("payments", () => {
     ).rejects.toThrow(/exceeds available credit/);
   });
 
-  test("refundCredit is admin-only", async () => {
+  test("refundCredit is gated by gabinet_payments.refund (issue #1690)", async () => {
     const t = createTestCtx();
     const { organizationId, identity } = await seedTestUser(t, {
       role: "member",
@@ -438,7 +438,7 @@ describe("payments", () => {
         amount: 50,
         paymentMethod: "cash",
       }),
-    ).rejects.toThrow(/admins can refund/);
+    ).rejects.toThrow(/REFUND_NOT_AUTHORIZED/);
   });
 
   test("refunding a payment with creditEarned releases that credit", async () => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1690.

Closes #1690

---

## Claude summary

Committed `a7aade4` on `claude/issue-1690`.

Summary of the fix: in the appointment payment dialog (`_layout.gabinet.appointments.$appointmentId.lazy.tsx`), when the user checks "Użyj salda klienta", the payment method `<Select>` now disappears — matching the user's expectation that "rozliczenie z salda" is itself the payment method. The submit handler also accepts an empty amount in that case (treats it as 0), so a balance-only settlement just needs one click on the checkbox + Submit; the existing `creditApplied = min(balance, outstanding − amount)` math then takes care of the rest.