### PR TITLE
produkty/magazyn

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -117,7 +117,7 @@
     "contacts": "Contacts",
     "companies": "Companies",
     "insights": "Insights",
-    "products": "Products",
+    "products": "Products / Warehouse",
     "calls": "Calls",
     "gabinet": {
       "_": "Cabinet",
@@ -270,7 +270,7 @@
     "templates": "Templates",
     "usagesThisMonth": "Uses/month",
     "topTemplate": "Top Template",
-    "products": "Products",
+    "products": "Products / Warehouse",
     "inDeals": "In Deals",
     "topSeller": "Top Seller",
     "newThisMonth": "New/month",
@@ -855,7 +855,7 @@
     }
   },
   "products": {
-    "title": "Products",
+    "title": "Products / Warehouse",
     "description": "Manage your product catalog.",
     "addProduct": "Add Product",
     "newProduct": "New Product",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -117,7 +117,7 @@
     "contacts": "Kontakty",
     "companies": "Firmy",
     "insights": "Statystyki",
-    "products": "Produkty",
+    "products": "Produkty / Magazyn",
     "calls": "Połączenia",
     "gabinet": {
       "_": "Gabinet",
@@ -270,7 +270,7 @@
     "templates": "Szablony",
     "usagesThisMonth": "Użycia/mies.",
     "topTemplate": "Najczęstszy",
-    "products": "Produkty",
+    "products": "Produkty / Magazyn",
     "inDeals": "W dealach",
     "topSeller": "Top",
     "newThisMonth": "Nowe w mies.",
@@ -856,7 +856,7 @@
     }
   },
   "products": {
-    "title": "Produkty",
+    "title": "Produkty / Magazyn",
     "description": "Zarządzaj katalogiem produktów.",
     "addProduct": "Dodaj produkt",
     "newProduct": "Nowy produkt",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2031.

Closes #2031

---

## Claude summary

Done. Here's a summary of what changed:

The module rename is purely a translation change — no routing, permissions, or business logic was touched. I updated 3 keys in each locale file:

| Key | PL (before → after) | EN (before → after) |
|---|---|---|
| `nav.products` | Produkty → **Produkty / Magazyn** | Products → **Products / Warehouse** |
| `widgets.products` (line 273) | Produkty → **Produkty / Magazyn** | Products → **Products / Warehouse** |
| `products.title` | Produkty → **Produkty / Magazyn** | Products → **Products / Warehouse** |

The `nav.products` key drives both the sidebar menu item and the breadcrumb/page-context title (via `titleKey: "nav.products"` in `manifest.ts:211`). The `products.title` key drives the `PageHeader` on the products page. This covers all three user-visible surfaces listed in the issue (menu, page header, breadcrumbs).

Deliberately not changed: `relationships.products` (tab label in the deal entity panel) and `usageStats.products` (org settings usage counter) — those refer to the "products" entity type in unrelated contexts, not the module name.