### PR TITLE
Sprzęt/parametry

### DIFF
--- a/convex/gabinet/equipment.ts
+++ b/convex/gabinet/equipment.ts
@@ -12,6 +12,19 @@ import type {
 
 // Dual-write refs removed — Supabase is now primary for equipment writes
 
+function normalizeUnits(units: string[] | undefined): string[] | null {
+  if (!units) return null;
+  const cleaned: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of units) {
+    const trimmed = raw.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    cleaned.push(trimmed);
+  }
+  return cleaned.length > 0 ? cleaned : null;
+}
+
 export const listEquipment = action({
   args: {
     organizationId: v.id("organizations"),
@@ -85,6 +98,7 @@ export const createEquipment = action({
     currentLocationId: v.optional(v.union(v.string(), v.null())),
     currentRoomId: v.optional(v.union(v.string(), v.null())),
     status: v.optional(equipmentStatusValidator),
+    parameterUnits: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(
@@ -108,6 +122,7 @@ export const createEquipment = action({
       currentLocationId: args.currentLocationId ?? null,
       currentRoomId: args.currentRoomId ?? null,
       status: args.status ?? "available",
+      parameterUnits: normalizeUnits(args.parameterUnits),
       createdBy: String(authResult.userId),
       createdAt: now,
       updatedAt: now,
@@ -125,6 +140,7 @@ export const updateEquipment = action({
     description: v.optional(v.union(v.string(), v.null())),
     serialNumber: v.optional(v.union(v.string(), v.null())),
     status: v.optional(equipmentStatusValidator),
+    parameterUnits: v.optional(v.union(v.array(v.string()), v.null())),
   },
   handler: async (ctx, args) => {
     await ctx.runQuery(
@@ -144,9 +160,13 @@ export const updateEquipment = action({
       throw new Error("Equipment not found");
     }
 
-    const { organizationId, equipmentId, ...updates } = args;
+    const { organizationId, equipmentId, parameterUnits, ...updates } = args;
     const now = Date.now();
-    await db.patch("gabinetEquipment", equipmentId, { ...updates, updatedAt: now });
+    const patch: Record<string, unknown> = { ...updates, updatedAt: now };
+    if (parameterUnits !== undefined) {
+      patch.parameterUnits = parameterUnits === null ? null : normalizeUnits(parameterUnits);
+    }
+    await db.patch("gabinetEquipment", equipmentId, patch);
 
     return equipmentId;
   },

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -905,6 +905,10 @@ export function createGabinetTables({
       v.literal("maintenance"),
       v.literal("retired"),
     ),
+    // Parameter units this equipment supports (e.g. ["J", "W", "ms"]). Surfaced
+    // on the appointment documentation tab so the operator can pick a matching
+    // unit when recording treatment parameters during a visit. See #1847.
+    parameterUnits: v.optional(v.array(v.string())),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.optional(v.number()),

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3564,6 +3564,12 @@
       "transferTo": "Transfer to",
       "notes": "Notes",
       "noEquipment": "No equipment",
+      "parameterUnits": "Parameter units",
+      "parameterUnit": "Parameter unit",
+      "parameterUnitPlaceholder": "e.g. J, W, ms",
+      "parameterUnitsHint": "Units offered when adding treatment parameters during a visit.",
+      "parameterUnitsEmpty": "No units defined.",
+      "addParameterUnit": "Add unit",
       "statuses": {
         "available": "Available",
         "in_use": "In use",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3584,6 +3584,12 @@
       "transferTo": "Przenieś do",
       "notes": "Notatki",
       "noEquipment": "Brak sprzętu",
+      "parameterUnits": "Jednostki parametrów",
+      "parameterUnit": "Jednostka parametru",
+      "parameterUnitPlaceholder": "np. J, W, ms",
+      "parameterUnitsHint": "Lista jednostek do wyboru przy dodawaniu parametrów zabiegu w trakcie wizyty.",
+      "parameterUnitsEmpty": "Brak zdefiniowanych jednostek.",
+      "addParameterUnit": "Dodaj jednostkę",
       "statuses": {
         "available": "Dostępny",
         "in_use": "W użyciu",

--- a/src/components/gabinet/documentation-tab.tsx
+++ b/src/components/gabinet/documentation-tab.tsx
@@ -96,6 +96,9 @@ interface DocumentationTabProps {
     photos?: Photo[];
   };
   treatmentParameters?: TreatmentParamDefinition[];
+  // Unit suggestions surfaced when adding a custom parameter — typically
+  // derived from the equipment required by the treatment. See #1847.
+  equipmentParameterUnits?: string[];
   onChanged?: () => void | Promise<void>;
 }
 
@@ -108,6 +111,7 @@ export function DocumentationTab({
   appointmentId,
   appointment,
   treatmentParameters,
+  equipmentParameterUnits,
   onChanged,
 }: DocumentationTabProps) {
   const { t } = useTranslation();
@@ -175,9 +179,27 @@ export function DocumentationTab({
   const handleAddCustomParam = () => {
     setParamValues((prev) => [
       ...prev,
-      { name: "", type: "text", value: "", isCustom: true, unit: "" },
+      {
+        name: "",
+        type: "text",
+        value: "",
+        isCustom: true,
+        unit: equipmentParameterUnits?.[0] ?? "",
+      },
     ]);
   };
+
+  const suggestedUnits = useMemo(() => {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const u of equipmentParameterUnits ?? []) {
+      const trimmed = u.trim();
+      if (!trimmed || seen.has(trimmed)) continue;
+      seen.add(trimmed);
+      out.push(trimmed);
+    }
+    return out;
+  }, [equipmentParameterUnits]);
 
   const handleRemoveParam = (index: number) => {
     setParamValues((prev) => prev.filter((_, i) => i !== index));
@@ -446,7 +468,19 @@ export function DocumentationTab({
                             "gabinet.documentation.paramUnit",
                             "Jednostka",
                           )}
+                          list={
+                            suggestedUnits.length > 0
+                              ? `param-unit-suggestions-${i}`
+                              : undefined
+                          }
                         />
+                        {suggestedUnits.length > 0 && (
+                          <datalist id={`param-unit-suggestions-${i}`}>
+                            {suggestedUnits.map((u) => (
+                              <option key={u} value={u} />
+                            ))}
+                          </datalist>
+                        )}
                       </div>
                       <Button
                         type="button"

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -2564,6 +2564,7 @@ export interface Database {
           current_location_id: string | null;
           current_room_id: string | null;
           status: string;
+          parameter_units: string[] | null;
           created_by: string;
           created_at: number;
           updated_at: number | null;
@@ -2577,6 +2578,7 @@ export interface Database {
           current_location_id?: string | null;
           current_room_id?: string | null;
           status: string;
+          parameter_units?: string[] | null;
           created_by: string;
           created_at: number;
           updated_at?: number | null;
@@ -2590,6 +2592,7 @@ export interface Database {
           current_location_id?: string | null;
           current_room_id?: string | null;
           status?: string;
+          parameter_units?: string[] | null;
           created_by?: string;
           created_at?: number;
           updated_at?: number | null;

--- a/src/lib/supabase/mappers/gabinet/equipment.ts
+++ b/src/lib/supabase/mappers/gabinet/equipment.ts
@@ -15,6 +15,7 @@ export interface MappedGabinetEquipment {
   currentLocationId?: string;
   currentRoomId?: string;
   status: string;
+  parameterUnits?: string[];
   createdBy: string;
   createdAt: number;
   updatedAt?: number;

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { createLazyFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
@@ -9,6 +9,7 @@ import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatPhoneNumber } from "@/lib/phone";
 import { formatCurrencyPLN } from "@/lib/format-currency";
 import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
+import { useSupabaseGabinetEquipmentList } from "@/hooks/use-supabase-gabinet-equipment";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -496,6 +497,28 @@ function AppointmentDetail() {
       entityId: appointmentId,
     }),
   );
+
+  // Equipment list used to surface parameter units on the Documentation tab —
+  // when the appointment's treatment lists required equipment, the editor
+  // pre-fills the unit field with that equipment's catalog. See #1847.
+  const { data: orgEquipment } = useSupabaseGabinetEquipmentList(organizationId);
+  const equipmentParameterUnits = useMemo(() => {
+    const requiredIds =
+      (detail?.treatment?.requiredEquipmentIds as string[] | undefined) ?? [];
+    if (requiredIds.length === 0 || !orgEquipment) return [];
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const eq of orgEquipment) {
+      if (!requiredIds.includes(eq._id)) continue;
+      for (const u of eq.parameterUnits ?? []) {
+        const trimmed = u.trim();
+        if (!trimmed || seen.has(trimmed)) continue;
+        seen.add(trimmed);
+        out.push(trimmed);
+      }
+    }
+    return out;
+  }, [detail?.treatment?.requiredEquipmentIds, orgEquipment]);
 
   // Initialize internal notes from appointment data
   useEffect(() => {
@@ -2543,6 +2566,7 @@ function AppointmentDetail() {
           appointmentId={appointment._id}
           appointment={appointment}
           treatmentParameters={treatment?.parameters as any}
+          equipmentParameterUnits={equipmentParameterUnits}
           onChanged={async () => {
             await invalidateAppointmentCaches();
             await refetch();

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
@@ -35,6 +35,7 @@ import {
   History,
   ArrowRight,
   MapPin,
+  Trash2,
 } from "@/lib/ez-icons";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -55,6 +56,73 @@ type LocationItem = {
   _id: string;
   name: string;
 };
+
+function ParameterUnitsEditor({
+  value,
+  onChange,
+  idPrefix,
+}: {
+  value: string[];
+  onChange: (next: string[]) => void;
+  idPrefix: string;
+}) {
+  const { t } = useTranslation();
+
+  const handleUnitChange = (index: number, next: string) => {
+    const copy = [...value];
+    copy[index] = next;
+    onChange(copy);
+  };
+
+  const handleRemove = (index: number) => {
+    onChange(value.filter((_, i) => i !== index));
+  };
+
+  const handleAdd = () => {
+    onChange([...value, ""]);
+  };
+
+  return (
+    <div className="space-y-2">
+      {value.length === 0 && (
+        <p className="text-xs text-muted-foreground italic">
+          {t("gabinet.equipment.parameterUnitsEmpty")}
+        </p>
+      )}
+      {value.map((unit, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <Input
+            id={`${idPrefix}-${i}`}
+            value={unit}
+            onChange={(e) => handleUnitChange(i, e.target.value)}
+            placeholder={t("gabinet.equipment.parameterUnitPlaceholder")}
+            className="flex-1"
+            aria-label={t("gabinet.equipment.parameterUnit")}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9 shrink-0 text-destructive"
+            onClick={() => handleRemove(i)}
+            aria-label={t("common.delete")}
+          >
+            <Trash2 className="h-4 w-4" variant="stroke" />
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={handleAdd}
+      >
+        <Plus className="mr-1.5 h-4 w-4" variant="stroke" />
+        {t("gabinet.equipment.addParameterUnit")}
+      </Button>
+    </div>
+  );
+}
 
 function StatusBadge({
   status,
@@ -160,6 +228,9 @@ function EquipmentCard({
   const [editStatus, setEditStatus] = useState<EquipmentStatus>(
     item.status as EquipmentStatus,
   );
+  const [editParameterUnits, setEditParameterUnits] = useState<string[]>(
+    item.parameterUnits ?? [],
+  );
   const [saving, setSaving] = useState(false);
   const [transferOpen, setTransferOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
@@ -205,6 +276,7 @@ function EquipmentCard({
         description: editDescription.trim() || null,
         serialNumber: editSerial.trim() || null,
         status: editStatus,
+        parameterUnits: editParameterUnits,
       });
       toast.success(t("common.saved"));
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetEquipment.list(organizationId) });
@@ -368,6 +440,17 @@ function EquipmentCard({
                   rows={2}
                 />
               </div>
+              <div className="space-y-1.5 col-span-2">
+                <Label>{t("gabinet.equipment.parameterUnits")}</Label>
+                <p className="text-xs text-muted-foreground">
+                  {t("gabinet.equipment.parameterUnitsHint")}
+                </p>
+                <ParameterUnitsEditor
+                  value={editParameterUnits}
+                  onChange={setEditParameterUnits}
+                  idPrefix={`eq-units-${item._id}`}
+                />
+              </div>
             </div>
 
             <div className="flex items-center justify-between pt-2">
@@ -501,6 +584,7 @@ function EquipmentSettingsPage() {
   const [newSerial, setNewSerial] = useState("");
   const [newStatus, setNewStatus] = useState<EquipmentStatus>("available");
   const [newLocationId, setNewLocationId] = useState<string>("");
+  const [newParameterUnits, setNewParameterUnits] = useState<string[]>([]);
   const [creating, setCreating] = useState(false);
 
   const queryClient = useQueryClient();
@@ -537,6 +621,7 @@ function EquipmentSettingsPage() {
         serialNumber: newSerial.trim() || null,
         status: newStatus,
         currentLocationId: newLocationId || null,
+        parameterUnits: newParameterUnits,
       });
       toast.success(t("gabinet.equipment.addEquipment"));
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetEquipment.list(organizationId) });
@@ -546,6 +631,7 @@ function EquipmentSettingsPage() {
       setNewSerial("");
       setNewStatus("available");
       setNewLocationId("");
+      setNewParameterUnits([]);
     } catch (e) {
       toast.error(
         formatActionError(e, t, {
@@ -660,6 +746,17 @@ function EquipmentSettingsPage() {
                 value={newDescription}
                 onChange={(e) => setNewDescription(e.target.value)}
                 rows={2}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>{t("gabinet.equipment.parameterUnits")}</Label>
+              <p className="text-xs text-muted-foreground">
+                {t("gabinet.equipment.parameterUnitsHint")}
+              </p>
+              <ParameterUnitsEditor
+                value={newParameterUnits}
+                onChange={setNewParameterUnits}
+                idPrefix="eq-units-new"
               />
             </div>
             <div className="flex justify-end gap-2">

--- a/supabase/migrations/00015_gabinet_equipment_parameter_units.sql
+++ b/supabase/migrations/00015_gabinet_equipment_parameter_units.sql
@@ -1,0 +1,8 @@
+-- Issue #1847: add parameter unit catalog to equipment
+--
+-- Each equipment can list the units it supports for treatment parameters
+-- (e.g. {"J", "W", "ms"} for a laser). The appointment documentation tab
+-- uses these to suggest a matching unit when adding custom parameters.
+
+ALTER TABLE gabinet_equipment
+  ADD COLUMN IF NOT EXISTS parameter_units TEXT[];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1847.

Closes #1847

---

## Claude summary

Committed. Summary of what shipped for issue #1847:

Equipment now carries an optional `parameterUnits` catalog (e.g. `["J", "W", "ms"]` for a laser). The settings page (`_layout.gabinet.settings.equipment.tsx`) gained a small editor inside both the create dialog and inline edit card — add/remove rows, one input per unit, supporting multiple units as the issue requested. The backend action normalizes input (trims, dedupes, drops empties).

On the appointment Documentation tab (`src/components/gabinet/documentation-tab.tsx`), when an operator adds an ad-hoc custom parameter during a visit, the unit field pre-fills with the first unit from the treatment's required equipment and offers the rest via a native `<datalist>` for quick selection. The appointment route derives this list from `requiredEquipmentIds` ∩ `useSupabaseGabinetEquipmentList`.

Schema/storage: optional `text[]` column added via Convex schema + Supabase migration `00015_gabinet_equipment_parameter_units.sql`. PL/EN translations added.

Verified: `npm run typecheck` passes; `npm run test:unit` passes (156 convex + 28 frontend). Lint issues touching the modified files are all pre-existing rule-not-found warnings, not introduced here.