### PR TITLE
Karta klienta

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3217,6 +3217,8 @@
       "patientPackages": "Packages",
       "addOrSell": "Add / Sell",
       "noPatientPackages": "No packages purchased",
+      "showMore": "Show {{count}} more packages",
+      "collapse": "Collapse",
       "expires": "Expires",
       "status": {
         "active": "Active",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3239,6 +3239,8 @@
       "patientPackages": "Pakiety",
       "addOrSell": "Dodaj/Sprzedaj",
       "noPatientPackages": "Brak zakupionych pakietów",
+      "showMore": "Pokaż jeszcze {{count}} pakietów",
+      "collapse": "Zwiń",
       "expires": "Wygasa",
       "status": {
         "active": "Aktywny",

--- a/src/components/gabinet/patient-packages-card.tsx
+++ b/src/components/gabinet/patient-packages-card.tsx
@@ -57,10 +57,13 @@ const statusColors: Record<string, "default" | "secondary" | "destructive" | "ou
   cancelled: "outline",
 };
 
+const COLLAPSED_PACKAGE_LIMIT = 2;
+
 export function PatientPackagesCard({ patientId, organizationId }: PatientPackagesCardProps) {
   const { t } = useTranslation();
   const [purchaseOpen, setPurchaseOpen] = useState(false);
   const [detailUsageId, setDetailUsageId] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(false);
 
   const getPatientPackagesAction = useAction(api.gabinet.packages.getPatientPackages);
   const { data: usages } = useQuery({
@@ -159,7 +162,7 @@ export function PatientPackagesCard({ patientId, organizationId }: PatientPackag
             </div>
           ) : (
             <div className="space-y-3">
-              {items.map((usage) => {
+              {(expanded ? items : items.slice(0, COLLAPSED_PACKAGE_LIMIT)).map((usage) => {
                 const pkg = packageMap.get(usage.packageId);
                 const pkgName = pkg?.name ?? t("common.unknown");
 
@@ -225,6 +228,21 @@ export function PatientPackagesCard({ patientId, organizationId }: PatientPackag
                   </div>
                 );
               })}
+
+              {items.length > COLLAPSED_PACKAGE_LIMIT && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full h-8 text-xs"
+                  onClick={() => setExpanded((v) => !v)}
+                >
+                  {expanded
+                    ? t("gabinet.packages.collapse", "Zwiń")
+                    : t("gabinet.packages.showMore", "Pokaż jeszcze {{count}} pakietów", {
+                        count: items.length - COLLAPSED_PACKAGE_LIMIT,
+                      })}
+                </Button>
+              )}
             </div>
           )}
         </CardContent>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1921.

Closes #1921

---

## Claude summary

Committed. Summary of changes:

The Packages section on the patient card (`src/components/gabinet/patient-packages-card.tsx`) now renders only the first two packages by default. When a patient has more than two, a ghost "Pokaż jeszcze X pakietów" button appears under the list; clicking it expands the full list and switches the label to "Zwiń". The card visuals, usage display (e.g. `1/10`), Dodaj/Sprzedaj action, and packages logic are untouched — only the slicing of the items array changed. Translation keys `gabinet.packages.showMore` and `gabinet.packages.collapse` were added to PL and EN locales. Typecheck passes.