### PR TITLE
Check box zabiegi

### DIFF
--- a/src/components/crm/data-list-filter-bar.tsx
+++ b/src/components/crm/data-list-filter-bar.tsx
@@ -477,7 +477,7 @@ export function DataListFilterBar({
                   <button
                     key={col.id}
                     type="button"
-                    className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left hover:bg-bg-primary_hover"
+                    className="flex min-h-11 w-full select-none items-center gap-3 rounded-md px-2.5 py-2.5 text-left transition-colors hover:bg-bg-primary_hover active:bg-bg-primary_hover"
                     onClick={() => onToggleColumn(col.id)}
                   >
                     <CheckboxBase

--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -361,10 +361,11 @@ export function EmployeeForm({
               />
             </div>
           )}
-          <div className="max-h-48 overflow-y-auto rounded-md border p-2 space-y-1">
+          <div className="max-h-64 overflow-y-auto rounded-md border p-2">
             {filteredTreatments.length > 0 && (
-              <label className="-mx-2 -mt-2 mb-1 flex items-center gap-2 rounded-t bg-muted/60 px-2 py-2 text-sm font-medium cursor-pointer border-b">
+              <label className="-mx-2 -mt-2 mb-1 flex min-h-11 select-none items-center gap-3 rounded-t border-b bg-muted/60 px-3 py-2.5 text-sm font-medium cursor-pointer active:bg-muted">
                 <Checkbox
+                  className="h-5 w-5"
                   checked={
                     filteredTreatments.every((tr) => selectedTreatments.includes(tr._id))
                       ? true
@@ -392,9 +393,10 @@ export function EmployeeForm({
             {filteredTreatments.map((tr) => (
               <label
                 key={tr._id}
-                className="flex items-center gap-2 text-sm cursor-pointer"
+                className="-mx-2 flex min-h-11 select-none items-center gap-3 rounded-md px-3 py-2.5 text-sm cursor-pointer transition-colors hover:bg-accent/40 active:bg-accent"
               >
                 <Checkbox
+                  className="h-5 w-5"
                   checked={selectedTreatments.includes(tr._id)}
                   onCheckedChange={() => toggleTreatment(tr._id)}
                 />

--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -409,10 +409,42 @@ export function UserInvitationForm({
                   />
                 </div>
               )}
-              <div className="max-h-48 overflow-y-auto rounded-md border p-2 space-y-1">
-                {filteredTreatments.map((tr) => (
-                  <label key={tr._id} className="flex items-center gap-2 text-sm cursor-pointer">
+              <div className="max-h-64 overflow-y-auto rounded-md border p-2">
+                {filteredTreatments.length > 0 && (
+                  <label className="-mx-2 -mt-2 mb-1 flex min-h-11 select-none items-center gap-3 rounded-t border-b bg-muted/60 px-3 py-2.5 text-sm font-medium cursor-pointer active:bg-muted">
                     <Checkbox
+                      className="h-5 w-5"
+                      checked={
+                        filteredTreatments.every((tr) => selectedTreatments.includes(tr._id))
+                          ? true
+                          : filteredTreatments.some((tr) => selectedTreatments.includes(tr._id))
+                            ? "indeterminate"
+                            : false
+                      }
+                      onCheckedChange={(checked) => {
+                        const visibleIds = filteredTreatments.map((tr) => tr._id);
+                        if (checked === true) {
+                          setSelectedTreatments(
+                            Array.from(new Set([...selectedTreatments, ...visibleIds])),
+                          );
+                        } else {
+                          const visibleSet = new Set(visibleIds);
+                          setSelectedTreatments(
+                            selectedTreatments.filter((id) => !visibleSet.has(id)),
+                          );
+                        }
+                      }}
+                    />
+                    {t("common.selectAll")}
+                  </label>
+                )}
+                {filteredTreatments.map((tr) => (
+                  <label
+                    key={tr._id}
+                    className="-mx-2 flex min-h-11 select-none items-center gap-3 rounded-md px-3 py-2.5 text-sm cursor-pointer transition-colors hover:bg-accent/40 active:bg-accent"
+                  >
+                    <Checkbox
+                      className="h-5 w-5"
                       checked={selectedTreatments.includes(tr._id)}
                       onCheckedChange={(checked) => {
                         if (checked) {

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -1359,20 +1359,18 @@ export function AppointmentDialog({
                 {/* Walk-in toggle — explicit opt-in to expose past time slots
                     so the user can record an appointment they already saw.
                     Default-off keeps past slots filtered server-side. #1406. */}
-                <div className="flex items-start gap-2">
+                <Label
+                  htmlFor="record-walk-in"
+                  className="-mx-1 flex min-h-11 select-none items-start gap-3 rounded-md px-1 py-1.5 text-sm leading-tight mb-0 cursor-pointer transition-colors hover:bg-accent/40 active:bg-accent"
+                >
                   <Checkbox
                     id="record-walk-in"
                     checked={recordWalkIn}
                     onCheckedChange={(c) => setRecordWalkIn(c as boolean)}
                     className="mt-0.5"
                   />
-                  <Label
-                    htmlFor="record-walk-in"
-                    className="text-sm leading-tight mb-0"
-                  >
-                    {t("gabinet.appointments.recordWalkIn")}
-                  </Label>
-                </div>
+                  {t("gabinet.appointments.recordWalkIn")}
+                </Label>
 
                 {/* Find nearest slot */}
                 <Button
@@ -1421,7 +1419,10 @@ export function AppointmentDialog({
 
                 {/* Recurring */}
                 <div className="space-y-2">
-                  <div className="flex items-center gap-2">
+                  <Label
+                    htmlFor="recurring-appt"
+                    className="-mx-1 flex min-h-11 select-none items-center gap-3 rounded-md px-1 py-1.5 text-sm mb-0 cursor-pointer transition-colors hover:bg-accent/40 active:bg-accent"
+                  >
                     <Checkbox
                       id="recurring-appt"
                       checked={isRecurring}
@@ -1429,13 +1430,8 @@ export function AppointmentDialog({
                         setIsRecurring(c as boolean)
                       }
                     />
-                    <Label
-                      htmlFor="recurring-appt"
-                      className="text-sm mb-0"
-                    >
-                      {t("gabinet.appointments.recurring")}
-                    </Label>
-                  </div>
+                    {t("gabinet.appointments.recurring")}
+                  </Label>
                   {isRecurring && (
                     <div className="grid gap-2">
                       <Select

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -1776,7 +1776,10 @@ export function AppointmentPreviewContent({
 
           {eligiblePackageUsages.length > 0 && (
             <div className="space-y-2 rounded-md border border-blue-200 bg-blue-50 p-2.5 dark:border-blue-900 dark:bg-blue-950/30">
-              <div className="flex items-start gap-2">
+              <Label
+                htmlFor="settle-use-package"
+                className="-mx-1 flex min-h-11 select-none items-start gap-3 rounded-md px-1 py-1.5 cursor-pointer text-sm font-normal leading-snug active:bg-blue-100 dark:active:bg-blue-900/40"
+              >
                 <Checkbox
                   id="settle-use-package"
                   checked={settleUsePackage}
@@ -1787,17 +1790,15 @@ export function AppointmentPreviewContent({
                       setSettlePackageUsageId(eligiblePackageUsages[0]._id);
                     }
                   }}
+                  className="mt-0.5"
                 />
-                <Label
-                  htmlFor="settle-use-package"
-                  className="cursor-pointer text-sm font-normal leading-snug"
-                >
+                <span>
                   {t("gabinet.appointmentDetail.deductFromPackage", {
                     defaultValue:
                       "Zdejmij sztuki z aktywnego pakietu pacjenta",
                   })}
-                </Label>
-              </div>
+                </span>
+              </Label>
               {settleUsePackage && (
                 <>
                   {eligiblePackageUsages.length > 1 && (
@@ -1959,10 +1960,14 @@ export function AppointmentPreviewContent({
 
           {patient?._id && patientCreditBalance > 0 && (
             <div className="space-y-2 rounded-md border border-emerald-200 bg-emerald-50 p-2.5 dark:border-emerald-900 dark:bg-emerald-950/30">
-              <div className="flex items-start gap-2">
+              <Label
+                htmlFor="settle-use-credit"
+                className="-mx-1 flex min-h-11 select-none items-start gap-3 rounded-md px-1 py-1.5 cursor-pointer text-sm font-normal leading-snug active:bg-emerald-100 dark:active:bg-emerald-900/40"
+              >
                 <Checkbox
                   id="settle-use-credit"
                   checked={settleUseCredit}
+                  className="mt-0.5"
                   onCheckedChange={(v) => {
                     const next = v === true;
                     setSettleUseCredit(next);
@@ -1990,10 +1995,7 @@ export function AppointmentPreviewContent({
                     }
                   }}
                 />
-                <Label
-                  htmlFor="settle-use-credit"
-                  className="cursor-pointer text-sm font-normal leading-snug"
-                >
+                <span>
                   {t("gabinet.payments.useCredit", {
                     defaultValue: "Użyj salda nadpłat",
                     amount: formatCurrencyPLN(patientCreditBalance),
@@ -2001,8 +2003,8 @@ export function AppointmentPreviewContent({
                   <span className="text-muted-foreground">
                     ({formatCurrencyPLN(patientCreditBalance)})
                   </span>
-                </Label>
-              </div>
+                </span>
+              </Label>
               {settleUseCredit && (
                 <div className="space-y-1">
                   <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">

--- a/src/components/gabinet/calendar/event-dialog.tsx
+++ b/src/components/gabinet/calendar/event-dialog.tsx
@@ -380,7 +380,7 @@ export function EventDialog({
                   <button
                     type="button"
                     onClick={selectAllEmployees}
-                    className="flex w-full items-center gap-2 border-b px-3 py-2 text-left text-sm hover:bg-accent"
+                    className="flex min-h-11 w-full select-none items-center gap-3 border-b px-3 py-2.5 text-left text-sm transition-colors hover:bg-accent active:bg-accent"
                   >
                     <Checkbox
                       checked={employeeIds.length === 0}
@@ -408,7 +408,7 @@ export function EventDialog({
                             key={emp.userId}
                             type="button"
                             onClick={() => toggleEmployee(emp.userId)}
-                            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent"
+                            className="flex min-h-11 w-full select-none items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors hover:bg-accent active:bg-accent"
                           >
                             <Checkbox
                               checked={selected}

--- a/src/components/gabinet/documentation-tab.tsx
+++ b/src/components/gabinet/documentation-tab.tsx
@@ -396,7 +396,7 @@ export function DocumentationTab({
                       />
                     )}
                     {paramType === "checkbox" && (
-                      <div className="flex items-center gap-2 pt-1">
+                      <label className="-mx-2 flex min-h-11 select-none items-center gap-3 rounded-md px-2 py-2.5 cursor-pointer transition-colors hover:bg-accent/40 active:bg-accent">
                         <Checkbox
                           checked={param.value === true || param.value === "true"}
                           onCheckedChange={(checked) => handleParamChange(i, !!checked)}
@@ -404,7 +404,7 @@ export function DocumentationTab({
                         <span className="text-sm text-muted-foreground">
                           {def?.options?.[0] ?? t("common.yes", "Tak")}
                         </span>
-                      </div>
+                      </label>
                     )}
                     {paramType === "radio" && def?.options && (
                       <RadioGroup

--- a/src/components/gabinet/package-purchase-drawer.tsx
+++ b/src/components/gabinet/package-purchase-drawer.tsx
@@ -364,21 +364,22 @@ export function PackagePurchaseDrawer({
             </Select>
           </div>
 
-          <div className="flex items-center gap-2">
+          <Label
+            htmlFor="split-payment"
+            className="-mx-2 flex min-h-11 select-none items-center gap-3 rounded-md px-2 py-2.5 cursor-pointer text-sm font-normal transition-colors hover:bg-accent/40 active:bg-accent"
+          >
             <Checkbox
               id="split-payment"
               checked={splitPayment}
               onCheckedChange={(v) => setSplitPayment(v === true)}
             />
-            <Label htmlFor="split-payment" className="cursor-pointer text-sm font-normal">
-              {isInstallment
-                ? t(
-                    "gabinet.packages.splitFirstInstallment",
-                    "Split first installment",
-                  )
-                : t("gabinet.packages.splitPayment", "Split payment")}
-            </Label>
-          </div>
+            {isInstallment
+              ? t(
+                  "gabinet.packages.splitFirstInstallment",
+                  "Split first installment",
+                )
+              : t("gabinet.packages.splitPayment", "Split payment")}
+          </Label>
 
           {isInstallment && selectedPkg && (
             <div className="rounded-lg border p-3 space-y-3">

--- a/src/components/gabinet/package-usage-selector.tsx
+++ b/src/components/gabinet/package-usage-selector.tsx
@@ -68,7 +68,7 @@ export function PackageUsageSelector({
         return (
           <label
             key={usage._id}
-            className="flex items-center gap-3 rounded-lg border p-3 cursor-pointer hover:bg-muted/50 transition-colors"
+            className="flex min-h-11 select-none items-center gap-3 rounded-lg border p-3 cursor-pointer transition-colors hover:bg-muted/50 active:bg-muted"
           >
             <Checkbox
               checked={isChecked}

--- a/src/components/gabinet/patient-packages-card.tsx
+++ b/src/components/gabinet/patient-packages-card.tsx
@@ -507,19 +507,17 @@ function InstallmentPayButton({
           </Select>
         </div>
 
-        <div className="flex items-center gap-2">
+        <Label
+          htmlFor={`split-installment-${paymentId}`}
+          className="-mx-2 flex min-h-11 select-none items-center gap-3 rounded-md px-2 py-2.5 cursor-pointer text-xs font-normal transition-colors hover:bg-accent/40 active:bg-accent"
+        >
           <Checkbox
             id={`split-installment-${paymentId}`}
             checked={splitPayment}
             onCheckedChange={(v) => setSplitPayment(v === true)}
           />
-          <Label
-            htmlFor={`split-installment-${paymentId}`}
-            className="cursor-pointer text-xs font-normal"
-          >
-            {t("gabinet.packages.splitPayment", "Split payment")}
-          </Label>
-        </div>
+          {t("gabinet.packages.splitPayment", "Split payment")}
+        </Label>
 
         {splitPayment && (
           <div className="space-y-2">

--- a/src/components/gabinet/sell-package-panel.tsx
+++ b/src/components/gabinet/sell-package-panel.tsx
@@ -249,19 +249,17 @@ export function SellPackagePanel({
           </Select>
         </div>
 
-        <div className="flex items-center gap-2">
+        <Label
+          htmlFor="sell-package-split-payment"
+          className="-mx-2 flex min-h-11 select-none items-center gap-3 rounded-md px-2 py-2.5 cursor-pointer text-sm font-normal transition-colors hover:bg-accent/40 active:bg-accent"
+        >
           <Checkbox
             id="sell-package-split-payment"
             checked={splitPayment}
             onCheckedChange={(v) => setSplitPayment(v === true)}
           />
-          <Label
-            htmlFor="sell-package-split-payment"
-            className="cursor-pointer text-sm font-normal"
-          >
-            {t("gabinet.packages.splitPayment", "Podziel płatność")}
-          </Label>
-        </div>
+          {t("gabinet.packages.splitPayment", "Podziel płatność")}
+        </Label>
 
         {splitPayment && (
           <div className="rounded-lg border p-3 space-y-3">

--- a/src/components/gabinet/treatment-purchase-drawer.tsx
+++ b/src/components/gabinet/treatment-purchase-drawer.tsx
@@ -398,21 +398,19 @@ export function TreatmentPurchaseDrawer({
             </Select>
           </div>
 
-          <div className="flex items-center gap-2">
+          <Label
+            htmlFor="treatment-split-payment"
+            className="-mx-2 flex min-h-11 select-none items-center gap-3 rounded-md px-2 py-2.5 cursor-pointer text-sm font-normal transition-colors hover:bg-accent/40 active:bg-accent"
+          >
             <Checkbox
               id="treatment-split-payment"
               checked={splitPayment}
               onCheckedChange={(v) => setSplitPayment(v === true)}
             />
-            <Label
-              htmlFor="treatment-split-payment"
-              className="cursor-pointer text-sm font-normal"
-            >
-              {isInstallment
-                ? t("gabinet.packages.splitFirstInstallment", "Podziel pierwszą ratę")
-                : t("gabinet.packages.splitPayment", "Podziel płatność")}
-            </Label>
-          </div>
+            {isInstallment
+              ? t("gabinet.packages.splitFirstInstallment", "Podziel pierwszą ratę")
+              : t("gabinet.packages.splitPayment", "Podziel płatność")}
+          </Label>
 
           {isInstallment && selectedTreatment && (
             <div className="rounded-lg border p-3 space-y-3">

--- a/src/components/layout/sidebar-filter-action.tsx
+++ b/src/components/layout/sidebar-filter-action.tsx
@@ -112,21 +112,20 @@ export function SidebarFilterAction({
               {selected.length > 0 ? "Clear" : "Reset"}
             </Button>
           </div>
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col">
             {options.map((option) => (
-              <div key={option.value} className="flex items-center gap-2">
+              <Label
+                key={option.value}
+                htmlFor={`filter-${option.value}`}
+                className="-mx-2 flex min-h-11 select-none items-center gap-3 rounded-md px-2 py-2.5 cursor-pointer text-sm font-normal transition-colors hover:bg-accent/40 active:bg-accent"
+              >
                 <Checkbox
                   id={`filter-${option.value}`}
                   checked={selected.includes(option.value)}
                   onCheckedChange={() => handleToggle(option.value)}
                 />
-                <Label
-                  htmlFor={`filter-${option.value}`}
-                  className="cursor-pointer text-sm font-normal"
-                >
-                  {option.label}
-                </Label>
-              </div>
+                {option.label}
+              </Label>
             ))}
           </div>
           {selected.length > 0 && (

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -11,7 +11,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "grid place-content-center peer h-4 w-4 shrink-0 rounded-[3px] border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "relative grid place-content-center peer h-4 w-4 pointer-coarse:h-5 pointer-coarse:w-5 shrink-0 rounded-[3px] border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground pointer-coarse:before:absolute pointer-coarse:before:-inset-2 pointer-coarse:before:content-['']",
       className
     )}
     {...props}
@@ -19,7 +19,7 @@ const Checkbox = React.forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn("grid place-content-center text-current")}
     >
-      <Check className="h-4 w-4" />
+      <Check className="h-4 w-4 pointer-coarse:h-5 pointer-coarse:w-5" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ))

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
@@ -289,7 +289,7 @@ function LeaveTypeDialog({
             />
           </div>
 
-          <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <label className="-mx-3 flex min-h-11 select-none items-center gap-3 rounded-md px-3 py-2.5 text-sm cursor-pointer transition-colors hover:bg-accent/40 active:bg-accent">
             <Checkbox
               checked={isPaid}
               onCheckedChange={(checked) => setIsPaid(checked as boolean)}
@@ -297,7 +297,7 @@ function LeaveTypeDialog({
             {t("gabinet.leaveTypes.paid")}
           </label>
 
-          <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <label className="-mx-3 flex min-h-11 select-none items-center gap-3 rounded-md px-3 py-2.5 text-sm cursor-pointer transition-colors hover:bg-accent/40 active:bg-accent">
             <Checkbox
               checked={requiresApproval}
               onCheckedChange={(checked) => setRequiresApproval(checked as boolean)}
@@ -306,7 +306,7 @@ function LeaveTypeDialog({
           </label>
 
           {initial && (
-            <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <label className="-mx-3 flex min-h-11 select-none items-center gap-3 rounded-md px-3 py-2.5 text-sm cursor-pointer transition-colors hover:bg-accent/40 active:bg-accent">
               <Checkbox
                 checked={isActive}
                 onCheckedChange={(checked) => setIsActive(checked as boolean)}

--- a/src/routes/sign.$token.tsx
+++ b/src/routes/sign.$token.tsx
@@ -311,7 +311,7 @@ function SigningFlow({
           {(!needsOtp || otpVerified) && (
             <div className="space-y-4">
               {/* Acknowledgment checkbox */}
-              <label className="flex items-start gap-3 cursor-pointer">
+              <label className="-mx-2 flex min-h-11 select-none items-start gap-3 rounded-md px-2 py-2.5 cursor-pointer transition-colors hover:bg-accent/40 active:bg-accent">
                 <Checkbox
                   checked={acknowledged}
                   onCheckedChange={(v) => setAcknowledged(!!v)}

--- a/src/routes/sign.form.$token.tsx
+++ b/src/routes/sign.form.$token.tsx
@@ -216,7 +216,7 @@ function SignatureSection({
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <label className="flex items-start gap-3 cursor-pointer">
+        <label className="-mx-2 flex min-h-11 select-none items-start gap-3 rounded-md px-2 py-2.5 cursor-pointer transition-colors hover:bg-accent/40 active:bg-accent">
           <Checkbox
             checked={acknowledged}
             onCheckedChange={(v) => setAcknowledged(!!v)}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1762.

Closes #1762

---

## Claude summary

Committed as `9c5a01e`. Here's what changed in response to @aslocka's request to make checkboxes easier to tap on mobile *everywhere*:

The Checkbox primitive (`src/components/ui/checkbox.tsx`) now grows from 16px → 20px on touch devices (`pointer-coarse:` variant) and adds an invisible 8px hit-area extension via a `before:` pseudo-element. Desktop/mouse rendering is unchanged. This single change improves every `<Checkbox>` in the app, including ones I didn't manually touch.

Then I applied the established min-h-11 + py-2.5 + active-state row pattern (the same one from #1763) to the highest-impact mobile checkbox surfaces: patient document signing (`sign.$token.tsx`, `sign.form.$token.tsx`), the appointment "use package / use credit" settlement toggles, recurring/walk-in toggles in the appointment dialog, the employee-scope multi-select in event dialog, package usage selector, split-payment toggles across all four checkout drawers, leave-type settings dialog, documentation parameter renderer, the generic sidebar filter popover, and the CRM column visibility picker.

Typecheck has a pre-existing `TS2589` error in `sign.$token.tsx` (Convex API type recursion) that exists on `origin/main` too — confirmed by stashing my changes and re-running; not introduced here.