### PR TITLE
Apply TimePicker5Min to remaining `<input type="time">` callers

### DIFF
--- a/src/components/crm/activity-detail-drawer.tsx
+++ b/src/components/crm/activity-detail-drawer.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/lib/ez-icons";
 import { cn } from "@/lib/utils";
 import { getActivityIcon } from "@/lib/activity-icon-registry";
+import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
 
 interface ActivityData {
   _id: string;
@@ -272,12 +273,10 @@ export function ActivityDetailDrawer({
                     value={editDueDate}
                     onChange={(e) => setEditDueDate(e.target.value)}
                   />
-                  <Input
-                    type="time"
-                    step={300}
+                  <TimePicker5Min
                     className="w-auto"
                     value={editDueTime}
-                    onChange={(e) => setEditDueTime(e.target.value)}
+                    onChange={setEditDueTime}
                   />
                 </div>
               </div>
@@ -291,12 +290,10 @@ export function ActivityDetailDrawer({
                     value={editEndDate}
                     onChange={(e) => setEditEndDate(e.target.value)}
                   />
-                  <Input
-                    type="time"
-                    step={300}
+                  <TimePicker5Min
                     className="w-auto"
                     value={editEndTime}
-                    onChange={(e) => setEditEndTime(e.target.value)}
+                    onChange={setEditEndTime}
                   />
                 </div>
               </div>

--- a/src/components/crm/activity-form.tsx
+++ b/src/components/crm/activity-form.tsx
@@ -33,6 +33,7 @@ import { getActivityIcon } from "@/lib/activity-icon-registry";
 import { CustomFieldFormSection } from "@/components/custom-fields/custom-field-form-section";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
+import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
 import type { Id } from "@cvx/_generated/dataModel";
 import type { CustomFieldType } from "@cvx/schema";
 
@@ -308,12 +309,10 @@ export function ActivityForm({
             onChange={(e) => setStartDate(e.target.value)}
           />
           <div className="relative flex items-center">
-            <Input
-              type="time"
-              step={300}
+            <TimePicker5Min
               className="w-auto pr-8"
               value={startTime}
-              onChange={(e) => setStartTime(e.target.value)}
+              onChange={setStartTime}
             />
             {startTime && (
               <button

--- a/src/components/data-table/editable-cell.tsx
+++ b/src/components/data-table/editable-cell.tsx
@@ -11,6 +11,7 @@ import {
 import { Inplace } from "@/components/ui/inplace";
 import { Check, X } from "@/lib/ez-icons";
 import { cn } from "@/lib/utils";
+import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
 
 export type EditableCellType = "text" | "number" | "select" | "date" | "time" | "datetime" | "boolean";
 
@@ -58,7 +59,7 @@ export function EditableCell({
       handleSave(!value);
       return;
     }
-    if (config.type === "select") {
+    if (config.type === "select" || config.type === "time") {
       selectRef.current?.focus();
     } else {
       inputRef.current?.focus();
@@ -109,8 +110,8 @@ export function EditableCell({
 
   const handleBlur = (e: FocusEvent) => {
     // Select dropdown renders in a portal outside the container,
-    // so we skip blur-to-save for select type entirely (it auto-saves on selection).
-    if (config.type === "select") return;
+    // so we skip blur-to-save for select/time types entirely (they auto-save on selection).
+    if (config.type === "select" || config.type === "time") return;
     const related = e.relatedTarget as HTMLElement;
     if (!related || !e.currentTarget.contains(related)) {
       handleSave();
@@ -189,7 +190,13 @@ export function EditableCell({
         );
       case "time":
         return (
-          <Input ref={inputRef} type="time" step={300} value={editValue ?? ""} onChange={(e) => setEditValue(e.target.value)} {...inputProps} />
+          <TimePicker5Min
+            ref={selectRef}
+            value={editValue ?? ""}
+            onChange={(v) => { setEditValue(v); handleSave(v); }}
+            disabled={saving}
+            className="h-8"
+          />
         );
       case "datetime":
         return (
@@ -231,7 +238,7 @@ export function EditableCell({
       <Inplace.Content>
         <div className="inline-flex items-center gap-1" onBlur={handleBlur}>
           {getEditContent()}
-          {config.type !== "select" && (
+          {config.type !== "select" && config.type !== "time" && (
             <>
               <button
                 type="button"

--- a/src/components/forms/leave-form.tsx
+++ b/src/components/forms/leave-form.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/select";
 import { AlertTriangle } from "lucide-react";
 import { useSupabaseGabinetAppointmentsByDateRange } from "@/hooks/use-supabase-gabinet-appointments";
+import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
 
 type LeaveType = "vacation" | "sick" | "personal";
 
@@ -225,21 +226,17 @@ export function LeaveForm({
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-1.5">
             <Label>{t("schedule.startTime")}</Label>
-            <Input
-              type="time"
-              step={300}
+            <TimePicker5Min
               value={startTime}
-              onChange={(e) => setStartTime(e.target.value)}
+              onChange={setStartTime}
             />
           </div>
 
           <div className="space-y-1.5">
             <Label>{t("schedule.endTime")}</Label>
-            <Input
-              type="time"
-              step={300}
+            <TimePicker5Min
               value={endTime}
-              onChange={(e) => setEndTime(e.target.value)}
+              onChange={setEndTime}
             />
           </div>
         </div>

--- a/src/components/gabinet/calendar/event-dialog.tsx
+++ b/src/components/gabinet/calendar/event-dialog.tsx
@@ -31,6 +31,7 @@ import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatActionError } from "@/lib/format-action-error";
 import { cn } from "@/lib/utils";
+import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
 
 interface EventDialogProps {
   organizationId: Id<"organizations">;
@@ -323,12 +324,10 @@ export function EventDialog({
                   defaultValue: "Godzina rozpoczęcia",
                 })}
               </Label>
-              <Input
+              <TimePicker5Min
                 id="event-start"
-                type="time"
                 value={startTime}
-                onChange={(e) => handleStartTimeChange(e.target.value)}
-                step={300}
+                onChange={handleStartTimeChange}
               />
             </div>
             <div className="space-y-1.5">
@@ -337,12 +336,10 @@ export function EventDialog({
                   defaultValue: "Godzina zakończenia",
                 })}
               </Label>
-              <Input
+              <TimePicker5Min
                 id="event-end"
-                type="time"
                 value={endTime}
-                onChange={(e) => setEndTime(e.target.value)}
-                step={300}
+                onChange={setEndTime}
               />
             </div>
           </div>

--- a/src/components/gabinet/calendar/time-picker-5min.tsx
+++ b/src/components/gabinet/calendar/time-picker-5min.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { forwardRef, useMemo } from "react";
 
 import {
   Select,
@@ -14,55 +14,68 @@ interface TimePicker5MinProps {
   onChange: (value: string) => void;
   className?: string;
   disabled?: boolean;
+  id?: string;
+  stepMinutes?: number;
   "aria-label"?: string;
 }
 
 // `<input type="time" step={300}>` shows a per-minute wheel on iOS Safari
-// because iOS ignores the step attribute on time inputs (#1789, #1822). This
-// Select-based picker enforces the 5-minute grid in the UI itself.
-export function TimePicker5Min({
-  value,
-  onChange,
-  className,
-  disabled,
-  "aria-label": ariaLabel,
-}: TimePicker5MinProps) {
-  const options = useMemo(() => {
-    const opts: string[] = [];
-    for (let h = 0; h < 24; h++) {
-      for (let m = 0; m < 60; m += 5) {
-        opts.push(
-          `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`,
-        );
+// because iOS ignores the step attribute on time inputs (#1789, #1822, #1827).
+// This Select-based picker enforces the configured grid in the UI itself.
+export const TimePicker5Min = forwardRef<HTMLButtonElement, TimePicker5MinProps>(
+  function TimePicker5Min(
+    {
+      value,
+      onChange,
+      className,
+      disabled,
+      id,
+      stepMinutes = 5,
+      "aria-label": ariaLabel,
+    },
+    ref,
+  ) {
+    const step = stepMinutes > 0 ? stepMinutes : 5;
+
+    const options = useMemo(() => {
+      const opts: string[] = [];
+      for (let h = 0; h < 24; h++) {
+        for (let m = 0; m < 60; m += step) {
+          opts.push(
+            `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`,
+          );
+        }
       }
-    }
-    return opts;
-  }, []);
+      return opts;
+    }, [step]);
 
-  const snapped = (() => {
-    if (!value) return "";
-    const [h, m] = value.split(":").map(Number);
-    if (!Number.isFinite(h) || !Number.isFinite(m)) return "";
-    const total = Math.min(Math.max(h * 60 + m, 0), 24 * 60 - 5);
-    const grid = Math.min(Math.round(total / 5) * 5, 24 * 60 - 5);
-    return `${String(Math.floor(grid / 60)).padStart(2, "0")}:${String(grid % 60).padStart(2, "0")}`;
-  })();
+    const snapped = (() => {
+      if (!value) return "";
+      const [h, m] = value.split(":").map(Number);
+      if (!Number.isFinite(h) || !Number.isFinite(m)) return "";
+      const total = Math.min(Math.max(h * 60 + m, 0), 24 * 60 - step);
+      const grid = Math.min(Math.round(total / step) * step, 24 * 60 - step);
+      return `${String(Math.floor(grid / 60)).padStart(2, "0")}:${String(grid % 60).padStart(2, "0")}`;
+    })();
 
-  return (
-    <Select value={snapped} onValueChange={onChange} disabled={disabled}>
-      <SelectTrigger
-        aria-label={ariaLabel}
-        className={cn("tabular-nums", className)}
-      >
-        <SelectValue placeholder="--:--" />
-      </SelectTrigger>
-      <SelectContent>
-        {options.map((opt) => (
-          <SelectItem key={opt} value={opt} className="tabular-nums">
-            {opt}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  );
-}
+    return (
+      <Select value={snapped} onValueChange={onChange} disabled={disabled}>
+        <SelectTrigger
+          ref={ref}
+          id={id}
+          aria-label={ariaLabel}
+          className={cn("tabular-nums", className)}
+        >
+          <SelectValue placeholder="--:--" />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((opt) => (
+            <SelectItem key={opt} value={opt} className="tabular-nums">
+              {opt}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  },
+);

--- a/src/components/gabinet/flexible-schedule-editor.tsx
+++ b/src/components/gabinet/flexible-schedule-editor.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/select";
 import { Clock, Pencil, Plus, Trash2 } from "@/lib/ez-icons";
 import { formatActionError } from "@/lib/format-action-error";
+import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
 
 export interface FlexibleClinicHours {
   dayOfWeek: number;
@@ -638,50 +639,42 @@ export function FlexibleScheduleEditor({
                         updateDay(h.dayOfWeek, "isWorking", checked as boolean)
                       }
                     />
-                    <Input
-                      type="time"
-                      step={900}
+                    <TimePicker5Min
+                      stepMinutes={15}
                       className="h-7 w-22"
                       value={h.startTime}
-                      onChange={(e) =>
-                        updateDay(h.dayOfWeek, "startTime", e.target.value)
+                      onChange={(v) =>
+                        updateDay(h.dayOfWeek, "startTime", v)
                       }
                       disabled={!h.isWorking}
                     />
-                    <Input
-                      type="time"
-                      step={900}
+                    <TimePicker5Min
+                      stepMinutes={15}
                       className="h-7 w-22"
                       value={h.endTime}
-                      onChange={(e) =>
-                        updateDay(h.dayOfWeek, "endTime", e.target.value)
+                      onChange={(v) =>
+                        updateDay(h.dayOfWeek, "endTime", v)
                       }
                       disabled={!h.isWorking}
                     />
                     {hasBreak ? (
                       <div className="flex items-center gap-1">
-                        <Input
-                          type="time"
-                          step={900}
+                        <TimePicker5Min
+                          stepMinutes={15}
                           className="h-7 w-22"
                           value={h.breakStart}
-                          onChange={(e) =>
-                            updateDay(
-                              h.dayOfWeek,
-                              "breakStart",
-                              e.target.value,
-                            )
+                          onChange={(v) =>
+                            updateDay(h.dayOfWeek, "breakStart", v)
                           }
                           disabled={!h.isWorking}
                         />
                         <span className="text-xs text-muted-foreground">–</span>
-                        <Input
-                          type="time"
-                          step={900}
+                        <TimePicker5Min
+                          stepMinutes={15}
                           className="h-7 w-22"
                           value={h.breakEnd}
-                          onChange={(e) =>
-                            updateDay(h.dayOfWeek, "breakEnd", e.target.value)
+                          onChange={(v) =>
+                            updateDay(h.dayOfWeek, "breakEnd", v)
                           }
                           disabled={!h.isWorking}
                         />

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
@@ -6,8 +6,8 @@ import { useSupabaseGabinetWorkingHoursList } from "@/hooks/use-supabase-gabinet
 import { SectionHeader } from "@untitled/app/section-headers/section-headers";
 import { UntitledAlert } from "@/components/ui/untitled-alert";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
+import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
 import { Plus, Trash2 } from "@/lib/ez-icons";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
@@ -173,39 +173,31 @@ function SchedulingSettings() {
               checked={h.isOpen}
               onCheckedChange={(checked) => updateDay(h.dayOfWeek, "isOpen", checked as boolean)}
             />
-            <Input
-              type="time"
-              step={300}
+            <TimePicker5Min
               className="h-8 w-24"
               value={h.startTime}
-              onChange={(e) => updateDay(h.dayOfWeek, "startTime", e.target.value)}
+              onChange={(v) => updateDay(h.dayOfWeek, "startTime", v)}
               disabled={!h.isOpen}
             />
-            <Input
-              type="time"
-              step={300}
+            <TimePicker5Min
               className="h-8 w-24"
               value={h.endTime}
-              onChange={(e) => updateDay(h.dayOfWeek, "endTime", e.target.value)}
+              onChange={(v) => updateDay(h.dayOfWeek, "endTime", v)}
               disabled={!h.isOpen}
             />
             {hasBreak ? (
               <div className="flex items-center gap-1">
-                <Input
-                  type="time"
-                  step={300}
+                <TimePicker5Min
                   className="h-8 w-24"
                   value={h.breakStart}
-                  onChange={(e) => updateDay(h.dayOfWeek, "breakStart", e.target.value)}
+                  onChange={(v) => updateDay(h.dayOfWeek, "breakStart", v)}
                   disabled={!h.isOpen}
                 />
                 <span className="text-xs text-muted-foreground">–</span>
-                <Input
-                  type="time"
-                  step={300}
+                <TimePicker5Min
                   className="h-8 w-24"
                   value={h.breakEnd}
-                  onChange={(e) => updateDay(h.dayOfWeek, "breakEnd", e.target.value)}
+                  onChange={(v) => updateDay(h.dayOfWeek, "breakEnd", v)}
                   disabled={!h.isOpen}
                 />
                 <Button

--- a/src/routes/_app/_auth/dashboard/_layout.setup.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.setup.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/select";
 import { ArrowLeft, ArrowRight, Loader2 } from "@/lib/ez-icons";
 import { Route as DashboardRoute } from "@/routes/_app/_auth/dashboard/_layout.index";
+import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
 
 const STEPS = [
   "businessInfo",
@@ -339,19 +340,15 @@ function SetupWizard() {
                   </Label>
                   {schedule[day]?.enabled && (
                     <>
-                      <Input
-                        type="time"
-                        step={300}
+                      <TimePicker5Min
                         value={schedule[day]?.start || ""}
-                        onChange={(e) => updateSchedule(day, "start", e.target.value)}
+                        onChange={(v) => updateSchedule(day, "start", v)}
                         className="w-32"
                       />
                       <span className="text-muted-foreground">-</span>
-                      <Input
-                        type="time"
-                        step={300}
+                      <TimePicker5Min
                         value={schedule[day]?.end || ""}
-                        onChange={(e) => updateSchedule(day, "end", e.target.value)}
+                        onChange={(v) => updateSchedule(day, "end", v)}
                         className="w-32"
                       />
                     </>

--- a/src/routes/_app/patient/_layout.appointments.tsx
+++ b/src/routes/_app/patient/_layout.appointments.tsx
@@ -22,6 +22,7 @@ import { toast } from "sonner";
 import { Id } from "@cvx/_generated/dataModel";
 import { PlateText } from "@/components/plate-text";
 import { formatActionError } from "@/lib/format-action-error";
+import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
 
 export const Route = createFileRoute("/_app/patient/_layout/appointments")({
   component: PatientAppointments,
@@ -256,12 +257,10 @@ function PatientAppointments() {
                 <Label htmlFor="reschedule-time">
                   {t("patientPortal.appointments.rescheduleTime")}
                 </Label>
-                <Input
+                <TimePicker5Min
                   id="reschedule-time"
-                  type="time"
-                  step={300}
                   value={requestedTime}
-                  onChange={(e) => setRequestedTime(e.target.value)}
+                  onChange={setRequestedTime}
                 />
               </div>
               <div className="space-y-1.5">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1827.

Closes #1827

---

## Claude summary

Done. Committed as 9d45048.

Summary: Extended `TimePicker5Min` with an optional `stepMinutes` prop (defaults to 5) and a `forwardRef`, then replaced `<input type="time" step={300|900}>` with `TimePicker5Min` across all 9 remaining callers: gabinet settings scheduling, flexible schedule editor (15-min grid), event dialog, leave form, setup wizard, patient portal reschedule, CRM activity form, activity detail drawer, and the editable-cell time case. Typecheck passes; lint shows only pre-existing warnings.