### PR TITLE
Produkty 9

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -482,35 +482,22 @@ function ProductsPage() {
       getSortValue: (item) => item.name,
     },
     {
+      id: "productSection",
+      label: t("products.sections.label", { defaultValue: "Sekcja" }),
+      render: (item) => {
+        if (!item.productSection) return "—";
+        return t(`products.sections.${item.productSection}`, { defaultValue: item.productSection });
+      },
+    },
+    {
       id: "sku",
       label: t('products.sku'),
       render: (item) => item.sku ?? "—",
     },
     {
-      id: "catalogNumber",
-      label: t("products.catalogNumber", { defaultValue: "Nr katalogowy" }),
-      render: (item) => item.catalogNumber ?? "—",
-    },
-    {
       id: "manufacturer",
       label: t("products.manufacturer", { defaultValue: "Producent" }),
       render: (item) => item.manufacturer ?? "—",
-    },
-    {
-      id: "unitPrice",
-      label: t('products.unitPrice'),
-      sortable: true,
-      render: (item) => formatCurrency(item.unitPrice),
-      getSortValue: (item) => item.unitPrice,
-    },
-    {
-      id: "taxRate",
-      label: t('products.taxRate'),
-      render: (item) => {
-        if (item.taxExempt) return "ZW";
-        if (item.taxRate == null) return "—";
-        return `${item.taxRate}%`;
-      },
     },
     {
       id: "stock",
@@ -547,11 +534,24 @@ function ProductsPage() {
       sortable: true,
     },
     {
-      id: "productSection",
-      label: t("products.sections.label", { defaultValue: "Sekcja" }),
+      id: "catalogNumber",
+      label: t("products.catalogNumber", { defaultValue: "Nr katalogowy" }),
+      render: (item) => item.catalogNumber ?? "—",
+    },
+    {
+      id: "unitPrice",
+      label: t('products.unitPrice'),
+      sortable: true,
+      render: (item) => formatCurrency(item.unitPrice),
+      getSortValue: (item) => item.unitPrice,
+    },
+    {
+      id: "taxRate",
+      label: t('products.taxRate'),
       render: (item) => {
-        if (!item.productSection) return "—";
-        return t(`products.sections.${item.productSection}`, { defaultValue: item.productSection });
+        if (item.taxExempt) return "ZW";
+        if (item.taxRate == null) return "—";
+        return `${item.taxRate}%`;
       },
     },
     {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2129.

Closes #2129

---

## Claude summary

Done. Here's a summary of the investigation and what was changed.

**Triage**: The module exists and is fully functional. All requested columns and quick actions were already present — no missing features to add.

**What was wrong**: The column order did not match the operational priority the issue specified. `productSection` (Sekcja) was in position 9 of 10 (second-to-last), while the issue explicitly lists it as the second most important column after the product name.

**Change made** — one file, `_layout.products.index.tsx`: reordered the `columns` array so the table now reads left-to-right as: **Nazwa → Sekcja → SKU → Producent → Stan → Min. stan → Nr katalogowy → Cena → VAT → Aktywny**.

**Confirmed already working** (no changes needed):
- "Stan" column uses `StockBadge` with color-coded low-stock status (amber = low, red = out of stock) — satisfies "status niskiego stanu"
- Row actions: Edit (all products), Przyjęcie magazynowe + Historia operacji (products with `trackStock=true`) — all three are present
- No important actions hidden
- Mobile: table uses `overflow-x-auto` for horizontal scroll, row actions are a dropdown menu accessible via tap on iOS/Android

No migrations, no new tables/columns, no style changes, no design modifications.