### PR TITLE
Form field

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -4296,7 +4296,22 @@
       "clientForm": "Client form"
     },
     "previewNoFields": "No form fields for this view",
-    "previewSelectEntity": "Select entity type and provide ID to see preview"
+    "previewSelectEntity": "Select entity type and provide ID to see preview",
+    "formField": {
+      "labelLabel": "Label",
+      "labelPlaceholder": "Field label...",
+      "fieldIdLabel": "Field ID",
+      "typeLabel": "Type",
+      "typeText": "Text",
+      "typeTextarea": "Textarea",
+      "typeDate": "Date",
+      "typeCheckbox": "Checkbox",
+      "optionsLabel": "Options (comma-separated)",
+      "placeholderLabel": "Placeholder",
+      "placeholderPlaceholder": "Enter value...",
+      "done": "Done",
+      "fieldFallback": "Field"
+    }
   },
   "documentEditor": {
     "fillFields": "Fill in the form fields before generating the document.",
@@ -4540,7 +4555,9 @@
       "insertSection1": "Insert 1-column section",
       "insertLayout2": "Insert 2-column layout",
       "insertLayout3": "Insert 3-column layout",
-      "insertLayout4": "Insert 4-column layout"
+      "insertLayout4": "Insert 4-column layout",
+      "insertFormField": "Insert form field",
+      "formFieldLabel": "Form field"
     },
     "htmlBlock": {
       "linkEntityField": "Link to entity field",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -4322,7 +4322,22 @@
       "clientForm": "Formularz klienta"
     },
     "previewNoFields": "Brak pól formularza dla tego widoku",
