### PR TITLE
Nie generuje się dokument

### DIFF
--- a/src/components/documents/document-renderer.tsx
+++ b/src/components/documents/document-renderer.tsx
@@ -13,6 +13,11 @@ import Image from "@tiptap/extension-image";
 import { PageBreakNode } from "@/components/documents/page-break-node";
 import { FormFieldNode } from "@/components/documents/form-field-node";
 import { HtmlBlockNode } from "@/components/documents/html-block-node";
+import { ComponentBlockNode } from "@/components/documents/component-block-node";
+import {
+  ColumnLayoutNode,
+  ColumnNode,
+} from "@/components/documents/column-layout-node";
 import {
   VariableMentionAt,
   VariableMentionCurly,
@@ -52,7 +57,11 @@ export interface ExtractedFormField {
 }
 
 // ---------------------------------------------------------------------------
-// Extensions list (same as the editor, needed for generateHTML)
+// Extensions list — MUST stay in sync with the editor's extension list in
+// document-template-editor.tsx. A node type present in saved template JSON
+// but missing from this list throws "Unknown node type: <name>" inside
+// generateHTML, which the route error boundary surfaces as "Something went
+// wrong" with no recovery path (#1907).
 // ---------------------------------------------------------------------------
 
 const renderExtensions = [
@@ -68,6 +77,9 @@ const renderExtensions = [
   PageBreakNode,
   FormFieldNode,
   HtmlBlockNode,
+  ComponentBlockNode,
+  ColumnLayoutNode,
+  ColumnNode,
   VariableMentionAt,
   VariableMentionCurly,
 ];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1907.

Closes #1907

---

## Claude summary

The branch `claude/issue-1907` already contains both fixes for this issue, merged via PRs #1909 and #1914:

1. Commit `930d091` (PR #1909) — fixed the original iOS bug. `TemplateCard` in `src/components/documents/generate-document-dialog.tsx` was a `<button>` nested inside a `TreeItem` `<button>`, which iOS Safari swallowed. Changed to `<div role="button">` with keyboard handler.

2. Commit `ea1ebed` (PR #1914) — fixed the follow-up "Something went wrong / Unknown node type: column" error that @aslocka reported, which they later clarified only affected RODO documents. The editor in `src/components/documents/document-template-editor.tsx:106-124` registers `ColumnLayoutNode`, `ColumnNode`, and `ComponentBlockNode`, but `document-renderer.tsx`'s extension list did not. The renderer list now mirrors the editor's exactly (`src/components/documents/document-renderer.tsx:67-85`), with a comment pinning the invariant. RODO documents are templates that use column layouts to lay out checkbox/consent sections side by side — they were the documents that triggered the crash.

Working tree is clean and the two fixes together fully address every symptom reported in this thread: tap registering on iOS, and rendering not crashing for RODO/column-using templates. The two follow-ups originally noted on PR #1914 are already tracked as separate issues #1915 (resolve `ComponentBlockNode` content during static render) and #1916 (add guard test that renderer extensions stay in sync with editor extensions), so no new follow-ups to log here. Nothing further to commit.