### PR TITLE
feat(payments): wire gratis + barter payment methods

### DIFF
--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -20,6 +20,8 @@ const paymentMethodValidator = v.union(
   v.literal("card"),
   v.literal("transfer"),
   v.literal("package"),
+  v.literal("gratis"),
+  v.literal("barter"),
   v.literal("other"),
 );
 
@@ -1310,8 +1312,11 @@ export const _claimRefundAuthRequest = internalMutation({
   handler: async (ctx, args) => {
     const siblings = await ctx.db
       .query("notifications")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .filter((q) => q.eq(q.field("type"), "refund_authorization_requested"))
+      .withIndex("by_orgAndType", (q) =>
+        q
+          .eq("organizationId", args.organizationId)
+          .eq("type", "refund_authorization_requested"),
+      )
       .collect();
 
     const matching = siblings.filter((n) => {

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -465,6 +465,8 @@ export function createCrmTables({
       v.literal("card"),
       v.literal("transfer"),
       v.literal("package"),
+      v.literal("gratis"),
+      v.literal("barter"),
       v.literal("other"),
     ),
     status: v.union(
@@ -667,7 +669,8 @@ export function createCrmTables({
   })
     .index("by_user", ["userId", "createdAt"])
     .index("by_userAndRead", ["userId", "isRead", "createdAt"])
-    .index("by_org", ["organizationId"]),
+    .index("by_org", ["organizationId"])
+    .index("by_orgAndType", ["organizationId", "type"]),
 
   // --- Audit Log ---
 

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3643,6 +3643,8 @@
         "cash": "Cash",
         "other": "Other",
         "package": "Series/Package",
+        "gratis": "Gratis",
+        "barter": "Barter",
         "transfer": "Transfer"
       },
       "noPayments": "No payments",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3665,6 +3665,8 @@
         "cash": "Gotówka",
         "other": "Inna",
         "package": "Seria/Karnet",
+        "gratis": "Gratis",
+        "barter": "Barter",
         "transfer": "Przelew"
       },
       "noPayments": "Brak płatności",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1065,7 +1065,14 @@ function AppointmentDetail() {
         appointmentId: appointment._id,
         amount,
         currency: "PLN",
-        paymentMethod: paymentMethod as "cash" | "card" | "transfer" | "package" | "other",
+        paymentMethod: paymentMethod as
+          | "cash"
+          | "card"
+          | "transfer"
+          | "package"
+          | "gratis"
+          | "barter"
+          | "other",
         notes: paymentNote || undefined,
         creditEarned: creditEarned > 0 ? creditEarned : undefined,
         creditApplied: creditApplied > 0 ? creditApplied : undefined,
@@ -2926,6 +2933,12 @@ function AppointmentDetail() {
                   </SelectItem>
                   <SelectItem value="package">
                     {t("gabinet.payments.methods.package")}
+                  </SelectItem>
+                  <SelectItem value="gratis">
+                    {t("gabinet.payments.methods.gratis")}
+                  </SelectItem>
+                  <SelectItem value="barter">
+                    {t("gabinet.payments.methods.barter")}
                   </SelectItem>
                   <SelectItem value="other">
                     {t("gabinet.payments.methods.other")}


### PR DESCRIPTION
Completes the deferred wiring from #2081 (which added `gratis`/`barter` to `payment_method_enum` as migration-only).

## Changes
- `paymentMethodValidator` (convex/payments.ts) and the `payments` table `paymentMethod` union (convex/schema/crm.ts) now accept `gratis` and `barter`.
- Visit settle payment selector (gabinet appointment detail) offers **Gratis** and **Barter**; the submit cast is widened accordingly.
- PL/EN labels added under `gabinet.payments.methods` (used by both the selector and the payment display list).

## Drive-by
Editing `payments.ts` is gated by the project's convex-lint `.filter` rule, which flagged a pre-existing `by_org` + `.filter(type)` notification query in `_claimRefundAuthRequest`. Replaced it with a new `notifications.by_orgAndType` index (behaviour-equivalent) so the file complies.

## Verification
- `tsc -p tsconfig.app.json` → 0 errors
- `tsc -p convex/tsconfig.json` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)