### PR TITLE
Raport finansowy — ustalić gdzie użytkownik może sprawdzić obrót

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3504,7 +3504,7 @@
     },
     "reports": {
       "title": "Gabinet Reports",
-      "description": "Analyze your clinic performance",
+      "description": "Analyze clinic performance and estimated revenue from appointments",
       "totalAppointments": "Total Appointments",
       "completed": "Completed",
       "cancelled": "Cancelled",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3526,7 +3526,7 @@
     },
     "reports": {
       "title": "Raporty Gabinetu",
-      "description": "Analizuj wydajność kliniki",
+      "description": "Analizuj wydajność kliniki i szacunkowy obrót z wizyt",
       "totalAppointments": "Wizyty ogółem",
       "completed": "Zakończone",
       "cancelled": "Anulowane",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2228.

Closes #2228

---

## Claude summary

---

**Odpowiedzi na 4 pytania z issue:**

**1. Czy istnieje widok, gdzie użytkownik może sprawdzić obrót?**

TAK. Ścieżka: `/dashboard/gabinet/reports`. Jak wejść: Sidebar Gabinet → menu główne → "Raporty" (ostatnia pozycja z ikoną wykresu kołowego). Plik: `src/modules/gabinet/manifest.ts:60` + `src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx`.

**2. Co pokazuje ten widok?**

Karta "Przychody" (`RevenueSummaryCard`, linia 163–217) pokazuje trzy wartości: Ostatni dzień / Ostatnie 7 dni / Cały okres. Pod tytułem jest podtytuł: "Szacowane na podstawie zakończonych wizyt" — to właściwy disclaimer, już tam jest. Źródło danych: wizyty ze statusem `completed`, wartość `priceAtBooking ?? treatment.price`, z wykluczeniem gratis/barter. To jest **obrót szacunkowy** — nie pochodzi z tabeli `payments`. Zakres dat działa: dropdown 7d/30d/90d/365d + niestandardowy.

**3. Czy użytkownik może to łatwo znaleźć?**

NIE DO KOŃCA. Widok istnieje i jest w menu, ale:
- Sidebar pokazuje "Raporty" — użytkownik szukający "obrót" lub "finanse" może nie wiedzieć, że właśnie tam.
- Opis strony (pod tytułem "Raporty Gabinetu") brzmiał "Analizuj wydajność kliniki" — bez żadnej wzmianki o przychodach czy obrocie.

**4. Wykonane minimum:**

Zaktualizowano opis strony w obu lokalach:
- PL: "Analizuj wydajność kliniki i szacunkowy obrót z wizyt"
- EN: "Analyze clinic performance and estimated revenue from appointments"

Teraz opis pod nagłówkiem strony oraz w PageHeader widoczny na górze raportu od razu mówi użytkownikowi, że tu znajdzie szacunkowy obrót. Karta przychodów wewnątrz już miała poprawny podtytuł z disclaimerem "szacowane" — nie dotykałem tej logiki.

## Follow-ups

- Revenue card title "Przychody" vs user expectation of "Obrót": in Polish business context these differ (przychody = income/revenue, obrót = gross turnover); consider whether to rename the card title to "Szacunkowy obrót" or add a parenthetical to avoid confusion
- Payments table unused in reports: the `payments` table exists but the reports view reads only from appointments — if real payment data is ever needed, a separate widget or flag would be required to distinguish estimated vs. actual collected revenue