### PR TITLE
Add `contraindication_alerts_reviewed` to `database.types.ts` and `MappedGabinet

### DIFF
--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -3304,6 +3304,7 @@ export interface Database {
           category_id: string | null;
           requires_completion: boolean | null;
           price_at_booking: number | null;
+          contraindication_alerts_reviewed: boolean | null;
           created_by: string;
           created_at: number;
           updated_at: number;
@@ -3349,6 +3350,7 @@ export interface Database {
           category_id?: string | null;
           requires_completion?: boolean | null;
           price_at_booking?: number | null;
+          contraindication_alerts_reviewed?: boolean | null;
           created_by: string;
           created_at: number;
           updated_at: number;
@@ -3394,6 +3396,7 @@ export interface Database {
           category_id?: string | null;
           requires_completion?: boolean | null;
           price_at_booking?: number | null;
+          contraindication_alerts_reviewed?: boolean | null;
           created_by?: string;
           created_at?: number;
           updated_at?: number;

--- a/src/lib/supabase/mappers/gabinet/appointments.ts
+++ b/src/lib/supabase/mappers/gabinet/appointments.ts
@@ -47,6 +47,7 @@ export interface MappedGabinetAppointment {
   categoryId?: string;
   requiresCompletion?: boolean;
   priceAtBooking?: number;
+  contraindicationAlertsReviewed?: boolean;
   createdBy: string;
   createdAt: number;
   updatedAt: number;

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1458,7 +1458,7 @@ function AppointmentDetail() {
                         {t("gabinet.treatments.contraindications")}
                       </span>
                     </div>
-                    {(appointment as Record<string, unknown>).contraindicationAlertsReviewed ? (
+                    {appointment.contraindicationAlertsReviewed ? (
                       <div className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
                         <CheckCircle className="h-3.5 w-3.5" variant="stroke" />
                         <span>{t("gabinet.appointmentDetail.contraindicationDiscussed", "Omówiono")}</span>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2093.

Closes #2093

---

## Claude summary

Done. Three files changed:

- `src/lib/supabase/database.types.ts` — added `contraindication_alerts_reviewed: boolean | null` to the `Row`, `Insert`, and `Update` sections of `gabinet_appointments`
- `src/lib/supabase/mappers/gabinet/appointments.ts` — added `contraindicationAlertsReviewed?: boolean` to `MappedGabinetAppointment`
- `_layout.gabinet.appointments.$appointmentId.lazy.tsx:1461` — replaced the unsafe `(appointment as Record<string, unknown>).contraindicationAlertsReviewed` cast with the direct typed access `appointment.contraindicationAlertsReviewed`

The generic mapper already handles `snake_case → camelCase` conversion automatically via `snakeToCamelKey`, so no custom field mapping was needed in the mapper factory call.