### PR TITLE
Add `gabinet_dashboard` to `GABINET_FEATURES` consideration in `_layout.gabinet.

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3834,7 +3834,8 @@
         "employees": "Employees",
         "payments": "Payments",
         "reports": "Reports",
-        "settings": "Settings"
+        "settings": "Settings",
+        "dashboard": "Dashboard"
       }
     }
   },

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3856,7 +3856,8 @@
         "employees": "Pracownicy",
         "payments": "Płatności",
         "reports": "Raporty",
-        "settings": "Ustawienia"
+        "settings": "Ustawienia",
+        "dashboard": "Pulpit"
       }
     }
   },

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.roles.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.roles.tsx
@@ -32,6 +32,11 @@ type Scope = "none" | "own" | "all";
 
 const GABINET_FEATURES = [
   {
+    key: "gabinet_dashboard",
+    labelKey: "gabinet.roles.features.dashboard",
+    actions: ["view"] as const,
+  },
+  {
     key: "gabinet_patients",
     labelKey: "gabinet.roles.features.patients",
     actions: ["view", "create", "edit", "delete"] as const,
@@ -75,7 +80,7 @@ const GABINET_FEATURES = [
 
 const ALL_FEATURES = [
   "leads", "contacts", "companies", "documents", "activities", "calls", "email",
-  "products", "pipelines", "gabinet_patients", "gabinet_appointments",
+  "products", "pipelines", "gabinet_dashboard", "gabinet_patients", "gabinet_appointments",
   "gabinet_treatments", "gabinet_packages", "gabinet_employees", "gabinet_payments",
   "gabinet_reports", "gabinet_settings", "settings", "team", "document_templates",
   "document_instances", "tagDefinitions", "categoryDefinitions",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2163.

Closes #2163

---

## Claude summary

The fix is committed. Here's what was wrong and what changed:

`permissionTypes.ts` declared `gabinet_dashboard` as a valid `Feature` (line 16), but `_layout.gabinet.settings.roles.tsx` had two stale local lists that didn't include it:

- `GABINET_FEATURES` — controls which rows appear in the permission matrix table. `gabinet_dashboard` was simply absent, so admins had no way to configure its permissions.
- `ALL_FEATURES` — used by `buildFullPermissions()` to construct the full permission object sent to the server. Without `gabinet_dashboard` here, saving any role's permissions would silently omit it, potentially leaving it as undefined in the DB.

Changes made across 3 files:
- Added `gabinet_dashboard` entry to `GABINET_FEATURES` with `actions: ["view"]` (view-only, same pattern as `gabinet_reports`)
- Added `gabinet_dashboard` to `ALL_FEATURES`  
- Added `gabinet.roles.features.dashboard` translation key: "Dashboard" (EN) and "Pulpit" (PL)