### PR TITLE
Add `gabinet_reports` feature-key to permission system

### DIFF
--- a/convex/_helpers/gabinetRolePermissions.ts
+++ b/convex/_helpers/gabinetRolePermissions.ts
@@ -66,6 +66,7 @@ function buildGabinet(
     "gabinet_packages",
     "gabinet_employees",
     "gabinet_payments",
+    "gabinet_reports",
     "gabinet_settings",
     "settings",
     "team",
@@ -137,6 +138,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_packages: { view: "all", create: "all", edit: "all", delete: "all" },
     gabinet_employees: { view: "all", create: "all", edit: "all", delete: "all" },
     gabinet_payments: { view: "all", create: "all", edit: "all", delete: "all", refund: "all" },
+    gabinet_reports: { view: "all" },
     gabinet_settings: { view: "all", create: "all", edit: "all", delete: "all" },
   }),
   other: buildGabinet({

--- a/convex/_helpers/permissionTypes.ts
+++ b/convex/_helpers/permissionTypes.ts
@@ -19,6 +19,7 @@ export const FEATURES = [
   "gabinet_packages",
   "gabinet_employees",
   "gabinet_payments",
+  "gabinet_reports",
   "gabinet_settings",
   "settings",
   "team",

--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -49,6 +49,16 @@ DEFAULT_PERMISSIONS.viewer.gabinet_payments = {
   view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
 };
 
+// --- Per-feature overrides for gabinet_reports ---
+// owner/admin: all (default). member: view only (reports are read-only).
+// viewer: no access by default — financial summaries are sensitive.
+DEFAULT_PERMISSIONS.member.gabinet_reports = {
+  view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
+};
+DEFAULT_PERMISSIONS.viewer.gabinet_reports = {
+  view: "none", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
+};
+
 // --- Per-feature overrides for document_templates ---
 // owner/admin: all actions allowed (approve/sign not applicable to templates)
 // member: view only (no create/edit/delete)

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -6,6 +6,7 @@ import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-t
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
 import { useOrganization } from "@/components/org-context";
+import { usePermission } from "@/hooks/use-permission";
 import { formatCurrencyPLN } from "@/lib/format-currency";
 import { PageHeader } from "@/components/layout/page-header";
 import { SidePanel } from "@/components/crm/side-panel";
@@ -789,6 +790,26 @@ function TopTreatmentsByRevenue({
 function GabinetReports() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
+  const { allowed: canViewReports, loading: permLoading } = usePermission("gabinet_reports", "view");
+
+  if (permLoading) {
+    return (
+      <div className="flex flex-col gap-6 p-6">
+        <Skeleton className="h-10 w-64" />
+      </div>
+    );
+  }
+
+  if (!canViewReports) {
+    return (
+      <div className="flex flex-col gap-6 p-6">
+        <PageHeader
+          title={t("gabinet.reports.title")}
+          description={t("common.noPermission", "You don't have permission to view this page.")}
+        />
+      </div>
+    );
+  }
   const [dateRange, setDateRange] = useState<DateRangeKey>("30d");
   const [dateFilterPanelOpen, setDateFilterPanelOpen] = useState(false);
   const todayIso = new Date().toISOString().split("T")[0];

--- a/src/routes/_app/_auth/dashboard/_layout.settings.permissions.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.permissions.tsx
@@ -40,6 +40,8 @@ const FEATURES = [
   { key: "gabinet_treatments", labelKey: "permissions.features.gabinet_treatments", label: "Gabinet: Treatments" },
   { key: "gabinet_packages", labelKey: "permissions.features.gabinet_packages", label: "Gabinet: Packages" },
   { key: "gabinet_employees", labelKey: "permissions.features.gabinet_employees", label: "Gabinet: Employees" },
+  { key: "gabinet_payments", labelKey: "permissions.features.gabinet_payments", label: "Gabinet: Payments" },
+  { key: "gabinet_reports", labelKey: "permissions.features.gabinet_reports", label: "Gabinet: Reports" },
   { key: "settings", labelKey: "permissions.features.settings", label: "Settings" },
   { key: "team", labelKey: "permissions.features.team", label: "Team" },
 ] as const;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2099.

Closes #2099

---

## Claude summary

The issue is confirmed and fixed. Here's what was done across 5 files:

**`convex/_helpers/permissionTypes.ts`** — Added `"gabinet_reports"` to the `FEATURES` const array (the single source of truth for the type system).

**`convex/_helpers/permissions.ts`** — Added per-role defaults for `gabinet_reports`:
- member: `view: "all"` (can see reports by default; admin can restrict via the UI)
- viewer: `view: "none"` (financial summaries are sensitive; must be explicitly unlocked)
- owner/admin: inherit the all-access default from `buildDefaults`

**`convex/_helpers/gabinetRolePermissions.ts`** — Added `"gabinet_reports"` to the feature list in `buildGabinet` and gave the gabinet `admin` role `view: "all"` access.

**`src/routes/_app/_auth/dashboard/_layout.settings.permissions.tsx`** — Added `gabinet_reports` and also added the previously-missing `gabinet_payments` row to the permissions matrix UI (both were absent from the UI despite being in the backend).

**`src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx`** — Added `usePermission("gabinet_reports", "view")` guard at the top of the `GabinetReports` component. Users without access see a "no permission" message instead of the financial dashboard.

## Follow-ups

- Add `gabinet_payments` to the gabinet role permission defaults in `gabinetRolePermissions.ts` for `admin` role's explicit `view` scope: the `admin` gabinet role already has `gabinet_payments: { ... }` but `gabinet_reports` was missing and not audited together with payments during the original payments PR.
- Add a permission guard to the gabinet payments page: similar to the reports page, the gabinet payments UI (`_layout.gabinet.patients.$patientId.tsx` and any standalone payments route) relies on `usePermission("gabinet_payments", ...)` only in the patient detail — a dedicated payments list route (if it exists) may also be unguarded.