### PR TITLE
Zgoda wyświetlanie checkbox

### DIFF
--- a/src/components/documents/document-form-filler.tsx
+++ b/src/components/documents/document-form-filler.tsx
@@ -67,9 +67,14 @@ export function DocumentFormFiller({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    // Validate required visible fields
+    // Validate required visible fields. Checkboxes require an explicit "true"
+    // value — checking !value.trim() would wrongly pass for "false" (unchecked).
     for (const field of visibleFields) {
-      if (field.required && !values[field.fieldId]?.trim()) {
+      if (!field.required) continue;
+      const val = values[field.fieldId];
+      if (field.fieldType === "checkbox") {
+        if (val !== "true") return;
+      } else if (!val?.trim()) {
         return;
       }
     }

--- a/src/components/documents/document-renderer.tsx
+++ b/src/components/documents/document-renderer.tsx
@@ -254,3 +254,37 @@ export function renderDocument(
 
   return doc.body.innerHTML;
 }
+
+/**
+ * Prepare document HTML for inline interactive form rendering.
+ *
+ * Resolves variables and employee-filled fields (same as renderDocument), then
+ * replaces each client-filled form-field placeholder span with an empty marker
+ * element that InlineDocumentForm targets via React portals. This keeps the
+ * checkboxes positioned exactly where they were placed in the editor rather
+ * than pulling them out into a separate "Formularz" card.
+ */
+export function prepareDocumentForInlineForm(
+  contentJson: string,
+  scopeData: Record<string, string>,
+  employeeFieldValues: Record<string, string>,
+): string {
+  // Resolve variables + employee fields; client field spans survive intact
+  const html = renderDocument(contentJson, scopeData, employeeFieldValues);
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, "text/html");
+
+  // Replace surviving client-filled field spans with portal marker elements
+  doc.querySelectorAll("[data-form-field][data-filled-by='client']").forEach(
+    (el) => {
+      const fieldId = el.getAttribute("data-form-field");
+      if (!fieldId) return;
+      const marker = doc.createElement("span");
+      marker.id = `ff_portal_${CSS.escape(fieldId)}`;
+      el.replaceWith(marker);
+    },
+  );
+
+  return doc.body.innerHTML;
+}

--- a/src/components/documents/inline-document-form.tsx
+++ b/src/components/documents/inline-document-form.tsx
@@ -1,0 +1,237 @@
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { ExtractedFormField } from "./document-renderer";
+import { prepareDocumentForInlineForm } from "./document-renderer";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface InlineDocumentFormProps {
+  contentJson: string;
+  scopeData: Record<string, string>;
+  /** All field values already stored on the document (employee + any pre-filled
+   *  client values from a previous session). Client-field IDs are excluded from
+   *  the document render so they appear as interactive portals instead. */
+  existingFieldValues: Record<string, string>;
+  /** Only client-facing form fields (filledBy === "client"). */
+  formFields: ExtractedFormField[];
+  /** Current client-filled values managed by the parent. */
+  values: Record<string, string>;
+  onValueChange: (fieldId: string, value: string) => void;
+}
+
+interface PortalTarget {
+  element: Element;
+  field: ExtractedFormField;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders the document as HTML with interactive client form fields injected
+ * inline at their exact positions via React portals. This replaces the old
+ * pattern of showing a static preview + a separate "Formularz" card below it.
+ */
+export function InlineDocumentForm({
+  contentJson,
+  scopeData,
+  existingFieldValues,
+  formFields,
+  values,
+  onValueChange,
+}: InlineDocumentFormProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [portals, setPortals] = useState<PortalTarget[]>([]);
+
+  // Client field IDs that should become interactive portals
+  const clientFieldIds = useMemo(
+    () => new Set(formFields.map((f) => f.fieldId)),
+    [formFields],
+  );
+
+  // Employee-only values: used to resolve employee fields in the HTML while
+  // leaving client-field spans intact for portal injection.
+  const employeeValues = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(existingFieldValues).filter(
+          ([k]) => !clientFieldIds.has(k),
+        ),
+      ),
+    [existingFieldValues, clientFieldIds],
+  );
+
+  // HTML with variables + employee fields resolved; client fields replaced
+  // with <span id="ff_portal_FIELDID"> marker elements.
+  const markedHtml = useMemo(
+    () => prepareDocumentForInlineForm(contentJson, scopeData, employeeValues),
+    [contentJson, scopeData, employeeValues],
+  );
+
+  // After the DOM is updated, locate each marker span and record it as a
+  // portal target. useLayoutEffect runs before the browser paints, so there
+  // is no visible flash of empty markers.
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+    const targets: PortalTarget[] = [];
+    for (const field of formFields) {
+      const escapedId = CSS.escape(field.fieldId);
+      const el = containerRef.current.querySelector(
+        `#ff_portal_${escapedId}`,
+      );
+      if (el) targets.push({ element: el, field });
+    }
+    setPortals(targets);
+  }, [markedHtml, formFields]);
+
+  return (
+    <>
+      <div
+        ref={containerRef}
+        className="prose prose-sm max-w-none text-gray-900 [&_*]:!text-gray-900 [&_a]:!text-blue-700 [&_table]:w-full [&_table]:border-collapse [&_td]:border [&_td]:border-gray-300 [&_td]:p-2 [&_th]:border [&_th]:border-gray-300 [&_th]:bg-gray-100 [&_th]:p-2"
+        dangerouslySetInnerHTML={{ __html: markedHtml }}
+      />
+      {portals.map(({ element, field }) =>
+        createPortal(
+          <InlineFieldControl
+            key={field.fieldId}
+            field={field}
+            value={
+              values[field.fieldId] ??
+              (field.fieldType === "checkbox" ? "false" : "")
+            }
+            onChange={(v) => onValueChange(field.fieldId, v)}
+          />,
+          element,
+        ),
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-field interactive control (rendered via portal into the marker span)
+// ---------------------------------------------------------------------------
+
+function InlineFieldControl({
+  field,
+  value,
+  onChange,
+}: {
+  field: ExtractedFormField;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  if (field.fieldType === "checkbox") {
+    return (
+      <label
+        style={{
+          display: "inline-flex",
+          alignItems: "flex-start",
+          gap: "10px",
+          cursor: "pointer",
+          userSelect: "none",
+          width: "100%",
+          padding: "6px 0",
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={value === "true"}
+          onChange={(e) => onChange(e.target.checked ? "true" : "false")}
+          style={{
+            marginTop: "2px",
+            width: "16px",
+            height: "16px",
+            minWidth: "16px",
+            cursor: "pointer",
+            accentColor: "#7C6AE8",
+          }}
+        />
+        <span style={{ fontSize: "14px", lineHeight: "1.5", color: "#111827" }}>
+          {field.label}
+          {field.required && (
+            <span style={{ color: "#ef4444", marginLeft: "4px" }}>*</span>
+          )}
+        </span>
+      </label>
+    );
+  }
+
+  if (field.fieldType === "textarea") {
+    return (
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={field.placeholder || field.label}
+        required={field.required}
+        rows={3}
+        style={{
+          display: "block",
+          width: "100%",
+          border: "1px solid #d1d5db",
+          borderRadius: "4px",
+          padding: "6px 10px",
+          fontSize: "14px",
+          color: "#111827",
+          background: "#fff",
+        }}
+      />
+    );
+  }
+
+  if (field.fieldType === "select") {
+    const opts = field.options
+      .split(",")
+      .map((o) => o.trim())
+      .filter(Boolean);
+    return (
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        required={field.required}
+        style={{
+          display: "inline-block",
+          border: "1px solid #d1d5db",
+          borderRadius: "4px",
+          padding: "4px 8px",
+          fontSize: "14px",
+          color: "#111827",
+          background: "#fff",
+          minWidth: "140px",
+        }}
+      >
+        <option value="">{field.placeholder || "Wybierz..."}</option>
+        {opts.map((opt) => (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  // text / date / default
+  return (
+    <input
+      type={field.fieldType === "date" ? "date" : "text"}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={field.placeholder || field.label}
+      required={field.required}
+      style={{
+        display: "inline-block",
+        border: "1px solid #d1d5db",
+        borderRadius: "4px",
+        padding: "4px 8px",
+        fontSize: "14px",
+        color: "#111827",
+        background: "#fff",
+        minWidth: "140px",
+      }}
+    />
+  );
+}

--- a/src/routes/sign.form.$token.tsx
+++ b/src/routes/sign.form.$token.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { SignaturePad } from "@/components/documents/signature-pad";
-import { DocumentFormFiller } from "@/components/documents/document-form-filler";
+import { InlineDocumentForm } from "@/components/documents/inline-document-form";
 import {
   extractFormFields,
   renderDocument,
@@ -19,7 +19,6 @@ import {
   ShieldCheck,
   AlertTriangle,
   Loader2,
-  ClipboardList,
 } from "@/lib/ez-icons";
 
 // ---------------------------------------------------------------------------
@@ -414,6 +413,23 @@ function DocumentSigningFlow({ token, document, template }: FlowProps) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Client form field values managed on this page (checkboxes, text inputs, etc.)
+  const [formValues, setFormValues] = useState<Record<string, string>>(() => {
+    const init: Record<string, string> = {};
+    for (const field of formFields) {
+      const existing = existingFormFieldValues[field.fieldId];
+      init[field.fieldId] =
+        existing ?? (field.fieldType === "checkbox" ? "false" : "");
+    }
+    return init;
+  });
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const handleValueChange = useCallback((fieldId: string, value: string) => {
+    setFormValues((prev) => ({ ...prev, [fieldId]: value }));
+    setValidationError(null);
+  }, []);
+
   // Document preview rendered from the template + scope + any employee-filled
   // values. Used as the displayed HTML when the form has no client fields and
   // as the in-context preview shown above the form during the fill step so the
@@ -465,6 +481,36 @@ function DocumentSigningFlow({ token, document, template }: FlowProps) {
     [template.contentJson, prefilledData, existingFormFieldValues, submitFormFields, token],
   );
 
+  const handleSubmitFormValues = useCallback(async () => {
+    // Validate required client fields before proceeding to signature step.
+    // Checkboxes require value === "true"; other field types require non-empty.
+    for (const field of formFields) {
+      if (!field.required) continue;
+      const val = formValues[field.fieldId];
+      if (field.fieldType === "checkbox") {
+        if (val !== "true") {
+          setValidationError(
+            t(
+              "documents.signing.requiredConsents",
+              "Zaznacz wszystkie wymagane zgody przed podpisaniem dokumentu.",
+            ),
+          );
+          return;
+        }
+      } else if (!val?.trim()) {
+        setValidationError(
+          t(
+            "documents.signing.requiredFields",
+            "Uzupełnij wszystkie wymagane pola przed podpisaniem dokumentu.",
+          ),
+        );
+        return;
+      }
+    }
+    setValidationError(null);
+    await handleFormComplete(formValues);
+  }, [formFields, formValues, handleFormComplete, t]);
+
   if (step === "done") return <SuccessState />;
 
   const signingMethod = template.signatureConfig?.method ?? "click";
@@ -495,51 +541,46 @@ function DocumentSigningFlow({ token, document, template }: FlowProps) {
         </CardHeader>
       </Card>
 
-      {/* Step 1: Form fill (only for draft documents with form fields) */}
+      {/* Step 1: Form fill — checkboxes and inputs rendered inline within the
+          document, exactly where they were placed in the editor. */}
       {step === "fill" && (
         <>
-          {previewHtml && (
-            <Card>
-              <CardContent className="pt-6">
-                <div
-                  className="prose prose-sm max-w-none rounded-lg border bg-white p-6 text-gray-900 [&_*]:!text-gray-900 [&_a]:!text-blue-700 [&_table]:w-full [&_table]:border-collapse [&_td]:border [&_td]:border-gray-300 [&_td]:p-2 [&_th]:border [&_th]:border-gray-300 [&_th]:bg-gray-100 [&_th]:p-2"
-                  dangerouslySetInnerHTML={{ __html: previewHtml }}
-                />
-              </CardContent>
-            </Card>
-          )}
           <Card>
-            <CardHeader>
-              <CardTitle className="text-base flex items-center gap-2">
-                <ClipboardList className="h-5 w-5" />
-                {t("documents.signing.formTitle", "Formularz")}
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {submitting && (
-                <div className="flex items-center justify-center gap-2 py-8">
-                  <Loader2 className="h-5 w-5 animate-spin" />
+            <CardContent className="pt-6">
+              <div className="rounded-lg border bg-white p-6">
+                <InlineDocumentForm
+                  contentJson={template.contentJson!}
+                  scopeData={prefilledData}
+                  existingFieldValues={existingFormFieldValues}
+                  formFields={formFields}
+                  values={formValues}
+                  onValueChange={handleValueChange}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="py-4 space-y-3">
+              {validationError && (
+                <p className="text-sm text-destructive">{validationError}</p>
+              )}
+              {submitting ? (
+                <div className="flex items-center gap-2 py-2">
+                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
                   <span className="text-sm text-muted-foreground">
                     {t("common.saving", "Zapisywanie...")}
                   </span>
                 </div>
+              ) : (
+                <Button
+                  onClick={() => void handleSubmitFormValues()}
+                  className="w-full"
+                >
+                  {t("documents.signing.signButton", "Podpisz dokument")}
+                </Button>
               )}
-              {!submitting && (
-                <DocumentFormFiller
-                  formFields={formFields}
-                  filledByFilter="client"
-                  hideTopAction
-                  submitLabel={t(
-                    "documents.signing.signButton",
-                    "Podpisz dokument",
-                  )}
-                  onComplete={handleFormComplete}
-                  onCancel={() => {
-                    // No cancel action on public page — just a no-op
-                  }}
-                />
-              )}
-              {error && <p className="mt-3 text-sm text-destructive">{error}</p>}
+              {error && <p className="text-sm text-destructive">{error}</p>}
             </CardContent>
           </Card>
         </>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2003.

Closes #2003

---

## Claude summary

The fix is committed. Here's a summary of what was changed and why:

**Root cause:** The client signing page had a two-step layout for the "fill" step: (1) a static document preview with blue `[placeholder]` boxes for form fields, followed by (2) a separate "Formularz" card that extracted all client checkboxes into a flat list with no contextual headings. This is why checkboxes appeared disconnected from their corresponding sections.

**Changes made:**

`src/components/documents/document-renderer.tsx` — Added `prepareDocumentForInlineForm()`: resolves variables and employee-filled fields (same as `renderDocument`), then replaces client-field placeholder spans with `<span id="ff_portal_FIELDID">` marker elements instead of leaving them as blue placeholders.

`src/components/documents/inline-document-form.tsx` (new) — `InlineDocumentForm` component: renders the processed HTML via `dangerouslySetInnerHTML`, then uses `useLayoutEffect` + `createPortal` to inject interactive checkboxes/inputs into the marker spans at their exact positions in the document. The portals update reactively as checkbox values change.

`src/routes/sign.form.$token.tsx` — Replaced the fill step (static preview card + Formularz card) with a single card containing `InlineDocumentForm` plus a separate submit card. Added proper validation: required checkboxes must have `value === "true"` before proceeding to signature; optional checkboxes do not block signing.

`src/components/documents/document-form-filler.tsx` — Fixed broken required-checkbox validation: `!value.trim()` returned `false` for the string `"false"` (unchecked), so required checkboxes were never blocked. Now checks `value !== "true"` for checkboxes specifically.

## Follow-ups

- Fix required-checkbox validation bypass in employee-facing form fill: `document-form-filler.tsx` was also used when employees fill out forms internally; the same `!value.trim()` bug existed there and was fixed, but there are no tests covering this path.
- Add `data-filled-by` attribute selector test to `document-extensions.test.ts`: `prepareDocumentForInlineForm` relies on `[data-filled-by='client']` being present in rendered HTML; a regression in `FormFieldNode.renderHTML` removing that attribute would silently break the inline form without any test catching it.