### PR TITLE
Klawiatura 

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -234,6 +234,7 @@ export function TreatmentForm({
           </Label>
           <Input
             type="number"
+            inputMode="numeric"
             min="1"
             value={duration}
             onChange={(e) => setDuration(e.target.value)}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1970.

Closes #1970

---

## Claude summary

Fixed the iOS Safari keyboard inconsistency in the treatment form. The "Czas trwania (minuty)" field at `src/components/gabinet/treatment-form.tsx:235` had only `type="number"`, which iOS Safari does not reliably honor. Added `inputMode="numeric"` to mirror the adjacent price field (which uses `inputMode="decimal"`), so both numeric fields now open a numeric keyboard on mobile.