### PR TITLE
Dokumenty do podpisu przez klienta/pacjenta

### DIFF
--- a/src/components/documents/document-form-filler.tsx
+++ b/src/components/documents/document-form-filler.tsx
@@ -23,6 +23,7 @@ interface DocumentFormFillerProps {
   filledByFilter?: "employee" | "client";
   initialValues?: Record<string, string>;
   submitLabel?: string;
+  hideTopAction?: boolean;
   onComplete: (fieldValues: Record<string, string>) => void;
   onCancel: () => void;
 }
@@ -36,6 +37,7 @@ export function DocumentFormFiller({
   filledByFilter,
   initialValues,
   submitLabel,
+  hideTopAction = false,
   onComplete,
   onCancel,
 }: DocumentFormFillerProps) {
@@ -76,14 +78,16 @@ export function DocumentFormFiller({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="flex gap-2">
-        <Button type="submit" className="flex-1">
-          {submitLabel ?? t("documentEditor.generate", "Generuj dokument")}
-        </Button>
-        <Button type="button" variant="outline" onClick={onCancel}>
-          {t("common.cancel", "Anuluj")}
-        </Button>
-      </div>
+      {!hideTopAction && (
+        <div className="flex gap-2">
+          <Button type="submit" className="flex-1">
+            {submitLabel ?? t("documentEditor.generate", "Generuj dokument")}
+          </Button>
+          <Button type="button" variant="outline" onClick={onCancel}>
+            {t("common.cancel", "Anuluj")}
+          </Button>
+        </div>
+      )}
 
       <p className="text-sm text-muted-foreground">
         {t(

--- a/src/routes/sign.form.$token.tsx
+++ b/src/routes/sign.form.$token.tsx
@@ -528,6 +528,11 @@ function DocumentSigningFlow({ token, document, template }: FlowProps) {
                 <DocumentFormFiller
                   formFields={formFields}
                   filledByFilter="client"
+                  hideTopAction
+                  submitLabel={t(
+                    "documents.signing.signButton",
+                    "Podpisz dokument",
+                  )}
                   onComplete={handleFormComplete}
                   onCancel={() => {
                     // No cancel action on public page — just a no-op


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1932.

Closes #1932

---

## Claude summary

Committed. Summary of the change:

On the public client-facing signing page (`src/routes/sign.form.$token.tsx`), the form-fill step used `DocumentFormFiller`, which always rendered "Generuj dokument" buttons at both the top and bottom of the form — confusing for a patient/client. I added an optional `hideTopAction` prop to `DocumentFormFiller` (`src/components/documents/document-form-filler.tsx`) and passed it from the client signing page along with `submitLabel={t("documents.signing.signButton", "Podpisz dokument")}`. The result is one primary action at the bottom of the form labeled "Podpisz dokument", shown after the document preview and the client's form fields — matching the requested UX. Employee-facing usages (`generate-document-dialog.tsx`, `after-completion-documents-dialog.tsx`, gabinet documents edit mode) don't pass the new prop and keep the existing top + bottom layout with "Generuj dokument".