### PR TITLE
Stabilność ekranu

### DIFF
--- a/src/components/documents/entity-documents-tab.tsx
+++ b/src/components/documents/entity-documents-tab.tsx
@@ -6,7 +6,8 @@ import {
   DndContext,
   type DragEndEvent,
   KeyboardSensor,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   closestCenter,
   useSensor,
   useSensors,
@@ -185,7 +186,10 @@ export function EntityDocumentsTab({
   }, [documents, orderedIds]);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(MouseSensor, { activationConstraint: { distance: 10 } }),
+    // Touch: require a 250 ms press-hold before drag starts; movement beyond
+    // 5 px during that window cancels drag so native scroll is unblocked.
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 

--- a/src/components/kanban/kanban-board.tsx
+++ b/src/components/kanban/kanban-board.tsx
@@ -6,7 +6,8 @@ import {
   DragStartEvent,
   closestCorners,
   KeyboardSensor,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   useSensor,
   useSensors,
   useDroppable,
@@ -99,7 +100,11 @@ export function KanbanBoard({
   const [overDropZone, setOverDropZone] = useState<string | null>(null);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(MouseSensor, { activationConstraint: { distance: 10 } }),
+    // Touch: require a 250 ms press-hold before drag starts; if the finger
+    // moves more than 5 px during that window the drag is aborted and native
+    // scroll takes over, preventing accidental card activation on swipe.
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
     useSensor(KeyboardSensor)
   );
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2175.

Closes #2175

---

## Claude summary

The fix is committed. Here's what was done and why:

**Root cause:** Both the Kanban board (`kanban-board.tsx`) and the document list (`entity-documents-tab.tsx`) used dnd-kit's `PointerSensor` with tiny distance thresholds (8 px and 5 px). On touch devices, a normal tap carries several pixels of finger drift, and vertical scroll carries even more — so dnd-kit's drag activation was triggering constantly during ordinary scroll gestures. This caused the "floating" card effect and also let the card's `onClick` fire after an aborted drag, accidentally navigating to an item the user only intended to scroll past.

**Fix:** Replaced `PointerSensor` with two specialised sensors in both files:

| Sensor | Constraint | Effect |
|---|---|---|
| `MouseSensor` | `distance: 10` | Desktop drag still works; slightly more forgiving than before |
| `TouchSensor` | `delay: 250 ms, tolerance: 5 px` | Touch drag requires a deliberate long-press; any finger movement > 5 px during the window cancels the pending drag and hands control back to native scroll |

This is the canonical pattern recommended by the dnd-kit docs for preventing drag/scroll conflicts on mobile.

**Files changed:** `src/components/kanban/kanban-board.tsx`, `src/components/documents/entity-documents-tab.tsx`