### PR TITLE
￼ Przejście z okienka klienta nie powinno od razu wywoływać tworzenia następnej wizyty tylko pokazywać kalendarz i dopiero potem po kliknięciu w odpowiednie miejsce wykonać akcję @claude 

### DIFF
--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -358,7 +358,17 @@ export function DraggableAppointment({
           grid's onMouseDown drag-to-create handler and open the new-
           appointment dialog (issue #1797). Stop the synthetic events here —
           the native DOM event still reaches Radix's document-level
-          outside-click listener, so the popover continues to close. */}
+          outside-click listener (which uses pointerdown), so the popover
+          continues to close.
+
+          iOS Safari needs an extra guard (issue #1790): Radix closes the
+          popover on the native pointerdown, which unmounts the backdrop
+          before the synthesized mousedown/mouseup/click sequence fires
+          after touchend. Those synthesized events then land on whatever is
+          topmost — the calendar grid — bypassing the stopPropagation above
+          because the backdrop element is gone. Calling preventDefault() on
+          touchstart tells Safari not to synthesize mouse events for this
+          touch at all, so the calendar slot click never fires. */}
       {popoverOpen && typeof document !== "undefined"
         ? createPortal(
             <div
@@ -366,6 +376,7 @@ export function DraggableAppointment({
               className="fixed inset-0 z-40 bg-foreground/20 backdrop-blur-[2px] animate-in fade-in-0 duration-150"
               onMouseDown={(e) => e.stopPropagation()}
               onClick={(e) => e.stopPropagation()}
+              onTouchStart={(e) => e.preventDefault()}
             />,
             document.body,
           )


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1790.

Closes #1790

---

## Claude summary

The fix is committed. Summary of what was done:

The issue describes the same bug already reported and partially fixed in #1797: tapping outside the appointment-preview popover (to close it, since the X button is hidden behind iOS's notch/status bar on small screens) also opens the "new appointment" dialog. The user filed #1797 as a clearer desktop reproduction of #1790, the fix landed at 12:07Z, and the user's follow-up at 12:13Z ("do you already know everything?") was asking whether the iOS case is also covered.

The desktop fix in #1797 added React `onMouseDown`/`onClick` stopPropagation on the popover backdrop. That works on desktop because the native mousedown bubbles up through React's tree while the backdrop is still mounted. On iOS, however, Radix's `pointerdown`-based outside-click detector closes the popover before the synthesized mousedown fires — by then the backdrop is unmounted and the click lands on the calendar grid directly.

Fix: added `onTouchStart={(e) => e.preventDefault()}` on the backdrop in `src/components/gabinet/calendar/draggable-appointment.tsx`. Per the Touch Events spec, that suppresses the synthesized mouse-event sequence on iOS for that touch, while Radix's `pointerdown`-based listener (verified against the local `@radix-ui/react-dismissable-layer` bundle) is unaffected and still closes the popover. Typecheck and ESLint clean on the changed file.

## Follow-ups
- Make sure the preview popover's title bar stays in viewport on small iOS screens: the screenshot in #1790 shows the popover overflowing the top of the viewport so the X close button is hidden behind the iPhone status bar/notch, which is what forced the user to dismiss by tapping the backdrop in the first place.