### PR TITLE
Opcja zapisz/szablon

### DIFF
--- a/src/components/documents/template-settings-sheet.tsx
+++ b/src/components/documents/template-settings-sheet.tsx
@@ -3,11 +3,13 @@ import {
   Sheet,
   SheetContent,
   SheetDescription,
+  SheetFooter,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -64,6 +66,8 @@ interface TemplateSettingsSheetProps {
   onOpenChange: (open: boolean) => void;
   settings: TemplateSettings;
   onSettingsChange: (settings: TemplateSettings) => void;
+  onSave?: () => void;
+  saving?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -117,6 +121,8 @@ export function TemplateSettingsSheet({
   onOpenChange,
   settings,
   onSettingsChange,
+  onSave,
+  saving = false,
 }: TemplateSettingsSheetProps) {
   const { t } = useTranslation();
 
@@ -143,7 +149,7 @@ export function TemplateSettingsSheet({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="w-full sm:max-w-lg">
+      <SheetContent className="flex w-full flex-col sm:max-w-lg">
         <SheetHeader>
           <SheetTitle>
             {t("formEditor.settings.title", "Ustawienia szablonu")}
@@ -156,7 +162,7 @@ export function TemplateSettingsSheet({
           </SheetDescription>
         </SheetHeader>
 
-        <ScrollArea className="mt-6 h-[calc(100vh-10rem)] pr-4">
+        <ScrollArea className="-mr-4 mt-6 min-h-0 flex-1 pr-4">
           <div className="space-y-6">
             {/* Name */}
             <div className="space-y-2">
@@ -342,6 +348,27 @@ export function TemplateSettingsSheet({
             </div>
           </div>
         </ScrollArea>
+
+        {onSave && (
+          <SheetFooter className="mt-4 border-t pt-4">
+            <Button
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={saving}
+            >
+              {t("common.close")}
+            </Button>
+            <Button
+              onClick={onSave}
+              disabled={saving || !settings.name.trim()}
+              className="min-w-[6rem]"
+            >
+              {saving
+                ? t("common.saving")
+                : t("formEditor.save", "Zapisz")}
+            </Button>
+          </SheetFooter>
+        )}
       </SheetContent>
     </Sheet>
   );

--- a/src/routes/_app/_auth/dashboard/_layout.document-editor.$id.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.document-editor.$id.tsx
@@ -347,6 +347,8 @@ function EditDocumentEditorPage() {
         onOpenChange={setSettingsOpen}
         settings={settings}
         onSettingsChange={setSettings}
+        onSave={handleSave}
+        saving={saving}
       />
 
       <Sheet open={navOpen} onOpenChange={setNavOpen}>

--- a/src/routes/_app/_auth/dashboard/_layout.document-editor.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.document-editor.new.tsx
@@ -257,6 +257,8 @@ function NewDocumentEditorPage() {
         onOpenChange={setSettingsOpen}
         settings={settings}
         onSettingsChange={setSettings}
+        onSave={handleSave}
+        saving={saving}
       />
 
       {/* Navigation overlay sidebar */}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1812.

Closes #1812

---

## Claude summary

Committed.

Summary: Added a save button inside the "Ustawienia szablonu" (Template Settings) sheet so users can save the template directly from the settings panel without first closing the sheet to reach the header Zapisz button. `TemplateSettingsSheet` now accepts optional `onSave`/`saving` props and renders a sticky `SheetFooter` with Close + Save buttons when `onSave` is provided; both the `new` and `$id` document editor pages pass their existing `handleSave` and `saving` state through. The save button is disabled while saving or when the template name is empty, matching the behavior of the header button.