### PR TITLE
Quick-create `renderQuickCreateForm` callback excludes `orgTags`, `contactCatego

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -768,7 +768,7 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
           return null;
       }
     },
-    [firstOrg, isCreating, createContact, createCompany, createLead, createPatient, createTreatment, createPackage, createEmployee, createActivity, createLeave, createInvitation, createProduct, createCall, user, queryClient]
+    [firstOrg, isCreating, createContact, createCompany, createLead, createPatient, createTreatment, createPackage, createEmployee, createActivity, createLeave, createInvitation, createProduct, createCall, user, queryClient, orgTags, contactCategories, patientCategories, productCategories, contactCustomFieldDefs]
   );
 
   const pathname = useRouterState({ select: (s) => s.location.pathname });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2265.

Closes #2265

---

## Claude summary

The bug was real and the fix is clean. In `src/routes/_app/_auth/dashboard/_layout.tsx:771`, the `useCallback` deps array for `renderQuickCreateForm` was missing five variables that are read inside the callback:

- `orgTags` — passed as `tagDefinitions` to ContactForm, PatientForm, and ProductForm
- `contactCategories` — passed as `categoryDefinitions` to ContactForm
- `patientCategories` — passed as `categoryDefinitions` to PatientForm
- `productCategories` — passed as `categoryDefinitions` to ProductForm
- `contactCustomFieldDefs` — passed as `customFieldDefinitions` to ContactForm and used to build the `customFields` payload on submit

Without these in the deps array, the callback is memoized with stale references after the first render, so any category or tag changes fetched later in the session wouldn't be reflected in the quick-create forms until the whole page remounted.