### PR TITLE
Translate residual literals surfaced in `src/components/ui/`

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -87,7 +87,24 @@
     },
     "previous": "Previous",
     "next": "Next",
-    "select": "Select"
+    "select": "Select",
+    "command": "Command",
+    "sidebar": "Sidebar",
+    "sidebarMobileDescription": "Displays the mobile sidebar.",
+    "toggleSidebar": "Toggle Sidebar",
+    "indent": "Indent",
+    "outdent": "Outdent",
+    "todo": "Todo",
+    "listStyles": {
+      "default": "Default",
+      "circle": "Circle",
+      "square": "Square",
+      "decimal": "Decimal (1, 2, 3)",
+      "lowerAlpha": "Lower Alpha (a, b, c)",
+      "upperAlpha": "Upper Alpha (A, B, C)",
+      "lowerRoman": "Lower Roman (i, ii, iii)",
+      "upperRoman": "Upper Roman (I, II, III)"
+    }
   },
   "nav": {
     "deals": "Deals",
@@ -380,7 +397,8 @@
     "perPage": "{{count}} per page",
     "pageSize": "Page Size",
     "pageLabel": "Page",
-    "ofTotal": "of {{total}}"
+    "ofTotal": "of {{total}}",
+    "morePages": "More pages"
   },
   "table": {
     "columns": "Columns",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -87,7 +87,24 @@
     },
     "previous": "Poprzedni",
     "next": "Następny",
