### PR TITLE
Add manual "Receive / issue stock" dialog on the products table

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -115,6 +115,7 @@ import type * as google_oauth from "../google/oauth.js";
 import type * as googleCalendarSyncConfigs from "../googleCalendarSyncConfigs.js";
 import type * as http from "../http.js";
 import type * as init from "../init.js";
+import type * as inventory from "../inventory.js";
 import type * as invitations from "../invitations.js";
 import type * as leads from "../leads.js";
 import type * as lostReasons from "../lostReasons.js";
@@ -298,6 +299,7 @@ declare const fullApi: ApiFromModules<{
   googleCalendarSyncConfigs: typeof googleCalendarSyncConfigs;
   http: typeof http;
   init: typeof init;
+  inventory: typeof inventory;
   invitations: typeof invitations;
   leads: typeof leads;
   lostReasons: typeof lostReasons;

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -778,7 +778,25 @@
       "trackHelp": "Every stock change is recorded in the movement history. When disabled, history can still be kept manually, but the running balance is not enforced.",
       "unitLabel": "Unit",
       "unitPlaceholder": "pcs, ml, g…",
-      "initialLabel": "Initial stock"
+      "initialLabel": "Initial stock",
+      "adjust": {
+        "action": "Receive / issue stock",
+        "title": "Receive / issue stock",
+        "currentBalance": "Current balance",
+        "modeLabel": "Operation",
+        "receive": "Receive (+)",
+        "issue": "Issue (−)",
+        "quantityLabel": "Quantity",
+        "projected": "New balance: {{value}}",
+        "negativeHint": "warning: negative stock",
+        "locationLabel": "Location",
+        "locationNone": "No location",
+        "noteLabel": "Note",
+        "notePlaceholder": "Reason, document number, …",
+        "success": "Stock updated.",
+        "negativeWarning": "Stock went negative. Review the movement history and correct shortages.",
+        "error": "Could not update stock."
+      }
     }
   },
   "calls": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -792,7 +792,25 @@
       "trackHelp": "Każda zmiana stanu zapisuje się w historii ruchów. Jeśli wyłączone, historia może być nadal prowadzona ręcznie, ale stan nie jest pilnowany.",
       "unitLabel": "Jednostka",
       "unitPlaceholder": "szt., ml, g…",
