### PR TITLE
Wybór godziny

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -144,14 +144,14 @@ function computeEndTime(start: string, durationMinutes: number): string {
  * Snap a "HH:MM" string to the nearest 15-minute boundary. Chrome's clock
  * picker and direct typing ignore the input's `step` attribute, so we enforce
  * the grid on every change. Mirrors the helper used by the appointment preview
- * popover and detail page (issue #1365).
+ * popover and detail page (issues #1365, #1789).
  */
-function snapTimeTo15Min(value: string): string {
+function snapTimeTo5Min(value: string): string {
   if (!value) return value;
   const [h, m] = value.split(":").map(Number);
   if (!Number.isFinite(h) || !Number.isFinite(m)) return value;
   const total = Math.min(Math.max(h * 60 + m, 0), 24 * 60 - 1);
-  const snapped = Math.min(Math.round(total / 15) * 15, 24 * 60 - 1);
+  const snapped = Math.min(Math.round(total / 5) * 5, 24 * 60 - 1);
   return `${String(Math.floor(snapped / 60)).padStart(2, "0")}:${String(snapped % 60).padStart(2, "0")}`;
 }
 
@@ -1547,7 +1547,7 @@ export function AppointmentDialog({
                                     )}
                                     <input
                                       type="time"
-                                      step={900}
+                                      step={300}
                                       value={occ.startTime}
                                       disabled={occ.index === 0}
                                       onChange={(e) =>
@@ -1555,7 +1555,7 @@ export function AppointmentDialog({
                                           ...prev,
                                           [occ.index]: {
                                             ...prev[occ.index],
-                                            startTime: snapTimeTo15Min(
+                                            startTime: snapTimeTo5Min(
                                               e.target.value,
                                             ),
                                           },

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -279,17 +279,17 @@ export function AppointmentPreviewContent({
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
 
-  const snapTimeTo15Min = (value: string): string => {
+  const snapTimeTo5Min = (value: string): string => {
     if (!value) return value;
     const [h, m] = value.split(":").map(Number);
     if (!Number.isFinite(h) || !Number.isFinite(m)) return value;
     const total = Math.min(Math.max(h * 60 + m, 0), 24 * 60 - 1);
-    const snapped = Math.min(Math.round(total / 15) * 15, 24 * 60 - 1);
+    const snapped = Math.min(Math.round(total / 5) * 5, 24 * 60 - 1);
     return `${String(Math.floor(snapped / 60)).padStart(2, "0")}:${String(snapped % 60).padStart(2, "0")}`;
   };
 
   const handleStartTimeChange = (rawStart: string) => {
-    const newStart = snapTimeTo15Min(rawStart);
+    const newStart = snapTimeTo5Min(rawStart);
     setStartTime(newStart);
     if (!newStart || !startTime || !endTime) return;
     const toMin = (s: string) => {
@@ -1487,7 +1487,7 @@ export function AppointmentPreviewContent({
             </Label>
             <Input
               type="time"
-              step={900}
+              step={300}
               value={startTime}
               onChange={(e) => handleStartTimeChange(e.target.value)}
               className="h-8 w-[88px] text-sm"
@@ -1499,9 +1499,9 @@ export function AppointmentPreviewContent({
             </Label>
             <Input
               type="time"
-              step={900}
+              step={300}
               value={endTime}
-              onChange={(e) => setEndTime(snapTimeTo15Min(e.target.value))}
+              onChange={(e) => setEndTime(snapTimeTo5Min(e.target.value))}
               className="h-8 w-[88px] text-sm"
             />
           </div>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -334,12 +334,12 @@ function AppointmentDetail() {
   const [editDate, setEditDate] = useState("");
   const [editStartTime, setEditStartTime] = useState("");
   const [editEndTime, setEditEndTime] = useState("");
-  const snapTimeTo15Min = (value: string): string => {
+  const snapTimeTo5Min = (value: string): string => {
     if (!value) return value;
     const [h, m] = value.split(":").map(Number);
     if (!Number.isFinite(h) || !Number.isFinite(m)) return value;
     const total = Math.min(Math.max(h * 60 + m, 0), 24 * 60 - 1);
-    const snapped = Math.min(Math.round(total / 15) * 15, 24 * 60 - 1);
+    const snapped = Math.min(Math.round(total / 5) * 5, 24 * 60 - 1);
     return `${String(Math.floor(snapped / 60)).padStart(2, "0")}:${String(snapped % 60).padStart(2, "0")}`;
   };
   const [editLocationId, setEditLocationId] = useState("");
@@ -1489,9 +1489,9 @@ function AppointmentDetail() {
                   </Label>
                   <Input
                     type="time"
-                    step={900}
+                    step={300}
                     value={editStartTime}
-                    onChange={(e) => setEditStartTime(snapTimeTo15Min(e.target.value))}
+                    onChange={(e) => setEditStartTime(snapTimeTo5Min(e.target.value))}
                     className="h-9 w-[110px]"
                   />
                 </div>
@@ -1501,9 +1501,9 @@ function AppointmentDetail() {
                   </Label>
                   <Input
                     type="time"
-                    step={900}
+                    step={300}
                     value={editEndTime}
-                    onChange={(e) => setEditEndTime(snapTimeTo15Min(e.target.value))}
+                    onChange={(e) => setEditEndTime(snapTimeTo5Min(e.target.value))}
                     className="h-9 w-[110px]"
                   />
                 </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1789.

Closes #1789

---

## Claude summary

Committed as `937c3f5`.

Changed the gabinet appointment time pickers from 15-minute snap/step to 5-minute. The user (on iOS) sees the native wheel picker, which previously scrolled per-minute despite `step={900}` because iOS Safari ignores the `step` attribute on `<input type="time">`. The codebase already had a `snapTimeTo15Min` helper as a workaround. Per the user's request ("co 5 min"), updated three locations to `step={300}` plus `snapTimeTo5Min`:

- `src/components/gabinet/calendar/appointment-dialog.tsx` (recurring occurrence time override)
- `src/components/gabinet/calendar/appointment-preview-content.tsx` (start/end time)
- `src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx` (edit start/end time)

I scoped the change to appointment scheduling. The `flexible-schedule-editor.tsx` (working-hours configuration) still uses `step={900}` since the screenshot context is appointments and 15-minute increments are reasonable for working hours; happy to broaden if the user wants it global.