### PR TITLE
Edytuj

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -273,9 +273,12 @@ function EmployeesIndex() {
         // selected employee's calendar column).
         setEventDefaultUserIds(selectedRows.map((row) => row.userId));
         setEventDialogOpen(true);
+      } else if (action === "edit") {
+        const first = selectedRows[0];
+        if (first) navigate({ to: `/dashboard/gabinet/employees/${first._id}` });
       }
     },
-    [removeEmployee, organizationId]
+    [removeEmployee, organizationId, navigate]
   );
 
   return (
@@ -351,6 +354,7 @@ function EmployeesIndex() {
         enableBulkSelect
         hiddenColumnIds={hiddenColumnIds}
         bulkActions={[
+          { label: t("common.edit"), value: "edit" },
           { label: t("gabinet.events.create", { defaultValue: "Nowe zdarzenie" }), value: "addEvent" },
           { label: t("common.delete"), value: "delete", variant: "destructive" },
         ]}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1743.

Closes #1743

---

## Claude summary

Done. Added an "Edytuj" entry to the bulk-action dropdown on the Gabinet employees list (`src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx:357`). When selected, it navigates to the first selected employee's detail/edit page — matching the existing per-row edit action. The "Nowe zdarzenie" and "Usuń" options are kept as-is.