### PR TITLE
Implement `scope

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -398,7 +398,7 @@ export const list = action({
       .order("createdAt", false)
       .collect()) as GabinetAppointmentRow[];
     if (perm.scope === "own") {
-      page = page.filter((r) => String(r.createdBy) === userIdStr);
+      page = page.filter((r) => String(r.employeeId) === userIdStr);
     }
     return { page, isDone: true, continueCursor: "" };
   },
@@ -426,7 +426,7 @@ export const getById = action({
     if (!appt || String(appt.organizationId) !== String(args.organizationId)) {
       throw new Error("Appointment not found");
     }
-    if (perm.scope === "own" && String(appt.createdBy) !== String(authResult.userId)) {
+    if (perm.scope === "own" && String(appt.employeeId) !== String(authResult.userId)) {
       throw new Error("Permission denied: you can only view your own records");
     }
     return appt;
@@ -457,7 +457,7 @@ export const listByDate = action({
       .eq("date", args.date)
       .collect()) as GabinetAppointmentRow[];
     if (perm.scope === "own") {
-      results = results.filter((r) => String(r.createdBy) === String(authResult.userId));
+      results = results.filter((r) => String(r.employeeId) === String(authResult.userId));
     }
     return results;
   },
@@ -493,7 +493,7 @@ export const listByDateRange = action({
     }
     let results = (await builder.collect()) as GabinetAppointmentRow[];
     if (perm.scope === "own") {
-      results = results.filter((r) => String(r.createdBy) === String(authResult.userId));
+      results = results.filter((r) => String(r.employeeId) === String(authResult.userId));
     }
     return results;
   },
@@ -523,7 +523,7 @@ export const listByPatient = action({
       .eq("patientId", args.patientId)
       .collect()) as GabinetAppointmentRow[];
     if (perm.scope === "own") {
-      results = results.filter((r) => String(r.createdBy) === String(authResult.userId));
+      results = results.filter((r) => String(r.employeeId) === String(authResult.userId));
     }
     return results;
   },
@@ -553,7 +553,7 @@ export const listByEmployee = action({
       .eq("employeeId", args.employeeId)
       .collect()) as GabinetAppointmentRow[];
     if (perm.scope === "own") {
-      results = results.filter((r) => String(r.createdBy) === String(authResult.userId));
+      results = results.filter((r) => String(r.employeeId) === String(authResult.userId));
     }
     return results;
   },
@@ -583,7 +583,7 @@ export const listPatientsForEmployee = action({
       .eq("employeeId", args.employeeId)
       .collect()) as GabinetAppointmentRow[];
     if (perm.scope === "own") {
-      appointments = appointments.filter((r) => String(r.createdBy) === String(authResult.userId));
+      appointments = appointments.filter((r) => String(r.employeeId) === String(authResult.userId));
     }
 
     const uniquePatientIds = [...new Set(appointments.map((a) => String(a.patientId)))];
@@ -635,7 +635,7 @@ export const listPatientsWithStatsForEmployee = action({
       .collect()) as GabinetAppointmentRow[];
 
     if (perm.scope === "own") {
-      appointments = appointments.filter((r) => String(r.createdBy) === String(authResult.userId));
+      appointments = appointments.filter((r) => String(r.employeeId) === String(authResult.userId));
     }
 
     // Group by patient
@@ -1458,7 +1458,7 @@ export const update = action({
     if (!appt || String(appt.organizationId) !== String(args.organizationId)) {
       throw new Error("Appointment not found");
     }
-    if (perm.scope === "own" && String(appt.createdBy) !== String(authResult.userId)) {
+    if (perm.scope === "own" && String(appt.employeeId) !== String(authResult.userId)) {
       throw new Error("Permission denied: you can only edit your own records");
     }
 
@@ -1758,7 +1758,7 @@ export const updateStatus = action({
     if (!appt || String(appt.organizationId) !== String(args.organizationId)) {
       throw new Error("Appointment not found");
     }
-    if (perm.scope === "own" && String(appt.createdBy) !== String(authResult.userId)) {
+    if (perm.scope === "own" && String(appt.employeeId) !== String(authResult.userId)) {
       throw new Error("Permission denied: you can only edit your own records");
     }
 
@@ -2103,7 +2103,7 @@ export const cancel = action({
     if (!appt || String(appt.organizationId) !== String(args.organizationId)) {
       throw new Error("Appointment not found");
     }
-    if (perm.scope === "own" && String(appt.createdBy) !== String(authResult.userId)) {
+    if (perm.scope === "own" && String(appt.employeeId) !== String(authResult.userId)) {
       throw new Error(
         "Permission denied: you can only delete your own records",
       );
@@ -2635,7 +2635,7 @@ export const getFullDetail = action({
     }
     if (
       perm.scope === "own" &&
-      String(appointmentRaw.createdBy) !== String(authResult.userId)
+      String(appointmentRaw.employeeId) !== String(authResult.userId)
     ) {
       throw new Error("Permission denied: you can only view your own records");
     }

--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -46,7 +46,13 @@ export const list = action({
         return fn.includes(term) || ln.includes(term) || em.includes(term) || ph.includes(term);
       }).slice(0, 50);
       if (perm.scope === "own") {
-        results = results.filter((r) => String(r.createdBy) === userIdStr);
+        const ownAppts = (await db
+          .query("gabinetAppointments")
+          .eq("organizationId", orgIdStr)
+          .eq("employeeId", userIdStr)
+          .collect()) as Array<{ patientId: unknown }>;
+        const ownPatientIds = new Set(ownAppts.map((a) => String(a.patientId)));
+        results = results.filter((r) => ownPatientIds.has(String(r._id)));
       }
       return { page: results, isDone: true, continueCursor: "" };
     }
@@ -57,7 +63,13 @@ export const list = action({
       .order("createdAt", false)
       .collect()) as GabinetPatientRow[];
     if (perm.scope === "own") {
-      page = page.filter((r) => String(r.createdBy) === userIdStr);
+      const ownAppts = (await db
+        .query("gabinetAppointments")
+        .eq("organizationId", orgIdStr)
+        .eq("employeeId", userIdStr)
+        .collect()) as Array<{ patientId: unknown }>;
+      const ownPatientIds = new Set(ownAppts.map((a) => String(a.patientId)));
+      page = page.filter((r) => ownPatientIds.has(String(r._id)));
     }
     return { page, isDone: true, continueCursor: "" };
   },
@@ -136,8 +148,14 @@ export const getById = action({
     if (!patient || String(patient.organizationId) !== String(args.organizationId)) {
       throw new Error("Patient not found");
     }
-    if (perm.scope === "own" && String(patient.createdBy) !== String(authResult.userId)) {
-      throw new Error("Permission denied: you can only view your own records");
+    if (perm.scope === "own") {
+      const hasAppt = await db
+        .query("gabinetAppointments")
+        .eq("organizationId", String(args.organizationId))
+        .eq("employeeId", String(authResult.userId))
+        .eq("patientId", args.patientId)
+        .first();
+      if (!hasAppt) throw new Error("Permission denied: you can only view your own records");
     }
 
     return patient;
@@ -431,8 +449,14 @@ export const update = action({
     if (!patient || String(patient.organizationId) !== String(args.organizationId)) {
       throw new Error("Patient not found");
     }
-    if (perm.scope === "own" && String(patient.createdBy) !== String(authResult.userId)) {
-      throw new Error("Permission denied: you can only edit your own records");
+    if (perm.scope === "own") {
+      const hasAppt = await db
+        .query("gabinetAppointments")
+        .eq("organizationId", String(args.organizationId))
+        .eq("employeeId", String(authResult.userId))
+        .eq("patientId", args.patientId)
+        .first();
+      if (!hasAppt) throw new Error("Permission denied: you can only edit your own records");
     }
 
     // --- Build updates and PATCH to Supabase ---
@@ -523,8 +547,14 @@ export const remove = action({
     if (!patient || String(patient.organizationId) !== String(args.organizationId)) {
       throw new Error("Patient not found");
     }
-    if (perm.scope === "own" && String(patient.createdBy) !== String(authResult.userId)) {
-      throw new Error("Permission denied: you can only delete your own records");
+    if (perm.scope === "own") {
+      const hasAppt = await db
+        .query("gabinetAppointments")
+        .eq("organizationId", String(args.organizationId))
+        .eq("employeeId", String(authResult.userId))
+        .eq("patientId", args.patientId)
+        .first();
+      if (!hasAppt) throw new Error("Permission denied: you can only delete your own records");
     }
 
     // --- Soft-delete: PATCH isActive=false in Supabase ---
@@ -663,7 +693,11 @@ export const merge = action({
     }
     if (perm.scope === "own") {
       const userIdStr = String(authResult.userId);
-      if (String(target.createdBy) !== userIdStr || String(source.createdBy) !== userIdStr) {
+      const [hasTargetAppt, hasSourceAppt] = await Promise.all([
+        db.query("gabinetAppointments").eq("organizationId", orgIdStr).eq("employeeId", userIdStr).eq("patientId", args.targetPatientId).first(),
+        db.query("gabinetAppointments").eq("organizationId", orgIdStr).eq("employeeId", userIdStr).eq("patientId", args.sourcePatientId).first(),
+      ]);
+      if (!hasTargetAppt || !hasSourceAppt) {
         throw new Error("Permission denied: you can only merge your own records");
       }
     }
@@ -920,7 +954,13 @@ export const getByContact = action({
       .collect()) as GabinetPatientRow[];
 
     if (perm.scope === "own") {
-      results = results.filter((r) => String(r.createdBy) === String(authResult.userId));
+      const ownAppts = (await db
+        .query("gabinetAppointments")
+        .eq("organizationId", String(args.organizationId))
+        .eq("employeeId", String(authResult.userId))
+        .collect()) as Array<{ patientId: unknown }>;
+      const ownPatientIds = new Set(ownAppts.map((a) => String(a.patientId)));
+      results = results.filter((r) => ownPatientIds.has(String(r._id)));
     }
     return results;
   },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2102.

Closes #2102

---

## Claude summary

The fix is committed. Here's a summary of what was done and why.

**Root cause:** The `scope: "own"` filtering in both `appointments.ts` and `patients.ts` was using `createdBy` (the user who created the record in the system, typically a receptionist) instead of the correct field for clinical ownership.

**appointments.ts (7 query functions + 4 write functions fixed):** Every `scope === "own"` check now filters by `employeeId === userId`. An appointment "belongs to" a clinical user when they are the assigned provider, not when they typed it into the system.

**patients.ts (6 locations fixed):** Since `gabinetPatients` has no direct `employeeId` field, the fix queries `gabinetAppointments` as a cross-join to determine which patients a clinical user has treated. For list queries this builds a Set of patient IDs; for single-record operations it does a targeted `.first()` check.

The scope `"own"` for appointment and patient `view` is not the default for any gabinet role (all clinical roles default to `view: "all"`), so this bug only manifests when an org admin configures custom `view: "own"` permissions. The `edit` scope is `"own"` by default for doctors/therapists/nurses, so the write-path fixes (`update`, `remove`, `cancel`, `updateStatus`) affect everyday usage.

## Follow-ups

- Fix scope:"own" filtering in `employees.ts` uses `createdBy` for access control: lines 132, 619, 747 filter employee records by `createdBy` when scope is "own", but a user's "own" employee record should be identified by `userId === authResult.userId`, not who created the record
- Fix scope:"own" filtering in `packages.ts` and `treatments.ts` may be semantically wrong: lines 107, 245, 292 (packages) and 81, 292, 395 (treatments) use `createdBy` — for catalog items "own" via creator is more defensible, but worth reviewing against business intent
- `listCustomReferralSources` in `patients.ts` ignores scope:"own": line 91–110 fetches all patients to enumerate referral sources without applying the scope filter, so a restricted clinical user sees sources from all patients