### PR TITLE
Wysyłanie dokumentu do klienta

### DIFF
--- a/src/components/documents/appointment-document-checklist.tsx
+++ b/src/components/documents/appointment-document-checklist.tsx
@@ -423,7 +423,6 @@ function DocumentSection({
         await resendSigningEmail({ organizationId, documentId: docId });
         setResendSuccess(docId);
         toast.success(t("documents.emailSent", "Wysłano e-mail do klienta"));
-        setTimeout(() => setResendSuccess(null), 3000);
       } catch (err) {
         // Surface the real reason — previously this was a silent `catch {}`
         // so users on the appointment > Dokumenty tab saw the send button

--- a/src/components/documents/entity-documents-tab.tsx
+++ b/src/components/documents/entity-documents-tab.tsx
@@ -88,6 +88,7 @@ interface FormDocument {
   signatureData?: string;
   signedByName?: string;
   signingToken?: string;
+  signingEmailSentAt?: number;
 }
 
 interface FormTemplate {
@@ -118,29 +119,6 @@ export function EntityDocumentsTab({
   const reorderByEntity = useAction(api.documents.documents.reorderByEntity);
   const removeDocument = useAction(api.documents.documents.remove);
 
-  const handleSend = useCallback(
-    async (e: React.MouseEvent, docId: Id<"formDocuments">) => {
-      e.stopPropagation();
-      setSendingDocId(docId);
-      setSendSuccessDocId(null);
-      try {
-        await resendSigningEmail({ organizationId, documentId: docId });
-        setSendSuccessDocId(docId);
-        toast.success(t("documents.emailSent", "Wysłano e-mail do klienta"));
-        setTimeout(() => setSendSuccessDocId(null), 3000);
-      } catch (err) {
-        toast.error(
-          err instanceof Error
-            ? err.message
-            : t("documents.sendFailed", "Nie udało się wysłać e-maila"),
-        );
-      } finally {
-        setSendingDocId(null);
-      }
-    },
-    [resendSigningEmail, organizationId, t],
-  );
-
   // --- Document list ---
 
   const listDocumentsByEntity = useAction(api.documents.documents.listByEntity);
@@ -159,6 +137,29 @@ export function EntityDocumentsTab({
     enabled: !!organizationId && !!entityType && !!entityId,
   });
   const documents = documentsRaw as unknown as FormDocument[] | undefined;
+
+  const handleSend = useCallback(
+    async (e: React.MouseEvent, docId: Id<"formDocuments">) => {
+      e.stopPropagation();
+      setSendingDocId(docId);
+      setSendSuccessDocId(null);
+      try {
+        await resendSigningEmail({ organizationId, documentId: docId });
+        setSendSuccessDocId(docId);
+        toast.success(t("documents.emailSent", "Wysłano e-mail do klienta"));
+        void refetch();
+      } catch (err) {
+        toast.error(
+          err instanceof Error
+            ? err.message
+            : t("documents.sendFailed", "Nie udało się wysłać e-maila"),
+        );
+      } finally {
+        setSendingDocId(null);
+      }
+    },
+    [resendSigningEmail, organizationId, t, refetch],
+  );
 
   // Local ordering so drag-and-drop is responsive while the server persists.
   // Resynced whenever the server-side list changes (creation, deletion).
@@ -649,7 +650,7 @@ function SortableDocumentRow({
           >
             {sendingDocId === doc._id ? (
               <Loader2 className="h-3.5 w-3.5 animate-spin sm:mr-1" />
-            ) : sendSuccessDocId === doc._id ? (
+            ) : (sendSuccessDocId === doc._id || doc.signingEmailSentAt) ? (
               <CircleCheck className="h-3.5 w-3.5 text-green-600 sm:mr-1" />
             ) : (
               <Send className="h-3.5 w-3.5 sm:mr-1" variant="stroke" />
@@ -657,7 +658,9 @@ function SortableDocumentRow({
             <span className="max-sm:sr-only">
               {sendSuccessDocId === doc._id
                 ? t("documents.emailSentShort", "Wysłano")
-                : t("documents.send", "Wyślij")}
+                : doc.signingEmailSentAt
+                  ? t("documents.resend", "Wyślij ponownie")
+                  : t("documents.send", "Wyślij")}
             </span>
           </Button>
         )}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2071.

Closes #2071

---

## Claude summary

Done. Here's what was changed:

**Root cause:** Both send-document components had a `setTimeout(..., 3000)` that reset the success state 3 seconds after sending, causing the button to revert from "Wysłano" back to "Wyślij".

**Fix in `entity-documents-tab.tsx`:**
- Added `signingEmailSentAt?: number` to the local `FormDocument` interface (the DB field already existed but wasn't declared in the type)
- Removed the `setTimeout` and added `refetch()` instead — so after sending, the document list reloads and `signingEmailSentAt` is populated from the database
- Moved `handleSend` after the `useQuery` block (so `refetch` is in scope)
- Button now shows three states: spinner while sending → "Wysłano" immediately after success → "Wyślij ponownie" on subsequent loads (driven by `doc.signingEmailSentAt`)

**Fix in `appointment-document-checklist.tsx`:**
- Removed the same `setTimeout` so "Wysłano" persists as long as the component is mounted