### PR TITLE
Add optimistic-concurrency guard on refund authorization approve

### DIFF
--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -1171,6 +1171,18 @@ export const approveRefundAuth = action({
       );
     }
 
+    // DB-level claim (#1730): atomically transition every sibling notification
+    // for this requestId from "pending" → "approved" inside a single Convex
+    // transaction. Two admins clicking Approve at the same time both pass the
+    // JS-level check above, but only the first claim mutation lands — the
+    // second sees status="approved" and throws before we touch Supabase.
+    await ctx.runMutation(internal.payments._claimRefundAuthRequest, {
+      organizationId: args.organizationId,
+      callerId: authResult.userId,
+      requestId: meta.requestId,
+      decision: "approved",
+    });
+
     const paymentMethod = args.paymentMethod ?? "cash";
     const now = Date.now();
     const paymentId = await db.insert("payments", {
@@ -1247,6 +1259,17 @@ export const rejectRefundAuth = action({
     }
 
     const meta = loaded.metadata;
+
+    // DB-level claim (#1730): see approveRefundAuth for the full rationale.
+    // We claim before side effects so two concurrent rejects can't both
+    // generate a "rejected" requester notification and audit log entry.
+    await ctx.runMutation(internal.payments._claimRefundAuthRequest, {
+      organizationId: args.organizationId,
+      callerId: authResult.userId,
+      requestId: meta.requestId,
+      decision: "rejected",
+    });
+
     await ctx.runMutation(internal.payments._resolveRefundAuthSideEffects, {
       organizationId: args.organizationId,
       approverId: authResult.userId,
@@ -1265,6 +1288,57 @@ export const rejectRefundAuth = action({
   },
 });
 
+/**
+ * Atomic DB-level claim for a refund-authorization request (#1730).
+ *
+ * Convex runs each mutation as a serializable transaction, so concurrent
+ * callers cannot both observe `status === "pending"` here: the second one
+ * sees the patched siblings and throws "Refund request already resolved"
+ * before the action proceeds to insert a payment row in Supabase.
+ *
+ * Patches every sibling notification for `requestId` to the final decision
+ * status, so any other admin that already had the bell open stops seeing the
+ * inline Approve/Reject buttons the moment one of them lands.
+ */
+export const _claimRefundAuthRequest = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    callerId: v.id("users"),
+    requestId: v.string(),
+    decision: v.union(v.literal("approved"), v.literal("rejected")),
+  },
+  handler: async (ctx, args) => {
+    const siblings = await ctx.db
+      .query("notifications")
+      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+      .filter((q) => q.eq(q.field("type"), "refund_authorization_requested"))
+      .collect();
+
+    const matching = siblings.filter((n) => {
+      const meta = n.metadata as RefundAuthMetadata | undefined;
+      return meta?.requestId === args.requestId;
+    });
+    if (matching.length === 0) {
+      throw new Error("Refund request notification not found");
+    }
+    if (
+      matching.some(
+        (n) => (n.metadata as RefundAuthMetadata).status !== "pending",
+      )
+    ) {
+      throw new Error("Refund request already resolved");
+    }
+
+    for (const n of matching) {
+      const meta = n.metadata as RefundAuthMetadata;
+      await ctx.db.patch(n._id, {
+        isRead: true,
+        metadata: { ...meta, status: args.decision },
+      });
+    }
+  },
+});
+
 export const _resolveRefundAuthSideEffects = internalMutation({
   args: {
     organizationId: v.id("organizations"),
@@ -1280,26 +1354,9 @@ export const _resolveRefundAuthSideEffects = internalMutation({
     reason: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    // Resolve every sibling notification carrying the same requestId so
-    // other admins immediately see the request has been handled.
-    const siblings = await ctx.db
-      .query("notifications")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .filter((q) => q.eq(q.field("type"), "refund_authorization_requested"))
-      .collect();
-
-    for (const n of siblings) {
-      const meta = n.metadata as RefundAuthMetadata | undefined;
-      if (!meta || meta.requestId !== args.requestId) continue;
-      if (meta.status !== "pending") continue;
-      await ctx.db.patch(n._id, {
-        isRead: true,
-        metadata: {
-          ...meta,
-          status: args.decision,
-        },
-      });
-    }
+    // Sibling notifications are already patched to the decision status by
+    // `_claimRefundAuthRequest` (called from the action before the Supabase
+    // insert). This mutation only handles requester notification + audit log.
 
     // Tell the requester what happened so they don't keep refreshing the
     // patient page wondering whether their request landed.

--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -712,5 +712,97 @@ describe("payments", () => {
           }),
       ).rejects.toThrow(/already resolved/i);
     });
+
+    test("concurrent approveRefundAuth calls produce exactly one refund (#1730)", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity: ownerIdentity, userId: ownerUserId } =
+        await seedTestUser(t);
+      // Second owner so two distinct admin sessions each have their own
+      // notification carrying the shared requestId.
+      const { identity: secondOwnerIdentity } = await seedSecondUser(
+        t,
+        organizationId,
+        { role: "owner" },
+      );
+      const { identity: memberIdentity } = await seedSecondUser(
+        t,
+        organizationId,
+        { role: "member" },
+      );
+      const patientId = TEST_PATIENT_ID;
+
+      await t.withIdentity(ownerIdentity).action(api.payments.create, {
+        organizationId,
+        patientId,
+        amount: 500,
+        currency: "PLN",
+        paymentMethod: "cash",
+        creditEarned: 500,
+      });
+
+      await t
+        .withIdentity(memberIdentity)
+        .action(api.payments.requestRefundAuthorization, {
+          organizationId,
+          patientId,
+          amount: 150,
+        });
+
+      const ownerNotifications = await t.run(async (ctx) =>
+        ctx.db
+          .query("notifications")
+          .withIndex("by_user", (q) => q.eq("userId", ownerUserId))
+          .collect(),
+      );
+      const refundNotification = ownerNotifications.find(
+        (n) => n.type === "refund_authorization_requested",
+      )!;
+
+      // Locate the sibling notification fanned out to the second owner so
+      // each session approves from its own notification id — the worst case
+      // for the race described in #1730.
+      const siblingNotification = await t.run(async (ctx) => {
+        const rows = await ctx.db
+          .query("notifications")
+          .withIndex("by_org", (q) => q.eq("organizationId", organizationId))
+          .filter((q) =>
+            q.eq(q.field("type"), "refund_authorization_requested"),
+          )
+          .collect();
+        return rows.find((n) => n._id !== refundNotification._id)!;
+      });
+
+      // Kick off both approvals in parallel. Convex serializes mutations, so
+      // the DB-level claim guarantees exactly one of them lands the refund.
+      const results = await Promise.allSettled([
+        t.withIdentity(ownerIdentity).action(api.payments.approveRefundAuth, {
+          organizationId,
+          notificationId: refundNotification._id,
+        }),
+        t
+          .withIdentity(secondOwnerIdentity)
+          .action(api.payments.approveRefundAuth, {
+            organizationId,
+            notificationId: siblingNotification._id,
+          }),
+      ]);
+
+      const fulfilled = results.filter((r) => r.status === "fulfilled");
+      const rejected = results.filter((r) => r.status === "rejected");
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      expect((rejected[0] as PromiseRejectedResult).reason.message).toMatch(
+        /already resolved/i,
+      );
+
+      // Patient credit reflects a single 150 refund, not two.
+      const credit = await t
+        .withIdentity(ownerIdentity)
+        .action(api.payments.getPatientCredit, {
+          organizationId,
+          patientId,
+        });
+      expect(credit.balance).toBe(350);
+    });
   });
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1730.

Closes #1730

---

## Claude summary

Confirmed the bug, fixed it, and committed.

The race was in `convex/payments.ts:1118` (`approveRefundAuth`): it did a JS-level `metadata.status === "pending"` check, then ran a Supabase HTTP insert, then patched the notification — so two parallel admin clicks both passed the check and both inserted refund payments.

Fix: introduced `_claimRefundAuthRequest` internal mutation that the action calls *before* the Supabase insert. Convex serializes mutations, so two concurrent claims interleave deterministically — the first patches all sibling notifications (for the shared `requestId`) to the decision status, and the second sees `status !== "pending"` inside the same transaction and throws `Refund request already resolved` before any Supabase write happens. Applied the same guard to `rejectRefundAuth`. `_resolveRefundAuthSideEffects` no longer needs to patch siblings — it now only writes the requester notification + audit log.

Verified by stashing only `convex/payments.ts` and running the new test: it fails (two fulfilled, two refunds). With the fix restored, all 21 payments tests pass and `tsc --noEmit` is clean.