### PR TITLE
Ikony produktów

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -863,7 +863,7 @@
     "editProduct": "Edit Product",
     "createDescription": "Add a new product to your catalog.",
     "updateDescription": "Update product details.",
-    "searchPlaceholder": "Search products...",
+    "searchPlaceholder": "Search name, SKU, manufacturer, notes...",
     "productName": "Product name",
     "productDescription": "Product description...",
     "sku": "SKU",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -864,7 +864,7 @@
     "editProduct": "Edytuj produkt",
     "createDescription": "Dodaj nowy produkt do katalogu.",
     "updateDescription": "Aktualizuj szczegóły produktu.",
-    "searchPlaceholder": "Szukaj produktów...",
+    "searchPlaceholder": "Szukaj nazwy, SKU, producenta, notatki...",
     "productName": "Nazwa produktu",
     "productDescription": "Opis produktu...",
     "sku": "SKU",

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -203,7 +203,20 @@ function ProductsPage() {
   const {
     views, activeViewId, onViewChange, onCreateView, onDeleteView, applyFilters,
   } = useSavedViews({ organizationId, entityType: "product", systemViews });
-  const [activeSection, setActiveSection] = useState<ProductSection | "all">("all");
+  const [activeSection, setActiveSection] = useState<ProductSection | "all">(() => {
+    try {
+      const stored = localStorage.getItem("products:section");
+      if (stored === "all" || (PRODUCT_SECTIONS as readonly string[]).includes(stored ?? "")) {
+        return stored as ProductSection | "all";
+      }
+    } catch { /* ignore */ }
+    return "all";
+  });
+
+  const handleSectionChange = (section: ProductSection | "all") => {
+    setActiveSection(section);
+    try { localStorage.setItem("products:section", section); } catch { /* ignore */ }
+  };
   const [panelOpen, setPanelOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
   const [savedViewsDialogOpen, setSavedViewsDialogOpen] = useState(false);
@@ -320,7 +333,8 @@ function ProductsPage() {
         p.name.toLowerCase().includes(q) ||
         p.sku?.toLowerCase().includes(q) ||
         p.manufacturer?.toLowerCase().includes(q) ||
-        p.catalogNumber?.toLowerCase().includes(q)
+        p.catalogNumber?.toLowerCase().includes(q) ||
+        p.stockNote?.toLowerCase().includes(q)
       );
     }
     return data;
@@ -607,17 +621,17 @@ function ProductsPage() {
         <StatCard
           label={t("products.sections.sale")}
           value={inventoryStats.bySale}
-          onClick={() => setActiveSection("sale")}
+          onClick={() => handleSectionChange("sale")}
         />
         <StatCard
           label={t("products.sections.treatment")}
           value={inventoryStats.byTreatment}
-          onClick={() => setActiveSection("treatment")}
+          onClick={() => handleSectionChange("treatment")}
         />
         <StatCard
           label={t("products.sections.disposable")}
           value={inventoryStats.byDisposable}
-          onClick={() => setActiveSection("disposable")}
+          onClick={() => handleSectionChange("disposable")}
         />
         <StatCard
           label={t("products.stats.belowMin", { defaultValue: "Poniżej min. stanu" })}
@@ -629,7 +643,7 @@ function ProductsPage() {
         />
       </div>
 
-      <Tabs value={activeSection} onValueChange={(v) => setActiveSection(v as ProductSection | "all")}>
+      <Tabs value={activeSection} onValueChange={(v) => handleSectionChange(v as ProductSection | "all")}>
         <TabsList>
           <TabsTrigger value="all">
             {t("products.sections.all", { defaultValue: "Wszystkie" })}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2128.

Closes #2128

---

## Claude summary

Done. Here's a summary of what was done and what already worked:

**Already working (no changes needed):**
- Section filtering via tabs (sale / treatment / disposable / all)
- Low stock + no stock filtering via URL `nudge=low_stock` (covers both "low" and "out" statuses)
- Active/inactive filtering via saved views ("Aktywne produkty")
- Combined filters: section tab stacks correctly with nudge filter, saved views, and advanced filters
- Context preservation when switching sections: search value, active filters, and nudge URL param all survive tab changes

**Changes made:**

1. `_layout.products.index.tsx` — `stockNote` added to the client-side search predicate (was missing alongside name, SKU, manufacturer, catalogNumber)
2. `_layout.products.index.tsx` — `activeSection` now initializes from `localStorage.getItem("products:section")` and is saved via `handleSectionChange` whenever the user clicks a stat card or switches tabs. No DB calls, no migrations.
3. `public/locales/pl/translation.json` + `public/locales/en/translation.json` — search placeholder updated to communicate the full search scope to users.