### PR TITLE
Apply `"field" in appt` probe to migration-added appointment columns

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1517,6 +1517,7 @@ export const update = action({
       appointmentId,
       status,
       cancellationReason,
+      contraindicationAlertsReviewed,
       ...updates
     } = args;
 
@@ -1525,6 +1526,16 @@ export const update = action({
       ...updates,
       updatedAt: now,
     };
+
+    // contraindicationAlertsReviewed was added by migration 00021.
+    // Use the "field in record" probe so it is only included in the patch when
+    // the column exists, keeping pre-migration environments safe.
+    if (
+      contraindicationAlertsReviewed !== undefined &&
+      "contraindicationAlertsReviewed" in appt
+    ) {
+      patch.contraindicationAlertsReviewed = contraindicationAlertsReviewed;
+    }
 
     // Handle status change with cancellation support
     if (status) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2210.

Closes #2210

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Bug confirmed:** In `convex/gabinet/appointments.ts`, the `update` action destructured `args` leaving `contraindicationAlertsReviewed` inside `...updates`, which was then unconditionally spread into the Supabase patch object. If migration 00021 (`gabinet_appointments_contraindication_alerts_reviewed.sql`) hasn't been applied to the environment, this causes a "column does not exist" error on every call that passes the field.

**Fix applied:** Extracted `contraindicationAlertsReviewed` from the destructuring (removing it from `...updates`) and added a guard that only writes it to the patch when both the caller passed a value AND the column exists in the fetched appointment row (`"contraindicationAlertsReviewed" in appt`). This is the same `"field" in record` probe pattern established in issues #2199 and #2207.