### PR TITLE
Apply defensive pattern to `payments.splitMarkPaid` INSERT

### DIFF
--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -566,6 +566,10 @@ export const splitMarkPaid = action({
       updatedAt: now,
     });
 
+    // Build INSERT defensively — migration 00008 columns (kind, creditEarned,
+    // creditApplied) may not exist on pre-00008 environments. A split payment
+    // never earns/applies credit, so both are null and we omit them entirely.
+    // kind=NULL is treated as "payment" by the DB check constraint.
     const newPaymentId = await db.insert("payments", {
       organizationId: String(args.organizationId),
       patientId: (payment.patientId as string | null) ?? null,
@@ -577,9 +581,6 @@ export const splitMarkPaid = action({
       status: "completed",
       paidAt: now,
       notes: appendSplit(args.secondMethod),
-      kind: "payment",
-      creditEarned: null,
-      creditApplied: null,
       createdBy: String(authResult.userId),
       createdAt: now,
       updatedAt: now,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2197.

Closes #2197

---

## Claude summary

Done. The fix removes `kind: "payment"`, `creditEarned: null`, and `creditApplied: null` from the `splitMarkPaid` INSERT in `convex/payments.ts:569-587`. These are migration-00008 columns that don't exist on pre-00008 databases — including them unconditionally with literal `null` values causes a "column does not exist" error on those environments.

The fix follows the same defensive pattern already used in `payments.create` (line 186-204): omit `kind` entirely (NULL satisfies the `"payment"` default in the DB constraint), and only include `creditEarned`/`creditApplied` when non-null. For a split payment both credit fields are always null, so neither is ever added to the INSERT object.