### PR TITLE
Fix scope

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -45,7 +45,7 @@ export const list = action({
       let all = (await q.collect()) as GabinetEmployeeRow[];
       let filtered = args.activeOnly ? all.filter((e) => e.isActive) : all;
       if (perm.scope === "own") {
-        filtered = filtered.filter((e) => String(e.createdBy) === userIdStr);
+        filtered = filtered.filter((e) => String(e.userId) === userIdStr);
       }
       return filtered;
     }
@@ -57,7 +57,7 @@ export const list = action({
         .eq("isActive", true)
         .collect()) as GabinetEmployeeRow[];
       if (perm.scope === "own") {
-        results = results.filter((e) => String(e.createdBy) === userIdStr);
+        results = results.filter((e) => String(e.userId) === userIdStr);
       }
       return results;
     }
@@ -68,7 +68,7 @@ export const list = action({
       .order("createdAt", false)
       .collect()) as GabinetEmployeeRow[];
     if (perm.scope === "own") {
-      page = page.filter((e) => String(e.createdBy) === userIdStr);
+      page = page.filter((e) => String(e.userId) === userIdStr);
     }
     return { page, isDone: true, continueCursor: "" };
   },
@@ -101,7 +101,7 @@ export const listAll = action({
     }
     let results = (await q.collect()) as GabinetEmployeeRow[];
     if (perm.scope === "own") {
-      results = results.filter((e) => String(e.createdBy) === userIdStr);
+      results = results.filter((e) => String(e.userId) === userIdStr);
     }
     return results;
   },
@@ -129,7 +129,7 @@ export const getById = action({
     if (!emp || String(emp.organizationId) !== String(args.organizationId)) {
       throw new Error("Employee not found");
     }
-    if (perm.scope === "own" && String(emp.createdBy) !== String(authResult.userId)) {
+    if (perm.scope === "own" && String(emp.userId) !== String(authResult.userId)) {
       throw new Error("Permission denied: you can only view your own records");
     }
     return emp;
@@ -616,7 +616,7 @@ export const update = action({
     if (!emp || String(emp.organizationId) !== String(args.organizationId)) {
       throw new Error("Employee not found");
     }
-    if (perm.scope === "own" && String(emp.createdBy) !== String(authResult.userId)) {
+    if (perm.scope === "own" && String(emp.userId) !== String(authResult.userId)) {
       throw new Error("Permission denied: you can only edit your own records");
     }
 
@@ -744,7 +744,7 @@ export const remove = action({
     if (!emp || String(emp.organizationId) !== String(args.organizationId)) {
       throw new Error("Employee not found");
     }
-    if (perm.scope === "own" && String(emp.createdBy) !== String(authResult.userId)) {
+    if (perm.scope === "own" && String(emp.userId) !== String(authResult.userId)) {
       throw new Error("Permission denied: you can only delete your own records");
     }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2110.

Closes #2110

---

## Claude summary

The fix is committed. Here's what was wrong and what changed:

The `gabinet_employees` table has two distinct user-related fields: `user_id` (the platform user this employee profile belongs to) and `created_by` (whoever created the record — often an admin). When RBAC scope is `"own"`, the intent is "you can only access your own employee profile", which means checking `userId === authResult.userId`. All 7 scope checks in `list`, `listAll`, `getById`, `update`, and `remove` were incorrectly comparing against `createdBy`, meaning a user could be blocked from their own profile if someone else created it, while getting access to any record they happened to create (e.g. an admin who set up other employees' profiles).