### PR TITLE
Resolve ComponentBlockNode content during static render in document-renderer.tsx

### DIFF
--- a/convex/documents/components.ts
+++ b/convex/documents/components.ts
@@ -2,6 +2,7 @@ import { action, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { v } from "convex/values";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
+import { resolveComponentsInContent } from "./resolveComponents";
 import {
   componentCategoryValidator,
 } from "../schema/documents";
@@ -105,6 +106,30 @@ export const getContent = action({
       protected: Boolean(comp.protected),
       positionConstraint: (comp.positionConstraint as string | null) ?? null,
     };
+  },
+});
+
+/**
+ * Resolve componentBlock nodes inside an arbitrary TipTap contentJson string.
+ * Returns the contentJson with each componentBlock replaced by the referenced
+ * component's actual nodes. Used by render-time contexts that hold contentJson
+ * in memory (template editor preview, document viewer fallback) and need
+ * resolved content before calling generateHTML — otherwise componentBlock's
+ * renderHTML emits the literal placeholder "[Komponent: <id>]" (#1915).
+ */
+export const resolveContentJson = action({
+  args: {
+    organizationId: v.id("organizations"),
+    contentJson: v.string(),
+  },
+  handler: async (ctx, args): Promise<string> => {
+    await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    const db = createSupabaseDb();
+    const resolved = await resolveComponentsInContent(db, args.contentJson);
+    return resolved ?? args.contentJson;
   },
 });
 

--- a/convex/documents/generate.ts
+++ b/convex/documents/generate.ts
@@ -4,6 +4,7 @@ import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { EntityType, ScopeData } from "./scopeResolver";
 import { resolveScopeSupabase } from "./scopeResolver_supabase";
+import { resolveComponentsInContent } from "./resolveComponents";
 import { Id } from "../_generated/dataModel";
 
 // Dual-write refs removed — Supabase is now primary for document writes
@@ -77,11 +78,14 @@ export const previewDocumentData = action({
       }
     }
 
