### PR TITLE
fix(worker): never label claude:done when Claude exits non-zero

### DIFF
--- a/automation/worker/run-claude.sh
+++ b/automation/worker/run-claude.sh
@@ -213,7 +213,7 @@ fi
 COMMENT_FILE=$(mktemp)
 FINAL_LABEL=""
 
-if [ "$COMMITS_AHEAD" -gt 0 ]; then
+if [ "$CLAUDE_EXIT" -eq 0 ] && [ "$COMMITS_AHEAD" -gt 0 ]; then
   echo "pushing branch $BRANCH"
   git push --set-upstream origin "$BRANCH" 2>&1 | tail -3
 


### PR DESCRIPTION
## Problem

A user reported issues being marked `claude:done` while the comment still contained `401 Invalid authentication credentials`. Investigation on the worker host showed the worker's OAuth token expired on 2026-06-20 (no refresh token), so every `claude -p` run since exits non-zero with a 401.

The outcome logic in `run-claude.sh` decided success purely on `COMMITS_AHEAD > 0`. When an issue branch from a *prior* (pre-expiry) attempt already had commits, a fresh failed run would: re-push those stale commits, auto-merge the PR, label `claude:done`, and paste `${CLAUDE_MSG}` (the 401 error) into the issue comment. False success.

## Fix

Require a clean Claude exit before treating branch commits as completed work:

```diff
-if [ "$COMMITS_AHEAD" -gt 0 ]; then
+if [ "$CLAUDE_EXIT" -eq 0 ] && [ "$COMMITS_AHEAD" -gt 0 ]; then
```

Non-zero exits (401, timeout, max-turns) now fall through to the existing `claude:failed` path regardless of leftover commits. The clean-exit-no-commits triage/needs-info branch is unchanged.

The running copy on the worker host has been patched in place (syntax-checked) ahead of this PR.

## Note — separate root cause

This PR only fixes the false-`done` labeling. The underlying auth failure (expired subscription token, no auto-refresh) is being resolved separately by reinstalling a long-lived `CLAUDE_CODE_OAUTH_TOKEN` on the worker host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)