### PR TITLE
`listCustomReferralSources` in `patients.ts` ignores scope

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -92,7 +92,7 @@ export const listCustomReferralSources = action({
     organizationId: v.id("organizations"),
   },
   handler: async (ctx, args): Promise<string[]> => {
-    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+    const authResult = await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
@@ -103,10 +103,22 @@ export const listCustomReferralSources = action({
     if (!perm.allowed) return [];
 
     const db = createSupabaseDb();
-    const patients = (await db
+    const orgIdStr = String(args.organizationId);
+    let patients = (await db
       .query("gabinetPatients")
-      .eq("organizationId", String(args.organizationId))
+      .eq("organizationId", orgIdStr)
       .collect()) as GabinetPatientRow[];
+
+    if (perm.scope === "own") {
+      const userIdStr = String(authResult.userId);
+      const ownAppts = (await db
+        .query("gabinetAppointments")
+        .eq("organizationId", orgIdStr)
+        .eq("employeeId", userIdStr)
+        .collect()) as Array<{ patientId: unknown }>;
+      const ownPatientIds = new Set(ownAppts.map((a) => String(a.patientId)));
+      patients = patients.filter((r) => ownPatientIds.has(String(r._id)));
+    }
 
     const seen = new Set<string>();
     const custom: string[] = [];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2112.

Closes #2112

---

## Claude summary

The bug was real and is now fixed. Here's what changed in `convex/gabinet/patients.ts`:

- Captured the return value of `verifyOrgAccess` (was being discarded with bare `await`)
- When `perm.scope === "own"`, queries `gabinetAppointments` filtered by `employeeId` (the current user) and restricts the patient list to only those patients — exactly the same pattern used in the `list` action (lines 65–73)

Without the fix, any user with `scope:"own"` on `gabinet_patients` view would see custom referral source strings from every patient in the organization when using the patient form's referral source picker, leaking data from patients they have no appointment with.