-    // Content resolution was previously done via ctx.db reads. Since we're
-    // in an action now and resolveComponentsInContent expects QueryCtx, we
-    // pass the template contentJson through as-is. Component resolution can
-    // happen at render time instead.
-    const resolvedContentJson = (template.contentJson as string) ?? "";
+    // Resolve componentBlock nodes so the editor JSON returned here already
+    // has each component's actual content inlined. Without this, the client
+    // calls generateHTML over `componentBlock` nodes whose renderHTML emits
+    // the literal placeholder "[Komponent: <id>]" — that placeholder then
+    // gets baked into responseData.html and into every generated document
+    // (#1915).
+    const resolvedContentJson =
+      (await resolveComponentsInContent(db, template.contentJson as string)) ?? "";
 
     return {
       prefilledData,

--- a/src/components/documents/after-completion-documents-dialog.tsx
+++ b/src/components/documents/after-completion-documents-dialog.tsx
@@ -127,6 +127,9 @@ export function AfterCompletionDocumentsDialog({
     enabled: !!activeDoc?.templateId,
   });
   const activeTemplate = activeTemplateRaw as unknown as FormTemplate | undefined;
+  const resolveContentJsonAction = useAction(
+    api.documents.components.resolveContentJson,
+  );
 
   // Parse scope data from the document's responseData
   const scopeData = useMemo(() => {
@@ -183,10 +186,19 @@ export function AfterCompletionDocumentsDialog({
       if (!activeDoc || !activeTemplate) return;
       setSubmitting(true);
       try {
-        // Render the document with scope data + employee field values
-        const html = activeTemplate.contentJson
-          ? renderDocument(activeTemplate.contentJson, scopeData, fieldValues)
-          : `<div class="document"><h1>${activeDoc.title}</h1></div>`;
+        // Render the document with scope data + employee field values.
+        // Resolve componentBlock nodes before generateHTML so the persisted
+        // HTML doesn't contain "[Komponent: <id>]" placeholders (#1915).
+        let html: string;
+        if (activeTemplate.contentJson) {
+          const resolved = await resolveContentJsonAction({
+            organizationId,
+            contentJson: activeTemplate.contentJson,
+          });
+          html = renderDocument(resolved, scopeData, fieldValues);
+        } else {
+          html = `<div class="document"><h1>${activeDoc.title}</h1></div>`;
+        }
 
         await submitEmployeeFormFields({
           organizationId,
@@ -228,6 +240,7 @@ export function AfterCompletionDocumentsDialog({
       activeTemplate,
       scopeData,
       submitEmployeeFormFields,
+      resolveContentJsonAction,
       organizationId,
       t,
       afterDocs,
@@ -241,10 +254,19 @@ export function AfterCompletionDocumentsDialog({
     if (!activeDoc || !activeTemplate) return;
     setSubmitting(true);
     try {
-      // Render HTML from TipTap contentJson if available; otherwise use a minimal wrapper
-      const html = activeTemplate.contentJson
-        ? renderDocument(activeTemplate.contentJson, scopeData)
-        : `<div class="document"><h1>${activeDoc.title}</h1></div>`;
+      // Render HTML from TipTap contentJson if available; otherwise use a minimal wrapper.
+      // Resolve componentBlock nodes before generateHTML so the persisted HTML
+      // doesn't contain "[Komponent: <id>]" placeholders (#1915).
+      let html: string;
+      if (activeTemplate.contentJson) {
+        const resolved = await resolveContentJsonAction({
+          organizationId,
+          contentJson: activeTemplate.contentJson,
+        });
+        html = renderDocument(resolved, scopeData);
+      } else {
+        html = `<div class="document"><h1>${activeDoc.title}</h1></div>`;
+      }
       await submitEmployeeFormFields({
         organizationId,
         documentId: activeDoc._id as Id<"formDocuments">,
@@ -282,6 +304,7 @@ export function AfterCompletionDocumentsDialog({
     activeTemplate,
     scopeData,
     submitEmployeeFormFields,
+    resolveContentJsonAction,
     organizationId,
     t,
     afterDocs,

--- a/src/components/documents/appointment-document-checklist.tsx
+++ b/src/components/documents/appointment-document-checklist.tsx
@@ -28,7 +28,7 @@ import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import { DocumentStatusBadge } from "./document-status-badge";
 import { DocumentViewer } from "./document-viewer";
-import { renderDocument } from "./document-renderer";
+import { TemplateFallbackViewer } from "./template-fallback-viewer";
 import { GenerateDocumentDialog } from "./generate-document-dialog";
 
 // ---------------------------------------------------------------------------
@@ -341,11 +341,11 @@ export function AppointmentDocumentChecklist({
                       for (const [k, v] of Object.entries(rd)) {
                         if (v != null) scope[k] = String(v);
                       }
-                      const html = renderDocument(viewingTemplate.contentJson, scope);
                       return (
-                        <DocumentViewer
+                        <TemplateFallbackViewer
                           title={viewingDoc.title}
-                          html={html}
+                          contentJson={viewingTemplate.contentJson}
+                          scopeData={scope}
                           signatureData={viewingDoc.signatureData}
                           signedByName={viewingDoc.signedByName}
                           signedAt={viewingDoc.signedAt}

--- a/src/components/documents/entity-documents-tab.tsx
+++ b/src/components/documents/entity-documents-tab.tsx
@@ -56,7 +56,7 @@ import { useTranslation } from "react-i18next";
 import { DocumentStatusBadge } from "./document-status-badge";
 import { GenerateDocumentDialog } from "./generate-document-dialog";
 import { DocumentViewer } from "./document-viewer";
-import { renderDocument } from "./document-renderer";
+import { TemplateFallbackViewer } from "./template-fallback-viewer";
 import { flattenScopeData } from "@/lib/document-variables";
 
 // ---------------------------------------------------------------------------
@@ -479,29 +479,22 @@ export function EntityDocumentsTab({
                       viewingTemplate.templateType === "document" &&
                       viewingTemplate.contentJson
                     ) {
-                      try {
-                        const scopeFlat: Record<string, string> = {};
-                        for (const [k, v] of Object.entries(
-                          mergedResponseData,
-                        )) {
-                          if (v != null) scopeFlat[k] = String(v);
-                        }
-                        const html = renderDocument(
-                          viewingTemplate.contentJson,
-                          scopeFlat,
-                        );
-                        return (
-                          <DocumentViewer
-                            title={viewingDoc.title}
-                            html={html}
-                            signatureData={viewingDoc.signatureData}
-                            signedByName={viewingDoc.signedByName}
-                            signedAt={viewingDoc.signedAt}
-                          />
-                        );
-                      } catch {
-                        // contentJson invalid — fall through to empty state
+                      const scopeFlat: Record<string, string> = {};
+                      for (const [k, v] of Object.entries(
+                        mergedResponseData,
+                      )) {
+                        if (v != null) scopeFlat[k] = String(v);
                       }
+                      return (
+                        <TemplateFallbackViewer
+                          title={viewingDoc.title}
+                          contentJson={viewingTemplate.contentJson}
+                          scopeData={scopeFlat}
+                          signatureData={viewingDoc.signatureData}
+                          signedByName={viewingDoc.signedByName}
+                          signedAt={viewingDoc.signedAt}
+                        />
+                      );
                     }
 
                     // Fallback: no viewable content

--- a/src/components/documents/template-fallback-viewer.tsx
+++ b/src/components/documents/template-fallback-viewer.tsx
@@ -1,0 +1,62 @@
+import { Loader2 } from "@/lib/ez-icons";
+import { useTranslation } from "react-i18next";
+import { renderDocument } from "@/components/documents/document-renderer";
+import { DocumentViewer } from "@/components/documents/document-viewer";
+import { useResolvedContentJson } from "@/hooks/use-resolved-content-json";
+
+interface TemplateFallbackViewerProps {
+  title: string;
+  contentJson: string;
+  scopeData: Record<string, string>;
+  signatureData?: string;
+  signedByName?: string;
+  signedAt?: number;
+}
+
+/**
+ * Fallback document viewer that re-renders from a template's contentJson when
+ * the formDocument has no pre-rendered HTML in responseData. Resolves
+ * componentBlock nodes via the server before calling renderDocument so the
+ * literal "[Komponent: <id>]" placeholder is not emitted (#1915).
+ */
+export function TemplateFallbackViewer({
+  title,
+  contentJson,
+  scopeData,
+  signatureData,
+  signedByName,
+  signedAt,
+}: TemplateFallbackViewerProps) {
+  const { t } = useTranslation();
+  const { resolvedContentJson, isLoading } = useResolvedContentJson(contentJson);
+
+  if (isLoading || !resolvedContentJson) {
+    return (
+      <div className="flex items-center justify-center py-12 text-sm text-muted-foreground gap-2">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        {t("common.loading", "Ladowanie...")}
+      </div>
+    );
+  }
+
+  let html: string;
+  try {
+    html = renderDocument(resolvedContentJson, scopeData);
+  } catch {
+    return (
+      <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+        {t("documents.noContentAvailable", "Brak tresci dokumentu do wyswietlenia.")}
+      </div>
+    );
+  }
+
+  return (
+    <DocumentViewer
+      title={title}
+      html={html}
+      signatureData={signatureData}
+      signedByName={signedByName}
+      signedAt={signedAt}
+    />
+  );
+}

--- a/src/components/documents/template-preview-sheet.tsx
+++ b/src/components/documents/template-preview-sheet.tsx
@@ -29,6 +29,7 @@ import {
   renderDocument,
   type ExtractedFormField,
 } from "@/components/documents/document-renderer";
+import { useResolvedContentJson } from "@/hooks/use-resolved-content-json";
 import { flattenScopeData, VARIABLE_REGISTRY } from "@/lib/document-variables";
 import type { VariableField } from "@/lib/document-variables";
 import type { EntityType } from "@/components/documents/template-settings-sheet";
@@ -387,11 +388,15 @@ export function TemplatePreviewSheet({
     return flattenScopeData(scopeData as Record<string, Record<string, unknown>>);
   }, [scopeData]);
 
+  // Inline componentBlock nodes before rendering — without this, generateHTML
+  // calls componentBlock.renderHTML which emits "[Komponent: <id>]" (#1915).
+  const { resolvedContentJson } = useResolvedContentJson(contentJson);
+
   // Detect missing variables
   const missingVars = useMemo(() => {
-    if (!contentJson || !flatScope) return [];
+    if (!resolvedContentJson || !flatScope) return [];
     try {
-      const json = JSON.parse(contentJson);
+      const json = JSON.parse(resolvedContentJson);
       const paths = extractVariablePaths(json);
       return paths.filter((path) => {
         if (path.startsWith("system.") || path.startsWith("organization.")) return false;
@@ -401,18 +406,18 @@ export function TemplatePreviewSheet({
     } catch {
       return [];
     }
-  }, [contentJson, flatScope]);
+  }, [resolvedContentJson, flatScope]);
 
   const renderedHtml = useMemo(() => {
-    if (!flatScope || !contentJson) return null;
+    if (!flatScope || !resolvedContentJson) return null;
     try {
-      return renderDocument(contentJson, flatScope, undefined, {
+      return renderDocument(resolvedContentJson, flatScope, undefined, {
         highlightMissing: true,
       });
     } catch {
       return null;
     }
-  }, [contentJson, flatScope]);
+  }, [resolvedContentJson, flatScope]);
 
   const { employeeFields, clientFields } = useMemo(() => {
     if (!contentJson) return { employeeFields: [], clientFields: [] };

--- a/src/hooks/use-resolved-content-json.ts
+++ b/src/hooks/use-resolved-content-json.ts
@@ -1,0 +1,45 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAction } from "convex/react";
+import { api } from "@cvx/_generated/api";
+import { useOrganization } from "@/components/org-context";
+
+/**
+ * Resolve componentBlock nodes in a TipTap contentJson string via the server.
+ * Returns the resolved JSON (or the original on miss / error / loading) so
+ * callers can pass it straight into renderDocument without rendering the
+ * literal "[Komponent: <id>]" placeholder that componentBlock.renderHTML
+ * emits for unresolved blocks (#1915).
+ *
+ * Server-rendered contexts (previewDocumentData, getBySigningToken) already
+ * resolve before returning contentJson — use this hook when the contentJson
+ * arrives from a list/get template action or from in-memory editor state.
+ */
+export function useResolvedContentJson(contentJson: string | null | undefined): {
+  resolvedContentJson: string | null | undefined;
+  isLoading: boolean;
+} {
+  const { organizationId } = useOrganization();
+  const resolveContentJson = useAction(api.documents.components.resolveContentJson);
+
+  const hasComponentBlocks = !!contentJson && contentJson.includes("componentBlock");
+  const enabled = !!organizationId && hasComponentBlocks;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["documents.components.resolveContentJson", organizationId, contentJson],
+    queryFn: () =>
+      resolveContentJson({
+        organizationId,
+        contentJson: contentJson as string,
+      }),
+    enabled,
+    staleTime: 60_000,
+  });
+
+  if (!hasComponentBlocks) {
+    return { resolvedContentJson: contentJson, isLoading: false };
+  }
+  return {
+    resolvedContentJson: data ?? contentJson,
+    isLoading: enabled && isLoading,
+  };
+}

--- a/src/routes/_app/_auth/dashboard/_layout.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.documents.index.tsx
@@ -9,7 +9,7 @@ import { PageHeader } from "@/components/layout/page-header";
 import { DocumentStatusBadge } from "@/components/documents/document-status-badge";
 import type { FormDocumentStatus } from "@/components/documents/document-status-badge";
 import { DocumentViewer } from "@/components/documents/document-viewer";
-import { renderDocument } from "@/components/documents/document-renderer";
+import { TemplateFallbackViewer } from "@/components/documents/template-fallback-viewer";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -590,12 +590,12 @@ function DocumentsPage() {
                   for (const [k, v] of Object.entries(parsed)) {
                     if (v != null) scopeFlat[k] = String(v);
                   }
-                  const html = renderDocument(selectedTemplate.contentJson, scopeFlat);
                   return (
                     <div className="mt-6">
-                      <DocumentViewer
+                      <TemplateFallbackViewer
                         title={selectedDoc.title}
-                        html={html}
+                        contentJson={selectedTemplate.contentJson}
+                        scopeData={scopeFlat}
                         signatureData={selectedDoc.signatureData}
                         signedAt={selectedDoc.signedAt}
                       />

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -9,6 +9,7 @@ import { PageHeader } from "@/components/layout/page-header";
 import { DocumentStatusBadge } from "@/components/documents/document-status-badge";
 import { DocumentViewer } from "@/components/documents/document-viewer";
 import { DocumentFormFiller } from "@/components/documents/document-form-filler";
+import { TemplateFallbackViewer } from "@/components/documents/template-fallback-viewer";
 import {
   extractFormFields,
   renderDocument,
@@ -150,6 +151,9 @@ function GabinetDocumentsPage() {
   const resendSigningEmail = useAction(api.documents.documents.resendSigningEmail);
   const removeDocument = useAction(api.documents.documents.remove);
   const updateResponseData = useAction(api.documents.documents.updateResponseData);
+  const resolveContentJsonAction = useAction(
+    api.documents.components.resolveContentJson,
+  );
 
   // --- Edit mode state ---
   const [isEditing, setIsEditing] = useState(false);
@@ -378,8 +382,14 @@ function GabinetDocumentsPage() {
       setSavingEdit(true);
       try {
         const mergedFieldValues = { ...existingFormFieldValues, ...fieldValues };
+        // Resolve componentBlock nodes before generateHTML so the persisted
+        // HTML doesn't contain "[Komponent: <id>]" placeholders (#1915).
+        const resolvedContentJson = await resolveContentJsonAction({
+          organizationId,
+          contentJson: selectedTemplate.contentJson,
+        });
         const renderedHtml = renderDocument(
-          selectedTemplate.contentJson,
+          resolvedContentJson,
           existingScopeData,
           mergedFieldValues,
         );
@@ -418,6 +428,7 @@ function GabinetDocumentsPage() {
       existingFormFieldValues,
       existingScopeData,
       updateResponseData,
+      resolveContentJsonAction,
       organizationId,
       queryClient,
       t,
@@ -872,15 +883,12 @@ function GabinetDocumentsPage() {
                     for (const [k, v] of Object.entries(parsed)) {
                       if (v != null) scopeFlat[k] = String(v);
                     }
-                    const html = renderDocument(
-                      selectedTemplate.contentJson,
-                      scopeFlat,
-                    );
                     return (
                       <div className="mt-6">
-                        <DocumentViewer
+                        <TemplateFallbackViewer
                           title={selectedDoc.title}
-                          html={html}
+                          contentJson={selectedTemplate.contentJson}
+                          scopeData={scopeFlat}
                           signatureData={selectedDoc.signatureData}
                           signedAt={selectedDoc.signedAt}
                         />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1915.

Closes #1915

---

## Claude summary

The fix for #1915 is already committed on this branch (`f0b4d0c`). Typecheck passes cleanly.

Summary of investigation: The `ComponentBlockNode.renderHTML` in `src/components/documents/component-block-node.tsx:303-313` still emits the literal `[Komponent: <id>]` placeholder. Rather than make `document-renderer.tsx` async (which would force a server roundtrip from a pure client function), the committed fix takes the cleaner approach: it resolves componentBlock nodes BEFORE `generateHTML` runs, so the placeholder branch is never hit. The plumbing covers every `renderDocument` call site:

- Server paths already pre-resolve: `previewDocumentData` (`convex/documents/generate.ts:87-88`) and `getBySigningToken` (`convex/documents/documents.ts:141-149`) both pipe contentJson through `resolveComponentsInContent` before returning.
- Client paths that hold contentJson in memory now use the new `documents.components.resolveContentJson` action or the `useResolvedContentJson` hook (`src/hooks/use-resolved-content-json.ts`) before calling `renderDocument`: `template-preview-sheet.tsx:393`, `template-fallback-viewer.tsx:31` (used by `entity-documents-tab`, `appointment-document-checklist`, `_layout.documents.index`, `_layout.gabinet.documents.index`), plus `after-completion-documents-dialog.tsx` and the gabinet save-edit handler.

Verified all 7 `renderDocument(...)` call sites: each one receives contentJson that has already been resolved via one of those mechanisms. Nothing further to do.