### PR TITLE
Fix hooks-ordering violation in reports.lazy.tsx

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -792,24 +792,6 @@ function GabinetReports() {
   const { organizationId } = useOrganization();
   const { allowed: canViewReports, loading: permLoading } = usePermission("gabinet_reports", "view");
 
-  if (permLoading) {
-    return (
-      <div className="flex flex-col gap-6 p-6">
-        <Skeleton className="h-10 w-64" />
-      </div>
-    );
-  }
-
-  if (!canViewReports) {
-    return (
-      <div className="flex flex-col gap-6 p-6">
-        <PageHeader
-          title={t("gabinet.reports.title")}
-          description={t("common.noPermission", "You don't have permission to view this page.")}
-        />
-      </div>
-    );
-  }
   const [dateRange, setDateRange] = useState<DateRangeKey>("30d");
   const [dateFilterPanelOpen, setDateFilterPanelOpen] = useState(false);
   const todayIso = new Date().toISOString().split("T")[0];
@@ -1117,6 +1099,25 @@ function GabinetReports() {
   ]);
 
   useSidebarDispatch("exportReport", handleExportReport);
+
+  if (permLoading) {
+    return (
+      <div className="flex flex-col gap-6 p-6">
+        <Skeleton className="h-10 w-64" />
+      </div>
+    );
+  }
+
+  if (!canViewReports) {
+    return (
+      <div className="flex flex-col gap-6 p-6">
+        <PageHeader
+          title={t("gabinet.reports.title")}
+          description={t("common.noPermission", "You don't have permission to view this page.")}
+        />
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2116.

Closes #2116

---

## Claude summary

The bug was real and is now fixed. The `GabinetReports` component had two early conditional returns (lines 795–811 in the original) gating on `permLoading` and `!canViewReports`, but roughly 30 hooks — `useState`, `useMemo`, `useRef`, `useSidebarDispatch`, `useCallback`, and four data-fetching hooks — were called after those returns. This violates React's Rules of Hooks and would cause a runtime crash whenever the permission check resolved to either loading or denied state.

The fix moves all those hooks above the early returns so they always execute unconditionally, and the three conditional returns (`permLoading`, `!canViewReports`, `isLoading`) remain grouped after the last hook call.