### PR TITLE
Gate row-level "Toggle active" (Power icon) action on `gabinet_treatments.edit` 

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -535,33 +535,33 @@ function TreatmentsIndex() {
               icon: <Pencil className="h-4 w-4" variant="stroke" />,
               onClick: () => openEditPanel(row),
             },
+            {
+              label: row.isActive ? t("common.inactive") : t("common.active"),
+              icon: <Power className="h-4 w-4" variant="stroke" />,
+              onClick: async () => {
+                // Soft toggle by removing (deactivate) or updating
+                if (row.isActive) {
+                  await removeTreatment({ organizationId, treatmentId: row._id as Id<"gabinetTreatments"> });
+                } else {
+                  await updateTreatment({
+                    organizationId,
+                    treatmentId: row._id as Id<"gabinetTreatments">,
+                    name: row.name,
+                  });
+                }
+              },
+            },
+            {
+              label: t("common.delete"),
+              icon: <Trash2 className="h-4 w-4" variant="stroke" />,
+              onClick: async () => {
+                if (window.confirm(t("gabinet.treatments.confirmDelete"))) {
+                  await removeTreatment({ organizationId, treatmentId: row._id as Id<"gabinetTreatments"> });
+                }
+              },
+            },
           ]
         : []),
-      {
-        label: row.isActive ? t("common.inactive") : t("common.active"),
-        icon: <Power className="h-4 w-4" variant="stroke" />,
-        onClick: async () => {
-          // Soft toggle by removing (deactivate) or updating
-          if (row.isActive) {
-            await removeTreatment({ organizationId, treatmentId: row._id as Id<"gabinetTreatments"> });
-          } else {
-            await updateTreatment({
-              organizationId,
-              treatmentId: row._id as Id<"gabinetTreatments">,
-              name: row.name,
-            });
-          }
-        },
-      },
-      {
-        label: t("common.delete"),
-        icon: <Trash2 className="h-4 w-4" variant="stroke" />,
-        onClick: async () => {
-          if (window.confirm(t("gabinet.treatments.confirmDelete"))) {
-            await removeTreatment({ organizationId, treatmentId: row._id as Id<"gabinetTreatments"> });
-          }
-        },
-      },
     ],
     [t, removeTreatment, updateTreatment, organizationId, canEdit],
   );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2139.

Closes #2139

---

## Claude summary

The bug was real and is now fixed.

In `_layout.gabinet.treatments.index.tsx:529-567`, the `rowActions` callback had the "Edit" action correctly guarded by `canEdit`, but the "Toggle active" (Power icon) and "Delete" (Trash icon) actions were unconditionally included. Any user without `gabinet_treatments.edit` permission could still activate/deactivate or delete treatments from the row menu.

The fix moves all three mutating actions inside the single `canEdit` conditional, so the row menu is empty for read-only users.