### PR TITLE
Generuj dokument

### DIFF
--- a/src/components/documents/document-form-filler.tsx
+++ b/src/components/documents/document-form-filler.tsx
@@ -24,7 +24,6 @@ interface DocumentFormFillerProps {
   filledByFilter?: "employee" | "client";
   initialValues?: Record<string, string>;
   submitLabel?: string;
-  hideTopAction?: boolean;
   onComplete: (fieldValues: Record<string, string>) => void;
   onCancel: () => void;
 }
@@ -33,12 +32,13 @@ interface DocumentFormFillerProps {
 // Component
 // ---------------------------------------------------------------------------
 
+const LONG_FORM_THRESHOLD = 3;
+
 export function DocumentFormFiller({
   formFields,
   filledByFilter,
   initialValues,
   submitLabel,
-  hideTopAction = false,
   onComplete,
   onCancel,
 }: DocumentFormFillerProps) {
@@ -82,9 +82,11 @@ export function DocumentFormFiller({
     onComplete(values);
   };
 
+  const showTopAction = visibleFields.length > LONG_FORM_THRESHOLD;
+
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      {!hideTopAction && (
+      {showTopAction && (
         <div className="flex gap-2">
           <Button type="submit" className="flex-1">
             {submitLabel ?? t("documentEditor.generate", "Generuj dokument")}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2194.

Closes #2194

---

## Claude summary

NOT_A_BUG: The fix for this issue was already merged to `main` (via PR #2204) and is present in this branch. Looking at `src/components/documents/document-form-filler.tsx:35-111`:

- Line 35 defines `const LONG_FORM_THRESHOLD = 3;`
- Line 98: `const showTopAction = visibleFields.length > LONG_FORM_THRESHOLD;`
- Lines 102–111: the top "Generuj dokument" button renders only when `showTopAction` is true (i.e., more than 3 visible fields)

Short forms (≤3 fields) show only the bottom button. Long forms (>3 fields) show both top and bottom buttons. This matches exactly what the issue and @aleksanderem's comment describe. No code changes are needed — the fix is already in the codebase.