### PR TITLE
Apply defensive pattern to `payments.create` for `kind

### DIFF
--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -179,7 +179,11 @@ export const create = action({
       }
     }
 
-    const paymentId = await db.insert("payments", {
+    // Build INSERT defensively — migration 00008 columns (kind, creditEarned,
+    // creditApplied) may not exist on pre-00008 environments; only include them
+    // when non-null. kind=NULL is treated as "payment" by the DB check
+    // constraint, so omitting it is always safe.
+    const insertRow: Record<string, unknown> = {
       organizationId: String(args.organizationId),
       patientId: args.patientId ?? null,
       appointmentId: args.appointmentId ?? null,
@@ -190,13 +194,14 @@ export const create = action({
       status,
       paidAt: status === "completed" ? now : null,
       notes: args.notes ?? null,
-      creditEarned,
-      creditApplied,
-      kind: "payment",
       createdBy: String(authResult.userId),
       createdAt: now,
       updatedAt: now,
-    });
+    };
+    if (creditEarned !== null) insertRow.creditEarned = creditEarned;
+    if (creditApplied !== null) insertRow.creditApplied = creditApplied;
+
+    const paymentId = await db.insert("payments", insertRow);
 
     // Side effects (audit log) via internal mutation
     try {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2191.

Closes #2191

---

## Claude summary

Done. The fix in `convex/payments.ts:182-204` changes `payments.create` to build the INSERT payload without migration-00008 columns (`kind`, `creditEarned`, `creditApplied`) in the base object, then only appends `creditEarned` and `creditApplied` when they're non-null. `kind` is dropped entirely since migration 00008 explicitly states "Existing NULLs are treated as 'payment'" — semantically safe and avoids the 42703 error on pre-00008 environments. This matches the pattern already used in `convex/products.ts` for conditional migration-column inclusion.

## Follow-ups

- Apply defensive pattern to `payments.refundCredit` INSERT: line 351-368 always includes `kind: "credit_refund"`, `creditEarned`, and `creditApplied` unconditionally — same 42703 risk on pre-00008 environments (though `kind` here is `"credit_refund"` not NULL, so omitting it would change semantics; the column must be included only after checking migration has run or using a try/catch fallback like in `autoGenerateDocuments.ts`)
- Apply defensive pattern to `payments.splitMarkPaid` INSERT: line 545-562 includes `kind: "payment"`, `creditEarned: null`, `creditApplied: null` unconditionally after the #2193 fix — same pre-00008 risk as the original `payments.create` bug
- Apply defensive pattern to `payments.approveRefundAuth` INSERT: line 1193-1210 includes `kind: "credit_refund"`, `creditEarned`, and `creditApplied` unconditionally — same migration-gating issue