### PR TITLE
Generuj przycisk + zgody

### DIFF
--- a/src/components/documents/document-form-filler.tsx
+++ b/src/components/documents/document-form-filler.tsx
@@ -46,7 +46,7 @@ export function DocumentFormFiller({
 
   // Filter fields by filledBy if a filter is specified
   const visibleFields = filledByFilter
-    ? formFields.filter((f) => (f.filledBy || "employee") === filledByFilter)
+    ? formFields.filter((f) => (f.filledBy || "client") === filledByFilter)
     : formFields;
 
   const [values, setValues] = useState<Record<string, string>>(() => {
@@ -62,22 +62,25 @@ export function DocumentFormFiller({
     return init;
   });
 
+  const [showErrors, setShowErrors] = useState(false);
+
   const setValue = (fieldId: string, value: string) => {
     setValues((prev) => ({ ...prev, [fieldId]: value }));
   };
 
+  const isFieldInvalid = (field: (typeof visibleFields)[number]): boolean => {
+    if (!field.required) return false;
+    const val = values[field.fieldId];
+    if (field.fieldType === "checkbox") return val !== "true";
+    return !val?.trim();
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    // Validate required visible fields. Checkboxes require an explicit "true"
-    // value — checking !value.trim() would wrongly pass for "false" (unchecked).
-    for (const field of visibleFields) {
-      if (!field.required) continue;
-      const val = values[field.fieldId];
-      if (field.fieldType === "checkbox") {
-        if (val !== "true") return;
-      } else if (!val?.trim()) {
-        return;
-      }
+    const hasInvalid = visibleFields.some(isFieldInvalid);
+    if (hasInvalid) {
+      setShowErrors(true);
+      return;
     }
     onComplete(values);
   };
@@ -104,107 +107,125 @@ export function DocumentFormFiller({
         )}
       </p>
 
-      {visibleFields.map((field) => (
-        <div key={field.fieldId} className="space-y-1.5">
-          <Label className="text-sm">
-            {field.label || field.fieldId}
-            {field.required && <span className="ml-1 text-red-500">*</span>}
-          </Label>
+      {visibleFields.map((field) => {
+        const invalid = showErrors && isFieldInvalid(field);
+        return (
+          <div key={field.fieldId} className="space-y-1.5">
+            <Label className={cn("text-sm", invalid && "text-destructive")}>
+              {field.label || field.fieldId}
+              {field.required && <span className="ml-1 text-red-500">*</span>}
+            </Label>
 
-          {field.fieldType === "text" && (
-            <Input
-              value={values[field.fieldId] ?? ""}
-              onChange={(e) => setValue(field.fieldId, e.target.value)}
-              placeholder={field.placeholder}
-              required={field.required}
-            />
-          )}
+            {field.fieldType === "text" && (
+              <Input
+                value={values[field.fieldId] ?? ""}
+                onChange={(e) => setValue(field.fieldId, e.target.value)}
+                placeholder={field.placeholder}
+                required={field.required}
+                className={cn(invalid && "border-destructive")}
+              />
+            )}
 
-          {field.fieldType === "textarea" && (
-            <Textarea
-              value={values[field.fieldId] ?? ""}
-              onChange={(e) => setValue(field.fieldId, e.target.value)}
-              placeholder={field.placeholder}
-              required={field.required}
-              rows={3}
-            />
-          )}
+            {field.fieldType === "textarea" && (
+              <Textarea
+                value={values[field.fieldId] ?? ""}
+                onChange={(e) => setValue(field.fieldId, e.target.value)}
+                placeholder={field.placeholder}
+                required={field.required}
+                rows={3}
+                className={cn(invalid && "border-destructive")}
+              />
+            )}
 
-          {field.fieldType === "select" && (
-            <Select
-              value={values[field.fieldId] ?? ""}
-              onValueChange={(v) => setValue(field.fieldId, v)}
-            >
-              <SelectTrigger>
-                <SelectValue
-                  placeholder={
-                    field.placeholder ||
-                    t("common.select", "Wybierz...")
-                  }
-                />
-              </SelectTrigger>
-              <SelectContent>
+            {field.fieldType === "select" && (
+              <Select
+                value={values[field.fieldId] ?? ""}
+                onValueChange={(v) => setValue(field.fieldId, v)}
+              >
+                <SelectTrigger className={cn(invalid && "border-destructive")}>
+                  <SelectValue
+                    placeholder={
+                      field.placeholder ||
+                      t("common.select", "Wybierz...")
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {field.options
+                    .split(",")
+                    .map((opt) => opt.trim())
+                    .filter(Boolean)
+                    .map((opt) => (
+                      <SelectItem key={opt} value={opt}>
+                        {opt}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            )}
+
+            {field.fieldType === "date" && (
+              <Input
+                type="date"
+                value={values[field.fieldId] ?? ""}
+                onChange={(e) => setValue(field.fieldId, e.target.value)}
+                required={field.required}
+                className={cn(invalid && "border-destructive")}
+              />
+            )}
+
+            {field.fieldType === "button_select" && (
+              <div className="flex flex-wrap gap-2">
                 {field.options
                   .split(",")
                   .map((opt) => opt.trim())
                   .filter(Boolean)
                   .map((opt) => (
-                    <SelectItem key={opt} value={opt}>
+                    <button
+                      key={opt}
+                      type="button"
+                      onClick={() => setValue(field.fieldId, opt)}
+                      className={cn(
+                        "min-h-[44px] rounded-lg border-2 px-5 py-2.5 text-sm font-medium transition-colors",
+                        values[field.fieldId] === opt
+                          ? "border-primary bg-primary/10 text-primary"
+                          : "border-border bg-background text-foreground hover:border-primary/50",
+                      )}
+                    >
                       {opt}
-                    </SelectItem>
+                    </button>
                   ))}
-              </SelectContent>
-            </Select>
-          )}
+              </div>
+            )}
 
-          {field.fieldType === "date" && (
-            <Input
-              type="date"
-              value={values[field.fieldId] ?? ""}
-              onChange={(e) => setValue(field.fieldId, e.target.value)}
-              required={field.required}
-            />
-          )}
+            {field.fieldType === "checkbox" && (
+              <div className={cn(
+                "flex items-center gap-2 rounded-md px-2 py-1.5",
+                invalid && "bg-destructive/5 ring-1 ring-destructive/30 rounded-md",
+              )}>
+                <Switch
+                  checked={values[field.fieldId] === "true"}
+                  onCheckedChange={(v) =>
+                    setValue(field.fieldId, v ? "true" : "false")
+                  }
+                />
+                <span className={cn(
+                  "text-sm",
+                  invalid ? "text-destructive" : "text-muted-foreground",
+                )}>
+                  {field.placeholder || field.label}
+                </span>
+              </div>
+            )}
 
-          {field.fieldType === "button_select" && (
-            <div className="flex flex-wrap gap-2">
-              {field.options
-                .split(",")
-                .map((opt) => opt.trim())
-                .filter(Boolean)
-                .map((opt) => (
-                  <button
-                    key={opt}
-                    type="button"
-                    onClick={() => setValue(field.fieldId, opt)}
-                    className={cn(
-                      "min-h-[44px] rounded-lg border-2 px-5 py-2.5 text-sm font-medium transition-colors",
-                      values[field.fieldId] === opt
-                        ? "border-primary bg-primary/10 text-primary"
-                        : "border-border bg-background text-foreground hover:border-primary/50",
-                    )}
-                  >
-                    {opt}
-                  </button>
-                ))}
-            </div>
-          )}
-
-          {field.fieldType === "checkbox" && (
-            <div className="flex items-center gap-2">
-              <Switch
-                checked={values[field.fieldId] === "true"}
-                onCheckedChange={(v) =>
-                  setValue(field.fieldId, v ? "true" : "false")
-                }
-              />
-              <span className="text-sm text-muted-foreground">
-                {field.placeholder || field.label}
-              </span>
-            </div>
-          )}
-        </div>
-      ))}
+            {invalid && field.fieldType !== "checkbox" && (
+              <p className="text-xs text-destructive">
+                {t("common.fieldRequired", "To pole jest wymagane.")}
+              </p>
+            )}
+          </div>
+        );
+      })}
 
       <div className="flex gap-2 pt-2">
         <Button type="submit" className="flex-1">

--- a/src/components/documents/document-renderer.tsx
+++ b/src/components/documents/document-renderer.tsx
@@ -117,7 +117,7 @@ export function extractFormFields(json: TipTapNode): ExtractedFormField[] {
         options: (node.attrs.options as string) || "",
         required: (node.attrs.required as boolean) || false,
         placeholder: (node.attrs.placeholder as string) || "",
-        filledBy: (node.attrs.filledBy as string) || "employee",
+        filledBy: (node.attrs.filledBy as string) || "client",
       });
     }
     if (node.content) node.content.forEach(walk);

--- a/src/components/documents/generate-document-dialog.tsx
+++ b/src/components/documents/generate-document-dialog.tsx
@@ -141,8 +141,8 @@ function DocumentTemplateFormStep({
 }) {
   const json = JSON.parse(contentJson);
   const allFormFields = extractFormFields(json);
-  const employeeFields = allFormFields.filter((f) => (f.filledBy || "employee") === "employee");
-  const clientFields = allFormFields.filter((f) => f.filledBy === "client");
+  const employeeFields = allFormFields.filter((f) => (f.filledBy || "client") === "employee");
+  const clientFields = allFormFields.filter((f) => (f.filledBy || "client") === "client");
   const hasClientFields = clientFields.length > 0;
 
   if (employeeFields.length === 0) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2200.

Closes #2200

---

## Claude summary

Both bugs are fixed and committed. Here's a summary of the changes:

**Bug 1 — Consent checkboxes appearing in the employee form** (`document-renderer.tsx`):

`extractFormFields` was using `|| "employee"` as the fallback when a TipTap node has no `filledBy` attribute. Templates seeded before the `filledBy` feature was introduced have consent checkbox nodes without this attribute, so they were misclassified as employee-required fields and shown in step 2. Fixed by changing the fallback to `"client"`, matching every other default in the codebase (`FormFieldNode.addAttributes`, `insertFormField`, the seed `formField` helper).

**Bug 2 — "Generuj dokument" button silently does nothing** (`document-form-filler.tsx`):

`handleSubmit` returned early with no user feedback when required fields were unmet. Added a `showErrors` state that activates on the first failed submit attempt, triggering destructive styling (red border, red label, red helper text) on each unmet required field so the employee knows what to fill.

## Follow-ups

- Auto-run `migrateFormFieldFilledBy` on gabinet module activation: organizations with templates seeded before `filledBy` was introduced won't see the correct employee/client split until the backfill mutation is triggered manually — it should run automatically on module activation
- Patient portal signing form should validate client consent checkboxes before enabling the sign action: currently relies on `DocumentFormFiller` client-filter but has no explicit guard preventing signature submission when required client fields are unchecked