### PR TITLE
Widok

### DIFF
--- a/convex/_helpers/gabinetRolePermissions.ts
+++ b/convex/_helpers/gabinetRolePermissions.ts
@@ -62,6 +62,7 @@ function buildGabinet(
     "email",
     "products",
     "pipelines",
+    "gabinet_dashboard",
     "gabinet_patients",
     "gabinet_appointments",
     "gabinet_treatments",

--- a/src/hooks/use-permission.ts
+++ b/src/hooks/use-permission.ts
@@ -88,14 +88,16 @@ export function PermissionGate({
   action,
   children,
   fallback,
+  loadingFallback,
 }: {
   feature: Feature;
   action: Action;
   children: React.ReactNode;
   fallback?: React.ReactNode;
+  loadingFallback?: React.ReactNode;
 }): React.ReactNode {
   const { allowed, loading } = usePermission(feature, action);
-  if (loading) return null;
+  if (loading) return loadingFallback ?? null;
   if (!allowed) return fallback ?? null;
   return children;
 }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
@@ -19,6 +19,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { ReactNode } from "react";
@@ -48,11 +49,34 @@ import TotalIncomeCard from "@/components/shadcn-studio/blocks/chart-total-incom
 import EarningReportCard from "@/components/shadcn-studio/blocks/chart-earning-report";
 import TotalOrdersCard from "@/components/shadcn-studio/blocks/chart-total-orders";
 
+function GabinetDashboardSkeleton() {
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <Skeleton className="h-10 w-72" />
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <Skeleton className="h-32" />
+        <Skeleton className="h-32" />
+        <Skeleton className="h-32" />
+        <Skeleton className="h-32" />
+      </div>
+      <Skeleton className="h-64" />
+      <div className="grid gap-6 md:grid-cols-2">
+        <Skeleton className="h-48" />
+        <Skeleton className="h-48" />
+      </div>
+    </div>
+  );
+}
+
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/"
 )({
   component: () => (
-    <PermissionGate feature="gabinet_dashboard" action="view">
+    <PermissionGate
+      feature="gabinet_dashboard"
+      action="view"
+      loadingFallback={<GabinetDashboardSkeleton />}
+    >
       <GabinetDashboard />
     </PermissionGate>
   ),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2159.

Closes #2159

---

## Claude summary

Here's a summary of what was found and fixed:

---

**Issue 1: Migration banner (CRM Dashboard)** — NOT a code bug. Migration `00022_gabinet_appointments_price_at_booking.sql` was committed (in PR #2090/#2092) but not yet applied to the database. The `MigrationHealthBanner` is working exactly as designed. The administrator needs to run `npm run migrations:apply` — after that the banner disappears. No code change needed here.

**Issue 2: Gabinet empty screen** — Real regression introduced by commit `b1c5a2c` (today, "gate gabinet dashboard route with gabinet_dashboard feature"). Adding `PermissionGate` to `_layout.gabinet.index.tsx` caused it to return `null` while the Convex `getMyPermissions` query was in flight (typically ~50–200ms), leaving only the sidebar/topbar visible. The fix:

1. Added optional `loadingFallback` prop to `PermissionGate` in `src/hooks/use-permission.ts` — backward-compatible, existing callers unaffected.
2. Passed a `GabinetDashboardSkeleton` as `loadingFallback` in the Gabinet index route so the content area shows a proportional skeleton instead of blank space while permissions resolve.
3. Added `"gabinet_dashboard"` to the hardcoded feature list in `buildGabinet` (`convex/_helpers/gabinetRolePermissions.ts`) — it was missing, causing `DEFAULT_GABINET_ROLE_PERMISSIONS` to have `undefined` at runtime for that slot despite the TypeScript cast.

Permissions themselves are correct for all roles (all roles default to `gabinet_dashboard.view = "all"`), so the empty screen was purely a loading-state UX regression.

## Follow-ups

- Fix pre-existing TypeScript error TS2345 in `_layout.gabinet.settings.roles.tsx:26`: route path `"/_app/_auth/dashboard/_layout/gabinet/settings/roles"` is not in `FileRoutesByPath` — likely a TanStack Router codegen issue where the generated routes file is stale.
- Fix pre-existing TypeScript errors in `src/hooks/use-supabase-products.ts:221-233`: `product_stock_movements` table rows typed as `never` — the database.types.ts is missing the `product_stock_movements` table definition added in migration 00013/00020.
- Add `gabinet_dashboard` to `GABINET_FEATURES` consideration in `_layout.gabinet.settings.roles.tsx` or at minimum update its local `ALL_FEATURES` list to stay in sync with `permissionTypes.ts:FEATURES`.