### PR TITLE
Add a guard test that renderer extensions stay in sync with editor extensions

### DIFF
--- a/src/components/documents/document-extensions.test.ts
+++ b/src/components/documents/document-extensions.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { editorExtensions } from "./document-template-editor";
+import { renderExtensions } from "./document-renderer";
+
+// Guards against the regression fixed in #1907 / #1914: the renderer extension
+// list silently drifted from the editor's, so saved templates containing
+// columnLayout/column or componentBlock nodes threw "Unknown node type" inside
+// generateHTML and surfaced as the route error boundary.
+const namesOf = (extensions: ReadonlyArray<{ name: string }>) =>
+  extensions.map((extension) => extension.name);
+
+describe("document template / renderer extensions", () => {
+  it("editor and renderer expose the same extension names in the same order", () => {
+    expect(namesOf(renderExtensions)).toEqual(namesOf(editorExtensions));
+  });
+
+  it("editor extension name snapshot stays stable", () => {
+    expect(namesOf(editorExtensions)).toMatchInlineSnapshot(`
+      [
+        "starterKit",
+        "underline",
+        "horizontalRule",
+        "textAlign",
+        "table",
+        "tableRow",
+        "tableHeader",
+        "tableCell",
+        "image",
+        "pageBreak",
+        "formField",
+        "htmlBlock",
+        "componentBlock",
+        "columnLayout",
+        "column",
+        "variableMentionAt",
+        "variableMentionCurly",
+      ]
+    `);
+  });
+});

--- a/src/components/documents/document-renderer.tsx
+++ b/src/components/documents/document-renderer.tsx
@@ -64,7 +64,7 @@ export interface ExtractedFormField {
 // wrong" with no recovery path (#1907).
 // ---------------------------------------------------------------------------
 
-const renderExtensions = [
+export const renderExtensions = [
   StarterKit,
   Underline,
   HorizontalRule,

--- a/src/components/documents/document-template-editor.tsx
+++ b/src/components/documents/document-template-editor.tsx
@@ -65,6 +65,31 @@ import {
 import { useTranslation } from "react-i18next";
 
 // ---------------------------------------------------------------------------
+// Extensions list — MUST stay in sync with the renderer's extension list in
+// document-renderer.tsx. Drift is guarded by document-extensions.test.ts.
+// ---------------------------------------------------------------------------
+
+export const editorExtensions = [
+  StarterKit,
+  Underline,
+  HorizontalRule,
+  TextAlign.configure({ types: ["heading", "paragraph"] }),
+  Table.configure({ resizable: true }),
+  TableRow,
+  TableHeader,
+  TableCell,
+  Image.configure({ inline: false, allowBase64: true }),
+  PageBreakNode,
+  FormFieldNode,
+  HtmlBlockNode,
+  ComponentBlockNode,
+  ColumnLayoutNode,
+  ColumnNode,
+  VariableMentionAt,
+  VariableMentionCurly,
+];
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -103,25 +128,7 @@ export const DocumentTemplateEditor = forwardRef<
   }, [entityTypes]);
 
   const editor = useEditor({
-    extensions: [
-      StarterKit,
-      Underline,
-      HorizontalRule,
-      TextAlign.configure({ types: ["heading", "paragraph"] }),
-      Table.configure({ resizable: true }),
-      TableRow,
-      TableHeader,
-      TableCell,
-      Image.configure({ inline: false, allowBase64: true }),
-      PageBreakNode,
-      FormFieldNode,
-      HtmlBlockNode,
-      ComponentBlockNode,
-      ColumnLayoutNode,
-      ColumnNode,
-      VariableMentionAt,
-      VariableMentionCurly,
-    ],
+    extensions: editorExtensions,
     content: value ? JSON.parse(value) : undefined,
     onUpdate: ({ editor: e }) => {
       onChangeRef.current(JSON.stringify(e.getJSON()));


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1916.

Closes #1916

---

## Claude summary

Committed. Summary: extracted the editor's TipTap extension list to a module-level `editorExtensions` export in `document-template-editor.tsx`, exported the existing `renderExtensions` from `document-renderer.tsx`, and added `document-extensions.test.ts` which asserts both lists expose identical `name` arrays in identical order plus an inline snapshot to lock the canonical name set. The test catches the #1907-style regression where the renderer silently fell behind on `columnLayout` / `column` / `componentBlock`. All 30 frontend tests pass and typecheck is clean.