### PR TITLE
Okienko do zapisywania

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -22,6 +22,7 @@ import { format } from "date-fns";
 import { pl } from "date-fns/locale";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogTitle,
   DialogDescription,
@@ -72,6 +73,7 @@ import {
   UserPlus,
   MapPin,
   Building2,
+  X,
 } from "@/lib/ez-icons";
 import { CalendarSearch } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -1008,6 +1010,11 @@ export function AppointmentDialog({
           isDragging && "cursor-grabbing select-none",
         )}
         overlayClassName="bg-black/40"
+        // The default top-right X is invisible on iOS Safari because the
+        // drag bar's `backdrop-blur-sm` creates a stacking context that
+        // hides the close button behind it (#1830). We render an explicit
+        // close button inside the drag bar instead.
+        hideClose
       >
         <DialogTitle className="sr-only">
           {t("gabinet.appointments.createAppointment")}
@@ -1021,16 +1028,32 @@ export function AppointmentDialog({
             which dominated the dialog header. The pointer handler lives on
             DialogContent so a click anywhere on the dialog body initiates a
             drag (#1459); this bar still triggers it via event bubbling and
-            keeps the discoverability cue added in #1281. */}
+            keeps the discoverability cue added in #1281.
+
+            The close (X) button is rendered here instead of relying on
+            DialogContent's default top-right X: the drag bar's
+            `backdrop-blur-sm` creates a stacking context that hid the
+            default close on iOS Safari, leaving mobile users with no
+            visible way to dismiss the dialog (#1830). */}
         <div
           className={cn(
-            "flex items-center justify-center border-b border-border/60 bg-background/90 py-2 select-none touch-none transition-colors backdrop-blur-sm hover:bg-muted/40",
+            "relative flex items-center justify-center border-b border-border/60 bg-background/90 py-2 select-none touch-none transition-colors backdrop-blur-sm hover:bg-muted/40",
             isDragging ? "cursor-grabbing" : "cursor-grab",
           )}
           title={t("gabinet.appointments.dragToMove", "Przeciągnij, aby przesunąć")}
           aria-label={t("gabinet.appointments.dragToMove", "Przeciągnij, aby przesunąć")}
         >
           <div className="h-1 w-9 rounded-full bg-foreground/25" />
+          <DialogClose
+            aria-label={t("common.close")}
+            className={cn(
+              "absolute right-1 top-1/2 -translate-y-1/2 inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors",
+              "hover:bg-accent hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+              isDragging && "pointer-events-none",
+            )}
+          >
+            <X className="size-4" />
+          </DialogClose>
         </div>
 
         {/* "Utwórz zdarzenie zamiast wizyty" — lets the user pivot from the

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -32,12 +32,20 @@ type DialogContentProps = React.ComponentPropsWithoutRef<
   typeof DialogPrimitive.Content
 > & {
   overlayClassName?: string
+  /**
+   * Hide the built-in top-right X close button. Use when the dialog provides
+   * its own close affordance (e.g. inside a custom header / drag bar) and the
+   * default would either duplicate it or be obscured by a sibling with
+   * `backdrop-filter`, which creates a stacking context that can hide the
+   * default close on iOS Safari (#1830).
+   */
+  hideClose?: boolean
 }
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   DialogContentProps
->(({ className, children, overlayClassName, ...props }, ref) => {
+>(({ className, children, overlayClassName, hideClose, ...props }, ref) => {
   const { t } = useTranslation()
   return (
     <DialogPortal>
@@ -51,10 +59,12 @@ const DialogContent = React.forwardRef<
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-          <X className="h-4 w-4" />
-          <span className="sr-only">{t("common.close")}</span>
-        </DialogPrimitive.Close>
+        {!hideClose && (
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+            <X className="h-4 w-4" />
+            <span className="sr-only">{t("common.close")}</span>
+          </DialogPrimitive.Close>
+        )}
       </DialogPrimitive.Content>
     </DialogPortal>
   )


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1830.

Closes #1830

---

## Claude summary

Committed `ac24fe0`. The new-appointment dialog ("Okienko do zapisywania") was using `DialogContent`'s default top-right X, but the drag bar's `backdrop-blur-sm` creates a CSS stacking context that hid the X on iOS Safari — matching what the screenshot showed (no visible close affordance anywhere). I added an opt-in `hideClose` prop to `DialogContent` and rendered an explicit `DialogClose` inside the drag bar with a 32px touch target, so mobile users now have a clearly visible "Zamknij" button right next to the drag handle.