### PR TITLE
Przełączenie

### DIFF
--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -112,6 +112,7 @@ export function AppSidebar() {
                 activeWorkspace={activeWorkspace}
                 workspaces={visibleModules.map((module) => module.workspace)}
                 onSelect={closeMobile}
+                inline
               />
             </div>
           )}

--- a/src/components/layout/workspace-switcher.tsx
+++ b/src/components/layout/workspace-switcher.tsx
@@ -1,5 +1,5 @@
 import { ChevronsUpDown, CircleCheckIcon } from "@/lib/ez-icons";
-import { useNavigate } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import type { ModuleId, ModuleWorkspaceOption } from "@/modules/types";
 import {
@@ -9,14 +9,16 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { cn } from "@/utils/misc";
 
 interface WorkspaceSwitcherProps {
   activeWorkspace: ModuleId;
   workspaces: ModuleWorkspaceOption[];
   onSelect?: () => void;
+  inline?: boolean;
 }
 
-export function WorkspaceSwitcher({ activeWorkspace, workspaces, onSelect }: WorkspaceSwitcherProps) {
+export function WorkspaceSwitcher({ activeWorkspace, workspaces, onSelect, inline }: WorkspaceSwitcherProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
@@ -25,6 +27,43 @@ export function WorkspaceSwitcher({ activeWorkspace, workspaces, onSelect }: Wor
   }
 
   const current = workspaces.find((workspace) => workspace.id === activeWorkspace) ?? workspaces[0];
+
+  if (inline) {
+    return (
+      <div className="flex flex-col gap-1.5">
+        {workspaces.map((workspace) => {
+          const isActive = activeWorkspace === workspace.id;
+          return (
+            <Link
+              key={workspace.id}
+              to={workspace.href}
+              onClick={onSelect}
+              className={cn(
+                "flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-left transition-colors",
+                isActive ? "bg-secondary" : "hover:bg-secondary/60",
+              )}
+            >
+              <div
+                className={cn(
+                  "flex size-9 shrink-0 items-center justify-center rounded-md",
+                  isActive ? "bg-primary text-primary-foreground" : "bg-primary/10 text-primary",
+                )}
+              >
+                <workspace.icon className="size-4" />
+              </div>
+              <div className="flex min-w-0 flex-1 flex-col gap-0.5 leading-none">
+                <span className="text-sm font-semibold leading-none">{t(workspace.nameKey)}</span>
+                <span className="text-muted-foreground text-xs">{t(workspace.descKey)}</span>
+              </div>
+              {isActive && (
+                <CircleCheckIcon className="text-muted-foreground ml-auto size-4 shrink-0" variant="stroke" />
+              )}
+            </Link>
+          );
+        })}
+      </div>
+    );
+  }
 
   return (
     <DropdownMenu>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1786.

Closes #1786

---

## Claude summary

Committed. Summary: on mobile the sidebar workspace switcher now lists all available workspaces (Gabinet, CRM) inline so users tap once to switch — no more dropdown-to-expand step. The desktop sidebar still uses the dropdown variant via the new `inline` prop on `WorkspaceSwitcher` (`src/components/layout/workspace-switcher.tsx:31-66`).