### PR TITLE
Responsive layout for appointment detail page (`_layout.gabinet.appointments.$ap

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1505,8 +1505,8 @@ function AppointmentDetail() {
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4 px-6 py-4">
-              <div className="grid grid-cols-[1fr_auto_auto] items-end gap-2">
-                <div className="space-y-1.5">
+              <div className="grid grid-cols-2 sm:grid-cols-[1fr_auto_auto] items-end gap-2">
+                <div className="col-span-2 sm:col-span-1 space-y-1.5">
                   <Label className="text-xs uppercase tracking-wide text-muted-foreground">
                     {t("common.date")}
                   </Label>
@@ -1795,7 +1795,7 @@ function AppointmentDetail() {
               </CardTitle>
             </CardHeader>
             <CardContent className="px-6 py-4">
-              <div className="grid grid-cols-3 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 <div className="text-center p-4 bg-muted/50 rounded-lg">
                   <p className="text-sm text-muted-foreground">
                     {t("gabinet.payments.treatmentPrice")}
@@ -1845,7 +1845,7 @@ function AppointmentDetail() {
 
           {/* Payments Table */}
           <Card>
-            <CardHeader className="flex flex-row items-center justify-between px-6 py-3 border-b">
+            <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2 px-6 py-3 border-b">
               <div>
                 <CardTitle className="text-sm flex items-center gap-2">
                   <CreditCard className="h-4 w-4" variant="stroke" />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2034.

Closes #2034

---

## Claude summary

The issue is a real bug. Three targeted fixes were applied to `_layout.gabinet.appointments.$appointmentId.lazy.tsx`:

1. **Payment Summary card** — `grid grid-cols-3` changed to `grid grid-cols-1 sm:grid-cols-3`. Three columns with `text-2xl` prices would be crushed to ~65px each on a 375px phone; they now stack vertically on mobile (same pattern applied to RevenueSummaryCard in #2018).

2. **Scheduling card** — the date + two 110px time pickers in `grid-cols-[1fr_auto_auto]` would leave the date field just ~91px wide on mobile. Changed to a 2-col grid on mobile where the date spans full width (`col-span-2`) and the two time pickers sit side-by-side below it; the original 3-col layout resumes at `sm:` (640px).

3. **Payments card header** — `flex flex-row items-center justify-between` with title block and "Add Payment" button; added `flex-wrap gap-2` so the button wraps to a new row on very narrow screens instead of overflowing.