### PR TITLE
`checkPermission` in `permissions.ts` (used by mutations/queries) also lacks gab

### DIFF
--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -113,7 +113,7 @@ export async function checkPermission(
   feature: Feature,
   action: Action,
 ): Promise<PermissionResult> {
-  const { membership } = await verifyOrgAccess(ctx, orgId);
+  const { user, membership } = await verifyOrgAccess(ctx, orgId);
   const role = membership.role as OrgRole;
 
   if (role === "owner" || role === "admin") {
@@ -126,15 +126,41 @@ export async function checkPermission(
     .withIndex("by_orgAndRole", (q) => q.eq("organizationId", orgId).eq("role", role))
     .unique();
 
-  let scope: Scope;
+  let orgScope: Scope;
   if (override) {
     const perms = override.permissions as FeaturePermissions;
-    scope = perms?.[feature]?.[action] ?? DEFAULT_PERMISSIONS[role][feature][action];
+    orgScope = perms?.[feature]?.[action] ?? DEFAULT_PERMISSIONS[role][feature][action];
   } else {
-    scope = DEFAULT_PERMISSIONS[role][feature][action];
+    orgScope = DEFAULT_PERMISSIONS[role][feature][action];
   }
 
-  return { allowed: scope !== "none", scope };
+  // MAX-merge gabinet-role permissions for gabinet_* features, mirroring
+  // authAction.checkPermission so mutation/query enforcement matches action enforcement.
+  let effectiveScope: Scope = orgScope;
+  if (feature.startsWith("gabinet_")) {
+    const gabinetMembership = await ctx.db
+      .query("gabinetMemberships")
+      .withIndex("by_orgAndUser", (q) =>
+        q.eq("organizationId", orgId).eq("userId", user._id),
+      )
+      .unique();
+    if (gabinetMembership && gabinetMembership.isActive) {
+      const gRole = gabinetMembership.gabinetRole;
+      const gOverride = await ctx.db
+        .query("gabinetRolePermissions")
+        .withIndex("by_orgAndRole", (q) =>
+          q.eq("organizationId", orgId).eq("gabinetRole", gRole),
+        )
+        .unique();
+      const gabinetScope: Scope = gOverride
+        ? ((gOverride.permissions as Record<string, Record<string, string>>)?.[feature]?.[action]
+            ?? defaultGabinetScope(gRole, feature, action)) as Scope
+        : defaultGabinetScope(gRole, feature, action);
+      effectiveScope = maxScope(orgScope, gabinetScope);
+    }
+  }
+
+  return { allowed: effectiveScope !== "none", scope: effectiveScope };
 }
 
 // --- checkResourceAccess ---


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2133.

Closes #2133

---

## Claude summary

The bug was real and the fix is committed. Here's a summary of what was done:

**Root cause:** `checkPermission` in `convex/_helpers/permissions.ts` (the helper used by all mutations and queries) only computed the org-role scope when checking `gabinet_*` features. It didn't consult the user's `gabinetMembership` / `gabinetRolePermissions`, so a `member` or `viewer` who also had an active gabinet role (e.g. `receptionist`, `doctor`) would be incorrectly rejected by the mutation-layer gate even though:
- `authAction.checkPermission` (used by actions) already did the MAX-merge, and  
- `getEffectivePermissions` (used by the frontend) already did the MAX-merge.

**Fix:** Added the identical gabinet-role MAX-merge block from `authAction.checkPermission` into `checkPermission`. Both `defaultGabinetScope` and `maxScope` were already imported in the file, so this was purely additive logic. The three helpers now enforce permissions consistently across the full call stack.