### PR TITLE
Zabiegi

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -250,7 +250,7 @@ function TreatmentsIndex() {
         sortable: true,
         isRowHeader: true,
         render: (item) => (
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 pl-2 md:pl-0">
             <span
               className="h-4 w-4 rounded-full shrink-0"
               style={{ backgroundColor: item.color ?? "transparent" }}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1779.

Closes #1779

---

## Claude summary

Fixed and committed. The colored dot in the treatments list was sitting visually flush against the checkbox on mobile because PR #1776 narrowed the selection cell from 96px to 48px, pulling the name column much closer to the checkbox. Added 8px of left padding (`pl-2 md:pl-0`) on the name cell content on mobile so the dot has breathing room from the checkbox while names still align across rows. Commit `4c9de92`.