### PR TITLE
Zapisać Zabieg

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -65,6 +65,10 @@ interface TreatmentFormProps {
   isSubmitting?: boolean;
   categorySelector?: React.ReactNode;
   children?: React.ReactNode;
+  // Server-rejection messages keyed by TreatmentFormData field name. Lets the
+  // route surface "Cena — to pole jest wymagane" next to the bad input
+  // instead of only as a toast (#1972).
+  fieldErrors?: Partial<Record<keyof TreatmentFormData, string>>;
 }
 
 // VAT-exempt ("zwolniony") is tracked as a separate boolean (taxExempt) on the
@@ -96,6 +100,7 @@ export function TreatmentForm({
   isSubmitting = false,
   categorySelector,
   children,
+  fieldErrors,
 }: TreatmentFormProps) {
   const { t } = useTranslation();
   const [name, setName] = useState(initialData?.name ?? "");
@@ -215,6 +220,18 @@ export function TreatmentForm({
     });
   };
 
+  const fieldErr = (key: keyof TreatmentFormData) => fieldErrors?.[key];
+  const errorClass = "border-destructive focus-visible:ring-destructive";
+  const renderFieldError = (key: keyof TreatmentFormData) => {
+    const msg = fieldErr(key);
+    if (!msg) return null;
+    return (
+      <p className="text-xs text-destructive" role="alert">
+        {msg}
+      </p>
+    );
+  };
+
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       <div className="grid gap-4 sm:grid-cols-2">
@@ -226,7 +243,10 @@ export function TreatmentForm({
             value={name}
             onChange={(e) => setName(e.target.value)}
             required
+            aria-invalid={!!fieldErr("name")}
+            className={fieldErr("name") ? errorClass : undefined}
           />
+          {renderFieldError("name")}
         </div>
         <div className="space-y-1.5">
           <Label>
@@ -241,7 +261,10 @@ export function TreatmentForm({
             onWheel={(e) => (e.currentTarget as HTMLInputElement).blur()}
             placeholder="30"
             required
+            aria-invalid={!!fieldErr("duration")}
+            className={fieldErr("duration") ? errorClass : undefined}
           />
+          {renderFieldError("duration")}
         </div>
         <div className="space-y-1.5">
           <Label>
@@ -259,7 +282,10 @@ export function TreatmentForm({
             }}
             placeholder="0.00"
             required
+            aria-invalid={!!fieldErr("price")}
+            className={fieldErr("price") ? errorClass : undefined}
           />
+          {renderFieldError("price")}
         </div>
         <div className="space-y-1.5">
           <Label>{t("gabinet.treatments.currency")}</Label>
@@ -267,12 +293,18 @@ export function TreatmentForm({
             value={currency}
             onChange={(e) => setCurrency(e.target.value)}
             placeholder="PLN"
+            aria-invalid={!!fieldErr("currency")}
+            className={fieldErr("currency") ? errorClass : undefined}
           />
+          {renderFieldError("currency")}
         </div>
         <div className="space-y-1.5">
           <Label>{t("gabinet.treatments.taxRate")}</Label>
           <Select value={taxRate} onValueChange={setTaxRate}>
-            <SelectTrigger>
+            <SelectTrigger
+              aria-invalid={!!fieldErr("taxRate")}
+              className={fieldErr("taxRate") ? errorClass : undefined}
+            >
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -283,6 +315,7 @@ export function TreatmentForm({
               ))}
             </SelectContent>
           </Select>
+          {renderFieldError("taxRate")}
         </div>
         <div className="space-y-1.5">
           <Label>{t("gabinet.treatments.package", "Pakiet")}</Label>
@@ -310,7 +343,10 @@ export function TreatmentForm({
               value={selectedPackageId}
               onValueChange={setSelectedPackageId}
             >
-              <SelectTrigger>
+              <SelectTrigger
+                aria-invalid={!!fieldErr("packageId")}
+                className={fieldErr("packageId") ? errorClass : undefined}
+              >
                 <SelectValue
                   placeholder={t(
                     "gabinet.treatments.selectPackagePlaceholder",
@@ -335,6 +371,7 @@ export function TreatmentForm({
                 )}
               </SelectContent>
             </Select>
+            {renderFieldError("packageId")}
             <p className="text-xs text-muted-foreground">
               {t(
                 "gabinet.treatments.linkedPackageHint",
@@ -482,6 +519,7 @@ export function TreatmentForm({
               )}
             </PopoverContent>
           </Popover>
+          {renderFieldError("requiredEquipmentIds")}
           {hasLegacyEquipment && (
             <p className="text-xs text-muted-foreground">
               {t("gabinet.treatments.legacyEquipment", "Legacy (text):")} {legacyEquipment.join(", ")}

--- a/src/lib/format-action-error.test.ts
+++ b/src/lib/format-action-error.test.ts
@@ -2,6 +2,7 @@ import type { TFunction } from "i18next";
 import { describe, expect, it } from "vitest";
 import {
   extractFieldValidationDetail,
+  extractTreatmentFieldError,
   formatTreatmentError,
 } from "./format-action-error";
 
@@ -136,6 +137,33 @@ describe("formatTreatmentError", () => {
     });
     expect(msg).toContain("Czas trwania");
     expect(msg).toContain("to pole jest wymagane");
+  });
+
+  it("maps snake_case Postgres column to camelCase form field (issue #1972)", () => {
+    const err = new Error(
+      'supabaseDb.insert(gabinetTreatments): null value in column "tax_rate" of relation "gabinet_treatments" violates not-null constraint',
+    );
+    expect(extractTreatmentFieldError(err)).toEqual({
+      field: "taxRate",
+      reason: "to pole jest wymagane",
+    });
+  });
+
+  it("maps Convex camelCase argument to form field (issue #1972)", () => {
+    const err = new Error(
+      "[CONVEX A(gabinet/treatments:create)] [Request ID: xx] Server Error\n" +
+        "Uncaught ArgumentValidationError: Validator error: Expected `string`, got `null`\n" +
+        "    at path 'price'\n" +
+        "  Called by client",
+    );
+    expect(extractTreatmentFieldError(err)).toEqual({
+      field: "price",
+      reason: "nieprawidłowa wartość",
+    });
+  });
+
+  it("returns null for non-field errors so route falls back to toast only (issue #1972)", () => {
+    expect(extractTreatmentFieldError(new Error("Permission denied"))).toBeNull();
   });
 
   it("surfaces field when Convex emits 'at path' on a follow-up line (issue #1966)", () => {

--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -415,6 +415,67 @@ export function formatTreatmentError(
   return t(fallback.key, { defaultValue: fallback.defaultValue });
 }
 
+// Map raw column / argument names from extractFieldValidationDetail to the
+// camelCase form-state keys used inside TreatmentForm. Lets the route surface
+// inline errors next to the offending input (#1972 — generic toast hid which
+// field was wrong, especially on mobile where the toast can be missed).
+const TREATMENT_FIELD_ALIASES: Record<string, string> = {
+  // Snake-case (Postgres column names)
+  name: "name",
+  duration: "duration",
+  price: "price",
+  currency: "currency",
+  tax_rate: "taxRate",
+  tax_exempt: "taxRate",
+  required_equipment: "requiredEquipmentIds",
+  required_equipment_ids: "requiredEquipmentIds",
+  package_id: "packageId",
+  category_id: "categoryId",
+  tag_ids: "tagIds",
+  description: "description",
+  contraindications: "contraindications",
+  preparation_instructions: "preparationInstructions",
+  aftercare_instructions: "aftercareInstructions",
+  requires_approval: "requiresApproval",
+  color: "color",
+  treatment_count: "treatmentCount",
+  required_form_templates: "requiredFormTemplates",
+  // Convex camelCase variants (argument validators name these directly)
+  taxRate: "taxRate",
+  taxExempt: "taxRate",
+  requiredEquipment: "requiredEquipmentIds",
+  requiredEquipmentIds: "requiredEquipmentIds",
+  packageId: "packageId",
+  categoryId: "categoryId",
+  tagIds: "tagIds",
+  preparationInstructions: "preparationInstructions",
+  aftercareInstructions: "aftercareInstructions",
+  requiresApproval: "requiresApproval",
+  treatmentCount: "treatmentCount",
+  requiredFormTemplates: "requiredFormTemplates",
+};
+
+// Return the treatment-form input key (camelCase) blamed by the action error
+// together with the short Polish reason from extractFieldValidationDetail,
+// or null when the error cannot be tied to a specific input. Callers use the
+// field key to highlight the right control inline and the reason as the
+// per-field error message (#1972).
+export interface TreatmentFieldError {
+  field: string;
+  reason: string;
+}
+
+export function extractTreatmentFieldError(
+  err: unknown,
+): TreatmentFieldError | null {
+  const inner = extractActionErrorMessage(err);
+  const detail = extractFieldValidationDetail(inner);
+  if (!detail) return null;
+  const field = TREATMENT_FIELD_ALIASES[detail.rawField];
+  if (!field) return null;
+  return { field, reason: detail.reason };
+}
+
 const GENERIC_ERROR_MAP: Array<{
   test: (msg: string) => boolean;
   key: string;

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -39,7 +39,7 @@ import { CategoriesManagerSlideout } from "@/components/categories-tags/categori
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
-import { formatTreatmentError } from "@/lib/format-action-error";
+import { formatTreatmentError, extractTreatmentFieldError } from "@/lib/format-action-error";
 import { reportError } from "@/lib/error-reporter";
 
 // shadcn/studio statistics blocks
@@ -132,6 +132,9 @@ function TreatmentsIndex() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [tagIds, setTagIds] = useState<Id<"tagDefinitions">[]>([]);
   const [categoryId, setCategoryId] = useState<Id<"categoryDefinitions"> | undefined>(undefined);
+  const [fieldErrors, setFieldErrors] = useState<
+    Partial<Record<keyof TreatmentFormData, string>>
+  >({});
 
   const systemViews = useMemo(
     (): SavedView[] => [
@@ -428,6 +431,7 @@ function TreatmentsIndex() {
     setEditingTreatment(null);
     setTagIds([]);
     setCategoryId(undefined);
+    setFieldErrors({});
     setPanelOpen(true);
   };
 
@@ -435,12 +439,14 @@ function TreatmentsIndex() {
     setEditingTreatment(treatment);
     setTagIds((treatment.tagIds as Id<"tagDefinitions">[]) ?? []);
     setCategoryId(treatment.categoryId as Id<"categoryDefinitions"> | undefined);
+    setFieldErrors({});
     setPanelOpen(true);
   };
 
   const handleSubmit = useCallback(
     async (formData: TreatmentFormData) => {
       setIsSubmitting(true);
+      setFieldErrors({});
       try {
         if (editingTreatment) {
           await updateTreatment({
@@ -478,6 +484,12 @@ function TreatmentsIndex() {
           }),
           organizationId,
         });
+        const fieldError = extractTreatmentFieldError(e);
+        if (fieldError) {
+          setFieldErrors({
+            [fieldError.field as keyof TreatmentFormData]: fieldError.reason,
+          });
+        }
         toast.error(
           formatTreatmentError(e, t, {
             key: editingTreatment
@@ -809,6 +821,7 @@ function TreatmentsIndex() {
             setEditingTreatment(null);
           }}
           isSubmitting={isSubmitting}
+          fieldErrors={fieldErrors}
           categorySelector={
             <CategoryPicker
               categories={categories}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1972.

Closes #1972

---

## Claude summary

Committed as `0c081d9` on branch `claude/issue-1972`.

Summary: completed the partially-staged work on this branch. The route now sets `fieldErrors` from `extractTreatmentFieldError(e)` in the catch handler, passes them into `<TreatmentForm fieldErrors={…} />`, and resets them on open/edit panel and at the start of each submit. The form draws red borders + `aria-invalid` + inline error text on the matching input, alongside the existing toast. Added a small helper `extractTreatmentFieldError` (returning `{ field, reason }`) plus three unit tests covering snake_case → camelCase mapping, Convex camelCase mapping, and the null-fallback.

I didn't change the Convex create/update validators or the form payload itself. The issue body suggested investigating "which field is being rejected" — but without the Jam recording's network log, the actual rejecting field is unknown, and a quick read of the validator vs. the form payload shows them as compatible for a typical filled-out form. The existing field-detection in `formatTreatmentError` already produces a localized toast; this change just plumbs that same detail to the input instead of swallowing it. If a real rejection persists after this, the inline error will name the field so the next iteration can target it directly.

## Follow-ups
- Resolve pre-existing TS2589 in src/components/gabinet/treatment-form.tsx:136: `useAction(api.gabinet.equipment.listEquipment)` already throws "Type instantiation is excessively deep" on main; same anti-pattern as #585 — likely needs a typed wrapper or generic narrowing.