### PR TITLE
feat(payments): add gratis + barter to payment_method_enum (migration only)

### DIFF
--- a/supabase/migrations/00021_payment_method_gratis_barter.sql
+++ b/supabase/migrations/00021_payment_method_gratis_barter.sql
@@ -1,0 +1,24 @@
+-- Add 'gratis' and 'barter' to payment_method_enum.
+--
+-- Business context: visits may be settled as a free-of-charge ("gratis")
+-- correction/complaint/gift/promo, or as a non-cash "barter" (e.g. an
+-- Instagram collaboration / service exchange). Both need to be a distinct,
+-- separately-reportable settlement type rather than reusing 'other'.
+--
+-- This migration ONLY makes the two values storable. It does NOT implement
+-- any of the business rules (gratis = 0 PLN, no split, no credit, mandatory
+-- reason; barter not partial, mandatory description; exclusion from turnover
+-- and separate barter reporting). Those are application-layer concerns and
+-- are handled separately:
+--   - convex/payments.ts (paymentMethodValidator)
+--   - convex/schema/crm.ts (payments.paymentMethod)
+--   - frontend selectors, split/credit guards, and reporting logic
+-- Until those land, these enum values are inert (the write path rejects them).
+--
+-- Adding enum values is additive, non-destructive and idempotent. Same proven
+-- pattern as migration 00009 which added 'package'. On PostgreSQL 15 this is
+-- safe; the only ALTER TYPE ... ADD VALUE caveat (a freshly added value cannot
+-- be used in the same transaction) does not apply here as we only add values.
+
+ALTER TYPE payment_method_enum ADD VALUE IF NOT EXISTS 'gratis';
+ALTER TYPE payment_method_enum ADD VALUE IF NOT EXISTS 'barter';


### PR DESCRIPTION
## Cel

Dodaje dwie wartości do enuma `payment_method_enum` w Postgresie, aby wizyty można było rozliczać jako **gratis** (0 zł — poprawka / reklamacja / prezent / promocja) oraz **barter** (rozliczenie bezgotówkowe, np. współpraca Instagram / wymiana usług).

## Czy to bezpieczne? TAK

- `payment_method_enum` to realny enum Postgresa (PG 15.8). Obecne wartości: `cash, card, transfer, other, package`.
- `ALTER TYPE ... ADD VALUE IF NOT EXISTS` jest **addytywne, nie rusza istniejących danych, idempotentne**.
- Bezpośredni precedens: migracja `00009` dodała `package` dokładnie tym samym wzorcem.
- Niuans `ADD VALUE` (świeżo dodanej wartości nie można użyć w tej samej transakcji) **nie dotyczy** — migracja tylko dodaje wartości.

## ⚠️ Zakres — to JEST tylko migracja

Ten PR **nie implementuje** reguł biznesowych i **nie czyni wartości używalnymi end-to-end**. Po samej migracji enum będzie miał wartości, ale warstwa zapisu je odrzuci. Wymagane osobno (kolejny PR):

1. **Backend (twardy blocker):** `convex/payments.ts:18` (`paymentMethodValidator`) i `convex/schema/crm.ts:463` (`payments.paymentMethod`) mają zahardkodowane 5 metod — trzeba dodać `gratis`/`barter`, inaczej mutacja odrzuca wartość zanim trafi do bazy.
2. **Frontend:** zahardkodowane unie `"cash" | "card" | ...` + UI wyboru + reguły: gratis = 0 zł, bez split paymentu, bez kredytu/nadpłaty, obowiązkowa notatka; barter niepodzielny, obowiązkowy opis. Kolumna `payments.notes` już istnieje i może nieść powód/opis.
3. **Raporty:** wyłączenie gratis/barter z obrotu gotówka/karta/przelew + osobne raporty barterowe/gratis.

Migracja jest **inertna i bezpieczna** do zmergowania niezależnie (najwyżej enum ma chwilowo nieużywane wartości).

## Wdrożenie na prod

Dotyka rozliczeń — **do ręcznego uruchomienia na produkcji po review**, nie auto-aplikowane. SQL do wykonania:

```sql
ALTER TYPE payment_method_enum ADD VALUE IF NOT EXISTS 'gratis';
ALTER TYPE payment_method_enum ADD VALUE IF NOT EXISTS 'barter';
```

Nie zaaplikowano jeszcze nigdzie (ani dev, ani prod) — czeka na Twoją akceptację.

🤖 Generated with [Claude Code](https://claude.com/claude-code)