### PR TITLE
Employee schedule Sheet content (`FlexibleScheduleEditor`)

### DIFF
--- a/src/components/gabinet/flexible-schedule-editor.tsx
+++ b/src/components/gabinet/flexible-schedule-editor.tsx
@@ -609,7 +609,8 @@ export function FlexibleScheduleEditor({
               </div>
             </div>
 
-            <div className="rounded-lg border">
+            <div className="overflow-x-auto">
+            <div className="rounded-lg border min-w-[600px]">
               <div className="grid grid-cols-[180px_50px_1fr_1fr_2fr_1fr] gap-2 border-b bg-muted/50 px-3 py-2 text-xs font-medium text-muted-foreground">
                 <span>{t("gabinet.scheduling.day")}</span>
                 <span>{t("gabinet.scheduling.open")}</span>
@@ -740,6 +741,7 @@ export function FlexibleScheduleEditor({
                   </div>
                 );
               })}
+            </div>
             </div>
 
             {periodFrom && periodTo && (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2035.

Closes #2035

---

## Claude summary

The bug is confirmed and fixed. The `FlexibleScheduleEditor` edit form used `grid-cols-[180px_50px_1fr_1fr_2fr_1fr]` with no overflow protection — on a narrow mobile screen inside the Sheet (`sm:max-w-[760px]` which becomes full-width on mobile), this grid would overflow the viewport with no way to scroll.

The fix wraps the fixed-width grid in `overflow-x-auto` with `min-w-[600px]` on the inner div, identical to the approach already used for the week-preview table in the same component (line 389: `"rounded-md border overflow-x-auto"`).