### PR TITLE
Czarny motyw mobilny 

### DIFF
--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -11,7 +11,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "relative grid place-content-center peer h-4 w-4 pointer-coarse:h-5 pointer-coarse:w-5 shrink-0 rounded-[3px] border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground pointer-coarse:before:absolute pointer-coarse:before:-inset-2 pointer-coarse:before:content-['']",
+      "relative grid place-content-center peer h-4 w-4 pointer-coarse:h-5 pointer-coarse:w-5 shrink-0 rounded-[3px] border border-primary bg-background ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground pointer-coarse:before:absolute pointer-coarse:before:-inset-2 pointer-coarse:before:content-['']",
       className
     )}
     {...props}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2072.

Closes #2072

---

## Claude summary

Fixed. The root cause: `src/components/ui/checkbox.tsx:14` had no `bg-*` class for the unchecked state. The checkbox was transparent, so in dark mode the near-black page background (`oklch(0.17 0.01 285.76)`) showed through, making the checkbox appear as a solid black square before it was checked. Adding `bg-background` gives the checkbox an explicit background that matches the page theme — transparent to the same color in light mode (still near-white), and explicitly dark-mode-aware on iOS.