### PR TITLE
Gate gabinet documents and document-templates routes

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.document-templates.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.document-templates.tsx
@@ -1,8 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { FormTemplatesListPage } from "./_layout.settings.form-templates.index";
+import { PermissionGate } from "@/hooks/use-permission";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/document-templates",
 )({
-  component: FormTemplatesListPage,
+  component: () => (
+    <PermissionGate feature="document_templates" action="view">
+      <FormTemplatesListPage />
+    </PermissionGate>
+  ),
 });

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { PermissionGate } from "@/hooks/use-permission";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
@@ -60,7 +61,11 @@ import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/documents/",
 )({
-  component: GabinetDocumentsPage,
+  component: () => (
+    <PermissionGate feature="document_instances" action="view">
+      <GabinetDocumentsPage />
+    </PermissionGate>
+  ),
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2114.

Closes #2114

---

## Claude summary

Done. Here's a summary of what was done:

The two gabinet document routes were missing `PermissionGate` wrappers. Both `document_instances` and `document_templates` feature keys were already fully defined in `convex/_helpers/permissionTypes.ts` and had default permissions configured in `convex/_helpers/permissions.ts` — only the route-level gates were absent.

Changes made:

- `_layout.gabinet.documents.index.tsx` — wrapped `GabinetDocumentsPage` with `<PermissionGate feature="document_instances" action="view">`
- `_layout.gabinet.document-templates.tsx` — wrapped `FormTemplatesListPage` with `<PermissionGate feature="document_templates" action="view">`

No new feature keys were needed — the existing `document_instances`/`document_templates` pair maps cleanly to these two routes (instances = filled documents list, templates = template management).