### PR TITLE
Wire `formatCurrencyPLN` in convex/payments.ts

### DIFF
--- a/convex/_helpers/formatCurrency.ts
+++ b/convex/_helpers/formatCurrency.ts
@@ -1,0 +1,15 @@
+/**
+ * Backend equivalent of src/lib/format-currency.ts for use in Convex
+ * mutations/actions where notification and email strings are built.
+ * Keeps currency display consistent between server-generated strings and UI.
+ */
+export function formatCurrencyPLN(
+  amount: number,
+  currency = "PLN",
+): string {
+  const formatted = new Intl.NumberFormat("pl-PL", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+  return `${formatted} ${currency}`;
+}

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -12,6 +12,7 @@ import { paginationOptsValidator } from "convex/server";
 import { logAudit } from "./auditLog";
 import { logActivity } from "./_helpers/activities";
 import { createNotificationDirect } from "./notifications";
+import { formatCurrencyPLN } from "./_helpers/formatCurrency";
 import { sendEmail } from "@cvx/email";
 import { AUTH_RESEND_KEY, SITE_URL } from "@cvx/env";
 
@@ -933,7 +934,7 @@ export const _requestRefundAuthSideEffects = internalMutation({
       (m) => m.role === "owner" || m.role === "admin",
     );
 
-    const message = `${args.requesterName} prosi o autoryzację zwrotu ${args.amount.toFixed(2)} zł z salda klienta ${args.patientLabel}${args.notes ? ` (${args.notes})` : ""}.`;
+    const message = `${args.requesterName} prosi o autoryzację zwrotu ${formatCurrencyPLN(args.amount, "zł")} z salda klienta ${args.patientLabel}${args.notes ? ` (${args.notes})` : ""}.`;
     const link = `/dashboard/gabinet/patients/${args.patientId}?tab=payments`;
 
     // Shared requestId so approve/reject can find sibling notifications across
@@ -1026,7 +1027,7 @@ export const _sendRefundAuthEmails = internalAction({
 
     const path = `/dashboard/gabinet/patients/${args.patientId}?tab=payments`;
     const deepLink = SITE_URL ? `${SITE_URL}${path}` : path;
-    const amountLabel = `${args.amount.toFixed(2)} zł`;
+    const amountLabel = formatCurrencyPLN(args.amount, "zł");
     const subject = `Prośba o autoryzację zwrotu ${amountLabel} — ${orgName}`;
     const notesLine = args.notes
       ? `<p style="margin: 0 0 16px; color: #444;">Uwagi: ${escapeHtml(args.notes)}</p>`
@@ -1373,7 +1374,7 @@ export const _resolveRefundAuthSideEffects = internalMutation({
     // Tell the requester what happened so they don't keep refreshing the
     // patient page wondering whether their request landed.
     const requesterUserId = args.requesterId as Id<"users">;
-    const amountLabel = `${args.amount.toFixed(2)} zł`;
+    const amountLabel = formatCurrencyPLN(args.amount, "zł");
     const title =
       args.decision === "approved"
         ? "Zwrot zatwierdzony"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2298.

Closes #2298

---

## Claude summary

Done. Here's what was done:

Created `convex/_helpers/formatCurrency.ts` — a backend equivalent of `src/lib/format-currency.ts` that uses `Intl.NumberFormat("pl-PL", …)` to produce consistent Polish-locale formatting (e.g. `1 234,56 zł` with non-breaking-space thousands separator and comma decimal).

Replaced the three bare `amount.toFixed(2) + " zł"` expressions in `convex/payments.ts`:
- Line 937 — notification message when a refund auth request is sent to admins
- Line 1030 — email `amountLabel` used in subject line and HTML body
- Line 1377 — notification message when a refund decision (approve/reject) is sent to the requester