### PR TITLE
Inconsistent revenue calculation in reports page

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -975,7 +975,7 @@ function GabinetReports() {
           const tid = a.treatmentId as string;
           const tr = treatmentMap.get(tid);
           if (!tr) continue;
-          const price = tr.price;
+          const price = (a.priceAtBooking as number | undefined) ?? tr.price;
           currency = tr.currency;
           total += price;
           if (a.date >= sevenDaysBeforeEnd) last7 += price;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2218.

Closes #2218

---

## Claude summary

The bug was real and the fix is a single line.

The revenue summary calculation in `GabinetReports` (line 978 of `_layout.gabinet.reports.lazy.tsx`) used `tr.price` — the treatment's current catalog price — for `totalRevenue`, `last7Revenue`, and `lastDayRevenue`. The `treatmentStats` memo (which feeds `TopTreatmentsByRevenue`) and `revenueChartPoints` both used `a.priceAtBooking ?? tr.price` — the historically accurate price recorded at booking time, falling back to the current catalog price only if absent.

The fix changes that one line to `(a.priceAtBooking as number | undefined) ?? tr.price`, making all three revenue computations on the page consistent. This means if a treatment's price was changed after appointments were booked, the reports page will now correctly reflect what was actually charged.