### PR TITLE
Localize "Show less" / "{n} more fields" in EntityDetailLayout

### DIFF
--- a/src/components/crm/entity-detail-layout.tsx
+++ b/src/components/crm/entity-detail-layout.tsx
@@ -455,11 +455,12 @@ export function EntityDetailLayout({
               >
                 {showAllFields ? (
                   <>
-                    Show less <ChevronUp className="ml-1 h-3 w-3" />
+                    {t("detail.sidebar.showLess")}{" "}
+                    <ChevronUp className="ml-1 h-3 w-3" />
                   </>
                 ) : (
                   <>
-                    {hiddenCount} more fields{" "}
+                    {t("detail.sidebar.showMore", { count: hiddenCount })}{" "}
                     <ChevronDown className="ml-1 h-3 w-3" />
                   </>
                 )}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2068.

Closes #2068

---

## Claude summary

Done. The fix replaces the hardcoded English strings at lines 456–466 of `src/components/crm/entity-detail-layout.tsx` with `t("detail.sidebar.showLess")` and `t("detail.sidebar.showMore", { count: hiddenCount })`. Both translation keys already existed in `public/locales/pl/translation.json` ("Zwiń" and "{{count}} pól więcej") — the component just wasn't using them.