### PR TITLE
Apply defensive pattern to `payments.refundCredit` INSERT

### DIFF
--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -353,7 +353,14 @@ export const refundCredit = action({
     }
 
     const now = Date.now();
-    const paymentId = await db.insert("payments", {
+    // Build INSERT defensively — migration 00008 columns (kind, creditEarned)
+    // may not exist on pre-00008 environments. Unlike `create` where kind=NULL
+    // defaults to "payment", here kind="credit_refund" is semantically required
+    // so we use try/catch: attempt the full INSERT and fall back to base columns
+    // on a 42703 "column does not exist" error. The fallback is unreachable in
+    // practice because computePatientCreditBalance returns 0 on pre-00008 envs,
+    // causing the balance check above to throw before we reach this INSERT.
+    const baseRow: Record<string, unknown> = {
       organizationId: String(args.organizationId),
       patientId: args.patientId,
       appointmentId: null,
@@ -364,13 +371,25 @@ export const refundCredit = action({
       status: "completed",
       paidAt: now,
       notes: args.notes ?? null,
-      creditEarned: -args.amount,
-      creditApplied: null,
-      kind: "credit_refund",
       createdBy: String(authResult.userId),
       createdAt: now,
       updatedAt: now,
-    });
+    };
+    let paymentId: string;
+    try {
+      paymentId = await db.insert("payments", {
+        ...baseRow,
+        kind: "credit_refund",
+        creditEarned: -args.amount,
+      });
+    } catch (e: unknown) {
+      const msg = (e as { message?: string })?.message ?? "";
+      if (/code=42703/.test(msg) || /column .* does not exist/i.test(msg)) {
+        paymentId = await db.insert("payments", baseRow);
+      } else {
+        throw e;
+      }
+    }
 
     try {
       await ctx.runMutation(internal.payments._refundCreditSideEffects, {
@@ -1195,7 +1214,8 @@ export const approveRefundAuth = action({
 
     const paymentMethod = args.paymentMethod ?? "cash";
     const now = Date.now();
-    const paymentId = await db.insert("payments", {
+    // Same defensive try/catch pattern as refundCredit above — see that comment.
+    const baseRow: Record<string, unknown> = {
       organizationId: String(args.organizationId),
       patientId: meta.patientId,
       appointmentId: null,
@@ -1206,13 +1226,25 @@ export const approveRefundAuth = action({
       status: "completed",
       paidAt: now,
       notes: meta.notes ?? null,
-      creditEarned: -meta.amount,
-      creditApplied: null,
-      kind: "credit_refund",
       createdBy: String(authResult.userId),
       createdAt: now,
       updatedAt: now,
-    });
+    };
+    let paymentId: string;
+    try {
+      paymentId = await db.insert("payments", {
+        ...baseRow,
+        kind: "credit_refund",
+        creditEarned: -meta.amount,
+      });
+    } catch (e: unknown) {
+      const msg = (e as { message?: string })?.message ?? "";
+      if (/code=42703/.test(msg) || /column .* does not exist/i.test(msg)) {
+        paymentId = await db.insert("payments", baseRow);
+      } else {
+        throw e;
+      }
+    }
 
     await ctx.runMutation(internal.payments._resolveRefundAuthSideEffects, {
       organizationId: args.organizationId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2196.

Closes #2196

---

## Claude summary

The fix is committed. Here's what was done:

Both `refundCredit` (line ~356) and `approveRefundAuth` (line ~1215) in `convex/payments.ts` were unconditionally including `kind: "credit_refund"`, `creditEarned: -amount`, and `creditApplied: null` in their Supabase INSERT calls. On a pre-migration-00008 environment, these columns don't exist and the INSERT would fail with Postgres error 42703.

The null-omission approach used in `payments.create` doesn't work here because `kind: "credit_refund"` is semantically required (it's not the NULL/default value). Instead, both locations now use a try/catch pattern: attempt the INSERT with all migration-00008 columns, and if 42703 fires, retry with only the base columns. The fallback is unreachable in practice because `computePatientCreditBalance` returns 0 on pre-00008 environments, causing the balance check to throw before reaching the INSERT.

All 158 tests pass.

## Follow-ups

- Apply defensive pattern to `splitMarkPaid` INSERT: lines 550-567 unconditionally include `kind: "payment"`, `creditEarned: null`, `creditApplied: null` — same 42703 risk; since `kind: "payment"` is the default (same as NULL), the null-omission approach from `payments.create` is appropriate here.