### PR TITLE
Wizyta - opłacona - czerwony wykrzknik

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -677,11 +677,19 @@ export function AppointmentPreviewContent({
   };
 
   const treatmentPrice = treatment?.price ?? 0;
+  // Credit applied from the patient's overpayment balance (issue #1059) counts
+  // toward the paid total — a visit settled purely from credit lands as
+  // `amount=0, creditApplied=price` (#1856), so without summing creditApplied
+  // the visit would look unpaid (red "!") even though it's fully settled.
   const totalPaid = (detail.payments ?? [])
     .filter(
       (p) => p.status === "completed" || p.status === "pending",
     )
-    .reduce((sum, p) => sum + (p.amount ?? 0), 0);
+    .reduce(
+      (sum, p) =>
+        sum + (p.amount ?? 0) + ((p as { creditApplied?: number | null }).creditApplied ?? 0),
+      0,
+    );
   const outstanding = Math.max(0, treatmentPrice - totalPaid);
   const canMarkCompleted = availableTransitions.includes("completed");
 
@@ -690,7 +698,11 @@ export function AppointmentPreviewContent({
   // booked, so they mustn't count as actually paid. Issue #1031.
   const completedPaid = (detail.payments ?? [])
     .filter((p) => p.status === "completed")
-    .reduce((sum, p) => sum + (p.amount ?? 0), 0);
+    .reduce(
+      (sum, p) =>
+        sum + (p.amount ?? 0) + ((p as { creditApplied?: number | null }).creditApplied ?? 0),
+      0,
+    );
 
   // Drives the "already settled" affordance on the Rozlicz button (issue #1688).
   // Settle = visit closed AND nothing left to pay; otherwise the primary button

--- a/src/hooks/use-supabase-gabinet-appointments.ts
+++ b/src/hooks/use-supabase-gabinet-appointments.ts
@@ -436,6 +436,11 @@ export function useSupabaseGabinetAppointmentRecurringPositions(
  * pending payments are auto-created at booking time and must not be treated
  * as actual receipts (mirrors `appointment-preview-content.tsx` logic).
  *
+ * Credit applied from the patient's overpayment balance (`credit_applied`,
+ * issue #1059) counts toward the paid total — a visit settled purely from
+ * credit lands as `amount=0, credit_applied=price` (#1856), and must light
+ * up the green "✓" indicator, not the red "!".
+ *
  * Returned map keys are appointment IDs; values are the total in PLN.
  */
 export function useSupabaseGabinetAppointmentPaymentTotals(
@@ -461,7 +466,7 @@ export function useSupabaseGabinetAppointmentPaymentTotals(
 
       const { data, error } = await client
         .from("payments")
-        .select("appointment_id, amount")
+        .select("appointment_id, amount, credit_applied")
         .eq("organization_id", organizationId)
         .eq("status", "completed")
         .in("appointment_id", stableIds);
@@ -471,10 +476,13 @@ export function useSupabaseGabinetAppointmentPaymentTotals(
       for (const row of (data ?? []) as {
         appointment_id: string | null;
         amount: number;
+        credit_applied: number | null;
       }[]) {
         if (!row.appointment_id) continue;
         const current = result.get(row.appointment_id) ?? 0;
-        result.set(row.appointment_id, current + (Number(row.amount) || 0));
+        const contribution =
+          (Number(row.amount) || 0) + (Number(row.credit_applied) || 0);
+        result.set(row.appointment_id, current + contribution);
       }
       return result;
     },

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1221,11 +1221,21 @@ function AppointmentDetail() {
   const getReplies = (noteId: string) =>
     notes.filter((n) => n.parentNoteId === noteId);
 
-  // Calculate payment summary
+  // Calculate payment summary. Credit applied from the patient's overpayment
+  // balance (issue #1059) counts toward the paid total alongside `amount` —
+  // a visit settled purely from credit lands as `amount=0, creditApplied=price`
+  // (#1856), so without summing creditApplied the outstanding would stay at
+  // the full visit price even after settlement.
   const treatmentPrice = treatment?.price ?? 0;
   const totalPaid = payments
     .filter((p: Record<string, unknown>) => p.status === "completed")
-    .reduce((sum: number, p: Record<string, unknown>) => sum + (p.amount as number), 0);
+    .reduce(
+      (sum: number, p: Record<string, unknown>) =>
+        sum +
+        ((p.amount as number | null) ?? 0) +
+        ((p.creditApplied as number | null) ?? 0),
+      0,
+    );
   const outstanding = treatmentPrice - totalPaid;
 
   const availableTransitions = VALID_TRANSITIONS[appointment.status] ?? [];

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -626,13 +626,23 @@ function PatientDetail() {
             ? treatmentsData?.find((tr) => tr._id === apt.treatmentId)?.price ??
               0
             : 0;
+        // Credit applied to prior payments on this visit (issue #1059) counts
+        // toward the paid total — without it, a visit already fully settled
+        // from credit would look unpaid and any new cash payment would skip
+        // the creditEarned overpayment routing (#1856).
         const paidForVisit = (patientPayments ?? [])
           .filter(
             (p) =>
               p.appointmentId === addPaymentAppointmentId &&
               p.status === "completed",
           )
-          .reduce((sum, p) => sum + (p.amount ?? 0), 0);
+          .reduce(
+            (sum, p) =>
+              sum +
+              (p.amount ?? 0) +
+              ((p as { creditApplied?: number | null }).creditApplied ?? 0),
+            0,
+          );
         const outstanding = Math.max(0, treatmentPrice - paidForVisit);
         if (amount > outstanding + 0.005) {
           creditEarned = Math.round((amount - outstanding) * 100) / 100;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1856.

Closes #1856

---

## Claude summary

Fixed. The bug: when a visit is settled entirely from the patient's overpayment balance (saldo), the payment row is recorded as `amount=0, creditApplied=visitPrice` (see appointment-preview-content.tsx:1044-1056). However, every per-visit "paid total" reducer in the code only summed `amount`, so credit-only settlements left totalPaid at 0 and the visit kept the red `!` indicator instead of switching to the green `✓`.

Patched four spots so `creditApplied` contributes to the paid total alongside `amount`:
- `src/hooks/use-supabase-gabinet-appointments.ts:441` — `useSupabaseGabinetAppointmentPaymentTotals` (drives the calendar tile indicator)
- `src/components/gabinet/calendar/appointment-preview-content.tsx:680,691` — `totalPaid` (drives the popover's outstanding/Rozlicz button) and `completedPaid` (drives the popover indicator pill)
- `src/routes/.../_layout.gabinet.appointments.$appointmentId.lazy.tsx:1226` — `totalPaid` for the appointment detail page summary
- `src/routes/.../_layout.gabinet.patients.$patientId.tsx:629` — `paidForVisit` in the patient page "Dodaj wpłatę" dialog, so overpayment routing stays correct after a credit-only settle

Typecheck passes (`tsc -p tsconfig.app.json`). Committed as `ecf775a`.