### PR TITLE
Okienko w kalendarzu

### DIFF
--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -299,12 +299,14 @@ export function DraggableAppointment({
       {...listeners}
       {...attributes}
       data-appointment-card="true"
-      // `touch-none` lets dnd-kit detect drag intent from anywhere on the card
-      // on touch (issue #1766). Without it, iOS preempts pointer events with
-      // native scroll the moment the user starts moving their finger, so the
-      // PointerSensor never sees enough movement to cross its 5px activation
-      // threshold and the user can't drag the appointment from the card body.
-      // Desktop is unaffected — `touch-action` only gates touch input.
+      // `touch-none` keeps iOS from preempting the touch as a scroll gesture
+      // before the TouchSensor's 200ms press-and-hold activation can fire
+      // (issue #1766). The original fix paired this with a distance-based
+      // PointerSensor, but that meant any micro-movement during a tap looked
+      // like a drag and users could never reach the preview popover — see the
+      // delay-based TouchSensor in `_layout.gabinet.calendar.index.lazy.tsx`
+      // that now disambiguates quick taps (→ click → preview) from holds (→
+      // drag). Desktop is unaffected — `touch-action` only gates touch input.
       className={`relative h-full touch-none ${isDragging ? "opacity-50 cursor-grabbing" : "cursor-grab"}`}
       style={
         previewHeightPx !== null ? { height: `${previewHeightPx}px` } : undefined

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -44,7 +44,8 @@ import {
   DragEndEvent,
   DragOverlay,
   DragStartEvent,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -210,11 +211,25 @@ function GabinetCalendarPage() {
   const updateAppointment = useAction(api.gabinet.appointments.update);
   const queryClient = useQueryClient();
 
-  // DnD sensors
+  // DnD sensors — split mouse vs touch so taps still open the preview on iOS
+  // (issue #1766 follow-up). The previous PointerSensor with `distance: 5`
+  // combined with `touch-none` on the card meant any finger micro-movement
+  // during a tap crossed the threshold and activated drag instead of click,
+  // so users could never tap to open the preview popover and "see what's in
+  // the window". Mouse keeps the snappy 5px-distance activation; touch uses a
+  // 200ms press-and-hold with 5px tolerance, so quick taps fall through to
+  // the card button's onClick (preview opens) and only a deliberate hold
+  // starts a drag.
   const sensors = useSensors(
-    useSensor(PointerSensor, {
+    useSensor(MouseSensor, {
       activationConstraint: {
         distance: 5,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 200,
+        tolerance: 5,
       },
     }),
   );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1766.

Closes #1766

---

## Claude summary

Committed `47e2eaf` on `claude/issue-1766`.

Root cause of the user's follow-up "nie widzę co jest w okienku": PR #1767 added `touch-none` to the appointment card wrapper (`src/components/gabinet/calendar/draggable-appointment.tsx:308`) but kept the unified `PointerSensor` with a 5px distance activation (`src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx:215`). The two together broke tap-to-preview on iOS — `touch-none` removes the browser's native tap/scroll disambiguation, and a 5px threshold is below the natural finger wobble of a normal tap, so dnd-kit went straight into drag mode and the underlying `<button>`'s `onClick` (which opens the preview popover) never fired. The user could drag but could no longer see what was in the card.

Fix: replace the single `PointerSensor` with a `MouseSensor` (`distance: 5`, desktop unchanged) and a `TouchSensor` with delay-based activation (`delay: 200ms`, `tolerance: 5px`). Touch now needs a 200ms press-and-hold to start a drag, so quick taps fall through to the card's `onClick` (preview opens) and a deliberate hold-then-drag still works from anywhere on the card. `touch-none` stays on the wrapper so iOS doesn't preempt the touch during the 200ms delay window.