### PR TITLE
Brak pytań +wywiad

### DIFF
--- a/src/components/documents/inline-document-form.tsx
+++ b/src/components/documents/inline-document-form.tsx
@@ -24,6 +24,33 @@ interface InlineDocumentFormProps {
 interface PortalTarget {
   element: Element;
   field: ExtractedFormField;
+  isStandalone: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Standalone detection — mirrors the isFieldStandalone check in
+// document-renderer.tsx but operates on portal marker spans rather than
+// original form-field spans. A marker is "standalone" when its parent block
+// has no other meaningful text content, meaning the field label IS the
+// question (not just a blank inside a sentence).
+// ---------------------------------------------------------------------------
+
+function isMarkerStandalone(el: Element): boolean {
+  const parent = el.parentElement;
+  if (!parent) return false;
+  for (const node of Array.from(parent.childNodes)) {
+    if (node === el) continue;
+    if (node.nodeType === Node.TEXT_NODE) {
+      if ((node.textContent ?? "").trim()) return false;
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      const sibling = node as Element;
+      // Other portal markers on the same line are acceptable siblings
+      if (sibling.id?.startsWith("ff_portal_")) continue;
+      if (sibling.tagName === "BR") continue;
+      if ((sibling.textContent ?? "").trim()) return false;
+    }
+  }
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -82,7 +109,13 @@ export function InlineDocumentForm({
       const el = containerRef.current.querySelector(
         `#ff_portal_${escapedId}`,
       );
-      if (el) targets.push({ element: el, field });
+      if (el) {
+        targets.push({
+          element: el,
+          field,
+          isStandalone: isMarkerStandalone(el),
+        });
+      }
     }
     setPortals(targets);
   }, [markedHtml, formFields]);
@@ -94,7 +127,7 @@ export function InlineDocumentForm({
         className="prose prose-sm max-w-none text-gray-900 [&_*]:text-gray-900 [&_a]:!text-blue-700 [&_table]:w-full [&_table]:border-collapse [&_td]:border [&_td]:border-gray-300 [&_td]:p-2 [&_th]:border [&_th]:border-gray-300 [&_th]:bg-gray-100 [&_th]:p-2"
         dangerouslySetInnerHTML={{ __html: markedHtml }}
       />
-      {portals.map(({ element, field }) =>
+      {portals.map(({ element, field, isStandalone }) =>
         createPortal(
           <InlineFieldControl
             key={field.fieldId}
@@ -104,6 +137,7 @@ export function InlineDocumentForm({
               (field.fieldType === "checkbox" ? "false" : "")
             }
             onChange={(v) => onValueChange(field.fieldId, v)}
+            isStandalone={isStandalone}
           />,
           element,
         ),
@@ -120,11 +154,35 @@ function InlineFieldControl({
   field,
   value,
   onChange,
+  isStandalone,
 }: {
   field: ExtractedFormField;
   value: string;
   onChange: (value: string) => void;
+  isStandalone?: boolean;
 }) {
+  // Show the field label as a visible question prompt for standalone fields
+  // where the label IS the question (not just a blank inside a sentence).
+  // Checkboxes are excluded — they always show their label inline.
+  const showLabel = isStandalone && !!field.label && field.fieldType !== "checkbox";
+
+  const labelNode = showLabel ? (
+    <span
+      style={{
+        display: "block",
+        fontSize: "14px",
+        fontWeight: "500",
+        color: "#111827",
+        marginBottom: "4px",
+      }}
+    >
+      {field.label}
+      {field.required && (
+        <span style={{ color: "#ef4444", marginLeft: "4px" }}>*</span>
+      )}
+    </span>
+  ) : null;
+
   if (field.fieldType === "checkbox") {
     return (
       <label
@@ -163,23 +221,26 @@ function InlineFieldControl({
 
   if (field.fieldType === "textarea") {
     return (
-      <textarea
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={field.placeholder || field.label}
-        required={field.required}
-        rows={3}
-        style={{
-          display: "block",
-          width: "100%",
-          border: "1px solid #d1d5db",
-          borderRadius: "4px",
-          padding: "6px 10px",
-          fontSize: "14px",
-          color: "#111827",
-          background: "#fff",
-        }}
-      />
+      <span style={{ display: "block", width: "100%" }}>
+        {labelNode}
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={field.placeholder || (showLabel ? "" : field.label)}
+          required={field.required}
+          rows={3}
+          style={{
+            display: "block",
+            width: "100%",
+            border: "1px solid #d1d5db",
+            borderRadius: "4px",
+            padding: "6px 10px",
+            fontSize: "14px",
+            color: "#111827",
+            background: "#fff",
+          }}
+        />
+      </span>
     );
   }
 
@@ -189,9 +250,43 @@ function InlineFieldControl({
       .map((o) => o.trim())
       .filter(Boolean);
     return (
-      <select
+      <span style={{ display: showLabel ? "block" : "inline-block" }}>
+        {labelNode}
+        <select
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          required={field.required}
+          style={{
+            display: "inline-block",
+            border: "1px solid #d1d5db",
+            borderRadius: "4px",
+            padding: "4px 8px",
+            fontSize: "14px",
+            color: "#111827",
+            background: "#fff",
+            minWidth: "140px",
+          }}
+        >
+          <option value="">{field.placeholder || "Wybierz..."}</option>
+          {opts.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+      </span>
+    );
+  }
+
+  // text / date / default
+  return (
+    <span style={{ display: showLabel ? "block" : "inline-block" }}>
+      {labelNode}
+      <input
+        type={field.fieldType === "date" ? "date" : "text"}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        placeholder={field.placeholder || (showLabel ? "" : field.label)}
         required={field.required}
         style={{
           display: "inline-block",
@@ -203,35 +298,7 @@ function InlineFieldControl({
           background: "#fff",
           minWidth: "140px",
         }}
-      >
-        <option value="">{field.placeholder || "Wybierz..."}</option>
-        {opts.map((opt) => (
-          <option key={opt} value={opt}>
-            {opt}
-          </option>
-        ))}
-      </select>
-    );
-  }
-
-  // text / date / default
-  return (
-    <input
-      type={field.fieldType === "date" ? "date" : "text"}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      placeholder={field.placeholder || field.label}
-      required={field.required}
-      style={{
-        display: "inline-block",
-        border: "1px solid #d1d5db",
-        borderRadius: "4px",
-        padding: "4px 8px",
-        fontSize: "14px",
-        color: "#111827",
-        background: "#fff",
-        minWidth: "140px",
-      }}
-    />
+      />
+    </span>
   );
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2019.

Closes #2019

---

## Claude summary

The fix is committed. Here's what was wrong and what changed:

**Root cause:** In `InlineDocumentForm`, each client form field span (which contains the label as its text content) gets replaced by an empty portal marker `<span id="ff_portal_FIELDID"></span>`. The `InlineFieldControl` component then renders only the interactive control (a `<select>` or `<input>`) into that marker — with no visible question text. For `checkbox` fields the label was already shown inline, but `select`, `text`, `textarea`, and `date` types showed nothing, or at best showed the label as a grayed-out placeholder that disappears when you type.

**Fix in `src/components/documents/inline-document-form.tsx`:**

1. Added `isMarkerStandalone()` — mirrors the existing `isFieldStandalone` logic in `document-renderer.tsx` but operates on the portal marker spans. A marker is "standalone" when its parent `<p>` has no other meaningful text, meaning the field label IS the question (not a fill-in-the-blank inside a sentence like "Imię: [field]").

2. Extended `PortalTarget` with `isStandalone: boolean`, computed via `isMarkerStandalone()` in `useLayoutEffect`.

3. In `InlineFieldControl`, when `isStandalone` is true and the field has a label: renders the label as a bold question prompt above the control, with a red asterisk for required fields. Clears the label from the `placeholder` when it's already shown visually. Non-standalone inline fields and `checkbox` fields are unchanged.

## Follow-ups

- Add a label display for non-standalone required fields: currently there is no visual asterisk for required fields that are inline (not standalone) — the client has no indication a field is required until validation fires.
- Cover `InlineDocumentForm` with a unit/integration test: the component has no tests; a test rendering a standalone select/text field and asserting the label is visible would catch this regression class.