### PR TITLE
Remove unused `totalTreatments` variable in gabinet dashboard

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
@@ -231,7 +231,6 @@ function GabinetDashboard() {
 
   const pendingLeaves = (leavesData ?? []).filter((l) => l.status === "pending");
   const totalPatients = patientsData?.length ?? 0;
-  const totalTreatments = treatments?.length ?? 0;
   const todayCount = enrichedAppointments.length;
   const completedTodayCount = enrichedAppointments.filter((a) => a.status === "completed").length;
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2293.

Closes #2293

---

## Claude summary

Done. The unused `const totalTreatments = treatments?.length ?? 0;` on line 234 has been removed and committed. The `treatments` variable itself remains — it's used to build the `treatmentNameMap` memo for display in the packages section.