### PR TITLE
Pola wersja mobilna

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -825,7 +825,10 @@ function PatientDetail() {
     {
       label: t("gabinet.patients.tabs.overview"),
       content: (
-        <div className="space-y-6">
+        // Issue #1931: on mobile, push the Status/Dodano/Pochodzenie tiles to
+        // the very bottom so the primary patient sections (upcoming, history,
+        // medical info) come first. Desktop layout is unchanged via md:order-none.
+        <div className="flex flex-col space-y-6">
           <Card>
             <CardContent className="pt-6 space-y-4">
               <h3 className="text-sm font-semibold flex items-center gap-2">
@@ -847,7 +850,7 @@ function PatientDetail() {
             </CardContent>
           </Card>
 
-          <div className="grid gap-4 sm:grid-cols-3">
+          <div className="order-last grid gap-4 sm:grid-cols-3 md:order-none">
             <Card>
               <CardContent className="pt-6">
                 <div className="flex items-center gap-3">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1931.

Closes #1931

---

## Claude summary

Committed. Summary:

The patient detail view's overview tab had a 3-tile grid (Status, Dodano, Pochodzenie klienta) sitting between the upcoming appointments card and the last-appointments / medical-info sections. On mobile (`<md`) the tiles stack vertically and pushed more important sections below the fold (related to the recent #1928 collapse change).

Fix in `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx:824-853`: switched the overview wrapper from `space-y-6` to `flex flex-col space-y-6`, and added `order-last md:order-none` to the 3-tile grid. Result: on mobile the tiles render after the upcoming, last-appointments, and medical-info cards; on `md+` the natural document order is restored, so the desktop layout is unchanged.

Typecheck passes; no other files touched.