### PR TITLE
Add a permission guard to the gabinet payments page

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -264,6 +264,10 @@ function PatientDetail() {
     "gabinet_payments",
     "create",
   );
+  const { allowed: canViewPayments } = usePermission(
+    "gabinet_payments",
+    "view",
+  );
 
   const getPaymentForLabel = (payment: {
     appointmentId?: string;
@@ -1187,7 +1191,7 @@ function PatientDetail() {
         />
       ),
     },
-    {
+    ...(canViewPayments ? [{
       // Issue #1690: one merged tab — wpłaty, saldo, naliczenia, zwroty in
       // a single chronological table with a "Typ" column.
       label: t("gabinet.payments.payments"),
@@ -1523,7 +1527,7 @@ function PatientDetail() {
           </div>
         );
       })(),
-    },
+    }] : []),
     {
       label: t("gabinet.patients.tabs.documents"),
       count: patientDocuments?.length ?? 0,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2106.

Closes #2106

---

## Claude summary

The fix is in. Here's what was wrong and what changed:

The payments tab on the patient detail page (`_layout.gabinet.patients.$patientId.tsx`) already used `usePermission("gabinet_payments", ...)` to gate the refund, cancel, and create **actions** — but the tab itself was always visible to anyone who could view patients. A user with `gabinet_patients:view` but no `gabinet_payments:view` could see all payment amounts, dates, and history.

The fix adds a `canViewPayments` check via `usePermission("gabinet_payments", "view")` and conditionally spreads the payments tab into the tabs array only when that permission is granted. Users without it simply won't see the tab at all — consistent with how `gabinet_reports` gates its page via a view permission check.

There's no standalone payments route in the codebase (the issue correctly flagged it as "if it exists"), so no other files needed changes.