### PR TITLE
Wypełnia

### DIFF
--- a/src/components/documents/appointment-document-checklist.tsx
+++ b/src/components/documents/appointment-document-checklist.tsx
@@ -224,7 +224,7 @@ export function AppointmentDocumentChecklist({
         {/* Before appointment section */}
         {beforeDocs.length > 0 && (
           <DocumentSection
-            title={t("documents.beforeAppointment", "Przed wizyta")}
+            title={t("documents.beforeAppointment", "Przed wizytą")}
             documents={beforeDocs}
             organizationId={organizationId}
             onDocumentClick={handleDocClick}

--- a/src/components/documents/document-gate-dialog.tsx
+++ b/src/components/documents/document-gate-dialog.tsx
@@ -97,7 +97,7 @@ export function DocumentGateDialog({
 
   const timingLabel =
     timing === "before_start"
-      ? t("documents.gate.timingBefore", "Przed wizyta")
+      ? t("documents.gate.timingBefore", "Przed wizytą")
       : t("documents.gate.timingAfter", "Po wizycie");
 
   const drag = useDraggableDialog(open);

--- a/src/components/documents/treatment-required-documents-field.tsx
+++ b/src/components/documents/treatment-required-documents-field.tsx
@@ -265,7 +265,7 @@ export function TreatmentRequiredDocumentsField({
 
             <div className="space-y-2">
               <label className="text-sm font-medium">
-                {t("documents.requiredDocs.timing", "Moment wypelnienia")}
+                {t("documents.requiredDocs.timing", "Wypełnia:")}
               </label>
               <Select
                 value={selectedTiming}
@@ -280,7 +280,7 @@ export function TreatmentRequiredDocumentsField({
                   <SelectItem value="before_start">
                     {t(
                       "documents.requiredDocs.beforeStart",
-                      "Przed wizyta",
+                      "Przed wizytą",
                     )}
                   </SelectItem>
                   <SelectItem value="after_completion">
@@ -353,7 +353,7 @@ function TimingBadge({
         variant="outline"
       >
         {isBefore
-          ? t("documents.requiredDocs.beforeStart", "Przed wizyta")
+          ? t("documents.requiredDocs.beforeStart", "Przed wizytą")
           : t("documents.requiredDocs.afterCompletion", "Po wizycie")}
       </Badge>
     </button>

--- a/src/components/documents/treatment-required-documents.tsx
+++ b/src/components/documents/treatment-required-documents.tsx
@@ -364,7 +364,7 @@ export function TreatmentRequiredDocuments({
             {/* Timing selector */}
             <div className="space-y-2">
               <label className="text-sm font-medium">
-                {t("documents.requiredDocs.timing", "Moment wypelnienia")}
+                {t("documents.requiredDocs.timing", "Wypełnia:")}
               </label>
               <Select
                 value={selectedTiming}
@@ -379,7 +379,7 @@ export function TreatmentRequiredDocuments({
                   <SelectItem value="before_start">
                     {t(
                       "documents.requiredDocs.beforeStart",
-                      "Przed wizyta",
+                      "Przed wizytą",
                     )}
                   </SelectItem>
                   <SelectItem value="after_completion">
@@ -452,7 +452,7 @@ function TimingBadge({
         variant="outline"
       >
         {isBefore
-          ? t("documents.requiredDocs.beforeStart", "Przed wizyta")
+          ? t("documents.requiredDocs.beforeStart", "Przed wizytą")
           : t("documents.requiredDocs.afterCompletion", "Po wizycie")}
       </Badge>
     </button>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1939.

Closes #1939

---

## Claude summary

Wypełnia:

Fixed the two Polish-language issues visible in the "Dodaj wymagany dokument" dialog from the screenshot. In `src/components/documents/treatment-required-documents-field.tsx:268` and `treatment-required-documents.tsx:367` the picker's timing label is now `Wypełnia:` (per the user's request, replacing the wordy and diacritic-stripped `Moment wypelnienia`), and the option text `Przed wizyta` is corrected to `Przed wizytą` (proper instrumental case after the preposition `przed`). The same grammar fix is applied at three other call sites that render that label: the timing badge in both `treatment-required-documents*.tsx` files, the `Przed wizyta` section header in `appointment-document-checklist.tsx:227`, and the `timingLabel` in `document-gate-dialog.tsx:100`. Committed as `bc5fb4a`.