### PR TITLE
wywiad

### DIFF
--- a/src/components/gabinet/documentation-tab.tsx
+++ b/src/components/gabinet/documentation-tab.tsx
@@ -604,12 +604,12 @@ export function DocumentationTab({
         <CardHeader className="px-6 py-3 border-b">
           <CardTitle className="text-sm flex items-center gap-2">
             <MessageSquare className="h-4 w-4" variant="stroke" />
-            {t("gabinet.documentation.interview", "Wywiad")}
+            {t("gabinet.documentation.interview", "Beauty plan")}
           </CardTitle>
           <CardDescription className="text-xs">
             {t(
               "gabinet.documentation.interviewDesc",
-              "Notatki z wywiadu z pacjentem przed zabiegiem.",
+              "Plan zabiegowy dla pacjenta.",
             )}
           </CardDescription>
         </CardHeader>
@@ -619,7 +619,7 @@ export function DocumentationTab({
             onChange={setInterview}
             placeholder={t(
               "gabinet.documentation.interviewPlaceholder",
-              "Opisz wywiad z pacjentem...",
+              "Opisz beauty plan dla pacjenta...",
             )}
           />
           <div className="flex justify-end pt-3">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1893.

Closes #1893

---

## Claude summary

Renamed the "Wywiad" section to "Beauty plan" on the appointment documentation tab (`src/components/gabinet/documentation-tab.tsx:607`). Also updated the section's description and placeholder so the copy is internally consistent with the new name. The i18n keys themselves are unchanged (`gabinet.documentation.interview*`) — only the inline Polish fallback strings were updated, since no translation overrides exist for these keys in `public/locales/*/translation.json`. Committed as `2fb92b7`.