### PR TITLE
Statystyki 

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -24,7 +24,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Plus, Pencil, Trash2, Power, X, LayoutDashboard } from "@/lib/ez-icons";
+import { Plus, Pencil, Trash2, Power, X, LayoutDashboard, ChevronDown, ChevronUp } from "@/lib/ez-icons";
 import type { SavedView, FieldDef, FilterCondition } from "@/components/crm/types";
 import { Id } from "@cvx/_generated/dataModel";
 import type { MappedGabinetTreatment } from "@/lib/supabase/mappers/gabinet/treatments";
@@ -88,6 +88,7 @@ function TreatmentsIndex() {
   const [categoriesSlideoutOpen, setCategoriesSlideoutOpen] = useState(false);
   const [filterSlideoutOpen, setFilterSlideoutOpen] = useState(false);
   const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor | undefined>(undefined);
+  const [showStatsMobile, setShowStatsMobile] = useState(false);
 
   useSidebarDispatch("manageTags", () => setTagsSlideoutOpen(true));
   useSidebarDispatch("manageCategories", () => setCategoriesSlideoutOpen(true));
@@ -612,8 +613,25 @@ function TreatmentsIndex() {
         onFiltersChange={setActiveFilters}
       />
 
+      {/* Mobile-only toggle: collapse KPI cards by default on small screens */}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setShowStatsMobile((s) => !s)}
+        aria-expanded={showStatsMobile}
+        className="md:hidden w-full justify-between"
+      >
+        {showStatsMobile ? t("common.hideStats") : t("common.showStats")}
+        {showStatsMobile ? (
+          <ChevronUp className="size-4" />
+        ) : (
+          <ChevronDown className="size-4" />
+        )}
+      </Button>
+
       {/* KPI Statistics Cards */}
-      <div className="grid gap-4 sm:grid-cols-3">
+      <div className={`${showStatsMobile ? "grid" : "hidden md:grid"} gap-4 sm:grid-cols-3`}>
         <StatisticsOrderCard
           title={t("gabinet.treatments.totalTreatments", "Zabiegi")}
           description={t("gabinet.treatments.inCatalog", "W katalogu")}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1942.

Closes #1942

---

## Claude summary

Committed as `4f30989` on `claude/issue-1942`.

The user's screenshot revealed the page in question was the Gabinet treatments list (`/dashboard/gabinet/treatments`), not the dashboards that #1965 already fixed. That page had its own 3 KPI cards ("W katalogu", "Wykonane w tym mies.", "Najpopularniejszy") with no mobile toggle. I applied the same pattern from #1965: a `md:hidden` outline button labelled with the existing `common.showStats`/`common.hideStats` i18n keys, plus `hidden md:grid` on the KPI grid so it collapses on mobile and stays visible on desktop. Typecheck passes.