### PR TITLE
Add `getMyGabinetRole` query to expose the calling user's gabinet role

### DIFF
--- a/convex/permissions.ts
+++ b/convex/permissions.ts
@@ -21,6 +21,21 @@ export const getMyRole = query({
   },
 });
 
+export const getMyGabinetRole = query({
+  args: { organizationId: v.id("organizations") },
+  handler: async (ctx, args) => {
+    const { user } = await verifyOrgAccess(ctx, args.organizationId);
+    const membership = await ctx.db
+      .query("gabinetMemberships")
+      .withIndex("by_orgAndUser", (q) =>
+        q.eq("organizationId", args.organizationId).eq("userId", user._id)
+      )
+      .unique();
+    if (!membership) return { gabinetRole: null, isActive: null };
+    return { gabinetRole: membership.gabinetRole, isActive: membership.isActive };
+  },
+});
+
 export const getOrgPermissionOverrides = query({
   args: { organizationId: v.id("organizations") },
   handler: async (ctx, args) => {

--- a/src/hooks/use-permission.ts
+++ b/src/hooks/use-permission.ts
@@ -83,6 +83,25 @@ export function useRole(): {
   return { role: result.role, loading: false };
 }
 
+export function useGabinetRole(): {
+  gabinetRole: string | null;
+  isActive: boolean | null;
+  loading: boolean;
+} {
+  const { organizationId } = useOrganization();
+
+  const result = useQuery(
+    api.permissions.getMyGabinetRole,
+    organizationId ? { organizationId } : "skip"
+  );
+
+  if (result === undefined) {
+    return { gabinetRole: null, isActive: null, loading: true };
+  }
+
+  return { gabinetRole: result.gabinetRole, isActive: result.isActive, loading: false };
+}
+
 export function PermissionGate({
   feature,
   action,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2171.

Closes #2171

---

## Claude summary

Done. The issue was real: `api.permissions.getMyRole` only surfaces the org-level role from `teamMemberships`, and there was no equivalent for the gabinet role stored in `gabinetMemberships`.

**Changes made:**

`convex/permissions.ts` — new `getMyGabinetRole` query (lines 24–37): verifies org membership, then looks up `gabinetMemberships` by `by_orgAndUser` index and returns `{ gabinetRole, isActive }` (both nullable for users with no employee record).

`src/hooks/use-permission.ts` — new `useGabinetRole()` hook (lines 86–103): follows the exact same pattern as `useRole()`, wraps `api.permissions.getMyGabinetRole`, returns `{ gabinetRole, isActive, loading }`.