### PR TITLE
Check box zabiegi

### DIFF
--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -361,10 +361,11 @@ export function EmployeeForm({
               />
             </div>
           )}
-          <div className="max-h-48 overflow-y-auto rounded-md border p-2 space-y-1">
+          <div className="max-h-64 overflow-y-auto rounded-md border p-2">
             {filteredTreatments.length > 0 && (
-              <label className="-mx-2 -mt-2 mb-1 flex items-center gap-2 rounded-t bg-muted/60 px-2 py-2 text-sm font-medium cursor-pointer border-b">
+              <label className="-mx-2 -mt-2 mb-1 flex min-h-11 select-none items-center gap-3 rounded-t border-b bg-muted/60 px-3 py-2.5 text-sm font-medium cursor-pointer active:bg-muted">
                 <Checkbox
+                  className="h-5 w-5"
                   checked={
                     filteredTreatments.every((tr) => selectedTreatments.includes(tr._id))
                       ? true
@@ -392,9 +393,10 @@ export function EmployeeForm({
             {filteredTreatments.map((tr) => (
               <label
                 key={tr._id}
-                className="flex items-center gap-2 text-sm cursor-pointer"
+                className="-mx-2 flex min-h-11 select-none items-center gap-3 rounded-md px-3 py-2.5 text-sm cursor-pointer transition-colors hover:bg-accent/40 active:bg-accent"
               >
                 <Checkbox
+                  className="h-5 w-5"
                   checked={selectedTreatments.includes(tr._id)}
                   onCheckedChange={() => toggleTreatment(tr._id)}
                 />

--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -409,10 +409,42 @@ export function UserInvitationForm({
                   />
                 </div>
               )}
-              <div className="max-h-48 overflow-y-auto rounded-md border p-2 space-y-1">
-                {filteredTreatments.map((tr) => (
-                  <label key={tr._id} className="flex items-center gap-2 text-sm cursor-pointer">
+              <div className="max-h-64 overflow-y-auto rounded-md border p-2">
+                {filteredTreatments.length > 0 && (
+                  <label className="-mx-2 -mt-2 mb-1 flex min-h-11 select-none items-center gap-3 rounded-t border-b bg-muted/60 px-3 py-2.5 text-sm font-medium cursor-pointer active:bg-muted">
                     <Checkbox
+                      className="h-5 w-5"
+                      checked={
+                        filteredTreatments.every((tr) => selectedTreatments.includes(tr._id))
+                          ? true
+                          : filteredTreatments.some((tr) => selectedTreatments.includes(tr._id))
+                            ? "indeterminate"
+                            : false
+                      }
+                      onCheckedChange={(checked) => {
+                        const visibleIds = filteredTreatments.map((tr) => tr._id);
+                        if (checked === true) {
+                          setSelectedTreatments(
+                            Array.from(new Set([...selectedTreatments, ...visibleIds])),
+                          );
+                        } else {
+                          const visibleSet = new Set(visibleIds);
+                          setSelectedTreatments(
+                            selectedTreatments.filter((id) => !visibleSet.has(id)),
+                          );
+                        }
+                      }}
+                    />
+                    {t("common.selectAll")}
+                  </label>
+                )}
+                {filteredTreatments.map((tr) => (
+                  <label
+                    key={tr._id}
+                    className="-mx-2 flex min-h-11 select-none items-center gap-3 rounded-md px-3 py-2.5 text-sm cursor-pointer transition-colors hover:bg-accent/40 active:bg-accent"
+                  >
+                    <Checkbox
+                      className="h-5 w-5"
                       checked={selectedTreatments.includes(tr._id)}
                       onCheckedChange={(checked) => {
                         if (checked) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1762.

Closes #1762

---

## Claude summary

Made the treatments checkbox list easier to use on mobile in both `src/components/forms/employee-form.tsx:392-407` and `src/components/forms/user-invitation-form.tsx:413-461`:

- Each row is now a 44px-min-height touch target (iOS HIG) with `py-2.5` and `px-3` padding so the whole row is comfortably tappable.
- Checkbox bumped from 16px to 20px on these rows (`h-5 w-5`).
- Added `hover:bg-accent/40 active:bg-accent` for visual press feedback, plus `select-none` so tapping doesn't accidentally select text.
- Expanded the list container from `max-h-48` to `max-h-64` so fewer scrolls are needed.
- Added the same "Zaznacz wszystkie" select-all toggle to the invitation form that already existed in the employee form.

Committed as `6936382`.