### PR TITLE
Gate row-level "Edit" action for treatments on `gabinet_treatments.edit` permiss

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -41,7 +41,7 @@ import { CategoryPicker } from "@/components/categories-tags/category-picker";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { formatTreatmentError, extractTreatmentFieldError } from "@/lib/format-action-error";
 import { reportError } from "@/lib/error-reporter";
-import { PermissionGate } from "@/hooks/use-permission";
+import { PermissionGate, usePermission } from "@/hooks/use-permission";
 
 // shadcn/studio statistics blocks
 import StatisticsOrderCard from "@/components/shadcn-studio/blocks/statistics-order-card";
@@ -82,6 +82,8 @@ function TreatmentsIndex() {
   const createTreatment = useAction(api.gabinet.treatments.create);
   const updateTreatment = useAction(api.gabinet.treatments.update);
   const removeTreatment = useAction(api.gabinet.treatments.remove);
+
+  const { allowed: canEdit } = usePermission("gabinet_treatments", "edit");
 
   const { tags } = useTagDefinitions(organizationId);
   const { categories } = useCategoryDefinitions(organizationId, "gabinetTreatment");
@@ -526,11 +528,15 @@ function TreatmentsIndex() {
 
   const rowActions = useCallback(
     (row: Treatment) => [
-      {
-        label: t("common.edit"),
-        icon: <Pencil className="h-4 w-4" variant="stroke" />,
-        onClick: () => openEditPanel(row),
-      },
+      ...(canEdit
+        ? [
+            {
+              label: t("common.edit"),
+              icon: <Pencil className="h-4 w-4" variant="stroke" />,
+              onClick: () => openEditPanel(row),
+            },
+          ]
+        : []),
       {
         label: row.isActive ? t("common.inactive") : t("common.active"),
         icon: <Power className="h-4 w-4" variant="stroke" />,
@@ -557,7 +563,7 @@ function TreatmentsIndex() {
         },
       },
     ],
-    [t, removeTreatment, updateTreatment, organizationId],
+    [t, removeTreatment, updateTreatment, organizationId, canEdit],
   );
 
   return (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2132.

Closes #2132

---

## Claude summary

The fix is committed. Here's what was done:

**Bug confirmed and fixed.** The `rowActions` callback in `_layout.gabinet.treatments.index.tsx` unconditionally included an Edit entry (pencil icon), regardless of the user's `gabinet_treatments.edit` permission. This was symmetric to the bug fixed in #2120.

**Changes made to `src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx`:**
- Added `usePermission` to the import from `@/hooks/use-permission` (alongside the existing `PermissionGate`)
- Called `usePermission("gabinet_treatments", "edit")` at the top of `TreatmentsIndex` to get `canEdit`
- Wrapped the edit entry in `rowActions` with a conditional spread so it only appears when `canEdit` is `true`
- Added `canEdit` to the `useCallback` dependency array

## Follow-ups

- Gate row-level "Toggle active" (Power icon) action on `gabinet_treatments.edit` permission: the activate/deactivate row action in the same `rowActions` callback calls `updateTreatment`/`removeTreatment` and is also ungated — users without edit permission can still toggle treatment active status
- Gate row-level "Delete" action on `gabinet_treatments.delete` permission: the delete row action in the same `rowActions` callback has no permission check, users without delete permission can still delete treatments via the dropdown