### PR TITLE
Magazyn CD

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -831,12 +831,12 @@ function ProductsPage() {
 
           <div className="space-y-1.5">
             <Label>{t("products.sections.label", { defaultValue: "Sekcja" })}</Label>
-            <Select value={productSection} onValueChange={(v) => setProductSection(v as ProductSection | "")}>
+            <Select value={productSection || "none"} onValueChange={(v) => setProductSection(v === "none" ? "" : v as ProductSection)}>
               <SelectTrigger>
                 <SelectValue placeholder={t("products.sections.placeholder", { defaultValue: "Wybierz sekcję" })} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">{t("products.sections.none", { defaultValue: "Bez sekcji" })}</SelectItem>
+                <SelectItem value="none">{t("products.sections.none", { defaultValue: "Bez sekcji" })}</SelectItem>
                 {PRODUCT_SECTIONS.map((section) => (
                   <SelectItem key={section} value={section}>
                     {t(`products.sections.${section}`)}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2237.

Closes #2237

---

## Claude summary

The bug was on line 839 of `_layout.products.index.tsx`. The "Sekcja" (section) Select had `<SelectItem value="">Bez sekcji</SelectItem>` — Radix UI Select reserves the empty string to represent "no selection / show placeholder", so it throws when any item carries that value.

The fix replaces the empty-string value with the sentinel `"none"`, and converts it back to `""` (which the submit handler already normalises to `null` via `productSection || null`) in the `onValueChange` callback. Internal state and API payload are unchanged.