### PR TITLE
Fix pre-existing TS2589 error in sign.form.$token.tsx

### DIFF
--- a/src/routes/sign.form.$token.tsx
+++ b/src/routes/sign.form.$token.tsx
@@ -36,9 +36,8 @@ export const Route = createFileRoute("/sign/form/$token")({
 function FormSigningPage() {
   const { t } = useTranslation();
   const { token } = Route.useParams();
-  const getBySigningToken = useAction(
-    api.documents.documents.getBySigningToken,
-  );
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen for this action
+  const getBySigningToken = useAction(api.documents.documents.getBySigningToken);
   const { data, isLoading } = useQuery({
     queryKey: ["documents.documents.getBySigningToken", token],
     queryFn: () => getBySigningToken({ token }),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2026.

Closes #2026

---

## Claude summary

Done. The fix applies the project-standard `// @ts-ignore — TS2589` suppression to the `useAction(api.documents.documents.getBySigningToken)` call on line 40 of `src/routes/sign.form.$token.tsx`, and also consolidates the multiline call to a single line so the suppression comment lands correctly on the preceding line.

The same pattern is used in 15+ other places in the codebase (e.g. `treatment-purchase-drawer.tsx:47`, `app-sidebar.tsx:48`, `_layout.gabinet.patients.$patientId.tsx:99`) — it's the established fix for Convex-generated API types that exceed TypeScript 5.5's instantiation depth limit. The CI `typecheck.yml` only checks `convex/` backend files, not the frontend `src/` tree, so the error wouldn't have blocked PRs but would surface locally.