### PR TITLE
#1790

### DIFF
--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -350,12 +350,22 @@ export function DraggableAppointment({
           backdrop sits below the popover (z-40 vs Popover's z-50). Clicking
           it bubbles to Radix's outside-click detector which closes the
           popover; drag-to-peek (#1476) still works because the body-drag
-          handler on PopoverContent fires first on its own surface. */}
+          handler on PopoverContent fires first on its own surface.
+
+          The backdrop is portaled to document.body but stays in the React
+          tree, so React synthetic events bubble up through Popover →
+          DraggableAppointment → the calendar slot, which would trigger the
+          grid's onMouseDown drag-to-create handler and open the new-
+          appointment dialog (issue #1797). Stop the synthetic events here —
+          the native DOM event still reaches Radix's document-level
+          outside-click listener, so the popover continues to close. */}
       {popoverOpen && typeof document !== "undefined"
         ? createPortal(
             <div
               aria-hidden
               className="fixed inset-0 z-40 bg-foreground/20 backdrop-blur-[2px] animate-in fade-in-0 duration-150"
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
             />,
             document.body,
           )


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1797.

Closes #1797

---

## Claude summary

Committed as `355a2da`.

Root cause: the appointment-preview popover backdrop (added in #1738 via `src/components/gabinet/calendar/draggable-appointment.tsx:362–372`) is portaled to `document.body` but stays in the React tree. React synthetic events from the backdrop bubble up through `<Popover>` → `<DraggableAppointment>` → the calendar slot, where `calendar-week-view.tsx:227` (and the day/day-by-employee views) bind `onMouseDown={dragHandler.handleMouseDown}`. That handler is the drag-to-create gesture in `use-drag-to-create.ts:91` — a tap with no movement counts as a click and opens the new-appointment dialog. `PopoverContent` already stops propagation for exactly this reason (line 394); the backdrop just missed it.

Fix: add `onMouseDown` / `onClick` `stopPropagation` handlers on the backdrop div. Radix's outside-click detector uses a document-level native listener, so the popover still closes — only the synthetic React bubble that triggered the calendar grid is suppressed.