### PR TITLE
Dodaj możliwość ukrywania statystyk w widoku mobilnym za opcją „Pokaż statystyki”.

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -66,6 +66,8 @@
     "price": "Price",
     "processing": "Processing...",
     "stats": "Stats",
+    "showStats": "Show statistics",
+    "hideStats": "Hide statistics",
     "time": "Time",
     "titleRequired": "Title is required",
     "phoneTooShort": "Phone number must be at least 9 digits.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -66,6 +66,8 @@
     "price": "Cena",
     "processing": "Przetwarzanie...",
     "stats": "Statystyki",
+    "showStats": "Pokaż statystyki",
+    "hideStats": "Ukryj statystyki",
     "time": "Godzina",
     "titleRequired": "Tytuł jest wymagany",
     "phoneTooShort": "Numer telefonu musi mieć co najmniej 9 cyfr.",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
@@ -17,7 +17,8 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { useMemo, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { ReactNode } from "react";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
@@ -31,6 +32,8 @@ import {
   CheckCircle,
   XCircle,
   AlertCircle,
+  ChevronDown,
+  ChevronUp,
 } from "@/lib/ez-icons";
 
 // shadcn/studio statistics blocks
@@ -73,6 +76,7 @@ function GabinetDashboard() {
   const { organizationId } = useOrganization();
   const today = new Date().toISOString().split("T")[0];
   const todayScheduleRef = useRef<HTMLDivElement | null>(null);
+  const [showStatsMobile, setShowStatsMobile] = useState(false);
 
   useSidebarDispatch("viewTodaySchedule", () => {
     todayScheduleRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
@@ -265,8 +269,27 @@ function GabinetDashboard() {
         description={t("gabinet.dashboard.description")}
       />
 
+      {/* Mobile-only toggle: collapse KPI cards by default on small screens */}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setShowStatsMobile((s) => !s)}
+        aria-expanded={showStatsMobile}
+        className="md:hidden w-full justify-between"
+      >
+        {showStatsMobile ? t("common.hideStats") : t("common.showStats")}
+        {showStatsMobile ? (
+          <ChevronUp className="size-4" />
+        ) : (
+          <ChevronDown className="size-4" />
+        )}
+      </Button>
+
       {/* KPI Statistics Cards */}
-      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <div
+        className={`${showStatsMobile ? "grid" : "hidden md:grid"} gap-4 sm:grid-cols-2 xl:grid-cols-4`}
+      >
         <Link to="/dashboard/gabinet/calendar" className="block">
           <StatisticsOrderCard
             title={t("gabinet.dashboard.todayAppointments")}

--- a/src/routes/_app/_auth/dashboard/_layout.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { useConvexMutation } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
@@ -10,6 +10,7 @@ import { CrmPipelineChart } from "@/components/dashboard/crm-pipeline-chart";
 import { UpcomingActivities } from "@/components/dashboard/upcoming-activities";
 import { TopPerformers } from "@/components/dashboard/top-performers";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import type { ChartConfig } from "@/components/ui/chart";
 import { useDateRange } from "@/components/crm/date-range-context";
 
@@ -49,6 +50,8 @@ import {
   Trophy,
   DollarSign,
   CheckCircle,
+  ChevronDown,
+  ChevronUp,
 } from "@/lib/ez-icons";
 
 export const Route = createFileRoute("/_app/_auth/dashboard/_layout/")({
@@ -140,6 +143,7 @@ function DashboardIndex() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
   const { timeRange } = useDateRange();
+  const [showStatsMobile, setShowStatsMobile] = useState(false);
 
   // --- Auto-seed defaults for existing orgs ---
   const { data: sources } = useSupabaseSourcesList(organizationId);
@@ -339,15 +343,36 @@ function DashboardIndex() {
         description={t("dashboard.subtitle")}
       />
 
+      {/* Mobile-only toggle: collapse KPI cards by default on small screens */}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setShowStatsMobile((s) => !s)}
+        aria-expanded={showStatsMobile}
+        className="md:hidden w-full justify-between"
+      >
+        {showStatsMobile ? t("common.hideStats") : t("common.showStats")}
+        {showStatsMobile ? (
+          <ChevronUp className="size-4" />
+        ) : (
+          <ChevronDown className="size-4" />
+        )}
+      </Button>
+
       {/* KPI Statistics Cards */}
       {statsLoading ? (
-        <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-5">
+        <div
+          className={`${showStatsMobile ? "grid" : "hidden md:grid"} gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-5`}
+        >
           {Array.from({ length: 5 }).map((_, i) => (
             <Skeleton key={i} className="h-52 w-full rounded-lg" />
           ))}
         </div>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-5">
+        <div
+          className={`${showStatsMobile ? "grid" : "hidden md:grid"} gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-5`}
+        >
           <StatisticsOrderCard
             title={t("dashboard.totalContacts")}
             description="Total"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1935.

Closes #1935

---

## Claude summary

Committed. Summary of changes:

Added a "Pokaż statystyki" / "Ukryj statystyki" toggle button visible only on mobile (`<md`) on both dashboards — the CRM dashboard (`src/routes/_app/_auth/dashboard/_layout.index.tsx`) and the Gabinet dashboard (`src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx`). The KPI stats grid is `hidden` by default on mobile and gets toggled to `grid` when the user expands; on desktop the `md:grid` utility always wins so layout is unchanged. Added `common.showStats` / `common.hideStats` translations in PL and EN.