### PR TITLE
Zadanie: Dodanie odpowiedzi kafelkowych Tak/Nie w module „Szablony dokumentów”

### DIFF
--- a/src/components/documents/document-form-filler.tsx
+++ b/src/components/documents/document-form-filler.tsx
@@ -12,6 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
 import type { ExtractedFormField } from "@/components/documents/document-renderer";
 
 // ---------------------------------------------------------------------------
@@ -161,6 +162,30 @@ export function DocumentFormFiller({
               onChange={(e) => setValue(field.fieldId, e.target.value)}
               required={field.required}
             />
+          )}
+
+          {field.fieldType === "button_select" && (
+            <div className="flex flex-wrap gap-2">
+              {field.options
+                .split(",")
+                .map((opt) => opt.trim())
+                .filter(Boolean)
+                .map((opt) => (
+                  <button
+                    key={opt}
+                    type="button"
+                    onClick={() => setValue(field.fieldId, opt)}
+                    className={cn(
+                      "min-h-[44px] rounded-lg border-2 px-5 py-2.5 text-sm font-medium transition-colors",
+                      values[field.fieldId] === opt
+                        ? "border-primary bg-primary/10 text-primary"
+                        : "border-border bg-background text-foreground hover:border-primary/50",
+                    )}
+                  >
+                    {opt}
+                  </button>
+                ))}
+            </div>
           )}
 
           {field.fieldType === "checkbox" && (

--- a/src/components/documents/form-field-node.tsx
+++ b/src/components/documents/form-field-node.tsx
@@ -29,6 +29,7 @@ import {
   List,
   Calendar,
   CheckSquare,
+  LayoutGrid,
   Users,
 } from "lucide-react";
 
@@ -36,7 +37,7 @@ import {
 // Types
 // ---------------------------------------------------------------------------
 
-export type FormFieldType = "text" | "textarea" | "select" | "date" | "checkbox";
+export type FormFieldType = "text" | "textarea" | "select" | "button_select" | "date" | "checkbox";
 export type FilledBy = "employee" | "client";
 
 export interface FormFieldAttrs {
@@ -57,6 +58,7 @@ const FIELD_TYPE_ICONS: Record<FormFieldType, typeof Type> = {
   text: Type,
   textarea: AlignLeft,
   select: List,
+  button_select: LayoutGrid,
   date: Calendar,
   checkbox: CheckSquare,
 };
@@ -115,20 +117,21 @@ function FormFieldConfig({
             <SelectItem value="text">Text</SelectItem>
             <SelectItem value="textarea">Textarea</SelectItem>
             <SelectItem value="select">{t("common.select")}</SelectItem>
+            <SelectItem value="button_select">Przyciski (Tak/Nie)</SelectItem>
             <SelectItem value="date">Date</SelectItem>
             <SelectItem value="checkbox">Checkbox</SelectItem>
           </SelectContent>
         </Select>
       </div>
 
-      {attrs.fieldType === "select" && (
+      {(attrs.fieldType === "select" || attrs.fieldType === "button_select") && (
         <div className="space-y-1">
           <Label className="text-xs">Options (comma-separated)</Label>
           <Input
             value={attrs.options}
             onChange={(e) => onChange({ options: e.target.value })}
             className="h-8 text-sm"
-            placeholder="Option A, Option B, Option C"
+            placeholder="Nie, Tak, Tak — wymaga omówienia"
           />
         </div>
       )}

--- a/src/components/documents/inline-document-form.tsx
+++ b/src/components/documents/inline-document-form.tsx
@@ -287,6 +287,54 @@ export function InlineFieldControl({
     );
   }
 
+  if (field.fieldType === "button_select") {
+    const opts = field.options
+      .split(",")
+      .map((o) => o.trim())
+      .filter(Boolean);
+    return (
+      <span style={{ display: "block", width: "100%" }}>
+        {labelNode}
+        <span
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "8px",
+          }}
+        >
+          {opts.map((opt) => {
+            const selected = value === opt;
+            return (
+              <button
+                key={opt}
+                type="button"
+                onClick={() => onChange(opt)}
+                style={{
+                  padding: "10px 20px",
+                  border: selected ? "2px solid #7C6AE8" : "2px solid #d1d5db",
+                  borderRadius: "8px",
+                  background: selected ? "#ede9ff" : "#fff",
+                  color: selected ? "#4C3D9E" : "#111827",
+                  fontSize: "14px",
+                  fontWeight: selected ? "600" : "400",
+                  cursor: "pointer",
+                  minHeight: "44px",
+                  minWidth: "80px",
+                  transition: "border-color 0.15s, background 0.15s",
+                  lineHeight: "1.4",
+                  textAlign: "center",
+                  wordBreak: "break-word",
+                }}
+              >
+                {opt}
+              </button>
+            );
+          })}
+        </span>
+      </span>
+    );
+  }
+
   // text / date / default
   return (
     <span style={{ display: showLabel ? "block" : "inline-block" }}>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2074.

Closes #2074

---

## Claude summary

The implementation is done. Here's what was changed across 3 files:

**`form-field-node.tsx`** — Added `"button_select"` to the `FormFieldType` union, added a `LayoutGrid` icon for it, registered it in `FIELD_TYPE_ICONS`, added "Przyciski (Tak/Nie)" to the type dropdown in the template editor, and made the options config field appear for both `select` and `button_select` (with a Polish placeholder hint).

**`inline-document-form.tsx`** — Added a `button_select` branch in `InlineFieldControl` that renders options as large tile buttons (min 44px height for mobile tap targets, flex-wrap for long labels, purple highlight on the selected option). Uses inline styles since this component lives inside a white document container.

**`document-form-filler.tsx`** — Added the same tile button rendering for the employee-side form filler, using Tailwind classes.

No changes were needed to `document-renderer.tsx` — `button_select` values are plain text strings, so they fall into the existing non-checkbox rendering path in `renderDocument`, which correctly displays "**Label**: Tak — wymaga omówienia" in signed/completed documents (satisfying requirement #13).

The full flow works: create template with button_select → preview shows `[Label]` chip → client fills via tile buttons → value saved as plain string → signed document shows label + selected text.