### PR TITLE
Zapisywanie szablonu

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.document-editor.$id.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.document-editor.$id.tsx
@@ -145,6 +145,7 @@ function EditDocumentEditorPage() {
       });
 
       toast.success(t("settings.formTemplates.saved"));
+      setSettingsOpen(false);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(message);

--- a/src/routes/_app/_auth/dashboard/_layout.document-editor.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.document-editor.new.tsx
@@ -107,6 +107,7 @@ function NewDocumentEditorPage() {
       });
 
       toast.success(t("settings.formTemplates.created"));
+      setSettingsOpen(false);
       navigate({
         to: "/dashboard/document-editor/$id",
         params: { id: templateId },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1814.

Closes #1814

---

## Claude summary

Fixed and committed.

The Settings sheet in the document template editor (opened via the "Ustawienia" button) has a Save button that called `handleSave` in the parent route but never closed the sheet. Added `setSettingsOpen(false)` to the success branch of `handleSave` in both `_layout.document-editor.$id.tsx:148` (edit) and `_layout.document-editor.new.tsx:110` (new) so the sheet closes after a successful save — matching the user's expectation in the Jam recording.