### PR TITLE
Zmień etykietę przełącznika „Odziedziczone” na bardziej intuicyjną dla użytkowników biznesowych.

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2648,7 +2648,7 @@
         "shortDescription": "Short description",
         "active": "Active",
         "inactive": "Inactive",
-        "inherited": "Inherited",
+        "inherited": "Default",
         "overridden": "Custom",
         "inheritFromParent": "Inherit from parent",
         "useCustomValue": "Use custom value",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2665,7 +2665,7 @@
         "shortDescription": "Krótki opis",
         "active": "Aktywny",
         "inactive": "Nieaktywny",
-        "inherited": "Odziedziczone",
+        "inherited": "Domyślne",
         "overridden": "Własna wartość",
         "inheritFromParent": "Dziedzicz z zabiegu",
         "useCustomValue": "Użyj własnej wartości",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1934.

Closes #1934

---

## Claude summary

Renamed the variant override toggle label from "Odziedziczone" to "Domyślne" in `public/locales/pl/translation.json:2668`, and updated the EN counterpart to "Default" in `public/locales/en/translation.json:2651` for consistency. The key `gabinet.treatmentDetail.variants.inherited` is the single source for the label and is used in 7 places in `src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx` — 3 in the variant list badge view and 4 in the variant editor dialog (price, duration, short description, description), covering both the desktop and mobile renderings of the same component. Internal variable names like `priceInherited` were intentionally left unchanged per the issue's UI-only scope.