### PR TITLE
Godziny w okienku

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -1519,7 +1519,16 @@ export function AppointmentPreviewContent({
           </TooltipProvider>
         </div>
 
-        <div className="grid grid-cols-[1fr_auto_auto] items-end gap-1.5">
+        {/* On phones the popover is only ~360px wide so DATA + OD + DO in one
+            row crams the date input into ~140px. Worse, iOS Safari renders
+            `<input type="date">` taller than the Select-based TimePicker5Min,
+            and the previous `items-end` aligned the bottoms so OD/DO labels
+            ended up at a different vertical position than DATA — the "krzywo"
+            (crooked) layout reported in #1824. Stack vertically below `sm` so
+            the date gets a full-width row and OD/DO share the next row; on
+            tablets and up restore the horizontal grid but with `items-start`
+            so labels stay aligned even when input heights differ. */}
+        <div className="flex flex-col gap-3 sm:grid sm:grid-cols-[1fr_auto_auto] sm:items-start sm:gap-1.5">
           <div className="space-y-1">
             <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
               {t("common.date")}
@@ -1528,28 +1537,30 @@ export function AppointmentPreviewContent({
               type="date"
               value={date}
               onChange={(e) => setDate(e.target.value)}
-              className="h-8 text-sm"
+              className="h-8 w-full text-sm"
             />
           </div>
-          <div className="space-y-1">
-            <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
-              {t("common.from", "Od")}
-            </Label>
-            <TimePicker5Min
-              value={startTime}
-              onChange={handleStartTimeChange}
-              className="h-8 w-[88px] text-sm"
-            />
-          </div>
-          <div className="space-y-1">
-            <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
-              {t("common.to", "Do")}
-            </Label>
-            <TimePicker5Min
-              value={endTime}
-              onChange={(v) => setEndTime(snapTimeTo5Min(v))}
-              className="h-8 w-[88px] text-sm"
-            />
+          <div className="grid grid-cols-2 gap-3 sm:contents">
+            <div className="space-y-1">
+              <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                {t("common.from", "Od")}
+              </Label>
+              <TimePicker5Min
+                value={startTime}
+                onChange={handleStartTimeChange}
+                className="h-8 w-full text-sm sm:w-[88px]"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                {t("common.to", "Do")}
+              </Label>
+              <TimePicker5Min
+                value={endTime}
+                onChange={(v) => setEndTime(snapTimeTo5Min(v))}
+                className="h-8 w-full text-sm sm:w-[88px]"
+              />
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1824.

Closes #1824

---

## Claude summary

Fix committed (`c6ff1a4`).

The root cause: `appointment-preview-content.tsx:1522` used `grid grid-cols-[1fr_auto_auto] items-end` for the DATA / OD / DO row. iOS Safari renders the native `<input type="date">` noticeably taller than the Select-based `TimePicker5Min` introduced in #1822, so bottom-aligning the columns pushed the OD/DO labels to a different vertical position than DATA — what the user called "krzywo" (crooked).

The fix stacks the date input on its own full-width row below the `sm` breakpoint and lets OD/DO share the next row 50/50; on tablets and up the original horizontal grid is restored but with `items-start` so labels stay aligned even when input heights differ slightly. Uses `sm:contents` on the OD/DO wrapper so it becomes transparent in the desktop 3-column grid. The pattern matches recent mobile fixes in the same file (#1829).