### PR TITLE
Gwiazdka czerwona dokument

### DIFF
--- a/src/components/documents/inline-document-form.tsx
+++ b/src/components/documents/inline-document-form.tsx
@@ -91,7 +91,7 @@ export function InlineDocumentForm({
     <>
       <div
         ref={containerRef}
-        className="prose prose-sm max-w-none text-gray-900 [&_*]:!text-gray-900 [&_a]:!text-blue-700 [&_table]:w-full [&_table]:border-collapse [&_td]:border [&_td]:border-gray-300 [&_td]:p-2 [&_th]:border [&_th]:border-gray-300 [&_th]:bg-gray-100 [&_th]:p-2"
+        className="prose prose-sm max-w-none text-gray-900 [&_*]:text-gray-900 [&_a]:!text-blue-700 [&_table]:w-full [&_table]:border-collapse [&_td]:border [&_td]:border-gray-300 [&_td]:p-2 [&_th]:border [&_th]:border-gray-300 [&_th]:bg-gray-100 [&_th]:p-2"
         dangerouslySetInnerHTML={{ __html: markedHtml }}
       />
       {portals.map(({ element, field }) =>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2010.

Closes #2010

---

## Claude summary

Fixed. The root cause was in `src/components/documents/inline-document-form.tsx:94`: the Tailwind class `[&_*]:!text-gray-900` uses the `!` prefix which generates `color: rgb(17,24,39) !important` and forces ALL descendants to be dark-gray — including the required-field asterisk `<span style={{ color: "#ef4444" }}>`. CSS `!important` beats inline styles, so the asterisk appeared black instead of red.

The fix removes the `!` flag (`[&_*]:text-gray-900`). Inline styles always win over non-`!important` class rules, so the red asterisk now shows correctly, while all other document text still defaults to gray-900.