### PR TITLE
Audyt tworzenie zabiegu

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -136,15 +136,19 @@ export const create = action({
       const db = createSupabaseDb();
 
       // --- INSERT treatment directly to Supabase ---
-      const treatmentId = await db.insert("gabinetTreatments", {
+      // Only include taxExempt when true — omitting it avoids a "column does
+      // not exist" failure on environments where migration 00005 hasn't been
+      // applied yet (null and false are semantically equivalent: not exempt).
+      // Only include packageId when non-null — same reasoning for migration
+      // 00010.
+      const insertRow: Record<string, unknown> = {
         organizationId: String(args.organizationId),
         name: args.name,
         description: args.description ?? null,
         duration: args.duration,
         price: args.price,
         currency: args.currency ?? null,
-        taxRate: args.taxExempt ? null : args.taxRate ?? null,
-        taxExempt: args.taxExempt ?? null,
+        taxRate: args.taxExempt === true ? null : args.taxRate ?? null,
         requiredEquipment: args.requiredEquipment ?? null,
         requiredEquipmentIds: args.requiredEquipmentIds ?? null,
         contraindications: args.contraindications ?? null,
@@ -155,14 +159,17 @@ export const create = action({
         color: args.color ?? null,
         sortOrder: args.sortOrder ?? null,
         treatmentCount: args.treatmentCount ?? null,
-        packageId: args.packageId ?? null,
         requiredFormTemplates: args.requiredFormTemplates ?? null,
         tagIds: args.tagIds ?? null,
         categoryId: args.categoryId ?? null,
         createdBy: String(authResult.userId),
         createdAt: now,
         updatedAt: now,
-      });
+      };
+      if (args.taxExempt === true) insertRow.taxExempt = true;
+      if (args.packageId != null) insertRow.packageId = args.packageId;
+
+      const treatmentId = await db.insert("gabinetTreatments", insertRow);
 
       // --- Delegate post-write side effects ---
       try {

--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -208,7 +208,7 @@ export function TreatmentForm({
       price: parseFloat(price.replace(",", ".")) || 0,
       currency: currency || undefined,
       taxRate: numericTaxRate,
-      taxExempt: isExempt ? true : false,
+      taxExempt: isExempt ? true : undefined,
       requiredEquipmentIds: selectedEquipmentIds.length > 0 ? selectedEquipmentIds : undefined,
       contraindications: initialData?.contraindications ?? null,
       preparationInstructions: initialData?.preparationInstructions ?? null,

--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -62,14 +62,25 @@ export function extractFieldValidationDetail(
     };
   }
 
-  // Postgres: column "X" of relation "..." does not exist (also raw column
-  // missing — PGRST204 is caught separately by the schemaCache matcher).
+  // Postgres: column "X" of relation "..." does not exist (double-quoted form,
+  // e.g. raw Postgres 42703 errors).
   const missingCol = msg.match(/column "([^"]+)" (?:of relation [^ ]+ )?does not exist/i);
   if (missingCol) {
     return {
       rawField: missingCol[1],
       fieldLabel: humanFieldLabel(missingCol[1]),
       reason: "kolumna nie istnieje w bazie",
+    };
+  }
+
+  // PostgREST PGRST204 schema-cache miss: "Column 'X' of table 'T' does not exist"
+  // or "Could not find column 'X' in the schema cache" — single-quoted column name.
+  const missingColPgrst = msg.match(/(?:column|find(?:\s+column)?)\s+'([^']+)'(?:\s+of\s+(?:table|relation)\s+'[^']*')?\s+(?:does not exist|in the schema cache)/i);
+  if (missingColPgrst) {
+    return {
+      rawField: missingColPgrst[1],
+      fieldLabel: humanFieldLabel(missingColPgrst[1]),
+      reason: "kolumna nie istnieje w bazie (schema cache)",
     };
   }
 
@@ -367,7 +378,10 @@ const TREATMENT_ERROR_MAP: Array<{
     fallback: "Brak uprawnień do tej operacji na zabiegu.",
   },
   {
-    test: (m) => /pgrst204|schema cache/i.test(m),
+    // PostgREST PGRST204 (schema cache not refreshed after migration) and raw
+    // Postgres 42703 (column doesn't exist in DB at all). Both are migration
+    // problems. The schemaCache message is shown first with specific guidance.
+    test: (m) => /pgrst204|schema cache|does not exist in the schema|could not find.*column/i.test(m),
     key: "gabinet.treatments.errors.schemaCache",
     fallback:
       "Brak kolumny w schemacie bazy — najpewniej nie zastosowano migracji. Uruchom `npm run migrations:apply` i odśwież stronę.",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2061.

Closes #2061

---

## Claude summary

The fix is committed. Here's the precise diagnosis:

**Root cause**: The `create` handler always included `tax_exempt` and `package_id` in every INSERT — even for a minimal treatment with no VAT exemption and no package. On any environment where migrations `00005` (`tax_exempt` column) or `00010` (`package_id` column) have not been applied, the INSERT fails with a Postgres 42703 "column does not exist" error. After running migration `00018` (the `during_visit` timing fix for `form_documents`), the error persisted because those earlier migrations were still missing. The UI showed the generic "nieprawidłowe dane" toast instead of a specific message because the PGRST204 error variant uses single-quoted column names, which the existing regex didn't match.

**Three changes made**:
1. `convex/gabinet/treatments.ts` — `create` handler now only adds `taxExempt` to the INSERT when it's `true`, and `packageId` only when non-null. A minimal treatment (no ZW exemption, no package link) no longer touches those columns at all, so it works regardless of migration status.
2. `src/components/gabinet/treatment-form.tsx` — the form now sends `taxExempt: undefined` (omitted) instead of `false`; the backend and database both treat absence the same as `false`.
3. `src/lib/format-action-error.ts` — added a single-quote regex variant for PostgREST PGRST204 errors and broadened the `schemaCache` test to catch `"could not find column"` patterns, so when a column-not-exist error still occurs (e.g. for the ZW or package path), the user sees a specific diagnostic message naming the missing column and pointing to migrations rather than the generic "nieprawidłowe dane".

## Follow-ups

- Fix `update` handler for same column-not-exist risk: `treatments.update` spreads all args into the PATCH payload unconditionally — if `taxExempt: false` or `packageId: null` is passed, it includes them in the PATCH and would fail on environments missing migrations 00005/00010.
- Apply same defensive pattern to `gabinetAppointments.create`: if `appointmentWorkflowHistory` or other recently-added tables have similar migration-gated columns written unconditionally, the same class of failure can occur there.