### PR TITLE
Panel Gabinetu — przetłumaczyć teksty kolejnej wizyty w aktywnych pakietach

### DIFF
--- a/src/components/gabinet/patient-packages-card.tsx
+++ b/src/components/gabinet/patient-packages-card.tsx
@@ -245,12 +245,12 @@ export function PatientPackagesCard({ patientId, organizationId }: PatientPackag
                         {nextAppointment
                           ? t(
                               "gabinet.packages.nextVisit",
-                              "Next visit: {{date}}",
+                              "Następna wizyta: {{date}}",
                               {
                                 date: new Date(nextAppointment.date).toLocaleDateString("pl-PL"),
                               },
                             )
-                          : t("gabinet.packages.noNextVisit", "No next visit booked")}
+                          : t("gabinet.packages.noNextVisit", "Brak zaplanowanej kolejnej wizyty")}
                       </p>
                     )}
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2300.

Closes #2300

---

## Claude summary

Done. The fix was straightforward — in `src/components/gabinet/patient-packages-card.tsx:248-253`, the two i18n fallback strings were in English. They're now:

- `"Next visit: {{date}}"` → `"Następna wizyta: {{date}}"`
- `"No next visit booked"` → `"Brak zaplanowanej kolejnej wizyty"`

The i18n keys (`gabinet.packages.nextVisit`, `gabinet.packages.noNextVisit`) are unchanged, so any translation files that already define those keys will continue to work. The `text-xs` class keeps the text compact for mobile.