### PR TITLE
`activity-feed.test.tsx` emits `react-i18next

### DIFF
--- a/src/components/crm/activity-feed.test.tsx
+++ b/src/components/crm/activity-feed.test.tsx
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
 import { ActivityFeed, type FeedEntry } from "./activity-feed";
 
 function countActorSystemLabels(markup: string) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2015.

Closes #2015

---

## Claude summary

The fix is committed. Here's what was done:

Added `vi.mock("react-i18next", ...)` to `src/components/crm/activity-feed.test.tsx`, making the `useTranslation` hook return a `t` function that passes through the fallback string (or the key if no fallback). This matches the pattern already established in `entity-detail-layout.test.tsx` and `app-sidebar.test.tsx`. The mock silences the `react-i18next:: You will need to pass in an i18next instance` warning and means any future assertions on translated strings will work correctly.