### PR TITLE
Przycisk do wyświetlania

### DIFF
--- a/src/components/documents/entity-documents-tab.tsx
+++ b/src/components/documents/entity-documents-tab.tsx
@@ -661,7 +661,15 @@ function SortableDocumentRow({
             </span>
           </Button>
         )}
-        <Eye className="hidden sm:block h-4 w-4 text-muted-foreground" />
+        <Button
+          size="sm"
+          variant="ghost"
+          className="hidden sm:flex h-7 w-7 p-0 text-muted-foreground shrink-0"
+          aria-label={t("documents.view", "Podgląd")}
+          onClick={(e) => { e.stopPropagation(); onOpen(); }}
+        >
+          <Eye className="h-4 w-4" variant="stroke" />
+        </Button>
         <Button
           size="sm"
           variant="ghost"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2066.

Closes #2066

---

## Claude summary

The bug was in `src/components/documents/entity-documents-tab.tsx:664`. The eye (👁️) icon next to each document in the Documents tab was rendered as a plain static element with no click handler:

```tsx
<Eye className="hidden sm:block h-4 w-4 text-muted-foreground" />
```

It looked like a button, but clicking it did nothing — only clicking the document's filename text area opened the viewer. The fix wraps it in a proper `Button` that calls `onOpen()` (with `e.stopPropagation()` so the drag handler doesn't fire), matching user expectation that clicking the eye icon opens the document.

## Follow-ups

- Localize "Show less" / "{n} more fields" in EntityDetailLayout: lines 456–466 in `src/components/crm/entity-detail-layout.tsx` have hardcoded English strings not run through `t()`, so they appear in English in the Polish UI.