### PR TITLE
Gate row-level "Delete" action on `gabinet_treatments.delete` permission

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -84,6 +84,7 @@ function TreatmentsIndex() {
   const removeTreatment = useAction(api.gabinet.treatments.remove);
 
   const { allowed: canEdit } = usePermission("gabinet_treatments", "edit");
+  const { allowed: canDelete } = usePermission("gabinet_treatments", "delete");
 
   const { tags } = useTagDefinitions(organizationId);
   const { categories } = useCategoryDefinitions(organizationId, "gabinetTreatment");
@@ -551,6 +552,10 @@ function TreatmentsIndex() {
                 }
               },
             },
+          ]
+        : []),
+      ...(canDelete
+        ? [
             {
               label: t("common.delete"),
               icon: <Trash2 className="h-4 w-4" variant="stroke" />,
@@ -563,7 +568,7 @@ function TreatmentsIndex() {
           ]
         : []),
     ],
-    [t, removeTreatment, updateTreatment, organizationId, canEdit],
+    [t, removeTreatment, updateTreatment, organizationId, canEdit, canDelete],
   );
 
   return (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2140.

Closes #2140

---

## Claude summary

The bug was real and the fix is in. Here's the summary:

**Root cause:** In `rowActions` (line 530), all three actions — Edit, Toggle active, and Delete — were wrapped in a single `...(canEdit ? [...] : [])` spread. The Delete action inherited the `gabinet_treatments.edit` check instead of checking `gabinet_treatments.delete`.

**Fix:** Added `const { allowed: canDelete } = usePermission("gabinet_treatments", "delete")` (line 87) and split the Delete action into its own conditional block gated on `canDelete`. Edit and Toggle active remain gated on `canEdit`. Updated `useCallback` deps accordingly.

The change is minimal and surgical — one new `usePermission` call and a restructured spread in `rowActions`.