### PR TITLE
Nowy zabieg 

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -114,64 +114,90 @@ export const create = action({
     categoryId: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
-    // --- Auth + permissions (via internal queries) ---
-    const authResult = await ctx.runQuery(
-      internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: args.organizationId },
-    );
-    await ctx.runQuery(internal._helpers.authAction.checkPermission, {
-      organizationId: args.organizationId,
-      feature: "gabinet_treatments",
-      action: "create",
-    }).then((perm: { allowed: boolean; scope: string }) => {
-      if (!perm.allowed) throw new Error("Permission denied");
-    });
-
-    const now = Date.now();
-    const db = createSupabaseDb();
-
-    // --- INSERT treatment directly to Supabase ---
-    const treatmentId = await db.insert("gabinetTreatments", {
-      organizationId: String(args.organizationId),
-      name: args.name,
-      description: args.description ?? null,
-      duration: args.duration,
-      price: args.price,
-      currency: args.currency ?? null,
-      taxRate: args.taxExempt ? null : args.taxRate ?? null,
-      taxExempt: args.taxExempt ?? null,
-      requiredEquipment: args.requiredEquipment ?? null,
-      requiredEquipmentIds: args.requiredEquipmentIds ?? null,
-      contraindications: args.contraindications ?? null,
-      preparationInstructions: args.preparationInstructions ?? null,
-      aftercareInstructions: args.aftercareInstructions ?? null,
-      isActive: true,
-      requiresApproval: args.requiresApproval ?? null,
-      color: args.color ?? null,
-      sortOrder: args.sortOrder ?? null,
-      treatmentCount: args.treatmentCount ?? null,
-      packageId: args.packageId ?? null,
-      requiredFormTemplates: args.requiredFormTemplates ?? null,
-      tagIds: args.tagIds ?? null,
-      categoryId: args.categoryId ?? null,
-      createdBy: String(authResult.userId),
-      createdAt: now,
-      updatedAt: now,
-    });
-
-    // --- Delegate post-write side effects ---
     try {
-      await ctx.runMutation(internal.gabinet.treatments._createSideEffects, {
-        treatmentId,
+      // --- Auth + permissions (via internal queries) ---
+      const authResult = await ctx.runQuery(
+        internal._helpers.authAction.verifyOrgAccess,
+        { organizationId: args.organizationId },
+      );
+      await ctx.runQuery(internal._helpers.authAction.checkPermission, {
         organizationId: args.organizationId,
-        name: args.name,
-        createdBy: String(authResult.userId),
+        feature: "gabinet_treatments",
+        action: "create",
+      }).then((perm: { allowed: boolean; scope: string }) => {
+        if (!perm.allowed) throw new Error("Permission denied");
       });
-    } catch (e) {
-      console.error("[treatments.create] Side effects FAILED for treatment", treatmentId, ":", e);
-    }
 
-    return treatmentId;
+      const now = Date.now();
+      const db = createSupabaseDb();
+
+      // --- INSERT treatment directly to Supabase ---
+      const treatmentId = await db.insert("gabinetTreatments", {
+        organizationId: String(args.organizationId),
+        name: args.name,
+        description: args.description ?? null,
+        duration: args.duration,
+        price: args.price,
+        currency: args.currency ?? null,
+        taxRate: args.taxExempt ? null : args.taxRate ?? null,
+        taxExempt: args.taxExempt ?? null,
+        requiredEquipment: args.requiredEquipment ?? null,
+        requiredEquipmentIds: args.requiredEquipmentIds ?? null,
+        contraindications: args.contraindications ?? null,
+        preparationInstructions: args.preparationInstructions ?? null,
+        aftercareInstructions: args.aftercareInstructions ?? null,
+        isActive: true,
+        requiresApproval: args.requiresApproval ?? null,
+        color: args.color ?? null,
+        sortOrder: args.sortOrder ?? null,
+        treatmentCount: args.treatmentCount ?? null,
+        packageId: args.packageId ?? null,
+        requiredFormTemplates: args.requiredFormTemplates ?? null,
+        tagIds: args.tagIds ?? null,
+        categoryId: args.categoryId ?? null,
+        createdBy: String(authResult.userId),
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      // --- Delegate post-write side effects ---
+      try {
+        await ctx.runMutation(internal.gabinet.treatments._createSideEffects, {
+          treatmentId,
+          organizationId: args.organizationId,
+          name: args.name,
+          createdBy: String(authResult.userId),
+        });
+      } catch (e) {
+        console.error("[treatments.create] Side effects FAILED for treatment", treatmentId, ":", e);
+      }
+
+      return treatmentId;
+    } catch (err) {
+      // Persist failures to errorLogs so #1941-style "nieprawidłowe dane"
+      // reports can be debugged from /admin/errors without round-tripping
+      // through the user. Logging is swallow-safe.
+      await logError(ctx, err, {
+        scope: "gabinet.treatments",
+        fnName: "create",
+        argsJson: JSON.stringify({
+          organizationId: args.organizationId,
+          name: args.name,
+          duration: args.duration,
+          price: args.price,
+          currency: args.currency,
+          taxRate: args.taxRate,
+          taxExempt: args.taxExempt,
+          requiredEquipmentIds: args.requiredEquipmentIds,
+          packageId: args.packageId,
+          requiredFormTemplatesCount: args.requiredFormTemplates?.length,
+          tagIdsCount: args.tagIds?.length,
+          categoryId: args.categoryId,
+        }),
+        organizationId: args.organizationId,
+      });
+      throw err;
+    }
   },
 });
 
@@ -225,55 +251,73 @@ export const update = action({
     categoryId: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
-    // --- Auth + permissions (via internal queries) ---
-    const authResult = await ctx.runQuery(
-      internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: args.organizationId },
-    );
-    const perm = await ctx.runQuery(
-      internal._helpers.authAction.checkPermission,
-      {
-        organizationId: args.organizationId,
-        feature: "gabinet_treatments",
-        action: "edit",
-      },
-    ) as { allowed: boolean; scope: string };
-    if (!perm.allowed) throw new Error("Permission denied");
-
-    const db = createSupabaseDb();
-
-    // --- Read treatment from Supabase ---
-    const treatment = await db.get("gabinetTreatments", args.treatmentId);
-    if (!treatment || String(treatment.organizationId) !== String(args.organizationId)) {
-      throw new Error("Treatment not found");
-    }
-    if (perm.scope === "own" && String(treatment.createdBy) !== String(authResult.userId)) {
-      throw new Error("Permission denied: you can only edit your own records");
-    }
-
-    // --- Build updates and PATCH to Supabase ---
-    const { organizationId, treatmentId, ...updates } = args;
-    // ZW (VAT-exempt) is now tracked via the dedicated taxExempt flag; ensure
-    // taxRate is cleared whenever the caller marks the treatment exempt.
-    const patchPayload: Record<string, unknown> = { ...updates, updatedAt: Date.now() };
-    if (updates.taxExempt === true) {
-      patchPayload.taxRate = null;
-    }
-    await db.patch("gabinetTreatments", treatmentId, patchPayload);
-
-    // --- Delegate post-write side effects ---
     try {
-      await ctx.runMutation(internal.gabinet.treatments._updateSideEffects, {
-        treatmentId,
-        organizationId,
-        treatmentName: (treatment.name as string) ?? "",
-        updatedBy: String(authResult.userId),
-      });
-    } catch (e) {
-      console.error("[treatments.update] Side effects FAILED for treatment", treatmentId, ":", e);
-    }
+      // --- Auth + permissions (via internal queries) ---
+      const authResult = await ctx.runQuery(
+        internal._helpers.authAction.verifyOrgAccess,
+        { organizationId: args.organizationId },
+      );
+      const perm = await ctx.runQuery(
+        internal._helpers.authAction.checkPermission,
+        {
+          organizationId: args.organizationId,
+          feature: "gabinet_treatments",
+          action: "edit",
+        },
+      ) as { allowed: boolean; scope: string };
+      if (!perm.allowed) throw new Error("Permission denied");
 
-    return treatmentId;
+      const db = createSupabaseDb();
+
+      // --- Read treatment from Supabase ---
+      const treatment = await db.get("gabinetTreatments", args.treatmentId);
+      if (!treatment || String(treatment.organizationId) !== String(args.organizationId)) {
+        throw new Error("Treatment not found");
+      }
+      if (perm.scope === "own" && String(treatment.createdBy) !== String(authResult.userId)) {
+        throw new Error("Permission denied: you can only edit your own records");
+      }
+
+      // --- Build updates and PATCH to Supabase ---
+      const { organizationId, treatmentId, ...updates } = args;
+      // ZW (VAT-exempt) is now tracked via the dedicated taxExempt flag; ensure
+      // taxRate is cleared whenever the caller marks the treatment exempt.
+      const patchPayload: Record<string, unknown> = { ...updates, updatedAt: Date.now() };
+      if (updates.taxExempt === true) {
+        patchPayload.taxRate = null;
+      }
+      await db.patch("gabinetTreatments", treatmentId, patchPayload);
+
+      // --- Delegate post-write side effects ---
+      try {
+        await ctx.runMutation(internal.gabinet.treatments._updateSideEffects, {
+          treatmentId,
+          organizationId,
+          treatmentName: (treatment.name as string) ?? "",
+          updatedBy: String(authResult.userId),
+        });
+      } catch (e) {
+        console.error("[treatments.update] Side effects FAILED for treatment", treatmentId, ":", e);
+      }
+
+      return treatmentId;
+    } catch (err) {
+      await logError(ctx, err, {
+        scope: "gabinet.treatments",
+        fnName: "update",
+        argsJson: JSON.stringify({
+          organizationId: args.organizationId,
+          treatmentId: args.treatmentId,
+          updatedFields: Object.keys(args).filter(
+            (k) => k !== "organizationId" && k !== "treatmentId",
+          ),
+          requiredFormTemplatesCount: args.requiredFormTemplates?.length,
+          tagIdsCount: args.tagIds?.length,
+        }),
+        organizationId: args.organizationId,
+      });
+      throw err;
+    }
   },
 });
 

