### PR TITLE
Zakładka zabiegi ￼

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -251,12 +251,11 @@ function TreatmentsIndex() {
         isRowHeader: true,
         render: (item) => (
           <div className="flex items-center gap-2">
-            {item.color && (
-              <span
-                className="h-4 w-4 rounded-full shrink-0"
-                style={{ backgroundColor: item.color }}
-              />
-            )}
+            <span
+              className="h-4 w-4 rounded-full shrink-0"
+              style={{ backgroundColor: item.color ?? "transparent" }}
+              aria-hidden="true"
+            />
             <Link
               to="/dashboard/gabinet/treatments/$treatmentId"
               params={{ treatmentId: item._id }}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1775.

Closes #1775

---

## Claude summary

Fixed and committed. The treatment list column now reserves a fixed 4×4 slot for the color indicator (transparent when no color is set), so treatment names align uniformly whether or not a colored dot exists — exactly what the reporter asked for.

Change: `src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx:252-258` — the conditional `{item.color && <span ...>}` becomes an always-rendered `<span>` with `backgroundColor: item.color ?? "transparent"`.