### PR TITLE
Payments table unused in reports

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3539,7 +3539,8 @@
       },
       "periodTotal": "Period total",
       "ofTotal": "of total",
-      "topN": "Top {{count}}"
+      "topN": "Top {{count}}",
+      "collectedFromPayments": "Based on recorded payments"
     },
     "bodyChart": {
       "description": "Mark body areas related to the appointment",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3561,7 +3561,8 @@
       },
       "periodTotal": "Cały okres",
       "ofTotal": "ogółem",
-      "topN": "Top {{count}}"
+      "topN": "Top {{count}}",
+      "collectedFromPayments": "Na podstawie płatności"
     },
     "bodyChart": {
       "description": "Zaznacz obszary ciała powiązane z wizytą",

--- a/src/hooks/use-supabase-payments.ts
+++ b/src/hooks/use-supabase-payments.ts
@@ -128,6 +128,67 @@ export function useSupabaseGabinetPatientCreditBalances(
 }
 
 // ---------------------------------------------------------------------------
+// Payments Revenue by Date Range (for reports)
+// ---------------------------------------------------------------------------
+
+export interface PaymentRevenueSummary {
+  amount: number;
+  paidAt: number;
+  currency: string;
+}
+
+/**
+ * Returns completed non-gratis/barter payments within a date range, used by
+ * the gabinet reports page to show actual collected revenue alongside the
+ * appointment-based estimate. Only payments with a non-null `paid_at` are
+ * included; `paid_at` timestamps are compared as milliseconds UTC.
+ */
+export function useSupabasePaymentsRevenueByDateRange(
+  organizationId: string,
+  startDate: string, // YYYY-MM-DD
+  endDate: string,   // YYYY-MM-DD
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  return useQuery<PaymentRevenueSummary[], Error>({
+    queryKey: [
+      ...supabaseKeys.payments.list(organizationId),
+      "revenueByDateRange",
+      startDate,
+      endDate,
+    ],
+    queryFn: async (): Promise<PaymentRevenueSummary[]> => {
+      if (!client) throw new Error("Supabase client not ready");
+
+      const startTs = new Date(startDate + "T00:00:00.000Z").getTime();
+      const endTs = new Date(endDate + "T23:59:59.999Z").getTime();
+
+      const { data, error } = await client
+        .from("payments")
+        .select("amount, paid_at, currency")
+        .eq("organization_id", organizationId)
+        .eq("status", "completed")
+        .neq("payment_method", "gratis")
+        .neq("payment_method", "barter")
+        .not("paid_at", "is", null)
+        .gte("paid_at", startTs)
+        .lte("paid_at", endTs);
+
+      if (error) throw error;
+
+      return (data ?? []).map((row) => ({
+        amount: Number(row.amount),
+        paidAt: Number(row.paid_at ?? 0),
+        currency: (row.currency as string) ?? "PLN",
+      }));
+    },
+    enabled: enabled && isReady && !!organizationId && !!startDate && !!endDate,
+  } satisfies UseQueryOptions<PaymentRevenueSummary[], Error>);
+}
+
+// ---------------------------------------------------------------------------
 // Payments by Patient
 // ---------------------------------------------------------------------------
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -2,7 +2,10 @@ import { createLazyFileRoute } from "@tanstack/react-router";
 import Papa from "papaparse";
 import { toast } from "sonner";
 import { useSupabaseGabinetAppointmentsByDateRange } from "@/hooks/use-supabase-gabinet-appointments";
-import { useSupabaseGratisBarterAppointmentIds } from "@/hooks/use-supabase-payments";
+import {
+  useSupabaseGratisBarterAppointmentIds,
+  useSupabasePaymentsRevenueByDateRange,
+} from "@/hooks/use-supabase-payments";
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
@@ -165,51 +168,90 @@ function RevenueSummaryCard({
   last7Revenue,
   totalRevenue,
   currency,
+  actualLastDay,
+  actualLast7,
+  actualTotal,
 }: {
   lastDayRevenue: number;
   last7Revenue: number;
   totalRevenue: number;
   currency: string;
+  actualLastDay: number;
+  actualLast7: number;
+  actualTotal: number;
 }) {
   const { t } = useTranslation();
 
   return (
     <Card>
       <CardHeader className="flex justify-between border-b">
-        <div className="flex flex-col gap-1">
-          <span className="text-lg font-semibold">
-            {t("gabinet.reports.revenue")}
-          </span>
-          <span className="text-muted-foreground text-sm">
-            {t("gabinet.reports.estimatedFromCompletedAppointments")}
-          </span>
-        </div>
+        <span className="text-lg font-semibold">
+          {t("gabinet.reports.revenue")}
+        </span>
         <CardMenu />
       </CardHeader>
-      <CardContent className="grid grid-cols-1 gap-4 pt-4 sm:grid-cols-3">
-        <div className="flex flex-col gap-1 sm:border-r sm:pr-4">
-          <span className="text-muted-foreground text-sm">
-            {t("gabinet.reports.lastDay")}
-          </span>
-          <span className="text-xl font-semibold">
-            {formatCurrencyPLN(lastDayRevenue, currency, { fractionDigits: 0 })}
-          </span>
+      <CardContent className="flex flex-col gap-4 pt-4">
+        <div>
+          <p className="text-muted-foreground mb-3 text-xs font-medium">
+            {t("gabinet.reports.estimatedFromCompletedAppointments")}
+          </p>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div className="flex flex-col gap-1 sm:border-r sm:pr-4">
+              <span className="text-muted-foreground text-sm">
+                {t("gabinet.reports.lastDay")}
+              </span>
+              <span className="text-xl font-semibold">
+                {formatCurrencyPLN(lastDayRevenue, currency, { fractionDigits: 0 })}
+              </span>
+            </div>
+            <div className="flex flex-col gap-1 sm:border-r sm:pr-4">
+              <span className="text-muted-foreground text-sm">
+                {t("gabinet.reports.last7days")}
+              </span>
+              <span className="text-xl font-semibold">
+                {formatCurrencyPLN(last7Revenue, currency, { fractionDigits: 0 })}
+              </span>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-muted-foreground text-sm">
+                {t("gabinet.reports.periodTotal")}
+              </span>
+              <span className="text-xl font-semibold">
+                {formatCurrencyPLN(totalRevenue, currency, { fractionDigits: 0 })}
+              </span>
+            </div>
+          </div>
         </div>
-        <div className="flex flex-col gap-1 sm:border-r sm:pr-4">
-          <span className="text-muted-foreground text-sm">
-            {t("gabinet.reports.last7days")}
-          </span>
-          <span className="text-xl font-semibold">
-            {formatCurrencyPLN(last7Revenue, currency, { fractionDigits: 0 })}
-          </span>
-        </div>
-        <div className="flex flex-col gap-1">
-          <span className="text-muted-foreground text-sm">
-            {t("gabinet.reports.periodTotal")}
-          </span>
-          <span className="text-xl font-semibold">
-            {formatCurrencyPLN(totalRevenue, currency, { fractionDigits: 0 })}
-          </span>
+        <div className="border-t pt-4">
+          <p className="text-muted-foreground mb-3 text-xs font-medium">
+            {t("gabinet.reports.collectedFromPayments")}
+          </p>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div className="flex flex-col gap-1 sm:border-r sm:pr-4">
+              <span className="text-muted-foreground text-sm">
+                {t("gabinet.reports.lastDay")}
+              </span>
+              <span className="text-xl font-semibold">
+                {formatCurrencyPLN(actualLastDay, currency, { fractionDigits: 0 })}
+              </span>
+            </div>
+            <div className="flex flex-col gap-1 sm:border-r sm:pr-4">
+              <span className="text-muted-foreground text-sm">
+                {t("gabinet.reports.last7days")}
+              </span>
+              <span className="text-xl font-semibold">
+                {formatCurrencyPLN(actualLast7, currency, { fractionDigits: 0 })}
+              </span>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-muted-foreground text-sm">
+                {t("gabinet.reports.periodTotal")}
+              </span>
+              <span className="text-xl font-semibold">
+                {formatCurrencyPLN(actualTotal, currency, { fractionDigits: 0 })}
+              </span>
+            </div>
+          </div>
         </div>
       </CardContent>
     </Card>
@@ -866,8 +908,11 @@ function GabinetReports() {
   const { data: gratisBarterIds, isLoading: loadingGratisBarter } =
     useSupabaseGratisBarterAppointmentIds(organizationId, completedAppointmentIds);
 
+  const { data: actualPayments, isLoading: loadingActualPayments } =
+    useSupabasePaymentsRevenueByDateRange(organizationId, startDate, endDate);
+
   const isLoading =
-    loadingAppointments || loadingTreatments || loadingPatients || loadingEmployees || loadingGratisBarter;
+    loadingAppointments || loadingTreatments || loadingPatients || loadingEmployees || loadingGratisBarter || loadingActualPayments;
 
   // Treatment map: id → { name, price, currency }
   const treatmentMap = useMemo(() => {
@@ -1002,6 +1047,20 @@ function GabinetReports() {
       };
     }, [appointments, treatmentMap, sevenDaysBeforeEnd, endDate, gratisBarterIds]);
 
+  const { actualTotal, actualLast7, actualLastDay } = useMemo(() => {
+    let total = 0, last7 = 0, lastDay = 0;
+    if (actualPayments) {
+      const sevenDaysBeforeEndTs = new Date(sevenDaysBeforeEnd + "T00:00:00.000Z").getTime();
+      const endDayStartTs = new Date(endDate + "T00:00:00.000Z").getTime();
+      for (const p of actualPayments) {
+        total += p.amount;
+        if (p.paidAt >= sevenDaysBeforeEndTs) last7 += p.amount;
+        if (p.paidAt >= endDayStartTs) lastDay += p.amount;
+      }
+    }
+    return { actualTotal: total, actualLast7: last7, actualLastDay: lastDay };
+  }, [actualPayments, sevenDaysBeforeEnd, endDate]);
+
   const totalAppointments = appointments?.length ?? 0;
   const completedCount =
     appointments?.filter((a) => a.status === "completed").length ?? 0;
@@ -1062,9 +1121,12 @@ function GabinetReports() {
     rows.push({ section: "summary", metric: "cancelled", value: cancelledCount, revenue: "" });
     rows.push({ section: "summary", metric: "totalPatients", value: totalPatients, revenue: "" });
     rows.push({ section: "summary", metric: "completionRate", value: completionRate, revenue: "" });
-    rows.push({ section: "revenue", metric: "lastDay", value: lastDayRevenue, revenue: "" });
-    rows.push({ section: "revenue", metric: "last7days", value: last7Revenue, revenue: "" });
-    rows.push({ section: "revenue", metric: "total", value: totalRevenue, revenue: "" });
+    rows.push({ section: "revenue_estimated", metric: "lastDay", value: lastDayRevenue, revenue: "" });
+    rows.push({ section: "revenue_estimated", metric: "last7days", value: last7Revenue, revenue: "" });
+    rows.push({ section: "revenue_estimated", metric: "total", value: totalRevenue, revenue: "" });
+    rows.push({ section: "revenue_actual", metric: "lastDay", value: actualLastDay, revenue: "" });
+    rows.push({ section: "revenue_actual", metric: "last7days", value: actualLast7, revenue: "" });
+    rows.push({ section: "revenue_actual", metric: "total", value: actualTotal, revenue: "" });
     for (const tr of treatmentStats) {
       rows.push({ section: "treatment", metric: tr.name, value: tr.count, revenue: tr.revenue });
     }
@@ -1102,6 +1164,9 @@ function GabinetReports() {
     lastDayRevenue,
     last7Revenue,
     totalRevenue,
+    actualLastDay,
+    actualLast7,
+    actualTotal,
     treatmentStats,
     statusStats,
     dailyStats,
@@ -1224,6 +1289,9 @@ function GabinetReports() {
           last7Revenue={last7Revenue}
           totalRevenue={totalRevenue}
           currency={defaultCurrency}
+          actualLastDay={actualLastDay}
+          actualLast7={actualLast7}
+          actualTotal={actualTotal}
         />
       </div>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2246.

Closes #2246

---

## Claude summary

The fix is committed. Here's what was done:

**Root cause**: The `payments` table stored actual collected amounts but the reports page only used it to filter out gratis/barter appointments — the revenue card displayed estimated revenue (sum of `priceAtBooking` from completed appointments) with no way to see what was actually collected.

**Fix (4 files):**

1. `src/hooks/use-supabase-payments.ts` — added `useSupabasePaymentsRevenueByDateRange` hook that queries completed, non-gratis/barter payments with a non-null `paid_at` within the selected date range, returning per-payment `{ amount, paidAt, currency }` records.

2. `src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx` — called the new hook, computed `actualTotal`/`actualLast7`/`actualLastDay` in a `useMemo`, updated `RevenueSummaryCard` to show two labeled sections ("Estimated from completed appointments" and "Based on recorded payments"), and included both sections in the CSV export (`revenue_estimated` / `revenue_actual`).

3. `public/locales/pl/translation.json` + `public/locales/en/translation.json` — added `collectedFromPayments` key ("Na podstawie płatności" / "Based on recorded payments").

## Follow-ups

- Add Postgres index on `(organization_id, status, paid_at)` in payments: the new reports query filters by all three; the existing `payments_org_status_idx` covers `(organization_id, status)` but adding `paid_at` as a third column would avoid a sequential scan over the date range for busy clinics.