### PR TITLE
Translate legend list status text in StatusDistributionChart

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3537,7 +3537,8 @@
         "cancelled": "Cancelled",
         "no_show": "No Show"
       },
-      "periodTotal": "Period total"
+      "periodTotal": "Period total",
+      "ofTotal": "of total"
     },
     "bodyChart": {
       "description": "Mark body areas related to the appointment",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3559,7 +3559,8 @@
         "cancelled": "Anulowane",
         "no_show": "Nieobecność"
       },
-      "periodTotal": "Cały okres"
+      "periodTotal": "Cały okres",
+      "ofTotal": "ogółem"
     },
     "bodyChart": {
       "description": "Zaznacz obszary ciała powiązane z wizytą",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -469,11 +469,11 @@ function StatusDistributionChart({
               </Avatar>
               <div className="flex flex-col gap-0.5">
                 <span className="font-medium capitalize">
-                  {item.status.replace("_", " ")}
+                  {t(`gabinet.reports.statuses.${item.status}`, item.status.replace("_", " "))}
                 </span>
                 <span className="text-muted-foreground text-sm">
                   {total > 0
-                    ? `${Math.round((item.count / total) * 100)}% of total`
+                    ? `${Math.round((item.count / total) * 100)}% ${t("gabinet.reports.ofTotal")}`
                     : "0%"}
                 </span>
               </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2124.

Closes #2124

---

## Claude summary

Fixed. The legend items in `StatusDistributionChart` were using raw `item.status.replace("_", " ")` instead of the i18n `t()` function. Translation keys for all appointment statuses already existed in both `en` and `pl` locales under `gabinet.reports.statuses.*`, so the fix was just wiring them up. I also fixed the hardcoded "% of total" suffix in the same block by adding a new `gabinet.reports.ofTotal` key ("of total" in EN, "ogółem" in PL).

Changes in 3 files:
- `_layout.gabinet.reports.lazy.tsx:472` — use `t()` for status name (with fallback to the replace-based string)
- `_layout.gabinet.reports.lazy.tsx:476` — use `t("gabinet.reports.ofTotal")` for the "of total" suffix
- `public/locales/en/translation.json` + `pl/translation.json` — added `"ofTotal"` key

## Follow-ups
- Translate "Top N" label inside StatusDistributionChart donut center: line 441 renders `Top {top.length}` as a hardcoded English SVG tspan inside the PieChart — not covered by the status-legend keys and needs its own translation key