### PR TITLE
Klawiatura 

### DIFF
--- a/src/components/crm/activity-form.tsx
+++ b/src/components/crm/activity-form.tsx
@@ -353,6 +353,7 @@ export function ActivityForm({
             })}
             <Input
               type="number"
+              inputMode="numeric"
               min={5}
               step={5}
               className="w-20 h-8 text-xs"
@@ -384,6 +385,7 @@ export function ActivityForm({
               </button>
               <Input
                 type="number"
+                inputMode="numeric"
                 className="w-24 pl-7"
                 value={reminderValue}
                 onChange={(e) => setReminderValue(e.target.value)}

--- a/src/components/crm/lead-products-sidebar-card.tsx
+++ b/src/components/crm/lead-products-sidebar-card.tsx
@@ -151,6 +151,7 @@ export function LeadProductsDialogBody({
           <Input
             id="lead-product-quantity"
             type="number"
+            inputMode="numeric"
             min="1"
             step="1"
             value={quantity}

--- a/src/components/custom-fields/custom-field-renderer.tsx
+++ b/src/components/custom-fields/custom-field-renderer.tsx
@@ -88,6 +88,7 @@ export function CustomFieldRenderer({
           </Label>
           <Input
             type="number"
+            inputMode="decimal"
             value={(value as number) ?? ""}
             onChange={(e) =>
               onChange(e.target.value ? Number(e.target.value) : null)

--- a/src/components/data-table/editable-cell.tsx
+++ b/src/components/data-table/editable-cell.tsx
@@ -181,7 +181,7 @@ export function EditableCell({
         );
       case "number":
         return (
-          <Input ref={inputRef} type="number" value={editValue ?? ""} onChange={(e) => setEditValue(e.target.valueAsNumber || "")}
+          <Input ref={inputRef} type="number" inputMode="decimal" value={editValue ?? ""} onChange={(e) => setEditValue(e.target.valueAsNumber || "")}
             min={config.min} max={config.max} step={config.step} placeholder={config.placeholder} {...inputProps} />
         );
       case "date":

--- a/src/components/forms/lead-form.tsx
+++ b/src/components/forms/lead-form.tsx
@@ -176,6 +176,7 @@ export function LeadForm({
           <Label>{t('leadForm.value')}</Label>
           <Input
             type="number"
+            inputMode="decimal"
             value={value}
             onChange={(e) => setValue(e.target.value)}
             placeholder="0"

--- a/src/components/forms/package-form.tsx
+++ b/src/components/forms/package-form.tsx
@@ -177,6 +177,7 @@ export function PackageForm({
           <Label>{t("gabinet.packages.validityDays")}</Label>
           <Input
             type="number"
+            inputMode="numeric"
             min="1"
             value={validityDays}
             onChange={(e) => setValidityDays(e.target.value)}
@@ -187,6 +188,7 @@ export function PackageForm({
           <Label>{t("gabinet.packages.discountPercent")}</Label>
           <Input
             type="number"
+            inputMode="numeric"
             min="0"
             max="100"
             value={discountPercent}
@@ -198,6 +200,7 @@ export function PackageForm({
           <Label>{t("gabinet.packages.loyaltyPoints")}</Label>
           <Input
             type="number"
+            inputMode="numeric"
             min="0"
             value={loyaltyPoints}
             onChange={(e) => setLoyaltyPoints(e.target.value)}
@@ -260,6 +263,7 @@ export function PackageForm({
                 </Label>
                 <Input
                   type="number"
+                  inputMode="numeric"
                   min="1"
                   value={st.quantity}
                   onChange={(e) =>

--- a/src/components/forms/product-form.tsx
+++ b/src/components/forms/product-form.tsx
@@ -144,6 +144,7 @@ export function ProductForm({
           </Label>
           <Input
             type="number"
+            inputMode="decimal"
             min={0}
             step={0.01}
             value={unitPrice}

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -2108,6 +2108,7 @@ export function AppointmentPreviewContent({
                     </Label>
                     <Input
                       type="number"
+                      inputMode="numeric"
                       min={1}
                       max={
                         selectedPackageEntry

--- a/src/components/gabinet/documentation-tab.tsx
+++ b/src/components/gabinet/documentation-tab.tsx
@@ -524,6 +524,7 @@ export function DocumentationTab({
                   {paramType === "number" && (
                     <Input
                       type="number"
+                      inputMode="decimal"
                       value={String(param.value ?? "")}
                       onChange={(e) => handleParamChange(i, e.target.value)}
                       placeholder="—"

--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -234,6 +234,7 @@ export function TreatmentForm({
           </Label>
           <Input
             type="number"
+            inputMode="numeric"
             min="1"
             value={duration}
             onChange={(e) => setDuration(e.target.value)}

--- a/src/routes/_app/_auth/dashboard/_layout.email-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.email-templates.index.tsx
@@ -601,6 +601,7 @@ function EventBindingsTab() {
               <Label>{t("emailTemplates.priority")}</Label>
               <Input
                 type="number"
+                inputMode="numeric"
                 value={editPriority}
                 onChange={(e) => setEditPriority(e.target.value)}
                 min={0}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -2956,6 +2956,7 @@ function AppointmentDetail() {
                   </div>
                   <Input
                     type="number"
+                    inputMode="numeric"
                     className="w-20"
                     min={0}
                     max={item.remaining}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -2187,6 +2187,7 @@ function DetailedDataTab({
                   <Label>{t("gabinet.employees.detailedData.yearsOfExperience")}</Label>
                   <Input
                     type="number"
+                    inputMode="numeric"
                     min={0}
                     value={formData.yearsOfExperience}
                     onChange={(e) => setFormData({ ...formData, yearsOfExperience: e.target.value })}
@@ -2391,6 +2392,7 @@ function DetailedDataTab({
                   <Label>{t("gabinet.employees.detailedData.baseSalary")}</Label>
                   <Input
                     type="number"
+                    inputMode="decimal"
                     min={0}
                     step={0.01}
                     value={formData.baseSalary}
@@ -2402,6 +2404,7 @@ function DetailedDataTab({
                   <Label>{t("gabinet.employees.detailedData.commissionPercent")}</Label>
                   <Input
                     type="number"
+                    inputMode="decimal"
                     min={0}
                     max={100}
                     step={0.1}
@@ -2657,6 +2660,7 @@ function AssignedItemsTab({
                   </Label>
                   <Input
                     type="number"
+                    inputMode="numeric"
                     min={1}
                     value={newQuantity}
                     onChange={(e) => setNewQuantity(e.target.value)}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -596,21 +596,21 @@ function PackagesIndex() {
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
               <Label>{t("gabinet.packages.totalPrice")}</Label>
-              <Input type="number" value={totalPrice} onChange={(e) => setTotalPrice(e.target.value)} />
+              <Input type="number" inputMode="decimal" value={totalPrice} onChange={(e) => setTotalPrice(e.target.value)} />
             </div>
             <div className="space-y-1.5">
               <Label>{t("gabinet.packages.validityDays")}</Label>
-              <Input type="number" value={validityDays} onChange={(e) => setValidityDays(e.target.value)} />
+              <Input type="number" inputMode="numeric" value={validityDays} onChange={(e) => setValidityDays(e.target.value)} />
             </div>
           </div>
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
               <Label>{t("gabinet.packages.discountPercent")}</Label>
-              <Input type="number" value={discountPercent} onChange={(e) => setDiscountPercent(e.target.value)} />
+              <Input type="number" inputMode="numeric" value={discountPercent} onChange={(e) => setDiscountPercent(e.target.value)} />
             </div>
             <div className="space-y-1.5">
               <Label>{t("gabinet.packages.loyaltyPoints")}</Label>
-              <Input type="number" value={loyaltyPoints} onChange={(e) => setLoyaltyPoints(e.target.value)} />
+              <Input type="number" inputMode="numeric" value={loyaltyPoints} onChange={(e) => setLoyaltyPoints(e.target.value)} />
             </div>
           </div>
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
@@ -282,6 +282,7 @@ function LeaveTypeDialog({
             <Label>{t("gabinet.leaveTypes.annualQuota")}</Label>
             <Input
               type="number"
+              inputMode="numeric"
               min={0}
               value={quota}
               onChange={(e) => setQuota(e.target.value)}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.reminders.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.reminders.tsx
@@ -94,6 +94,7 @@ function ReminderSettings() {
             <Input
               id="hoursBefore"
               type="number"
+              inputMode="numeric"
               className="w-32"
               min={1}
               max={168}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -1415,6 +1415,7 @@ function TreatmentDetail() {
               {variantForm.overrideDuration ? (
                 <Input
                   type="number"
+                  inputMode="numeric"
                   value={variantForm.duration}
                   onChange={(e) =>
                     setVariantForm((prev) => ({ ...prev, duration: e.target.value }))

--- a/src/routes/_app/_auth/dashboard/_layout.settings.email-sequences.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.email-sequences.tsx
@@ -714,6 +714,7 @@ function StepRow({
           <Input
             id={`step-delay-${step._id}`}
             type="number"
+            inputMode="numeric"
             min={0}
             className="h-8 w-20 text-xs"
             value={delayHours}

--- a/src/routes/_app/_auth/dashboard/_layout.settings.pipelines.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.pipelines.tsx
@@ -401,6 +401,7 @@ function StageActions({
               <Label className="text-xs">{t("stageActions.dueInDays")}</Label>
               <Input
                 type="number"
+                inputMode="numeric"
                 min={0}
                 value={dueInDays}
                 onChange={(e) => setDueInDays(Number(e.target.value))}

--- a/src/routes/_app/_auth/dashboard/_layout.setup.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.setup.tsx
@@ -296,6 +296,7 @@ function SetupWizard() {
                     placeholder={t("onboarding.price")}
                     className="w-24"
                     type="number"
+                    inputMode="decimal"
                   />
                   <Input
                     aria-label={t("onboarding.duration")}
@@ -304,6 +305,7 @@ function SetupWizard() {
                     placeholder={t("onboarding.duration")}
                     className="w-20"
                     type="number"
+                    inputMode="numeric"
                   />
                   {treatments.length > 1 && (
                     <Button


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1970.

Closes #1970

---

## Claude summary

Committed as `bba829d`. The narrower duration-only fix from the earlier reply (`863354e`) is already on this branch; my commit completes the broader audit @aslocka asked for in the follow-up comment.

Summary: I added `inputMode="numeric"` to all integer `type="number"` Inputs (durations, days, hours, quantities, counts, priority) and `inputMode="decimal"` to fields that accept decimals (salary `step=0.01`, commission `step=0.1`, package totalPrice, product unitPrice, lead value, custom-field renderer, generic editable-cell, documentation parameter, onboarding price). 19 files changed, +30/−5 lines. Recharts `<XAxis type="number">` and unused `shadcn-studio/blocks/*` template files were intentionally excluded. `npm run typecheck` passes.