### PR TITLE
Translate hardcoded "Appointments" label in DailyVolumeChart config

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -488,10 +488,6 @@ function StatusDistributionChart({
 
 /* ─── Daily Volume (bar chart) ─── */
 
-const dailyChartConfig = {
-  count: { label: "Appointments" },
-} satisfies ChartConfig;
-
 function DailyVolumeChart({
   data,
   rangeLabel,
@@ -500,6 +496,10 @@ function DailyVolumeChart({
   rangeLabel: string;
 }) {
   const { t } = useTranslation();
+
+  const dailyChartConfig = {
+    count: { label: t("gabinet.reports.appointments") },
+  } satisfies ChartConfig;
 
   const chartData = useMemo(
     () =>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2137.

Closes #2137

---

## Claude summary

Fixed. The `dailyChartConfig` was defined at module scope (outside any component), so it couldn't call `t()`. The fix moves it inside `DailyVolumeChart`, which already had `useTranslation()`, and uses the existing `t("gabinet.reports.appointments")` key — present in both `en/translation.json` (line 3526, "Appointments") and `pl/translation.json` (line 3548, "Wizyty").