### PR TITLE
Widok okienka w kalendarzu

### DIFF
--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -366,9 +366,20 @@ export function DraggableAppointment({
         // made tall content unreadable. Drag-to-peek is now touch-driven only
         // via the grab pill at the top, which has its own `touch-none` zone.
         className={cn(
-          "w-[553px] max-w-[calc(100vw-24px)] max-h-[calc(100dvh-24px)] overflow-y-auto p-0 rounded-xl border-border/60 shadow-2xl",
+          "w-[553px] max-w-[calc(100vw-24px)] overflow-y-auto p-0 rounded-xl border-border/60 shadow-2xl",
           isPreviewDragging && "cursor-grabbing select-none",
         )}
+        // Use Radix's collision-aware available height (set via
+        // `--radix-popover-content-available-height`) instead of a hard-coded
+        // `max-h-[calc(100dvh-24px)]` (issue #1769 follow-up). On iOS Safari
+        // with the URL bar at the bottom and the status bar at the top, the
+        // bare `100dvh` value can exceed the actually-visible viewport, which
+        // pushed the popover's top (patient header, close button, drag pill)
+        // behind the status bar — the user reported "nic nie widać" because
+        // they only saw the bottom half of the popover and could not reach
+        // the close affordance. Radix recalculates this value against the
+        // real collision boundary, including `collisionPadding`.
+        style={{ maxHeight: "var(--radix-popover-content-available-height)" }}
         // On mobile the appointment can sit on either side of the screen, and a
         // 378px popover does not fit beside it. Anchor it to the bottom of the
         // card and center horizontally so the whole preview stays on-screen;

--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -145,14 +145,11 @@ export function DraggableAppointment({
   const handlePreviewDragStart = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       if (e.button !== 0) return;
-      // Touch input is allowed here too (issue #1741): mobile users complained
-      // that only the tiny grab pill at the top could drag the popover. The
-      // interactive-element filter below already lets taps on buttons,
-      // inputs, textareas etc. fall through, so native scroll inside the
-      // textarea (the only realistically scrollable surface on mobile) and
-      // form interactions still work. Drag-from-anywhere wins over native
-      // popover-body scrolling on non-interactive surface — the popover is
-      // short enough on mobile that this is the right trade-off.
+      // Skip touch — on iOS the popover content scrolls natively (issue #1769)
+      // and body-wide drag-from-anywhere only worked by suppressing that scroll
+      // (#1756), which made tall content unreachable on small phones. Mobile
+      // users drag via the grab pill at the top (which has its own touch-none).
+      if (e.pointerType === "touch") return;
       const target = e.target as HTMLElement | null;
       if (
         target?.closest(
@@ -363,12 +360,13 @@ export function DraggableAppointment({
         : null}
       <PopoverContent
         ref={previewContentRef}
-        // `touch-none` here is what makes body-drag actually win on iOS: without
-        // it, the `overflow-y-auto` surface starts a native scroll before our
-        // `onPointerDown`'s `preventDefault()` can take effect (issue #1756).
-        // Desktop wheel scroll is unaffected; `touch-action` only gates touch.
+        // Touch scrolling is left on so users on small phones can reach all the
+        // content inside the popover (issue #1769). The earlier `touch-none`
+        // (#1756) made body-drag win over native scroll on iOS, but it also
+        // made tall content unreadable. Drag-to-peek is now touch-driven only
+        // via the grab pill at the top, which has its own `touch-none` zone.
         className={cn(
-          "w-[553px] max-w-[calc(100vw-24px)] max-h-[calc(100dvh-24px)] overflow-y-auto p-0 rounded-xl border-border/60 shadow-2xl touch-none",
+          "w-[553px] max-w-[calc(100vw-24px)] max-h-[calc(100dvh-24px)] overflow-y-auto p-0 rounded-xl border-border/60 shadow-2xl",
           isPreviewDragging && "cursor-grabbing select-none",
         )}
         // On mobile the appointment can sit on either side of the screen, and a


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1769.

Closes #1769

---

## Claude summary

Committed. The previous fix (#1771) restored touch scrolling inside the popover, but the root cause of "nic nie widać" was different: the popover overflowed the iOS-visible viewport because `max-h-[calc(100dvh-24px)]` didn't match Safari's actually-visible area between the status bar and the bottom URL bar. With the top of the popover hidden behind the status bar/notch, the patient header and close X were unreachable.

Replaced the hard-coded max-height with Radix's collision-aware `--radix-popover-content-available-height` — the same pattern already used by the treatment picker on line 1218 of `appointment-preview-content.tsx`. Radix recomputes this against the real visible viewport with `collisionPadding={12}` applied, so the entire popover (including the sticky grab pill and the X close button) stays in view on iOS small phones.