### PR TITLE
Numer telefonu

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -68,6 +68,7 @@
     "stats": "Stats",
     "time": "Time",
     "titleRequired": "Title is required",
+    "phoneTooShort": "Phone number must be at least 9 digits.",
     "type": "Type",
     "actionCannotBeUndone": "This action cannot be undone",
     "module": "Module",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -68,6 +68,7 @@
     "stats": "Statystyki",
     "time": "Godzina",
     "titleRequired": "Tytuł jest wymagany",
+    "phoneTooShort": "Numer telefonu musi mieć co najmniej 9 cyfr.",
     "type": "Typ",
     "actionCannotBeUndone": "Tej operacji nie można cofnąć",
     "module": "Moduł",

--- a/src/components/forms/patient-form.tsx
+++ b/src/components/forms/patient-form.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PhoneInput } from "@/components/ui/phone-input";
+import { isPhoneNumberValid } from "@/lib/phone";
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
 import {
   Select,
@@ -410,7 +411,17 @@ export function PatientForm({
         <Button type="button" variant="outline" onClick={onCancel}>
           {t("common.cancel")}
         </Button>
-        <Button type="submit" disabled={!firstName.trim() || !lastName.trim() || !email.trim() || !phone.trim() || isSubmitting}>
+        <Button
+          type="submit"
+          disabled={
+            !firstName.trim() ||
+            !lastName.trim() ||
+            !email.trim() ||
+            !isPhoneNumberValid(phone, { required: true }) ||
+            !isPhoneNumberValid(emergencyContactPhone, { required: false }) ||
+            isSubmitting
+          }
+        >
           {isSubmitting
             ? t("common.saving")
             : initialData

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -8,14 +9,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { COUNTRIES, DEFAULT_DIAL_CODE, detectDialCode } from "@/lib/phone";
-
-function parseInitialValue(value: string): { dialCode: string; number: string } {
-  if (!value) return { dialCode: DEFAULT_DIAL_CODE, number: "" };
-  const detected = detectDialCode(value);
-  if (detected) return { dialCode: detected.dialCode, number: detected.rest };
-  return { dialCode: DEFAULT_DIAL_CODE, number: value };
-}
+import {
+  COUNTRIES,
+  DEFAULT_DIAL_CODE,
+  MIN_PHONE_NATIONAL_DIGITS,
+  detectDialCode,
+} from "@/lib/phone";
+import { cn } from "@/lib/utils";
 
 function combine(dialCode: string, number: string): string {
   const trimmed = number.trim();
@@ -39,14 +39,26 @@ export function PhoneInput({
   placeholder,
   className,
 }: PhoneInputProps) {
-  const [{ dialCode, number }, setState] = useState(() =>
-    parseInitialValue(value),
-  );
+  const { t } = useTranslation();
+  const [{ dialCode, number }, setState] = useState(() => {
+    if (!value) return { dialCode: DEFAULT_DIAL_CODE, number: "" };
+    const detected = detectDialCode(value);
+    if (detected) return { dialCode: detected.dialCode, number: detected.rest };
+    return { dialCode: DEFAULT_DIAL_CODE, number: value };
+  });
+  const [touched, setTouched] = useState(false);
 
   const isKnown = useMemo(
     () => COUNTRIES.some((c) => c.code === dialCode),
     [dialCode],
   );
+
+  const digitCount = useMemo(() => number.replace(/\D/g, "").length, [number]);
+  const isInvalid =
+    digitCount === 0
+      ? Boolean(required)
+      : digitCount < MIN_PHONE_NATIONAL_DIGITS;
+  const showError = touched && isInvalid && digitCount > 0;
 
   const handleNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = e.target.value;
@@ -66,31 +78,43 @@ export function PhoneInput({
   };
 
   return (
-    <div className={`flex gap-2 ${className ?? ""}`}>
-      <Select value={isKnown ? dialCode : DEFAULT_DIAL_CODE} onValueChange={handleDialChange}>
-        <SelectTrigger className="w-[90px] shrink-0" size="sm">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectGroup>
-            {COUNTRIES.map((c) => (
-              <SelectItem key={c.iso} value={c.code}>
-                <span className="mr-1">{c.flag}</span>
-                {c.code}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-        </SelectContent>
-      </Select>
-      <Input
-        type="tel"
-        id={id}
-        value={number}
-        onChange={handleNumberChange}
-        required={required}
-        placeholder={placeholder}
-        className="flex-1"
-      />
+    <div className={cn("space-y-1", className)}>
+      <div className="flex gap-2">
+        <Select value={isKnown ? dialCode : DEFAULT_DIAL_CODE} onValueChange={handleDialChange}>
+          <SelectTrigger className="w-[90px] shrink-0" size="sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {COUNTRIES.map((c) => (
+                <SelectItem key={c.iso} value={c.code}>
+                  <span className="mr-1">{c.flag}</span>
+                  {c.code}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+        <Input
+          type="tel"
+          id={id}
+          value={number}
+          onChange={handleNumberChange}
+          onBlur={() => setTouched(true)}
+          required={required}
+          placeholder={placeholder}
+          aria-invalid={showError || undefined}
+          className={cn(
+            "flex-1",
+            showError && "border-destructive focus-visible:border-destructive",
+          )}
+        />
+      </div>
+      {showError && (
+        <p className="text-xs text-destructive" role="alert">
+          {t("common.phoneTooShort")}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -47,6 +47,11 @@ export const COUNTRIES: Country[] = [
 
 export const DEFAULT_DIAL_CODE = "+48";
 
+// Minimum number of digits required after the dial code for a phone number
+// to be considered well-formed. Matches the Polish 9-digit national format
+// and is sufficient as a baseline for the other supported countries.
+export const MIN_PHONE_NATIONAL_DIGITS = 9;
+
 export const SORTED_CODES = [...COUNTRIES].sort(
   (a, b) => b.code.length - a.code.length,
 );
@@ -106,6 +111,32 @@ function applyGrouping(digits: string, pattern: number[]): string {
 // "+1 555 123 4567" for the US convention.
 // Falls back to the original input when no dial code is detected and no
 // digits are present.
+// Counts digits in the national part of a phone number (i.e. after the
+// dial code, if one is recognised). Returns 0 for empty/blank input.
+export function countPhoneNationalDigits(
+  value: string | null | undefined,
+): number {
+  if (!value) return 0;
+  const trimmed = value.trim();
+  if (!trimmed) return 0;
+  const detected = detectDialCode(trimmed);
+  const rest = detected ? detected.rest : trimmed;
+  return rest.replace(/\D/g, "").length;
+}
+
+// Returns true when the phone number is acceptable for submission.
+// An empty value is acceptable iff the field is not required.
+// A non-empty value must contain at least MIN_PHONE_NATIONAL_DIGITS digits
+// in the national part.
+export function isPhoneNumberValid(
+  value: string | null | undefined,
+  options: { required?: boolean } = {},
+): boolean {
+  const digits = countPhoneNationalDigits(value);
+  if (digits === 0) return !options.required;
+  return digits >= MIN_PHONE_NATIONAL_DIGITS;
+}
+
 export function formatPhoneNumber(value: string | null | undefined): string {
   if (!value) return "";
   const trimmed = value.trim();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1747.

Closes #1747

---

## Claude summary

Committed. Summary of the fix for #1747:

The `PhoneInput` component (`src/components/ui/phone-input.tsx`) now tracks an internal `touched` state on blur, computes digit count of the national part, and renders an inline error (`common.phoneTooShort` translation) plus `aria-invalid` styling whenever the user has typed fewer than 9 digits. To avoid yelling at users mid-typing or when an existing record loads, the error only appears after blur and only when the user has actually entered some digits.

A shared `isPhoneNumberValid` helper lives in `src/lib/phone.ts` (alongside a new `MIN_PHONE_NATIONAL_DIGITS` constant) so forms can mirror the same rule for submit-disable logic. The patient form (`src/components/forms/patient-form.tsx` — the only consumer of `PhoneInput`) now uses it for both the required main phone and the optional emergency contact phone: the optional field is valid when empty but invalid when partially filled. Polish/English translations added under `common.phoneTooShort`. Typecheck and lint pass clean.