--- a/src/lib/format-action-error.test.ts
+++ b/src/lib/format-action-error.test.ts
@@ -56,6 +56,40 @@ describe("extractFieldValidationDetail", () => {
   it("returns null for unrelated messages", () => {
     expect(extractFieldValidationDetail("Some other error")).toBeNull();
   });
+
+  it("extracts field from Convex 'Validator error: Missing required field' (issue #1941)", () => {
+    const detail = extractFieldValidationDetail(
+      "Validator error: Missing required field `name` in object",
+    );
+    expect(detail?.rawField).toBe("name");
+    expect(detail?.fieldLabel).toBe("Nazwa");
+    expect(detail?.reason).toBe("to pole jest wymagane");
+  });
+
+  it("extracts field from Convex 'Validator error: Unexpected field'", () => {
+    const detail = extractFieldValidationDetail(
+      "Validator error: Unexpected field `categoryId` in object",
+    );
+    expect(detail?.rawField).toBe("categoryId");
+    expect(detail?.fieldLabel).toBe("Kategoria");
+    expect(detail?.reason).toBe("nieoczekiwane pole");
+  });
+
+  it("extracts field from Convex 'Validator error: ... at path X.Y'", () => {
+    const detail = extractFieldValidationDetail(
+      "Validator error: Expected `string`, got `null` at path 'price'",
+    );
+    expect(detail?.rawField).toBe("price");
+    expect(detail?.fieldLabel).toBe("Cena");
+  });
+
+  it("reports type-mismatch when no field name is present in Validator error", () => {
+    const detail = extractFieldValidationDetail(
+      "Validator error: Expected `string`, got `null`",
+    );
+    expect(detail?.fieldLabel).toContain("string");
+    expect(detail?.reason).toContain("null");
+  });
 });
 
 describe("formatTreatmentError", () => {
@@ -87,5 +121,20 @@ describe("formatTreatmentError", () => {
       defaultValue: "Nie udało się utworzyć zabiegu.",
     });
     expect(msg).toBe("Nie udało się utworzyć zabiegu.");
+  });
+
+  it("surfaces field when Convex throws 'Validator error: Missing required field' (issue #1941)", () => {
+    const err = new Error(
+      "[CONVEX A(gabinet/treatments:create)] [Request ID: xx] Server Error\n" +
+        "Uncaught ArgumentValidationError: Validator error: Missing required field `duration` in object\n" +
+        "    at validateValidator\n" +
+        "  Called by client",
+    );
+    const msg = formatTreatmentError(err, t, {
+      key: "gabinet.treatments.errors.createFailed",
+      defaultValue: "Nie udało się utworzyć zabiegu.",
+    });
+    expect(msg).toContain("Czas trwania");
+    expect(msg).toContain("to pole jest wymagane");
   });
 });

