### PR TITLE
Mobile — przewijanie kategorii magazynu

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -685,16 +685,18 @@ function ProductsPage() {
       </div>
 
       <Tabs value={activeSection} onValueChange={(v) => handleSectionChange(v as ProductSection | "all")}>
-        <TabsList>
-          <TabsTrigger value="all">
-            {t("products.sections.all", { defaultValue: "Wszystkie" })}
-          </TabsTrigger>
-          {PRODUCT_SECTIONS.map((section) => (
-            <TabsTrigger key={section} value={section}>
-              {t(`products.sections.${section}`)}
+        <div className="overflow-x-auto">
+          <TabsList>
+            <TabsTrigger value="all">
+              {t("products.sections.all", { defaultValue: "Wszystkie" })}
             </TabsTrigger>
-          ))}
-        </TabsList>
+            {PRODUCT_SECTIONS.map((section) => (
+              <TabsTrigger key={section} value={section}>
+                {t(`products.sections.${section}`)}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </div>
       </Tabs>
 
       {nudgeFilter === "unused" && (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2256.

Closes #2256

---

## Claude summary

The fix is committed. Here's a summary:

**Root cause:** The `TabsList` component uses `inline-flex` which doesn't scroll — on mobile, the 4 Polish category labels overflow without any scrollable container.

**Fix:** Wrapped the `TabsList` in a `<div className="overflow-x-auto">` at `src/routes/_app/_auth/dashboard/_layout.products.index.tsx:688`. Since `TabsTrigger` already uses `whitespace-nowrap`, the tabs stay on a single line and the user can swipe horizontally to reach all of them. The filtering logic is untouched.