### PR TITLE
Produkty 6

### DIFF
--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -18,6 +18,7 @@ type ProductRow = SupabaseRow<"products">;
 
 const REASON_VALIDATOR = v.union(
   v.literal("initial"),
+  v.literal("warehouse_receive"),
   v.literal("manual_adjust"),
   v.literal("appointment_use"),
   v.literal("appointment_return"),

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -348,6 +348,7 @@ export function createCrmTables({
     balanceAfter: v.optional(v.number()),
     reason: v.union(
       v.literal("initial"),
+      v.literal("warehouse_receive"),
       v.literal("manual_adjust"),
       v.literal("appointment_use"),
       v.literal("appointment_return"),

--- a/src/components/forms/product-stock-adjust-dialog.tsx
+++ b/src/components/forms/product-stock-adjust-dialog.tsx
@@ -56,6 +56,7 @@ type AdjustStockArgs = {
   setTo?: number;
   reason?:
     | "initial"
+    | "warehouse_receive"
     | "manual_adjust"
     | "appointment_use"
     | "appointment_return"
@@ -144,7 +145,7 @@ export function ProductStockAdjustDialog({
             ? null
             : (locationId as Id<"gabinetLocations">),
         delta,
-        reason: "manual_adjust",
+        reason: mode === "receive" ? "warehouse_receive" : "manual_adjust",
         note: note.trim() || null,
       });
       void queryClient.invalidateQueries({

--- a/src/components/forms/product-stock-history-dialog.tsx
+++ b/src/components/forms/product-stock-history-dialog.tsx
@@ -1,0 +1,201 @@
+import { useTranslation } from "react-i18next";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import {
+  useSupabaseProductStockMovements,
+  useSupabaseProductStockTotals,
+  type MappedStockMovement,
+  type StockMovementReason,
+} from "@/hooks/use-supabase-products";
+import type { MappedProduct } from "@/lib/supabase/mappers/products";
+import { cn } from "@/lib/utils";
+
+interface ProductStockHistoryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationId: string;
+  product: MappedProduct | null;
+}
+
+function formatDate(ts: number): string {
+  return new Intl.DateTimeFormat("pl-PL", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(ts));
+}
+
+function reasonLabel(reason: StockMovementReason, t: ReturnType<typeof useTranslation>["t"]): string {
+  const map: Record<StockMovementReason, string> = {
+    warehouse_receive: t("products.stock.reason.warehouse_receive", { defaultValue: "Przyjęcie magazynowe" }),
+    initial: t("products.stock.reason.initial", { defaultValue: "Stan początkowy" }),
+    manual_adjust: t("products.stock.reason.manual_adjust", { defaultValue: "Korekta ręczna" }),
+    appointment_use: t("products.stock.reason.appointment_use", { defaultValue: "Zużycie podczas wizyty" }),
+    appointment_return: t("products.stock.reason.appointment_return", { defaultValue: "Zwrot po wizycie" }),
+    deal_close: t("products.stock.reason.deal_close", { defaultValue: "Zamknięcie transakcji" }),
+    deal_reopen: t("products.stock.reason.deal_reopen", { defaultValue: "Wznowienie transakcji" }),
+    transfer_in: t("products.stock.reason.transfer_in", { defaultValue: "Transfer — przyjęcie" }),
+    transfer_out: t("products.stock.reason.transfer_out", { defaultValue: "Transfer — wydanie" }),
+    other: t("products.stock.reason.other", { defaultValue: "Inne" }),
+  };
+  return map[reason] ?? reason;
+}
+
+function MovementRow({ movement, unit }: { movement: MappedStockMovement; unit: string }) {
+  const { t } = useTranslation();
+  const isPositive = movement.delta > 0;
+  const deltaStr = isPositive
+    ? `+${movement.delta}${unit ? ` ${unit}` : ""}`
+    : `${movement.delta}${unit ? ` ${unit}` : ""}`;
+
+  return (
+    <div className="grid grid-cols-[1fr_auto] gap-x-4 gap-y-0.5 rounded-md border px-3 py-2.5 text-sm">
+      <div className="flex flex-col gap-0.5">
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className={cn(
+              "font-semibold tabular-nums",
+              isPositive
+                ? "text-emerald-600 dark:text-emerald-400"
+                : "text-destructive",
+            )}
+          >
+            {deltaStr}
+          </span>
+          <Badge variant="secondary" className="text-xs py-0 px-1.5">
+            {reasonLabel(movement.reason, t)}
+          </Badge>
+        </div>
+        {movement.note && (
+          <p className="text-xs text-muted-foreground">{movement.note}</p>
+        )}
+        <p className="text-xs text-muted-foreground">
+          {movement.performedByName ?? movement.performedBy}
+        </p>
+      </div>
+      <div className="flex flex-col items-end gap-0.5 shrink-0">
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          {formatDate(movement.createdAt)}
+        </span>
+        {movement.balanceAfter != null && (
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {t("products.stock.history.balanceAfter", {
+              defaultValue: "Stan: {{value}}",
+              value: `${movement.balanceAfter}${unit ? ` ${unit}` : ""}`,
+            })}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ProductStockHistoryDialog({
+  open,
+  onOpenChange,
+  organizationId,
+  product,
+}: ProductStockHistoryDialogProps) {
+  const { t } = useTranslation();
+  const { totalsByProductId } = useSupabaseProductStockTotals(organizationId, {
+    enabled: open && !!product,
+  });
+  const { data: movements = [], isLoading } = useSupabaseProductStockMovements(
+    organizationId,
+    product?._id ?? null,
+    { enabled: open && !!product },
+  );
+
+  if (!product) return null;
+
+  const stockSummary = totalsByProductId.get(product._id);
+  const currentStock = stockSummary?.total ?? 0;
+  const unit = product.stockUnit?.trim() ?? "";
+  const unitStr = unit ? ` ${unit}` : "";
+
+  const lastReceipt = movements.find(
+    (m) => m.reason === "warehouse_receive" || (m.delta > 0 && m.reason === "initial"),
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>
+            {t("products.stock.history.title", {
+              defaultValue: "Historia przyjęć",
+            })}
+          </DialogTitle>
+          <DialogDescription>{product.name}</DialogDescription>
+        </DialogHeader>
+
+        {/* Summary strip */}
+        <div className="grid grid-cols-3 gap-2 rounded-md border bg-muted/30 px-3 py-2.5 text-sm shrink-0">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-xs text-muted-foreground">
+              {t("products.stock.adjust.currentBalance", {
+                defaultValue: "Aktualny stan",
+              })}
+            </span>
+            <span className="font-semibold tabular-nums">
+              {product.trackStock ? `${currentStock}${unitStr}` : "—"}
+            </span>
+          </div>
+          <div className="flex flex-col gap-0.5">
+            <span className="text-xs text-muted-foreground">
+              {t("products.stock.history.lastReceive", {
+                defaultValue: "Ostatnie przyjęcie",
+              })}
+            </span>
+            <span className="font-semibold tabular-nums">
+              {lastReceipt ? `+${lastReceipt.delta}${unitStr}` : "—"}
+            </span>
+          </div>
+          <div className="flex flex-col gap-0.5">
+            <span className="text-xs text-muted-foreground">
+              {t("products.stock.history.lastReceiveDate", {
+                defaultValue: "Data przyjęcia",
+              })}
+            </span>
+            <span className="font-medium text-xs">
+              {lastReceipt
+                ? new Intl.DateTimeFormat("pl-PL", {
+                    day: "2-digit",
+                    month: "2-digit",
+                    year: "numeric",
+                  }).format(new Date(lastReceipt.createdAt))
+                : "—"}
+            </span>
+          </div>
+        </div>
+
+        {/* Movement list */}
+        <div className="flex-1 overflow-y-auto space-y-2 min-h-0">
+          {isLoading && (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              {t("common.loading", { defaultValue: "Ładowanie…" })}
+            </p>
+          )}
+          {!isLoading && movements.length === 0 && (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              {t("products.stock.history.empty", {
+                defaultValue: "Brak operacji magazynowych dla tego produktu.",
+              })}
+            </p>
+          )}
+          {movements.map((m) => (
+            <MovementRow key={m._id} movement={m} unit={unit} />
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/use-supabase-products.ts
+++ b/src/hooks/use-supabase-products.ts
@@ -2,6 +2,34 @@
  * React Query hooks for fetching products from Supabase (PostgreSQL).
  */
 
+export type StockMovementReason =
+  | "initial"
+  | "warehouse_receive"
+  | "manual_adjust"
+  | "appointment_use"
+  | "appointment_return"
+  | "deal_close"
+  | "deal_reopen"
+  | "transfer_in"
+  | "transfer_out"
+  | "other";
+
+export interface MappedStockMovement {
+  _id: string;
+  organizationId: string;
+  productId: string;
+  locationId: string | null;
+  delta: number;
+  balanceAfter: number | null;
+  reason: StockMovementReason;
+  sourceType: string | null;
+  sourceId: string | null;
+  note: string | null;
+  performedBy: string;
+  performedByName?: string;
+  createdAt: number;
+}
+
 import { useMemo } from "react";
 import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
 import { useSupabase } from "@/components/supabase-provider";
@@ -149,4 +177,63 @@ export function useSupabaseProductStockTotals(
   }, [query.data]);
 
   return { ...query, totalsByProductId };
+}
+
+// ---------------------------------------------------------------------------
+// Product Stock Movements (#2056 — warehouse receiving MVP)
+//
+// Fetches the movement history for a single product, ordered newest-first.
+// Joins the users table so performer names are available without a second query.
+// ---------------------------------------------------------------------------
+
+export function useSupabaseProductStockMovements(
+  organizationId: string,
+  productId: string | null,
+  options: { enabled?: boolean; limit?: number } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true, limit = 100 } = options;
+
+  return useQuery<MappedStockMovement[], Error>({
+    queryKey: [
+      ...supabaseKeys.productStockMovements.list(organizationId),
+      productId ?? "",
+    ],
+    queryFn: async (): Promise<MappedStockMovement[]> => {
+      if (!client || !productId) return [];
+
+      const { data, error } = await client
+        .from("product_stock_movements")
+        .select(
+          `id, organization_id, product_id, location_id, delta, balance_after, reason, source_type, source_id, note, performed_by, created_at,
+           users:users!product_stock_movements_performed_by_fkey (id, name, email)`,
+        )
+        .eq("organization_id", organizationId)
+        .eq("product_id", productId)
+        .order("created_at", { ascending: false })
+        .limit(limit);
+
+      if (error) throw error;
+
+      return (data ?? []).map((row) => {
+        const user = (row as unknown as { users?: { id?: string; name?: string | null; email?: string | null } | null }).users;
+        return {
+          _id: row.id,
+          organizationId: row.organization_id,
+          productId: row.product_id,
+          locationId: row.location_id,
+          delta: Number(row.delta),
+          balanceAfter: row.balance_after != null ? Number(row.balance_after) : null,
+          reason: row.reason as StockMovementReason,
+          sourceType: row.source_type,
+          sourceId: row.source_id,
+          note: row.note,
+          performedBy: row.performed_by,
+          performedByName: user?.name ?? user?.email ?? undefined,
+          createdAt: Number(row.created_at),
+        };
+      });
+    },
+    enabled: enabled && isReady && !!organizationId && !!productId,
+  });
 }

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -29,10 +29,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Plus, Pencil, Trash2, Power, Upload, Download, X, Package, AlertTriangle } from "@/lib/ez-icons";
+import { Plus, Pencil, Trash2, Power, Upload, Download, X, Package, AlertTriangle, History } from "@/lib/ez-icons";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { CsvImportDialog } from "@/components/csv/csv-import-dialog";
 import { ProductStockAdjustDialog } from "@/components/forms/product-stock-adjust-dialog";
+import { ProductStockHistoryDialog } from "@/components/forms/product-stock-history-dialog";
 import type { SavedView, FieldDef, FilterCondition } from "@/components/crm/types";
 import { Id } from "@cvx/_generated/dataModel";
 import type { MappedProduct } from "@/lib/supabase/mappers/products";
@@ -242,6 +243,7 @@ function ProductsPage() {
   useSidebarDispatch("manageCategories", () => setCategoriesSlideoutOpen(true));
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
   const [stockAdjustProduct, setStockAdjustProduct] = useState<Product | null>(null);
+  const [stockHistoryProduct, setStockHistoryProduct] = useState<Product | null>(null);
 
   // Form state
   const [name, setName] = useState("");
@@ -558,9 +560,14 @@ function ProductsPage() {
     ];
     if (row.trackStock) {
       actions.push({
-        label: t('products.stock.adjust.action', { defaultValue: 'Przyjmij / wydaj towar' }),
+        label: t("products.stock.receive.action", { defaultValue: "Przyjęcie magazynowe" }),
         icon: <Package className="h-4 w-4" variant="stroke" />,
         onClick: () => setStockAdjustProduct(row),
+      });
+      actions.push({
+        label: t("products.stock.history.action", { defaultValue: "Historia operacji" }),
+        icon: <History className="h-4 w-4" variant="stroke" />,
+        onClick: () => setStockHistoryProduct(row),
       });
     }
     actions.push(
@@ -981,6 +988,15 @@ function ProductsPage() {
         }}
         organizationId={organizationId}
         product={stockAdjustProduct}
+      />
+
+      <ProductStockHistoryDialog
+        open={!!stockHistoryProduct}
+        onOpenChange={(open) => {
+          if (!open) setStockHistoryProduct(null);
+        }}
+        organizationId={organizationId}
+        product={stockHistoryProduct}
       />
 
       <TagsManagerSlideout


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2056.

Closes #2056

---

## Claude summary

Committed. Here's a summary of what was implemented:

## Summary

This PR was a legitimate feature request. The infrastructure (tables, Convex actions, adjust dialog) was already in place from earlier PRs, but the "przyjęcia magazynowe" workflow was missing key pieces:

**What was added (6 files, 310 lines):**

1. **`"warehouse_receive"` reason** — added to the Convex schema union validator and `REASON_VALIDATOR` in `inventory.ts`. No SQL migration needed since `reason` is a plain `TEXT` column in Postgres.

2. **Receipt-specific tracking** — `ProductStockAdjustDialog` now writes `reason: "warehouse_receive"` (instead of `"manual_adjust"`) when in receive mode. Issues remain `"manual_adjust"`. This lets the history be filtered to show only real deliveries.

3. **`useSupabaseProductStockMovements` hook** — new React Query hook that fetches per-product movement history from Supabase (newest first), with a Supabase JOIN to the `users` table for performer names in a single query.

4. **`ProductStockHistoryDialog`** — new dialog component showing:
   - Summary strip: current stock, last receipt quantity, last receipt date
   - Scrollable movement list: date/time, delta (green/red), reason badge, note, performer name, running balance

5. **Row menu** — products with `trackStock=true` now show two actions: "Przyjęcie magazynowe" (opens receive dialog) and "Historia operacji" (opens history dialog).

All existing sections (Produkty, Preparaty, Materiały) get the new behavior automatically.