### PR TITLE
Nie generuje się dokument

### DIFF
--- a/src/components/documents/document-renderer.tsx
+++ b/src/components/documents/document-renderer.tsx
@@ -13,6 +13,11 @@ import Image from "@tiptap/extension-image";
 import { PageBreakNode } from "@/components/documents/page-break-node";
 import { FormFieldNode } from "@/components/documents/form-field-node";
 import { HtmlBlockNode } from "@/components/documents/html-block-node";
+import { ComponentBlockNode } from "@/components/documents/component-block-node";
+import {
+  ColumnLayoutNode,
+  ColumnNode,
+} from "@/components/documents/column-layout-node";
 import {
   VariableMentionAt,
   VariableMentionCurly,
@@ -52,7 +57,11 @@ export interface ExtractedFormField {
 }
 
 // ---------------------------------------------------------------------------
-// Extensions list (same as the editor, needed for generateHTML)
+// Extensions list — MUST stay in sync with the editor's extension list in
+// document-template-editor.tsx. A node type present in saved template JSON
+// but missing from this list throws "Unknown node type: <name>" inside
+// generateHTML, which the route error boundary surfaces as "Something went
+// wrong" with no recovery path (#1907).
 // ---------------------------------------------------------------------------
 
 const renderExtensions = [
@@ -68,6 +77,9 @@ const renderExtensions = [
   PageBreakNode,
   FormFieldNode,
   HtmlBlockNode,
+  ComponentBlockNode,
+  ColumnLayoutNode,
+  ColumnNode,
   VariableMentionAt,
   VariableMentionCurly,
 ];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1907.

Closes #1907

---

## Claude summary

The branch `claude/issue-1907` already contains both fixes for this issue and the working tree is clean.

Commit `930d091` (PR #1909) fixed the original iOS bug by changing `TemplateCard` in `src/components/documents/generate-document-dialog.tsx:339` to a `<div role="button">` so it is no longer nested inside the `TreeItem`'s `<button>`.

Commit `ea1ebed` (PR #1914) fixed the follow-up "Something went wrong / Unknown node type: column" error on RODO documents by registering `ColumnLayoutNode`, `ColumnNode`, and `ComponentBlockNode` in the renderer's extension list (`src/components/documents/document-renderer.tsx:67-85`), with a comment pinning the invariant.

Both fixes were already cherry-picked to main (PR #1922 → commit `bf2b55e` on origin/main). The two follow-ups originally noted on PR #1914 are also already resolved: #1915 by `285a2c2` and #1916 by `c94a8f9`. Nothing further to commit.