### PR TITLE
Wizyta pakietowa/cykliczna

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2821,7 +2821,7 @@
       "endTime": "End Time",
       "notes": "Notes",
       "notesPlaceholder": "Additional notes for the appointment...",
-      "recurring": "Package visits",
+      "recurring": "Recurring visits",
       "recurringPreview": "Visit dates and times",
       "recurringPreviewSelectSlot": "Pick the date and time of the first appointment to see the preview.",
       "recurringPreviewHint": "Each date and time can be customized independently of the cycle.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2841,7 +2841,7 @@
       "endTime": "Godzina zakończenia",
       "notes": "Notatki",
       "notesPlaceholder": "Dodatkowe uwagi do wizyty...",
-      "recurring": "Wizyty pakietowe",
+      "recurring": "Wizyty cykliczne",
       "recurringPreview": "Daty i godziny wizyt",
       "recurringPreviewSelectSlot": "Wybierz datę i godzinę pierwszej wizyty, aby zobaczyć podgląd.",
       "recurringPreviewHint": "Każdą datę i godzinę możesz dostosować niezależnie od cyklu.",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1851.

Closes #1851

---

## Claude summary

Fixed and committed. The `gabinet.appointments.recurring` translation key labeled the recurring-appointment checkbox in the appointment dialog as "Wizyty pakietowe" (PL) and "Package visits" (EN) — a mislabel, since "package visits" is a separate, unrelated feature. Updated to "Wizyty cykliczne" / "Recurring visits" in `public/locales/{pl,en}/translation.json`.