### PR TITLE
Revenue card title "Przychody" vs user expectation of "Obrót"

### DIFF
--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3536,7 +3536,7 @@
       "treatmentPopularity": "Popularność zabiegów",
       "statusDistribution": "Rozkład statusów wizyt",
       "dailyVolume": "Dzienny wolumen wizyt",
-      "revenue": "Przychody",
+      "revenue": "Szacunkowy obrót",
       "estimatedFromCompletedAppointments": "Szacowane na podstawie zakończonych wizyt",
       "today": "Dziś",
       "lastDay": "Ostatni dzień",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2245.

Closes #2245

---

## Claude summary

Done. The fix is a single-line change in `public/locales/pl/translation.json`: the Gabinet reports revenue card title changed from "Przychody" to "Szacunkowy obrót".

The reasoning: the card shows estimated gross turnover from completed appointments, not accounting revenue. The page description (`gabinet.reports.description`) already used "szacunkowy obrót z wizyt", so the card title was inconsistent with its own surrounding context. "Szacunkowy obrót" is now consistent with the subtitle "Szacowane na podstawie zakończonych wizyt" and matches what the data actually represents.