### PR TITLE
Wyświetlanie zdajesz mobilny 

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2320,6 +2320,7 @@
         "openAppointment": "Open appointment",
         "noTreatment": "Appointment",
         "compare": "Compare photos",
+        "compareVisit": "Compare",
         "compareTitle": "Before / after photo comparison"
       },
       "byDay": "Clients by Day",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2335,6 +2335,7 @@
         "openAppointment": "Otwórz wizytę",
         "noTreatment": "Wizyta",
         "compare": "Porównaj zdjęcia",
+        "compareVisit": "Porównaj",
         "compareTitle": "Porównanie zdjęć przed i po"
       },
       "byDay": "Klienci wg dnia",

--- a/src/components/gabinet/patient-photos-tab.tsx
+++ b/src/components/gabinet/patient-photos-tab.tsx
@@ -137,6 +137,28 @@ export function PatientPhotosTab({
 
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
   const [compareOpen, setCompareOpen] = useState(false);
+  const [compareAppointmentId, setCompareAppointmentId] = useState<
+    string | null
+  >(null);
+
+  const dialogBeforeEntries = useMemo(
+    () =>
+      compareAppointmentId === null
+        ? beforeEntries
+        : beforeEntries.filter(
+            (e) => e.group.appointment._id === compareAppointmentId,
+          ),
+    [beforeEntries, compareAppointmentId],
+  );
+  const dialogAfterEntries = useMemo(
+    () =>
+      compareAppointmentId === null
+        ? afterEntries
+        : afterEntries.filter(
+            (e) => e.group.appointment._id === compareAppointmentId,
+          ),
+    [afterEntries, compareAppointmentId],
+  );
 
   const closePreview = useCallback(() => setPreviewIndex(null), []);
 
@@ -197,7 +219,10 @@ export function PatientPhotosTab({
           <Button
             variant="outline"
             size="sm"
-            onClick={() => setCompareOpen(true)}
+            onClick={() => {
+              setCompareAppointmentId(null);
+              setCompareOpen(true);
+            }}
           >
             <ColumnsIcon className="mr-1.5 size-4" />
             {t("gabinet.patients.photos.compare", "Porównaj zdjęcia")}
@@ -207,6 +232,8 @@ export function PatientPhotosTab({
       {groups.map((group) => {
         const beforePhotos = group.photos.filter((p) => p.type === "before");
         const afterPhotos = group.photos.filter((p) => p.type === "after");
+        const canCompareGroup =
+          beforePhotos.length > 0 && afterPhotos.length > 0;
         const treatmentName = treatments?.find(
           (tr) => tr._id === group.appointment.treatmentId,
         )?.name;
@@ -225,18 +252,36 @@ export function PatientPhotosTab({
                     {group.appointment.endTime}
                   </CardDescription>
                 </div>
-                <Button asChild size="sm" variant="outline">
-                  <Link
-                    to="/dashboard/gabinet/appointments/$appointmentId"
-                    params={{ appointmentId: group.appointment._id }}
-                    search={{ tab: "documentation" }}
-                  >
-                    {t(
-                      "gabinet.patients.photos.openAppointment",
-                      "Otwórz wizytę",
-                    )}
-                  </Link>
-                </Button>
+                <div className="flex flex-wrap gap-2">
+                  {canCompareGroup && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        setCompareAppointmentId(group.appointment._id);
+                        setCompareOpen(true);
+                      }}
+                    >
+                      <ColumnsIcon className="mr-1.5 size-4" />
+                      {t(
+                        "gabinet.patients.photos.compareVisit",
+                        "Porównaj",
+                      )}
+                    </Button>
+                  )}
+                  <Button asChild size="sm" variant="outline">
+                    <Link
+                      to="/dashboard/gabinet/appointments/$appointmentId"
+                      params={{ appointmentId: group.appointment._id }}
+                      search={{ tab: "documentation" }}
+                    >
+                      {t(
+                        "gabinet.patients.photos.openAppointment",
+                        "Otwórz wizytę",
+                      )}
+                    </Link>
+                  </Button>
+                </div>
               </div>
             </CardHeader>
             <CardContent className="px-6 py-4">
@@ -345,9 +390,12 @@ export function PatientPhotosTab({
 
       <ComparisonDialog
         open={compareOpen}
-        onOpenChange={setCompareOpen}
-        beforeEntries={beforeEntries}
-        afterEntries={afterEntries}
+        onOpenChange={(o) => {
+          setCompareOpen(o);
+          if (!o) setCompareAppointmentId(null);
+        }}
+        beforeEntries={dialogBeforeEntries}
+        afterEntries={dialogAfterEntries}
         urlMap={urlMap}
         treatments={treatments}
       />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1879.

Closes #1879

---

## Claude summary

Added a per‑appointment "Porównaj" button to each card in the patient photos tab. On mobile (and desktop), users can now tap "Porównaj" next to "Otwórz wizytę" on any visit card that has both a before and an after photo, and the existing comparison dialog opens scoped to just that visit. The top‑level cross‑appointment "Porównaj zdjęcia" button (added in #1871) is unchanged.

Changes in `src/components/gabinet/patient-photos-tab.tsx:138-161,222-225,255-271` plus a new `compareVisit` i18n key in both PL/EN. Typecheck clean. Committed as `46faa36`.