### PR TITLE
Numer telefonu

### DIFF
--- a/src/components/documents/generate-document-dialog.tsx
+++ b/src/components/documents/generate-document-dialog.tsx
@@ -5,6 +5,7 @@ import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { PhoneInput } from "@/components/ui/phone-input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { ScrollShadow } from "@/components/ui/scroll-shadow";
@@ -579,24 +580,35 @@ function MissingDataFormStep({
                   ? varInfo.labelEn
                   : varInfo.label
                 : path;
-              const inputType = varInfo?.type === "date" ? "date" : "text";
+              const fieldType = varInfo?.type ?? "text";
               return (
                 <div key={path} className="space-y-1.5">
                   <Label htmlFor={`missing-${path}`} className="text-sm">
                     {label}
                   </Label>
-                  <Input
-                    id={`missing-${path}`}
-                    type={inputType}
-                    value={values[path] ?? ""}
-                    onChange={(e) =>
-                      setValues((prev) => ({
-                        ...prev,
-                        [path]: e.target.value,
-                      }))
-                    }
-                    placeholder={inputType === "date" ? undefined : label}
-                  />
+                  {fieldType === "phone" ? (
+                    <PhoneInput
+                      id={`missing-${path}`}
+                      value={values[path] ?? ""}
+                      onChange={(v) =>
+                        setValues((prev) => ({ ...prev, [path]: v }))
+                      }
+                      placeholder={label}
+                    />
+                  ) : (
+                    <Input
+                      id={`missing-${path}`}
+                      type={fieldType === "date" ? "date" : "text"}
+                      value={values[path] ?? ""}
+                      onChange={(e) =>
+                        setValues((prev) => ({
+                          ...prev,
+                          [path]: e.target.value,
+                        }))
+                      }
+                      placeholder={fieldType === "date" ? undefined : label}
+                    />
+                  )}
                 </div>
               );
             })}

--- a/src/components/ui/phone-input.tsx
+++ b/src/components/ui/phone-input.tsx
@@ -14,11 +14,12 @@ import {
   DEFAULT_DIAL_CODE,
   MIN_PHONE_NATIONAL_DIGITS,
   detectDialCode,
+  formatPhoneNational,
 } from "@/lib/phone";
 import { cn } from "@/lib/utils";
 
