### PR TITLE
Tabela produktów — zawijanie nagłówków kolumn i poprawa szerokości

### DIFF
--- a/src/components/application/table/table.tsx
+++ b/src/components/application/table/table.tsx
@@ -183,9 +183,11 @@ TableHeader.displayName = "TableHeader";
 interface TableHeadProps extends AriaColumnProps, Omit<ThHTMLAttributes<HTMLTableCellElement>, "children" | "className" | "style" | "id"> {
     label?: string;
     tooltip?: string;
+    /** Extra className applied to the inner label <span>. Use to allow header text to wrap (e.g. whitespace-normal leading-tight). */
+    labelClassName?: string;
 }
 
-const TableHead = ({ className, tooltip, label, children, ...props }: TableHeadProps) => {
+const TableHead = ({ className, tooltip, label, labelClassName, children, ...props }: TableHeadProps) => {
     return (
         <AriaColumn
             {...props}
@@ -200,7 +202,7 @@ const TableHead = ({ className, tooltip, label, children, ...props }: TableHeadP
             {(state) => (
                 <AriaGroup className="flex items-center gap-1">
                     <div className="flex items-center gap-1">
-                        {label && <span className="text-xs font-semibold whitespace-nowrap text-fg-quaternary">{label}</span>}
+                        {label && <span className={cx("text-xs font-semibold whitespace-nowrap text-fg-quaternary", labelClassName)}>{label}</span>}
                         {typeof children === "function" ? children(state) : children}
                     </div>
 

--- a/src/components/crm/enhanced-data-table.tsx
+++ b/src/components/crm/enhanced-data-table.tsx
@@ -26,6 +26,8 @@ export interface CrmColumn<TData> {
   isRowHeader?: boolean;
   /** Extra className on <Table.Head> and <Table.Cell>. */
   className?: string;
+  /** Extra className on the label <span> inside <Table.Head>. Use to allow long headers to wrap (e.g. whitespace-normal leading-tight). */
+  headerClassName?: string;
   /** Render cell content for this column. */
   render: (item: TData) => ReactNode;
   /** Value used for sorting. Required if `sortable` is true. */
@@ -251,6 +253,7 @@ export function CrmDataTable<TData>({
                   allowsSorting={col.sortable}
                   isRowHeader={col.isRowHeader}
                   className={col.className}
+                  labelClassName={col.headerClassName}
                 />
               ))}
               {hasActions && <Table.Head id="actions" />}

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -433,6 +433,7 @@ function ProductsPage() {
     {
       id: "minStock",
       label: t("products.stock.minLabel", { defaultValue: "Min. stan" }),
+      headerClassName: "whitespace-normal leading-tight",
       render: (item) => {
         if (!item.trackStock || item.minStock == null) return "—";
         const unit = item.stockUnit?.trim();
@@ -444,18 +445,21 @@ function ProductsPage() {
     {
       id: "catalogNumber",
       label: t("products.catalogNumber", { defaultValue: "Nr katalogowy" }),
+      headerClassName: "whitespace-normal leading-tight",
       render: (item) => item.catalogNumber ?? "—",
     },
     {
       id: "unitPrice",
       label: t('products.unitPrice'),
+      headerClassName: "whitespace-normal leading-tight",
       sortable: true,
       render: (item) => formatCurrency(item.unitPrice),
       getSortValue: (item) => item.unitPrice,
     },
     {
       id: "taxRate",
-      label: t('products.taxRate'),
+      label: t("products.taxRateShort", { defaultValue: "Stawka VAT (%)" }),
+      headerClassName: "whitespace-normal leading-tight",
       render: (item) => {
         if (item.taxExempt) return "ZW";
         if (item.taxRate == null) return "—";


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2269.

Closes #2269

---

## Claude summary

Done. Here's what changed:

**`src/components/application/table/table.tsx`** — Added a `labelClassName` prop to `TableHead`. When supplied, it's merged with the existing `whitespace-nowrap` classes via `cx()`, so `whitespace-normal` will win and allow wrapping.

**`src/components/crm/enhanced-data-table.tsx`** — Added `headerClassName?: string` to `CrmColumn` and passes it as `labelClassName` to `Table.Head`. No other tables are affected.

**`src/routes/_app/_auth/dashboard/_layout.products.index.tsx`** — Applied `headerClassName: "whitespace-normal leading-tight"` to four columns: `unitPrice` (Cena jednostkowa), `taxRate` (renamed to Stawka VAT (%) per the issue suggestion), `catalogNumber` (Nr katalogowy), and `minStock` (Min. stan). Because table layout sizes columns to their data cell content, removing `whitespace-nowrap` lets the browser wrap the header text to fit the narrower data-driven column width automatically — no explicit `max-width` needed.