### PR TITLE
Auto-run `migrateFormFieldFilledBy` on gabinet module activation

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -9,4 +9,13 @@ crons.interval(
   internal.google.calendarSync.syncAll
 );
 
+// Backfill filledBy on formField nodes for all onboarded orgs. Covers orgs
+// that completed gabinet setup before the filledBy feature was introduced.
+// Idempotent — becomes a no-op once all templates are already correct.
+crons.daily(
+  "backfill-form-field-filled-by",
+  { hourUTC: 3, minuteUTC: 0 },
+  internal.documents.seed.backfillFilledByAllOrgs,
+);
+
 export default crons;

--- a/convex/documents/seed.ts
+++ b/convex/documents/seed.ts
@@ -1,4 +1,5 @@
-import { mutation, internalMutation, type MutationCtx } from "../_generated/server";
+import { mutation, internalMutation, internalQuery, internalAction, type MutationCtx } from "../_generated/server";
+import { internal } from "../_generated/api";
 import { v, type GenericId } from "convex/values";
 import { verifyOrgAccess } from "../_helpers/auth";
 import { buildSystemComponents } from "./components";
@@ -174,6 +175,43 @@ export const migrateFormFieldFilledByInternal = internalMutation({
   args: { organizationId: v.id("organizations") },
   handler: async (ctx, args) => {
     return await _migrateFilledByHandler(ctx, args.organizationId);
+  },
+});
+
+/**
+ * Internal: list IDs of all organizations that have completed gabinet onboarding.
+ * Used by the backfill cron to find orgs that need the filledBy migration.
+ */
+export const _listOnboardedOrgIds = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const orgs = await ctx.db.query("organizations").collect();
+    return orgs
+      .filter((o) => o.onboardingCompleted === true)
+      .map((o) => o._id);
+  },
+});
+
+/**
+ * Backfill `filledBy` on form-field nodes for ALL onboarded organizations.
+ * Runs as a daily cron so existing orgs (that completed setup before the
+ * filledBy feature was introduced) get migrated automatically.
+ * New orgs are already covered by the `completeSetup` action.
+ * Safe to run multiple times — idempotent.
+ */
+export const backfillFilledByAllOrgs = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const orgIds = await ctx.runQuery(internal.documents.seed._listOnboardedOrgIds, {});
+    let totalPatched = 0;
+    for (const orgId of orgIds) {
+      const { patched } = await ctx.runMutation(
+        internal.documents.seed.migrateFormFieldFilledByInternal,
+        { organizationId: orgId },
+      );
+      totalPatched += patched;
+    }
+    return { totalPatched, orgsProcessed: orgIds.length };
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2239.

Closes #2239

---

## Claude summary

The fix is committed. Here's a summary:

**Root cause**: `completeSetup` (the gabinet onboarding wizard completion action) already calls `migrateFormFieldFilledByInternal` — but this only fires when an org goes through the setup wizard for the first time. Organizations that completed onboarding before the `filledBy` feature was added in #2200 never call `completeSetup` again, so their templates remain unpatched.

**Fix**: Two additions in `convex/documents/seed.ts` and `convex/crons.ts`:

1. `_listOnboardedOrgIds` — internal query that returns all org IDs where `onboardingCompleted === true`.
2. `backfillFilledByAllOrgs` — internal action that iterates those orgs and calls `migrateFormFieldFilledByInternal` for each one.
3. A `crons.daily` entry (`backfill-form-field-filled-by`) registered at 03:00 UTC. After the first run patches all pre-existing orgs, subsequent runs are no-ops (the migration checks `filledBy === expected` before writing).