### PR TITLE
Fix totalPatients KPI date consistency

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3500,7 +3500,8 @@
       "goToCalendar": "Open Calendar",
       "goToPatients": "View Clients",
       "goToPackages": "View Packages",
-      "goToDocuments": "View Documents"
+      "goToDocuments": "View Documents",
+      "allTime": "Total"
     },
     "reports": {
       "title": "Gabinet Reports",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3522,7 +3522,8 @@
       "goToCalendar": "Otwórz kalendarz",
       "goToPatients": "Klienci",
       "goToPackages": "Pakiety",
-      "goToDocuments": "Dokumenty"
+      "goToDocuments": "Dokumenty",
+      "allTime": "Ogółem"
     },
     "reports": {
       "title": "Raporty Gabinetu",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
@@ -406,7 +406,7 @@ function GabinetDashboard() {
         <Link to="/dashboard/gabinet/patients" className="block">
           <StatisticsSalesGrowthCard
             title={t("gabinet.dashboard.totalPatients")}
-            description={t("gabinet.dashboard.last6Months", "Ostatnie 6 mies.")}
+            description={t("gabinet.dashboard.allTime", "Ogółem")}
             value={String(totalPatients)}
             changePercentage={
               monthlyPatients && monthlyPatients.length > 0


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2304.

Closes #2304

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Root cause:** In `_layout.gabinet.index.tsx:409`, the "Klienci" KPI card passed `description={t("gabinet.dashboard.last6Months", "Ostatnie 6 mies.")}` — but the `value` was `patientsData?.length` (an unfiltered all-time count from `useSupabaseGabinetPatientsList`). The description implied a 6-month date window that didn't actually apply to the number being displayed.

**Fix:** Changed the description to `t("gabinet.dashboard.allTime", "Ogółem")` ("Total") and added the `allTime` key to both `pl/translation.json` ("Ogółem") and `en/translation.json` ("Total"). The card now accurately describes what the value represents — an all-time count — without suggesting a filtered date range.