### PR TITLE
Audyt formularza produktu — poprawa UX (SKU + nazewnictwo „Sekcja”)

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -883,9 +883,9 @@
       "sale": "Sales Products",
       "treatment": "Treatment Preparations",
       "disposable": "Disposable Materials",
-      "label": "Section",
-      "placeholder": "Select section",
-      "none": "No section"
+      "label": "Product type",
+      "placeholder": "Select product type",
+      "none": "None"
     },
     "form": {
       "name": "Product Name",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -884,9 +884,9 @@
       "sale": "Produkty do sprzedaży",
       "treatment": "Preparaty zabiegowe",
       "disposable": "Materiały jednorazowe",
-      "label": "Sekcja",
-      "placeholder": "Wybierz sekcję",
-      "none": "Bez sekcji"
+      "label": "Rodzaj produktu",
+      "placeholder": "Wybierz rodzaj produktu",
+      "none": "Brak"
     },
     "form": {
       "name": "Nazwa produktu",

--- a/src/components/forms/product-form.tsx
+++ b/src/components/forms/product-form.tsx
@@ -183,14 +183,11 @@ export function ProductForm({
           />
         </div>
         <div className="space-y-1.5">
-          <Label>
-            {t("products.form.sku")} <span className="text-destructive">*</span>
-          </Label>
+          <Label>{t("products.form.sku")}</Label>
           <Input
             value={sku}
             onChange={(e) => setSku(e.target.value)}
             placeholder={t("products.form.skuPlaceholder")}
-            required
           />
         </div>
         <div className="space-y-3 sm:col-span-2">
@@ -214,13 +211,13 @@ export function ProductForm({
           </div>
         </div>
         <div className="space-y-1.5 sm:col-span-2">
-          <Label>{t("products.sections.label", { defaultValue: "Sekcja" })}</Label>
+          <Label>{t("products.sections.label", { defaultValue: "Rodzaj produktu" })}</Label>
           <Select value={productSection || "none"} onValueChange={(v) => setProductSection(v === "none" ? "" : v as ProductSection)}>
             <SelectTrigger>
-              <SelectValue placeholder={t("products.sections.placeholder", { defaultValue: "Wybierz sekcję" })} />
+              <SelectValue placeholder={t("products.sections.placeholder", { defaultValue: "Wybierz rodzaj produktu" })} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="none">{t("products.sections.none", { defaultValue: "Bez sekcji" })}</SelectItem>
+              <SelectItem value="none">{t("products.sections.none", { defaultValue: "Brak" })}</SelectItem>
               {PRODUCT_SECTIONS.map((section) => (
                 <SelectItem key={section} value={section}>
                   {t(`products.sections.${section}`)}

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -391,7 +391,7 @@ function ProductsPage() {
     },
     {
       id: "productSection",
-      label: t("products.sections.label", { defaultValue: "Sekcja" }),
+      label: t("products.sections.label", { defaultValue: "Rodzaj produktu" }),
       render: (item) => {
         if (!item.productSection) return "—";
         return t(`products.sections.${item.productSection}`, { defaultValue: item.productSection });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2267.

Closes #2267

---

## Claude summary

Done. Here's a summary of what was changed across 4 files:

**SKU field (issue #1):** Removed the `required` attribute and the red asterisk from the SKU input in `product-form.tsx`. The auto-generation logic (`generateSku()`) and the pre-filled value are untouched — the field still shows the generated SKU and the user can override it, but the browser no longer blocks form submission if it's empty.

**"Sekcja" → "Rodzaj produktu" (issue #2 & #3):** Updated the `products.sections.label` translation key in both `pl/translation.json` ("Sekcja" → "Rodzaj produktu") and `en/translation.json` ("Section" → "Product type"), plus the corresponding placeholder and "none" option text. Since both the product form and the products table column header read from this same translation key, both surfaces update automatically. The fallback `defaultValue` strings in the component code were updated to match. The underlying values (sale / treatment / disposable) and all business logic are unchanged.