### PR TITLE
Produkty 10

### DIFF
--- a/src/components/forms/product-stock-history-dialog.tsx
+++ b/src/components/forms/product-stock-history-dialog.tsx
@@ -131,7 +131,7 @@ export function ProductStockHistoryDialog({
         <DialogHeader>
           <DialogTitle>
             {t("products.stock.history.title", {
-              defaultValue: "Historia przyjęć",
+              defaultValue: "Historia operacji",
             })}
           </DialogTitle>
           <DialogDescription>{product.name}</DialogDescription>

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -1,6 +1,8 @@
 import { useState, useMemo } from "react";
 import { createFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { useAction } from "convex/react";
+import { useQueryClient } from "@tanstack/react-query";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
@@ -194,6 +196,7 @@ function ProductsPage() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { nudge: nudgeFilter } = useSearch({ from: Route.id });
   const systemViews: SavedView[] = useMemo(() => [
     { id: "all", name: t('products.views.all'), isSystem: true, isDefault: true },
@@ -458,6 +461,12 @@ function ProductsPage() {
           stockNote: stockNote.trim() || null,
         });
       }
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.products.list(organizationId) });
+      toast.success(
+        editingProduct
+          ? t("products.success.updated", { defaultValue: "Produkt zaktualizowany." })
+          : t("products.success.created", { defaultValue: "Produkt dodany." }),
+      );
       setPanelOpen(false);
       resetForm();
     } catch (e) {
@@ -588,12 +597,36 @@ function ProductsPage() {
       {
         label: row.isActive ? t('products.deactivate') : t('products.activate'),
         icon: <Power className="h-4 w-4" variant="stroke" />,
-        onClick: () => toggleActive({ organizationId, productId: row._id }),
+        onClick: async () => {
+          try {
+            await toggleActive({ organizationId, productId: row._id });
+            void queryClient.invalidateQueries({ queryKey: supabaseKeys.products.list(organizationId) });
+          } catch (e) {
+            toast.error(
+              formatActionError(e, t, {
+                key: "products.errors.toggleFailed",
+                defaultValue: "Nie udało się zmienić stanu aktywności.",
+              }),
+            );
+          }
+        },
       },
       {
         label: t('common.delete'),
         icon: <Trash2 className="h-4 w-4" variant="stroke" />,
-        onClick: () => removeProduct({ organizationId, productId: row._id }),
+        onClick: async () => {
+          try {
+            await removeProduct({ organizationId, productId: row._id });
+            void queryClient.invalidateQueries({ queryKey: supabaseKeys.products.list(organizationId) });
+          } catch (e) {
+            toast.error(
+              formatActionError(e, t, {
+                key: "products.errors.deleteFailed",
+                defaultValue: "Nie udało się usunąć produktu.",
+              }),
+            );
+          }
+        },
       },
     );
     return actions;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2130.

Closes #2130

---

## Claude summary

Here's a summary of what I investigated and fixed:

## Investigation report (issue #2130)

All 10 test flows from the issue exist and are structurally sound. The module has: section tabs (Produkty do sprzedaży / Preparaty zabiegowe / Materiały jednorazowe), create/edit forms, stock tracking toggle with initial stock seed, min-stock threshold, low-stock alert widget (amber card), warehouse receive dialog (delta-based — correctly adds, never overwrites), operation history dialog with movement reasons, and search across name/SKU/manufacturer/catalogNumber/stockNote. No Gabinet-specific products page exists; the shared `/dashboard/products` page is available to both CRM and Gabinet users.

## Bugs found and fixed

**Bug 1 — Stale product list after CRUD operations** (most impactful)
The page uses Supabase React Query reads (`useSupabaseProductsList`) but writes via Convex actions. After create, update, delete, and toggle-active, the React Query cache was never invalidated, so the list stayed stale until window focus triggered an automatic background refetch. Fixed by adding `queryClient.invalidateQueries({ queryKey: supabaseKeys.products.list(organizationId) })` after each successful write. Also added success toasts for create/update, which were previously silent.

**Bug 2 — Incorrect history dialog title**
The "Historia operacji" row action opened a dialog titled "Historia przyjęć" (receipts history), but the dialog shows all movement types (initial stock, manual adjustments, appointment use, deal events, etc.). Fixed to "Historia operacji".

No migrations, new tables, new columns, or architecture changes were required.

## Follow-ups
- Add delete confirmation dialog for products: `removeProduct` fires immediately on click with no "Are you sure?" prompt, risking accidental deletion with no undo
- Stock adjustment invalidation missing for stock history dialog: after closing `ProductStockAdjustDialog`, `ProductStockHistoryDialog` may still show stale movements until refocus, since both dialogs are independent and the history dialog only invalidates on its own open
- `convex/products.ts` `list` query still uses legacy Convex DB reads (not Supabase) and would return empty results since product data now lives in Supabase; should be removed or converted to a Supabase query to avoid misleading callers