### PR TITLE
fix(responsive): improve mobile layout across gabinet views (#2018)

### DIFF
--- a/src/components/layout/page-header.tsx
+++ b/src/components/layout/page-header.tsx
@@ -13,14 +13,14 @@ export function PageHeader({
   actions,
 }: PageHeaderProps) {
   return (
-    <div className="flex items-center justify-between pb-6">
-      <div>
+    <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-3 pb-6">
+      <div className="min-w-0">
         <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
         {description && (
           <p className="mt-1 text-sm text-muted-foreground">{description}</p>
         )}
       </div>
-      {actions && <div className="flex items-center gap-2">{actions}</div>}
+      {actions && <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div>}
     </div>
   );
 }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -593,7 +593,7 @@ function PackagesIndex() {
             <Label>{t("gabinet.packages.descriptionField")}</Label>
             <RichTextEditor value={description} onChange={(val) => setDescription(val ?? "")} minHeight="80px" />
           </div>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div className="space-y-1.5">
               <Label>{t("gabinet.packages.totalPrice")}</Label>
               <Input type="number" inputMode="decimal" value={totalPrice} onChange={(e) => setTotalPrice(e.target.value)} />
@@ -603,7 +603,7 @@ function PackagesIndex() {
               <Input type="number" inputMode="numeric" value={validityDays} onChange={(e) => setValidityDays(e.target.value)} />
             </div>
           </div>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div className="space-y-1.5">
               <Label>{t("gabinet.packages.discountPercent")}</Label>
               <Input type="number" inputMode="numeric" value={discountPercent} onChange={(e) => setDiscountPercent(e.target.value)} />

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -184,8 +184,8 @@ function RevenueSummaryCard({
         </div>
         <CardMenu />
       </CardHeader>
-      <CardContent className="grid grid-cols-3 gap-4 pt-4">
-        <div className="flex flex-col gap-1 border-r pr-4 last:border-r-0">
+      <CardContent className="grid grid-cols-1 gap-4 pt-4 sm:grid-cols-3">
+        <div className="flex flex-col gap-1 sm:border-r sm:pr-4">
           <span className="text-muted-foreground text-sm">
             {t("gabinet.reports.today")}
           </span>
@@ -193,7 +193,7 @@ function RevenueSummaryCard({
             {formatCurrencyPLN(dailyRevenue, currency, { fractionDigits: 0 })}
           </span>
         </div>
-        <div className="flex flex-col gap-1 border-r pr-4 last:border-r-0">
+        <div className="flex flex-col gap-1 sm:border-r sm:pr-4">
           <span className="text-muted-foreground text-sm">
             {t("gabinet.reports.thisWeek")}
           </span>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -560,7 +560,7 @@ function TreatmentsIndex() {
         title={t("gabinet.treatments.title")}
         description={t("gabinet.treatments.description")}
         actions={
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <Button
               variant={groupByEquipment ? "default" : "outline"}
               onClick={() => setGroupByEquipment((prev) => !prev)}


### PR DESCRIPTION
Targeted mobile responsiveness fixes for issue #2018.

- PageHeader: flex-wrap + shrink-0 so actions wrap on narrow screens (affects all pages)
- Treatments: flex-wrap on action buttons (second button was cut off)
- Reports RevenueSummaryCard: grid-cols-1 sm:grid-cols-3 (3 revenue values stacked on mobile)
- Packages form: two grid-cols-2 panels -> grid-cols-1 sm:grid-cols-2 (fields stack in narrow SidePanel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)