### PR TITLE
Gate gabinet dashboard route

### DIFF
--- a/convex/_helpers/permissionTypes.ts
+++ b/convex/_helpers/permissionTypes.ts
@@ -13,6 +13,7 @@ export const FEATURES = [
   "email",
   "products",
   "pipelines",
+  "gabinet_dashboard",
   "gabinet_patients",
   "gabinet_appointments",
   "gabinet_treatments",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
+import { PermissionGate } from "@/hooks/use-permission";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseGabinetAppointmentsByDateRange } from "@/hooks/use-supabase-gabinet-appointments";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
@@ -50,7 +51,11 @@ import TotalOrdersCard from "@/components/shadcn-studio/blocks/chart-total-order
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/"
 )({
-  component: GabinetDashboard,
+  component: () => (
+    <PermissionGate feature="gabinet_dashboard" action="view">
+      <GabinetDashboard />
+    </PermissionGate>
+  ),
 });
 
 const statusColors: Record<string, string> = {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2115.

Closes #2115

---

## Claude summary

Done. Here's what was changed:

**`convex/_helpers/permissionTypes.ts`** — added `"gabinet_dashboard"` to `FEATURES`. Because `buildDefaults` in `convex/_helpers/permissions.ts` iterates over all features automatically, default scopes are immediately correct: `view: "all"` for owner/admin/member/viewer, matching the sensible default that the dashboard is a read-only overview accessible to all roles. Admins can override this per-org through the existing RBAC settings UI.

**`src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx`** — imported `PermissionGate` and changed the route's `component` to wrap `<GabinetDashboard />` in `<PermissionGate feature="gabinet_dashboard" action="view">`, matching the pattern used by every other gabinet route (e.g. `gabinet.patients.index.tsx`, `gabinet.calendar.index.lazy.tsx`).