### PR TITLE
feat(payments): lock amount to treatment price for gratis & barter

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3628,6 +3628,7 @@
       "addPayment": "Add payment",
       "addPaymentDesc": "Add payment linked to appointment",
       "amount": "Amount",
+      "amountLockedToTreatment": "Amount set from the treatment price",
       "amountRequired": "Amount is required",
       "create": "Create payment",
       "created": "Payment created",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3650,6 +3650,7 @@
       "addPayment": "Dodaj płatność",
       "addPaymentDesc": "Dodaj płatność powiązaną z wizytą",
       "amount": "Kwota",
+      "amountLockedToTreatment": "Kwota ustalona na podstawie ceny zabiegu",
       "amountRequired": "Kwota jest wymagana",
       "create": "Utwórz płatność",
       "created": "Płatność utworzona",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1244,6 +1244,11 @@ function AppointmentDetail() {
   // (#1856), so without summing creditApplied the outstanding would stay at
   // the full visit price even after settlement.
   const treatmentPrice = treatment?.price ?? 0;
+  // gratis / barter always settle at the full treatment price and the amount
+  // is locked (no manual edit) — the method just records that no cash changed
+  // hands (gratis) or it was exchanged in kind (barter).
+  const isFixedAmountMethod =
+    paymentMethod === "gratis" || paymentMethod === "barter";
   const totalPaid = payments
     .filter((p: Record<string, unknown>) => p.status === "completed")
     .reduce(
@@ -2860,7 +2865,10 @@ function AppointmentDetail() {
               <Input
                 type="text"
                 inputMode="decimal"
-                value={paymentAmount}
+                value={
+                  isFixedAmountMethod ? treatmentPrice.toFixed(2) : paymentAmount
+                }
+                disabled={isFixedAmountMethod}
                 onChange={(e) => {
                   const v = e.target.value;
                   if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
@@ -2869,6 +2877,11 @@ function AppointmentDetail() {
                 }}
                 placeholder={outstanding > 0 ? outstanding.toFixed(2) : "0.00"}
               />
+              {isFixedAmountMethod && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t("gabinet.payments.amountLockedToTreatment")}
+                </p>
+              )}
               {outstanding > 0 && (
                 <p className="text-xs text-muted-foreground mt-1">
                   {t("gabinet.payments.outstanding")}: {formatCurrencyPLN(outstanding)}
@@ -2917,7 +2930,15 @@ function AppointmentDetail() {
             )}
             <div>
               <Label>{t("gabinet.payments.method")}</Label>
-              <Select value={paymentMethod} onValueChange={setPaymentMethod}>
+              <Select
+                value={paymentMethod}
+                onValueChange={(v) => {
+                  setPaymentMethod(v);
+                  if (v === "gratis" || v === "barter") {
+                    setPaymentAmount(treatmentPrice.toFixed(2));
+                  }
+                }}
+              >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>


### PR DESCRIPTION
Follow-up to #2181. For `gratis` and `barter`, the visit settle amount must equal the treatment price and cannot be edited.

- Selecting Gratis or Barter sets the amount to the full treatment price and disables the amount input (read-only) with a hint label.
- Other methods keep the editable amount as before.
- PL/EN: `gabinet.payments.amountLockedToTreatment`.

Frontend-only; `tsc -p tsconfig.app.json` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)