--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -139,6 +139,61 @@ export function extractFieldValidationDetail(
     };
   }
 
+  // Convex validator (server-side) errors carry no "for argument 'X'" prefix —
+  // their shape is `Validator error: <reason>` with optional path info like
+  // `at path '<arg>.<field>[<idx>].<subfield>'`. Without this branch the
+  // broad `Validator error` pattern still matches in TREATMENT_ERROR_MAP /
+  // GENERIC_ERROR_MAP, but no field detail is extracted, so the user sees
+  // the generic "nieprawidłowe dane" fallback (issue #1941).
+  const validatorAtPath = msg.match(
+    /Validator error:[^]*?at path ['"`]?([A-Za-z_][A-Za-z0-9_]*)(?:[.[][^'"`]*)?['"`]?/i,
+  );
+  if (validatorAtPath) {
+    const rawField = validatorAtPath[1];
+    return {
+      rawField,
+      fieldLabel: humanFieldLabel(rawField),
+      reason: "nieprawidłowa wartość",
+    };
+  }
+
+  const validatorMissing = msg.match(
+    /Validator error: Missing required field ['"`]([A-Za-z_][A-Za-z0-9_]*)['"`]/i,
+  );
+  if (validatorMissing) {
+    const rawField = validatorMissing[1];
+    return {
+      rawField,
+      fieldLabel: humanFieldLabel(rawField),
+      reason: "to pole jest wymagane",
+    };
+  }
+
+  const validatorUnexpected = msg.match(
+    /Validator error: Unexpected field ['"`]([A-Za-z_][A-Za-z0-9_]*)['"`]/i,
+  );
+  if (validatorUnexpected) {
+    const rawField = validatorUnexpected[1];
+    return {
+      rawField,
+      fieldLabel: humanFieldLabel(rawField),
+      reason: "nieoczekiwane pole",
+    };
+  }
+
+  // Generic `Validator error: Expected X, got Y` — no field name available,
+  // so report the type mismatch.
+  const validatorExpected = msg.match(
+    /Validator error: Expected ['"`]?([A-Za-z_][A-Za-z0-9_]*)['"`]?,? got ['"`]?([^'"`,\n]+?)['"`]?(?:\s|$|,)/i,
+  );
+  if (validatorExpected) {
+    return {
+      rawField: "validator",
+      fieldLabel: `oczekiwano: ${validatorExpected[1]}`,
+      reason: `otrzymano: ${validatorExpected[2]}`,
+    };
+  }
+
   return null;
 }
 
@@ -302,7 +357,7 @@ const TREATMENT_ERROR_MAP: Array<{
   },
   {
     test: (m) =>
-      /argumentvalidationerror|value does not match validator|invalid input syntax|violates .* constraint|column .* does not exist|null value in column/i.test(
+      /argumentvalidationerror|value does not match validator|validator error|invalid input syntax|violates .* constraint|column .* does not exist|null value in column/i.test(
         m,
       ),
     key: "gabinet.treatments.errors.invalidArguments",
@@ -361,7 +416,7 @@ const GENERIC_ERROR_MAP: Array<{
   },
   {
     test: (m) =>
-      /argumentvalidationerror|value does not match validator|invalid input syntax|violates .* constraint|column .* does not exist|null value in column/i.test(
+      /argumentvalidationerror|value does not match validator|validator error|invalid input syntax|violates .* constraint|column .* does not exist|null value in column/i.test(
         m,
       ),
     key: "common.errors.invalidArguments",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1941.

Closes #1941

---

## Claude summary

Committed. Here's a summary of what I shipped and why.

I could not reproduce the underlying `ArgumentValidationError` directly — the unit test for `treatments.create` with a `requiredFormTemplates` payload passes against the in-memory Supabase stub, and inspecting the request/validator shape (`convex/gabinet/treatments.ts:89-115`) against what the form submits (`src/components/gabinet/treatment-form.tsx:199-215`, with parent spread at `src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx:439-479`) showed every form field has a matching optional validator entry. The actual failed payload only exists on production (Jam shows the symptom, not the request body), so without server logs the precise field is invisible.

The issue explicitly asked for two things: surface the specific field instead of the generic message, and make this debuggable from logs. The commit does both. On the client, `format-action-error.ts` learns the Convex `Validator error: …` shapes (`Missing required field 'X'`, `Unexpected field 'X'`, `at path 'X.Y'`, `Expected T, got U`) and the `TREATMENT_ERROR_MAP` / `GENERIC_ERROR_MAP` regexes are widened to route those through the field extractor instead of falling through to the generic toast. On the server, `gabinet/treatments.ts` wraps `create` and `update` in try/catch and calls `logError` with the submitted field names and array sizes before re-throwing — `/admin/errors` will get a concrete row the next time this fails, with which fields/sizes were sent.

Tests pass (`npx vitest run` for both convex and frontend), and the typecheck is clean.

## Follow-ups
- Identify root cause of treatment create validator failure: once `/admin/errors` captures a failing payload (or the reporter shares Jam request body), pinpoint which validator argument is failing on production and patch the form or validator accordingly.
- Add try/catch + logError to remaining gabinet create/update actions: appointments, employees, patients, packages, etc. all currently throw raw ArgumentValidationErrors without surfacing the specific field — same UX bug, broader scope.