### PR TITLE
Add Postgres index on `(organization_id, status, paid_at)` in payments

### DIFF
--- a/supabase/migrations/00024_payments_org_status_paid_at_idx.sql
+++ b/supabase/migrations/00024_payments_org_status_paid_at_idx.sql
@@ -1,0 +1,6 @@
+-- Add composite index on (organization_id, status, paid_at) for the reports
+-- revenue query, which filters by all three columns. The existing
+-- payments_org_status_idx only covers (organization_id, status), leaving
+-- a sequential scan over the date range for the matching rows.
+CREATE INDEX IF NOT EXISTS payments_org_status_paid_at_idx
+  ON payments (organization_id, status, paid_at);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2249.

Closes #2249

---

## Claude summary

Done. The issue is real: the reports query in `src/hooks/use-supabase-payments.ts:168-177` filters by `organization_id`, `status = 'completed'`, and a `paid_at` range, but the existing index `payments_org_status_idx` only covers the first two columns. I added migration `00024_payments_org_status_paid_at_idx.sql` which creates `payments_org_status_paid_at_idx ON payments (organization_id, status, paid_at)` — Postgres will now be able to satisfy the entire filter from the index, avoiding a heap scan over the date range.