### PR TITLE
Fix mobile column overflow in CrmDataTable gabinet pages

### DIFF
--- a/src/components/crm/enhanced-data-table.tsx
+++ b/src/components/crm/enhanced-data-table.tsx
@@ -232,78 +232,80 @@ export function CrmDataTable<TData>({
       )}
 
       {paged.length > 0 ? (
-        <Table
-          aria-label="Data table"
-          selectionMode={enableBulkSelect ? "multiple" : undefined}
-          sortDescriptor={sort}
-          onSortChange={handleSortChange}
-          selectedKeys={enableBulkSelect ? selectedKeys : undefined}
-          onSelectionChange={enableBulkSelect ? setSelectedKeys : undefined}
-          onRowAction={tableRowAction}
-        >
-          <Table.Header>
-            {visibleColumns.map((col) => (
-              <Table.Head
-                key={col.id}
-                id={col.id}
-                label={col.label}
-                allowsSorting={col.sortable}
-                isRowHeader={col.isRowHeader}
-                className={col.className}
-              />
-            ))}
-            {hasActions && <Table.Head id="actions" />}
-          </Table.Header>
-          <Table.Body>
-            {paged.map((item, index) => {
-              const rowId = getRowId(item, (page - 1) * pageSize + index);
-              return (
-                <Table.Row
-                  key={rowId}
-                  id={rowId}
-                  className={onRowAction ? "cursor-pointer" : undefined}
-                >
-                  {visibleColumns.map((col) => (
-                    <Table.Cell key={col.id} className={col.className}>
-                      {col.render(item)}
-                    </Table.Cell>
-                  ))}
-                  {hasActions && (
-                    <Table.Cell className="px-4">
-                      <div className="flex justify-end">
-                        <Dropdown.Root>
-                          <Button
-                            size="sm"
-                            color="tertiary"
-                            iconLeading={<Menu01 className="size-5" />}
-                            onClick={(e: ReactMouseEvent<HTMLButtonElement>) => {
-                              e.stopPropagation();
-                            }}
-                            onPointerDown={(e: ReactPointerEvent<HTMLButtonElement>) => {
-                              // Prevent React Aria from starting selection on pointer down
-                              e.stopPropagation();
-                            }}
-                          />
-                          <Dropdown.Popover className="w-min">
-                            <Dropdown.Menu>
-                              {rowActions!(item).map((a) => (
-                                <Dropdown.Item
-                                  key={a.label}
-                                  label={a.label}
-                                  onAction={() => a.onClick(item)}
-                                />
-                              ))}
-                            </Dropdown.Menu>
-                          </Dropdown.Popover>
-                        </Dropdown.Root>
-                      </div>
-                    </Table.Cell>
-                  )}
-                </Table.Row>
-              );
-            })}
-          </Table.Body>
-        </Table>
+        <div className="overflow-x-auto">
+          <Table
+            aria-label="Data table"
+            selectionMode={enableBulkSelect ? "multiple" : undefined}
+            sortDescriptor={sort}
+            onSortChange={handleSortChange}
+            selectedKeys={enableBulkSelect ? selectedKeys : undefined}
+            onSelectionChange={enableBulkSelect ? setSelectedKeys : undefined}
+            onRowAction={tableRowAction}
+          >
+            <Table.Header>
+              {visibleColumns.map((col) => (
+                <Table.Head
+                  key={col.id}
+                  id={col.id}
+                  label={col.label}
+                  allowsSorting={col.sortable}
+                  isRowHeader={col.isRowHeader}
+                  className={col.className}
+                />
+              ))}
+              {hasActions && <Table.Head id="actions" />}
+            </Table.Header>
+            <Table.Body>
+              {paged.map((item, index) => {
+                const rowId = getRowId(item, (page - 1) * pageSize + index);
+                return (
+                  <Table.Row
+                    key={rowId}
+                    id={rowId}
+                    className={onRowAction ? "cursor-pointer" : undefined}
+                  >
+                    {visibleColumns.map((col) => (
+                      <Table.Cell key={col.id} className={col.className}>
+                        {col.render(item)}
+                      </Table.Cell>
+                    ))}
+                    {hasActions && (
+                      <Table.Cell className="px-4">
+                        <div className="flex justify-end">
+                          <Dropdown.Root>
+                            <Button
+                              size="sm"
+                              color="tertiary"
+                              iconLeading={<Menu01 className="size-5" />}
+                              onClick={(e: ReactMouseEvent<HTMLButtonElement>) => {
+                                e.stopPropagation();
+                              }}
+                              onPointerDown={(e: ReactPointerEvent<HTMLButtonElement>) => {
+                                // Prevent React Aria from starting selection on pointer down
+                                e.stopPropagation();
+                              }}
+                            />
+                            <Dropdown.Popover className="w-min">
+                              <Dropdown.Menu>
+                                {rowActions!(item).map((a) => (
+                                  <Dropdown.Item
+                                    key={a.label}
+                                    label={a.label}
+                                    onAction={() => a.onClick(item)}
+                                  />
+                                ))}
+                              </Dropdown.Menu>
+                            </Dropdown.Popover>
+                          </Dropdown.Root>
+                        </div>
+                      </Table.Cell>
+                    )}
+                  </Table.Row>
+                );
+              })}
+            </Table.Body>
+          </Table>
+        </div>
       ) : (
         <div className="flex items-center justify-center px-8 py-20">
           <EmptyState size="sm">

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -479,6 +479,7 @@ function GabinetDocumentsPage() {
       {
         id: "title",
         label: t("gabinet.formDocuments.colTitle", "Tytuł"),
+        className: "min-w-[200px]",
         render: (item) => (
           <div className="font-medium">{item.title}</div>
         ),
@@ -486,6 +487,7 @@ function GabinetDocumentsPage() {
       {
         id: "category",
         label: t("gabinet.formDocuments.colCategory", "Kategoria"),
+        className: "min-w-[120px]",
         render: (item) => (
           <Badge variant="secondary" className="text-xs">
             {getCategoryLabel(item.templateId)}
@@ -495,6 +497,7 @@ function GabinetDocumentsPage() {
       {
         id: "entityType",
         label: t("gabinet.formDocuments.colEntityType", "Typ"),
+        className: "min-w-[100px]",
         render: (item) => (
           <span className="text-sm text-muted-foreground">
             {getEntityTypeLabel(item.entityType)}
@@ -504,6 +507,7 @@ function GabinetDocumentsPage() {
       {
         id: "status",
         label: t("gabinet.formDocuments.colStatus", "Status"),
+        className: "min-w-[140px]",
         render: (item) => (
           <DocumentStatusBadge status={item.status as any} />
         ),
@@ -511,6 +515,7 @@ function GabinetDocumentsPage() {
       {
         id: "createdAt",
         label: t("gabinet.formDocuments.colCreatedAt", "Data utworzenia"),
+        className: "min-w-[130px]",
         render: (item) => (
           <span className="text-sm text-muted-foreground">
             {formatDate(item.createdAt)}
@@ -520,6 +525,7 @@ function GabinetDocumentsPage() {
       {
         id: "createdBy",
         label: t("gabinet.formDocuments.colCreatedBy", "Utworzony przez"),
+        className: "min-w-[130px]",
         render: (item) => (
           <span className="text-sm text-muted-foreground">
             {getUserName(item.createdBy)}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -178,6 +178,7 @@ function EmployeesIndex() {
       label: t("gabinet.employees.employee"),
       sortable: true,
       isRowHeader: true,
+      className: "min-w-[200px]",
       render: (item) => {
         const displayName = getDisplayName(item);
         const initials = getInitials(item);
@@ -210,11 +211,13 @@ function EmployeesIndex() {
     {
       id: "role",
       label: t("gabinet.employees.role"),
+      className: "min-w-[120px]",
       render: (item) => item.role ? t(`gabinet.employees.roles.${item.role}`) : "\u2014",
     },
     {
       id: "specialization",
       label: t("gabinet.employees.specialization"),
+      className: "min-w-[140px]",
       render: (item) => item.specialization ?? "\u2014",
     },
     {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -297,6 +297,7 @@ function PatientsIndex() {
         label: t("gabinet.patients.contact"),
         sortable: true,
         isRowHeader: true,
+        className: "min-w-[220px]",
         render: (item) => (
           <div className="flex items-center gap-3">
             <Link
@@ -325,6 +326,7 @@ function PatientsIndex() {
         id: "email",
         label: t("common.email"),
         sortable: true,
+        className: "min-w-[160px]",
         render: (item) => item.email ?? "—",
         getSortValue: (item) => item.email ?? "",
       },
@@ -332,6 +334,7 @@ function PatientsIndex() {
         id: "phone",
         label: t("common.phone"),
         sortable: true,
+        className: "min-w-[140px]",
         render: (item) =>
           item.phone ? (
             <span className="whitespace-nowrap">{formatPhoneNumber(item.phone)}</span>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2033.

Closes #2033

---

## Claude summary

Committed as `7933dc5`. Here's a summary of what was changed:

**`src/components/crm/enhanced-data-table.tsx`** — Wrapped the `<Table>` element in `<div className="overflow-x-auto">`. The toolbar, bulk-actions bar, and pagination stay full-width; only the table body scrolls horizontally. This benefits all `CrmDataTable` usages across the app, not just gabinet.

**`_layout.gabinet.patients.index.tsx`** — Added `className: "min-w-[220px]"` to the contact column (avatar + name + subtitle), `min-w-[160px]` to email, and `min-w-[140px]` to phone.

**`_layout.gabinet.employees.index.tsx`** — Added `className: "min-w-[200px]"` to the employee column, `min-w-[120px]` to role, and `min-w-[140px]` to specialization.

**`_layout.gabinet.documents.index.tsx`** — Added min-widths to all six data columns (title `200px`, category `120px`, entity type `100px`, status `140px`, created-at `130px`, created-by `130px`). Since `DocumentsGroupedView` wraps `CrmDataTable`, this flows through automatically.

## Follow-ups

- Add min-w classes to key columns in gabinet treatments table: the `_layout.gabinet.treatments.index.tsx` uses `CrmDataTable` with similar many-column layouts but was out of scope for this issue's specific call-out.
- Add min-w classes to key columns in gabinet packages table: `_layout.gabinet.packages.index.tsx` is likely in the same state as the treatments table — not mentioned in the issue but same root cause.