### PR TITLE
ci: add db-types-drift workflow to catch database.types.ts staleness

### DIFF
--- a/.github/workflows/db-types-drift.yml
+++ b/.github/workflows/db-types-drift.yml
@@ -1,0 +1,38 @@
+name: DB Types Drift
+
+# Ensures src/lib/supabase/database.types.ts and database.columns.ts stay in
+# sync with supabase/migrations/. Regenerates both files from the migration
+# files and fails if git sees any diff — catching the 9-migration drift found
+# in #2162. See #2167.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  db-types-drift:
+    name: Verify database.types.ts is up-to-date
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Regenerate DB types from migrations
+        run: node scripts/gen-db-types.mjs
+
+      - name: Fail if generated files differ from committed
+        run: |
+          if ! git diff --exit-code src/lib/supabase/database.types.ts src/lib/supabase/database.columns.ts; then
+            echo ""
+            echo "::error::database.types.ts or database.columns.ts is out of sync with supabase/migrations/."
+            echo "::error::Run 'node scripts/gen-db-types.mjs' locally and commit the result."
+            exit 1
+          fi
+          echo "OK: generated types match committed files."


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/db-types-drift.yml` — a PR and push gate that runs `node scripts/gen-db-types.mjs` and then `git diff --exit-code` on the two generated files
- Catches the 9-migration drift discovered during #2162, where `database.types.ts` was manually edited for 9 migrations worth of changes without being regenerated
- Closes #2167

## How it works

On every PR and push to `main`, the workflow:
1. Checks out the repo
2. Runs `node scripts/gen-db-types.mjs` (no install needed — the script only uses Node built-ins)
3. Fails with a clear error message if `src/lib/supabase/database.types.ts` or `src/lib/supabase/database.columns.ts` differs from the freshly generated output

The fix is always: run `node scripts/gen-db-types.mjs` locally and commit the result alongside the migration.

## Test plan

- [x] `database.types.ts` and `database.columns.ts` are already current (all 22 migrations reflected) — verified by running the script locally and confirming `git diff` is empty
- [x] New workflow file follows the same structure as existing CI workflows (`unit.yml`, `typecheck.yml`)
- [x] No `npm ci` needed since `gen-db-types.mjs` uses only Node built-ins (`fs`, `path`, `url`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)