### PR TITLE
pole

### DIFF
--- a/src/components/documents/document-form-filler.tsx
+++ b/src/components/documents/document-form-filler.tsx
@@ -76,6 +76,15 @@ export function DocumentFormFiller({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex gap-2">
+        <Button type="submit" className="flex-1">
+          {submitLabel ?? t("documentEditor.generate", "Generuj dokument")}
+        </Button>
+        <Button type="button" variant="outline" onClick={onCancel}>
+          {t("common.cancel", "Anuluj")}
+        </Button>
+      </div>
+
       <p className="text-sm text-muted-foreground">
         {t(
           "documentEditor.fillFields",

--- a/src/components/documents/generate-document-dialog.tsx
+++ b/src/components/documents/generate-document-dialog.tsx
@@ -150,6 +150,19 @@ function DocumentTemplateFormStep({
     const resolvedHtml = renderDocument(contentJson, prefilledData);
     return (
       <div className="space-y-4">
+        <div className="flex gap-2">
+          <Button
+            className="flex-1"
+            onClick={() =>
+              onComplete({ html: resolvedHtml, formFieldValues: {}, hasClientFields, scopeData: prefilledData })
+            }
+          >
+            Generuj dokument
+          </Button>
+          <Button variant="outline" onClick={onCancel}>
+            Anuluj
+          </Button>
+        </div>
         <div
           className="prose prose-sm max-w-none rounded-lg border bg-white p-6 text-gray-900 [&_*]:!text-gray-900 [&_a]:!text-blue-700 [&_table]:w-full [&_table]:border-collapse [&_td]:border [&_td]:border-gray-300 [&_td]:p-2 [&_th]:border [&_th]:border-gray-300 [&_th]:bg-gray-100 [&_th]:p-2"
           dangerouslySetInnerHTML={{ __html: resolvedHtml }}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1903.

Closes #1903

---

## Claude summary

Committed. Summary of the fix:

The "Generuj dokument" + "Anuluj" action row in the document generation dialog (visible on the patient page when generating a RODO/interview document from a template) was only at the bottom of the form. For long templates the user had to scroll the whole dialog to reach it. I mirrored the same button row at the top of the form so the action is always accessible without scrolling.

Files changed:
- `src/components/documents/document-form-filler.tsx:79` — added top submit/cancel row before the field list (mirrors the existing bottom row at line 173).
- `src/components/documents/generate-document-dialog.tsx:153` — added the same row above the auto-resolved document preview in the no-employee-fields branch.