### PR TITLE
Apply `PermissionGate` consistently across gabinet routes

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -106,6 +106,7 @@ import { Id } from "@cvx/_generated/dataModel";
 import type { AppointmentFullDetailNote } from "@cvx/gabinet/appointments";
 import { useTranslation } from "react-i18next";
 import { Link } from "@tanstack/react-router";
+import { PermissionGate } from "@/hooks/use-permission";
 import { toast } from "sonner";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
@@ -114,7 +115,7 @@ import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
 export const Route = createLazyFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/appointments/$appointmentId",
 )({
-  component: AppointmentDetail,
+  component: () => <PermissionGate feature="gabinet_appointments" action="view"><AppointmentDetail /></PermissionGate>,
 });
 
 // All statuses can transition to any other status. Lets staff correct mistakes

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -85,11 +85,12 @@ import { CategoriesManagerSlideout } from "@/components/categories-tags/categori
 import { EventDialog } from "@/components/gabinet/calendar/event-dialog";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatAppointmentError } from "@/lib/format-action-error";
+import { PermissionGate } from "@/hooks/use-permission";
 
 export const Route = createLazyFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/calendar/",
 )({
-  component: GabinetCalendarPage,
+  component: () => <PermissionGate feature="gabinet_appointments" action="view"><GabinetCalendarPage /></PermissionGate>,
 });
 
 type ViewMode = "day" | "week" | "month";

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -87,11 +87,12 @@ import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
 import { useSidebarSlot } from "@/components/layout/sidebar-slot-context";
 import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
+import { PermissionGate } from "@/hooks/use-permission";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/employees/$employeeId"
 )({
-  component: EmployeeDetail,
+  component: () => <PermissionGate feature="gabinet_employees" action="view"><EmployeeDetail /></PermissionGate>,
 });
 
 const ROLES = ["doctor", "nurse", "therapist", "receptionist", "admin", "other"] as const;

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -39,6 +39,7 @@ import { PlateText } from "@/components/plate-text";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { EmployeeForm } from "@/components/forms/employee-form";
 import { EventDialog } from "@/components/gabinet/calendar/event-dialog";
+import { PermissionGate } from "@/hooks/use-permission";
 import {
   FlexibleScheduleEditor,
   groupSchedulesIntoPeriods,
@@ -52,7 +53,7 @@ import StatisticsImpressionCard from "@/components/shadcn-studio/blocks/statisti
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/employees/"
 )({
-  component: EmployeesIndex,
+  component: () => <PermissionGate feature="gabinet_employees" action="view"><EmployeesIndex /></PermissionGate>,
 });
 
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -55,6 +55,7 @@ import type { MappedGabinetPackageUsage } from "@/lib/supabase/mappers/gabinet/p
 import StatisticsOrderCard from "@/components/shadcn-studio/blocks/statistics-order-card";
 import StatisticsProfitCard from "@/components/shadcn-studio/blocks/statistics-profit-card";
 import StatisticsImpressionCard from "@/components/shadcn-studio/blocks/statistics-impression-card";
+import { PermissionGate } from "@/hooks/use-permission";
 
 // Type alias for Convex mutation compatibility (Knowledge Pattern #9/#12)
 type TreatmentPackage = MappedGabinetTreatmentPackage;
