### PR TITLE
Menu karta klienta

### DIFF
--- a/src/components/crm/entity-detail-layout.tsx
+++ b/src/components/crm/entity-detail-layout.tsx
@@ -18,8 +18,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 // Shared tab trigger class for consistent styling across entity detail views.
 // `shrink-0` keeps each tab at its natural width so the row stays scrollable on narrow viewports.
+// On mobile the active tab also gets a tinted background + bolder font so it doesn't blend
+// into the content list below (issue #1926).
 export const tabTriggerClass =
-  "relative shrink-0 rounded-none border-b-2 border-transparent px-4 pb-3 pt-2 font-medium text-muted-foreground transition-none data-[state=active]:border-primary data-[state=active]:text-foreground data-[state=active]:shadow-none";
+  "relative shrink-0 rounded-none border-b-2 border-transparent px-4 pb-3 pt-2 font-medium text-muted-foreground transition-none data-[state=active]:border-primary data-[state=active]:text-foreground data-[state=active]:shadow-none max-md:data-[state=active]:bg-primary/10 max-md:data-[state=active]:rounded-t-md max-md:data-[state=active]:font-semibold";
 
 export interface DetailField {
   label: string;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1926.

Closes #1926

---

## Claude summary

Committed. Summary:

The patient card tabs (Zdjęcia / Płatności / Dokumenty / Lojalność) are rendered by the shared `EntityDetailLayout` using the exported `tabTriggerClass` in `src/components/crm/entity-detail-layout.tsx:21`. The active state was only a 2px primary underline + foreground text — on mobile that underline blends with the row's own `border-b` and the content list beneath, so the active tab read as plain text.

Fix: added three `max-md:`-prefixed utilities to the active state — `bg-primary/10`, `rounded-t-md`, `font-semibold` — so on mobile the active tab gets a subtle primary-tinted pill with bolder text. Desktop is unchanged (no `max-md:` rules apply ≥ 768 px), tab logic is untouched, no refactor. Typecheck passes.