### PR TITLE
Lewa nawigacja

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -107,7 +107,7 @@
       "patients": "Clients",
       "treatments": "Treatments",
       "packages": "Packages",
-      "documents": "Documents",
+      "documents": "Generated Documents",
       "employees": "Employees",
       "reports": "Reports",
       "scheduling": "Working Hours",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -107,7 +107,7 @@
       "patients": "Klienci",
       "treatments": "Zabiegi",
       "packages": "Pakiety",
-      "documents": "Dokumenty",
+      "documents": "Wygenerowane Dokumenty",
       "employees": "Pracownicy",
       "reports": "Raporty",
       "scheduling": "Godziny pracy",

--- a/src/lib/ez-icons/icon-map.ts
+++ b/src/lib/ez-icons/icon-map.ts
@@ -45,7 +45,7 @@ export const ICON_MAP: Record<string, string> = {
   Eye: "eye",
   FileCheck: "file-validation",
   FileSignature: "signature",
-  FilePlus: "file-add-02",
+  FilePlus: "file-add",
   FileText: "file-01",
   Filter: "filter",
   Flag: "flag-01",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1887.

Closes #1887

---

## Claude summary

Committed.

Summary of what was fixed for #1887:

1. Missing icon — `FilePlus` was mapped to `file-add-02` in `src/lib/ez-icons/icon-map.ts:48`, but that icon name does not exist in the IconsEasier library. I verified via the ezicons search API (`https://ezicons.com/api/search?q=file-add`) that only `file-add` exists. Changed the mapping to `file-add`. This also fixes the CRM `Szablony dokumentów` entry and the `prescription` document-type icon in `generate-document-dialog.tsx`, which use the same `FilePlus` export.

2. Sidebar rename — `nav.gabinet.documents` changed from `"Dokumenty"` → `"Wygenerowane Dokumenty"` in `public/locales/pl/translation.json:110` (and the EN equivalent `"Generated Documents"` in the EN file).