### PR TITLE
Drugi  wiersz godzin 

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -51,6 +51,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
+import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
 import { PlateText } from "@/components/plate-text";
 import { ScrollShadow } from "@/components/ui/scroll-shadow";
 import { Separator } from "@/components/ui/separator";
@@ -1545,23 +1546,19 @@ export function AppointmentDialog({
                                         )}
                                       />
                                     )}
-                                    <input
-                                      type="time"
-                                      step={300}
+                                    <TimePicker5Min
                                       value={occ.startTime}
                                       disabled={occ.index === 0}
-                                      onChange={(e) =>
+                                      onChange={(v) =>
                                         setRecurringOverrides((prev) => ({
                                           ...prev,
                                           [occ.index]: {
                                             ...prev[occ.index],
-                                            startTime: snapTimeTo5Min(
-                                              e.target.value,
-                                            ),
+                                            startTime: snapTimeTo5Min(v),
                                           },
                                         }))
                                       }
-                                      className="h-7 w-[88px] rounded-md border border-input bg-background px-2 text-xs tabular-nums focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-70"
+                                      className="h-7 w-[88px] px-2 text-xs"
                                       aria-label={t(
                                         "gabinet.appointments.calendarDialog.time",
                                       )}

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -50,6 +50,7 @@ import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
+import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
 import { ChangeEmployeeModal } from "@/components/gabinet/change-employee-modal";
 import { DocumentGateDialog } from "@/components/documents/document-gate-dialog";
 import { useAppointmentDocumentCounts } from "@/components/documents/appointment-document-checklist";
@@ -1534,11 +1535,9 @@ export function AppointmentPreviewContent({
             <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
               {t("common.from", "Od")}
             </Label>
-            <Input
-              type="time"
-              step={300}
+            <TimePicker5Min
               value={startTime}
-              onChange={(e) => handleStartTimeChange(e.target.value)}
+              onChange={handleStartTimeChange}
               className="h-8 w-[88px] text-sm"
             />
           </div>
@@ -1546,11 +1545,9 @@ export function AppointmentPreviewContent({
             <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
               {t("common.to", "Do")}
             </Label>
-            <Input
-              type="time"
-              step={300}
+            <TimePicker5Min
               value={endTime}
-              onChange={(e) => setEndTime(snapTimeTo5Min(e.target.value))}
+              onChange={(v) => setEndTime(snapTimeTo5Min(v))}
               className="h-8 w-[88px] text-sm"
             />
           </div>

--- a/src/components/gabinet/calendar/time-picker-5min.tsx
+++ b/src/components/gabinet/calendar/time-picker-5min.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from "react";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+interface TimePicker5MinProps {
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+  disabled?: boolean;
+  "aria-label"?: string;
+}
+
+// `<input type="time" step={300}>` shows a per-minute wheel on iOS Safari
+// because iOS ignores the step attribute on time inputs (#1789, #1822). This
+// Select-based picker enforces the 5-minute grid in the UI itself.
+export function TimePicker5Min({
+  value,
+  onChange,
+  className,
+  disabled,
+  "aria-label": ariaLabel,
+}: TimePicker5MinProps) {
+  const options = useMemo(() => {
+    const opts: string[] = [];
+    for (let h = 0; h < 24; h++) {
+      for (let m = 0; m < 60; m += 5) {
+        opts.push(
+          `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`,
+        );
+      }
+    }
+    return opts;
+  }, []);
+
+  const snapped = (() => {
+    if (!value) return "";
+    const [h, m] = value.split(":").map(Number);
+    if (!Number.isFinite(h) || !Number.isFinite(m)) return "";
+    const total = Math.min(Math.max(h * 60 + m, 0), 24 * 60 - 5);
+    const grid = Math.min(Math.round(total / 5) * 5, 24 * 60 - 5);
+    return `${String(Math.floor(grid / 60)).padStart(2, "0")}:${String(grid % 60).padStart(2, "0")}`;
+  })();
+
+  return (
+    <Select value={snapped} onValueChange={onChange} disabled={disabled}>
+      <SelectTrigger
+        aria-label={ariaLabel}
+        className={cn("tabular-nums", className)}
+      >
+        <SelectValue placeholder="--:--" />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((opt) => (
+          <SelectItem key={opt} value={opt} className="tabular-nums">
+            {opt}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -35,6 +35,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ChangeEmployeeModal } from "@/components/gabinet/change-employee-modal";
+import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
 import { DocumentationTab } from "@/components/gabinet/documentation-tab";
 import { TreatmentPicker } from "@/components/gabinet/appointment-shared/treatment-picker";
 import { RichTextEditor, plateJsonToText } from "@/components/gabinet/rich-text-editor";
@@ -1487,11 +1488,9 @@ function AppointmentDetail() {
                   <Label className="text-xs uppercase tracking-wide text-muted-foreground">
                     {t("common.from", "Od")}
                   </Label>
-                  <Input
-                    type="time"
-                    step={300}
+                  <TimePicker5Min
                     value={editStartTime}
-                    onChange={(e) => setEditStartTime(snapTimeTo5Min(e.target.value))}
+                    onChange={(v) => setEditStartTime(snapTimeTo5Min(v))}
                     className="h-9 w-[110px]"
                   />
                 </div>
@@ -1499,11 +1498,9 @@ function AppointmentDetail() {
                   <Label className="text-xs uppercase tracking-wide text-muted-foreground">
                     {t("common.to", "Do")}
                   </Label>
-                  <Input
-                    type="time"
-                    step={300}
+                  <TimePicker5Min
                     value={editEndTime}
-                    onChange={(e) => setEditEndTime(snapTimeTo5Min(e.target.value))}
+                    onChange={(v) => setEditEndTime(snapTimeTo5Min(v))}
                     className="h-9 w-[110px]"
                   />
                 </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1822.

Closes #1822

---

## Claude summary

Committed. 

The user reported that the appointment time picker on iOS still scrolls minute-by-minute even after the prior fix (#1789) added `step={300}`. The root cause is that iOS Safari ignores the `step` attribute on `type="time"` wheel pickers — the snap-to-5 helper only fixes submitted values, not the picker UI.

I added a new `TimePicker5Min` Radix Select–based picker (288 HH:MM options) and used it in all three appointment time picker spots: the preview popover (matching the screenshot), the create/edit dialog's recurring occurrences, and the appointment detail edit form. Typecheck passes.

## Follow-ups
- Apply TimePicker5Min to remaining `<input type="time">` callers: same iOS wheel issue affects gabinet settings scheduling, flexible-schedule-editor, event-dialog, leave-form, setup wizard, patient portal reschedule, CRM activity form/detail drawer, and the editable-cell — all rely on `step={300}` or `step={900}` that iOS silently drops.
- Centralize the duplicated `snapTimeTo5Min` helper: identical implementations exist in appointment-dialog.tsx, appointment-preview-content.tsx, and the appointment detail page (the TimePicker5Min already snaps incoming values, so callers no longer need their own helper).