### PR TITLE
Fix nested button in form-templates settings tree

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -414,18 +414,29 @@ function TemplateTree({
                 <div className="flex items-center gap-2 min-w-0 basis-full sm:basis-0 sm:flex-1">
                   <GripVertical className="h-4 w-4 text-muted-foreground/40 shrink-0" />
                   <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
-                  <button
-                    type="button"
-                    className="flex-1 min-w-0 text-left"
+                  {/* Rendered as a <div> rather than <button> because the outer
+                      TreeItem wrapper is already a <button>. Nested buttons are
+                      invalid HTML (#1910, same pattern as #1907). */}
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    className="flex-1 min-w-0 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
                     onClick={(e) => {
                       e.stopPropagation();
                       onEditTemplate(tpl._id);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        onEditTemplate(tpl._id);
+                      }
                     }}
                   >
                     <span className="text-sm font-medium truncate block">
                       {tpl.name}
                     </span>
-                  </button>
+                  </div>
                 </div>
                 <Badge variant="outline" className="text-[10px] shrink-0">
                   {t(`settings.formTemplates.categories.${tpl.category}`)}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1910.

Closes #1910

---

## Claude summary

Fixed and committed (`beaa0d8`).

Verified the issue: `src/components/reui/tree.tsx:138` confirms `TreeItem` renders as a `<button>` by default, so the inner `<button type="button">` in the template row at `src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx:417-428` produced nested buttons — invalid HTML, same pattern as #1907.

Applied the same fix shape as commit `930d091`: swap the inner `<button>` for `<div role="button" tabIndex={0}>` with an `onKeyDown` handler so Enter/Space still triggers the edit. The outer `TreeItem` keeps its button semantics; the row label is now a valid descendant. Scope is intentionally minimal — the folder row's `DropdownMenuTrigger` and the template row's `Switch`/`DropdownMenuTrigger` are Radix-rendered buttons but were also outside the prior fix's scope, and they correctly `stopPropagation`.

## Follow-ups
- Audit other TreeItem usages for nested buttons: the folder-row DropdownMenuTrigger (lines 352-362) and template-row Switch + DropdownMenuTrigger (lines 447-485) in the same file are also `<button>` elements nested inside the TreeItem button; they were excluded from #1907's narrow fix but are still invalid HTML.