### PR TITLE
Okienko w kalendarzu

### DIFF
--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -302,7 +302,13 @@ export function DraggableAppointment({
       {...listeners}
       {...attributes}
       data-appointment-card="true"
-      className={`relative h-full ${isDragging ? "opacity-50 cursor-grabbing" : "cursor-grab"}`}
+      // `touch-none` lets dnd-kit detect drag intent from anywhere on the card
+      // on touch (issue #1766). Without it, iOS preempts pointer events with
+      // native scroll the moment the user starts moving their finger, so the
+      // PointerSensor never sees enough movement to cross its 5px activation
+      // threshold and the user can't drag the appointment from the card body.
+      // Desktop is unaffected — `touch-action` only gates touch input.
+      className={`relative h-full touch-none ${isDragging ? "opacity-50 cursor-grabbing" : "cursor-grab"}`}
       style={
         previewHeightPx !== null ? { height: `${previewHeightPx}px` } : undefined
       }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1766.

Closes #1766

---

## Claude summary

Done. Issue #1766 fix committed as `0ef5130`.

Root cause: the appointment-card wrapper in `src/components/gabinet/calendar/draggable-appointment.tsx:300` uses `useDraggable` from `@dnd-kit/core` with a 5px-distance `PointerSensor` (configured at `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx:214`), but the wrapper had no `touch-action` override. On iOS, native scrolling preempted pointer events before dnd-kit could detect drag intent, so the card body felt undraggable on touch.

Fix: add Tailwind `touch-none` to the wrapper. Desktop is unaffected (touch-action only gates touch input). Taps still work because dnd-kit only activates drag after >5px of movement, so a still tap still flows through to the AppointmentCard button's onClick (opens the preview popover). Companion drag-from-anywhere fixes for the preview popover already landed in #1745 and #1758.