### PR TITLE
Dodaj grupy dokumentów tak jak jest w szablonach

### DIFF
--- a/src/components/documents/documents-grouped-view.tsx
+++ b/src/components/documents/documents-grouped-view.tsx
@@ -1,0 +1,128 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  CrmDataTable,
+  type CrmColumn,
+  type CrmDataTableProps,
+} from "@/components/crm/enhanced-data-table";
+import { Folder, FolderOpen, ChevronDown, ChevronRight } from "@/lib/ez-icons";
+
+interface DocumentsGroupedViewProps<TData>
+  extends Omit<CrmDataTableProps<TData>, "data" | "columns"> {
+  columns: CrmColumn<TData>[];
+  documents: TData[];
+  /**
+   * Returns the folder path for a document (e.g. "Gabinet/Zgody") or
+   * `undefined` if the document is not in any folder.
+   */
+  getFolderPath: (doc: TData) => string | undefined;
+}
+
+interface FolderGroup<TData> {
+  /** Full folder path or `undefined` for ungrouped. */
+  folderPath: string | undefined;
+  /** Display label — last segment of the path, or "Bez katalogu". */
+  label: string;
+  docs: TData[];
+}
+
+/**
+ * Wraps {@link CrmDataTable} with folder-based grouping. Documents inherit
+ * their group from their template's `folderPath`. When no folders are in use
+ * the view collapses to a flat table for parity with the original layout.
+ */
+export function DocumentsGroupedView<TData>({
+  documents,
+  getFolderPath,
+  columns,
+  ...tableProps
+}: DocumentsGroupedViewProps<TData>) {
+  const { t } = useTranslation();
+
+  const noFolderLabel = t("settings.formTemplates.noFolder", "Bez katalogu");
+
+  const groups = useMemo<FolderGroup<TData>[]>(() => {
+    const map = new Map<string, FolderGroup<TData>>();
+    for (const doc of documents) {
+      const path = getFolderPath(doc);
+      const key = path ?? "__none__";
+      let group = map.get(key);
+      if (!group) {
+        group = {
+          folderPath: path,
+          label: path ? (path.split("/").pop() ?? path) : noFolderLabel,
+          docs: [],
+        };
+        map.set(key, group);
+      }
+      group.docs.push(doc);
+    }
+    return Array.from(map.values()).sort((a, b) => {
+      // Folders first, ungrouped last
+      if (a.folderPath === undefined && b.folderPath !== undefined) return 1;
+      if (a.folderPath !== undefined && b.folderPath === undefined) return -1;
+      return (a.folderPath ?? "").localeCompare(b.folderPath ?? "");
+    });
+  }, [documents, getFolderPath, noFolderLabel]);
+
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+
+  // Fall back to flat table when no actual folders are in use — preserves the
+  // pre-grouping layout for organizations that haven't filed templates yet.
+  const hasFolders = groups.some((g) => g.folderPath !== undefined);
+  if (!hasFolders) {
+    return <CrmDataTable<TData> data={documents} columns={columns} {...tableProps} />;
+  }
+
+  const toggle = (key: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      {groups.map((group) => {
+        const key = group.folderPath ?? "__none__";
+        const isCollapsed = collapsed.has(key);
+        return (
+          <div key={key} className="space-y-2">
+            <button
+              type="button"
+              onClick={() => toggle(key)}
+              className="flex w-full items-center gap-2 rounded-md border bg-card px-3 py-2 text-sm font-medium hover:bg-accent/50 transition-colors"
+              aria-expanded={!isCollapsed}
+            >
+              {isCollapsed ? (
+                <ChevronRight className="h-4 w-4 text-muted-foreground" variant="stroke" />
+              ) : (
+                <ChevronDown className="h-4 w-4 text-muted-foreground" variant="stroke" />
+              )}
+              {isCollapsed ? (
+                <Folder className="h-4 w-4 text-amber-500" />
+              ) : (
+                <FolderOpen className="h-4 w-4 text-amber-500" />
+              )}
+              <span className="flex-1 text-left">
+                {group.folderPath ?? group.label}
+              </span>
+              <span className="text-xs text-muted-foreground font-normal">
+                ({group.docs.length})
+              </span>
+            </button>
+            {!isCollapsed && (
+              <CrmDataTable<TData>
+                data={group.docs}
+                columns={columns}
+                {...tableProps}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/routes/_app/_auth/dashboard/_layout.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.documents.index.tsx
@@ -30,11 +30,11 @@ import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
 import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
 import {
-  CrmDataTable,
   useColumnVisibility,
   useAllColumns,
   type CrmColumn,
 } from "@/components/crm/enhanced-data-table";
+import { DocumentsGroupedView } from "@/components/documents/documents-grouped-view";
 import { DataListFilterBar } from "@/components/crm/data-list-filter-bar";
 import type { SavedView, FieldDef, FilterCondition } from "@/components/crm/types";
 import { useSavedViews, applyFilterConditions } from "@/hooks/use-saved-views";
@@ -523,10 +523,13 @@ function DocumentsPage() {
         onFiltersChange={setActiveFilters}
       />
 
-      <CrmDataTable
+      <DocumentsGroupedView
         columns={allColumns}
         hiddenColumnIds={hiddenColumnIds}
-        data={filteredDocuments}
+        documents={filteredDocuments}
+        getFolderPath={(doc) =>
+          templateMap.get(doc.templateId as Id<"formTemplates">)?.folderPath ?? undefined
+        }
         rowActions={rowActions}
         isLoading={docsLoading}
         enableBulkSelect

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -8,7 +8,8 @@ import { PageHeader } from "@/components/layout/page-header";
 import { DocumentStatusBadge } from "@/components/documents/document-status-badge";
 import { DocumentViewer } from "@/components/documents/document-viewer";
 import { renderDocument } from "@/components/documents/document-renderer";
-import { CrmDataTable, type CrmColumn, useColumnVisibility, useAllColumns } from "@/components/crm/enhanced-data-table";
+import { type CrmColumn, useColumnVisibility, useAllColumns } from "@/components/crm/enhanced-data-table";
+import { DocumentsGroupedView } from "@/components/documents/documents-grouped-view";
 import { DataListFilterBar } from "@/components/crm/data-list-filter-bar";
 import { MiniChartsRow, type MiniChartData } from "@/components/crm/mini-charts";
 import { SidePanel } from "@/components/crm/side-panel";
@@ -545,10 +546,11 @@ function GabinetDocumentsPage() {
 
       {/* Data Table */}
       {!docsLoading && filteredDocuments.length > 0 && (
-        <CrmDataTable
-          data={filteredDocuments}
+        <DocumentsGroupedView
+          documents={filteredDocuments}
           columns={allColumns}
           hiddenColumnIds={hiddenColumnIds}
+          getFolderPath={(doc) => templateMap.get(doc.templateId)?.folderPath ?? undefined}
           enableBulkSelect={true}
           getRowId={(item, index) => item._id ?? String(index)}
           onBulkAction={(action, items) => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1788.

Closes #1788

---

## Claude summary

Committed. Summary of changes:

Added folder-based grouping to both document pages (`/dashboard/documents` and `/dashboard/gabinet/documents`), mirroring the templates folder UX. Documents inherit their group from their source template's `folderPath`, so any organization already filed in templates appears automatically. Each folder gets a collapsible header showing folder name + document count, with the table rendered inside. When no templates use folders, the view falls back to the original flat table to avoid empty chrome.

New file: `src/components/documents/documents-grouped-view.tsx` — a thin wrapper around `CrmDataTable` that handles the grouping + folder header. Both documents pages call it the same way, passing the same column/row-action props they used to pass directly to `CrmDataTable`.

Files changed: 3 (1 new component, 2 page edits). Typecheck passes; no new lint warnings.