### PR TITLE
przesuwanie

### DIFF
--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -152,11 +152,23 @@ export function DraggableAppointment({
       const target = e.target as HTMLElement | null;
       if (
         target?.closest(
-          'button, a, input, textarea, select, [role="button"], [role="combobox"], [role="menuitem"], [role="option"], [role="switch"], [role="checkbox"], [role="radio"], [role="tab"], [contenteditable="true"], [data-radix-popper-content-wrapper]',
+          'button, a, input, textarea, select, [role="button"], [role="combobox"], [role="menuitem"], [role="option"], [role="switch"], [role="checkbox"], [role="radio"], [role="tab"], [contenteditable="true"]',
         )
       ) {
         return;
       }
+      // Skip clicks coming from a NESTED popper (e.g. the treatment selector
+      // dropdown that opens from inside this popover). The selector list above
+      // intentionally does NOT include `[data-radix-popper-content-wrapper]`
+      // because the popover content is itself wrapped in one — including it
+      // would block drag from the entire popover body (regression from #1476
+      // that the dialog version doesn't have because Dialog has no popper
+      // wrapper ancestor). Compare against our own wrapper to detect nesting.
+      const ownWrapper = previewContentRef.current?.parentElement ?? null;
+      const closestWrapper = target?.closest(
+        "[data-radix-popper-content-wrapper]",
+      );
+      if (closestWrapper && closestWrapper !== ownWrapper) return;
       e.preventDefault();
       const startX = e.clientX;
       const startY = e.clientY;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1817.

Closes #1817

---

## Claude summary

Fixed and committed. Summary:

The body-wide drag-from-anywhere handler for the appointment preview popover (added in #1476) was broken since day one on desktop. Its skip selector included `[data-radix-popper-content-wrapper]`, but the popover content is itself a child of that wrapper element (every Radix popover is). So `target.closest()` always returned truthy and drag was unconditionally blocked from the entire popover body. Only the title-bar drag handle actually worked.

The selector was copied verbatim from the AppointmentDialog version, where it correctly skips drags landing inside a nested popover. Dialogs have no popper wrapper as ancestor, so the check only catches nested ones. Popovers do, so the same selector misfires.

Fix: pulled `[data-radix-popper-content-wrapper]` out of the interactive-element selector and added an explicit check that compares the target's closest popper wrapper against the popover's own wrapper (`previewContentRef.current.parentElement`). Drag is skipped only when those differ (target is inside a portaled nested popover like the inline treatment selector). The user can now drag the appointment preview from any non-interactive area of the popover body, exactly as the original feature intended.

## Follow-ups
- Audit other Popover-based drag-from-anywhere handlers for the same bug: the `[data-radix-popper-content-wrapper]` selector in any popover-attached pointerdown handler will block drag from the entire popover body — search for the selector list across the repo.