### PR TITLE
Add i18n entries for remaining requiredDocs/gate keys

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -751,10 +751,25 @@
     "beforeAppointment": "Before appointment",
     "duringAppointment": "During appointment",
     "afterAppointment": "After appointment",
+    "fill": "Fill in",
     "requiredDocs": {
       "beforeStart": "Before appointment",
       "duringVisit": "During appointment",
-      "afterCompletion": "After appointment"
+      "afterCompletion": "After appointment",
+      "title": "Required documents for this treatment",
+      "description": "These documents will be generated automatically when an appointment is created",
+      "empty": "No required documents. Click below to add one.",
+      "unknown": "Unknown template",
+      "add": "Add required document",
+      "addFromTemplate": "Add documents from template",
+      "addTitle": "Add required document",
+      "addDescription": "Choose a document template and specify when it should be filled in.",
+      "searchPlaceholder": "Search template...",
+      "noTemplates": "No templates available",
+      "timing": "When document is required",
+      "toggleTiming": "Click to change timing",
+      "added": "Required document added",
+      "removed": "Required document removed"
     },
     "gate": {
       "timingBefore": "Before appointment",
@@ -762,7 +777,12 @@
       "timingAfter": "After appointment",
       "beforeDescription": "The following documents should be filled in before the appointment starts:",
       "duringDescription": "The following documents should be filled in before the appointment ends:",
-      "afterDescription": "The following documents should be filled in after the appointment ends:"
+      "afterDescription": "The following documents should be filled in after the appointment ends:",
+      "title": "Incomplete documents",
+      "progress": "Filled in {{completed}} of {{total}} required documents",
+      "allComplete": "All documents are filled in.",
+      "proceedAnyway": "I know, continue without documents",
+      "fillDocuments": "Fill in documents"
     }
   },
   "products": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -752,10 +752,25 @@
     "beforeAppointment": "Przed wizytą",
     "duringAppointment": "W trakcie wizyty",
     "afterAppointment": "Po wizycie",
+    "fill": "Wypełnij",
     "requiredDocs": {
       "beforeStart": "Przed wizytą",
       "duringVisit": "W trakcie wizyty",
-      "afterCompletion": "Po wizycie"
+      "afterCompletion": "Po wizycie",
+      "title": "Wymagane dokumenty dla tego zabiegu",
+      "description": "Te dokumenty zostaną automatycznie wygenerowane przy tworzeniu wizyty",
+      "empty": "Brak wymaganych dokumentów. Kliknij poniżej, aby dodać.",
+      "unknown": "Nieznany szablon",
+      "add": "Dodaj wymagany dokument",
+      "addFromTemplate": "Dodaj dokumenty z szablonu",
+      "addTitle": "Dodaj wymagany dokument",
+      "addDescription": "Wybierz szablon dokumentu i określ, kiedy powinien zostać wypełniony.",
+      "searchPlaceholder": "Szukaj szablonu...",
+      "noTemplates": "Brak dostępnych szablonów",
+      "timing": "Moment wymagania dokumentu",
+      "toggleTiming": "Kliknij, aby zmienić moment",
+      "added": "Dodano wymagany dokument",
+      "removed": "Usunięto wymagany dokument"
     },
     "gate": {
       "timingBefore": "Przed wizytą",
@@ -763,7 +778,12 @@
       "timingAfter": "Po wizycie",
       "beforeDescription": "Następujące dokumenty powinny być wypełnione przed rozpoczęciem wizyty:",
       "duringDescription": "Następujące dokumenty powinny być wypełnione przed zakończeniem wizyty:",
-      "afterDescription": "Następujące dokumenty powinny być wypełnione po zakończeniu wizyty:"
+      "afterDescription": "Następujące dokumenty powinny być wypełnione po zakończeniu wizyty:",
+      "title": "Niekompletne dokumenty",
+      "progress": "Wypełniono {{completed}} z {{total}} wymaganych dokumentów",
+      "allComplete": "Wszystkie dokumenty są wypełnione.",
+      "proceedAnyway": "Wiem, kontynuuj bez dokumentów",
+      "fillDocuments": "Wypełnij dokumenty"
     }
   },
   "products": {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1957.

Closes #1957

---

## Claude summary

Added the 20 missing keys (`documents.fill`, `documents.gate.{title,progress,allComplete,proceedAnyway,fillDocuments}`, and `documents.requiredDocs.{title,description,empty,unknown,add,addFromTemplate,addTitle,addDescription,searchPlaceholder,noTemplates,timing,toggleTiming,added,removed}`) to both `public/locales/pl/translation.json` and `public/locales/en/translation.json`. PL values mirror the inline fallbacks in the components (with proper diacritics restored); EN values are proper English translations. Committed as `0d18209`.