### PR TITLE
Add `data-filled-by` attribute selector test to `document-extensions.test.ts`

### DIFF
--- a/src/components/documents/document-extensions.test.ts
+++ b/src/components/documents/document-extensions.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// @tiptap/html's server bundle statically imports 'happy-dom' (not installed).
+// Mock the module so that importing document-renderer.tsx doesn't fail at
+// module-load time in the node test environment. None of the tests here call
+// generateHTML; they only inspect extension metadata and renderHTML output.
+vi.mock("@tiptap/html", () => ({
+  generateHTML: vi.fn(),
+}));
 
 import { editorExtensions } from "./document-template-editor";
 import { renderExtensions } from "./document-renderer";
+import { FormFieldNode } from "./form-field-node";
 
 // Guards against the regression fixed in #1907 / #1914: the renderer extension
 // list silently drifted from the editor's, so saved templates containing
@@ -37,5 +46,72 @@ describe("document template / renderer extensions", () => {
         "variableMentionCurly",
       ]
     `);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FormFieldNode.renderHTML — data-filled-by attribute (regression guard)
+//
+// prepareDocumentForInlineForm relies on the CSS attribute selector
+// [data-form-field][data-filled-by='client'] to locate client-facing field
+// spans in the rendered HTML and replace them with interactive portals. If
+// renderHTML ever stops emitting data-filled-by, all client fields silently
+// vanish from the inline form with no runtime error (#2006).
+//
+// We call renderHTML directly and inspect the returned TipTap spec tuple to
+// avoid requiring a browser DOM (generateHTML needs happy-dom in node).
+// ---------------------------------------------------------------------------
+
+describe("FormFieldNode.renderHTML", () => {
+  // Invoke the renderHTML config method directly with synthetic HTMLAttributes.
+  // TipTap passes mergeAttributes-resolved attrs here; for our purposes we can
+  // pass the raw attrs since mergeAttributes is a plain object merge.
+  const callRenderHTML = (
+    filledBy: "client" | "employee",
+    fieldId = "field_1",
+  ) => {
+    const renderHTML = FormFieldNode.config.renderHTML!;
+    return renderHTML.call(
+      { options: FormFieldNode.config } as never,
+      {
+        HTMLAttributes: {
+          fieldId,
+          fieldType: "text",
+          label: "Test",
+          options: "",
+          required: false,
+          placeholder: "",
+          filledBy,
+        },
+        node: {} as never,
+      },
+    );
+  };
+
+  it("emits data-filled-by='client' in the attribute tuple for a client field", () => {
+    const [, attrs] = callRenderHTML("client") as [string, Record<string, string>, string];
+    expect(attrs["data-filled-by"]).toBe("client");
+  });
+
+  it("emits data-form-field with the field ID", () => {
+    const [, attrs] = callRenderHTML("client", "sig_1") as [string, Record<string, string>, string];
+    expect(attrs["data-form-field"]).toBe("sig_1");
+  });
+
+  it("emits data-filled-by='employee' for an employee field", () => {
+    const [, attrs] = callRenderHTML("employee") as [string, Record<string, string>, string];
+    expect(attrs["data-filled-by"]).toBe("employee");
+  });
+
+  it("falls back to 'employee' when filledBy is absent", () => {
+    const renderHTML = FormFieldNode.config.renderHTML!;
+    const [, attrs] = renderHTML.call(
+      { options: FormFieldNode.config } as never,
+      {
+        HTMLAttributes: { fieldId: "x", fieldType: "text", label: "", options: "", required: false, placeholder: "" },
+        node: {} as never,
+      },
+    ) as [string, Record<string, string>, string];
+    expect(attrs["data-filled-by"]).toBe("employee");
   });
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2006.

Closes #2006

---

## Claude summary

Done. Here's a summary of what was done and why:

**Problem**: `prepareDocumentForInlineForm` (`document-renderer.tsx:279`) uses the CSS selector `[data-form-field][data-filled-by='client']` to find client-facing field spans and replace them with interactive React portals. If `FormFieldNode.renderHTML` were ever changed to drop the `data-filled-by` attribute, all client fields would silently disappear from the inline form — no runtime error, no test failure.

**What I added** (`document-extensions.test.ts`):
- Four tests in a new `FormFieldNode.renderHTML` describe block that call `renderHTML` directly (via `FormFieldNode.config.renderHTML`) and inspect the returned TipTap spec tuple. No DOM or `generateHTML` needed.
- Tests verify: `data-filled-by="client"` for client fields, `data-form-field` contains the field ID, `data-filled-by="employee"` for employee fields, and fallback to `"employee"` when `filledBy` is absent.

**Bonus fix**: Added `vi.mock("@tiptap/html", ...)` at the top of the test file. The pre-existing extension-name tests were already failing (silently) because `@tiptap/html`'s server bundle statically imports `happy-dom` (not installed), crashing the entire suite at module-load time. The mock prevents that load; the existing tests don't call `generateHTML` so the mock is transparent to them.

## Follow-ups

- Fix pre-existing test failures in `app-sidebar.test.tsx` and `entity-detail-layout.test.tsx`: two test files committed in `5fc8fc9` have been failing since they were added (`useSidebar` mock is incomplete; "Akcje" text not rendered in the actions dropdown test)