### PR TITLE
Preserve multi-line context in cleanConvexMessage

### DIFF
--- a/src/lib/format-action-error.test.ts
+++ b/src/lib/format-action-error.test.ts
@@ -137,4 +137,23 @@ describe("formatTreatmentError", () => {
     expect(msg).toContain("Czas trwania");
     expect(msg).toContain("to pole jest wymagane");
   });
+
+  it("surfaces field when Convex emits 'at path' on a follow-up line (issue #1966)", () => {
+    // Real Convex server-side validator errors put the `at path '...'` detail
+    // on a *separate* line from the headline. The pre-fix cleanConvexMessage
+    // dropped everything after the first line, so extractFieldValidationDetail
+    // could never see the path and the user got the generic fallback.
+    const err = new Error(
+      "[CONVEX A(gabinet/treatments:create)] [Request ID: xx] Server Error\n" +
+        "Uncaught ArgumentValidationError: Validator error: Expected `string`, got `null`\n" +
+        "    at path 'price'\n" +
+        "    at handler (../convex/gabinet/treatments.ts:42:13)\n" +
+        "  Called by client",
+    );
+    const msg = formatTreatmentError(err, t, {
+      key: "gabinet.treatments.errors.createFailed",
+      defaultValue: "Nie udało się utworzyć zabiegu.",
+    });
+    expect(msg).toContain("Cena");
+  });
 });

--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -229,11 +229,28 @@ function cleanConvexMessage(raw: string): string {
   msg = msg.replace(/^\s*Server Error\s*\n?/i, "");
 
   // Convex wraps the thrown reason as "Uncaught Error: <msg>" (or similar).
+  // Capture the headline plus up to 5 follow-up lines so multi-line validator
+  // detail like `at path 'foo.bar'` survives for extractFieldValidationDetail
+  // — without it the path matcher can never fire and the user falls back to
+  // the generic "nieprawidłowe dane" toast (issue #1966).
   const uncaught = msg.match(
-    /Uncaught\s+(?:Error|ConvexError|ArgumentValidationError|TypeError)\s*:\s*([^\n]+)/i,
+    /Uncaught\s+(?:Error|ConvexError|ArgumentValidationError|TypeError)\s*:\s*([^\n]+(?:\n[^\n]*){0,5})/i,
   );
   if (uncaught) {
-    return uncaught[1].trim();
+    return uncaught[1]
+      .split(/\r?\n/)
+      .filter((line) => {
+        const trimmed = line.trim();
+        if (!trimmed) return false;
+        if (/^Called by client\s*$/i.test(trimmed)) return false;
+        // Drop stack frames ("at fn (file:N:N)" or bare "at fn") but keep
+        // validator detail lines like "at path 'foo.bar'".
+        if (/^at\s+path\b/i.test(trimmed)) return true;
+        if (/^at\s+\S/i.test(trimmed)) return false;
+        return true;
+      })
+      .join("\n")
+      .trim();
   }
 
   // Strip stack trace lines and any "Called by client" suffix.


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1966.

Closes #1966

---

## Claude summary

Committed.

Summary: `cleanConvexMessage` in `src/lib/format-action-error.ts` previously truncated to the first line, so Convex's `at path 'X'` follow-up never reached `extractFieldValidationDetail`'s multi-line `validatorAtPath` regex. Fixed by capturing up to 5 follow-up lines after the `Uncaught …:` headline and filtering out `Called by client` plus classic stack frames while preserving `at path '...'` detail. Added a regression test that asserts `Cena` surfaces from a multi-line `Validator error: Expected 'string', got 'null' / at path 'price'`. All 14 tests in `format-action-error.test.ts` pass.