### PR TITLE
Parametry/wizyta

### DIFF
--- a/src/components/gabinet/documentation-tab.tsx
+++ b/src/components/gabinet/documentation-tab.tsx
@@ -415,7 +415,7 @@ export function DocumentationTab({
                 : (def?.type ?? param.type ?? "text");
               const unit = param.isCustom ? param.unit : def?.unit;
               return (
-                <div key={`${i}-${param.name}`} className="space-y-1.5">
+                <div key={i} className="space-y-1.5">
                   {param.isCustom ? (
                     <div className="flex items-start gap-2">
                       <div className="grid flex-1 gap-2 sm:grid-cols-[1fr_8rem]">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1845.

Closes #1845

---

## Claude summary

Fixed and committed.

Root cause: the row `<div>` in the treatment-parameters list at `src/components/gabinet/documentation-tab.tsx:418` used `key={\`${i}-${param.name}\`}`. For ad-hoc parameters (added by the new "Dodaj parametr" button from PR #1843), the name `<Input>` is bound to `param.name`, so each keystroke changed the key. React then unmounted and remounted the row, dropping focus from the input — exactly the "click again after every letter" behavior in the Jam recording.

Fix: change the key to plain `i`. The render order is stable (template params first, then appended custom ones), so the index is sufficient. Single-line change, no other call sites or types affected.