### PR TITLE
￼ responsywność

### DIFF
--- a/src/components/layout/app-footer.tsx
+++ b/src/components/layout/app-footer.tsx
@@ -149,27 +149,31 @@ export function AppFooter() {
           <NudgesBadge />
         </div>
 
-        <div className="flex items-center gap-2 max-sm:min-w-0 max-sm:flex-1 max-sm:flex-nowrap max-sm:overflow-x-auto max-sm:-mx-4 max-sm:px-4 max-sm:scrollbar-none sm:flex-wrap">
-          {actions.map((action) => (
-            <Button
-              key={action.labelKey}
-              variant="outline"
-              size="sm"
-              className="h-7 text-xs shrink-0"
-              onClick={() => {
-                if (action.quickCreate) {
-                  openQuickCreate(action.quickCreate);
-                } else if (action.action) {
-                  dispatch(action.action);
-                } else if (action.href) {
-                  navigateTo(action.href, action.search);
-                }
-              }}
-            >
-              <action.icon className="mr-1 h-3.5 w-3.5" />
-              {t(action.labelKey)}
-            </Button>
-          ))}
+        <div className="flex items-center gap-2 max-sm:min-w-0 max-sm:flex-1 max-sm:flex-nowrap max-sm:justify-end sm:flex-wrap">
+          {actions.map((action) => {
+            const label = t(action.labelKey);
+            return (
+              <Button
+                key={action.labelKey}
+                variant="outline"
+                size="sm"
+                aria-label={label}
+                className="h-7 text-xs shrink-0 max-sm:h-8 max-sm:w-8 max-sm:p-0"
+                onClick={() => {
+                  if (action.quickCreate) {
+                    openQuickCreate(action.quickCreate);
+                  } else if (action.action) {
+                    dispatch(action.action);
+                  } else if (action.href) {
+                    navigateTo(action.href, action.search);
+                  }
+                }}
+              >
+                <action.icon className="h-3.5 w-3.5 sm:mr-1" />
+                <span className="max-sm:sr-only">{label}</span>
+              </Button>
+            );
+          })}
           {showGabinetQuickActions && <GabinetQuickActionsDropdown />}
         </div>
       </div>

--- a/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
+++ b/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
@@ -38,9 +38,16 @@ export function GabinetQuickActionsDropdown() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm" className="h-7 gap-1 text-xs">
-          <Plus className="mr-1 h-3.5 w-3.5" />
-          {t("sidebar.gabinet.quickActions", "Szybkie akcje")}
+        <Button
+          variant="outline"
+          size="sm"
+          aria-label={t("sidebar.gabinet.quickActions", "Szybkie akcje")}
+          className="h-7 gap-1 text-xs max-sm:h-8 max-sm:w-8 max-sm:gap-0 max-sm:p-0"
+        >
+          <Plus className="h-3.5 w-3.5 sm:mr-1" />
+          <span className="max-sm:sr-only">
+            {t("sidebar.gabinet.quickActions", "Szybkie akcje")}
+          </span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1744.

Closes #1744

---

## Claude summary

Committed. Summary of what changed:

The bottom action bar on the gabinet employees page (and every other page that uses `AppFooter`) was overflowing horizontally on a 390px iPhone, clipping the "Kategorie" button on the right and pushing the gabinet "Szybkie akcje" dropdown completely off-screen.

Fix in `src/components/layout/app-footer.tsx:152` and `src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx:41`: on `max-sm` the buttons collapse to a 32px square icon-only chip — text is wrapped in `<span className="max-sm:sr-only">` and exposed via `aria-label` so screen readers still announce them. The old `overflow-x-auto + -mx-4 + scrollbar-none` hack is no longer needed since 4-6 icon chips comfortably fit. From `sm` upward the original labeled outline buttons are unchanged.