### PR TITLE
Dodaj zabieg 

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -106,6 +106,10 @@ export const create = action({
     sortOrder: v.optional(v.number()),
     treatmentCount: v.optional(v.number()),
     packageId: v.optional(v.union(v.string(), v.null())),
+    requiredFormTemplates: v.optional(v.array(v.object({
+      templateId: v.string(),
+      timing: v.union(v.literal("before_start"), v.literal("after_completion")),
+    }))),
     tagIds: v.optional(v.array(v.string())),
     categoryId: v.optional(v.union(v.string(), v.null())),
   },
@@ -147,6 +151,7 @@ export const create = action({
       sortOrder: args.sortOrder ?? null,
       treatmentCount: args.treatmentCount ?? null,
       packageId: args.packageId ?? null,
+      requiredFormTemplates: args.requiredFormTemplates ?? null,
       tagIds: args.tagIds ?? null,
       categoryId: args.categoryId ?? null,
       createdBy: String(authResult.userId),

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2413,6 +2413,8 @@
       "contraindications": "Contraindications",
       "preparationInstructions": "Preparation Instructions",
       "aftercareInstructions": "Aftercare Instructions",
+      "requiredDocuments": "Required Documents",
+      "notes": "Notes",
       "requiresApproval": "Requires Approval",
       "treatmentCount": "Sessions per course",
       "treatmentCountHint": "Number of sessions in a course (e.g. 20). Auto-creates a package on first booking.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2428,6 +2428,8 @@
       "contraindications": "Przeciwwskazania",
       "preparationInstructions": "Instrukcje przygotowania",
       "aftercareInstructions": "Instrukcje po zabiegu",
+      "requiredDocuments": "Wymagane dokumenty",
+      "notes": "Uwagi / Notatki",
       "requiresApproval": "Wymaga zatwierdzenia",
       "treatmentCount": "Liczba zabiegów",
       "treatmentCountHint": "Ilość zabiegów w cyklu (np. 20). Automatycznie tworzy pakiet przy pierwszej wizycie.",

--- a/src/components/documents/treatment-required-documents-field.tsx
+++ b/src/components/documents/treatment-required-documents-field.tsx
@@ -1,0 +1,361 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAction } from "convex/react";
+import { api } from "@cvx/_generated/api";
+import type { Id } from "@cvx/_generated/dataModel";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { FileText, Plus, X, Search } from "@/lib/ez-icons";
+import { cn } from "@/lib/utils";
+import { useTranslation } from "react-i18next";
+
+function extractPlainText(desc: string): string {
+  if (!desc.startsWith("[")) return desc;
+  try {
+    const nodes = JSON.parse(desc) as Array<{ children?: Array<{ text?: string }> }>;
+    return nodes
+      .flatMap((n) => (n.children ?? []).map((c) => c.text ?? ""))
+      .join(" ")
+      .trim();
+  } catch {
+    return desc;
+  }
+}
+
+export interface RequiredFormTemplateValue {
+  templateId: Id<"formTemplates">;
+  timing: "before_start" | "after_completion";
+}
+
+interface FormTemplate {
+  _id: Id<"formTemplates">;
+  name: string;
+  description?: string;
+}
+
+interface TreatmentRequiredDocumentsFieldProps {
+  organizationId: Id<"organizations">;
+  value: RequiredFormTemplateValue[];
+  onChange: (value: RequiredFormTemplateValue[]) => void;
+}
+
+export function TreatmentRequiredDocumentsField({
+  organizationId,
+  value,
+  onChange,
+}: TreatmentRequiredDocumentsFieldProps) {
+  const { t } = useTranslation();
+
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [selectedTemplateId, setSelectedTemplateId] =
+    useState<Id<"formTemplates"> | null>(null);
+  const [selectedTiming, setSelectedTiming] = useState<
+    "before_start" | "after_completion"
+  >("before_start");
+
+  const listTemplatesByEntityType = useAction(api.documents.templates.listByEntityType);
+  const { data: allTemplatesRaw, isLoading: templatesLoading } = useQuery({
+    queryKey: ["documents.templates.listByEntityType", organizationId, "treatment"],
+    queryFn: () =>
+      listTemplatesByEntityType({
+        organizationId,
+        entityType: "treatment",
+      }),
+    enabled: !!organizationId,
+  });
+  const allTemplates = allTemplatesRaw as unknown as FormTemplate[] | undefined;
+
+  const templateMap = new Map<Id<"formTemplates">, FormTemplate>(
+    (allTemplates ?? []).map((tpl) => [tpl._id, tpl]),
+  );
+
+  const assignedIds = new Set(value.map((r) => r.templateId));
+
+  const filteredPickerTemplates = (allTemplates ?? []).filter(
+    (tpl) =>
+      !assignedIds.has(tpl._id) &&
+      tpl.name.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const handleAdd = () => {
+    if (!selectedTemplateId) return;
+    onChange([
+      ...value,
+      { templateId: selectedTemplateId, timing: selectedTiming },
+    ]);
+    setAddDialogOpen(false);
+    setSelectedTemplateId(null);
+    setSearch("");
+  };
+
+  const handleRemove = (templateId: Id<"formTemplates">) => {
+    onChange(value.filter((r) => r.templateId !== templateId));
+  };
+
+  const handleTimingChange = (
+    templateId: Id<"formTemplates">,
+    newTiming: "before_start" | "after_completion",
+  ) => {
+    onChange(
+      value.map((r) =>
+        r.templateId === templateId ? { ...r, timing: newTiming } : r,
+      ),
+    );
+  };
+
+  return (
+    <>
+      <div className="space-y-2">
+        <p className="text-xs text-muted-foreground">
+          {t(
+            "documents.requiredDocs.description",
+            "Te dokumenty zostana automatycznie wygenerowane przy tworzeniu wizyty",
+          )}
+        </p>
+
+        {value.length > 0 && (
+          <div className="rounded-lg border divide-y">
+            {value.map((req) => {
+              const tpl = templateMap.get(req.templateId);
+              return (
+                <div
+                  key={req.templateId}
+                  className="flex items-center justify-between gap-3 px-3 py-2"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
+                    <span className="text-sm font-medium truncate">
+                      {tpl?.name ??
+                        t("documents.requiredDocs.unknown", "Nieznany szablon")}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0">
+                    <TimingBadge
+                      timing={req.timing}
+                      onTimingChange={(newTiming) =>
+                        handleTimingChange(req.templateId, newTiming)
+                      }
+                      t={t as (key: string, fallback?: string) => string}
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                      onClick={() => handleRemove(req.templateId)}
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="w-full"
+          onClick={() => setAddDialogOpen(true)}
+        >
+          <Plus className="mr-2 h-4 w-4" variant="stroke" />
+          {t(
+            "documents.requiredDocs.addFromTemplate",
+            "Dodaj dokumenty z szablonu",
+          )}
+        </Button>
+      </div>
+
+      <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {t(
+                "documents.requiredDocs.addTitle",
+                "Dodaj wymagany dokument",
+              )}
+            </DialogTitle>
+            <DialogDescription>
+              {t(
+                "documents.requiredDocs.addDescription",
+                "Wybierz szablon dokumentu i okresl, kiedy powinien zostac wypelniony.",
+              )}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={t(
+                  "documents.requiredDocs.searchPlaceholder",
+                  "Szukaj szablonu...",
+                )}
+                className="pl-9"
+              />
+            </div>
+
+            <ScrollArea className="h-[240px]">
+              {templatesLoading ? (
+                <div className="space-y-2 p-1">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <Skeleton key={i} className="h-10 w-full rounded-lg" />
+                  ))}
+                </div>
+              ) : filteredPickerTemplates.length === 0 ? (
+                <p className="text-sm text-muted-foreground text-center py-8">
+                  {t(
+                    "documents.requiredDocs.noTemplates",
+                    "Brak dostepnych szablonow",
+                  )}
+                </p>
+              ) : (
+                <div className="space-y-1">
+                  {filteredPickerTemplates.map((tpl) => (
+                    <button
+                      key={tpl._id}
+                      type="button"
+                      onClick={() => setSelectedTemplateId(tpl._id)}
+                      className={cn(
+                        "w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left",
+                        "transition-colors cursor-pointer",
+                        selectedTemplateId === tpl._id
+                          ? "bg-primary/10 border border-primary/30"
+                          : "hover:bg-accent",
+                      )}
+                    >
+                      <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium">
+                          {tpl.name}
+                        </p>
+                        {tpl.description && (
+                          <p className="text-xs text-muted-foreground line-clamp-2">
+                            {extractPlainText(tpl.description)}
+                          </p>
+                        )}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </ScrollArea>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                {t("documents.requiredDocs.timing", "Moment wypelnienia")}
+              </label>
+              <Select
+                value={selectedTiming}
+                onValueChange={(v) =>
+                  setSelectedTiming(v as "before_start" | "after_completion")
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="before_start">
+                    {t(
+                      "documents.requiredDocs.beforeStart",
+                      "Przed wizyta",
+                    )}
+                  </SelectItem>
+                  <SelectItem value="after_completion">
+                    {t(
+                      "documents.requiredDocs.afterCompletion",
+                      "Po wizycie",
+                    )}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-2 mt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setAddDialogOpen(false);
+                setSelectedTemplateId(null);
+                setSearch("");
+              }}
+            >
+              {t("common.cancel", "Anuluj")}
+            </Button>
+            <Button
+              type="button"
+              onClick={handleAdd}
+              disabled={!selectedTemplateId}
+            >
+              {t("common.add", "Dodaj")}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function TimingBadge({
+  timing,
+  onTimingChange,
+  t,
+}: {
+  timing: "before_start" | "after_completion";
+  onTimingChange: (newTiming: "before_start" | "after_completion") => void;
+  t: (key: string, fallback?: string) => string;
+}) {
+  const isBefore = timing === "before_start";
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        onTimingChange(isBefore ? "after_completion" : "before_start")
+      }
+      className="cursor-pointer"
+      title={t(
+        "documents.requiredDocs.toggleTiming",
+        "Kliknij, aby zmienic moment",
+      )}
+    >
+      <Badge
+        className={cn(
+          "text-xs select-none",
+          isBefore
+            ? "bg-green-100 text-green-800 border-green-200 hover:bg-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800"
+            : "bg-blue-100 text-blue-800 border-blue-200 hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-800",
+        )}
+        variant="outline"
+      >
+        {isBefore
+          ? t("documents.requiredDocs.beforeStart", "Przed wizyta")
+          : t("documents.requiredDocs.afterCompletion", "Po wizycie")}
+      </Badge>
+    </button>
+  );
+}

--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -31,6 +31,10 @@ import {
 import { Check, ChevronsUpDown, Plus } from "@/lib/ez-icons";
 import { cn } from "@/lib/utils";
 import { formatActionError } from "@/lib/format-action-error";
+import {
+  TreatmentRequiredDocumentsField,
+  type RequiredFormTemplateValue,
+} from "@/components/documents/treatment-required-documents-field";
 import type { Id } from "@cvx/_generated/dataModel";
 
 export interface TreatmentFormData {
@@ -50,6 +54,7 @@ export interface TreatmentFormData {
   color?: string | null;
   treatmentCount?: number;
   packageId?: string | null;
+  requiredFormTemplates?: RequiredFormTemplateValue[];
 }
 
 interface TreatmentFormProps {
@@ -104,12 +109,10 @@ export function TreatmentForm({
     initialData?.requiredEquipmentIds ?? []
   );
   const [equipmentOpen, setEquipmentOpen] = useState(false);
-  const [preparationInstructions, setPreparationInstructions] = useState(
-    initialData?.preparationInstructions ?? ""
-  );
-  const [aftercareInstructions, setAftercareInstructions] = useState(
-    initialData?.aftercareInstructions ?? ""
-  );
+  const [notes, setNotes] = useState(initialData?.description ?? "");
+  const [requiredFormTemplates, setRequiredFormTemplates] = useState<
+    RequiredFormTemplateValue[]
+  >(initialData?.requiredFormTemplates ?? []);
   const [requiresApproval, setRequiresApproval] = useState(initialData?.requiresApproval ?? false);
   const initialTreatmentCount = initialData?.treatmentCount;
   const initialPackageId = initialData?.packageId ?? null;
@@ -195,7 +198,7 @@ export function TreatmentForm({
 
     onSubmit({
       name,
-      description: initialData?.description ?? null,
+      description: notes || null,
       duration: parseInt(duration) || 30,
       price: parseFloat(price.replace(",", ".")) || 0,
       currency: currency || undefined,
@@ -203,11 +206,12 @@ export function TreatmentForm({
       taxExempt: isExempt ? true : false,
       requiredEquipmentIds: selectedEquipmentIds.length > 0 ? selectedEquipmentIds : undefined,
       contraindications: initialData?.contraindications ?? null,
-      preparationInstructions: preparationInstructions || null,
-      aftercareInstructions: aftercareInstructions || null,
+      preparationInstructions: initialData?.preparationInstructions ?? null,
+      aftercareInstructions: initialData?.aftercareInstructions ?? null,
       requiresApproval: requiresApproval || undefined,
       color: initialData?.color ?? null,
       packageId: isPackage && selectedPackageId ? selectedPackageId : null,
+      requiredFormTemplates,
     });
   };
 
@@ -487,18 +491,20 @@ export function TreatmentForm({
 
       <div className="space-y-4 border-t pt-4">
         <div className="space-y-1.5">
-          <Label>{t("gabinet.treatments.preparationInstructions")}</Label>
-          <RichTextEditor
-            value={preparationInstructions}
-            onChange={(v) => setPreparationInstructions(v ?? "")}
-            minHeight="80px"
+          <Label>
+            {t("gabinet.treatments.requiredDocuments", "Wymagane dokumenty")}
+          </Label>
+          <TreatmentRequiredDocumentsField
+            organizationId={organizationId}
+            value={requiredFormTemplates}
+            onChange={setRequiredFormTemplates}
           />
         </div>
         <div className="space-y-1.5">
-          <Label>{t("gabinet.treatments.aftercareInstructions")}</Label>
+          <Label>{t("gabinet.treatments.notes", "Uwagi / Notatki")}</Label>
           <RichTextEditor
-            value={aftercareInstructions}
-            onChange={(v) => setAftercareInstructions(v ?? "")}
+            value={notes}
+            onChange={(v) => setNotes(v ?? "")}
             minHeight="80px"
           />
         </div>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -1280,6 +1280,10 @@ function TreatmentDetail() {
               color: treatment.color ?? undefined,
               treatmentCount: treatment.treatmentCount ?? undefined,
               packageId: treatment.packageId ?? null,
+              requiredFormTemplates:
+                (treatment.requiredFormTemplates as
+                  | TreatmentFormData["requiredFormTemplates"]
+                  | undefined) ?? undefined,
             }}
             onSubmit={handleEditSubmit}
             onCancel={() => setEditPanelOpen(false)}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -762,6 +762,10 @@ function TreatmentsIndex() {
                   color: editingTreatment.color ?? undefined,
                   treatmentCount: editingTreatment.treatmentCount ?? undefined,
                   packageId: editingTreatment.packageId ?? null,
+                  requiredFormTemplates:
+                    (editingTreatment.requiredFormTemplates as
+                      | TreatmentFormData["requiredFormTemplates"]
+                      | undefined) ?? undefined,
                 }
               : undefined
           }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1936.

Closes #1936

---

## Claude summary

Committed. Summary of what changed:

The treatment add/edit form (`src/components/gabinet/treatment-form.tsx`) now drops the two standalone rich-text editors for "Instrukcje przygotowania" and "Instrukcje po zabiegu" and replaces them with two clearer fields:

1. A "Wymagane dokumenty" section with a "Dodaj dokumenty z szablonu" button. It opens a picker over `formTemplates` (entityType `treatment`) and stores selections with timing (`before_start` / `after_completion`) into the existing `requiredFormTemplates` column. A new stateless picker component (`src/components/documents/treatment-required-documents-field.tsx`) handles this in both create and edit flows; the existing auto-save `TreatmentRequiredDocuments` in the detail page Documents tab is unchanged.

2. A single "Uwagi / Notatki" rich-text field, mapped to the existing `description` column — no schema migration needed.

The convex `gabinet.treatments.create` action now accepts `requiredFormTemplates` so selections persist for new treatments. Legacy `contraindications`, `preparationInstructions`, `aftercareInstructions` are still passed through on edit (so existing treatments keep displaying their data on the appointment detail page), but no longer have UI for editing in the form. Translations for `gabinet.treatments.notes` and `gabinet.treatments.requiredDocuments` were added in both PL and EN. `npm run typecheck` and the `gabinetTreatmentsCreate` unit tests pass.