### PR TITLE
Produkty 2

### DIFF
--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -12,6 +12,7 @@ import {
   Gift,
   Heart,
   LayoutDashboard,
+  Package,
   PieChart,
   PlusCircle,
   SearchIcon,
@@ -53,6 +54,7 @@ export const gabinetManifest: ModuleManifest = {
     { labelKey: "nav.gabinet.employees", href: "/dashboard/gabinet/employees", icon: UserCog },
     { labelKey: "nav.gabinet.documents", href: "/dashboard/gabinet/documents", icon: ClipboardList },
     { labelKey: "nav.gabinet.documentTemplates", href: "/dashboard/gabinet/document-templates", icon: FilePlus },
+    { labelKey: "nav.products", href: "/dashboard/products", icon: Package },
     { labelKey: "nav.gabinet.reports", href: "/dashboard/gabinet/reports", icon: PieChart },
   ],
   settingsNav: [


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2047.

Closes #2047

---

## Claude summary

The change is committed. Here's what was done and why:

**Change:** 2 lines added to `src/modules/gabinet/manifest.ts`.

1. Imported the `Package` icon (already used in CRM for the same nav item).
2. Added `{ labelKey: "nav.products", href: "/dashboard/products", icon: Package }` to `gabinetManifest.primaryNav`, placed between Document Templates and Reports.

**How it works:** The sidebar is fully driven by the module manifests. When a user is in the Gabinet workspace they see Gabinet's `primaryNav`. Clicking "Produkty / Magazyn" navigates them to `/dashboard/products` — the existing Products/Warehouse page. Because that route lives under `/dashboard` (CRM's workspaceRoot), the sidebar correctly switches to CRM mode on arrival, and the full existing Products UI (table, filters, create/edit forms, CSV import/export, etc.) is available. No new routes, tables, migrations, or screens were created.

The `nav.products` translation key already resolves to "Produkty / Magazyn" (PL) / "Products / Warehouse" (EN) from PR #2031.