### PR TITLE
Przesuwanie

### DIFF
--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -357,8 +357,12 @@ export function DraggableAppointment({
         : null}
       <PopoverContent
         ref={previewContentRef}
+        // `touch-none` here is what makes body-drag actually win on iOS: without
+        // it, the `overflow-y-auto` surface starts a native scroll before our
+        // `onPointerDown`'s `preventDefault()` can take effect (issue #1756).
+        // Desktop wheel scroll is unaffected; `touch-action` only gates touch.
         className={cn(
-          "w-[553px] max-w-[calc(100vw-24px)] max-h-[calc(100dvh-24px)] overflow-y-auto p-0 rounded-xl border-border/60 shadow-2xl",
+          "w-[553px] max-w-[calc(100vw-24px)] max-h-[calc(100dvh-24px)] overflow-y-auto p-0 rounded-xl border-border/60 shadow-2xl touch-none",
           isPreviewDragging && "cursor-grabbing select-none",
         )}
         // On mobile the appointment can sit on either side of the screen, and a


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1756.

Closes #1756

---

## Claude summary

Committed.

Summary: The appointment preview popover on the gabinet calendar wouldn't drag when touched on its body — only the small grab pill at the top worked. #1741 had attempted to fix this by accepting touch in the JS handler, but missed the CSS half: `PopoverContent` has `overflow-y-auto` and no `touch-action`, so iOS Safari started a native scroll before the JS handler's `preventDefault()` could run (per the Pointer Events spec, `preventDefault` on `pointerdown` does not cancel touch scrolling — only `touch-action: none` does). Added `touch-none` to `PopoverContent` in `src/components/gabinet/calendar/draggable-appointment.tsx`. Desktop wheel scroll is unaffected; the existing drag-offset clamp lets users drag the popover up to reveal any overflowing content.