### PR TITLE
Kolumna do zaznaczania rekordow w data-table

### DIFF
--- a/src/components/application/table/table.tsx
+++ b/src/components/application/table/table.tsx
@@ -156,7 +156,9 @@ const TableHeader = <T extends object>({ columns, children, bordered = true, cla
                         // Narrow on mobile so the selection cell doesn't eat ~25% of the
                         // row width as an accidental-toggle hit area (issue #1772 — finger
                         // taps meant to open a row landed on the wide checkbox cell on iOS).
-                        size === "sm" ? "w-12 md:w-24 md:pl-3" : "w-14 md:w-28 md:pl-4",
+                        // Desktop widened +50px (issue #1882) so the cell-wide toggle hit
+                        // area (Checkbox label uses `absolute inset-0`) is comfortably large.
+                        size === "sm" ? "w-12 md:w-[146px] md:pl-3" : "w-14 md:w-[162px] md:pl-4",
                     )}
                 >
                     {selectionMode === "multiple" && (
@@ -261,7 +263,9 @@ const TableRow = <T extends object>({ columns, children, className, highlightSel
                         // Narrow on mobile so the selection cell doesn't eat ~25% of the
                         // row width as an accidental-toggle hit area (issue #1772 — finger
                         // taps meant to open a row landed on the wide checkbox cell on iOS).
-                        size === "sm" ? "w-12 md:w-24 md:pl-3" : "w-14 md:w-28 md:pl-4",
+                        // Desktop widened +50px (issue #1882) so the cell-wide toggle hit
+                        // area (Checkbox label uses `absolute inset-0`) is comfortably large.
+                        size === "sm" ? "w-12 md:w-[146px] md:pl-3" : "w-14 md:w-[162px] md:pl-4",
                     )}
                 >
                     <Checkbox

--- a/src/components/application/table/table.tsx
+++ b/src/components/application/table/table.tsx
@@ -255,6 +255,14 @@ const TableRow = <T extends object>({ columns, children, className, highlightSel
         >
             {selectionBehavior === "toggle" && (
                 <AriaCell
+                    // Stop pointer/click events from bubbling to the row so React Aria's
+                    // row onAction (navigation) never fires from a click inside the
+                    // checkbox cell — even when the click lands in the empty area around
+                    // the visible checkbox. The Checkbox label still receives the click
+                    // first because it's a child of this cell (issue #1882).
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onPointerUp={(e) => e.stopPropagation()}
+                    onClick={(e) => e.stopPropagation()}
                     className={cx(
                         "relative py-2 pr-0 pl-2",
                         // Right separator via ::before so we don't clash with the parent's


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1882.

Closes #1882

---

## Claude summary

Investigation summary: the patients page uses `CrmDataTable` → UTUI `Table`, which I'd confirmed is the file that PR #1883 patched. The `absolute inset-0` Checkbox label was supposed to make cell-area clicks toggle selection (React Aria's `useToggle` wraps the label in `usePress`, which stops pointer-event propagation on pointerdown). In practice users still saw the row's `onRowAction` (navigation) fire on cell-area clicks.

Fix (commit `ec03b10`): added explicit `onPointerDown` / `onPointerUp` / `onClick` handlers on the selection `AriaCell` in `src/components/application/table/table.tsx:263-265` that call `e.stopPropagation()`. The Checkbox label still receives the event first (it's a DOM child of the cell), so the toggle still happens — but the event is then guaranteed not to reach the row's `usePress`, so `onRowAction` won't fire from any click inside the checkbox column. The +50px desktop column width from PR #1883 is preserved.