### PR TITLE
Produkty 4

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -879,9 +879,9 @@
     },
     "sections": {
       "all": "All",
-      "sale": "For Sale",
-      "treatment": "Treatment Preparations",
-      "disposable": "Disposable Materials",
+      "sale": "Products",
+      "treatment": "Preparations",
+      "disposable": "Materials",
       "label": "Section",
       "placeholder": "Select section",
       "none": "No section"

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -880,9 +880,9 @@
     },
     "sections": {
       "all": "Wszystkie",
-      "sale": "Produkty do sprzedaży",
-      "treatment": "Preparaty zabiegowe",
-      "disposable": "Materiały jednorazowe",
+      "sale": "Produkty",
+      "treatment": "Preparaty",
+      "disposable": "Materiały",
       "label": "Sekcja",
       "placeholder": "Wybierz sekcję",
       "none": "Bez sekcji"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2051.

Closes #2051

---

## Claude summary

Done. The changes are committed. Two translation files were updated — no logic, routing, database values, or component code needed touching because the section names flow entirely through i18n keys (`products.sections.sale/treatment/disposable`).

Summary of what changed:

| Key | PL before | PL after | EN before | EN after |
|---|---|---|---|---|
| `sale` | Produkty do sprzedaży | Produkty | For Sale | Products |
| `treatment` | Preparaty zabiegowe | Preparaty | Treatment Preparations | Preparations |
| `disposable` | Materiały jednorazowe | Materiały | Disposable Materials | Materials |

These keys drive the tabs, the Section column in the table, and the section select in the create/edit form — all three surfaces in scope update automatically.