-    "select": "Wybierz"
+    "select": "Wybierz",
+    "command": "Polecenia",
+    "sidebar": "Pasek boczny",
+    "sidebarMobileDescription": "Wyświetla mobilny pasek boczny.",
+    "toggleSidebar": "Przełącz pasek boczny",
+    "indent": "Zwiększ wcięcie",
+    "outdent": "Zmniejsz wcięcie",
+    "todo": "Lista zadań",
+    "listStyles": {
+      "default": "Domyślny",
+      "circle": "Okrąg",
+      "square": "Kwadrat",
+      "decimal": "Dziesiętne (1, 2, 3)",
+      "lowerAlpha": "Małe litery (a, b, c)",
+      "upperAlpha": "Wielkie litery (A, B, C)",
+      "lowerRoman": "Małe rzymskie (i, ii, iii)",
+      "upperRoman": "Wielkie rzymskie (I, II, III)"
+    }
   },
   "nav": {
     "deals": "Transakcje",
@@ -380,7 +397,8 @@
     "perPage": "{{count}} na stronę",
     "pageSize": "Rozmiar strony",
     "pageLabel": "Strona",
-    "ofTotal": "z {{total}}"
+    "ofTotal": "z {{total}}",
+    "morePages": "Więcej stron"
   },
   "table": {
     "columns": "Kolumny",

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -26,11 +26,12 @@ const Command = React.forwardRef<
 Command.displayName = CommandPrimitive.displayName
 
 const CommandDialog = ({ children, ...props }: DialogProps) => {
+  const { t } = useTranslation()
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
         <VisuallyHidden>
-          <DialogTitle>Command</DialogTitle>
+          <DialogTitle>{t("common.command")}</DialogTitle>
         </VisuallyHidden>
         <Command className="**:data-[selected=true]:bg-muted **:data-selected:bg-transparent [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}

--- a/src/components/ui/indent-toolbar-button.tsx
+++ b/src/components/ui/indent-toolbar-button.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import { useIndentButton, useOutdentButton } from '@platejs/indent/react';
 import { IndentIcon, OutdentIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 import { ToolbarButton } from './toolbar';
 
@@ -11,9 +12,10 @@ export function IndentToolbarButton(
   props: React.ComponentProps<typeof ToolbarButton>
 ) {
   const { props: buttonProps } = useIndentButton();
+  const { t } = useTranslation();
 
   return (
-    <ToolbarButton {...props} {...buttonProps} tooltip="Indent">
+    <ToolbarButton {...props} {...buttonProps} tooltip={t('common.indent')}>
       <IndentIcon />
     </ToolbarButton>
   );
@@ -23,9 +25,10 @@ export function OutdentToolbarButton(
   props: React.ComponentProps<typeof ToolbarButton>
 ) {
   const { props: buttonProps } = useOutdentButton();
+  const { t } = useTranslation();
 
   return (
-    <ToolbarButton {...props} {...buttonProps} tooltip="Outdent">
+    <ToolbarButton {...props} {...buttonProps} tooltip={t('common.outdent')}>
       <OutdentIcon />
     </ToolbarButton>
   );

--- a/src/components/ui/list-toolbar-button.tsx
+++ b/src/components/ui/list-toolbar-button.tsx
@@ -9,6 +9,7 @@ import {
 } from '@platejs/list/react';
 import { List, ListOrdered, ListTodoIcon } from 'lucide-react';
 import { useEditorRef, useEditorSelector } from 'platejs/react';
+import { useTranslation } from 'react-i18next';
 
 import {
   DropdownMenu,
@@ -28,6 +29,7 @@ import {
 export function BulletedListToolbarButton() {
   const editor = useEditorRef();
   const [open, setOpen] = React.useState(false);
+  const { t } = useTranslation();
 
   const pressed = useEditorSelector(
     (editor) =>
@@ -69,7 +71,7 @@ export function BulletedListToolbarButton() {
             >
               <div className="flex items-center gap-2">
                 <div className="size-2 rounded-full border border-current bg-current" />
-                Default
+                {t('common.listStyles.default')}
               </div>
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -81,7 +83,7 @@ export function BulletedListToolbarButton() {
             >
               <div className="flex items-center gap-2">
                 <div className="size-2 rounded-full border border-current" />
-                Circle
+                {t('common.listStyles.circle')}
               </div>
             </DropdownMenuItem>
             <DropdownMenuItem
@@ -93,7 +95,7 @@ export function BulletedListToolbarButton() {
             >
               <div className="flex items-center gap-2">
                 <div className="size-2 border border-current bg-current" />
-                Square
+                {t('common.listStyles.square')}
               </div>
             </DropdownMenuItem>
           </DropdownMenuGroup>
@@ -106,6 +108,7 @@ export function BulletedListToolbarButton() {
 export function NumberedListToolbarButton() {
   const editor = useEditorRef();
   const [open, setOpen] = React.useState(false);
+  const { t } = useTranslation();
 
   const pressed = useEditorSelector(
     (editor) =>
@@ -147,7 +150,7 @@ export function NumberedListToolbarButton() {
                 })
               }
             >
-              Decimal (1, 2, 3)
+              {t('common.listStyles.decimal')}
             </DropdownMenuItem>
             <DropdownMenuItem
               onSelect={() =>
@@ -156,7 +159,7 @@ export function NumberedListToolbarButton() {
                 })
               }
             >
-              Lower Alpha (a, b, c)
+              {t('common.listStyles.lowerAlpha')}
             </DropdownMenuItem>
             <DropdownMenuItem
               onSelect={() =>
@@ -165,7 +168,7 @@ export function NumberedListToolbarButton() {
                 })
               }
             >
-              Upper Alpha (A, B, C)
+              {t('common.listStyles.upperAlpha')}
             </DropdownMenuItem>
             <DropdownMenuItem
               onSelect={() =>
@@ -174,7 +177,7 @@ export function NumberedListToolbarButton() {
                 })
               }
             >
-              Lower Roman (i, ii, iii)
+              {t('common.listStyles.lowerRoman')}
             </DropdownMenuItem>
             <DropdownMenuItem
               onSelect={() =>
@@ -183,7 +186,7 @@ export function NumberedListToolbarButton() {
                 })
               }
             >
-              Upper Roman (I, II, III)
+              {t('common.listStyles.upperRoman')}
             </DropdownMenuItem>
           </DropdownMenuGroup>
         </DropdownMenuContent>
@@ -197,9 +200,10 @@ export function TodoListToolbarButton(
 ) {
   const state = useIndentTodoToolBarButtonState({ nodeType: 'todo' });
   const { props: buttonProps } = useIndentTodoToolBarButton(state);
+  const { t } = useTranslation();
 
   return (
-    <ToolbarButton {...props} {...buttonProps} tooltip="Todo">
+    <ToolbarButton {...props} {...buttonProps} tooltip={t('common.todo')}>
       <ListTodoIcon />
     </ToolbarButton>
   );

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -67,7 +67,7 @@ const PaginationPrevious = ({
   const { t } = useTranslation();
   return (
     <PaginationLink
-      aria-label="Go to previous page"
+      aria-label={t("pagination.goToPreviousPage")}
       size="default"
       className={cn("gap-1 pl-2.5", className)}
       {...props}
@@ -86,7 +86,7 @@ const PaginationNext = ({
   const { t } = useTranslation();
   return (
     <PaginationLink
-      aria-label="Go to next page"
+      aria-label={t("pagination.goToNextPage")}
       size="default"
       className={cn("gap-1 pr-2.5", className)}
       {...props}
@@ -101,16 +101,19 @@ PaginationNext.displayName = "PaginationNext"
 const PaginationEllipsis = ({
   className,
   ...props
-}: React.ComponentProps<"span">) => (
-  <span
-    aria-hidden
-    className={cn("flex h-9 w-9 items-center justify-center", className)}
-    {...props}
-  >
-    <MoreHorizontal className="h-4 w-4" />
-    <span className="sr-only">More pages</span>
-  </span>
-)
+}: React.ComponentProps<"span">) => {
+  const { t } = useTranslation();
+  return (
+    <span
+      aria-hidden
+      className={cn("flex h-9 w-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontal className="h-4 w-4" />
+      <span className="sr-only">{t("pagination.morePages")}</span>
+    </span>
+  )
+}
 PaginationEllipsis.displayName = "PaginationEllipsis"
 
 export {

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 import { PanelLeft } from "@/lib/ez-icons"
+import { useTranslation } from "react-i18next"
 
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
@@ -180,6 +181,7 @@ const Sidebar = React.forwardRef<
     ref
   ) => {
     const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+    const { t } = useTranslation()
 
     if (collapsible === "none") {
       return (
@@ -211,8 +213,8 @@ const Sidebar = React.forwardRef<
             side={side}
           >
             <SheetHeader className="sr-only">
-              <SheetTitle>Sidebar</SheetTitle>
-              <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+              <SheetTitle>{t("common.sidebar")}</SheetTitle>
+              <SheetDescription>{t("common.sidebarMobileDescription")}</SheetDescription>
             </SheetHeader>
             <div className="flex h-full w-full flex-col">{children}</div>
           </SheetContent>
@@ -272,6 +274,7 @@ const SidebarTrigger = React.forwardRef<
   React.ComponentProps<typeof Button>
 >(({ className, onClick, ...props }, ref) => {
   const { toggleSidebar } = useSidebar()
+  const { t } = useTranslation()
 
   return (
     <Button
@@ -287,7 +290,7 @@ const SidebarTrigger = React.forwardRef<
       {...props}
     >
       <PanelLeft />
-      <span className="sr-only">Toggle Sidebar</span>
+      <span className="sr-only">{t("common.toggleSidebar")}</span>
     </Button>
   )
 })
@@ -298,15 +301,17 @@ const SidebarRail = React.forwardRef<
   React.ComponentProps<"button">
 >(({ className, ...props }, ref) => {
   const { toggleSidebar } = useSidebar()
+  const { t } = useTranslation()
+  const toggleLabel = t("common.toggleSidebar")
 
   return (
     <button
       ref={ref}
       data-sidebar="rail"
-      aria-label="Toggle Sidebar"
+      aria-label={toggleLabel}
       tabIndex={-1}
       onClick={toggleSidebar}
-      title="Toggle Sidebar"
+      title={toggleLabel}
       className={cn(
         "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
         "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #1987.

Closes #1987

---

## Claude summary

Translated every residual English literal flagged by the new `local/no-untranslated-literal` rule in the five files listed in the issue (command.tsx, pagination.tsx, sidebar.tsx, indent-toolbar-button.tsx, list-toolbar-button.tsx). Added new keys under `common.*` (command, sidebar, sidebarMobileDescription, toggleSidebar, indent, outdent, todo, listStyles.*) and `pagination.morePages` in both PL and EN locales, reused existing `pagination.goToPreviousPage` / `goToNextPage` for the two pagination aria-labels. Verified with `npx eslint src/components/ui/**/*.{ts,tsx}` (all `no-untranslated-literal` warnings cleared) and `tsc -p tsconfig.app.json --noEmit` (clean). Committed as 1d527b8.