### PR TITLE
Add "Dodaj wizytę" deep-link to a pre-filled new-appointment modal

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
@@ -608,7 +608,7 @@ function GabinetDashboard() {
           {t("gabinet.dashboard.goToCalendar")}
         </Link>
         <Button asChild variant="outline" className="justify-start gap-2 h-auto py-3 px-3">
-          <Link to="/dashboard/gabinet/calendar">
+          <Link to="/dashboard/gabinet/calendar" search={{ action: "create-appointment" }}>
             <Plus className="size-4 shrink-0 text-muted-foreground" />
             {t("gabinet.dashboard.addAppointment", "Dodaj wizytę")}
           </Link>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2288.

Closes #2288

---

## Claude summary

The fix is committed. Here's the summary:

**Root cause**: The "Dodaj wizytę" quick-action button in the gabinet dashboard (`_layout.gabinet.index.tsx:611`) linked to `/dashboard/gabinet/calendar` with no search params, so it just opened the calendar page without triggering the create dialog.

**What already existed**: The calendar route (`_layout.gabinet.calendar.index.tsx`) already declares `action: "create-appointment"` as a valid search param, and the lazy component already has a `useEffect` (line 1006) that calls `openCreateDialog()` when `actionParam === "create-appointment"` and then clears the param to prevent dialog reopen on refresh.

**The fix**: One-character change — added `search={{ action: "create-appointment" }}` to the Link. The entire deep-link infrastructure was already in place; only the call site was missing the param.