### PR TITLE
Payment row on completion uses current treatment price

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2472,14 +2472,14 @@ async function handleAppointmentCompletion(
   // paid for at purchase, so the visit clears the calendar's unpaid
   // indicator without manual settling — #1524). Otherwise insert the
   // pending cash row staff settle later.
-  if (treatment && (treatment.price ?? 0) > 0) {
+  if (treatment && effectivePrice > 0) {
     const isPackageCovered = !!args.packageUsageId;
     await supabaseDb.insert("payments", {
       organizationId: organizationIdStr,
       patientId: patientIdStr,
       appointmentId: String(args.appointmentId),
       packageUsageId: isPackageCovered ? String(args.packageUsageId) : null,
-      amount: treatment.price as number,
+      amount: effectivePrice,
       currency: "PLN",
       paymentMethod: isPackageCovered ? "package" : "cash",
       status: isPackageCovered ? "completed" : "pending",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2095.

Closes #2095

---

## Claude summary

The fix is committed. Here's a summary of what was done:

`handleAppointmentCompletion` in `convex/gabinet/appointments.ts` already computed `effectivePrice = args.priceAtBooking ?? treatment.price` (line 2419) and used it correctly for loyalty point calculation. However, the payment row insert (lines 2475–2491) was reading `treatment.price` directly, bypassing the booked price. The fix replaces `treatment.price as number` with `effectivePrice` in both the guard condition and the `amount` field, making payment amounts consistent with what the patient was quoted at booking time.