### PR TITLE
Apply the same `modal` fix to the patient picker popover in `src/components/gabi

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -1104,6 +1104,11 @@ export function AppointmentDialog({
                     </button>
                   </div>
                   <Popover
+                    // `modal` stacks the popover's own `react-remove-scroll`
+                    // lock on top of the parent Dialog's lock so touchpad /
+                    // wheel scrolling works on the portaled patient list
+                    // (issue #1861, same root cause as #1850).
+                    modal
                     open={patientOpen}
                     onOpenChange={(o) => {
                       setPatientOpen(o);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1861.

Closes #1861

---

## Claude summary

Fix applied and committed. Added `modal` prop to the inline patient picker `Popover` in `src/components/gabinet/calendar/appointment-dialog.tsx:1106`, mirroring the merged treatment-picker fix from #1850. This stacks the popover's own `react-remove-scroll` lock on top of the parent Dialog's lock so touchpad/wheel events on the portaled patient list are no longer blocked.