### PR TITLE
Loyalty points use current treatment price at completion, not price at booking

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -246,6 +246,7 @@ async function applyAppointmentStatusChange(
         packageUsageId: args.appointment.packageUsageId as
           | Id<"gabinetPackageUsage">
           | undefined,
+        priceAtBooking: args.appointment.priceAtBooking as number | undefined,
         userId: args.actorUserId,
       });
     }
@@ -2359,6 +2360,7 @@ async function handleAppointmentCompletion(
     patientId: Id<"gabinetPatients">;
     treatmentId: Id<"gabinetTreatments">;
     packageUsageId?: Id<"gabinetPackageUsage">;
+    priceAtBooking?: number;
     userId: Id<"users">;
   },
 ) {
@@ -2410,9 +2412,13 @@ async function handleAppointmentCompletion(
     }
   }
 
-  // 2. Award loyalty points (1 point per PLN of treatment price)
-  if (treatment && (treatment.price ?? 0) > 0) {
-    const points = Math.floor(treatment.price as number);
+  // 2. Award loyalty points (1 point per PLN of treatment price at booking)
+  // Use priceAtBooking so points are consistent with the price the patient
+  // was quoted, not the current treatment price (which may have changed).
+  // Fall back to treatment.price for appointments pre-dating priceAtBooking.
+  const effectivePrice = args.priceAtBooking ?? (treatment?.price as number | undefined) ?? 0;
+  if (effectivePrice > 0) {
+    const points = Math.floor(effectivePrice);
     if (points > 0) {
       const loyalty = await supabaseDb
         .query("gabinetLoyaltyPoints")
@@ -2451,7 +2457,7 @@ async function handleAppointmentCompletion(
         patientId: patientIdStr,
         type: "earn",
         points,
-        reason: `Appointment completed: ${treatment.name ?? "Treatment"}`,
+        reason: `Appointment completed: ${treatment?.name ?? "Treatment"}`,
         referenceType: "appointment",
         referenceId: String(args.appointmentId),
         balanceAfter: newBalance,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2094.

Closes #2094

---

## Claude summary

Bug confirmed and fixed. Here's a summary of what changed in `convex/gabinet/appointments.ts`:

The `handleAppointmentCompletion` function was fetching the treatment record from Supabase and using its current `price` field to award loyalty points (`Math.floor(treatment.price)`). This is a real bug — if a clinic changes a treatment's price after a patient books, the patient would earn more or fewer points than expected based on what they were quoted.

The fix passes `priceAtBooking` (which is already snapshotted onto the appointment row at creation time, and already used by the revenue reports for consistency) down into `handleAppointmentCompletion`. The points calculation now uses `priceAtBooking ?? treatment.price` — the fallback preserves correct behavior for appointments created before `priceAtBooking` was introduced in #2090. The `treatment.name` reference in the loyalty transaction reason string was also guarded with optional chaining (`treatment?.name`) since a deleted treatment is now possible when `priceAtBooking` provides the price.