### PR TITLE
Widok okienka

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -1609,12 +1609,16 @@ export function AppointmentPreviewContent({
           popover matches the same scale (issue #1738 follow-up: previously
           this row mixed h-8/h-9 and a TagsPicker md trigger). "Przeprowadź
           zabieg" stays full-width on its own row because it's a primary
-          shortcut into a different surface. */}
-      <div className="flex flex-wrap items-center justify-end gap-1.5">
+          shortcut into a different surface. On phones the popover sits flush
+          against the viewport edges so right-aligned buttons in a flex-wrap
+          row could get clipped (issue #1823); stack vertically below `sm` so
+          every action stays fully visible. */}
+      <div className="flex flex-col gap-1.5 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
         <Button
           asChild
           variant="ghost"
           size="sm"
+          className="w-full sm:w-auto"
         >
           <Link
             to="/dashboard/gabinet/appointments/$appointmentId"
@@ -1629,6 +1633,7 @@ export function AppointmentPreviewContent({
           size="sm"
           onClick={handleSave}
           disabled={!dirty || saving || settleSubmitting}
+          className="w-full sm:w-auto"
         >
           {saving
             ? t("common.saving")
@@ -1639,6 +1644,7 @@ export function AppointmentPreviewContent({
           variant={isSettled ? "outline" : "default"}
           onClick={handleOpenSettleDialog}
           disabled={saving || settleSubmitting || isSettled}
+          className="w-full sm:w-auto"
         >
           {saving ? (
             t("common.saving")


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1823.

Closes #1823

---

## Claude summary

Fixed and committed.

The reporter's screenshot (iPhone, 390x844) shows the appointment preview popover with the action buttons "Edytuj | Zapisz zmiany | Rozlicz wizytę" clipped at the right edge — the popover is capped at `calc(100vw - 24px)` (366px on a 390px screen) and sits flush against the viewport, so a right-aligned `flex-wrap` row pushed the last button's text past the visible area.

Change in `src/components/gabinet/calendar/appointment-preview-content.tsx:1613-1654`: the action row now uses `flex flex-col gap-1.5 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end` and each button has `w-full sm:w-auto`. Below the `sm` breakpoint (covers all phones up to 640px) every action button spans the full popover width and is fully visible; at 640px+ the layout is unchanged. TypeScript passes (`tsc -p tsconfig.app.json`).