### PR TITLE
Funkcja dopisywania materiałów

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -543,6 +543,20 @@ export const update = action({
         v.null(),
       ),
     ),
+    assignedItems: v.optional(
+      v.union(
+        v.array(
+          v.object({
+            name: v.string(),
+            quantity: v.optional(v.number()),
+            issuedDate: v.optional(v.string()),
+            returnedDate: v.optional(v.string()),
+            notes: v.optional(v.string()),
+          }),
+        ),
+        v.null(),
+      ),
+    ),
     baseSalary: v.optional(v.union(v.number(), v.null())),
     commissionPercent: v.optional(v.union(v.number(), v.null())),
     bankAccount: v.optional(v.union(v.string(), v.null())),

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -290,6 +290,17 @@ export function createGabinetTables({
         }),
       ),
     ),
+    assignedItems: v.optional(
+      v.array(
+        v.object({
+          name: v.string(),
+          quantity: v.optional(v.number()),
+          issuedDate: v.optional(v.string()),
+          returnedDate: v.optional(v.string()),
+          notes: v.optional(v.string()),
+        }),
+      ),
+    ),
     baseSalary: v.optional(v.number()),
     commissionPercent: v.optional(v.number()),
     bankAccount: v.optional(v.string()),

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2708,6 +2708,7 @@
         "activities": "Activities",
         "detailedData": "Detailed Data",
         "schedule": "Schedule",
