### PR TITLE
`gratis`/`barter` turnover exclusion unimplemented

### DIFF
--- a/src/hooks/use-supabase-payments.ts
+++ b/src/hooks/use-supabase-payments.ts
@@ -11,6 +11,56 @@ import {
 } from "@/lib/supabase/mappers/payments";
 
 // ---------------------------------------------------------------------------
+// Gratis/Barter Appointment ID Set (for turnover exclusion)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the set of appointment IDs in `appointmentIds` that have at least
+ * one completed payment with payment_method in ('gratis', 'barter').
+ * Used by the reports page to exclude those appointments from turnover totals
+ * (migration 00023 deferred this application-layer rule to here).
+ */
+export function useSupabaseGratisBarterAppointmentIds(
+  organizationId: string,
+  appointmentIds: string[],
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  const stableIds = [...appointmentIds].sort();
+
+  return useQuery<Set<string>, Error>({
+    queryKey: [
+      ...supabaseKeys.payments.list(organizationId),
+      "gratisBarterAppointmentIds",
+      stableIds.join(","),
+    ],
+    queryFn: async (): Promise<Set<string>> => {
+      const result = new Set<string>();
+      if (!client) throw new Error("Supabase client not ready");
+      if (stableIds.length === 0) return result;
+
+      const { data, error } = await client
+        .from("payments")
+        .select("appointment_id")
+        .eq("organization_id", organizationId)
+        .eq("status", "completed")
+        .in("payment_method", ["gratis", "barter"])
+        .in("appointment_id", stableIds);
+
+      if (error) throw error;
+
+      for (const row of (data ?? []) as { appointment_id: string | null }[]) {
+        if (row.appointment_id) result.add(row.appointment_id);
+      }
+      return result;
+    },
+    enabled: enabled && isReady && !!organizationId && stableIds.length > 0,
+  } satisfies UseQueryOptions<Set<string>, Error>);
+}
+
+// ---------------------------------------------------------------------------
 // Patient Credit Balances (bulk)
 // ---------------------------------------------------------------------------
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -2,6 +2,7 @@ import { createLazyFileRoute } from "@tanstack/react-router";
 import Papa from "papaparse";
 import { toast } from "sonner";
 import { useSupabaseGabinetAppointmentsByDateRange } from "@/hooks/use-supabase-gabinet-appointments";
+import { useSupabaseGratisBarterAppointmentIds } from "@/hooks/use-supabase-payments";
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
@@ -855,8 +856,18 @@ function GabinetReports() {
   const { data: employees, isLoading: loadingEmployees } =
     useSupabaseGabinetEmployeesList(organizationId, { activeOnly: true });
 
+  const completedAppointmentIds = useMemo(() => {
+    if (!appointments) return [];
+    return appointments
+      .filter((a) => a.status === "completed")
+      .map((a) => a._id);
+  }, [appointments]);
+
+  const { data: gratisBarterIds, isLoading: loadingGratisBarter } =
+    useSupabaseGratisBarterAppointmentIds(organizationId, completedAppointmentIds);
+
   const isLoading =
-    loadingAppointments || loadingTreatments || loadingPatients || loadingEmployees;
+    loadingAppointments || loadingTreatments || loadingPatients || loadingEmployees || loadingGratisBarter;
 
   // Treatment map: id → { name, price, currency }
   const treatmentMap = useMemo(() => {
@@ -880,14 +891,14 @@ function GabinetReports() {
     );
   }, [employees]);
 
-  // Treatment stats: count + estimated revenue (completed only)
+  // Treatment stats: count + estimated revenue (completed only, gratis/barter excluded from revenue)
   const treatmentStats = useMemo(() => {
     if (!appointments) return [];
     const map = new Map<string, { count: number; revenue: number }>();
     for (const a of appointments) {
       const tid = a.treatmentId as string;
       const prev = map.get(tid) ?? { count: 0, revenue: 0 };
-      const price = a.status === "completed"
+      const price = a.status === "completed" && !gratisBarterIds?.has(a._id)
         ? (a.priceAtBooking ?? treatmentMap.get(tid)?.price ?? 0)
         : 0;
       map.set(tid, { count: prev.count + 1, revenue: prev.revenue + price });
@@ -900,7 +911,7 @@ function GabinetReports() {
       }))
       .sort((a, b) => b.count - a.count)
       .slice(0, 10);
-  }, [appointments, treatmentMap]);
+  }, [appointments, treatmentMap, gratisBarterIds]);
 
   const topByRevenue = useMemo(
     () =>
@@ -972,6 +983,7 @@ function GabinetReports() {
       if (appointments) {
         for (const a of appointments) {
           if (a.status !== "completed") continue;
+          if (gratisBarterIds?.has(a._id)) continue;
           const tid = a.treatmentId as string;
           const tr = treatmentMap.get(tid);
           if (!tr) continue;
@@ -988,7 +1000,7 @@ function GabinetReports() {
         lastDayRevenue: lastDay,
         defaultCurrency: currency,
       };
-    }, [appointments, treatmentMap, sevenDaysBeforeEnd, endDate]);
+    }, [appointments, treatmentMap, sevenDaysBeforeEnd, endDate, gratisBarterIds]);
 
   const totalAppointments = appointments?.length ?? 0;
   const completedCount =
@@ -1029,12 +1041,13 @@ function GabinetReports() {
     const map = new Map<string, number>();
     for (const a of appointments) {
       if (a.status !== "completed") continue;
+      if (gratisBarterIds?.has(a._id)) continue;
       const tid = a.treatmentId as string;
       const price = a.priceAtBooking ?? treatmentMap.get(tid)?.price ?? 0;
       map.set(a.date, (map.get(a.date) ?? 0) + price);
     }
     return bucketizePairs(Array.from(map.entries()));
-  }, [appointments, treatmentMap]);
+  }, [appointments, treatmentMap, gratisBarterIds]);
 
   const handleExportReport = useCallback(() => {
     type Row = {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2219.

Closes #2219

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Root cause**: Migration 00023 added `gratis` and `barter` to `payment_method_enum` and noted that turnover exclusion was deferred to the application layer. The write path (`convex/payments.ts`) already accepted these values, but the reports page computed revenue purely from `appointment.priceAtBooking ?? treatmentPrice` for all completed appointments — with no awareness of payment method. An appointment settled as `gratis` (supposed to be 0 PLN) or `barter` (non-cash exchange, excluded from turnover) would silently inflate the revenue figures.

**Fix** (2 files):

1. `src/hooks/use-supabase-payments.ts` — added `useSupabaseGratisBarterAppointmentIds(orgId, appointmentIds)` which queries the `payments` table for completed records with `payment_method IN ('gratis', 'barter')` and returns their appointment IDs as a `Set<string>`.

2. `src/routes/.../gabinet.reports.lazy.tsx` — the reports component now:
   - Extracts completed appointment IDs from the fetched appointments
   - Calls the new hook to get the gratis/barter exclusion set
   - Applies the exclusion in all three revenue computations: `totalRevenue/last7/lastDay`, `treatmentStats.revenue`, and `revenueChartPoints`
   - Treatment visit counts are unaffected — only the revenue contribution is excluded