### PR TITLE
Nie generuje się dokument

### DIFF
--- a/src/components/documents/generate-document-dialog.tsx
+++ b/src/components/documents/generate-document-dialog.tsx
@@ -348,14 +348,26 @@ function TemplateCard({
   const CategoryIcon = CATEGORY_ICONS[data.category ?? ""] ?? FileText;
   const fieldCount = countFormFields(data.formJson);
 
+  // Rendered as a <div> rather than <button> because the outer TreeItem
+  // wrapper is already a <button>. Nested buttons are invalid HTML and on
+  // iOS Safari the inner button's tap can be swallowed by the outer one —
+  // the dialog gets stuck on the picker step (#1907).
   return (
-    <button
-      type="button"
+    <div
+      role="button"
+      tabIndex={0}
       onClick={(e) => {
         e.stopPropagation();
         onClick();
       }}
-      className="w-full text-left rounded-lg border p-3 transition-colors hover:bg-accent hover:border-accent-foreground/20 cursor-pointer group"
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          e.stopPropagation();
+          onClick();
+        }
+      }}
+      className="w-full text-left rounded-lg border p-3 transition-colors hover:bg-accent hover:border-accent-foreground/20 cursor-pointer group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
     >
       <div className="flex items-start gap-3">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted group-hover:bg-background transition-colors">
@@ -388,7 +400,7 @@ function TemplateCard({
           )}
         </div>
       </div>
-    </button>
+    </div>
   );
 }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1907.

Closes #1907

---

## Claude summary

Fix committed.

## Summary

The `GenerateDocumentDialog` template picker rendered each leaf `TemplateCard` as a `<button>` inside a `TreeItem`, which itself renders as a `<button>` (see `src/components/reui/tree.tsx:138`). Nested `<button>` elements are invalid HTML; on iOS Safari this manifests as the inner button's tap being swallowed by the outer one, so tapping a template never advances the dialog past step 1. The user perceives this as "doesn't generate, page asks to refresh."

The fix in `src/components/documents/generate-document-dialog.tsx` changes `TemplateCard` to a `<div role="button">` with `tabIndex` and an Enter/Space key handler. The outer `TreeItem` keeps its button semantics; the card is now a valid descendant and taps register reliably on iOS.

## Follow-ups
- Fix nested button in form-templates settings tree: `src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx:407-487` has the same TreeItem-button-inside-button pattern (admin/desktop-only, but still invalid HTML)