+        "assignedItems": "Materials",
         "noPatients": "No clients seen yet."
       },
       "agenda": {
@@ -2734,6 +2735,22 @@
         "noResults": "No clients match the current filters.",
         "visits": "{{count}} visits",
         "lastVisit": "Last:"
+      },
+      "assignedItems": {
+        "heldTitle": "Issued items",
+        "returnedTitle": "Returned",
+        "add": "Add item",
+        "itemName": "Item",
+        "itemNamePlaceholder": "e.g. office keys, uniform, access card",
+        "quantity": "Quantity",
+        "issuedDate": "Issue date",
+        "issued": "Issued",
+        "returned": "Returned",
+        "notes": "Notes",
+        "notesPlaceholder": "e.g. serial number, color, locker 12",
+        "markReturned": "Mark as returned",
+        "markActive": "Undo return",
+        "empty": "No items currently issued to this employee."
       },
       "detailedData": {
         "personalData": "Personal Data",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2729,6 +2729,7 @@
         "activities": "Aktywności",
         "detailedData": "Dane szczegółowe",
         "schedule": "Grafik",
+        "assignedItems": "Materiały",
         "noPatients": "Brak obsługiwanych klientów."
       },
       "agenda": {
@@ -2755,6 +2756,22 @@
         "noResults": "Brak klientów pasujących do filtrów.",
         "visits": "{{count}} wizyt",
         "lastVisit": "Ostatnia:"
+      },
+      "assignedItems": {
+        "heldTitle": "Wydane materiały",
+        "returnedTitle": "Zwrócone",
+        "add": "Dodaj materiał",
+        "itemName": "Materiał",
+        "itemNamePlaceholder": "np. Klucze do gabinetu, fartuch, karta dostępu",
+        "quantity": "Ilość",
+        "issuedDate": "Data wydania",
+        "issued": "Wydano",
+        "returned": "Zwrócono",
+        "notes": "Uwagi",
+        "notesPlaceholder": "np. numer seryjny, kolor, szafka 12",
+        "markReturned": "Oznacz jako zwrócony",
+        "markActive": "Cofnij zwrot",
+        "empty": "Pracownik nie ma obecnie wydanych materiałów."
       },
       "detailedData": {
         "personalData": "Dane osobowe",

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -2802,6 +2802,7 @@ export interface Database {
           skills: string[] | null;
           years_of_experience: number | null;
           certifications: unknown | null;
+          assigned_items: unknown | null;
           base_salary: number | null;
           commission_percent: number | null;
           bank_account: string | null;
@@ -2838,6 +2839,7 @@ export interface Database {
           skills?: string[] | null;
           years_of_experience?: number | null;
           certifications?: unknown | null;
+          assigned_items?: unknown | null;
           base_salary?: number | null;
           commission_percent?: number | null;
           bank_account?: string | null;
@@ -2874,6 +2876,7 @@ export interface Database {
           skills?: string[] | null;
           years_of_experience?: number | null;
           certifications?: unknown | null;
+          assigned_items?: unknown | null;
           base_salary?: number | null;
           commission_percent?: number | null;
           bank_account?: string | null;

--- a/src/lib/supabase/mappers/gabinet/employees.ts
+++ b/src/lib/supabase/mappers/gabinet/employees.ts
@@ -32,6 +32,13 @@ export interface MappedGabinetEmployee {
   skills?: string[];
   yearsOfExperience?: number;
   certifications?: Array<{ name: string; dateObtained?: string; expiryDate?: string }>;
+  assignedItems?: Array<{
+    name: string;
+    quantity?: number;
+    issuedDate?: string;
+    returnedDate?: string;
+    notes?: string;
+  }>;
   baseSalary?: number;
   commissionPercent?: number;
   bankAccount?: string;

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -704,6 +704,18 @@ function EmployeeDetail() {
       ),
     },
     {
+      label: t("gabinet.employees.tabs.assignedItems"),
+      count: employee.assignedItems?.filter((it) => !it.returnedDate).length,
+      content: (
+        <AssignedItemsTab
+          employee={employee}
+          organizationId={organizationId}
+          onUpdate={async (a) => { await updateEmployee(a); invalidateEmployeeCache(); }}
+          t={t}
+        />
+      ),
+    },
+    {
       label: t("gabinet.employees.notes"),
       content: (
         <NotesTabContent
@@ -2430,6 +2442,306 @@ function DetailedDataTab({
           )}
         </CardContent>
       </Card>
+    </div>
+  );
+}
+
+// --- Assigned items (materials issued to employee: keys, uniform, access card, etc.) ---
+
+type AssignedItem = NonNullable<MappedGabinetEmployee["assignedItems"]>[number];
+
+function AssignedItemsTab({
+  employee,
+  organizationId,
+  onUpdate,
+  t,
+}: {
+  employee: MappedGabinetEmployee;
+  organizationId: Id<"organizations">;
+  onUpdate: (args: FunctionArgs<typeof api.gabinet.employees.update>) => Promise<void>;
+  t: TFunction;
+}) {
+  const [adding, setAdding] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newQuantity, setNewQuantity] = useState("1");
+  const [newIssuedDate, setNewIssuedDate] = useState(() => new Date().toISOString().split("T")[0]);
+  const [newNotes, setNewNotes] = useState("");
+
+  const items = employee.assignedItems ?? [];
+  const activeItems = items.filter((it) => !it.returnedDate);
+  const returnedItems = items.filter((it) => !!it.returnedDate);
+
+  const persist = async (next: AssignedItem[]) => {
+    setSaving(true);
+    try {
+      await onUpdate({
+        organizationId,
+        employeeId: employee._id,
+        assignedItems: next.length > 0 ? next : null,
+      });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.employees.errors.saveFailed",
+          defaultValue: "Nie udało się zapisać zmian pracownika.",
+        }),
+      );
+      throw e;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAdd = async () => {
+    if (!newName.trim()) return;
+    const qty = Number(newQuantity);
+    const item: AssignedItem = {
+      name: newName.trim(),
+      quantity: Number.isFinite(qty) && qty > 0 ? qty : undefined,
+      issuedDate: newIssuedDate || undefined,
+      notes: newNotes.trim() || undefined,
+    };
+    try {
+      await persist([...items, item]);
+      setNewName("");
+      setNewQuantity("1");
+      setNewIssuedDate(new Date().toISOString().split("T")[0]);
+      setNewNotes("");
+      setAdding(false);
+      toast.success(t("common.saved"));
+    } catch {
+      // toast handled in persist
+    }
+  };
+
+  const handleMarkReturned = async (index: number) => {
+    const next = items.map((it, i) =>
+      i === index
+        ? { ...it, returnedDate: new Date().toISOString().split("T")[0] }
+        : it,
+    );
+    try {
+      await persist(next);
+      toast.success(t("common.saved"));
+    } catch {
+      // toast handled in persist
+    }
+  };
+
+  const handleUnmarkReturned = async (index: number) => {
+    const next = items.map((it, i) =>
+      i === index ? { ...it, returnedDate: undefined } : it,
+    );
+    try {
+      await persist(next);
+      toast.success(t("common.saved"));
+    } catch {
+      // toast handled in persist
+    }
+  };
+
+  const handleRemove = async (index: number) => {
+    const next = items.filter((_, i) => i !== index);
+    try {
+      await persist(next);
+      toast.success(t("common.saved"));
+    } catch {
+      // toast handled in persist
+    }
+  };
+
+  const renderItemRow = (item: AssignedItem, index: number, isReturned: boolean) => (
+    <div
+      key={index}
+      className="flex flex-wrap items-start gap-3 rounded-md border p-3"
+    >
+      <Briefcase className="mt-0.5 h-4 w-4 text-muted-foreground" />
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">{item.name}</span>
+          {item.quantity && item.quantity > 1 && (
+            <Badge variant="secondary" className="text-xs">
+              ×{item.quantity}
+            </Badge>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+          {item.issuedDate && (
+            <span>
+              {t("gabinet.employees.assignedItems.issued")}: {item.issuedDate}
+            </span>
+          )}
+          {item.returnedDate && (
+            <span>
+              {t("gabinet.employees.assignedItems.returned")}: {item.returnedDate}
+            </span>
+          )}
+        </div>
+        {item.notes && (
+          <p className="text-xs text-muted-foreground">{item.notes}</p>
+        )}
+      </div>
+      <div className="flex items-center gap-1">
+        {isReturned ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => handleUnmarkReturned(index)}
+            disabled={saving}
+          >
+            {t("gabinet.employees.assignedItems.markActive")}
+          </Button>
+        ) : (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => handleMarkReturned(index)}
+            disabled={saving}
+          >
+            {t("gabinet.employees.assignedItems.markReturned")}
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0 text-destructive"
+          onClick={() => handleRemove(index)}
+          disabled={saving}
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-base">
+            {t("gabinet.employees.assignedItems.heldTitle")}
+            {activeItems.length > 0 && (
+              <span className="ml-2 text-sm text-muted-foreground">
+                ({activeItems.length})
+              </span>
+            )}
+          </CardTitle>
+          {!adding && (
+            <Button size="sm" variant="outline" onClick={() => setAdding(true)}>
+              <Plus className="mr-1 h-3.5 w-3.5" variant="stroke" />
+              {t("gabinet.employees.assignedItems.add")}
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {adding && (
+            <div className="space-y-3 rounded-md border bg-muted/30 p-3">
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-[1fr_120px_160px]">
+                <div className="space-y-1">
+                  <Label className="text-xs">
+                    {t("gabinet.employees.assignedItems.itemName")}
+                  </Label>
+                  <Input
+                    value={newName}
+                    onChange={(e) => setNewName(e.target.value)}
+                    placeholder={t("gabinet.employees.assignedItems.itemNamePlaceholder")}
+                    className="h-9"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">
+                    {t("gabinet.employees.assignedItems.quantity")}
+                  </Label>
+                  <Input
+                    type="number"
+                    min={1}
+                    value={newQuantity}
+                    onChange={(e) => setNewQuantity(e.target.value)}
+                    className="h-9"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">
+                    {t("gabinet.employees.assignedItems.issuedDate")}
+                  </Label>
+                  <Input
+                    type="date"
+                    value={newIssuedDate}
+                    onChange={(e) => setNewIssuedDate(e.target.value)}
+                    className="h-9"
+                  />
+                </div>
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">
+                  {t("gabinet.employees.assignedItems.notes")}
+                </Label>
+                <Input
+                  value={newNotes}
+                  onChange={(e) => setNewNotes(e.target.value)}
+                  placeholder={t("gabinet.employees.assignedItems.notesPlaceholder")}
+                  className="h-9"
+                />
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => {
+                    setAdding(false);
+                    setNewName("");
+                    setNewQuantity("1");
+                    setNewIssuedDate(new Date().toISOString().split("T")[0]);
+                    setNewNotes("");
+                  }}
+                  disabled={saving}
+                >
+                  {t("common.cancel")}
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={handleAdd}
+                  disabled={!newName.trim() || saving}
+                >
+                  {t("common.save")}
+                </Button>
+              </div>
+            </div>
+          )}
+          {activeItems.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {t("gabinet.employees.assignedItems.empty")}
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {items.map((item, index) =>
+                item.returnedDate ? null : renderItemRow(item, index, false),
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {returnedItems.length > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base text-muted-foreground">
+              {t("gabinet.employees.assignedItems.returnedTitle")}
+              <span className="ml-2 text-sm">({returnedItems.length})</span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {items.map((item, index) =>
+                item.returnedDate ? renderItemRow(item, index, true) : null,
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/supabase/migrations/00017_gabinet_employees_assigned_items.sql
+++ b/supabase/migrations/00017_gabinet_employees_assigned_items.sql
@@ -1,0 +1,9 @@
+-- Issue #1876: per-employee assigned items (keys, uniform, access card, etc.)
+--
+-- Stores a list of equipment / materials issued to an employee. Each entry
+-- captures the item name, optional quantity, issue/return dates, and free-form
+-- notes (e.g. serial number, locker number). Returned items are kept in the
+-- list with a returnedDate set so the history is preserved.
+
+ALTER TABLE gabinet_employees
+  ADD COLUMN IF NOT EXISTS assigned_items JSONB;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1876.

Closes #1876

---

## Claude summary

Done. Summary of changes for issue #1876:

Added a "Materiały" tab on the employee detail page (`/dashboard/gabinet/employees/$employeeId`) where admins can record items issued to staff — keys, uniform, access card, etc.

Approach: rather than introducing a new table for what is essentially a list per employee, the data lives in a new JSONB column `assigned_items` on `gabinet_employees`, mirroring the existing `certifications` pattern.

Each entry stores `name`, optional `quantity`, `issuedDate`, `returnedDate`, and free-form `notes` (for serial numbers, locker numbers, etc.). The tab UI shows two sections: actively held items at the top with a quick add form, and a returned-items section below for history. Returning an item just sets `returnedDate`; the entry stays in the list so the record is preserved. The tab badge shows the count of currently-held items.

Files: `convex/schema/gabinet.ts`, `convex/gabinet/employees.ts` (update validator), `supabase/migrations/00017_gabinet_employees_assigned_items.sql` (new), `src/lib/supabase/database.types.ts`, `src/lib/supabase/mappers/gabinet/employees.ts`, the employee route, plus PL/EN translations. `npm run typecheck` passes.