### PR TITLE
Add i18n entries for new timing keys

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -747,7 +747,23 @@
     "stepOf": "Step {{current}} of {{total}}",
     "searchTemplate": "Search template...",
     "noTemplatesDesc": "Add document templates in settings to generate documents.",
-    "goToSettings": "Go to settings"
+    "goToSettings": "Go to settings",
+    "beforeAppointment": "Before appointment",
+    "duringAppointment": "During appointment",
+    "afterAppointment": "After appointment",
+    "requiredDocs": {
+      "beforeStart": "Before appointment",
+      "duringVisit": "During appointment",
+      "afterCompletion": "After appointment"
+    },
+    "gate": {
+      "timingBefore": "Before appointment",
+      "timingDuring": "During appointment",
+      "timingAfter": "After appointment",
+      "beforeDescription": "The following documents should be filled in before the appointment starts:",
+      "duringDescription": "The following documents should be filled in before the appointment ends:",
+      "afterDescription": "The following documents should be filled in after the appointment ends:"
+    }
   },
   "products": {
     "title": "Products",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -748,7 +748,23 @@
     "stepOf": "Krok {{current}} z {{total}}",
     "searchTemplate": "Szukaj szablonu...",
     "noTemplatesDesc": "Dodaj szablony dokumentów w ustawieniach, aby móc generować dokumenty.",
-    "goToSettings": "Przejdź do ustawień"
+    "goToSettings": "Przejdź do ustawień",
+    "beforeAppointment": "Przed wizytą",
+    "duringAppointment": "W trakcie wizyty",
+    "afterAppointment": "Po wizycie",
+    "requiredDocs": {
+      "beforeStart": "Przed wizytą",
+      "duringVisit": "W trakcie wizyty",
+      "afterCompletion": "Po wizycie"
+    },
+    "gate": {
+      "timingBefore": "Przed wizytą",
+      "timingDuring": "W trakcie wizyty",
+      "timingAfter": "Po wizycie",
+      "beforeDescription": "Następujące dokumenty powinny być wypełnione przed rozpoczęciem wizyty:",
+      "duringDescription": "Następujące dokumenty powinny być wypełnione przed zakończeniem wizyty:",
+      "afterDescription": "Następujące dokumenty powinny być wypełnione po zakończeniu wizyty:"
+    }
   },
   "products": {
     "title": "Produkty",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1953.

Closes #1953

---

## Claude summary

Committed. Summary:

Added the missing `documents.requiredDocs.*`, `documents.gate.*`, and flat `documents.{before,during,after}Appointment` timing keys to both `public/locales/pl/translation.json` and `public/locales/en/translation.json`. Polish entries match the existing inline fallbacks from #1943; English entries provide proper translations so EN users no longer see "W trakcie wizyty" etc.

Scope kept tight to timing-related siblings (before/during/after) for each namespace — did not touch other `requiredDocs.*`/`gate.*` keys (like `gate.title`, `gate.progress`, `requiredDocs.addTitle`) that are out of scope for this timing-key issue.

## Follow-ups
- Add i18n entries for remaining requiredDocs/gate keys: Many other keys in `src/components/documents/{document-gate-dialog,treatment-required-documents,treatment-required-documents-field}.tsx` (e.g. `documents.gate.title`, `documents.gate.progress`, `documents.gate.proceedAnyway`, `documents.requiredDocs.addTitle`, `documents.requiredDocs.searchPlaceholder`) still only have Polish inline fallbacks and resolve to Polish for EN users.
- Add i18n entries for remaining `documents.*` flat keys with Polish-only fallbacks: e.g. `documents.fill`, `documents.preview`, `documents.resendEmail`, `documents.documentsCompleted`, `documents.completeMissingData`, `documents.noTemplatesSearch` and many others used across documents/ components.