### PR TITLE
Propagate the `"field" in productRecord` clearable-null pattern to similar updat

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -295,17 +295,17 @@ export const update = action({
 
       // --- Build updates and PATCH to Supabase ---
       const { organizationId, treatmentId, taxExempt, packageId, ...updates } = args;
-      // Only include taxExempt when true — omitting it avoids a "column does
-      // not exist" failure on environments where migration 00005 hasn't been
-      // applied yet (null and false are semantically equivalent: not exempt).
-      // Only include packageId when non-null — same reasoning for migration
-      // 00010.
+      // taxExempt and packageId were added by migrations 00005 and 00010.
+      // Use the "field in record" probe so null/false can clear the field once
+      // the column exists, while keeping pre-migration environments safe.
       const patchPayload: Record<string, unknown> = { ...updates, updatedAt: Date.now() };
       if (taxExempt === true) {
         patchPayload.taxExempt = true;
         patchPayload.taxRate = null;
+      } else if (taxExempt === false && "taxExempt" in treatment) {
+        patchPayload.taxExempt = false;
       }
-      if (packageId != null) {
+      if (packageId !== undefined && (packageId != null || "packageId" in treatment)) {
         patchPayload.packageId = packageId;
       }
       await db.patch("gabinetTreatments", treatmentId, patchPayload);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2207.

Closes #2207

---

## Claude summary

The fix is committed. Here's a summary:

**Triage**: Confirmed real bugs in `convex/gabinet/treatments.ts` update handler. Two optional fields added by migrations used guards that prevented clearing:

1. `if (packageId != null)` (line 308) — once set, `packageId` could never be cleared back to null.
2. `if (taxExempt === true)` only (line 304) — once a treatment was marked tax-exempt, it could never be un-exempted.

**Fix** (`convex/gabinet/treatments.ts:302-310`): Applied the same `"field" in record` probe pattern from `products.ts` (#2199):
- `packageId`: `packageId !== undefined && (packageId != null || "packageId" in treatment)` — allows null when migration 00010 column exists.
- `taxExempt`: added `else if (taxExempt === false && "taxExempt" in treatment)` — allows setting false when migration 00005 column exists.

**Appointments investigation**: The `appointments.update` handler uses `...updates` spread without any `!= null` guards, so it can already clear optional fields to null. It does NOT have the same inability to clear fields described in the issue.

## Follow-ups

- Apply `"field" in appt` probe to migration-added appointment columns: `contraindicationAlertsReviewed` (migration 00021) is spread unconditionally into the appointments patch; if the caller passes it while migration 00021 hasn't been applied, the Supabase patch fails with "column does not exist" — same pre-migration risk the products/treatments fixes address, just in the opposite direction (setting a value rather than clearing one).