### PR TITLE
Widok dokumentow w CRM

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -49,7 +49,7 @@ import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
 import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
 import { useSupabaseFormDocumentsList } from "@/hooks/use-supabase-form-documents";
-import { useSavedViews } from "@/hooks/use-saved-views";
+import { useSavedViews, applyFilterConditions } from "@/hooks/use-saved-views";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 
 // ---------------------------------------------------------------------------
@@ -114,7 +114,7 @@ function GabinetDocumentsPage() {
   const [searchValue, setSearchValue] = useState("");
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [docToDelete, setDocToDelete] = useState<string | null>(null);
-  const [, setActiveFilters] = useState<FilterCondition[]>([]);
+  const [activeFilters, setActiveFilters] = useState<FilterCondition[]>([]);
   const [savedViewsDialogOpen, setSavedViewsDialogOpen] = useState(false);
 
   // --- System views ---
@@ -256,26 +256,41 @@ function GabinetDocumentsPage() {
   const filteredDocuments = useMemo(() => {
     if (!documents) return [];
 
-    // Apply view-based filtering
-    let viewFiltered = documents;
+    // Decorate rows with derived fields used by manual filters (e.g. category)
+    let data = documents.map((doc) => ({
+      ...doc,
+      category: templateMap.get(doc.templateId)?.category ?? null,
+    }));
+
+    // Apply system-view (status-based) filtering
     switch (activeViewId) {
       case "draft":
-        viewFiltered = documents.filter((d) => d.status === "draft");
+        data = data.filter((d) => d.status === "draft");
         break;
       case "pending_signature":
-        viewFiltered = documents.filter((d) => d.status === "pending_signature");
+        data = data.filter((d) => d.status === "pending_signature");
         break;
       case "signed":
-        viewFiltered = documents.filter((d) => d.status === "signed");
+        data = data.filter((d) => d.status === "signed");
         break;
       default:
-        // "all" - no filtering
         break;
     }
 
-    // Apply filters from saved views or manual filters
-    return applyFilters(viewFiltered);
-  }, [documents, activeViewId, applyFilters]);
+    // Apply saved-view filters
+    data = applyFilters(data) as typeof data;
+
+    // Apply manual filter conditions from the filter bar
+    data = applyFilterConditions(data, activeFilters) as typeof data;
+
+    // Apply free-text search on title
+    if (searchValue.trim()) {
+      const q = searchValue.trim().toLowerCase();
+      data = data.filter((d) => d.title.toLowerCase().includes(q));
+    }
+
+    return data;
+  }, [documents, activeViewId, applyFilters, activeFilters, searchValue, templateMap]);
 
   // --- Selected document for viewer ---
   const selectedDoc = useMemo(() => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1885.

Closes #1885

---

## Claude summary

Committed. Summary:

Part 1 (filters not working) — fixed. On `/dashboard/gabinet/documents` the filter-bar state (`activeFilters` and `searchValue`) was captured but never applied — the `useState` for active filters was even destructured as `[, setActiveFilters]`, discarding the value. `filteredDocuments` only applied the saved-view filter. Now it applies, in order: status-based system view, saved-view filter, manual filter conditions (`applyFilterConditions`), and a title search. Rows are also decorated with the template `category` so the existing "Kategoria" filterable field actually matches against data. Matches the pattern used on `/dashboard/documents` (CRM) at `src/routes/_app/_auth/dashboard/_layout.documents.index.tsx:301-327`.

Part 2 (default CRM-visible / Gabinet-hidden with toggle in settings) — needs clarification before I implement. The wording in the issue is a bit confusing: the screenshot is from `/dashboard/gabinet/documents`, but the request says CRM docs should be visible by default and Gabinet docs hidden, which is the opposite of what I'd expect on that page. Could you confirm which of these you want?

(a) Each documents view scopes itself to its own module: `/dashboard/documents` (CRM) shows only documents tied to contacts/companies/leads by default, and `/dashboard/gabinet/documents` shows only documents tied to patients/appointments/employees/treatments by default. A new toggle in Settings would let users opt in to seeing the other module's documents too.

(b) Or literally what you wrote: on `/dashboard/gabinet/documents` the CRM documents are visible by default and the Gabinet ones are hidden by default, toggleable in Settings.

(c) Or you'd like this applied only on `/dashboard/documents` (the CRM page), where CRM docs are visible by default and Gabinet docs need to be enabled via Settings.

This second part requires a new `orgSettings` field, a mutation to update it, a Settings UI toggle, and per-route default filtering — too large to bundle with the filter fix without alignment first.