### PR TITLE
Add min-w classes to key columns in gabinet treatments table

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -263,6 +263,7 @@ function TreatmentsIndex() {
         label: t("gabinet.treatments.name"),
         sortable: true,
         isRowHeader: true,
+        className: "min-w-[200px]",
         render: (item) => (
           <div className="flex items-center gap-2 pl-2 md:pl-0">
             <span
@@ -290,6 +291,7 @@ function TreatmentsIndex() {
         id: "isPackage",
         label: t("gabinet.treatments.type", "Typ"),
         sortable: true,
+        className: "min-w-[120px]",
         render: (item) => {
           const linkedPackageName = item.packageId
             ? packageNameById.get(item.packageId)
@@ -343,6 +345,7 @@ function TreatmentsIndex() {
         id: "category",
         label: t("gabinet.treatments.category"),
         sortable: true,
+        className: "min-w-[140px]",
         render: (item) => getCategoryLabel(item) ?? "—",
         getSortValue: (item) => getCategoryLabel(item) ?? "",
       },
@@ -350,6 +353,7 @@ function TreatmentsIndex() {
         id: "duration",
         label: t("gabinet.treatments.duration"),
         sortable: true,
+        className: "min-w-[100px]",
         render: (item) => `${item.duration} min`,
         getSortValue: (item) => item.duration,
       },
@@ -357,6 +361,7 @@ function TreatmentsIndex() {
         id: "price",
         label: t("gabinet.treatments.price"),
         sortable: true,
+        className: "min-w-[120px]",
         render: (item) => formatCurrency(item.price, item.currency ?? undefined),
         getSortValue: (item) => item.price,
       },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2038.

Closes #2038

---

## Claude summary

Done. The fix adds `className: "min-w-[...]"` to five key columns in the gabinet treatments table, matching the pattern already applied to patients (`#2033`) and employees:

| Column | `min-w` |
|--------|---------|
| `name` | 200px |
| `isPackage` (Type) | 120px |
| `category` | 140px |
| `duration` | 100px |
| `price` | 120px |

The `taxRate` and `isActive` columns are intentionally left without min-w — they render very compact content (e.g. `"ZW"`, `"8%"`, and a dot) and don't need minimum widths to prevent overflow.