-    "previewSelectEntity": "Wybierz typ encji i podaj ID, aby zobaczyć podgląd"
+    "previewSelectEntity": "Wybierz typ encji i podaj ID, aby zobaczyć podgląd",
+    "formField": {
+      "labelLabel": "Etykieta",
+      "labelPlaceholder": "Etykieta pola...",
+      "fieldIdLabel": "ID pola",
+      "typeLabel": "Typ pola",
+      "typeText": "Tekst",
+      "typeTextarea": "Pole tekstowe",
+      "typeDate": "Data",
+      "typeCheckbox": "Pole wyboru",
+      "optionsLabel": "Opcje (oddzielone przecinkiem)",
+      "placeholderLabel": "Tekst pomocniczy",
+      "placeholderPlaceholder": "Wpisz wartość...",
+      "done": "Gotowe",
+      "fieldFallback": "Pole"
+    }
   },
   "documentEditor": {
     "fillFields": "Uzupełnij pola formularza przed wygenerowaniem dokumentu.",
@@ -4566,7 +4581,9 @@
       "insertSection1": "Wstaw sekcję 1-kolumnową",
       "insertLayout2": "Wstaw układ 2-kolumnowy",
       "insertLayout3": "Wstaw układ 3-kolumnowy",
-      "insertLayout4": "Wstaw układ 4-kolumnowy"
+      "insertLayout4": "Wstaw układ 4-kolumnowy",
+      "insertFormField": "Wstaw pole formularza",
+      "formFieldLabel": "Pole formularza"
     },
     "htmlBlock": {
       "linkEntityField": "Powiąż z polem encji",

--- a/src/components/documents/document-template-editor.tsx
+++ b/src/components/documents/document-template-editor.tsx
@@ -385,10 +385,10 @@ export const DocumentTemplateEditor = forwardRef<
           variant="ghost"
           className="h-8 px-2 text-xs text-muted-foreground"
           onClick={() => doInsertFormField()}
-          title="Insert form field"
+          title={t("documentsEditor.toolbar.insertFormField")}
         >
           <FormInput className="mr-1 h-4 w-4" />
-          Form field
+          {t("documentsEditor.toolbar.formFieldLabel")}
         </Button>
         <Button
           type="button"

--- a/src/components/documents/form-field-node.tsx
+++ b/src/components/documents/form-field-node.tsx
@@ -85,17 +85,17 @@ function FormFieldConfig({
   return (
     <div className="grid gap-3">
       <div className="space-y-1">
-        <Label className="text-xs">Label</Label>
+        <Label className="text-xs">{t("formEditor.formField.labelLabel")}</Label>
         <Input
           value={attrs.label}
           onChange={(e) => onChange({ label: e.target.value })}
           className="h-8 text-sm"
-          placeholder="Field label..."
+          placeholder={t("formEditor.formField.labelPlaceholder")}
         />
       </div>
 
       <div className="space-y-1">
-        <Label className="text-xs">Field ID</Label>
+        <Label className="text-xs">{t("formEditor.formField.fieldIdLabel")}</Label>
         <Input
           value={attrs.fieldId}
           onChange={(e) => onChange({ fieldId: e.target.value })}
@@ -105,7 +105,7 @@ function FormFieldConfig({
       </div>
 
       <div className="space-y-1">
-        <Label className="text-xs">Type</Label>
+        <Label className="text-xs">{t("formEditor.formField.typeLabel")}</Label>
         <Select
           value={attrs.fieldType}
           onValueChange={(v) => onChange({ fieldType: v as FormFieldType })}
@@ -114,19 +114,19 @@ function FormFieldConfig({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="text">Text</SelectItem>
-            <SelectItem value="textarea">Textarea</SelectItem>
+            <SelectItem value="text">{t("formEditor.formField.typeText")}</SelectItem>
+            <SelectItem value="textarea">{t("formEditor.formField.typeTextarea")}</SelectItem>
             <SelectItem value="select">{t("common.select")}</SelectItem>
             <SelectItem value="button_select">Przyciski (Tak/Nie)</SelectItem>
-            <SelectItem value="date">Date</SelectItem>
-            <SelectItem value="checkbox">Checkbox</SelectItem>
+            <SelectItem value="date">{t("formEditor.formField.typeDate")}</SelectItem>
+            <SelectItem value="checkbox">{t("formEditor.formField.typeCheckbox")}</SelectItem>
           </SelectContent>
         </Select>
       </div>
 
       {(attrs.fieldType === "select" || attrs.fieldType === "button_select") && (
         <div className="space-y-1">
-          <Label className="text-xs">Options (comma-separated)</Label>
+          <Label className="text-xs">{t("formEditor.formField.optionsLabel")}</Label>
           <Input
             value={attrs.options}
             onChange={(e) => onChange({ options: e.target.value })}
@@ -137,12 +137,12 @@ function FormFieldConfig({
       )}
 
       <div className="space-y-1">
-        <Label className="text-xs">Placeholder</Label>
+        <Label className="text-xs">{t("formEditor.formField.placeholderLabel")}</Label>
         <Input
           value={attrs.placeholder}
           onChange={(e) => onChange({ placeholder: e.target.value })}
           className="h-8 text-sm"
-          placeholder="Enter value..."
+          placeholder={t("formEditor.formField.placeholderPlaceholder")}
         />
       </div>
 
@@ -177,7 +177,7 @@ function FormFieldConfig({
       </div>
 
       <Button size="sm" variant="outline" onClick={onClose} className="w-full">
-        Done
+        {t("formEditor.formField.done")}
       </Button>
     </div>
   );
@@ -188,6 +188,7 @@ function FormFieldConfig({
 // ---------------------------------------------------------------------------
 
 function FormFieldNodeView({ node, updateAttributes, selected }: ReactNodeViewProps) {
+  const { t } = useTranslation();
   const [configOpen, setConfigOpen] = useState(false);
   const attrs = node.attrs as FormFieldAttrs;
   const isClient = attrs.filledBy === "client";
@@ -206,7 +207,7 @@ function FormFieldNodeView({ node, updateAttributes, selected }: ReactNodeViewPr
             )}
           >
             <FormFieldIcon type={attrs.fieldType} />
-            {attrs.label || attrs.fieldId || "Field"}
+            {attrs.label || attrs.fieldId || t("formEditor.formField.fieldFallback")}
             {attrs.required && <span className="text-red-500">*</span>}
             {isClient && <Users className="h-3 w-3 ml-0.5 opacity-60" />}
           </span>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2183.

Closes #2183

---

## Claude summary

The issue was real. Here's what was fixed:

**Files changed (4):**

- `src/components/documents/form-field-node.tsx` — The `FormFieldConfig` popover had 9 hardcoded English strings (`Label`, `Field ID`, `Type`, `Text`, `Textarea`, `Date`, `Checkbox`, `Options (comma-separated)`, `Placeholder`, `Enter value...`, `Done`). All are now resolved via `t()`. The inline field display fallback (`"Field"`) is also translated.

- `src/components/documents/document-template-editor.tsx` — The toolbar button label `Form field` and its `title="Insert form field"` tooltip were hardcoded English. Both now use `t("documentsEditor.toolbar.formFieldLabel")` and `t("documentsEditor.toolbar.insertFormField")`.

- `public/locales/pl/translation.json` — Added `formEditor.formField.*` (Polish translations for all config labels) and `documentsEditor.toolbar.insertFormField` / `formFieldLabel`.

- `public/locales/en/translation.json` — Same keys added with English values for consistency.

Note: `Przyciski (Tak/Nie)` (the button_select option label) was already Polish — left as-is since it's a special value with no EN equivalent in the file.