### PR TITLE
Add `manager` system gabinet-role

### DIFF
--- a/convex/_helpers/gabinetRolePermissions.ts
+++ b/convex/_helpers/gabinetRolePermissions.ts
@@ -20,6 +20,7 @@ export type SystemGabinetRole =
   | "nurse"
   | "therapist"
   | "receptionist"
+  | "manager"
   | "admin"
   | "other";
 
@@ -28,6 +29,7 @@ export const SYSTEM_GABINET_ROLES: readonly SystemGabinetRole[] = [
   "nurse",
   "therapist",
   "receptionist",
+  "manager",
   "admin",
   "other",
 ];
@@ -131,6 +133,19 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_payments: { view: "all", create: "all", edit: "all" },
     gabinet_settings: {},
   }),
+  // Manager: operational access without financial-admin powers.
+  // Can manage catalog (treatments/packages) and view reports — unlike receptionist.
+  // Cannot delete core records, issue refunds, or change gabinet settings — unlike admin.
+  manager: buildGabinet({
+    gabinet_patients: { view: "all", create: "all", edit: "all" },
+    gabinet_appointments: { view: "all", create: "all", edit: "all", delete: "all" },
+    gabinet_treatments: { view: "all", create: "all", edit: "all" },
+    gabinet_packages: { view: "all", create: "all", edit: "all" },
+    gabinet_employees: { view: "all" },
+    gabinet_payments: { view: "all", create: "all", edit: "all" },
+    gabinet_reports: { view: "all" },
+    gabinet_settings: {},
+  }),
   admin: buildGabinet({
     gabinet_patients: { view: "all", create: "all", edit: "all", delete: "all" },
     gabinet_appointments: { view: "all", create: "all", edit: "all", delete: "all" },
@@ -160,6 +175,7 @@ export const SYSTEM_GABINET_ROLE_LABELS: Record<
   nurse: { pl: "Pielęgniarka", en: "Nurse", color: "#22c55e", isClinical: true },
   therapist: { pl: "Terapeuta", en: "Therapist", color: "#8b5cf6", isClinical: true },
   receptionist: { pl: "Recepcjonista", en: "Receptionist", color: "#f59e0b", isClinical: false },
+  manager: { pl: "Menadżer", en: "Manager", color: "#0ea5e9", isClinical: false },
   admin: { pl: "Administrator", en: "Admin", color: "#ef4444", isClinical: false },
   other: { pl: "Inny", en: "Other", color: "#6b7280", isClinical: false },
 };

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2938,6 +2938,7 @@
         "nurse": "Assistant",
         "therapist": "Therapist",
         "receptionist": "Receptionist",
+        "manager": "Manager",
         "admin": "Administrator",
         "other": "Other"
       },

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2959,6 +2959,7 @@
         "nurse": "Pielęgniarka",
         "therapist": "Terapeuta",
         "receptionist": "Recepcjonista",
+        "manager": "Menadżer",
         "admin": "Administrator",
         "other": "Inny"
       },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2101.

Closes #2101

---

## Claude summary

Done. Here's a summary of what was added:

**`manager` system gabinet-role** — sits between `admin` and `receptionist` in the permission hierarchy:

| Capability | receptionist | manager (new) | admin |
|---|---|---|---|
| Patients (view/create/edit) | all | all | all |
| Patients (delete) | — | — | all |
| Appointments (full) | all | all | all |
| Treatments (view) | all | all | all |
| Treatments (create/edit) | — | all | all |
| Packages (create/edit) | — | all | all |
| Payments (view/create/edit) | all | all | all |
| Payments (refund/delete) | — | — | all |
| Reports (view) | — | all | all |
| Settings | — | — | all |

Changes across 3 files:
- `convex/_helpers/gabinetRolePermissions.ts` — added `manager` to the type union, `SYSTEM_GABINET_ROLES` array, `DEFAULT_GABINET_ROLE_PERMISSIONS` record, and `SYSTEM_GABINET_ROLE_LABELS` record (sky-blue `#0ea5e9`, non-clinical)
- `public/locales/en/translation.json` — `"manager": "Manager"`
- `public/locales/pl/translation.json` — `"manager": "Menadżer"`

The role will auto-surface in the gabinet roles settings UI and employee form immediately via the existing virtual-system-role mechanism in `listDefinitions`.