### PR TITLE
`gabinet_appointments` lacks `price_at_booking` column

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1207,6 +1207,7 @@ export const create = action({
       roomId: args.roomId ?? null,
       tagIds: args.tagIds ?? null,
       categoryId: args.categoryId ?? null,
+      priceAtBooking: (treatment?.price as number | undefined) ?? null,
       createdBy: String(authResult.userId),
       createdAt: now,
       updatedAt: now,

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -417,6 +417,7 @@ export function createGabinetTables({
     categoryId: v.optional(v.id("categoryDefinitions")),
     requiresCompletion: v.optional(v.boolean()),
     contraindicationAlertsReviewed: v.optional(v.boolean()),
+    priceAtBooking: v.optional(v.number()),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -3303,6 +3303,7 @@ export interface Database {
           tag_ids: string[] | null;
           category_id: string | null;
           requires_completion: boolean | null;
+          price_at_booking: number | null;
           created_by: string;
           created_at: number;
           updated_at: number;
@@ -3347,6 +3348,7 @@ export interface Database {
           tag_ids?: string[] | null;
           category_id?: string | null;
           requires_completion?: boolean | null;
+          price_at_booking?: number | null;
           created_by: string;
           created_at: number;
           updated_at: number;
@@ -3391,6 +3393,7 @@ export interface Database {
           tag_ids?: string[] | null;
           category_id?: string | null;
           requires_completion?: boolean | null;
+          price_at_booking?: number | null;
           created_by?: string;
           created_at?: number;
           updated_at?: number;

--- a/src/lib/supabase/mappers/gabinet/appointments.ts
+++ b/src/lib/supabase/mappers/gabinet/appointments.ts
@@ -46,6 +46,7 @@ export interface MappedGabinetAppointment {
   tagIds?: string[];
   categoryId?: string;
   requiresCompletion?: boolean;
+  priceAtBooking?: number;
   createdBy: string;
   createdAt: number;
   updatedAt: number;

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -885,7 +885,7 @@ function GabinetReports() {
       const tid = a.treatmentId as string;
       const prev = map.get(tid) ?? { count: 0, revenue: 0 };
       const price = a.status === "completed"
-        ? (treatmentMap.get(tid)?.price ?? 0)
+        ? (a.priceAtBooking ?? treatmentMap.get(tid)?.price ?? 0)
         : 0;
       map.set(tid, { count: prev.count + 1, revenue: prev.revenue + price });
     }
@@ -1027,7 +1027,7 @@ function GabinetReports() {
     for (const a of appointments) {
       if (a.status !== "completed") continue;
       const tid = a.treatmentId as string;
-      const price = treatmentMap.get(tid)?.price ?? 0;
+      const price = a.priceAtBooking ?? treatmentMap.get(tid)?.price ?? 0;
       map.set(a.date, (map.get(a.date) ?? 0) + price);
     }
     return bucketizePairs(Array.from(map.entries()));

--- a/supabase/migrations/00022_gabinet_appointments_price_at_booking.sql
+++ b/supabase/migrations/00022_gabinet_appointments_price_at_booking.sql
@@ -1,0 +1,6 @@
+-- Snapshot treatment price at booking time so revenue reports remain
+-- auditable when treatment prices change later. NULL for appointments
+-- created before this migration; the report falls back to the current
+-- treatment price for those rows.
+ALTER TABLE gabinet_appointments
+  ADD COLUMN IF NOT EXISTS price_at_booking NUMERIC;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2090.

Closes #2090

---

## Claude summary

Done. Here's what was changed:

**Root cause:** `gabinet_appointments` had no price field, so revenue reports fetched the current treatment price at query time — meaning any price edit silently rewrote historical revenue.

**Fix (6 files):**

- `supabase/migrations/00022_gabinet_appointments_price_at_booking.sql` — new `price_at_booking NUMERIC` column (nullable so existing rows are unaffected)
- `convex/schema/gabinet.ts` — `priceAtBooking: v.optional(v.number())` added to `gabinetAppointments`
- `src/lib/supabase/database.types.ts` — `price_at_booking: number | null` in Row/Insert/Update
- `src/lib/supabase/mappers/gabinet/appointments.ts` — `priceAtBooking?: number` in `MappedGabinetAppointment`
- `convex/gabinet/appointments.ts` — `priceAtBooking: treatment?.price ?? null` written into `baseRow` on create, so every new appointment captures the price at booking time
- `src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx` — both revenue calculations (treatment stats and revenue chart) now use `a.priceAtBooking ?? treatmentMap.get(tid)?.price ?? 0`, falling back gracefully for pre-migration rows

## Follow-ups

- Add `contraindication_alerts_reviewed` to `database.types.ts` and `MappedGabinetAppointment`: the column was added in migration 00021 but was never reflected in the type definitions — currently accessed via unsafe `(appointment as Record<string, unknown>).contraindicationAlertsReviewed` cast in the appointment detail page
- Loyalty points use current treatment price at completion, not price at booking: `convex/gabinet/appointments.ts:2413` awards points based on `treatment.price` at completion time; this should likely use `priceAtBooking` for consistency with revenue reporting
- Payment row on completion uses current treatment price: `convex/gabinet/appointments.ts:2475` inserts `amount: treatment.price` into `payments` at completion time rather than the booked price; the `payments` table could also benefit from a `price_at_booking` reference