### PR TITLE
Kolumna do zaznaczania rekordow w data-table

### DIFF
--- a/src/components/application/table/table.tsx
+++ b/src/components/application/table/table.tsx
@@ -156,7 +156,9 @@ const TableHeader = <T extends object>({ columns, children, bordered = true, cla
                         // Narrow on mobile so the selection cell doesn't eat ~25% of the
                         // row width as an accidental-toggle hit area (issue #1772 — finger
                         // taps meant to open a row landed on the wide checkbox cell on iOS).
-                        size === "sm" ? "w-12 md:w-24 md:pl-3" : "w-14 md:w-28 md:pl-4",
+                        // Desktop widened +50px (issue #1882) so the cell-wide toggle hit
+                        // area (Checkbox label uses `absolute inset-0`) is comfortably large.
+                        size === "sm" ? "w-12 md:w-[146px] md:pl-3" : "w-14 md:w-[162px] md:pl-4",
                     )}
                 >
                     {selectionMode === "multiple" && (
@@ -261,7 +263,9 @@ const TableRow = <T extends object>({ columns, children, className, highlightSel
                         // Narrow on mobile so the selection cell doesn't eat ~25% of the
                         // row width as an accidental-toggle hit area (issue #1772 — finger
                         // taps meant to open a row landed on the wide checkbox cell on iOS).
-                        size === "sm" ? "w-12 md:w-24 md:pl-3" : "w-14 md:w-28 md:pl-4",
+                        // Desktop widened +50px (issue #1882) so the cell-wide toggle hit
+                        // area (Checkbox label uses `absolute inset-0`) is comfortably large.
+                        size === "sm" ? "w-12 md:w-[146px] md:pl-3" : "w-14 md:w-[162px] md:pl-4",
                     )}
                 >
                     <Checkbox


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1882.

Closes #1882

---

## Claude summary

Changes committed. Summary:

The user asked for two things on the gabinet patients data-table: that the checkbox column behave like a normal column where clicks in the cell area select the row (with other cells without their own actions still navigating to details), and that the column be 50px wider.

The "click anywhere in the cell to toggle" part is already wired up by design — `src/components/application/table/table.tsx:163-170` renders the row's selection Checkbox with `absolute inset-0 !flex !items-center`, so the entire `AriaCell` area is a label that toggles the checkbox; row clicks elsewhere fall through to `onRowAction` (the navigation handler the page passes in at `_layout.gabinet.patients.index.tsx:610-612`). That two-mode behavior was deliberately set up in #1584/#1594.

The cell was simply small enough on desktop (96px / 112px) that the wide hit area wasn't obvious. I bumped the desktop selection column width by 50px (`md:w-24` → `md:w-[146px]`, `md:w-28` → `md:w-[162px]`) in both the header `AriaColumn` and the row `AriaCell` so they stay aligned. Mobile widths stay narrow per #1772 to avoid accidental toggles on touch.