@@ -64,7 +65,7 @@ type PackagesNudgeFilter = "expiring" | "no-usage";
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/packages/"
 )({
-  component: PackagesIndex,
+  component: () => <PermissionGate feature="gabinet_packages" action="view"><PackagesIndex /></PermissionGate>,
   validateSearch: (
     search: Record<string, unknown>,
   ): { nudge?: PackagesNudgeFilter } => {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -74,7 +74,7 @@ import {
 import { cn } from "@/lib/utils";
 
 import { useTranslation } from "react-i18next";
-import { usePermission } from "@/hooks/use-permission";
+import { usePermission, PermissionGate } from "@/hooks/use-permission";
 import { PatientPackagesCard } from "@/components/gabinet/patient-packages-card";
 import { PatientTreatmentsCard } from "@/components/gabinet/patient-treatments-card";
 import { PatientPhotosTab } from "@/components/gabinet/patient-photos-tab";
@@ -88,7 +88,7 @@ import { formatBirthDate } from "@/lib/format-date";
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/patients/$patientId",
 )({
-  component: PatientDetail,
+  component: () => <PermissionGate feature="gabinet_patients" action="view"><PatientDetail /></PermissionGate>,
 });
 
 function PatientDetail() {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -37,13 +37,14 @@ import { formatPhoneNumber } from "@/lib/phone";
 import { formatBirthDate } from "@/lib/format-date";
 import { plateJsonToText } from "@/components/gabinet/rich-text-editor";
 import { displayReferralSource } from "@/lib/options";
+import { PermissionGate } from "@/hooks/use-permission";
 
 type PatientNudgeFilter = "missing-contact" | "no-recent-visit" | "duplicates";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/patients/",
 )({
-  component: PatientsIndex,
+  component: () => <PermissionGate feature="gabinet_patients" action="view"><PatientsIndex /></PermissionGate>,
   validateSearch: (search: Record<string, unknown>): { nudge?: PatientNudgeFilter } => {
     const nudge =
       search.nudge === "missing-contact" ||

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
@@ -41,11 +41,12 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
+import { PermissionGate } from "@/hooks/use-permission";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/equipment"
 )({
-  component: EquipmentSettingsPage,
+  component: () => <PermissionGate feature="gabinet_settings" action="view"><EquipmentSettingsPage /></PermissionGate>,
 });
 
 type EquipmentStatus = "available" | "in_use" | "maintenance" | "retired";

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-balances.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-balances.tsx
@@ -10,11 +10,12 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { PermissionGate } from "@/hooks/use-permission";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/leave-balances"
 )({
-  component: LeaveBalancesPage,
+  component: () => <PermissionGate feature="gabinet_settings" action="view"><LeaveBalancesPage /></PermissionGate>,
 });
 
 function LeaveBalancesPage() {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
@@ -21,11 +21,12 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Id } from "@cvx/_generated/dataModel";
 import { formatActionError } from "@/lib/format-action-error";
+import { PermissionGate } from "@/hooks/use-permission";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/leave-types"
 )({
-  component: LeaveTypesSettings,
+  component: () => <PermissionGate feature="gabinet_settings" action="view"><LeaveTypesSettings /></PermissionGate>,
 });
 
 function LeaveTypesSettings() {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
@@ -47,13 +47,14 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
+import { PermissionGate } from "@/hooks/use-permission";
 
 type LeavesNudgeFilter = "pending";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/leaves"
 )({
-  component: LeavesPage,
+  component: () => <PermissionGate feature="gabinet_settings" action="view"><LeavesPage /></PermissionGate>,
   validateSearch: (
     search: Record<string, unknown>,
   ): { nudge?: LeavesNudgeFilter } => ({

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
@@ -34,11 +34,12 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
+import { PermissionGate } from "@/hooks/use-permission";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/locations"
 )({
-  component: LocationsSettingsPage,
+  component: () => <PermissionGate feature="gabinet_settings" action="view"><LocationsSettingsPage /></PermissionGate>,
 });
 
 type LocationWithRooms = {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.reminders.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.reminders.tsx
@@ -12,11 +12,12 @@ import { Label } from "@/components/ui/label";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { PermissionGate } from "@/hooks/use-permission";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/reminders"
 )({
-  component: ReminderSettings,
+  component: () => <PermissionGate feature="gabinet_settings" action="view"><ReminderSettings /></PermissionGate>,
 });
 
 function ReminderSettings() {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.roles.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.roles.tsx
@@ -20,11 +20,12 @@ import { Badge } from "@/components/ui/badge";
 import { RotateCcw } from "@/lib/ez-icons";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
+import { PermissionGate } from "@/hooks/use-permission";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/roles"
 )({
-  component: GabinetRolesSettingsPage,
+  component: () => <PermissionGate feature="gabinet_settings" action="view"><GabinetRolesSettingsPage /></PermissionGate>,
 });
 
 type Scope = "none" | "own" | "all";

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
@@ -13,11 +13,12 @@ import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
+import { PermissionGate } from "@/hooks/use-permission";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/scheduling"
 )({
-  component: SchedulingSettings,
+  component: () => <PermissionGate feature="gabinet_settings" action="view"><SchedulingSettings /></PermissionGate>,
 });
 
 const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
@@ -60,11 +60,12 @@ import type { MappedGabinetEmployee } from "@/lib/supabase/mappers/gabinet/emplo
 import type { MappedGabinetEmployeeSchedule } from "@/lib/supabase/mappers/gabinet/employee-schedules";
 import type { MappedGabinetWorkingHours } from "@/lib/supabase/mappers/gabinet/working-hours";
 import type { MappedGabinetLeave } from "@/lib/supabase/mappers/gabinet/leaves";
+import { PermissionGate } from "@/hooks/use-permission";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/timetable"
 )({
-  component: TimetablePage,
+  component: () => <PermissionGate feature="gabinet_settings" action="view"><TimetablePage /></PermissionGate>,
 });
 
 const DAY_NAMES_EN = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -65,11 +65,12 @@ import { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatTreatmentError } from "@/lib/format-action-error";
+import { PermissionGate } from "@/hooks/use-permission";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/treatments/$treatmentId",
 )({
-  component: TreatmentDetail,
+  component: () => <PermissionGate feature="gabinet_treatments" action="view"><TreatmentDetail /></PermissionGate>,
 });
 
 function formatCurrency(amount: number, currency?: string): string {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -41,6 +41,7 @@ import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { formatTreatmentError, extractTreatmentFieldError } from "@/lib/format-action-error";
 import { reportError } from "@/lib/error-reporter";
+import { PermissionGate } from "@/hooks/use-permission";
 
 // shadcn/studio statistics blocks
 import StatisticsOrderCard from "@/components/shadcn-studio/blocks/statistics-order-card";
@@ -52,7 +53,7 @@ type TreatmentsNudgeFilter = "no-price";
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/treatments/",
 )({
-  component: TreatmentsIndex,
+  component: () => <PermissionGate feature="gabinet_treatments" action="view"><TreatmentsIndex /></PermissionGate>,
   validateSearch: (
     search: Record<string, unknown>,
   ): { nudge?: TreatmentsNudgeFilter } => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2103.

Closes #2103

---

## Claude summary

Done. Here's a summary of what was done:

**18 gabinet route files** now wrap their page components in `<PermissionGate feature="..." action="view">` at the route definition level. This hides page content for unauthorized users without touching the large internal component code.

The approach used: instead of adding `usePermission` hooks inside every large component (which would have complicated hook ordering rules), `PermissionGate` is applied in the `component:` field of each TanStack Router route definition:

```tsx
component: () => (
  <PermissionGate feature="gabinet_patients" action="view">
    <PatientsIndex />
  </PermissionGate>
),
```

Feature-to-route mapping:
- `gabinet_patients` → patients list + patient detail
- `gabinet_appointments` → calendar + appointment detail
- `gabinet_treatments` → treatments list + treatment detail
- `gabinet_employees` → employees list + employee detail
- `gabinet_packages` → packages list
- `gabinet_settings` → all 9 settings pages
- `gabinet_reports` was already gated inline in `reports.lazy.tsx` — left unchanged

Routes skipped (stubs/redirects/no clear feature key): `calendar.index.tsx`, `appointments.$appointmentId.tsx`, `documents.tsx`, `settings.index.tsx`, `reports.tsx`, `index.tsx` (dashboard), `documents.index.tsx`, `document-templates.tsx`.

## Follow-ups

- Gate gabinet documents and document-templates routes: `documents.index.tsx` and `document-templates.tsx` have no gating; needs clarification on whether `document_instances`/`document_templates` feature keys apply here or if a new `gabinet_documents` feature key is warranted
- Gate gabinet dashboard route: `_layout.gabinet.index.tsx` aggregates data from multiple features with no single natural permission — consider a composite check or a new `gabinet_dashboard` feature key
- Fix hooks-ordering violation in reports.lazy.tsx: `GabinetReports` calls `useState` after early permission-check returns, violating React's Rules of Hooks; refactor so all hooks run unconditionally before any conditional returns