### PR TITLE
Build gabinet roles settings UI page

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3809,6 +3809,30 @@
         "saveFailed": "Could not save the equipment.",
         "transferFailed": "Could not transfer the equipment."
       }
+    },
+    "roles": {
+      "title": "Role Permissions",
+      "description": "Configure what each gabinet role can view, create, edit and delete. These permissions apply in addition to the user's organization role.",
+      "feature": "Feature",
+      "system": "system",
+      "saved": "Permissions saved",
+      "saveError": "Failed to save permissions",
+      "resetToDefault": "Reset to default permissions",
+      "resetCustom": "Permissions cleared",
+      "resetButton": "Reset to defaults",
+      "clearButton": "Clear permissions",
+      "resetError": "Failed to reset permissions",
+      "noRoles": "No roles found.",
+      "features": {
+        "patients": "Patients",
+        "appointments": "Appointments",
+        "treatments": "Treatments",
+        "packages": "Packages",
+        "employees": "Employees",
+        "payments": "Payments",
+        "reports": "Reports",
+        "settings": "Settings"
+      }
     }
   },
   "customFields": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3831,6 +3831,30 @@
         "saveFailed": "Nie udało się zapisać sprzętu.",
         "transferFailed": "Nie udało się przenieść sprzętu."
       }
+    },
+    "roles": {
+      "title": "Uprawnienia ról",
+      "description": "Skonfiguruj co każda rola gabinetowa może przeglądać, tworzyć, edytować i usuwać. Uprawnienia te są stosowane oprócz uprawnień roli organizacyjnej użytkownika.",
+      "feature": "Funkcja",
+      "system": "systemowa",
+      "saved": "Uprawnienia zapisane",
+      "saveError": "Nie udało się zapisać uprawnień",
+      "resetToDefault": "Przywrócono domyślne uprawnienia",
+      "resetCustom": "Uprawnienia wyczyszczone",
+      "resetButton": "Przywróć domyślne",
+      "clearButton": "Wyczyść uprawnienia",
+      "resetError": "Nie udało się zresetować uprawnień",
+      "noRoles": "Nie znaleziono ról.",
+      "features": {
+        "patients": "Pacjenci",
+        "appointments": "Wizyty",
+        "treatments": "Zabiegi",
+        "packages": "Pakiety",
+        "employees": "Pracownicy",
+        "payments": "Płatności",
+        "reports": "Raporty",
+        "settings": "Ustawienia"
+      }
     }
   },
   "customFields": {

--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -70,6 +70,7 @@ export const gabinetManifest: ModuleManifest = {
     { labelKey: "gabinet.reminders.title", to: "/dashboard/gabinet/settings/reminders" },
     { labelKey: "gabinet.locations.title", to: "/dashboard/gabinet/settings/locations" },
     { labelKey: "gabinet.equipment.title", to: "/dashboard/gabinet/settings/equipment" },
+    { labelKey: "gabinet.roles.title", to: "/dashboard/gabinet/settings/roles" },
   ],
   pageContexts: [
     {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.roles.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.roles.tsx
@@ -1,0 +1,392 @@
+import { useState, useEffect, useCallback } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { useQuery, useAction } from "convex/react";
+import { api } from "@cvx/_generated/api";
+import { useOrganization } from "@/components/org-context";
+import { SectionHeader } from "@untitled/app/section-headers/section-headers";
+import { UntitledAlert } from "@/components/ui/untitled-alert";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Badge } from "@/components/ui/badge";
+import { RotateCcw } from "@/lib/ez-icons";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
+
+export const Route = createFileRoute(
+  "/_app/_auth/dashboard/_layout/gabinet/settings/roles"
+)({
+  component: GabinetRolesSettingsPage,
+});
+
+type Scope = "none" | "own" | "all";
+
+const GABINET_FEATURES = [
+  {
+    key: "gabinet_patients",
+    labelKey: "gabinet.roles.features.patients",
+    actions: ["view", "create", "edit", "delete"] as const,
+  },
+  {
+    key: "gabinet_appointments",
+    labelKey: "gabinet.roles.features.appointments",
+    actions: ["view", "create", "edit", "delete"] as const,
+  },
+  {
+    key: "gabinet_treatments",
+    labelKey: "gabinet.roles.features.treatments",
+    actions: ["view", "create", "edit", "delete"] as const,
+  },
+  {
+    key: "gabinet_packages",
+    labelKey: "gabinet.roles.features.packages",
+    actions: ["view", "create", "edit", "delete"] as const,
+  },
+  {
+    key: "gabinet_employees",
+    labelKey: "gabinet.roles.features.employees",
+    actions: ["view", "create", "edit", "delete"] as const,
+  },
+  {
+    key: "gabinet_payments",
+    labelKey: "gabinet.roles.features.payments",
+    actions: ["view", "create", "edit", "delete", "refund"] as const,
+  },
+  {
+    key: "gabinet_reports",
+    labelKey: "gabinet.roles.features.reports",
+    actions: ["view"] as const,
+  },
+  {
+    key: "gabinet_settings",
+    labelKey: "gabinet.roles.features.settings",
+    actions: ["view", "create", "edit", "delete"] as const,
+  },
+] as const;
+
+const ALL_FEATURES = [
+  "leads", "contacts", "companies", "documents", "activities", "calls", "email",
+  "products", "pipelines", "gabinet_patients", "gabinet_appointments",
+  "gabinet_treatments", "gabinet_packages", "gabinet_employees", "gabinet_payments",
+  "gabinet_reports", "gabinet_settings", "settings", "team", "document_templates",
+  "document_instances", "tagDefinitions", "categoryDefinitions",
+] as const;
+
+const ALL_ACTIONS = ["view", "create", "edit", "delete", "approve", "sign", "refund"] as const;
+
+type LocalPerms = Partial<Record<string, Partial<Record<string, Scope>>>>;
+
+function buildLocalPerms(raw: Record<string, Record<string, string>> | null): LocalPerms {
+  const result: LocalPerms = {};
+  for (const f of GABINET_FEATURES) {
+    result[f.key] = {};
+    for (const action of f.actions) {
+      result[f.key]![action] = (raw?.[f.key]?.[action] as Scope) ?? "none";
+    }
+  }
+  return result;
+}
+
+function buildFullPermissions(local: LocalPerms): Record<string, Record<string, string>> {
+  const none: Record<string, string> = {};
+  for (const action of ALL_ACTIONS) none[action] = "none";
+
+  const result: Record<string, Record<string, string>> = {};
+  for (const f of ALL_FEATURES) {
+    result[f] = { ...none };
+  }
+  for (const f of GABINET_FEATURES) {
+    for (const action of f.actions) {
+      result[f.key][action] = local[f.key]?.[action] ?? "none";
+    }
+  }
+  return result;
+}
+
+function RolePermissionPanel({
+  organizationId,
+  roleKey,
+  isSystem,
+}: {
+  organizationId: string;
+  roleKey: string;
+  isSystem: boolean;
+}) {
+  const { t } = useTranslation();
+  const rawPerms = useQuery(api.gabinetRoles.getPermissions, {
+    organizationId: organizationId as never,
+    gabinetRole: roleKey,
+  });
+
+  const setPermissions = useAction(api.gabinetRoles.setPermissions);
+  const resetPermissions = useAction(api.gabinetRoles.resetPermissionsToDefault);
+
+  const [local, setLocal] = useState<LocalPerms>(() => buildLocalPerms(null));
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [resetting, setResetting] = useState(false);
+
+  useEffect(() => {
+    if (rawPerms !== undefined) {
+      setLocal(buildLocalPerms(rawPerms as Record<string, Record<string, string>> | null));
+      setDirty(false);
+    }
+  }, [rawPerms, roleKey]);
+
+  const handleChange = useCallback((feature: string, action: string, scope: Scope) => {
+    setLocal((prev) => ({
+      ...prev,
+      [feature]: { ...prev[feature], [action]: scope },
+    }));
+    setDirty(true);
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await setPermissions({
+        organizationId: organizationId as never,
+        gabinetRole: roleKey,
+        permissions: buildFullPermissions(local),
+      });
+      setDirty(false);
+      toast.success(t("gabinet.roles.saved", "Permissions saved"));
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.roles.saveError",
+          defaultValue: "Failed to save permissions",
+        })
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = async () => {
+    setResetting(true);
+    try {
+      await resetPermissions({
+        organizationId: organizationId as never,
+        gabinetRole: roleKey,
+      });
+      toast.success(
+        isSystem
+          ? t("gabinet.roles.resetToDefault", "Reset to default permissions")
+          : t("gabinet.roles.resetCustom", "Permissions cleared")
+      );
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.roles.resetError",
+          defaultValue: "Failed to reset permissions",
+        })
+      );
+    } finally {
+      setResetting(false);
+    }
+  };
+
+  if (rawPerms === undefined) {
+    return <div className="py-8 text-center text-sm text-muted-foreground">{t("common.loading", "Loading…")}</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b">
+              <th className="py-2 pr-6 text-left font-medium text-muted-foreground whitespace-nowrap">
+                {t("gabinet.roles.feature", "Feature")}
+              </th>
+              <th className="px-2 py-2 text-left font-medium text-muted-foreground">
+                {t("permissions.actions.view", "View")}
+              </th>
+              <th className="px-2 py-2 text-left font-medium text-muted-foreground">
+                {t("permissions.actions.create", "Create")}
+              </th>
+              <th className="px-2 py-2 text-left font-medium text-muted-foreground">
+                {t("permissions.actions.edit", "Edit")}
+              </th>
+              <th className="px-2 py-2 text-left font-medium text-muted-foreground">
+                {t("permissions.actions.delete", "Delete")}
+              </th>
+              <th className="px-2 py-2 text-left font-medium text-muted-foreground">
+                {t("permissions.actions.refund", "Refund")}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {GABINET_FEATURES.map((feature) => (
+              <tr key={feature.key} className="border-b last:border-0">
+                <td className="py-3 pr-6 font-medium whitespace-nowrap">
+                  {t(feature.labelKey, feature.key)}
+                </td>
+                {(["view", "create", "edit", "delete", "refund"] as const).map((action) => {
+                  const supported = (feature.actions as readonly string[]).includes(action);
+                  const scope = local[feature.key]?.[action] ?? "none";
+                  return (
+                    <td key={action} className="px-2 py-3">
+                      {supported ? (
+                        <ScopeSelect
+                          value={scope}
+                          onChange={(v) => handleChange(feature.key, action, v)}
+                        />
+                      ) : (
+                        <span className="text-xs text-muted-foreground/40">—</span>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between pt-2 border-t">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleReset}
+          disabled={resetting}
+        >
+          <RotateCcw className="mr-2 h-3.5 w-3.5" variant="stroke" />
+          {resetting
+            ? t("common.loading", "Loading…")
+            : isSystem
+            ? t("gabinet.roles.resetButton", "Reset to defaults")
+            : t("gabinet.roles.clearButton", "Clear permissions")}
+        </Button>
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={!dirty || saving}
+        >
+          {saving ? t("common.saving", "Saving…") : t("common.save", "Save")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ScopeSelect({ value, onChange }: { value: Scope; onChange: (v: Scope) => void }) {
+  const { t } = useTranslation();
+  return (
+    <Select value={value} onValueChange={(v) => onChange(v as Scope)}>
+      <SelectTrigger className="h-7 w-24 text-xs">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="none">{t("permissions.levels.none", "None")}</SelectItem>
+        <SelectItem value="own">{t("permissions.levels.own", "Own only")}</SelectItem>
+        <SelectItem value="all">{t("permissions.levels.all", "All")}</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}
+
+function GabinetRolesSettingsPage() {
+  const { t } = useTranslation();
+  const { organizationId } = useOrganization();
+
+  const definitions = useQuery(api.gabinetRoles.listDefinitions, { organizationId });
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (definitions && definitions.length > 0 && !selectedKey) {
+      setSelectedKey(definitions[0].key);
+    }
+  }, [definitions, selectedKey]);
+
+  const selectedDef = definitions?.find((d) => d.key === selectedKey);
+
+  return (
+    <div className="flex h-full w-full flex-col gap-6">
+      <SectionHeader.Root className="pt-4">
+        <SectionHeader.Group>
+          <SectionHeader.Heading className="flex-1">
+            {t("gabinet.roles.title", "Role Permissions")}
+          </SectionHeader.Heading>
+        </SectionHeader.Group>
+        <UntitledAlert>
+          {t(
+            "gabinet.roles.description",
+            "Configure what each gabinet role can view, create, edit and delete. These permissions apply in addition to the user's organization role."
+          )}
+        </UntitledAlert>
+      </SectionHeader.Root>
+
+      {definitions === undefined ? (
+        <div className="py-8 text-center text-sm text-muted-foreground">
+          {t("common.loading", "Loading…")}
+        </div>
+      ) : definitions.length === 0 ? (
+        <div className="py-8 text-center text-sm text-muted-foreground">
+          {t("gabinet.roles.noRoles", "No roles found.")}
+        </div>
+      ) : (
+        <>
+          <Tabs value={selectedKey ?? ""} onValueChange={setSelectedKey}>
+            <TabsList className="h-auto flex-wrap gap-1">
+              {definitions.map((def) => (
+                <TabsTrigger key={def.key} value={def.key} className="gap-2">
+                  {def.color && (
+                    <span
+                      className="h-2 w-2 rounded-full shrink-0"
+                      style={{ backgroundColor: def.color }}
+                    />
+                  )}
+                  {def.labelPl}
+                  {def.isSystem && (
+                    <Badge variant="secondary" className="text-[10px] px-1 py-0">
+                      {t("gabinet.roles.system", "system")}
+                    </Badge>
+                  )}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+
+          {selectedKey && selectedDef && (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base flex items-center gap-2">
+                  {selectedDef.color && (
+                    <span
+                      className="h-3 w-3 rounded-full shrink-0"
+                      style={{ backgroundColor: selectedDef.color }}
+                    />
+                  )}
+                  {selectedDef.labelPl}
+                  {selectedDef.isSystem && (
+                    <Badge variant="secondary" className="text-xs">
+                      {t("gabinet.roles.system", "system")}
+                    </Badge>
+                  )}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <RolePermissionPanel
+                  key={selectedKey}
+                  organizationId={organizationId}
+                  roleKey={selectedKey}
+                  isSystem={selectedDef.isSystem}
+                />
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2100.

Closes #2100

---

## Claude summary

The commit is done. Here's a summary of what was implemented:

**New route**: `src/routes/_app/_auth/dashboard/_layout.gabinet.settings.roles.tsx` — a settings page at `/dashboard/gabinet/settings/roles` with:
- A tab bar for all gabinet roles (doctor, nurse, therapist, receptionist, admin, other, plus any custom roles), each showing its color dot and a "system" badge
- A permission matrix table with 8 gabinet features as rows and 5 action columns (view / create / edit / delete / refund), where a `—` appears for actions not applicable to a feature (e.g. refund is only for payments, view is the only action for reports)
- Each cell has a `none / own / all` dropdown; cells for inapplicable actions render a muted dash
- Save button (enabled only when unsaved changes exist) calls `setPermissions` with a full `FeaturePermissions` object
- Reset button calls `resetPermissionsToDefault` (shows "Reset to defaults" for system roles, "Clear permissions" for custom ones)
- `key={selectedKey}` on the panel component ensures state resets cleanly on role switch

**Manifest**: `src/modules/gabinet/manifest.ts` — added the roles entry to `settingsNav` so it appears in the gabinet settings sidebar navigation.

**Translations**: Added `gabinet.roles.*` keys to both `public/locales/en/translation.json` and `public/locales/pl/translation.json`.