-      "initialLabel": "Stan początkowy"
+      "initialLabel": "Stan początkowy",
+      "adjust": {
+        "action": "Przyjmij / wydaj towar",
+        "title": "Przyjmij / wydaj towar",
+        "currentBalance": "Aktualny stan",
+        "modeLabel": "Operacja",
+        "receive": "Przyjęcie (+)",
+        "issue": "Wydanie (−)",
+        "quantityLabel": "Ilość",
+        "projected": "Nowy stan: {{value}}",
+        "negativeHint": "uwaga: stan ujemny",
+        "locationLabel": "Lokalizacja",
+        "locationNone": "Bez lokalizacji",
+        "noteLabel": "Notatka",
+        "notePlaceholder": "Powód operacji, numer dokumentu, …",
+        "success": "Stan magazynowy zaktualizowany.",
+        "negativeWarning": "Stan magazynowy spadł poniżej zera. Sprawdź historię ruchów i skoryguj braki.",
+        "error": "Nie udało się zaktualizować stanu magazynowego."
+      }
     }
   },
   "calls": {

--- a/src/components/forms/product-stock-adjust-dialog.tsx
+++ b/src/components/forms/product-stock-adjust-dialog.tsx
@@ -1,0 +1,370 @@
+import { useEffect, useMemo, useState } from "react";
+import { useAction } from "convex/react";
+import { makeFunctionReference } from "convex/server";
+import { useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import type { Id } from "@cvx/_generated/dataModel";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
+import { useSupabaseProductStockTotals } from "@/hooks/use-supabase-products";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
+import { formatActionError } from "@/lib/format-action-error";
+import { cn } from "@/lib/utils";
+import type { MappedProduct } from "@/lib/supabase/mappers/products";
+
+interface ProductStockAdjustDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationId: string;
+  product: MappedProduct | null;
+}
+
+type Mode = "receive" | "issue";
+
+const ALL_LOCATIONS_VALUE = "__all__";
+
+// `convex/inventory.ts` also exports a plain helper `applyMovementInternal`,
+// which inflates the inferred module type enough that going through
+// `api.inventory.adjustStock` trips TS's "type instantiation excessively deep"
+// guard. Build a FunctionReference by name instead, which keeps the call site
+// strictly typed without re-instantiating the whole API surface.
+type AdjustStockArgs = {
+  organizationId: Id<"organizations">;
+  productId: string;
+  locationId?: Id<"gabinetLocations"> | null;
+  delta?: number;
+  setTo?: number;
+  reason?:
+    | "initial"
+    | "manual_adjust"
+    | "appointment_use"
+    | "appointment_return"
+    | "deal_close"
+    | "deal_reopen"
+    | "transfer_in"
+    | "transfer_out"
+    | "other";
+  note?: string | null;
+};
+type AdjustStockResult = {
+  movementId: string;
+  balanceAfter: number;
+  warning: string | null;
+};
+const adjustStockRef = makeFunctionReference<
+  "action",
+  AdjustStockArgs,
+  AdjustStockResult
+>("inventory:adjustStock");
+
+export function ProductStockAdjustDialog({
+  open,
+  onOpenChange,
+  organizationId,
+  product,
+}: ProductStockAdjustDialogProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const adjustStock = useAction(adjustStockRef);
+  const { data: locations = [] } = useSupabaseGabinetLocationsList(
+    organizationId,
+    { activeOnly: true },
+  );
+  const { totalsByProductId } = useSupabaseProductStockTotals(organizationId);
+
+  const [mode, setMode] = useState<Mode>("receive");
+  const [quantity, setQuantity] = useState("");
+  const [locationId, setLocationId] = useState<string>(ALL_LOCATIONS_VALUE);
+  const [note, setNote] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Reset form when dialog opens for a new product.
+  useEffect(() => {
+    if (open) {
+      setMode("receive");
+      setQuantity("");
+      setLocationId(ALL_LOCATIONS_VALUE);
+      setNote("");
+    }
+  }, [open, product?._id]);
+
+  const stockSummary = product ? totalsByProductId.get(product._id) : undefined;
+  const unit = product?.stockUnit?.trim() || "";
+
+  const currentBalance = useMemo(() => {
+    if (!stockSummary) return 0;
+    const targetLocationId =
+      locationId === ALL_LOCATIONS_VALUE ? null : locationId;
+    const match = stockSummary.byLocation.find(
+      (row) => row.locationId === targetLocationId,
+    );
+    return match?.quantity ?? 0;
+  }, [stockSummary, locationId]);
+
+  const parsedQuantity = (() => {
+    if (!quantity.trim()) return null;
+    const parsed = parseFloat(quantity.replace(",", "."));
+    if (!Number.isFinite(parsed) || parsed <= 0) return null;
+    return parsed;
+  })();
+
+  const delta = parsedQuantity == null ? null : mode === "receive" ? parsedQuantity : -parsedQuantity;
+  const projectedBalance = delta == null ? currentBalance : currentBalance + delta;
+  const wouldGoNegative = projectedBalance < 0;
+
+  const handleSubmit = async () => {
+    if (!product || parsedQuantity == null || delta == null) return;
+    setIsSubmitting(true);
+    try {
+      const result = await adjustStock({
+        organizationId: organizationId as Id<"organizations">,
+        productId: product._id,
+        locationId:
+          locationId === ALL_LOCATIONS_VALUE
+            ? null
+            : (locationId as Id<"gabinetLocations">),
+        delta,
+        reason: "manual_adjust",
+        note: note.trim() || null,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: supabaseKeys.productStockLevels.list(organizationId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: supabaseKeys.productStockMovements.list(organizationId),
+      });
+      if (result.warning === "negative_stock") {
+        toast.warning(
+          t("products.stock.adjust.negativeWarning", {
+            defaultValue:
+              "Stan magazynowy spadł poniżej zera. Sprawdź historię ruchów i skoryguj braki.",
+          }),
+        );
+      } else {
+        toast.success(
+          t("products.stock.adjust.success", {
+            defaultValue: "Stan magazynowy zaktualizowany.",
+          }),
+        );
+      }
+      onOpenChange(false);
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "products.stock.adjust.error",
+          defaultValue: "Nie udało się zaktualizować stanu magazynowego.",
+        }),
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!product) return null;
+
+  const canSubmit = parsedQuantity != null && !isSubmitting;
+  const formatBalance = (value: number) =>
+    `${value}${unit ? ` ${unit}` : ""}`;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {t("products.stock.adjust.title", {
+              defaultValue: "Przyjmij / wydaj towar",
+            })}
+          </DialogTitle>
+          <DialogDescription>{product.name}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">
+                {t("products.stock.adjust.currentBalance", {
+                  defaultValue: "Aktualny stan",
+                })}
+              </span>
+              <span className="font-medium">
+                {formatBalance(currentBalance)}
+              </span>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>
+              {t("products.stock.adjust.modeLabel", {
+                defaultValue: "Operacja",
+              })}
+            </Label>
+            <RadioGroup
+              value={mode}
+              onValueChange={(value) => setMode(value as Mode)}
+              className="grid grid-cols-2 gap-2"
+            >
+              <label
+                htmlFor="stock-mode-receive"
+                className={cn(
+                  "flex cursor-pointer items-center gap-2 rounded-md border p-3 transition-colors hover:bg-muted/30",
+                  mode === "receive" && "border-primary bg-primary/5",
+                )}
+              >
+                <RadioGroupItem value="receive" id="stock-mode-receive" />
+                <span className="text-sm font-medium">
+                  {t("products.stock.adjust.receive", {
+                    defaultValue: "Przyjęcie (+)",
+                  })}
+                </span>
+              </label>
+              <label
+                htmlFor="stock-mode-issue"
+                className={cn(
+                  "flex cursor-pointer items-center gap-2 rounded-md border p-3 transition-colors hover:bg-muted/30",
+                  mode === "issue" && "border-primary bg-primary/5",
+                )}
+              >
+                <RadioGroupItem value="issue" id="stock-mode-issue" />
+                <span className="text-sm font-medium">
+                  {t("products.stock.adjust.issue", {
+                    defaultValue: "Wydanie (−)",
+                  })}
+                </span>
+              </label>
+            </RadioGroup>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="stock-quantity">
+              {t("products.stock.adjust.quantityLabel", {
+                defaultValue: "Ilość",
+              })}
+              <span className="text-destructive"> *</span>
+            </Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="stock-quantity"
+                type="text"
+                inputMode="decimal"
+                value={quantity}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                    setQuantity(v);
+                  }
+                }}
+                placeholder="0"
+                autoFocus
+              />
+              {unit && (
+                <span className="text-sm text-muted-foreground">{unit}</span>
+              )}
+            </div>
+            {parsedQuantity != null && (
+              <p
+                className={cn(
+                  "text-xs",
+                  wouldGoNegative
+                    ? "text-destructive"
+                    : "text-muted-foreground",
+                )}
+              >
+                {t("products.stock.adjust.projected", {
+                  defaultValue: "Nowy stan: {{value}}",
+                  value: formatBalance(projectedBalance),
+                })}
+                {wouldGoNegative
+                  ? ` — ${t("products.stock.adjust.negativeHint", {
+                      defaultValue: "uwaga: stan ujemny",
+                    })}`
+                  : ""}
+              </p>
+            )}
+          </div>
+
+          {locations.length > 0 && (
+            <div className="space-y-1.5">
+              <Label>
+                {t("products.stock.adjust.locationLabel", {
+                  defaultValue: "Lokalizacja",
+                })}
+              </Label>
+              <Select value={locationId} onValueChange={setLocationId}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL_LOCATIONS_VALUE}>
+                    {t("products.stock.adjust.locationNone", {
+                      defaultValue: "Bez lokalizacji",
+                    })}
+                  </SelectItem>
+                  {locations.map((loc) => (
+                    <SelectItem key={loc._id} value={loc._id}>
+                      {loc.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="stock-note">
+              {t("products.stock.adjust.noteLabel", {
+                defaultValue: "Notatka",
+              })}
+            </Label>
+            <Textarea
+              id="stock-note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder={t("products.stock.adjust.notePlaceholder", {
+                defaultValue: "Powód operacji, numer dokumentu, …",
+              })}
+              rows={2}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSubmitting}
+          >
+            {t("common.cancel")}
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+          >
+            {t("common.save")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -26,9 +26,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Plus, Pencil, Trash2, Power, Upload, Download, X } from "@/lib/ez-icons";
+import { Plus, Pencil, Trash2, Power, Upload, Download, X, Package } from "@/lib/ez-icons";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { CsvImportDialog } from "@/components/csv/csv-import-dialog";
+import { ProductStockAdjustDialog } from "@/components/forms/product-stock-adjust-dialog";
 import type { SavedView, FieldDef, FilterCondition } from "@/components/crm/types";
 import { Id } from "@cvx/_generated/dataModel";
 import type { MappedProduct } from "@/lib/supabase/mappers/products";
@@ -147,6 +148,7 @@ function ProductsPage() {
   useSidebarDispatch("manageTags", () => setTagsSlideoutOpen(true));
   useSidebarDispatch("manageCategories", () => setCategoriesSlideoutOpen(true));
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
+  const [stockAdjustProduct, setStockAdjustProduct] = useState<Product | null>(null);
 
   // Form state
   const [name, setName] = useState("");
@@ -356,23 +358,35 @@ function ProductsPage() {
   const { allColumns, defaultHidden } = useAllColumns(columns, filterableFields);
   const { hiddenColumnIds, toggleColumn, setHiddenColumns } = useColumnVisibility(defaultHidden, "products");
 
-  const rowActions = (row: Product) => [
-    {
-      label: t('common.edit'),
-      icon: <Pencil className="h-4 w-4" variant="stroke" />,
-      onClick: () => openEditPanel(row),
-    },
-    {
-      label: row.isActive ? t('products.deactivate') : t('products.activate'),
-      icon: <Power className="h-4 w-4" variant="stroke" />,
-      onClick: () => toggleActive({ organizationId, productId: row._id }),
-    },
-    {
-      label: t('common.delete'),
-      icon: <Trash2 className="h-4 w-4" variant="stroke" />,
-      onClick: () => removeProduct({ organizationId, productId: row._id }),
-    },
-  ];
+  const rowActions = (row: Product) => {
+    const actions = [
+      {
+        label: t('common.edit'),
+        icon: <Pencil className="h-4 w-4" variant="stroke" />,
+        onClick: () => openEditPanel(row),
+      },
+    ];
+    if (row.trackStock) {
+      actions.push({
+        label: t('products.stock.adjust.action', { defaultValue: 'Przyjmij / wydaj towar' }),
+        icon: <Package className="h-4 w-4" variant="stroke" />,
+        onClick: () => setStockAdjustProduct(row),
+      });
+    }
+    actions.push(
+      {
+        label: row.isActive ? t('products.deactivate') : t('products.activate'),
+        icon: <Power className="h-4 w-4" variant="stroke" />,
+        onClick: () => toggleActive({ organizationId, productId: row._id }),
+      },
+      {
+        label: t('common.delete'),
+        icon: <Trash2 className="h-4 w-4" variant="stroke" />,
+        onClick: () => removeProduct({ organizationId, productId: row._id }),
+      },
+    );
+    return actions;
+  };
 
   return (
     <div className="space-y-4">
@@ -629,6 +643,15 @@ function ProductsPage() {
           </div>
         </div>
       </SidePanel>
+
+      <ProductStockAdjustDialog
+        open={!!stockAdjustProduct}
+        onOpenChange={(open) => {
+          if (!open) setStockAdjustProduct(null);
+        }}
+        organizationId={organizationId}
+        product={stockAdjustProduct}
+      />
 
       <TagsManagerSlideout
         isOpen={tagsSlideoutOpen}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1725.

Closes #1725

---

## Claude summary

Committed `ce4940d` on `claude/issue-1725`.

The worktree already had most of the work in flight, so I verified, finished, and committed it. What landed:

- `src/components/forms/product-stock-adjust-dialog.tsx` — new dialog with receive/issue radio, decimal quantity input with unit suffix, optional location selector (uses `useSupabaseGabinetLocationsList`), note field, live "current → new balance" preview with a negative-stock hint. Submits to `inventory:adjustStock` via a `makeFunctionReference` (the in-file comment notes this is to dodge a TS "type instantiation excessively deep" error caused by `applyMovementInternal` co-located in `convex/inventory.ts`). Invalidates `productStockLevels` and `productStockMovements` query keys, surfaces the backend's `negative_stock` warning as a `toast.warning`.
- `src/routes/_app/_auth/dashboard/_layout.products.index.tsx` — adds a "Przyjmij / wydaj towar" row action conditionally rendered only when `row.trackStock` is true; mounts the dialog with `stockAdjustProduct` state.
- `public/locales/{en,pl}/translation.json` — `products.stock.adjust.*` keys for action label, title, mode, quantity, location, note, projected/negative-stock copy, success/warning/error toasts.
- `convex/_generated/api.d.ts` — regenerated to include `inventory` module.

Typecheck: the two pre-existing errors in `convex/gabinet/_availability_supabase.ts` exist on `main` too (verified by stashing) — unrelated to this issue.

## Follow-ups
- Fix typecheck errors in convex/gabinet/_availability_supabase.ts: `roomAppointments` declared-but-unused (line 449) and `appointments` undefined (line 456) — present on main, blocks clean `npm run typecheck`.