### PR TITLE
`_removeDealProducts` internalMutation still uses `ctx.db` to delete `dealProduc

### DIFF
--- a/convex/products.ts
+++ b/convex/products.ts
@@ -238,10 +238,12 @@ export const remove = action({
       throw new Error("Permission denied: you can only delete your own records");
     }
 
-    // Remove deal-product associations via internalMutation (needs ctx.db)
-    await ctx.runMutation(internal.products._removeDealProducts, {
-      productId: args.productId,
-    });
+    // Remove deal-product associations from Supabase before deleting the product
+    const { error: assocError } = await db.raw()
+      .from("deal_products")
+      .delete()
+      .eq("product_id", args.productId);
+    if (assocError) throw new Error(`Failed to remove deal-product associations: ${assocError.message}`);
 
     // Delete from Supabase
     await db.delete("products", args.productId);
@@ -258,19 +260,6 @@ export const remove = action({
     }
 
     return args.productId;
-  },
-});
-
-export const _removeDealProducts = internalMutation({
-  args: { productId: v.string() },
-  handler: async (ctx, args) => {
-    const dealProducts = await ctx.db
-      .query("dealProducts")
-      .withIndex("by_product", (q) => q.eq("productId", args.productId as Id<"products">))
-      .collect();
-    for (const dp of dealProducts) {
-      await ctx.db.delete(dp._id);
-    }
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2157.

Closes #2157

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Root cause**: `_removeDealProducts` was an `internalMutation` that used `ctx.db` (Convex native DB) to query and delete from `dealProducts`. However, `dealProducts` has been migrated to Supabase (`TABLE_MAP` entry: `dealProducts → deal_products`, and the table exists in `supabase/migrations/00001_initial_schema.sql`). Querying `ctx.db` for a table that no longer lives in Convex returns nothing, so the loop body never ran and deal-product associations were never cleaned up when a product was deleted.

**Fix**: Replaced the dead `_removeDealProducts` internalMutation (and the `ctx.runMutation` call to it) with a direct `db.raw().from("deal_products").delete().eq("product_id", args.productId)` call using the Supabase service-role client that the `remove` action already has open. This is a single atomic DELETE instead of the previous N+1 pattern.