### PR TITLE
Produkty 3

### DIFF
--- a/convex/products.ts
+++ b/convex/products.ts
@@ -78,6 +78,7 @@ export const create = action({
     trackStock: v.optional(v.union(v.boolean(), v.null())),
     stockUnit: v.optional(v.union(v.string(), v.null())),
     initialStock: v.optional(v.union(v.number(), v.null())),
+    productSection: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(
@@ -107,6 +108,7 @@ export const create = action({
       categoryId: args.categoryId ?? null,
       trackStock,
       stockUnit: args.stockUnit ?? null,
+      productSection: args.productSection ?? null,
       createdBy: String(authResult.userId),
       createdAt: now,
       updatedAt: now,
@@ -179,6 +181,7 @@ export const update = action({
     categoryId: v.optional(v.union(v.string(), v.null())),
     trackStock: v.optional(v.union(v.boolean(), v.null())),
     stockUnit: v.optional(v.union(v.string(), v.null())),
+    productSection: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -312,6 +312,8 @@ export function createCrmTables({
     // history but no balance is maintained.
     trackStock: v.optional(v.boolean()),
     stockUnit: v.optional(v.string()),
+    // Organisational section (#2049): "sale" | "treatment" | "disposable"
+    productSection: v.optional(v.string()),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -877,6 +877,15 @@
       "all": "All Products",
       "active": "Active Products"
     },
+    "sections": {
+      "all": "All",
+      "sale": "For Sale",
+      "treatment": "Treatment Preparations",
+      "disposable": "Disposable Materials",
+      "label": "Section",
+      "placeholder": "Select section",
+      "none": "No section"
+    },
     "form": {
       "name": "Product Name",
       "namePlaceholder": "Enter product name",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -878,6 +878,15 @@
       "all": "Wszystkie produkty",
       "active": "Aktywne produkty"
     },
+    "sections": {
+      "all": "Wszystkie",
+      "sale": "Produkty do sprzedaży",
+      "treatment": "Preparaty zabiegowe",
+      "disposable": "Materiały jednorazowe",
+      "label": "Sekcja",
+      "placeholder": "Wybierz sekcję",
+      "none": "Bez sekcji"
+    },
     "form": {
       "name": "Nazwa produktu",
       "namePlaceholder": "Wpisz nazwę produktu",

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -1349,6 +1349,7 @@ export interface Database {
           tax_exempt: boolean | null;
           track_stock: boolean | null;
           stock_unit: string | null;
+          product_section: string | null;
         };
         Insert: {
           id?: string;
@@ -1367,6 +1368,7 @@ export interface Database {
           tax_exempt?: boolean | null;
           track_stock?: boolean | null;
           stock_unit?: string | null;
+          product_section?: string | null;
         };
         Update: {
           id?: string;
@@ -1385,6 +1387,7 @@ export interface Database {
           tax_exempt?: boolean | null;
           track_stock?: boolean | null;
           stock_unit?: string | null;
+          product_section?: string | null;
         };
       };
       deal_products: {

--- a/src/lib/supabase/mappers/products.ts
+++ b/src/lib/supabase/mappers/products.ts
@@ -20,6 +20,7 @@ export interface MappedProduct {
   categoryId?: string;
   trackStock?: boolean;
   stockUnit?: string;
+  productSection?: string;
   createdBy: string;
   createdAt: number;
   updatedAt: number;

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -19,6 +19,7 @@ import { Label } from "@/components/ui/label";
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Select,
   SelectContent,
@@ -44,6 +45,9 @@ import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { formatActionError } from "@/lib/format-action-error";
 
 type ProductsNudgeFilter = "unused";
+
+const PRODUCT_SECTIONS = ["sale", "treatment", "disposable"] as const;
+type ProductSection = (typeof PRODUCT_SECTIONS)[number];
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/products/"
@@ -111,6 +115,7 @@ function ProductsPage() {
   const {
     views, activeViewId, onViewChange, onCreateView, onDeleteView, applyFilters,
   } = useSavedViews({ organizationId, entityType: "product", systemViews });
+  const [activeSection, setActiveSection] = useState<ProductSection | "all">("all");
   const [panelOpen, setPanelOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
   const [savedViewsDialogOpen, setSavedViewsDialogOpen] = useState(false);
@@ -163,6 +168,7 @@ function ProductsPage() {
   const [trackStock, setTrackStock] = useState(false);
   const [stockUnit, setStockUnit] = useState("");
   const [initialStock, setInitialStock] = useState("");
+  const [productSection, setProductSection] = useState<ProductSection | "">("");
 
   const { data: allProducts = [], isLoading } = useSupabaseProductsList(organizationId);
   const { data: usedProductIds } = useSupabaseUsedProductIds(organizationId, {
@@ -178,6 +184,9 @@ function ProductsPage() {
     if (nudgeFilter === "unused" && usedProductIds) {
       data = data.filter((p) => !usedProductIds.has(p._id));
     }
+    if (activeSection !== "all") {
+      data = data.filter((p) => p.productSection === activeSection);
+    }
     data = applyFilters(data);
     data = applyFilterConditions(data, activeFilters);
     if (searchValue.trim()) {
@@ -188,7 +197,7 @@ function ProductsPage() {
       );
     }
     return data;
-  }, [activeViewId, allProducts, applyFilters, activeFilters, searchValue, nudgeFilter, usedProductIds]);
+  }, [activeViewId, allProducts, applyFilters, activeFilters, searchValue, nudgeFilter, usedProductIds, activeSection]);
 
   const createProduct = useAction(api.products.create);
   const updateProduct = useAction(api.products.update);
@@ -207,6 +216,7 @@ function ProductsPage() {
     setTrackStock(false);
     setStockUnit("");
     setInitialStock("");
+    setProductSection(activeSection !== "all" ? activeSection : "");
     setEditingProduct(null);
   };
 
@@ -228,6 +238,7 @@ function ProductsPage() {
     setTrackStock(!!product.trackStock);
     setStockUnit(product.stockUnit ?? "");
     setInitialStock("");
+    setProductSection((product.productSection as ProductSection | undefined) ?? "");
     setPanelOpen(true);
   };
 
@@ -249,6 +260,7 @@ function ProductsPage() {
       const parsed = parseFloat(initialStock.replace(",", "."));
       return Number.isFinite(parsed) ? parsed : null;
     })();
+    const normalizedSection = productSection || null;
     try {
       if (editingProduct) {
         await updateProduct({
@@ -264,6 +276,7 @@ function ProductsPage() {
           categoryId: categoryId ?? null,
           trackStock,
           stockUnit: normalizedStockUnit,
+          productSection: normalizedSection,
         });
       } else {
         await createProduct({
@@ -280,6 +293,7 @@ function ProductsPage() {
           trackStock,
           stockUnit: normalizedStockUnit,
           initialStock: normalizedInitialStock,
+          productSection: normalizedSection,
         });
       }
       setPanelOpen(false);
@@ -349,6 +363,14 @@ function ProductsPage() {
       sortable: true,
     },
     {
+      id: "productSection",
+      label: t("products.sections.label", { defaultValue: "Sekcja" }),
+      render: (item) => {
+        if (!item.productSection) return "\u2014";
+        return t(`products.sections.${item.productSection}`, { defaultValue: item.productSection });
+      },
+    },
+    {
       id: "isActive",
       label: t('common.active'),
       render: (item) => item.isActive ? "\u2713" : "\u2014",
@@ -400,6 +422,19 @@ function ProductsPage() {
           </Button>
         }
       />
+
+      <Tabs value={activeSection} onValueChange={(v) => setActiveSection(v as ProductSection | "all")}>
+        <TabsList>
+          <TabsTrigger value="all">
+            {t("products.sections.all", { defaultValue: "Wszystkie" })}
+          </TabsTrigger>
+          {PRODUCT_SECTIONS.map((section) => (
+            <TabsTrigger key={section} value={section}>
+              {t(`products.sections.${section}`)}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
 
       {nudgeFilter === "unused" && (
         <div className="flex items-center justify-between rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
@@ -505,6 +540,23 @@ function ProductsPage() {
               onChange={(e) => setSku(e.target.value)}
               placeholder="PRD-XXXXXX"
             />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>{t("products.sections.label", { defaultValue: "Sekcja" })}</Label>
+            <Select value={productSection} onValueChange={(v) => setProductSection(v as ProductSection | "")}>
+              <SelectTrigger>
+                <SelectValue placeholder={t("products.sections.placeholder", { defaultValue: "Wybierz sekcję" })} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="">{t("products.sections.none", { defaultValue: "Bez sekcji" })}</SelectItem>
+                {PRODUCT_SECTIONS.map((section) => (
+                  <SelectItem key={section} value={section}>
+                    {t(`products.sections.${section}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
 
           <div className="grid gap-4 grid-cols-2">

--- a/supabase/migrations/00019_products_section.sql
+++ b/supabase/migrations/00019_products_section.sql
@@ -1,0 +1,18 @@
+-- Products section (#2049).
+--
+-- Adds an organisational `product_section` column to the products table.
+-- Products can belong to one of three sections:
+--
+--   • sale        — Produkty do sprzedaży (retail goods sold to clients)
+--   • treatment   — Preparaty zabiegowe (preparations used during treatments)
+--   • disposable  — Materiały jednorazowe (single-use consumables)
+--
+-- The column is nullable so that all existing products are unaffected.
+-- No stock-level, movement, or inventory logic is added here.
+
+ALTER TABLE products
+  ADD COLUMN IF NOT EXISTS product_section TEXT;
+
+CREATE INDEX IF NOT EXISTS products_section_idx
+  ON products (organization_id, product_section)
+  WHERE product_section IS NOT NULL;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2049.

Closes #2049

---

## Claude summary

The implementation is complete. Here's a summary of what was done:

**8 files changed** across the full stack:

**Database layer:**
- `supabase/migrations/00019_products_section.sql` — adds a nullable `product_section` TEXT column to the `products` table, with a partial index on `(organization_id, product_section)` for efficient tab filtering
- `src/lib/supabase/database.types.ts` — adds `product_section: string | null` to the products Row/Insert/Update types

**Backend:**
- `convex/schema/crm.ts` — adds `productSection: v.optional(v.string())` to the products schema
- `convex/products.ts` — threads `productSection` through both `create` and `update` actions

**Frontend:**
- `src/lib/supabase/mappers/products.ts` — adds `productSection?: string` to `MappedProduct`
- `src/routes/_app/_auth/dashboard/_layout.products.index.tsx` — adds:
  - Section tab bar (All / Produkty do sprzedaży / Preparaty zabiegowe / Materiały jednorazowe) above the filter bar
  - Section `<Select>` picker in the create/edit form (pre-populated with the active tab when creating)
  - "Sekcja" column in the data table
  - Section filter in the products memo
- `public/locales/pl/translation.json` and `en/translation.json` — adds `products.sections.*` translation keys

Existing products are unaffected (`product_section` is nullable). No stock levels, movements, or inventory logic was added — this is purely an organisational split as requested.