### PR TITLE
Expose `column.meta.label` in DataTableViewOptions

### DIFF
--- a/src/components/data-table/data-table-view-options.tsx
+++ b/src/components/data-table/data-table-view-options.tsx
@@ -1,4 +1,4 @@
-import { Table } from "@tanstack/react-table";
+import { Column, RowData, Table } from "@tanstack/react-table";
 import { Settings2 } from "@/lib/ez-icons";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
@@ -11,8 +11,23 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
+declare module "@tanstack/react-table" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    label?: string;
+  }
+}
+
 interface DataTableViewOptionsProps<TData> {
   table: Table<TData>;
+}
+
+function getColumnLabel<TData>(col: Column<TData, unknown>): string {
+  const metaLabel = col.columnDef.meta?.label;
+  if (metaLabel) return metaLabel;
+  const header = col.columnDef.header;
+  if (typeof header === "string" && header.length > 0) return header;
+  return col.id;
 }
 
 export function DataTableViewOptions<TData>({
@@ -44,7 +59,7 @@ export function DataTableViewOptions<TData>({
               checked={col.getIsVisible()}
               onCheckedChange={(value) => col.toggleVisibility(!!value)}
             >
-              {col.id}
+              {getColumnLabel(col)}
             </DropdownMenuCheckboxItem>
           ))}
       </DropdownMenuContent>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1983.

Closes #1983

---

## Claude summary

Committed. Summary: in `src/components/data-table/data-table-view-options.tsx` the column toggle now reads `col.columnDef.meta?.label` first, then a string `header`, then falls back to `col.id`. `ColumnMeta` is augmented with an optional `label` field so callers can pass a translated, user-facing name (e.g. via `t('contacts.columns.firstName')`).

Existing callers that don't set `meta.label` keep working — they either get the string `header` (e.g. "First name") or, if `header` is a render function or empty, the raw id like before. Nothing breaks; the path simply prefers a better label when one is provided.