### PR TITLE
Magazyn CD

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -831,12 +831,12 @@ function ProductsPage() {
 
           <div className="space-y-1.5">
             <Label>{t("products.sections.label", { defaultValue: "Sekcja" })}</Label>
-            <Select value={productSection} onValueChange={(v) => setProductSection(v as ProductSection | "")}>
+            <Select value={productSection || "none"} onValueChange={(v) => setProductSection(v === "none" ? "" : v as ProductSection)}>
               <SelectTrigger>
                 <SelectValue placeholder={t("products.sections.placeholder", { defaultValue: "Wybierz sekcję" })} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">{t("products.sections.none", { defaultValue: "Bez sekcji" })}</SelectItem>
+                <SelectItem value="none">{t("products.sections.none", { defaultValue: "Bez sekcji" })}</SelectItem>
                 {PRODUCT_SECTIONS.map((section) => (
                   <SelectItem key={section} value={section}>
                     {t(`products.sections.${section}`)}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2237.

Closes #2237

---

## Claude summary

Fixed. The crash was at `_layout.products.index.tsx:839` — the "Bez sekcji" `<SelectItem>` had `value=""`, which Radix UI Select forbids (it reserves the empty string to signal "show placeholder / no selection").

The fix replaces the item value with the sentinel `"none"` and converts it back to `""` in the `onValueChange` callback. The `productSection` state, the `productSection || null` submit normalisation (line 422), and the edit-prefill logic (line 391) are all untouched.