### PR TITLE
￼ Klawiatura

### DIFF
--- a/src/components/crm/side-panel.tsx
+++ b/src/components/crm/side-panel.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Loader2 } from "@/lib/ez-icons";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
@@ -23,6 +24,43 @@ interface SidePanelProps {
   className?: string;
 }
 
+// iOS Safari does not shrink the layout viewport when the soft keyboard
+// opens, so a `position: fixed` panel with `h-full` still covers the area
+// behind the keyboard. Constrain the sheet to the visual viewport so the
+// focused input (e.g. the rich text "Notatka" editor in the patient form)
+// is not hidden under the keyboard.
+function useKeyboardSafeSheetStyle(open: boolean): React.CSSProperties | undefined {
+  const [style, setStyle] = useState<React.CSSProperties | undefined>(undefined);
+
+  useEffect(() => {
+    if (!open || typeof window === "undefined") return;
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    const update = () => {
+      if (vv.height + 1 < window.innerHeight) {
+        setStyle({
+          top: vv.offsetTop,
+          height: vv.height,
+          bottom: "auto",
+        });
+      } else {
+        setStyle(undefined);
+      }
+    };
+
+    update();
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+    };
+  }, [open]);
+
+  return style;
+}
+
 export function SidePanel({
   open,
   onOpenChange,
@@ -35,6 +73,7 @@ export function SidePanel({
   className,
 }: SidePanelProps) {
   const { t } = useTranslation();
+  const keyboardSafeStyle = useKeyboardSafeSheetStyle(open);
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
@@ -43,6 +82,7 @@ export function SidePanel({
           "flex flex-col sm:max-w-[480px]",
           className
         )}
+        style={keyboardSafeStyle}
       >
         <SheetHeader>
           <SheetTitle>{title}</SheetTitle>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1742.

Closes #1742

---

## Claude summary

Fixed and committed. Summary of what was wrong and the fix:

The reporter's screenshot shows the patient edit drawer (gabinet) on iOS 26.5. The drawer is a Radix Sheet (`src/components/crm/side-panel.tsx`) with `position: fixed; inset-y-0; h-full`. On iOS Safari the layout viewport does not shrink when the soft keyboard opens, so the sheet keeps spanning the full screen and the keyboard hides the focused input (the "Notatka o kliencie" rich text editor and the inputs below it).

The fix adds a small `useKeyboardSafeSheetStyle` hook to `SidePanel` that uses the `VisualViewport` API. When `visualViewport.height < window.innerHeight` (i.e. the keyboard is up), it applies inline `top` + `height` + `bottom: auto` on the `SheetContent` so the panel ends at the top of the keyboard. The existing inner `flex-1 overflow-y-auto` container can then scroll the focused field into view normally. When the keyboard hides, the inline style is cleared and the original `inset-y-0 h-full` Tailwind classes take over again. Desktop is unaffected (visualViewport == innerHeight).

This fixes the bug for every `SidePanel`-based drawer in the app (patients, contacts, leads, employees, etc.), not only the one in the screenshot.