### PR TITLE
Install `happy-dom` or configure a JSDOM environment for TipTap-dependent tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -138,6 +138,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.7",
+        "happy-dom": "^20.8.9",
         "postcss": "^8.5.6",
         "prettier": "3.3.3",
         "tailwindcss": "^4.1.18",
@@ -13504,7 +13505,7 @@
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
       "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
       "license": "MIT",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",
+    "happy-dom": "^20.8.9",
     "postcss": "^8.5.6",
     "prettier": "3.3.3",
     "tailwindcss": "^4.1.18",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2028.

Closes #2028

---

## Claude summary

The fix is committed. Here's what was happening and what was changed:

**Root cause:** `@tiptap/html` lists `happy-dom` as a peer dependency. npm records it in `package-lock.json` with `"peer": true`, which means it's tracked but NOT actually installed in `node_modules`. The `@tiptap/html` server bundle (selected when Node resolves the package via the `"node"` exports condition) statically imports `happy-dom` — so every frontend vitest run hit `Cannot find package 'happy-dom'` before any tests could run.

The test file `document-extensions.test.ts` already had a `vi.mock("@tiptap/html")` workaround, but Vitest's module graph analysis can still trigger the peer dependency resolution before mocks are applied.

**Fix:** Added `"happy-dom": "^20.8.9"` to `devDependencies` in both `package.json` and `package-lock.json`, changing the lock file entry from `"peer": true` to `"dev": true` so npm installs it as a real devDependency going forward.