### PR TITLE
Rodzaj produktu — delikatne wyróżnienie pola

### DIFF
--- a/src/components/forms/product-form.tsx
+++ b/src/components/forms/product-form.tsx
@@ -213,7 +213,7 @@ export function ProductForm({
         <div className="space-y-1.5 sm:col-span-2">
           <Label>{t("products.sections.label", { defaultValue: "Rodzaj produktu" })}</Label>
           <Select value={productSection || "none"} onValueChange={(v) => setProductSection(v === "none" ? "" : v as ProductSection)}>
-            <SelectTrigger>
+            <SelectTrigger className={!productSection ? "border-purple-300 bg-purple-50/50 dark:border-purple-700 dark:bg-purple-950/20" : ""}>
               <SelectValue placeholder={t("products.sections.placeholder", { defaultValue: "Wybierz rodzaj produktu" })} />
             </SelectTrigger>
             <SelectContent>
@@ -225,6 +225,11 @@ export function ProductForm({
               ))}
             </SelectContent>
           </Select>
+          {!productSection && (
+            <p className="text-xs text-purple-600 dark:text-purple-400">
+              {t("products.sections.hint", { defaultValue: "Wybierz rodzaj produktu, aby poprawnie organizować magazyn." })}
+            </p>
+          )}
         </div>
         <div className="space-y-1.5">
           <Label>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2271.

Closes #2271

---

## Claude summary

Done. Here's what was changed in `src/components/forms/product-form.tsx`:

- `SelectTrigger` now receives a conditional `className` that applies `border-purple-300 bg-purple-50/50` (dark: `border-purple-700 bg-purple-950/20`) only when `productSection` is empty — i.e., "Brak" is selected or nothing has been chosen yet.
- A `<p>` element with the helper text "Wybierz rodzaj produktu, aby poprawnie organizować magazyn." renders below the select in the same condition, styled as small purple text (`text-xs text-purple-600`).
- Both effects disappear immediately once the user picks any product section.

No business logic, no schema changes, no validation added — purely a visual UX hint.