### PR TITLE
Fix flex-wrap on gabinet packages PageHeader action row

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -356,7 +356,7 @@ function PackagesIndex() {
 
   return (
     <div className="flex flex-col gap-6 p-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-4">
         <PageHeader title={t("gabinet.packages.title")} description={t("gabinet.packages.description")} />
         <Button size="sm" onClick={openCreate}>
           <Plus className="mr-2 h-4 w-4" variant="stroke" />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2044.

Closes #2044

---

## Claude summary

The fix is committed. Added `flex-wrap` and `gap-4` to the header row at line 359 of `_layout.gabinet.packages.index.tsx`, matching the same pattern applied in #2036 for leads and pipelines pages. On narrow screens the "Add Package" button will now wrap below the title instead of overflowing.