### PR TITLE
Translate "Top N" label inside StatusDistributionChart donut center

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3538,7 +3538,8 @@
         "no_show": "No Show"
       },
       "periodTotal": "Period total",
-      "ofTotal": "of total"
+      "ofTotal": "of total",
+      "topN": "Top {{count}}"
     },
     "bodyChart": {
       "description": "Mark body areas related to the appointment",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3560,7 +3560,8 @@
         "no_show": "Nieobecność"
       },
       "periodTotal": "Cały okres",
-      "ofTotal": "ogółem"
+      "ofTotal": "ogółem",
+      "topN": "Top {{count}}"
     },
     "bodyChart": {
       "description": "Zaznacz obszary ciała powiązane z wizytą",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -438,7 +438,7 @@ function StatusDistributionChart({
                             y={(viewBox.cy || 0) + 14}
                             className="fill-muted-foreground text-sm"
                           >
-                            Top {top.length}
+                            {t("gabinet.reports.topN", { count: top.length })}
                           </tspan>
                         </text>
                       );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2135.

Closes #2135

---

## Claude summary

Fixed. The hardcoded `Top {top.length}` string at `_layout.gabinet.reports.lazy.tsx:441` is now replaced with `t("gabinet.reports.topN", { count: top.length })`, and the `topN` key (`"Top {{count}}"`) has been added to both `public/locales/en/translation.json` and `public/locales/pl/translation.json` under `gabinet.reports`.