### PR TITLE
Mobile: brak drugiego poziomu nawigacji w Ustawieniach CRM

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.tsx
@@ -1,9 +1,53 @@
-import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { createFileRoute, Outlet, Link, useMatchRoute } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { convexQuery } from "@convex-dev/react-query";
+import { api } from "@cvx/_generated/api";
+import { useOrganization } from "@/components/org-context";
+import { useTranslation } from "react-i18next";
+import { getVisibleModules } from "@/modules/registry";
+import { cn } from "@/utils/misc";
 
 export const Route = createFileRoute("/_app/_auth/dashboard/_layout/settings")({
   component: DashboardSettingsLayout,
 });
 
 export default function DashboardSettingsLayout() {
-  return <Outlet />;
+  const { t } = useTranslation();
+  const matchRoute = useMatchRoute();
+  const { organizationId } = useOrganization();
+
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen
+  const { data: activeProducts } = useQuery(
+    convexQuery(api.productSubscriptions.getActiveProducts, { organizationId }),
+  );
+
+  const settingsNav = getVisibleModules(activeProducts).flatMap((m) => m.settingsNav);
+
+  return (
+    <>
+      {/* Mobile settings navigation — horizontal scroll, hidden on lg+ where sidebar handles it */}
+      <div className="lg:hidden -mx-4 sm:-mx-6 mb-4 overflow-x-auto border-b">
+        <nav className="flex gap-1 px-4 sm:px-6 py-2">
+          {settingsNav.map((item) => {
+            const isActive = !!matchRoute({ to: item.to });
+            return (
+              <Link
+                key={item.to}
+                to={item.to}
+                className={cn(
+                  "shrink-0 whitespace-nowrap rounded-md px-3 py-1.5 text-sm transition-colors",
+                  isActive
+                    ? "bg-primary/10 font-medium text-primary"
+                    : "text-foreground hover:bg-muted-foreground/10",
+                )}
+              >
+                {t(item.labelKey)}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+      <Outlet />
+    </>
+  );
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2274.

Closes #2274

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Root cause:** `_layout.settings.tsx` was just `<Outlet />` — it rendered settings content with no navigation. The second-level nav lives in `app-sidebar.tsx` inside a `div` with `max-lg:hidden`, so it's invisible on screens below 1024px.

**Fix:** Modified `_layout.settings.tsx` (single file change) to add a horizontally-scrollable settings nav bar that appears only on mobile/tablet (`lg:hidden`). It uses the same `settingsNav` data (from module manifests via `getVisibleModules`) that the desktop sidebar already uses, so all sections — Ogólne, Profil, Rozliczenia, Pipeline, Pola niestandardowe, Typy aktywności, Powody przegrania, Źródła, Zespół, Uprawnienia, Dziennik audytu, Poczta, Automatyzacje, Szablony e-mail, Zdarzenia email, Integracje, Kalendarz Google, etc. — are accessible. Active state styling matches the desktop sidebar (`bg-primary/10 font-medium text-primary`). Desktop layout is untouched.