### PR TITLE
Dokumenty szablony 

### DIFF
--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -6,6 +6,7 @@ import {
   Clock,
   ClipboardList,
   Download,
+  FilePlus,
   FileText,
   Filter,
   Gift,
@@ -51,6 +52,7 @@ export const gabinetManifest: ModuleManifest = {
     { labelKey: "nav.gabinet.packages", href: "/dashboard/gabinet/packages", icon: Gift },
     { labelKey: "nav.gabinet.employees", href: "/dashboard/gabinet/employees", icon: UserCog },
     { labelKey: "nav.gabinet.documents", href: "/dashboard/gabinet/documents", icon: ClipboardList },
+    { labelKey: "nav.gabinet.documentTemplates", href: "/dashboard/gabinet/document-templates", icon: FilePlus },
     { labelKey: "nav.gabinet.reports", href: "/dashboard/gabinet/reports", icon: PieChart },
   ],
   settingsNav: [

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -78,6 +78,7 @@ import { Route as AppAuthDashboardLayoutSettingsActivityTypesRouteImport } from 
 import { Route as AppAuthDashboardLayoutLeadsLeadIdRouteImport } from './routes/_app/_auth/dashboard/_layout.leads.$leadId'
 import { Route as AppAuthDashboardLayoutGabinetReportsRouteImport } from './routes/_app/_auth/dashboard/_layout.gabinet.reports'
 import { Route as AppAuthDashboardLayoutGabinetDocumentsRouteImport } from './routes/_app/_auth/dashboard/_layout.gabinet.documents'
+import { Route as AppAuthDashboardLayoutGabinetDocumentTemplatesRouteImport } from './routes/_app/_auth/dashboard/_layout.gabinet.document-templates'
 import { Route as AppAuthDashboardLayoutEmailTemplatesNewRouteImport } from './routes/_app/_auth/dashboard/_layout.email-templates.new'
 import { Route as AppAuthDashboardLayoutEmailTemplatesTemplateIdRouteImport } from './routes/_app/_auth/dashboard/_layout.email-templates.$templateId'
 import { Route as AppAuthDashboardLayoutDocumentEditorNewRouteImport } from './routes/_app/_auth/dashboard/_layout.document-editor.new'
@@ -512,6 +513,12 @@ const AppAuthDashboardLayoutGabinetDocumentsRoute =
     path: '/gabinet/documents',
     getParentRoute: () => AppAuthDashboardLayoutRoute,
   } as any)
