### PR TITLE
Localize fallback action labels in change history

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1844,6 +1844,23 @@
       "employee": "employee",
       "lead": "lead"
     },
+    "actionFallback": {
+      "created": "Created",
+      "updated": "Updated",
+      "deleted": "Deleted",
+      "note_added": "Note added",
+      "stage_changed": "Stage changed",
+      "assigned": "Assigned",
+      "relationship_added": "Relationship added",
+      "relationship_removed": "Relationship removed",
+      "document_uploaded": "Document uploaded",
+      "status_changed": "Status changed",
+      "email_sent": "Email sent",
+      "email_received": "Email received",
+      "sms_sent": "SMS sent",
+      "sms_received": "SMS received",
+      "package_assigned": "Package assigned"
+    },
     "descriptions": {
       "updatedAppointment": "Updated appointment",
       "rescheduledAppointment": "Rescheduled appointment from {{fromDate}} {{fromTime}} to {{toDate}} {{toTime}}",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1853,6 +1853,23 @@
       "employee": "Pracownik",
       "lead": "Lead"
     },
+    "actionFallback": {
+      "created": "Utworzono",
+      "updated": "Zaktualizowano",
+      "deleted": "Usunięto",
+      "note_added": "Dodano notatkę",
+      "stage_changed": "Zmiana etapu",
+      "assigned": "Przypisano",
+      "relationship_added": "Dodano powiązanie",
+      "relationship_removed": "Usunięto powiązanie",
+      "document_uploaded": "Dodano dokument",
+      "status_changed": "Zmiana statusu",
+      "email_sent": "Wysłano email",
+      "email_received": "Odebrano email",
+      "sms_sent": "Wysłano SMS",
+      "sms_received": "Odebrano SMS",
+      "package_assigned": "Przypisano pakiet"
+    },
     "descriptions": {
       "updatedAppointment": "Zaktualizowano wizytę",
       "rescheduledAppointment": "Przeniesiono wizytę z {{fromDate}} {{fromTime}} na {{toDate}} {{toTime}}",

--- a/src/components/activity-timeline/translate-description.ts
+++ b/src/components/activity-timeline/translate-description.ts
@@ -8,8 +8,9 @@
  * English copy into otherwise Polish UI. Rather than back-fill the DB, we
  * pattern-match known templates here and return the translated equivalent.
  *
- * If the input does not match any known template, it is returned unchanged so
- * free-text and not-yet-covered descriptions still render.
+ * Returns `undefined` when the input is empty or no rule matches, so callers
+ * can chain a per-action fallback (see `getActionFallbackLabel`) before
+ * showing the raw English description.
  */
 
 // Loose translator shape compatible with i18next's TFunction.
@@ -652,10 +653,28 @@ export function translateActivityDescription(
   description: string | undefined,
   t: Translator | undefined,
 ): string | undefined {
-  if (!description || !t) return description;
+  if (!description || !t) return undefined;
   for (const rule of rules) {
     const match = description.match(rule.pattern);
     if (match) return rule.build(match, t);
   }
-  return description;
+  return undefined;
+}
+
+// Localized fallback for activity rows whose stored English description does
+// not match any rule above (issue #1855). Used by the appointment change
+// history popover so unrecognised entries render a sensible per-action label
+// (e.g. "Zaktualizowano", "Zmiana statusu") instead of leaking raw English.
+// Returns undefined for unknown actions so callers can chain to the raw
+// description as a last resort.
+export function getActionFallbackLabel(
+  action: string | undefined,
+  t: Translator | undefined,
+): string | undefined {
+  if (!action || !t) return undefined;
+  const key = `activityTimeline.actionFallback.${action}`;
+  const translated = t(key, { defaultValue: "" });
+  return typeof translated === "string" && translated.length > 0
+    ? translated
+    : undefined;
 }

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -87,7 +87,10 @@ import {
   X,
 } from "lucide-react";
 import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
-import { translateActivityDescription } from "@/components/activity-timeline/translate-description";
+import {
+  getActionFallbackLabel,
+  translateActivityDescription,
+} from "@/components/activity-timeline/translate-description";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useDraggableDialog } from "@/hooks/use-draggable-dialog";
@@ -1707,8 +1710,13 @@ export function AppointmentPreviewContent({
                           minute: "2-digit",
                         },
                       );
+                      // Prefer a localized rule match; fall back to a
+                      // per-action label so unrecognised templates don't leak
+                      // raw English (#1855); raw description is the last
+                      // resort.
                       const label =
                         translateActivityDescription(a.description, t) ??
+                        getActionFallbackLabel(a.action, t) ??
                         a.description;
                       return (
                         <li


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1855.

Closes #1855

---

## Claude summary

Committed. Summary of the fix:

The change history popover in the appointment preview (`src/components/gabinet/calendar/appointment-preview-content.tsx:1713`) used `translateActivityDescription` to localize stored English activity descriptions, but unrecognised templates fell through to raw English. I added a `getActionFallbackLabel(action, t)` helper in `src/components/activity-timeline/translate-description.ts` that returns a localized label per action (`created` → "Utworzono", `updated` → "Zaktualizowano", `status_changed` → "Zmiana statusu", etc.), and changed `translateActivityDescription` to return `undefined` on no-match so callers can chain the fallback. The popover now does `translated ?? actionFallback ?? rawDescription`. Added `activityTimeline.actionFallback.*` keys to both PL and EN locales covering all 15 `ActivityAction` literals from the schema. The other caller (`src/components/crm/activity-feed-adapter.ts:86`) keeps identical behavior thanks to its existing `?? a.description` chain.