### PR TITLE
Edytuj ￼

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -460,9 +460,12 @@ function PatientsIndex() {
         }
         setMergeSourcePatient(selectedRows[0]);
         setMergePreselectedTargetId(selectedRows[1]._id);
+      } else if (action === "edit") {
+        const first = selectedRows[0];
+        if (first) navigate({ to: `/dashboard/gabinet/patients/${first._id}` });
       }
     },
-    [removePatient, organizationId, t],
+    [removePatient, organizationId, t, navigate],
   );
 
   const rowActions = useCallback(
@@ -589,6 +592,7 @@ function PatientsIndex() {
         onSortChange={setSortDescriptor}
         enableBulkSelect
         bulkActions={[
+          { label: t("common.edit"), value: "edit" },
           {
             label: t("gabinet.patients.merge.bulkAction", { defaultValue: "Scal zaznaczonych" }),
             value: "merge",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1746.

Closes #1746

---

## Claude summary

Added "Edytuj" to the bulk action menu on the Gabinet patients (Klienci) list in `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx`. When triggered, it navigates to the first selected patient's detail page, mirroring the per-row edit action and the analogous fix shipped for employees in #1743. Committed as `7de4319`.

Note: TypeScript is not installed in this worktree (`tsc: not found`), so I could not run `npm run typecheck`. The change is a small, type-stable edit (a new `bulkActions` entry and an `else if` branch using the same `navigate` pattern already used in `rowActions`).