### PR TITLE
Auto-run `migrateFormFieldFilledBy` on gabinet module activation

### DIFF
--- a/convex/documents/seed.ts
+++ b/convex/documents/seed.ts
@@ -116,50 +116,64 @@ const EMPLOYEE_FILLED_FIELD_IDS = new Set<string>([
   "protocol_next_visit",
 ]);
 
+async function _migrateFilledByHandler(
+  ctx: MutationCtx,
+  organizationId: GenericId<"organizations">,
+) {
+  const all = await ctx.db
+    .query("formTemplates")
+    .withIndex("by_org", (q) => q.eq("organizationId", organizationId))
+    .collect();
+
+  let patched = 0;
+  for (const t of all) {
+    if (!t.contentJson) continue;
+    let json: unknown;
+    try {
+      json = JSON.parse(t.contentJson);
+    } catch {
+      continue;
+    }
+
+    let changed = false;
+    const walk = (node: unknown) => {
+      if (!node || typeof node !== "object") return;
+      const n = node as { type?: string; attrs?: Record<string, unknown>; content?: unknown[] };
+      if (n.type === "formField" && n.attrs) {
+        const fieldId = typeof n.attrs.fieldId === "string" ? n.attrs.fieldId : "";
+        const expected = EMPLOYEE_FILLED_FIELD_IDS.has(fieldId) ? "employee" : "client";
+        if (n.attrs.filledBy !== expected) {
+          n.attrs.filledBy = expected;
+          changed = true;
+        }
+      }
+      if (Array.isArray(n.content)) n.content.forEach(walk);
+    };
+    walk(json);
+
+    if (changed) {
+      await ctx.db.patch(t._id, {
+        contentJson: JSON.stringify(json),
+        updatedAt: Date.now(),
+      });
+      patched++;
+    }
+  }
+  return { patched, total: all.length };
+}
+
 export const migrateFormFieldFilledBy = mutation({
   args: { organizationId: v.id("organizations") },
   handler: async (ctx, args) => {
     await verifyOrgAccess(ctx, args.organizationId);
-    const all = await ctx.db
-      .query("formTemplates")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .collect();
+    return await _migrateFilledByHandler(ctx, args.organizationId);
+  },
+});
 
-    let patched = 0;
-    for (const t of all) {
-      if (!t.contentJson) continue;
-      let json: unknown;
-      try {
-        json = JSON.parse(t.contentJson);
-      } catch {
-        continue;
-      }
-
-      let changed = false;
-      const walk = (node: unknown) => {
-        if (!node || typeof node !== "object") return;
-        const n = node as { type?: string; attrs?: Record<string, unknown>; content?: unknown[] };
-        if (n.type === "formField" && n.attrs) {
-          const fieldId = typeof n.attrs.fieldId === "string" ? n.attrs.fieldId : "";
-          const expected = EMPLOYEE_FILLED_FIELD_IDS.has(fieldId) ? "employee" : "client";
-          if (n.attrs.filledBy !== expected) {
-            n.attrs.filledBy = expected;
-            changed = true;
-          }
-        }
-        if (Array.isArray(n.content)) n.content.forEach(walk);
-      };
-      walk(json);
-
-      if (changed) {
-        await ctx.db.patch(t._id, {
-          contentJson: JSON.stringify(json),
-          updatedAt: Date.now(),
-        });
-        patched++;
-      }
-    }
-    return { patched, total: all.length };
+export const migrateFormFieldFilledByInternal = internalMutation({
+  args: { organizationId: v.id("organizations") },
+  handler: async (ctx, args) => {
+    return await _migrateFilledByHandler(ctx, args.organizationId);
   },
 });
 

--- a/convex/gabinet/onboarding.ts
+++ b/convex/gabinet/onboarding.ts
@@ -105,6 +105,12 @@ export const completeSetup = action({
       internal.gabinet.onboarding._completeSetupSideEffects,
       { organizationId: args.organizationId },
     );
+
+    // Backfill filledBy on any existing formField templates that pre-date
+    // the filledBy feature. Idempotent — no-op when values are already correct.
+    await ctx.runMutation(internal.documents.seed.migrateFormFieldFilledByInternal, {
+      organizationId: args.organizationId,
+    });
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2214.

Closes #2214

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Root cause**: `migrateFormFieldFilledBy` (which backfills the `filledBy` attribute on `formField` nodes in document templates) was only callable manually. Organizations with templates created before the `filledBy` feature was added would never have their templates fixed unless an admin ran the mutation explicitly.

**Fix**:
1. `convex/documents/seed.ts` — extracted the migration logic from `migrateFormFieldFilledBy` into a private `_migrateFilledByHandler` function, then exposed it as both the existing public `mutation` (auth-gated, for manual use) and a new `migrateFormFieldFilledByInternal` `internalMutation` (callable from actions).
2. `convex/gabinet/onboarding.ts` — added a call to `internal.documents.seed.migrateFormFieldFilledByInternal` in the `completeSetup` action, right after the org's `onboardingCompleted` flag is set. The migration is idempotent, so re-running setup won't cause issues.