### PR TITLE
Dodaj zabieg ￼

### DIFF
--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -11,6 +11,7 @@ import {
   type PermissionResult,
   type FeaturePermissions,
 } from "./permissionTypes";
+import { defaultGabinetScope, maxScope } from "./gabinetRolePermissions";
 
 export type { Feature, Action, Scope, PermissionResult, FeaturePermissions };
 
@@ -169,7 +170,7 @@ export async function getEffectivePermissions(
   ctx: QueryCtx | MutationCtx,
   orgId: Id<"organizations">,
 ): Promise<FeaturePermissions> {
-  const { membership } = await verifyOrgAccess(ctx, orgId);
+  const { membership, user } = await verifyOrgAccess(ctx, orgId);
   const role = membership.role as OrgRole;
 
   if (role === "owner" || role === "admin") {
@@ -181,13 +182,9 @@ export async function getEffectivePermissions(
     .withIndex("by_orgAndRole", (q) => q.eq("organizationId", orgId).eq("role", role))
     .unique();
 
-  if (!override) {
-    return DEFAULT_PERMISSIONS[role];
-  }
-
-  // Merge: override takes precedence, defaults fill gaps
+  // Build org-role base permissions (override fills gaps with defaults)
   const defaults = DEFAULT_PERMISSIONS[role];
-  const overridePerms = override.permissions as Partial<FeaturePermissions>;
+  const overridePerms = override ? (override.permissions as Partial<FeaturePermissions>) : undefined;
   const merged = {} as FeaturePermissions;
 
   for (const feature of ALL_FEATURES) {
@@ -201,6 +198,37 @@ export async function getEffectivePermissions(
       merged[feature] = mergedActions;
     } else {
       merged[feature] = { ...defaultActions };
+    }
+  }
+
+  // MAX-merge gabinet-role permissions for gabinet_* features, mirroring the
+  // logic in authAction.checkPermission so frontend gates match backend enforcement.
+  const gabinetMembership = await ctx.db
+    .query("gabinetMemberships")
+    .withIndex("by_orgAndUser", (q) =>
+      q.eq("organizationId", orgId).eq("userId", user._id),
+    )
+    .unique();
+
+  if (gabinetMembership && gabinetMembership.isActive) {
+    const gRole = gabinetMembership.gabinetRole;
+    const gOverride = await ctx.db
+      .query("gabinetRolePermissions")
+      .withIndex("by_orgAndRole", (q) =>
+        q.eq("organizationId", orgId).eq("gabinetRole", gRole),
+      )
+      .unique();
+    const gPerms = gOverride ? (gOverride.permissions as Partial<FeaturePermissions>) : undefined;
+
+    for (const feature of ALL_FEATURES) {
+      if (!feature.startsWith("gabinet_")) continue;
+      const mergedActions = { ...merged[feature] };
+      for (const action of ACTIONS) {
+        const gabinetScope: Scope = gPerms?.[feature as Feature]?.[action]
+          ?? defaultGabinetScope(gRole, feature as Feature, action);
+        mergedActions[action] = maxScope(mergedActions[action], gabinetScope);
+      }
+      merged[feature] = mergedActions;
     }
   }
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -577,10 +577,12 @@ function TreatmentsIndex() {
                 defaultValue: "Grupuj wg sprzętu",
               })}
             </Button>
-            <Button onClick={openCreatePanel}>
-              <Plus className="mr-2 h-4 w-4" variant="stroke" />
-              {t("gabinet.treatments.addTreatment")}
-            </Button>
+            <PermissionGate feature="gabinet_treatments" action="create">
+              <Button onClick={openCreatePanel}>
+                <Plus className="mr-2 h-4 w-4" variant="stroke" />
+                {t("gabinet.treatments.addTreatment")}
+              </Button>
+            </PermissionGate>
           </div>
         }
       />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2120.

Closes #2120

---

## Claude summary

The fix is committed. Here's a summary of what was found and fixed:

**Root cause:** The "Dodaj zabieg" button was shown to all users who could view the treatments page, but the backend `create` action always checked `gabinet_treatments.create` permission. Users with only `view` permission (e.g. `viewer` org-role, or clinical roles like doctor/nurse/therapist that have `gabinet_treatments: { view: "all" }` but no `create`) would see the button, open the form, and get a "Nie udało się utworzyć zabiegu" error toast after submission. The PermissionGate added in commit #2113 (13 min before the issue was filed) made the page properly accessible to `viewer`-role users, which made this pre-existing mismatch visible.

**Fixes in 2 files:**

- `convex/_helpers/permissions.ts` — `getEffectivePermissions` now MAX-merges gabinet-role permissions for `gabinet_*` features, matching the logic already in `authAction.checkPermission`. Previously the frontend permission query ignored gabinet-role entirely, so a `viewer + manager gabinet role` user would be denied by the UI even though the backend would allow the create.

- `src/routes/.../gabinet.treatments.index.tsx` — The "Dodaj zabieg" button is now wrapped in `PermissionGate feature="gabinet_treatments" action="create"`, so it only appears when the user actually has permission to create treatments.

## Follow-ups

- Gate row-level "Edit" action for treatments on `gabinet_treatments.edit` permission: the `rowActions` edit button in the treatments table has no permission gate, symmetric bug to the one fixed here.
- `checkPermission` in `permissions.ts` (used by mutations/queries) also lacks gabinet-role merge: only `authAction.checkPermission` (used by actions) and now `getEffectivePermissions` do the gabinet-role MAX-merge; the mutation/query helper should be aligned.