### PR TITLE
Expose appointment revenue total on the KPI row

### DIFF
--- a/src/hooks/use-supabase-gabinet-dashboard.ts
+++ b/src/hooks/use-supabase-gabinet-dashboard.ts
@@ -321,6 +321,50 @@ export function useSupabaseGabinetTopTreatments(organizationId: string) {
 }
 
 // ---------------------------------------------------------------------------
+// Weekly Revenue (sparkline — 7 days)
+// ---------------------------------------------------------------------------
+
+export function useSupabaseGabinetWeeklyRevenue(organizationId: string) {
+  const { client, isReady } = useSupabase();
+  const startDate = dateNDaysAgo(6);
+
+  return useQuery<{ day: string; revenue: number }[], Error>({
+    queryKey: [...supabaseKeys.gabinetAppointments.list(organizationId), "weekly-revenue"],
+    queryFn: async () => {
+      if (!client) throw new Error("Supabase client not ready");
+
+      const { data, error } = await client
+        .from("gabinet_appointments")
+        .select("date, price_at_booking, status")
+        .eq("organization_id", organizationId)
+        .gte("date", startDate)
+        .not("status", "in", '("cancelled","no_show")')
+        .order("date");
+
+      if (error) throw error;
+      const rows = (data ?? []) as Pick<AppointmentRow, "date" | "price_at_booking" | "status">[];
+
+      const revenueByDate = new Map<string, number>();
+      for (const r of rows) {
+        revenueByDate.set(r.date, (revenueByDate.get(r.date) ?? 0) + (r.price_at_booking ?? 0));
+      }
+
+      const days: { day: string; revenue: number }[] = [];
+      for (let i = 6; i >= 0; i--) {
+        const d = new Date();
+        d.setDate(d.getDate() - i);
+        const dateStr = d.toISOString().split("T")[0];
+        const dayLabel = d.toLocaleDateString("pl-PL", { weekday: "short" });
+        days.push({ day: dayLabel, revenue: revenueByDate.get(dateStr) ?? 0 });
+      }
+      return days;
+    },
+    enabled: isReady && !!organizationId,
+    staleTime: 60_000,
+  } satisfies UseQueryOptions<{ day: string; revenue: number }[], Error>);
+}
+
+// ---------------------------------------------------------------------------
 // Nudges
 // ---------------------------------------------------------------------------
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
@@ -14,6 +14,7 @@ import {
   useSupabaseGabinetMonthlyAppointments,
   useSupabaseGabinetAppointmentStatusDistribution,
   useSupabaseGabinetTopTreatments,
+  useSupabaseGabinetWeeklyRevenue,
 } from "@/hooks/use-supabase-gabinet-dashboard";
 import { PageHeader } from "@/components/layout/page-header";
 import { Badge } from "@/components/ui/badge";
