### PR TITLE
Add compact currency formatting utility

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
@@ -28,6 +28,7 @@ import { useTranslation } from "react-i18next";
 import type { ReactNode } from "react";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
+import { formatCurrencyPLN } from "@/lib/format-currency";
 
 import {
   CalendarCheck,
@@ -420,10 +421,10 @@ function GabinetDashboard() {
           <StatisticsImpressionCard
             title={t("gabinet.dashboard.dailyRevenue", "Przychód dziś")}
             description={t("gabinet.dashboard.fromAppointments", "z wizyt")}
-            value={`${todayRevenue.toFixed(2)} zł`}
+            value={formatCurrencyPLN(todayRevenue, "zł")}
             changePercentage={
               weeklyRevenue
-                ? `${weeklyRevenueTotal.toFixed(2)} zł ${t("gabinet.dashboard.thisWeekShort", "w tym tyg.")}`
+                ? `${formatCurrencyPLN(weeklyRevenueTotal, "zł")} ${t("gabinet.dashboard.thisWeekShort", "w tym tyg.")}`
                 : ""
             }
             chartData={revenueChartData.length > 0 ? revenueChartData : undefined}
@@ -543,11 +544,11 @@ function GabinetDashboard() {
                       </div>
                       <div className="text-right shrink-0">
                         <p className="text-sm font-semibold text-destructive">
-                          {remaining.toFixed(2)} zł
+                          {formatCurrencyPLN(remaining, "zł")}
                         </p>
                         {paid > 0 && (
                           <p className="text-muted-foreground text-xs">
-                            {t("gabinet.dashboard.paidPartial", "zapł.")} {paid.toFixed(2)} zł
+                            {t("gabinet.dashboard.paidPartial", "zapł.")} {formatCurrencyPLN(paid, "zł")}
                           </p>
                         )}
                       </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2294.

Closes #2294

---

## Claude summary

Done. The fix replaces the 4 raw `toFixed(2) + " zł"` usages on the gabinet dashboard with calls to the existing `formatCurrencyPLN` helper from `src/lib/format-currency.ts`. This gives amounts proper Polish-locale thousands-separator formatting (e.g. `10 000,00 zł` instead of `10000.00 zł`), consistent with the rest of the app.

One file changed: `src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx:31` (import added) and lines 424, 427, 547, 551 (4 formatting calls updated).

## Follow-ups

- Wire `formatCurrencyPLN` in convex/payments.ts: lines 936, 1029, and 1376 still use bare `amount.toFixed(2) + " zł"` in notification/email strings on the server side — those don't benefit from `Intl.NumberFormat` (server context), but a shared backend formatter would keep the style consistent if these strings are ever shown to users