### PR TITLE
Sync EN nav.gabinet translation keys

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -100,7 +100,20 @@
     "insights": "Insights",
     "products": "Products",
     "calls": "Calls",
-    "gabinet": "Cabinet",
+    "gabinet": {
+      "_": "Cabinet",
+      "dashboard": "Cabinet Dashboard",
+      "calendar": "Calendar",
+      "patients": "Clients",
+      "treatments": "Treatments",
+      "packages": "Packages",
+      "documents": "Documents",
+      "employees": "Employees",
+      "reports": "Reports",
+      "scheduling": "Working Hours",
+      "leaves": "Leaves",
+      "documentTemplates": "Document Templates"
+    },
     "sections": {
       "main": "Main",
       "database": "Database",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1801.

Closes #1801

---

## Claude summary

Committed as `ba35fc9` on `claude/issue-1801`.

Confirmed the bug, fixed it in `public/locales/en/translation.json:103`: replaced the flat `"gabinet": "Cabinet"` with an object mirroring PL's structure (`_`, `dashboard`, `calendar`, `patients`, `treatments`, `packages`, `documents`, `employees`, `reports`, `scheduling`, `leaves`, `documentTemplates`). Verified EN and PL key sets are now identical under `nav.gabinet`. EN sidebar labels will now render translated strings instead of raw keys like `nav.gabinet.dashboard`.