### PR TITLE
Tworzenie produktu — brak wyboru kategorii produktu

### DIFF
--- a/src/components/forms/product-form.tsx
+++ b/src/components/forms/product-form.tsx
@@ -49,6 +49,9 @@ interface CategoryDef {
   color?: string;
 }
 
+const PRODUCT_SECTIONS = ["sale", "treatment", "disposable"] as const;
+type ProductSection = (typeof PRODUCT_SECTIONS)[number];
+
 export interface ProductFormData {
   name: string;
   description?: string | null;
@@ -59,6 +62,7 @@ export interface ProductFormData {
   isActive: boolean;
   tagIds?: Id<"tagDefinitions">[];
   categoryId?: Id<"categoryDefinitions"> | null;
+  productSection?: ProductSection | null;
 }
 
 interface ProductFormProps {
@@ -91,6 +95,7 @@ export function ProductForm({
   const [isActive, setIsActive] = useState(initialData?.isActive ?? true);
   const [tagIds, setTagIds] = useState<Id<"tagDefinitions">[]>(initialData?.tagIds ?? []);
   const [categoryId, setCategoryId] = useState<Id<"categoryDefinitions"> | undefined>(initialData?.categoryId ?? undefined);
+  const [productSection, setProductSection] = useState<ProductSection | "">(initialData?.productSection ?? "");
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -110,6 +115,7 @@ export function ProductForm({
       isActive,
       tagIds: tagIds.length > 0 ? tagIds : undefined,
       categoryId: categoryId || null,
+      productSection: productSection || null,
     });
   };
 
@@ -137,6 +143,22 @@ export function ProductForm({
             placeholder={t("products.form.skuPlaceholder")}
             required
           />
+        </div>
+        <div className="space-y-1.5 sm:col-span-2">
+          <Label>{t("products.sections.label", { defaultValue: "Sekcja" })}</Label>
+          <Select value={productSection || "none"} onValueChange={(v) => setProductSection(v === "none" ? "" : v as ProductSection)}>
+            <SelectTrigger>
+              <SelectValue placeholder={t("products.sections.placeholder", { defaultValue: "Wybierz sekcję" })} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none">{t("products.sections.none", { defaultValue: "Bez sekcji" })}</SelectItem>
+              {PRODUCT_SECTIONS.map((section) => (
+                <SelectItem key={section} value={section}>
+                  {t(`products.sections.${section}`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
         <div className="space-y-1.5">
           <Label>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2257.

Closes #2257

---

## Claude summary

The fix is committed. Here's what was happening and what I changed:

**Root cause:** There are two paths for creating a product:
1. The products page (`/dashboard/products`) — uses an inline form inside the SidePanel, which already had the "Sekcja" selector.
2. The global quick-create menu (sidebar "+" button → "Produkt") — uses the shared `ProductForm` component (`src/components/forms/product-form.tsx`), which was **missing** the `productSection` field entirely.

**Fix in `src/components/forms/product-form.tsx`:**
- Added `PRODUCT_SECTIONS` constant and `ProductSection` type (mirroring `_layout.products.index.tsx`)
- Added `productSection?: ProductSection | null` to `ProductFormData`
- Added `productSection` state initialized from `initialData`
- Added the `productSection` Select UI between the SKU and unit-price fields
- Passes `productSection: productSection || null` on submit — which gets spread into `createProduct` in `_layout.tsx`, where `productSection` is already an accepted argument

## Follow-ups
- Sync `ProductForm` component with inline products form for other fields: the inline form in `_layout.products.index.tsx` also has `trackStock`, `stockUnit`, `initialStock`, `minStock`, `manufacturer`, `catalogNumber`, and `stockNote` fields that are absent from the shared `ProductForm` component — quick-create products via the sidebar cannot set any of these warehouse fields