### PR TITLE
Do magazynu

### DIFF
--- a/convex/products.ts
+++ b/convex/products.ts
@@ -98,9 +98,22 @@ export const create = action({
     } catch (e: unknown) {
       const msg = (e as { message?: string })?.message ?? "";
       if (/code=42703/.test(msg) || /column .* does not exist/i.test(msg)) {
+        // Strip ALL migration-added columns so the insert succeeds on
+        // environments where one or more migrations haven't been applied yet.
+        // The original fallback only removed 00013 columns (trackStock/stockUnit),
+        // causing a second 42703 failure when the user filled in warehouse fields
+        // from migrations 00019 (productSection) or 00020 (manufacturer etc.).
         const fallbackRow = { ...insertRow };
-        delete fallbackRow.trackStock;
-        delete fallbackRow.stockUnit;
+        delete fallbackRow.taxExempt;      // 00006
+        delete fallbackRow.trackStock;     // 00013
+        delete fallbackRow.stockUnit;      // 00013
+        delete fallbackRow.productSection; // 00019
+        delete fallbackRow.minStock;       // 00020
+        delete fallbackRow.manufacturer;   // 00020
+        delete fallbackRow.catalogNumber;  // 00020
+        delete fallbackRow.stockNote;      // 00020
+        // On pre-00006 environments tax_rate is NOT NULL; ensure it's not null.
+        if (fallbackRow.taxRate == null) fallbackRow.taxRate = 0;
         productId = await db.insert("products", fallbackRow);
       } else {
         throw e;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2217.

Closes #2217

---

## Claude summary

The fix is committed. Here's the root cause and what was done:

**Root cause:** The `products.create` fallback catch block (triggered when Postgres returns `42703 "column does not exist"`) only removed `trackStock` and `stockUnit` (migration 00013). When a user fills in ANY warehouse field — `manufacturer`, `catalogNumber`, `productSection`, `minStock`, or `stockNote` — and the environment doesn't have migrations 00019/00020 applied, the first insert fails with 42703, the fallback removes only the wrong columns, and the second insert fails with another unhandled 42703. Product creation silently fails.

**Fix:** The fallback now strips ALL migration-added columns (00006 `taxExempt`, 00013 `trackStock`/`stockUnit`, 00019 `productSection`, 00020 `minStock`/`manufacturer`/`catalogNumber`/`stockNote`) before retrying the insert. This ensures the fallback always succeeds with just the base schema columns regardless of which migration-added column triggered the error.

The title "Do magazynu" (To the warehouse) was a direct clue — the warehouse fields added in migrations 00019/00020 are exactly what the existing fallback failed to handle.

## Follow-ups

- Eliminate the 42703 try/catch pattern in products.create entirely: now that all migrations through 00023 exist, the correct fix is to ensure production always runs migrations before deploying code that writes new columns — the layered try/catch is fragile and each new warehouse migration requires extending the fallback list again.