### PR TITLE
Responsive PageHeader pattern in CRM module pages

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
@@ -539,7 +539,7 @@ function LeadsIndex() {
         title={t("deals.title")}
         description={t("deals.description")}
         actions={
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             {pipelines && pipelines.length > 0 && (
               <Select
                 value={activePipeline?._id ?? ""}

--- a/src/routes/_app/_auth/dashboard/_layout.pipelines.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.pipelines.index.tsx
@@ -118,7 +118,7 @@ function PipelinesIndex() {
         title={t('pipelines.title')}
         description={t('pipelines.description')}
         actions={
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             {pipelines && pipelines.length > 1 && (
               <div className="flex gap-1">
                 {pipelines.map((p) => (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2036.

Closes #2036

---

## Claude summary

The bug was real and the fix is committed. Both `_layout.leads.index.tsx:542` and `_layout.pipelines.index.tsx:121` had `flex items-center gap-2` on their PageHeader `actions` wrapper divs — missing `flex-wrap`. Added `flex-wrap` to both, matching the pattern already in `_layout.gabinet.treatments.index.tsx:563`.