### PR TITLE
Nie generuje się dokument

### DIFF
--- a/src/components/documents/document-renderer.tsx
+++ b/src/components/documents/document-renderer.tsx
@@ -13,6 +13,11 @@ import Image from "@tiptap/extension-image";
 import { PageBreakNode } from "@/components/documents/page-break-node";
 import { FormFieldNode } from "@/components/documents/form-field-node";
 import { HtmlBlockNode } from "@/components/documents/html-block-node";
+import { ComponentBlockNode } from "@/components/documents/component-block-node";
+import {
+  ColumnLayoutNode,
+  ColumnNode,
+} from "@/components/documents/column-layout-node";
 import {
   VariableMentionAt,
   VariableMentionCurly,
@@ -52,7 +57,11 @@ export interface ExtractedFormField {
 }
 
 // ---------------------------------------------------------------------------
-// Extensions list (same as the editor, needed for generateHTML)
+// Extensions list — MUST stay in sync with the editor's extension list in
+// document-template-editor.tsx. A node type present in saved template JSON
+// but missing from this list throws "Unknown node type: <name>" inside
+// generateHTML, which the route error boundary surfaces as "Something went
+// wrong" with no recovery path (#1907).
 // ---------------------------------------------------------------------------
 
 const renderExtensions = [
@@ -68,6 +77,9 @@ const renderExtensions = [
   PageBreakNode,
   FormFieldNode,
   HtmlBlockNode,
+  ComponentBlockNode,
+  ColumnLayoutNode,
+  ColumnNode,
   VariableMentionAt,
   VariableMentionCurly,
 ];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1907.

Closes #1907

---

## Claude summary

Fix committed. Summary:

The original PR #1909 fixed the iOS nested-button issue that prevented the template picker from advancing. After @aslocka tested again, a new error surfaced: "Something went wrong / Unknown node type: column". This is a separate bug — the renderer's TipTap extension list in `src/components/documents/document-renderer.tsx` had drifted out of sync with the editor in `src/components/documents/document-template-editor.tsx`. The editor registers `ColumnLayoutNode`, `ColumnNode`, and `ComponentBlockNode`; the renderer didn't, so any template containing a column layout (or component block) threw inside `generateHTML(json, renderExtensions)` and crashed into the route error boundary.

The fix registers the three missing nodes in `renderExtensions` and adds a comment pinning the invariant so the next person who adds a custom node has a chance of remembering to update both lists. Their existing `renderHTML()` methods produce sensible static HTML (column layout becomes an inline-grid div; component block becomes a placeholder with `[Komponent: <id>]` — see follow-up below).

Typecheck shows only one pre-existing error on main, unrelated to this change.

## Follow-ups
- Resolve ComponentBlockNode content during static render in document-renderer.tsx: current `renderHTML` only emits the literal text "[Komponent: <id>]" so generated documents that reference a component block will show that placeholder instead of the component's actual content. Needs the renderer to look up component contentJson (likely an async preview step before `generateHTML`).
- Add a guard test that renderer extensions stay in sync with editor extensions: a simple unit test that snapshots `extensionName` lists from `document-template-editor.tsx` and `document-renderer.tsx` would have caught both this regression and any future drift.