### PR TITLE
`convex/products.ts` `list` query still uses legacy Convex DB reads (not Supabas

### DIFF
--- a/convex/products.ts
+++ b/convex/products.ts
@@ -1,11 +1,8 @@
-import { query, action, internalMutation } from "./_generated/server";
+import { action, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
-import { paginationOptsValidator } from "convex/server";
-import { verifyOrgAccess } from "./_helpers/auth";
 import { logActivity } from "./_helpers/activities";
-import { checkPermission } from "./_helpers/permissions";
 import { Id } from "./_generated/dataModel";
 import type { SupabaseRow } from "./_helpers/supabaseRows";
 import { applyMovementInternal } from "./inventory";
@@ -18,50 +15,8 @@ export interface DealProductWithProduct extends DealProductRow {
 }
 
 // Dual-write refs removed — Supabase is now primary for product writes
-
-export const list = query({
-  args: {
-    organizationId: v.id("organizations"),
-    paginationOpts: paginationOptsValidator,
-  },
-  handler: async (ctx, args) => {
-    const { user } = await verifyOrgAccess(ctx, args.organizationId);
-    const perm = await checkPermission(ctx, args.organizationId, "products", "view");
-    if (!perm.allowed) throw new Error("Permission denied");
-
-    const result = await ctx.db
-      .query("products")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .order("desc")
-      .paginate(args.paginationOpts);
-    if (perm.scope === "own") {
-      return { ...result, page: result.page.filter((r) => r.createdBy === user._id) };
-    }
-    return result;
-  },
-});
-
-export const getById = query({
-  args: {
-    organizationId: v.id("organizations"),
-    productId: v.id("products"),
-  },
-  handler: async (ctx, args) => {
-    const { user } = await verifyOrgAccess(ctx, args.organizationId);
-    const perm = await checkPermission(ctx, args.organizationId, "products", "view");
-    if (!perm.allowed) throw new Error("Permission denied");
-
-    const product = await ctx.db.get(args.productId);
-    if (!product || product.organizationId !== args.organizationId) {
-      throw new Error("Product not found");
-    }
-    if (perm.scope === "own" && product.createdBy !== user._id) {
-      throw new Error("Permission denied");
-    }
-
-    return product;
-  },
-});
+// list and getById were removed: they used legacy ctx.db reads and returned empty results
+// since product data lives in Supabase. Use useSupabaseProductsList hook instead.
 
 export const create = action({
   args: {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2153.

Closes #2153

---

## Claude summary

The bug was real. Here's what I found and fixed:

**Root cause:** `convex/products.ts` exported two `query` handlers — `list` and `getById` — that read from the legacy Convex DB (`ctx.db`). Since product data was migrated to Supabase, these queries would always return empty results. The rest of the file's operations (`create`, `update`, `remove`, `toggleActive`, `listByDeal`, etc.) all correctly use `createSupabaseDb()`.

**Fix:** Removed both `list` and `getById` from `convex/products.ts` and cleaned up four now-unused imports (`query`, `paginationOptsValidator`, `verifyOrgAccess`, `checkPermission`). The frontend already exclusively uses `useSupabaseProductsList` from `src/hooks/use-supabase-products.ts` — neither removed query was called from any frontend or backend code.

## Follow-ups

- Fix pre-existing `implicit any` TypeScript errors in convex/products.ts handlers: All `internalMutation`/`action` handler `(ctx, args)` parameters have implicit `any` type; same pattern exists across `convex/_helpers/auth.ts`, `convex/_helpers/authAction.ts`, `convex/_helpers/permissions.ts`, and `convex/_test.ts`
- `_removeDealProducts` internalMutation still uses `ctx.db` to delete `dealProducts`: if `dealProducts` table is also migrated to Supabase, this will silently fail to clean up associations when a product is deleted