### PR TITLE
Expose effective permissions in the profile/account page

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.profile.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.profile.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { changeLanguage } from "i18next";
@@ -19,6 +19,8 @@ import { toast } from "sonner";
 import { cn } from "@/utils/misc";
 import { useConvexUpload } from "@/hooks/use-convex-upload";
 import { AVATAR_FALLBACK_GRADIENT } from "@/lib/avatar";
+import { useOrganization } from "@/components/org-context";
+import { Badge } from "@/components/ui/badge";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/settings/profile"
@@ -63,9 +65,55 @@ const THEME_OPTIONS = [
   { value: "system" as const, label: "System", icon: Monitor },
 ];
 
+const PERMISSION_FEATURES = [
+  { key: "leads", label: "Leads", group: "CRM" },
+  { key: "contacts", label: "Contacts", group: "CRM" },
+  { key: "companies", label: "Companies", group: "CRM" },
+  { key: "documents", label: "Documents", group: "CRM" },
+  { key: "activities", label: "Activities", group: "CRM" },
+  { key: "calls", label: "Calls", group: "CRM" },
+  { key: "email", label: "Email", group: "CRM" },
+  { key: "products", label: "Products", group: "CRM" },
+  { key: "pipelines", label: "Pipelines", group: "CRM" },
+  { key: "gabinet_dashboard", label: "Dashboard", group: "Gabinet" },
+  { key: "gabinet_patients", label: "Patients", group: "Gabinet" },
+  { key: "gabinet_appointments", label: "Appointments", group: "Gabinet" },
+  { key: "gabinet_treatments", label: "Treatments", group: "Gabinet" },
+  { key: "gabinet_packages", label: "Packages", group: "Gabinet" },
+  { key: "gabinet_employees", label: "Employees", group: "Gabinet" },
+  { key: "gabinet_payments", label: "Payments", group: "Gabinet" },
+  { key: "gabinet_reports", label: "Reports", group: "Gabinet" },
+  { key: "gabinet_settings", label: "Settings", group: "Gabinet" },
+  { key: "settings", label: "Settings", group: "Organization" },
+  { key: "team", label: "Team", group: "Organization" },
+] as const;
+
+const PERMISSION_ACTIONS = ["view", "create", "edit", "delete"] as const;
+
+function ScopeCell({ scope }: { scope: string }) {
+  if (scope === "all")
+    return <span className="text-xs font-semibold text-green-600 dark:text-green-400">All</span>;
+  if (scope === "own")
+    return <span className="text-xs font-semibold text-blue-600 dark:text-blue-400">Own</span>;
+  return <span className="text-xs text-muted-foreground">—</span>;
+}
+
 function ProfileSettings() {
   const { t, i18n } = useTranslation();
   const { data: user } = useQuery(convexQuery(api.app.getCurrentUser, {}));
+  const { organizationId } = useOrganization();
+  const { data: roleData } = useQuery({
+    ...convexQuery(api.permissions.getMyRole, { organizationId: organizationId! }),
+    enabled: !!organizationId,
+  });
+  const { data: gabinetRoleData } = useQuery({
+    ...convexQuery(api.permissions.getMyGabinetRole, { organizationId: organizationId! }),
+    enabled: !!organizationId,
+  });
+  const { data: myPermissions } = useQuery({
+    ...convexQuery(api.permissions.getMyPermissions, { organizationId: organizationId! }),
+    enabled: !!organizationId,
+  });
 
   const { mutateAsync: updateProfile } = useMutation({
     mutationFn: useConvexMutation(api.app.updateProfile),
@@ -343,6 +391,93 @@ function ProfileSettings() {
             ? t("common.saving", "Saving...")
             : t("common.save", "Save")}
         </Button>
+      </div>
+
+      {/* Effective Permissions */}
+      <div className="flex w-full flex-col items-start rounded-lg border border-border bg-card">
+        <div className="flex w-full flex-col gap-4 rounded-lg p-6">
+          <div className="flex flex-col gap-2">
+            <h2 className="text-xl font-medium text-foreground">
+              {t("profilePage.permissions", "My Permissions")}
+            </h2>
+            <p className="text-sm font-normal text-muted-foreground">
+              {t(
+                "profilePage.permissionsDescription",
+                "Your effective access permissions in this organization."
+              )}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            {roleData && (
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">
+                  {t("profilePage.orgRole", "Organization role")}:
+                </span>
+                <Badge variant="secondary" className="capitalize">{roleData.role}</Badge>
+              </div>
+            )}
+            {gabinetRoleData?.gabinetRole && (
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">
+                  {t("profilePage.gabinetRole", "Gabinet role")}:
+                </span>
+                <Badge
+                  variant={gabinetRoleData.isActive ? "default" : "outline"}
+                  className="capitalize"
+                >
+                  {gabinetRoleData.gabinetRole}
+                  {!gabinetRoleData.isActive && ` (${t("common.inactive", "inactive")})`}
+                </Badge>
+              </div>
+            )}
+          </div>
+          {myPermissions && (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border">
+                    <th className="pb-2 text-left font-medium text-muted-foreground w-40">
+                      {t("profilePage.permFeature", "Feature")}
+                    </th>
+                    {PERMISSION_ACTIONS.map((action) => (
+                      <th key={action} className="pb-2 text-center font-medium text-muted-foreground capitalize w-16">
+                        {t(`permissions.actions.${action}`, action)}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {PERMISSION_FEATURES.map((feature, i, arr) => {
+                    const prevGroup = i > 0 ? arr[i - 1].group : null;
+                    const showGroupRow = prevGroup !== feature.group;
+                    return (
+                      <React.Fragment key={feature.key}>
+                        {showGroupRow && (
+                          <tr>
+                            <td
+                              colSpan={PERMISSION_ACTIONS.length + 1}
+                              className="pt-4 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                            >
+                              {feature.group}
+                            </td>
+                          </tr>
+                        )}
+                        <tr className="border-b border-border/40 last:border-0">
+                          <td className="py-1.5 text-foreground">{feature.label}</td>
+                          {PERMISSION_ACTIONS.map((action) => (
+                            <td key={action} className="py-1.5 text-center">
+                              <ScopeCell scope={(myPermissions as Record<string, Record<string, string>>)[feature.key]?.[action] ?? "none"} />
+                            </td>
+                          ))}
+                        </tr>
+                      </React.Fragment>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2172.

Closes #2172

---

## Claude summary

Done. Here's what was added to `src/routes/_app/_auth/dashboard/_layout.settings.profile.tsx`:

A read-only "My Permissions" section at the bottom of Settings → Profile that shows:

1. **Organization role** badge (owner / admin / member / viewer) — fetched via `getMyRole`
2. **Gabinet role** badge — fetched via `getMyGabinetRole`, shown only if the user has a gabinet membership, with an "(inactive)" suffix if the membership is disabled
3. **Feature × action permissions table** — fetched via `getMyPermissions`, grouped into CRM / Gabinet / Organization sections, with columns for view / create / edit / delete showing "All", "Own", or "—" per cell

All three queries already existed on the backend; this change is purely additive on the frontend and adds no new API surface.