### PR TITLE
fix(gabinet/reports): Polonize status labels and date range dropdown (#2058)

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -78,6 +78,7 @@
     "continue": "Continue",
     "selectAll": "Select all",
     "deselectAll": "Deselect all",
+    "custom": "Custom",
     "errors": {
       "permissionDenied": "You don't have permission to perform this action.",
       "invalidArguments": "Invalid data. Please check the form and try again.",
@@ -3520,7 +3521,16 @@
       "dateRange": "Date range",
       "last7days": "Last 7 days",
       "last90days": "Last 90 days",
-      "lastYear": "Last year"
+      "lastYear": "Last year",
+      "statuses": {
+        "pending_confirmation": "Pending",
+        "scheduled": "Scheduled",
+        "confirmed": "Confirmed",
+        "in_progress": "In Progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "no_show": "No Show"
+      }
     },
     "bodyChart": {
       "description": "Mark body areas related to the appointment",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -78,6 +78,7 @@
     "continue": "Dalej",
     "selectAll": "Zaznacz wszystkie",
     "deselectAll": "Odznacz wszystkie",
+    "custom": "Własny zakres",
     "errors": {
       "permissionDenied": "Brak uprawnień do tej operacji.",
       "invalidArguments": "Nieprawidłowe dane. Sprawdź formularz i spróbuj ponownie.",
@@ -3542,7 +3543,16 @@
       "dateRange": "Zakres dat",
       "last7days": "Ostatnie 7 dni",
       "last90days": "Ostatnie 90 dni",
-      "lastYear": "Ostatni rok"
+      "lastYear": "Ostatni rok",
+      "statuses": {
+        "pending_confirmation": "Oczekujące",
+        "scheduled": "Zaplanowane",
+        "confirmed": "Potwierdzone",
+        "in_progress": "W trakcie",
+        "completed": "Zakończone",
+        "cancelled": "Anulowane",
+        "no_show": "Nieobecność"
+      }
     },
     "bodyChart": {
       "description": "Zaznacz obszary ciała powiązane z wizytą",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -344,7 +344,7 @@ function StatusDistributionChart({
     const items = top.map((item, i) => {
       const key = slugify(item.status);
       config[key] = {
-        label: item.status.replace("_", " "),
+        label: t(`gabinet.reports.statuses.${item.status}`, item.status.replace("_", " ")),
         color: DONUT_COLORS[i % DONUT_COLORS.length],
       };
       return { category: key, count: item.count, fill: `var(--color-${key})` };


### PR DESCRIPTION
## Summary

Fixes English labels appearing in the Gabinet Reports view.

- `StatusDistributionChart` was generating status labels via `item.status.replace("_", " ")`, producing raw English strings like "no show", "in progress", "scheduled". Now uses `t("gabinet.reports.statuses.<status>")` with proper Polish neuter forms.
- The date-range dropdown "Custom" option used `t("common.custom", "Custom")` but `common.custom` was missing from both locale files, so it always fell back to the English string.

## Labels changed

| English (before) | Polish (after) |
|---|---|
| Custom | Własny zakres |
| Scheduled | Zaplanowane |
| In Progress | W trakcie |
| Completed | Zakończone |
| Cancelled | Anulowane |
| No Show | Nieobecność |

## Files changed

- `public/locales/pl/translation.json` — added `common.custom` and `gabinet.reports.statuses` block
- `public/locales/en/translation.json` — same additions for English locale consistency
- `src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx` — one-line fix in `StatusDistributionChart` to use translation keys instead of raw string manipulation

## Test plan

- [ ] Open Gabinet → Raporty and verify status distribution chart legend shows Polish labels
- [ ] Open date-range dropdown and verify "Własny zakres" appears instead of "Custom"
- [ ] Confirm KPI cards (Zakończone, Anulowane) still display correctly
- [ ] Switch app language to English and verify English labels still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)