### PR TITLE
Klienci

### DIFF
--- a/src/components/application/table/table.tsx
+++ b/src/components/application/table/table.tsx
@@ -153,7 +153,10 @@ const TableHeader = <T extends object>({ columns, children, bordered = true, cla
                         // Right separator via ::before so we don't clash with the parent's
                         // [&>tr>th]:after rule that draws the header bottom border.
                         "before:pointer-events-none before:absolute before:inset-y-0 before:right-0 before:w-px before:bg-border-secondary before:content-['']",
-                        size === "sm" ? "w-24 md:pl-3" : "w-28 md:pl-4",
+                        // Narrow on mobile so the selection cell doesn't eat ~25% of the
+                        // row width as an accidental-toggle hit area (issue #1772 — finger
+                        // taps meant to open a row landed on the wide checkbox cell on iOS).
+                        size === "sm" ? "w-12 md:w-24 md:pl-3" : "w-14 md:w-28 md:pl-4",
                     )}
                 >
                     {selectionMode === "multiple" && (
@@ -255,7 +258,10 @@ const TableRow = <T extends object>({ columns, children, className, highlightSel
                         // Right separator via ::before so we don't clash with the parent's
                         // [&>td]:after rule that draws the row bottom border.
                         "before:pointer-events-none before:absolute before:inset-y-0 before:right-0 before:w-px before:bg-border-secondary before:content-['']",
-                        size === "sm" ? "w-24 md:pl-3" : "w-28 md:pl-4",
+                        // Narrow on mobile so the selection cell doesn't eat ~25% of the
+                        // row width as an accidental-toggle hit area (issue #1772 — finger
+                        // taps meant to open a row landed on the wide checkbox cell on iOS).
+                        size === "sm" ? "w-12 md:w-24 md:pl-3" : "w-14 md:w-28 md:pl-4",
                     )}
                 >
                     <Checkbox


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1772.

Closes #1772

---

## Claude summary

Committed as `bbe8813`. Summary:

The Klienci screen uses `CrmDataTable` with `enableBulkSelect` plus `onRowAction={navigate(...)}`. The intent was "row tap navigates, checkbox toggles selection". But the auto-rendered selection cell in `src/components/application/table/table.tsx` is `w-24` (96px) at every breakpoint, and its inner Checkbox has `absolute inset-0` — so on a 390px iPhone the leftmost ~25% of each row is a "toggle selection" hit area. Finger taps meant to open the patient card landed there and just ticked the box.

Fix: narrow the cell on mobile only — `w-12 md:w-24` (sm) and `w-14 md:w-28` (md). 48px still clears iOS's 44px touch-target minimum for the checkbox itself, but the rest of the row width is now the row body, so the navigate action fires reliably. Desktop (md and up) is unchanged. The change is in the shared Untitled UI Table component, so it benefits every list page (contacts, leads, deals, treatments, etc.), not just patients.