### PR TITLE
Wypełnia

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -775,7 +775,7 @@
       "addDescription": "Choose a document template and specify when it should be filled in.",
       "searchPlaceholder": "Search template...",
       "noTemplates": "No templates available",
-      "timing": "When document is required",
+      "timing": "When to fill in",
       "toggleTiming": "Click to change timing",
       "added": "Required document added",
       "removed": "Required document removed"

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -776,7 +776,7 @@
       "addDescription": "Wybierz szablon dokumentu i określ, kiedy powinien zostać wypełniony.",
       "searchPlaceholder": "Szukaj szablonu...",
       "noTemplates": "Brak dostępnych szablonów",
-      "timing": "Moment wymagania dokumentu",
+      "timing": "Moment wypełnienia",
       "toggleTiming": "Kliknij, aby zmienić moment",
       "added": "Dodano wymagany dokument",
       "removed": "Usunięto wymagany dokument"

--- a/src/components/documents/treatment-required-documents-field.tsx
+++ b/src/components/documents/treatment-required-documents-field.tsx
@@ -271,7 +271,7 @@ export function TreatmentRequiredDocumentsField({
               <label className="text-sm font-medium">
                 {t(
                   "documents.requiredDocs.timing",
-                  "Moment wymagania dokumentu",
+                  "Moment wypełnienia",
                 )}
               </label>
               <Select

--- a/src/components/documents/treatment-required-documents.tsx
+++ b/src/components/documents/treatment-required-documents.tsx
@@ -370,7 +370,7 @@ export function TreatmentRequiredDocuments({
               <label className="text-sm font-medium">
                 {t(
                   "documents.requiredDocs.timing",
-                  "Moment wymagania dokumentu",
+                  "Moment wypełnienia",
                 )}
               </label>
               <Select


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1939.

Closes #1939

---

## Claude summary

Done. Committed `ea578d3` on `claude/issue-1939` (rebased onto current `origin/main`).

What changed: the timing-selector label in the "Dodaj wymagany dokument" picker is now back to `Moment wypełnienia` (proper Polish spelling — the pre-#1940 label was `Moment wypelnienia` without the diacritic, which was clearly a typo). The label `Wypełnia:` introduced by PR #1940 had already been replaced with `Moment wymagania dokumentu` in PR #1952 when the during_visit option was added, but neither matched the original wording @aslocka asked for.

Files touched (4 lines total): `treatment-required-documents-field.tsx:274`, `treatment-required-documents.tsx:373` (TSX fallbacks), plus `public/locales/pl/translation.json` (`Moment wymagania dokumentu` → `Moment wypełnienia`) and `public/locales/en/translation.json` (`When document is required` → `When to fill in`, to keep EN aligned with the PL meaning).

The `Przed wizyta` → `Przed wizytą` grammar fix from #1940 is intentionally left in place — @aslocka's request was scoped to the label name, not the grammar correction.