### PR TITLE
Fix pre-existing test failures in `app-sidebar.test.tsx` and `entity-detail-layo

### DIFF
--- a/src/components/crm/entity-detail-layout.test.tsx
+++ b/src/components/crm/entity-detail-layout.test.tsx
@@ -1,5 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      if (key === "common.actions") return "Akcje";
+      return key;
+    },
+  }),
+}));
+
 import { EntityDetailLayout } from "./entity-detail-layout";
 
 function countLabel(markup: string, label: string) {

--- a/src/components/layout/app-sidebar.test.tsx
+++ b/src/components/layout/app-sidebar.test.tsx
@@ -48,6 +48,11 @@ vi.mock("@/components/ui/sidebar", () => ({
   SidebarMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SidebarMenuButton: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SidebarMenuItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  useSidebar: () => ({ isMobile: false, setOpenMobile: vi.fn() }),
+}));
+
+vi.mock("convex/react", () => ({
+  useAction: () => vi.fn(),
 }));
 
 vi.mock("@/components/layout/sidebar-context", () => ({


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2012.

Closes #2012

---

## Claude summary

Both failures are fixed. Here's a summary of what was wrong and what was changed:

**`app-sidebar.test.tsx` (2 failing tests → 2 passing)**
- The mock for `@/components/ui/sidebar` exported all the component stubs but forgot `useSidebar`. The component calls `const { isMobile, setOpenMobile } = useSidebar()` at render time, so vitest threw immediately with "No 'useSidebar' export is defined on the mock."
- `convex/react`'s `useAction` also had no mock; it would have thrown next since there's no ConvexProvider in the SSR render tree. Added a minimal mock returning `vi.fn()`.

**`entity-detail-layout.test.tsx` (1 failing test → 2 passing)**
- No `react-i18next` mock existed, so `t("common.actions")` returned the raw key string `"common.actions"` instead of `"Akcje"`. Added a targeted mock that maps the one key the assertion needs.

## Follow-ups

- `vitest.frontend.config.ts` include pattern in main repo still uses `src/**/*.test.ts` (no `.tsx`): the worktree has the `.tsx` fix but the main repo's config still excludes `.test.tsx` files from the frontend suite, so any new `.test.tsx` files added to `src/` would be silently skipped.
- `activity-feed.test.tsx` emits `react-i18next:: You will need to pass in an i18next instance` warning at runtime: it works because the test doesn't assert on translated strings, but it should get a `react-i18next` mock to silence the noise and guard future assertions.