@@ -136,6 +137,7 @@ function GabinetDashboard() {
   const { data: weeklyAppointments } = useSupabaseGabinetWeeklyAppointments(organizationId);
   const { data: monthlyPatients } = useSupabaseGabinetMonthlyNewPatients(organizationId);
   const { data: weeklyCompleted } = useSupabaseGabinetWeeklyCompletedTreatments(organizationId);
+  const { data: weeklyRevenue } = useSupabaseGabinetWeeklyRevenue(organizationId);
 
   // --- Chart block data (Supabase-backed) ---
   const { data: monthlyAppointments } = useSupabaseGabinetMonthlyAppointments(organizationId);
@@ -233,6 +235,19 @@ function GabinetDashboard() {
   const todayCount = enrichedAppointments.length;
   const completedTodayCount = enrichedAppointments.filter((a) => a.status === "completed").length;
 
+  const todayRevenue = useMemo(
+    () =>
+      enrichedAppointments
+        .filter((a) => a.status !== "cancelled" && a.status !== "no_show")
+        .reduce((sum, a) => sum + (a.priceAtBooking ?? 0), 0),
+    [enrichedAppointments],
+  );
+
+  const weeklyRevenueTotal = useMemo(
+    () => (weeklyRevenue ?? []).reduce((sum, d) => sum + d.revenue, 0),
+    [weeklyRevenue],
+  );
+
   // --- Build sparkline chart data for statistics cards ---
   const appointmentChartData = (weeklyAppointments ?? []).map((d) => ({
     day: d.day,
@@ -249,17 +264,10 @@ function GabinetDashboard() {
     profit: d.completed,
   }));
 
-  const leaveChartData = useMemo(() => {
-    const count = pendingLeaves.length;
-    return [
-      { month: "1", impression: Math.max(0, count - 2) },
-      { month: "2", impression: Math.max(0, count - 1) },
-      { month: "3", impression: count },
-      { month: "4", impression: Math.max(0, count + 1) },
-      { month: "5", impression: count },
-      { month: "6", impression: count },
-    ];
-  }, [pendingLeaves.length]);
+  const revenueChartData = (weeklyRevenue ?? []).map((d) => ({
+    month: d.day,
+    impression: d.revenue,
+  }));
 
   // --- TotalIncomeCard: monthly appointments area chart + summary ---
   const monthlyChartData = (monthlyAppointments ?? []).map((d) => ({
@@ -409,17 +417,17 @@ function GabinetDashboard() {
             gradientId="fillPatients"
           />
         </Link>
-        <Link to="/dashboard/gabinet/settings/leaves" className="block">
+        <Link to="/dashboard/gabinet/reports" className="block">
           <StatisticsImpressionCard
-            title={t("gabinet.dashboard.pendingLeaves")}
-            description={t("gabinet.dashboard.awaitingApproval", "Oczekujące")}
-            value={String(pendingLeaves.length)}
+            title={t("gabinet.dashboard.dailyRevenue", "Przychód dziś")}
+            description={t("gabinet.dashboard.fromAppointments", "z wizyt")}
+            value={`${todayRevenue.toFixed(2)} zł`}
             changePercentage={
-              pendingLeaves.length > 0
-                ? t("gabinet.dashboard.requiresAttention", "Wymaga uwagi")
-                : t("gabinet.dashboard.allClear", "Wszystko ok")
+              weeklyRevenue
+                ? `${weeklyRevenueTotal.toFixed(2)} zł ${t("gabinet.dashboard.thisWeekShort", "w tym tyg.")}`
+                : ""
             }
-            chartData={leaveChartData}
+            chartData={revenueChartData.length > 0 ? revenueChartData : undefined}
           />
         </Link>
       </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2289.

Closes #2289

---

## Claude summary

Done. Here's a summary of what was changed:

**`src/hooks/use-supabase-gabinet-dashboard.ts`** — Added `useSupabaseGabinetWeeklyRevenue` hook that queries `gabinet_appointments.price_at_booking` for the last 7 days (excluding `cancelled`/`no_show` statuses) and aggregates by day into a `{ day, revenue }` sparkline series.

**`src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx`** — Replaced the 4th KPI tile (pending-leaves count) with a "Przychód dziś" (daily revenue) tile:
- `todayRevenue` computed from already-fetched `todayAppointments` — sums `priceAtBooking` for all non-cancelled/no_show appointments today (zero extra network requests)
- `weeklyRevenueTotal` shown as the `changePercentage` label (e.g. "320.00 zł w tym tyg.")
- Sparkline from the new weekly revenue hook
- Card links to `/dashboard/gabinet/reports`
- Removed the now-unused `leaveChartData` derived array (pending leaves are still shown in section 7 at the bottom of the dashboard)

## Follow-ups

- Remove unused `totalTreatments` variable in gabinet dashboard: `src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx:234` assigns `totalTreatments` but it is never referenced anywhere in the component
- Add compact currency formatting utility: the dashboard uses raw `toFixed(2) + " zł"` in multiple places; a shared `formatPLN(amount)` helper would give consistent thousands-separator formatting for larger values