### PR TITLE
Generuj dokument

### DIFF
--- a/src/components/documents/document-form-filler.tsx
+++ b/src/components/documents/document-form-filler.tsx
@@ -24,7 +24,6 @@ interface DocumentFormFillerProps {
   filledByFilter?: "employee" | "client";
   initialValues?: Record<string, string>;
   submitLabel?: string;
-  hideTopAction?: boolean;
   onComplete: (fieldValues: Record<string, string>) => void;
   onCancel: () => void;
 }
@@ -33,12 +32,13 @@ interface DocumentFormFillerProps {
 // Component
 // ---------------------------------------------------------------------------
 
+const LONG_FORM_THRESHOLD = 3;
+
 export function DocumentFormFiller({
   formFields,
   filledByFilter,
   initialValues,
   submitLabel,
-  hideTopAction = false,
   onComplete,
   onCancel,
 }: DocumentFormFillerProps) {
@@ -82,9 +82,11 @@ export function DocumentFormFiller({
     onComplete(values);
   };
 
+  const showTopAction = visibleFields.length > LONG_FORM_THRESHOLD;
+
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      {!hideTopAction && (
+      {showTopAction && (
         <div className="flex gap-2">
           <Button type="submit" className="flex-1">
             {submitLabel ?? t("documentEditor.generate", "Generuj dokument")}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2194.

Closes #2194

---

## Claude summary

The fix is committed. Here's what changed:

`src/components/documents/document-form-filler.tsx` — the component that renders the document generation form had a `hideTopAction` prop (defaulting to `false`) that caused both the top and bottom "Generuj dokument" buttons to always appear together. No caller ever passed `hideTopAction` explicitly, so the prop was effectively dead code.

The fix replaces that static default with auto-detection: the top button is now shown only when `visibleFields.length > 3` (more than 3 fields = "long" form that benefits from having a button at both ends). Short forms — 3 fields or fewer — show only the bottom button.