### PR TITLE
Karta wizyty klienta

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -69,7 +69,9 @@ import {
   WalletIcon,
   RefreshCw,
   Sparkles,
+  ChevronDown,
 } from "@/lib/ez-icons";
+import { cn } from "@/lib/utils";
 
 import { useTranslation } from "react-i18next";
 import { usePermission } from "@/hooks/use-permission";
@@ -112,6 +114,10 @@ function PatientDetail() {
 
   const [editDrawerOpen, setEditDrawerOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  // Issue #1928: collapse the "Last appointments" overview card by default on
+  // mobile so other sections (medical info, status tiles) aren't pushed below
+  // the fold. On desktop (md+) the section stays expanded — see JSX below.
+  const [lastAppointmentsExpanded, setLastAppointmentsExpanded] = useState(false);
 
   // Tag and category definitions for the edit drawer PatientForm
   // (kept in sync with the patients list create-form props).
@@ -904,22 +910,50 @@ function PatientDetail() {
 
           <Card>
             <CardContent className="pt-6 space-y-4">
-              <h3 className="text-sm font-semibold flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setLastAppointmentsExpanded((v) => !v)}
+                aria-expanded={lastAppointmentsExpanded}
+                className="flex w-full items-center justify-between gap-2 text-left md:hidden"
+              >
+                <span className="text-sm font-semibold flex items-center gap-2">
+                  <Calendar
+                    className="h-4 w-4 text-muted-foreground"
+                    variant="stroke"
+                  />
+                  {t("gabinet.patients.lastAppointments")}
+                </span>
+                <ChevronDown
+                  className={cn(
+                    "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+                    lastAppointmentsExpanded && "rotate-180",
+                  )}
+                  variant="stroke"
+                />
+              </button>
+              <h3 className="hidden text-sm font-semibold md:flex items-center gap-2">
                 <Calendar
                   className="h-4 w-4 text-muted-foreground"
                   variant="stroke"
                 />
                 {t("gabinet.patients.lastAppointments")}
               </h3>
-              {pastAppointments.length === 0 ? (
-                <p className="text-sm text-muted-foreground">
-                  {t("gabinet.patients.noHistoryDesc")}
-                </p>
-              ) : (
-                <div className="space-y-2">
-                  {pastAppointments.map(renderAppointmentRow)}
-                </div>
-              )}
+              <div
+                className={cn(
+                  "space-y-4",
+                  !lastAppointmentsExpanded && "hidden md:block",
+                )}
+              >
+                {pastAppointments.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    {t("gabinet.patients.noHistoryDesc")}
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {pastAppointments.map(renderAppointmentRow)}
+                  </div>
+                )}
+              </div>
             </CardContent>
           </Card>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1928.

Closes #1928

---

## Claude summary

Committed as `faa5823`.

## Summary

On the patient detail page (`/dashboard/gabinet/patients/:patientId`, overview tab), the "Ostatnie wizyty klienta" Card showed up to three past appointment rows always-expanded. On mobile (< 768px) that card pushed the medical info, status tiles and other sections below the fold.

The fix in `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx`:

- Adds a `lastAppointmentsExpanded` state (defaults to `false`).
- Replaces the single `<h3>` heading with two siblings: a `<button md:hidden>` toggle (heading text + rotating `ChevronDown`) and the original `<h3 hidden md:flex>` for desktop. Only one renders at a time depending on the viewport.
- Wraps the appointment list in a `<div>` that gets `hidden md:block` when collapsed — so mobile starts collapsed but desktop is always expanded.

No data, sorting, query or business logic changed; the same three most-recent past appointments are rendered when expanded. Desktop view is byte-identical thanks to the `md:` responsive classes. Matches the `useIsMobile` breakpoint (768px) used elsewhere in the codebase.

Typecheck (`tsc -p tsconfig.app.json`) passes; the two ESLint messages emitted on the file are pre-existing and unrelated.