### PR TITLE
Ilość zabiegów w pakiecie 

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -622,27 +622,46 @@ function PackagesIndex() {
               </Button>
             </div>
             {selectedTreatments.map((st, i) => (
-              <div key={i} className="flex items-center gap-2">
-                <Select value={st.treatmentId} onValueChange={(val) => updateTreatment(i, "treatmentId", val)}>
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {(treatments ?? []).map((tr) => (
-                      <SelectItem key={tr._id} value={tr._id}>{tr.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <Input
-                  type="number"
-                  className="w-20"
-                  value={st.quantity}
-                  onChange={(e) => updateTreatment(i, "quantity", parseInt(e.target.value) || 1)}
-                  min={1}
-                />
-                <Button type="button" variant="ghost" size="sm" onClick={() => removeTreatment(i)}>
-                  <Trash2 className="h-4 w-4" variant="stroke" />
-                </Button>
+              <div key={i} className="rounded-md border p-3">
+                <div className="flex items-end gap-2">
+                  <div className="flex-1 min-w-0 space-y-1">
+                    <Label className="text-xs text-muted-foreground">
+                      {t("gabinet.packages.treatment")}
+                    </Label>
+                    <Select value={st.treatmentId} onValueChange={(val) => updateTreatment(i, "treatmentId", val)}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {(treatments ?? []).map((tr) => (
+                          <SelectItem key={tr._id} value={tr._id}>{tr.name}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="w-24 shrink-0 space-y-1">
+                    <Label className="text-xs text-muted-foreground">
+                      {t("gabinet.packages.quantity")}
+                    </Label>
+                    <Input
+                      type="number"
+                      inputMode="numeric"
+                      value={st.quantity}
+                      onChange={(e) => updateTreatment(i, "quantity", parseInt(e.target.value) || 1)}
+                      min={1}
+                    />
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="shrink-0"
+                    onClick={() => removeTreatment(i)}
+                    aria-label={t("common.delete")}
+                  >
+                    <Trash2 className="h-4 w-4" variant="stroke" />
+                  </Button>
+                </div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1764.

Closes #1764

---

## Claude summary

Committed `c5c8d0f`.

Diagnosis: the "Add package" form already had a per-treatment quantity input but it was a tiny unlabeled `w-20` box squeezed between the treatment Select and the trash button (`_layout.gabinet.packages.index.tsx:636-642`). On mobile the user didn't notice it and assumed they had to tap "Dodaj" once per treatment.

Fix: each treatment row is now a card with explicit `Zabieg` and `Ilość` labels above the inputs, a wider `w-24` quantity field with `inputMode="numeric"` so iOS shows a numeric keyboard, and an `aria-label` on the trash button. Uses existing i18n keys `gabinet.packages.treatment` and `gabinet.packages.quantity`.