### PR TITLE
Okno szcegolow w kalendarzu

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -1221,12 +1221,13 @@ export function AppointmentPreviewContent({
 
   return (
     <>
-    {/* Title bar — sticky modal-style header with patient name + close (#1738
-        follow-up). The bar is the drag affordance for touch users: pressing
-        the empty space starts the popover reposition (replaces the standalone
-        grab strip that broke the header rhythm). The drag handler skips
-        interactive children (Link, close button) so clicks still land on
-        them — same pattern as the body-wide drag handler in
+    {/* Title bar — sticky modal-style header with a visible drag handle pill,
+        patient name, and close button (issue #1886). The whole bar is the drag
+        affordance: the iOS-style grip pill at the top centers a clear visual
+        cue, and a distinct `bg-muted/60` background separates the header from
+        the popover body so the drag area is recognisable at a glance. The
+        drag handler still skips interactive children (Link, close button) so
+        clicks land on them — same pattern as the body-wide drag handler in
         draggable-appointment.tsx (#1476). */}
     <div
       role={titleDragHandler ? "button" : undefined}
@@ -1244,35 +1245,43 @@ export function AppointmentPreviewContent({
         titleDragHandler(e);
       }}
       className={cn(
-        "sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-border/60 bg-background/95 px-4 py-3 backdrop-blur-sm",
+        "sticky top-0 z-10 border-b border-border/60 bg-muted/60 backdrop-blur-sm",
         titleDragHandler && (isPreviewDragging ? "cursor-grabbing select-none touch-none" : "cursor-grab select-none touch-none"),
       )}
     >
-      <div className="min-w-0 flex-1">
-        {patient?._id ? (
-          <Link
-            to="/dashboard/gabinet/patients/$patientId"
-            params={{ patientId: patient._id }}
-            onClick={onClose}
-            className="block truncate text-base font-semibold leading-tight hover:underline focus:underline focus:outline-none"
-          >
-            {patientFullName}
-          </Link>
-        ) : (
-          <p className="truncate text-base font-semibold leading-tight">
-            {patientFullName}
-          </p>
-        )}
+      <div className="flex justify-center pt-1.5">
+        <div
+          className="h-1 w-10 rounded-full bg-muted-foreground/50"
+          aria-hidden="true"
+        />
       </div>
-      <button
-        type="button"
-        onClick={onClose}
-        disabled={saving}
-        aria-label={t("gabinet.appointmentDetail.close", "Zamknij")}
-        className="inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-      >
-        <X className="size-4" />
-      </button>
+      <div className="flex items-center justify-between gap-2 px-4 pt-1 pb-2">
+        <div className="min-w-0 flex-1">
+          {patient?._id ? (
+            <Link
+              to="/dashboard/gabinet/patients/$patientId"
+              params={{ patientId: patient._id }}
+              onClick={onClose}
+              className="block truncate text-base font-semibold leading-tight hover:underline focus:underline focus:outline-none"
+            >
+              {patientFullName}
+            </Link>
+          ) : (
+            <p className="truncate text-base font-semibold leading-tight">
+              {patientFullName}
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={saving}
+          aria-label={t("gabinet.appointmentDetail.close", "Zamknij")}
+          className="inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
     </div>
 
     <div className="space-y-4 px-4 py-4">

--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -1,5 +1,6 @@
 import { useDraggable } from "@dnd-kit/core";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import {
   Popover,
@@ -356,6 +357,21 @@ export function DraggableAppointment({
   return (
     <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
       <PopoverAnchor asChild>{card}</PopoverAnchor>
+      {/* Backdrop overlay (issue #1886): Radix Popover has no built-in
+          overlay, so the preview previously visually merged with the calendar
+          grid underneath. A portaled dimmer sits between the calendar and
+          the popover content (z-40 vs the popover's z-50) so the preview
+          stands out. Clicking the overlay falls through to Radix's outside-
+          click detection and closes the popover. */}
+      {popoverOpen &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            aria-hidden="true"
+            className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[1px] animate-in fade-in-0 duration-150"
+          />,
+          document.body,
+        )}
       <PopoverContent
         ref={previewContentRef}
         // Touch scrolling is left on so users on small phones can reach all the
@@ -403,14 +419,11 @@ export function DraggableAppointment({
         onMouseDown={(e) => e.stopPropagation()}
         onClick={(e) => e.stopPropagation()}
       >
-        {/* No dedicated drag bar (issue #1738 follow-up): the previous strip
-            broke the header rhythm and floated over the popover edge. The
-            touch drag handler is wired into the title row inside
-            AppointmentPreviewContent (`titleDragHandler`), where it
-            piggy-backs on the title bar so touch users can still reposition
-            the popover (#1626) without an extra visual element. Desktop mouse
-            users keep drag-from-anywhere via the body handler on
-            PopoverContent (#1476). */}
+        {/* Drag affordance lives inside AppointmentPreviewContent's title bar
+            (issue #1886): a visible grip pill plus a distinct background make
+            the bar obviously draggable for both mouse and touch users. The
+            body-wide handler on PopoverContent below (#1476) is still active
+            so desktop users can also drag-from-anywhere on the popup body. */}
         <AppointmentPreviewContent
           appointmentId={_id}
           onClose={() => setPopoverOpen(false)}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1886.

Closes #1886

---

## Claude summary

Committed. Summary of changes for issue #1886 (calendar appointment preview):

`src/components/gabinet/calendar/appointment-preview-content.tsx` — restructured the sticky title bar to make it a clearly recognisable drag header. Added an iOS-style grip pill centred at the top (`h-1 w-10 rounded-full bg-muted-foreground/50`) and swapped the title bar background from `bg-background/95` to `bg-muted/60` so the drag surface is visually distinct from the popover body. The existing patient-name link, close button, and `titleDragHandler` wiring are preserved.

`src/components/gabinet/calendar/draggable-appointment.tsx` — added a portaled backdrop (`fixed inset-0 z-40 bg-black/40 backdrop-blur-[1px]`) rendered while `popoverOpen` is true via `createPortal`. It sits between the calendar (no z-index) and the popover content (z-50) so the panel no longer blends with the grid. Clicks on the dimmer fall through to Radix's outside-click detection and close the popover normally; nested popovers (treatment / status / employee selectors) are unaffected because they portal above z-40.

Typecheck (`tsc -p tsconfig.app.json --noEmit`) passes with no errors.