### PR TITLE
Przetłumaczyć wszystkie elementy “Form field” w kreatorze szablonów dokumentów

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -4307,11 +4307,14 @@
       "typeTextarea": "Textarea",
       "typeDate": "Date",
       "typeCheckbox": "Checkbox",
+      "typeButtonSelect": "Buttons (Yes/No)",
       "optionsLabel": "Options (comma-separated)",
+      "optionsPlaceholder": "No, Yes, Yes — requires discussion",
       "placeholderLabel": "Placeholder",
       "placeholderPlaceholder": "Enter value...",
       "done": "Done",
-      "fieldFallback": "Field"
+      "fieldFallback": "Field",
+      "newFieldLabel": "New field"
     }
   },
   "documentEditor": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -4333,11 +4333,14 @@
       "typeTextarea": "Pole tekstowe",
       "typeDate": "Data",
       "typeCheckbox": "Pole wyboru",
+      "typeButtonSelect": "Przyciski (Tak/Nie)",
       "optionsLabel": "Opcje (oddzielone przecinkiem)",
+      "optionsPlaceholder": "Nie, Tak, Tak — wymaga omówienia",
       "placeholderLabel": "Tekst pomocniczy",
       "placeholderPlaceholder": "Wpisz wartość...",
       "done": "Gotowe",
-      "fieldFallback": "Pole"
+      "fieldFallback": "Pole",
+      "newFieldLabel": "Nowe pole"
     }
   },
   "documentEditor": {

--- a/src/components/documents/form-field-node.tsx
+++ b/src/components/documents/form-field-node.tsx
@@ -23,6 +23,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
+import i18n from "@/i18n";
 import {
   Type,
   AlignLeft,
@@ -117,7 +118,7 @@ function FormFieldConfig({
             <SelectItem value="text">{t("formEditor.formField.typeText")}</SelectItem>
             <SelectItem value="textarea">{t("formEditor.formField.typeTextarea")}</SelectItem>
             <SelectItem value="select">{t("common.select")}</SelectItem>
-            <SelectItem value="button_select">Przyciski (Tak/Nie)</SelectItem>
+            <SelectItem value="button_select">{t("formEditor.formField.typeButtonSelect")}</SelectItem>
             <SelectItem value="date">{t("formEditor.formField.typeDate")}</SelectItem>
             <SelectItem value="checkbox">{t("formEditor.formField.typeCheckbox")}</SelectItem>
           </SelectContent>
@@ -131,7 +132,7 @@ function FormFieldConfig({
             value={attrs.options}
             onChange={(e) => onChange({ options: e.target.value })}
             className="h-8 text-sm"
-            placeholder="Nie, Tak, Tak — wymaga omówienia"
+            placeholder={t("formEditor.formField.optionsPlaceholder")}
           />
         </div>
       )}
@@ -274,7 +275,7 @@ export const FormFieldNode = Node.create({
           : "inline-flex items-center rounded border border-dashed border-orange-300 bg-orange-50 px-2 py-0.5 text-xs text-orange-700",
         contenteditable: "false",
       }),
-      `[${HTMLAttributes.label || HTMLAttributes.fieldId || "Field"}]`,
+      `[${HTMLAttributes.label || HTMLAttributes.fieldId || i18n.t("formEditor.formField.fieldFallback")}]`,
     ];
   },
 
@@ -298,7 +299,7 @@ export function insertFormField(
     .focus()
     .insertContent({
       type: "formField",
-      attrs: { fieldId, fieldType: "text", label: "New field", filledBy: "client", ...attrs },
+      attrs: { fieldId, fieldType: "text", label: i18n.t("formEditor.formField.newFieldLabel"), filledBy: "client", ...attrs },
     })
     .run();
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2242.

Closes #2242

---

## Claude summary

Done. Here's what was fixed:

**Files changed:**

`src/components/documents/form-field-node.tsx` — 4 fixes:
- `"New field"` (default label when inserting a new form field into the editor) → now reads from `i18n.t("formEditor.formField.newFieldLabel")` → **"Nowe pole"** in Polish
- `"Field"` (HTML rendering fallback in `renderHTML`) → now reads from `i18n.t("formEditor.formField.fieldFallback")` → **"Pole"** in Polish (key already existed)
- `Przyciski (Tak/Nie)` (button_select type option in dropdown) → now uses `t("formEditor.formField.typeButtonSelect")`
- `Nie, Tak, Tak — wymaga omówienia` (options input placeholder) → now uses `t("formEditor.formField.optionsPlaceholder")`

`public/locales/pl/translation.json` — added 3 keys under `formEditor.formField`:
- `typeButtonSelect`: "Przyciski (Tak/Nie)"
- `optionsPlaceholder`: "Nie, Tak, Tak — wymaga omówienia"
- `newFieldLabel`: "Nowe pole"

`public/locales/en/translation.json` — added 3 matching keys with English values.

The `i18n` singleton (from `src/i18n.ts`) is imported directly for use in the non-React `renderHTML` and `insertFormField` functions, which can't use the `useTranslation` hook.