### PR TITLE
Zabieg-przesuwanie

### DIFF
--- a/src/components/gabinet/appointment-shared/treatment-picker.tsx
+++ b/src/components/gabinet/appointment-shared/treatment-picker.tsx
@@ -79,6 +79,12 @@ export function TreatmentPicker({
 
   return (
     <Popover
+      // `modal` stacks the popover's own `react-remove-scroll` lock on top of
+      // the parent Dialog's lock. Without it, the Dialog's lock blocks wheel
+      // events on the portaled popover content, so touchpad/wheel scrolling
+      // through a long treatment list does nothing while the scrollbar drag
+      // still works (issue #1850).
+      modal
       open={open}
       onOpenChange={(o) => {
         onOpenChange(o);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1850.

Closes #1850

---

## Claude summary

Committed `97697ca`.

Set `modal` on the `Popover` in `src/components/gabinet/appointment-shared/treatment-picker.tsx:81` so the popover stacks its own `react-remove-scroll` lock on top of the appointment dialog's lock. Wheel events on the portaled popover content are now treated as inside the active lock and allowed through — touchpad scrolling works alongside the existing scrollbar drag.

## Follow-ups
- Apply the same `modal` fix to the patient picker popover in `src/components/gabinet/calendar/appointment-dialog.tsx` (around line 1106): it's an inline Radix Popover inside the same modal Dialog, so the long patient list has the same touchpad-scroll bug, just not yet reported.