### PR TITLE
 Przełączenie z crm

### DIFF
--- a/src/components/layout/workspace-switcher.tsx
+++ b/src/components/layout/workspace-switcher.tsx
@@ -1,4 +1,4 @@
-import { CircleCheckIcon } from "@/lib/ez-icons";
+import { ChevronsUpDown, CircleCheckIcon } from "@/lib/ez-icons";
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import type { ModuleId, ModuleWorkspaceOption } from "@/modules/types";
@@ -32,10 +32,11 @@ export function WorkspaceSwitcher({ activeWorkspace, workspaces, onSelect }: Wor
         <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground">
           <current.icon className="size-4" />
         </div>
-        <div className="flex flex-col gap-0.5 leading-none">
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5 leading-none">
           <span className="text-sm font-semibold leading-none">{t(current.nameKey)}</span>
           <span className="text-muted-foreground text-xs">{t(current.descKey)}</span>
         </div>
+        <ChevronsUpDown className="text-muted-foreground ml-auto size-4 shrink-0" variant="stroke" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-60">
         <DropdownMenuLabel>{t("nav.sections.workspace", "Workspace")}</DropdownMenuLabel>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1783.

Closes #1783

---

## Claude summary

NOT_A_BUG: This issue has already been resolved. The fix was implemented and merged via PR #1784 (commit `b0a2099` on `main`), as confirmed by @aleksanderem's comment at 2026-06-15T09:30:32Z.

The workspace switcher in `src/components/layout/workspace-switcher.tsx:39` now renders a `ChevronsUpDown` icon on the right side of the `DropdownMenuTrigger`, giving the tile a visible dropdown affordance on mobile. The "switch to gabinet" entry then appears in the dropdown when the user taps the workspace tile in the mobile sidebar (`useGetModuleWorkspaceOptions` returns the active modules from `productSubscriptions`).

Branch `claude/issue-1783` already contains the fix (commit `e10f8f8`) and is identical to `main` for that file — `git diff main claude/issue-1783 -- src/components/layout/workspace-switcher.tsx` returns empty. Nothing further to commit.