-function combine(dialCode: string, number: string): string {
-  const trimmed = number.trim();
+function combine(dialCode: string, digits: string): string {
+  const trimmed = digits.trim();
   return trimmed ? `${dialCode} ${trimmed}` : "";
 }
 
@@ -43,8 +44,12 @@ export function PhoneInput({
   const [{ dialCode, number }, setState] = useState(() => {
     if (!value) return { dialCode: DEFAULT_DIAL_CODE, number: "" };
     const detected = detectDialCode(value);
-    if (detected) return { dialCode: detected.dialCode, number: detected.rest };
-    return { dialCode: DEFAULT_DIAL_CODE, number: value };
+    if (detected)
+      return {
+        dialCode: detected.dialCode,
+        number: detected.rest.replace(/\D/g, ""),
+      };
+    return { dialCode: DEFAULT_DIAL_CODE, number: value.replace(/\D/g, "") };
   });
   const [touched, setTouched] = useState(false);
 
@@ -53,22 +58,29 @@ export function PhoneInput({
     [dialCode],
   );
 
-  const digitCount = useMemo(() => number.replace(/\D/g, "").length, [number]);
+  const digitCount = number.length;
   const isInvalid =
     digitCount === 0
       ? Boolean(required)
       : digitCount < MIN_PHONE_NATIONAL_DIGITS;
   const showError = touched && isInvalid && digitCount > 0;
 
+  const displayValue = useMemo(
+    () => formatPhoneNational(number, dialCode),
+    [number, dialCode],
+  );
+
   const handleNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = e.target.value;
     const detected = detectDialCode(v);
     if (detected) {
-      setState({ dialCode: detected.dialCode, number: detected.rest });
-      onChange(combine(detected.dialCode, detected.rest));
+      const digits = detected.rest.replace(/\D/g, "");
+      setState({ dialCode: detected.dialCode, number: digits });
+      onChange(combine(detected.dialCode, digits));
     } else {
-      setState({ dialCode, number: v });
-      onChange(combine(dialCode, v));
+      const digits = v.replace(/\D/g, "");
+      setState({ dialCode, number: digits });
+      onChange(combine(dialCode, digits));
     }
   };
 
@@ -98,7 +110,7 @@ export function PhoneInput({
         <Input
           type="tel"
           id={id}
-          value={number}
+          value={displayValue}
           onChange={handleNumberChange}
           onBlur={() => setTouched(true)}
           required={required}

--- a/src/lib/document-variables.ts
+++ b/src/lib/document-variables.ts
@@ -16,7 +16,7 @@ export interface VariableField {
   /** Grouping category, e.g. "patient", "contact" */
   category: string;
   /** Input type hint — drives the form control used when collecting missing data */
-  type?: "text" | "date";
+  type?: "text" | "date" | "phone";
 }
 
 // ---------------------------------------------------------------------------
@@ -35,7 +35,7 @@ export const VARIABLE_REGISTRY: Record<string, VariableField[]> = {
     { path: "contact.firstName", label: "Imię kontaktu", labelEn: "Contact first name", category: "contact" },
     { path: "contact.lastName", label: "Nazwisko kontaktu", labelEn: "Contact last name", category: "contact" },
     { path: "contact.email", label: "Email kontaktu", labelEn: "Contact email", category: "contact" },
-    { path: "contact.phone", label: "Telefon kontaktu", labelEn: "Contact phone", category: "contact" },
+    { path: "contact.phone", label: "Telefon kontaktu", labelEn: "Contact phone", category: "contact", type: "phone" },
     { path: "contact.title", label: "Stanowisko kontaktu", labelEn: "Contact title", category: "contact" },
     { path: "contact.source", label: "Źródło kontaktu", labelEn: "Contact source", category: "contact" },
   ],
@@ -44,7 +44,7 @@ export const VARIABLE_REGISTRY: Record<string, VariableField[]> = {
     { path: "company.domain", label: "Domena firmy", labelEn: "Company domain", category: "company" },
     { path: "company.industry", label: "Branża firmy", labelEn: "Company industry", category: "company" },
     { path: "company.website", label: "Strona www firmy", labelEn: "Company website", category: "company" },
-    { path: "company.phone", label: "Telefon firmy", labelEn: "Company phone", category: "company" },
+    { path: "company.phone", label: "Telefon firmy", labelEn: "Company phone", category: "company", type: "phone" },
     { path: "company.address.street", label: "Ulica firmy", labelEn: "Company street", category: "company" },
     { path: "company.address.city", label: "Miasto firmy", labelEn: "Company city", category: "company" },
     { path: "company.address.zip", label: "Kod pocztowy firmy", labelEn: "Company ZIP", category: "company" },
@@ -54,7 +54,7 @@ export const VARIABLE_REGISTRY: Record<string, VariableField[]> = {
     { path: "patient.firstName", label: "Imię pacjenta", labelEn: "Patient first name", category: "patient" },
     { path: "patient.lastName", label: "Nazwisko pacjenta", labelEn: "Patient last name", category: "patient" },
     { path: "patient.email", label: "Email pacjenta", labelEn: "Patient email", category: "patient" },
-    { path: "patient.phone", label: "Telefon pacjenta", labelEn: "Patient phone", category: "patient" },
+    { path: "patient.phone", label: "Telefon pacjenta", labelEn: "Patient phone", category: "patient", type: "phone" },
     { path: "patient.pesel", label: "PESEL pacjenta", labelEn: "Patient PESEL", category: "patient" },
     { path: "patient.dateOfBirth", label: "Data urodzenia", labelEn: "Date of birth", category: "patient", type: "date" },
     { path: "patient.gender", label: "Płeć", labelEn: "Gender", category: "patient" },
@@ -65,7 +65,7 @@ export const VARIABLE_REGISTRY: Record<string, VariableField[]> = {
     { path: "patient.address.city", label: "Miasto pacjenta", labelEn: "Patient city", category: "patient" },
     { path: "patient.address.postalCode", label: "Kod pocztowy pacjenta", labelEn: "Patient postal code", category: "patient" },
     { path: "patient.emergencyContactName", label: "Kontakt awaryjny — imię", labelEn: "Emergency contact name", category: "patient" },
-    { path: "patient.emergencyContactPhone", label: "Kontakt awaryjny — telefon", labelEn: "Emergency contact phone", category: "patient" },
+    { path: "patient.emergencyContactPhone", label: "Kontakt awaryjny — telefon", labelEn: "Emergency contact phone", category: "patient", type: "phone" },
   ],
   employee: [
     { path: "employee.firstName", label: "Imię pracownika", labelEn: "Employee first name", category: "employee" },
@@ -73,7 +73,7 @@ export const VARIABLE_REGISTRY: Record<string, VariableField[]> = {
     { path: "employee.role", label: "Rola pracownika", labelEn: "Employee role", category: "employee" },
     { path: "employee.specialization", label: "Specjalizacja", labelEn: "Specialization", category: "employee" },
     { path: "employee.licenseNumber", label: "Numer licencji", labelEn: "License number", category: "employee" },
-    { path: "employee.phone", label: "Telefon pracownika", labelEn: "Employee phone", category: "employee" },
+    { path: "employee.phone", label: "Telefon pracownika", labelEn: "Employee phone", category: "employee", type: "phone" },
     { path: "employee.email", label: "Email pracownika", labelEn: "Employee email", category: "employee" },
     { path: "employee.position", label: "Stanowisko", labelEn: "Position", category: "employee" },
     { path: "employee.department", label: "Dział", labelEn: "Department", category: "employee" },

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -137,6 +137,25 @@ export function isPhoneNumberValid(
   return digits >= MIN_PHONE_NATIONAL_DIGITS;
 }
 
+// Formats the national portion of a phone number (digits after the dial code)
+// using either the country-specific grouping pattern from COUNTRIES or the
+// default 3-3-3-... grouping. Non-digit characters in the input are stripped.
+// Used by inputs that show the dial code separately and need just the
+// national digits formatted for display.
+export function formatPhoneNational(
+  value: string,
+  dialCode?: string,
+): string {
+  const digits = value.replace(/\D/g, "");
+  if (!digits) return "";
+  const country = dialCode
+    ? COUNTRIES.find((c) => c.code === dialCode)
+    : undefined;
+  return country?.grouping
+    ? applyGrouping(digits, country.grouping)
+    : groupDigitsByThree(digits);
+}
+
 export function formatPhoneNumber(value: string | null | undefined): string {
   if (!value) return "";
   const trimmed = value.trim();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1810.

Closes #1810

---

## Claude summary

Committed. Summary of the fix:

The screenshot showed the "Uzupełnij brakujące dane" dialog rendering `+48 793904950` (no grouping) for the company phone. Root cause: that dialog used a plain `<Input>` and `PhoneInput` itself never reformatted typed digits.

Changes:
- `src/lib/phone.ts:140` — added `formatPhoneNational(value, dialCode)` exporting the digit-grouping logic (default 3-3-3, or country-specific from `COUNTRIES.grouping`).
- `src/components/ui/phone-input.tsx` — internal state now holds raw digits; display value is `formatPhoneNational(number, dialCode)`. The `combine()` storage format is unchanged (`"+48 793904950"` shape) so existing readers (`formatPhoneNumber`) keep working.
- `src/lib/document-variables.ts` — added `"phone"` to `VariableField.type` and tagged `contact.phone`, `company.phone`, `patient.phone`, `patient.emergencyContactPhone`, `employee.phone` accordingly.
- `src/components/documents/generate-document-dialog.tsx` — `MissingDataFormStep` now renders `PhoneInput` (instead of `<Input>`) when `varInfo.type === "phone"`.

Verified with `npm run typecheck` and `npm run test:unit:frontend` (28/28 passing).