### PR TITLE
Centralize the duplicated `snapTimeTo5Min` helper

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -142,21 +142,6 @@ function computeEndTime(start: string, durationMinutes: number): string {
 }
 
 /**
- * Snap a "HH:MM" string to the nearest 15-minute boundary. Chrome's clock
- * picker and direct typing ignore the input's `step` attribute, so we enforce
- * the grid on every change. Mirrors the helper used by the appointment preview
- * popover and detail page (issues #1365, #1789).
- */
-function snapTimeTo5Min(value: string): string {
-  if (!value) return value;
-  const [h, m] = value.split(":").map(Number);
-  if (!Number.isFinite(h) || !Number.isFinite(m)) return value;
-  const total = Math.min(Math.max(h * 60 + m, 0), 24 * 60 - 1);
-  const snapped = Math.min(Math.round(total / 5) * 5, 24 * 60 - 1);
-  return `${String(Math.floor(snapped / 60)).padStart(2, "0")}:${String(snapped % 60).padStart(2, "0")}`;
-}
-
-/**
  * Mirror of backend `generateRecurringDates` (convex/gabinet/appointments.ts).
  * Keep in sync — both compute the list of recurrence dates following the base.
  * For "custom" frequency there is no cycle: every occurrence defaults to the
@@ -1554,7 +1539,7 @@ export function AppointmentDialog({
                                           ...prev,
                                           [occ.index]: {
                                             ...prev[occ.index],
-                                            startTime: snapTimeTo5Min(v),
+                                            startTime: v,
                                           },
                                         }))
                                       }

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -290,17 +290,7 @@ export function AppointmentPreviewContent({
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
 
-  const snapTimeTo5Min = (value: string): string => {
-    if (!value) return value;
-    const [h, m] = value.split(":").map(Number);
-    if (!Number.isFinite(h) || !Number.isFinite(m)) return value;
-    const total = Math.min(Math.max(h * 60 + m, 0), 24 * 60 - 1);
-    const snapped = Math.min(Math.round(total / 5) * 5, 24 * 60 - 1);
-    return `${String(Math.floor(snapped / 60)).padStart(2, "0")}:${String(snapped % 60).padStart(2, "0")}`;
-  };
-
-  const handleStartTimeChange = (rawStart: string) => {
-    const newStart = snapTimeTo5Min(rawStart);
+  const handleStartTimeChange = (newStart: string) => {
     setStartTime(newStart);
     if (!newStart || !startTime || !endTime) return;
     const toMin = (s: string) => {
@@ -1500,7 +1490,7 @@ export function AppointmentPreviewContent({
               </Label>
               <TimePicker5Min
                 value={endTime}
-                onChange={(v) => setEndTime(snapTimeTo5Min(v))}
+                onChange={setEndTime}
                 className="h-8 w-full text-sm sm:w-[88px]"
               />
             </div>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -335,14 +335,6 @@ function AppointmentDetail() {
   const [editDate, setEditDate] = useState("");
   const [editStartTime, setEditStartTime] = useState("");
   const [editEndTime, setEditEndTime] = useState("");
-  const snapTimeTo5Min = (value: string): string => {
-    if (!value) return value;
-    const [h, m] = value.split(":").map(Number);
-    if (!Number.isFinite(h) || !Number.isFinite(m)) return value;
-    const total = Math.min(Math.max(h * 60 + m, 0), 24 * 60 - 1);
-    const snapped = Math.min(Math.round(total / 5) * 5, 24 * 60 - 1);
-    return `${String(Math.floor(snapped / 60)).padStart(2, "0")}:${String(snapped % 60).padStart(2, "0")}`;
-  };
   const [editLocationId, setEditLocationId] = useState("");
   const [editRoomId, setEditRoomId] = useState("");
   const [treatmentPickerOpen, setTreatmentPickerOpen] = useState(false);
@@ -1490,7 +1482,7 @@ function AppointmentDetail() {
                   </Label>
                   <TimePicker5Min
                     value={editStartTime}
-                    onChange={(v) => setEditStartTime(snapTimeTo5Min(v))}
+                    onChange={setEditStartTime}
                     className="h-9 w-[110px]"
                   />
                 </div>
@@ -1500,7 +1492,7 @@ function AppointmentDetail() {
                   </Label>
                   <TimePicker5Min
                     value={editEndTime}
-                    onChange={(v) => setEditEndTime(snapTimeTo5Min(v))}
+                    onChange={setEditEndTime}
                     className="h-9 w-[110px]"
                   />
                 </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1828.

Closes #1828

---

## Claude summary

Removed all three duplicated `snapTimeTo5Min` helpers and their (no-op) call sites. The `TimePicker5Min` Select only emits values from its 5-minute grid options, so wrapping its onChange in a snap helper was redundant. Three files changed (`appointment-dialog.tsx`, `appointment-preview-content.tsx`, `_layout.gabinet.appointments.$appointmentId.lazy.tsx`), 5 inserts / 38 deletes, typecheck passes. Committed as `9b606e6`.