### PR TITLE
￼ Wszystkie zmiany terminów

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1589,12 +1589,39 @@ export const _updateSideEffects = internalMutation({
 
     // scheduledActivity patches moved to the parent action (Supabase-primary).
 
+    // Build a descriptive activity entry so the appointment history surfaces
+    // *what* changed (issue #1837 — staff need to see "who moved this visit
+    // from when to when" without digging through automation logs). Date/time
+    // moves are the highest-signal change; we emit a dedicated description for
+    // them and fall back to the generic "Updated appointment" line otherwise.
+    const prevStart = args.previousStartTime.slice(0, 5);
+    const prevEnd = args.previousEndTime.slice(0, 5);
+    const nextStart = args.newStartTime.slice(0, 5);
+    const nextEnd = args.newEndTime.slice(0, 5);
+    let description = "Updated appointment";
+    if (args.dateChanged) {
+      description = `Rescheduled appointment from ${args.previousDate} ${prevStart} to ${args.newDate} ${nextStart}`;
+    }
+
     await logActivity(ctx, {
       organizationId: args.organizationId,
       entityType: "gabinetAppointment",
       entityId: args.appointmentId,
       action: "updated",
-      description: `Updated appointment`,
+      description,
+      metadata: {
+        dateChanged: args.dateChanged,
+        employeeChanged: args.employeeChanged,
+        previousDate: args.previousDate,
+        previousStartTime: prevStart,
+        previousEndTime: prevEnd,
+        previousEmployeeId: args.previousEmployeeId,
+        newDate: args.newDate,
+        newStartTime: nextStart,
+        newEndTime: nextEnd,
+        newEmployeeId: args.newEmployeeId,
+        updatedFields: args.updatedFields,
+      },
       performedBy: actorUserId,
     });
 

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1846,6 +1846,7 @@
     },
     "descriptions": {
       "updatedAppointment": "Updated appointment",
+      "rescheduledAppointment": "Rescheduled appointment from {{fromDate}} {{fromTime}} to {{toDate}} {{toTime}}",
       "createdAppointment": "Created appointment for {{date}} at {{time}}",
       "cancelledAppointment": "Cancelled appointment",
       "cancelledAppointmentWithReason": "Cancelled appointment: {{reason}}",
@@ -2979,6 +2980,9 @@
       "packageNotSelected": "Choose the package to deduct units from.",
       "packageQuantityMin": "Unit count must be at least 1.",
       "packageQuantityExceeds": "Unit count exceeds the remaining package usage.",
+      "changeHistory": "All appointment changes",
+      "changeHistoryEmpty": "No changes recorded — nobody has modified this appointment since it was created.",
+      "changeHistoryUnknownActor": "Unknown user",
       "history": {
         "unifiedDescription": "Unified operational history for this appointment, including messages and workflow events.",
         "metadata": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1855,6 +1855,7 @@
     },
     "descriptions": {
       "updatedAppointment": "Zaktualizowano wizytę",
+      "rescheduledAppointment": "Przeniesiono wizytę z {{fromDate}} {{fromTime}} na {{toDate}} {{toTime}}",
       "createdAppointment": "Utworzono wizytę na {{date}} o {{time}}",
       "cancelledAppointment": "Anulowano wizytę",
       "cancelledAppointmentWithReason": "Anulowano wizytę: {{reason}}",
@@ -2999,6 +3000,9 @@
       "packageNotSelected": "Wybierz pakiet, z którego chcesz zdjąć sztuki.",
       "packageQuantityMin": "Liczba sztuk musi wynosić co najmniej 1.",
       "packageQuantityExceeds": "Liczba sztuk przekracza pozostałą ilość w pakiecie.",
+      "changeHistory": "Wszystkie zmiany terminów",
+      "changeHistoryEmpty": "Brak zmian — od utworzenia nikt nie modyfikował tej wizyty.",
+      "changeHistoryUnknownActor": "Nieznany użytkownik",
       "history": {
         "unifiedDescription": "Ujednolicona historia operacyjna tej wizyty, w tym wiadomości i zdarzenia workflow.",
         "metadata": {

--- a/src/components/activity-timeline/translate-description.ts
+++ b/src/components/activity-timeline/translate-description.ts
@@ -41,6 +41,18 @@ const rules: Rule[] = [
     build: (_m, t) => t("activityTimeline.descriptions.updatedAppointment", "Updated appointment"),
   },
   {
+    pattern: /^Rescheduled appointment from (\S+) (\S+) to (\S+) (\S+)$/,
+    build: (m, t) =>
+      t("activityTimeline.descriptions.rescheduledAppointment", {
+        defaultValue:
+          "Rescheduled appointment from {{fromDate}} {{fromTime}} to {{toDate}} {{toTime}}",
+        fromDate: m[1],
+        fromTime: m[2],
+        toDate: m[3],
+        toTime: m[4],
+      }),
+  },
+  {
     pattern: /^Created appointment for (.+) at (.+)$/,
     build: (m, t) =>
       t("activityTimeline.descriptions.createdAppointment", {

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -65,8 +65,10 @@ import { cn } from "@/lib/utils";
 import {
   BadgeCheck,
   Calendar,
+  ChevronDown,
   CircleCheck,
   Clock,
+  History,
   Mail,
   OctagonX,
   Phone,
@@ -84,6 +86,8 @@ import {
   Plus,
   X,
 } from "lucide-react";
+import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
+import { translateActivityDescription } from "@/components/activity-timeline/translate-description";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useDraggableDialog } from "@/hooks/use-draggable-dialog";
@@ -289,6 +293,17 @@ export function AppointmentPreviewContent({
   const [date, setDate] = useState("");
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
+  const [changeHistoryOpen, setChangeHistoryOpen] = useState(false);
+
+  // Appointment change history (issue #1837). Activities are recorded by the
+  // backend on every update — we surface only the ones that meaningfully
+  // describe a change ("updated", "status_changed") and show who/when/what.
+  const { data: appointmentActivities } = useSupabaseActivitiesByEntity(
+    organizationId,
+    "gabinetAppointment",
+    appointmentId,
+    { enabled: changeHistoryOpen, limit: 50 },
+  );
 
   const handleStartTimeChange = (newStart: string) => {
     setStartTime(newStart);
@@ -1607,6 +1622,92 @@ export function AppointmentPreviewContent({
               })}
             </div>
           </TooltipProvider>
+        </div>
+
+        {/* Appointment change history — issue #1837. Lazy-loaded on open so
+            we don't fetch activities for every preview popover the user
+            hovers over. Reschedule/status changes carry actor + timestamp
+            from the backend logActivity call. */}
+        <div className="space-y-1">
+          <button
+            type="button"
+            onClick={() => setChangeHistoryOpen((v) => !v)}
+            aria-expanded={changeHistoryOpen}
+            className="flex w-full items-center justify-between rounded-md border bg-background px-2.5 py-2 text-left text-xs font-medium hover:bg-accent focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <span className="inline-flex items-center gap-1.5">
+              <History className="size-3.5 text-muted-foreground" variant="stroke" />
+              {t(
+                "gabinet.appointmentDetail.changeHistory",
+                "Wszystkie zmiany terminów",
+              )}
+            </span>
+            <ChevronDown
+              className={cn(
+                "size-3.5 text-muted-foreground transition-transform",
+                changeHistoryOpen && "rotate-180",
+              )}
+              variant="stroke"
+            />
+          </button>
+          {changeHistoryOpen && (
+            <div className="rounded-md border bg-muted/40 px-2.5 py-2">
+              {(() => {
+                const entries = (appointmentActivities ?? []).filter(
+                  (a) =>
+                    a.action === "updated" ||
+                    a.action === "status_changed" ||
+                    a.action === "created",
+                );
+                if (entries.length === 0) {
+                  return (
+                    <p className="py-2 text-center text-[11px] text-muted-foreground">
+                      {t(
+                        "gabinet.appointmentDetail.changeHistoryEmpty",
+                        "Brak zmian — od utworzenia nikt nie modyfikował tej wizyty.",
+                      )}
+                    </p>
+                  );
+                }
+                return (
+                  <ul className="space-y-1.5">
+                    {entries.map((a) => {
+                      const actor =
+                        a.performedByName ??
+                        t(
+                          "gabinet.appointmentDetail.changeHistoryUnknownActor",
+                          "Nieznany użytkownik",
+                        );
+                      const when = new Date(a.createdAt).toLocaleString(
+                        i18n.language,
+                        {
+                          day: "2-digit",
+                          month: "2-digit",
+                          year: "numeric",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        },
+                      );
+                      const label =
+                        translateActivityDescription(a.description, t) ??
+                        a.description;
+                      return (
+                        <li
+                          key={a._id}
+                          className="rounded-md bg-background px-2 py-1.5 text-[11px] leading-tight"
+                        >
+                          <p className="font-medium text-foreground">{label}</p>
+                          <p className="mt-0.5 text-muted-foreground">
+                            {actor} · {when}
+                          </p>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                );
+              })()}
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1837.

Closes #1837

---

## Claude summary

Committed `63db916` on `claude/issue-1837` for issue #1837.

What was added: a collapsible "Wszystkie zmiany terminów" dropdown at the bottom of the appointment preview popover. Lazy-fetches activity history from Supabase only when opened; shows actor + timestamp + description for each change. The backend `_updateSideEffects` now emits a descriptive `Rescheduled appointment from <date> <time> to <date> <time>` line (translated to PL/EN via the existing `translate-description` rules) plus structured metadata when the date/time changes. Status changes already had a `Status changed from X to Y` rule and surface correctly.

Pre-existing TS2589 (`type instantiation excessively deep`) errors in `convex/gabinet/appointments.ts:122` and `appointment-preview-content.tsx` exist on `f5e16cd` (base) without my changes, so unrelated.

## Follow-ups
- Fix preexisting TS2589 "type instantiation excessively deep" errors: convex/gabinet/appointments.ts:122 and src/components/gabinet/calendar/appointment-preview-content.tsx — likely caused by useAction generic depth, blocks clean typecheck
- Localize fallback action labels in change history: when an activity description doesn't match any translation rule it falls through as raw English; consider a per-action default ("created" / "updated" / "status_changed") for robustness