+const AppAuthDashboardLayoutGabinetDocumentTemplatesRoute =
+  AppAuthDashboardLayoutGabinetDocumentTemplatesRouteImport.update({
+    id: '/gabinet/document-templates',
+    path: '/gabinet/document-templates',
+    getParentRoute: () => AppAuthDashboardLayoutRoute,
+  } as any)
 const AppAuthDashboardLayoutEmailTemplatesNewRoute =
   AppAuthDashboardLayoutEmailTemplatesNewRouteImport.update({
     id: '/email-templates/new',
@@ -767,6 +774,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/document-editor/new': typeof AppAuthDashboardLayoutDocumentEditorNewRoute
   '/dashboard/email-templates/$templateId': typeof AppAuthDashboardLayoutEmailTemplatesTemplateIdRoute
   '/dashboard/email-templates/new': typeof AppAuthDashboardLayoutEmailTemplatesNewRoute
+  '/dashboard/gabinet/document-templates': typeof AppAuthDashboardLayoutGabinetDocumentTemplatesRoute
   '/dashboard/gabinet/documents': typeof AppAuthDashboardLayoutGabinetDocumentsRouteWithChildren
   '/dashboard/gabinet/reports': typeof AppAuthDashboardLayoutGabinetReportsRoute
   '/dashboard/leads/$leadId': typeof AppAuthDashboardLayoutLeadsLeadIdRoute
@@ -865,6 +873,7 @@ export interface FileRoutesByTo {
   '/dashboard/document-editor/new': typeof AppAuthDashboardLayoutDocumentEditorNewRoute
   '/dashboard/email-templates/$templateId': typeof AppAuthDashboardLayoutEmailTemplatesTemplateIdRoute
   '/dashboard/email-templates/new': typeof AppAuthDashboardLayoutEmailTemplatesNewRoute
+  '/dashboard/gabinet/document-templates': typeof AppAuthDashboardLayoutGabinetDocumentTemplatesRoute
   '/dashboard/gabinet/reports': typeof AppAuthDashboardLayoutGabinetReportsRoute
   '/dashboard/leads/$leadId': typeof AppAuthDashboardLayoutLeadsLeadIdRoute
   '/dashboard/settings/activity-types': typeof AppAuthDashboardLayoutSettingsActivityTypesRoute
@@ -967,6 +976,7 @@ export interface FileRoutesById {
   '/_app/_auth/dashboard/_layout/document-editor/new': typeof AppAuthDashboardLayoutDocumentEditorNewRoute
   '/_app/_auth/dashboard/_layout/email-templates/$templateId': typeof AppAuthDashboardLayoutEmailTemplatesTemplateIdRoute
   '/_app/_auth/dashboard/_layout/email-templates/new': typeof AppAuthDashboardLayoutEmailTemplatesNewRoute
+  '/_app/_auth/dashboard/_layout/gabinet/document-templates': typeof AppAuthDashboardLayoutGabinetDocumentTemplatesRoute
   '/_app/_auth/dashboard/_layout/gabinet/documents': typeof AppAuthDashboardLayoutGabinetDocumentsRouteWithChildren
   '/_app/_auth/dashboard/_layout/gabinet/reports': typeof AppAuthDashboardLayoutGabinetReportsRoute
   '/_app/_auth/dashboard/_layout/leads/$leadId': typeof AppAuthDashboardLayoutLeadsLeadIdRoute
@@ -1072,6 +1082,7 @@ export interface FileRouteTypes {
     | '/dashboard/document-editor/new'
     | '/dashboard/email-templates/$templateId'
     | '/dashboard/email-templates/new'
+    | '/dashboard/gabinet/document-templates'
     | '/dashboard/gabinet/documents'
     | '/dashboard/gabinet/reports'
     | '/dashboard/leads/$leadId'
@@ -1170,6 +1181,7 @@ export interface FileRouteTypes {
     | '/dashboard/document-editor/new'
     | '/dashboard/email-templates/$templateId'
     | '/dashboard/email-templates/new'
+    | '/dashboard/gabinet/document-templates'
     | '/dashboard/gabinet/reports'
     | '/dashboard/leads/$leadId'
     | '/dashboard/settings/activity-types'
@@ -1271,6 +1283,7 @@ export interface FileRouteTypes {
     | '/_app/_auth/dashboard/_layout/document-editor/new'
     | '/_app/_auth/dashboard/_layout/email-templates/$templateId'
     | '/_app/_auth/dashboard/_layout/email-templates/new'
+    | '/_app/_auth/dashboard/_layout/gabinet/document-templates'
     | '/_app/_auth/dashboard/_layout/gabinet/documents'
     | '/_app/_auth/dashboard/_layout/gabinet/reports'
     | '/_app/_auth/dashboard/_layout/leads/$leadId'
@@ -1830,6 +1843,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppAuthDashboardLayoutGabinetDocumentsRouteImport
       parentRoute: typeof AppAuthDashboardLayoutRoute
     }
+    '/_app/_auth/dashboard/_layout/gabinet/document-templates': {
+      id: '/_app/_auth/dashboard/_layout/gabinet/document-templates'
+      path: '/gabinet/document-templates'
+      fullPath: '/dashboard/gabinet/document-templates'
+      preLoaderRoute: typeof AppAuthDashboardLayoutGabinetDocumentTemplatesRouteImport
+      parentRoute: typeof AppAuthDashboardLayoutRoute
+    }
     '/_app/_auth/dashboard/_layout/email-templates/new': {
       id: '/_app/_auth/dashboard/_layout/email-templates/new'
       path: '/email-templates/new'
@@ -2273,6 +2293,7 @@ interface AppAuthDashboardLayoutRouteChildren {
   AppAuthDashboardLayoutContactsContactIdRoute: typeof AppAuthDashboardLayoutContactsContactIdRoute
   AppAuthDashboardLayoutEmailTemplatesTemplateIdRoute: typeof AppAuthDashboardLayoutEmailTemplatesTemplateIdRoute
   AppAuthDashboardLayoutEmailTemplatesNewRoute: typeof AppAuthDashboardLayoutEmailTemplatesNewRoute
+  AppAuthDashboardLayoutGabinetDocumentTemplatesRoute: typeof AppAuthDashboardLayoutGabinetDocumentTemplatesRoute
   AppAuthDashboardLayoutGabinetDocumentsRoute: typeof AppAuthDashboardLayoutGabinetDocumentsRouteWithChildren
   AppAuthDashboardLayoutGabinetReportsRoute: typeof AppAuthDashboardLayoutGabinetReportsRoute
   AppAuthDashboardLayoutLeadsLeadIdRoute: typeof AppAuthDashboardLayoutLeadsLeadIdRoute
@@ -2328,6 +2349,8 @@ const AppAuthDashboardLayoutRouteChildren: AppAuthDashboardLayoutRouteChildren =
       AppAuthDashboardLayoutEmailTemplatesTemplateIdRoute,
     AppAuthDashboardLayoutEmailTemplatesNewRoute:
       AppAuthDashboardLayoutEmailTemplatesNewRoute,
+    AppAuthDashboardLayoutGabinetDocumentTemplatesRoute:
+      AppAuthDashboardLayoutGabinetDocumentTemplatesRoute,
     AppAuthDashboardLayoutGabinetDocumentsRoute:
       AppAuthDashboardLayoutGabinetDocumentsRouteWithChildren,
     AppAuthDashboardLayoutGabinetReportsRoute:

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.document-templates.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.document-templates.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { FormTemplatesListPage } from "./_layout.settings.form-templates.index";
+
+export const Route = createFileRoute(
+  "/_app/_auth/dashboard/_layout/gabinet/document-templates",
+)({
+  component: FormTemplatesListPage,
+});

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -100,7 +100,7 @@ function GabinetDocumentsPage() {
 
   useSidebarDispatch("openFilter", () => setFilterSlideoutOpen(true));
   useSidebarDispatch("createFromTemplate", () =>
-    navigate({ to: "/dashboard/settings/form-templates" }),
+    navigate({ to: "/dashboard/gabinet/document-templates" }),
   );
 
   // --- State ---
@@ -472,7 +472,7 @@ function GabinetDocumentsPage() {
         actions={
           <Button
             onClick={() =>
-              navigate({ to: "/dashboard/settings/form-templates" })
+              navigate({ to: "/dashboard/gabinet/document-templates" })
             }
             variant="outline"
           >

--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -497,7 +497,7 @@ function TemplateTree({
 // Main page
 // ---------------------------------------------------------------------------
 
-function FormTemplatesListPage() {
+export function FormTemplatesListPage() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
   const navigate = useNavigate();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1799.

Closes #1799

---

## Claude summary

Committed. Here's what changed:

- Exported `FormTemplatesListPage` from `_layout.settings.form-templates.index.tsx:500` so it can be reused.
- New route `src/routes/_app/_auth/dashboard/_layout.gabinet.document-templates.tsx` that renders the same component at `/dashboard/gabinet/document-templates`. Reusing the component (rather than duplicating ~900 lines) means CRM and Gabinet stay in lockstep.
- Added "Szablony dokumentów" to the Gabinet sidebar via `src/modules/gabinet/manifest.ts:55` (the `nav.gabinet.documentTemplates` translation key already existed).
- In `_layout.gabinet.documents.index.tsx`, the Szablony button and the `createFromTemplate` sidebar dispatch now point at the new in-workspace route instead of `/dashboard/settings/form-templates` — that avoids the sidebar flipping into settings mode when accessed from Gabinet.

Typecheck passes (`tsc -p tsconfig.app.json --noEmit`). The TanStack Router route tree was regenerated and includes the new route.

## Follow-ups
- Sync EN nav.gabinet translation keys: `public/locales/en/translation.json` has `nav.gabinet` as a flat string ("Cabinet") while PL has it as an object with sub-keys (dashboard/calendar/documents/documentTemplates/...). Every `nav.gabinet.*` labelKey used by the manifest currently has no EN translation and falls back to the key string.
- Delete or reconcile `src/components/layout/sidebar.tsx`: it is unused (the active sidebar is `app-sidebar.tsx` driven by the module registry) and contains a stale link to `/dashboard/gabinet/settings/document-templates`, a route that does not exist.