### PR TITLE
fix(signing-email): use org's mail_provider (Resend/Mailgun) before Gmail OAuth

### DIFF
--- a/convex/documents/signing.ts
+++ b/convex/documents/signing.ts
@@ -5,6 +5,7 @@ import type { Id } from "../_generated/dataModel";
 import { createSupabaseDb, type SupabaseDb } from "../_helpers/supabaseDb";
 import { getValidAccessToken } from "../google/_helpers";
 import { Resend } from "resend";
+import { sendViaResend, sendViaMailgun } from "../email/providers";
 import { RESEND_API_KEY, RESEND_FROM, SITE_URL, DEV_INTERCEPT_EMAILS } from "@cvx/env";
 
 async function markSent(db: SupabaseDb, documentId: string): Promise<void> {
@@ -252,6 +253,89 @@ export const sendSigningEmailInternal = internalAction({
       console.log("[signing] DEV_INTERCEPT: Email stored to devEmails instead of sending →", args.recipientEmail);
       await markSent(db, args.documentId);
       return;
+    }
+
+    // --- Provider preference order (issue: maile szły z osobistego Gmaila
+    //     mimo skonfigurowanego mail_providera typu "Karta") ---
+    //
+    //   1. `mail_providers.isDefault = true` for the org — the dedicated
+    //      transactional sender the user configured in /admin/email-config.
+    //      Used to be ignored entirely; signing went straight to Gmail OAuth.
+    //   2. Gmail OAuth fallback — only when no default mail provider exists.
+    //   3. Env-level Resend last-ditch fallback.
+    const defaultProvider: {
+      _id: string;
+      providerType: string;
+      fromEmail: string;
+      fromName: string;
+      replyToEmail?: string | null;
+      apiConfig?: { apiKey?: string; domain?: string; region?: string } | null;
+      status: string;
+    } | null = await ctx.runAction(
+      internal.mailProviders._getActiveDefaultForOrg,
+      { organizationId: data.organizationId as Id<"organizations"> },
+    );
+
+    if (defaultProvider && (defaultProvider.providerType === "resend" || defaultProvider.providerType === "mailgun")) {
+      const apiKey = defaultProvider.apiConfig?.apiKey;
+      const providerFrom = defaultProvider.fromName
+        ? `${defaultProvider.fromName} <${defaultProvider.fromEmail}>`
+        : defaultProvider.fromEmail;
+      try {
+        if (defaultProvider.providerType === "resend") {
+          if (!apiKey) throw new Error("Default Resend provider has no apiKey");
+          await sendViaResend(
+            {
+              to: args.recipientEmail,
+              subject,
+              html,
+              from: providerFrom,
+              replyTo: defaultProvider.replyToEmail ?? undefined,
+            },
+            { apiKey },
+          );
+        } else {
+          const domain = defaultProvider.apiConfig?.domain;
+          const region = (defaultProvider.apiConfig?.region ?? "us") as "us" | "eu";
+          if (!apiKey || !domain) throw new Error("Default Mailgun provider missing apiKey/domain");
+          await sendViaMailgun(
+            {
+              to: args.recipientEmail,
+              subject,
+              html,
+              from: providerFrom,
+              replyTo: defaultProvider.replyToEmail ?? undefined,
+            },
+            { apiKey, domain, region },
+          );
+        }
+        console.log(
+          `[signing] Signing email sent via ${defaultProvider.providerType} provider "${defaultProvider.fromEmail}" to`,
+          args.recipientEmail,
+        );
+        await ctx.runMutation(internal.emailSendLog.record, {
+          ...logBase,
+          provider: defaultProvider.providerType as "resend" | "mailgun",
+          status: "sent",
+          fromEmail: providerFrom,
+        });
+        await markSent(db, args.documentId);
+        return;
+      } catch (providerErr) {
+        const msg = providerErr instanceof Error ? providerErr.message : String(providerErr);
+        console.error(
+          `[signing] ${defaultProvider.providerType} provider send failed, falling back:`,
+          msg,
+        );
+        await ctx.runMutation(internal.emailSendLog.record, {
+          ...logBase,
+          provider: defaultProvider.providerType as "resend" | "mailgun",
+          status: "failed",
+          fromEmail: providerFrom,
+          errorMessage: msg.slice(0, 500),
+        });
+        // fall through to Gmail OAuth / env Resend
+      }
     }
 
     // Try sending via Gmail OAuth (tenant's configured connection)

--- a/convex/mailProviders.ts
+++ b/convex/mailProviders.ts
@@ -1,4 +1,4 @@
-import { query, action } from "./_generated/server";
+import { query, action, internalAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
@@ -333,5 +333,33 @@ export const testConnection = action({
     }
 
     return { ...result, providerId: args.providerId };
+  },
+});
+
+/**
+ * No-auth internal helper for system actions (signing emails etc.) that need
+ * the org's default mail provider without going through the
+ * `query`/verifyOrgAccess path. Returns the active default, or null.
+ * Reads from Supabase since mail_providers is the source of truth there now.
+ */
+export const _getActiveDefaultForOrg = internalAction({
+  args: { organizationId: v.id("organizations") },
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
+    const rows = (await db
+      .query("mailProviders")
+      .eq("organizationId", String(args.organizationId))
+      .eq("isDefault", true)
+      .collect()) as Array<{
+      _id: string;
+      providerType: string;
+      fromEmail: string;
+      fromName: string;
+      replyToEmail?: string | null;
+      apiConfig?: { apiKey?: string; domain?: string; region?: string } | null;
+      status: string;
+    }>;
+    const active = rows.find((r) => r.status === "active");
+    return active ?? null;
   },
 });


### PR DESCRIPTION
User-reported: maile signing szły z osobistego `aleksander@kolaboit.pl` mimo skonfigurowanego mail providera "Karta" (Resend, `karta@kolabogroup.pl`).

Root cause: `convex/documents/signing.ts` czytał tylko `emailAccounts` (org sender) + Gmail OAuth, a `mailProviders` traktował jakby nie istniało.

Fix: nowa kaskada providerów PRZED Gmail OAuth — najpierw `mailProviders.isDefault` active resend/mailgun → `sendViaResend`/`sendViaMailgun`, potem Gmail, na końcu env Resend.

Verified live na dev: signing test loguje `Signing email sent via resend provider "karta@kolabogroup.pl"`.