### PR TITLE
Zmiana nazw magazyn

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -880,9 +880,9 @@
     },
     "sections": {
       "all": "All",
-      "sale": "Products",
-      "treatment": "Preparations",
-      "disposable": "Materials",
+      "sale": "Sales Products",
+      "treatment": "Treatment Preparations",
+      "disposable": "Disposable Materials",
       "label": "Section",
       "placeholder": "Select section",
       "none": "No section"

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -881,9 +881,9 @@
     },
     "sections": {
       "all": "Wszystkie",
-      "sale": "Produkty",
-      "treatment": "Preparaty",
-      "disposable": "Materiały",
+      "sale": "Produkty do sprzedaży",
+      "treatment": "Preparaty zabiegowe",
+      "disposable": "Materiały jednorazowe",
       "label": "Sekcja",
       "placeholder": "Wybierz sekcję",
       "none": "Bez sekcji"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2127.

Closes #2127

---

## Claude summary

Done. Here's the summary of changes:

**What changed:** Two translation files updated, no code changes needed.

The section names were already fully i18n-driven — every tab, stat card, column header, dropdown option, badge, and filter in the products module reads from `t("products.sections.*")` keys. The abbreviated versions ("Produkty", "Preparaty", "Materiały") were only in the translation files, so updating them propagates to every UI surface simultaneously.

**Changes made:**

| Key | PL before → after | EN before → after |
|---|---|---|
| `sale` | "Produkty" → "Produkty do sprzedaży" | "Products" → "Sales Products" |
| `treatment` | "Preparaty" → "Preparaty zabiegowe" | "Preparations" → "Treatment Preparations" |
| `disposable` | "Materiały" → "Materiały jednorazowe" | "Materials" → "Disposable Materials" |

**Already correct / unchanged:** All other keys (`all`, `label`, `placeholder`, `none`), all logic, all routes, all backend code. No migrations needed.