### PR TITLE
Add a label display for non-standalone required fields

### DIFF
--- a/src/components/documents/inline-document-form.tsx
+++ b/src/components/documents/inline-document-form.tsx
@@ -166,6 +166,13 @@ function InlineFieldControl({
   // Checkboxes are excluded — they always show their label inline.
   const showLabel = isStandalone && !!field.label && field.fieldType !== "checkbox";
 
+  // For non-standalone required fields (inline inside a sentence), show a red
+  // asterisk after the control — the label is not shown, so without this the
+  // client has no indication the field is required until validation fires.
+  const inlineRequiredMarker = !isStandalone && field.required && field.fieldType !== "checkbox" ? (
+    <span style={{ color: "#ef4444", marginLeft: "2px" }}>*</span>
+  ) : null;
+
   const labelNode = showLabel ? (
     <span
       style={{
@@ -240,6 +247,7 @@ function InlineFieldControl({
             background: "#fff",
           }}
         />
+        {inlineRequiredMarker}
       </span>
     );
   }
@@ -274,6 +282,7 @@ function InlineFieldControl({
             </option>
           ))}
         </select>
+        {inlineRequiredMarker}
       </span>
     );
   }
@@ -299,6 +308,7 @@ function InlineFieldControl({
           minWidth: "140px",
         }}
       />
+      {inlineRequiredMarker}
     </span>
   );
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2023.

Closes #2023

---

## Claude summary

The fix is committed. Here's a summary:

**Root cause:** In `src/components/documents/inline-document-form.tsx`, the `InlineFieldControl` component only showed a label (and its asterisk) for standalone fields — those where the field occupies its own line and the label is the question. For non-standalone fields embedded inline in a sentence (e.g., "Please enter your name: [____]"), no label was shown, and therefore no required indicator either.

**Fix:** Added `inlineRequiredMarker` — a small red `*` rendered immediately after the input control for non-standalone required fields (text, date, select, textarea). Checkboxes were excluded since they always display their label inline and already had the asterisk there.

The change is in `src/components/documents/inline-document-form.tsx`, adding 10 lines total across 4 render branches.

## Follow-ups

- Fix pre-existing TS2589 error in sign.form.$token.tsx: `src/routes/sign.form.$token.tsx:40` has a type instantiation depth error unrelated to this issue that should be resolved to keep the typecheck clean.