### PR TITLE
zabieg

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3020,7 +3020,7 @@
       "saveChanges": "Save changes",
       "closeAndSettle": "Settle visit",
       "settled": "Settled",
-      "performTreatment": "Perform treatment",
+      "performTreatment": "Perform visit",
       "settleDesc": "Record payment and optionally close the appointment as completed.",
       "settleMarkCompleted": "Mark appointment as completed",
       "settleNothingToDo": "Enter an amount or check the close option.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3042,7 +3042,7 @@
       "saveChanges": "Zapisz zmiany",
       "closeAndSettle": "Rozlicz wizytę",
       "settled": "Rozliczono",
-      "performTreatment": "Przeprowadź zabieg",
+      "performTreatment": "Przeprowadź wizytę",
       "settleDesc": "Zarejestruj płatność i opcjonalnie zamknij wizytę jako zakończoną.",
       "settleMarkCompleted": "Oznacz wizytę jako zakończoną",
       "settleNothingToDo": "Wpisz kwotę lub zaznacz zamknięcie wizyty.",

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -1831,7 +1831,7 @@ export function AppointmentPreviewContent({
           onClick={onClose}
         >
           <Sparkles className="mr-1.5 size-3.5" />
-          {t("gabinet.appointmentDetail.performTreatment", "Przeprowadź zabieg")}
+          {t("gabinet.appointmentDetail.performTreatment", "Przeprowadź wizytę")}
         </Link>
       </Button>
     </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1896.

Closes #1896

---

## Claude summary

Renamed the appointment-preview action button from "Przeprowadź zabieg" to "Przeprowadź wizytę" (and updated the English fallback to "Perform visit"). Changed the i18n keys in both `public/locales/pl/translation.json` and `public/locales/en/translation.json`, plus the inline fallback string in `src/components/gabinet/calendar/appointment-preview-content.tsx:1834`. Committed as `c6bb1ff`.