### PR TITLE
Wrap room-conflict check in `!args.allowBookingConflict` in `checkConflictSupaba

### DIFF
--- a/convex/gabinet/_availability_supabase.ts
+++ b/convex/gabinet/_availability_supabase.ts
@@ -445,7 +445,7 @@ export async function checkConflictSupabase(
     }
   }
 
-  if (args.roomId) {
+  if (args.roomId && !args.allowBookingConflict) {
     const roomAppointments = await db
       .query("gabinetAppointments")
       .eq("organizationId", args.organizationId)


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1735.

Closes #1735

---

## Claude summary

Fixed. The room conflict check at `convex/gabinet/_availability_supabase.ts:448` is now wrapped in `!args.allowBookingConflict`, matching the soft/hard conflict split documented in the function's `allowBookingConflict` jsdoc (lines 309–313) and commit 64e351a's message. The call site at `convex/gabinet/appointments.ts:1110` already forwards `allowConflict`, so no other change was needed.