### PR TITLE
przycisk „+ Dodaj” w formularzu pakietu,

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3276,6 +3276,7 @@
       "discountPercent": "Discount %",
       "loyaltyPoints": "Loyalty Points",
       "treatments": "Treatments",
+      "treatmentsInPackage": "Treatments in package",
       "treatment": "Treatment",
       "quantity": "Quantity",
       "noTreatments": "Click Add to add treatments to the package",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3298,6 +3298,7 @@
       "discountPercent": "Rabat %",
       "loyaltyPoints": "Punkty lojalnościowe",
       "treatments": "Zabiegi",
+      "treatmentsInPackage": "Zabiegi w pakiecie",
       "treatment": "Zabieg",
       "quantity": "Ilość",
       "noTreatments": "Kliknij Dodaj, aby dodać zabiegi do pakietu",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -231,9 +231,10 @@ function PackagesIndex() {
   }, []);
 
   const addTreatment = () => {
-    if (treatments && treatments.length > 0) {
-      setSelectedTreatments((prev) => [...prev, { treatmentId: treatments[0]._id, quantity: 1 }]);
-    }
+    setSelectedTreatments((prev) => [
+      ...prev,
+      { treatmentId: treatments?.[0]?._id ?? "", quantity: 1 },
+    ]);
   };
 
   const removeTreatment = (index: number) => {
@@ -248,6 +249,7 @@ function PackagesIndex() {
 
   const handleSubmit = async () => {
     if (!name || !totalPrice || selectedTreatments.length === 0) return;
+    if (selectedTreatments.some((t) => !t.treatmentId || t.quantity < 1)) return;
     setSubmitting(true);
     try {
       const treatmentsList = selectedTreatments.map((t) => ({
@@ -616,11 +618,16 @@ function PackagesIndex() {
 
           <div className="space-y-2">
             <div className="flex items-center justify-between">
-              <Label>{t("gabinet.packages.treatments")}</Label>
+              <Label>{t("gabinet.packages.treatmentsInPackage")}</Label>
               <Button type="button" variant="outline" size="sm" onClick={addTreatment}>
                 <Plus className="mr-1 h-4 w-4" variant="stroke" /> {t("common.add")}
               </Button>
             </div>
+            {selectedTreatments.length === 0 && (
+              <p className="text-sm text-muted-foreground py-1">
+                {t("gabinet.packages.noTreatments")}
+              </p>
+            )}
             {selectedTreatments.map((st, i) => (
               <div key={i} className="rounded-md border p-3">
                 <div className="flex items-end gap-2">
@@ -630,12 +637,18 @@ function PackagesIndex() {
                     </Label>
                     <Select value={st.treatmentId} onValueChange={(val) => updateTreatment(i, "treatmentId", val)}>
                       <SelectTrigger>
-                        <SelectValue />
+                        <SelectValue placeholder={t("gabinet.packages.treatment")} />
                       </SelectTrigger>
                       <SelectContent>
-                        {(treatments ?? []).map((tr) => (
-                          <SelectItem key={tr._id} value={tr._id}>{tr.name}</SelectItem>
-                        ))}
+                        {(treatments ?? []).length === 0 ? (
+                          <SelectItem value="__none__" disabled>
+                            {t("gabinet.packages.noTreatmentsAvailable")}
+                          </SelectItem>
+                        ) : (
+                          (treatments ?? []).map((tr) => (
+                            <SelectItem key={tr._id} value={tr._id}>{tr.name}</SelectItem>
+                          ))
+                        )}
                       </SelectContent>
                     </Select>
                   </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2059.

Closes #2059

---

## Claude summary

The commit is done. Here's a summary:

## What was the root cause

The `addTreatment()` function had a silent guard: `if (treatments && treatments.length > 0)`. If the active-treatments data hadn't finished loading when the user clicked "+ Dodaj", or if the org had no active treatments configured at all, the button did nothing — no row was added, no error shown.

## Files changed

`src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx`
- `addTreatment()`: removed the silent guard; always appends a new row (`treatmentId` defaults to the first available treatment or `""` if none loaded yet)
- Section label now uses `gabinet.packages.treatmentsInPackage` ("Zabiegi w pakiecie") instead of the generic `treatments` key shared with the package card
- Added hint text (`noTreatments`) rendered when the list is empty so the user knows to click "+ Dodaj"
- `SelectContent` now shows a disabled "Brak dostępnych zabiegów" option if no active treatments exist, instead of an empty dropdown
- `handleSubmit` now validates that each row has a non-empty `treatmentId` and `quantity >= 1` before submitting

`public/locales/pl/translation.json` — added `treatmentsInPackage: "Zabiegi w pakiecie"`

`public/locales/en/translation.json` — added `treatmentsInPackage: "Treatments in package"`

## PR status

Changes are committed to `claude/issue-2059`. PR not yet created — awaiting merge to main.