### PR TITLE
Raporty — poprawić opis „Klienci ogółem”

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3530,6 +3530,7 @@
       "last7days": "Last 7 days",
       "last90days": "Last 90 days",
       "lastYear": "Last year",
+      "allClientsInSystem": "All clients in system",
       "statuses": {
         "pending_confirmation": "Pending",
         "scheduled": "Scheduled",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3552,6 +3552,7 @@
       "last7days": "Ostatnie 7 dni",
       "last90days": "Ostatnie 90 dni",
       "lastYear": "Ostatni rok",
+      "allClientsInSystem": "Łącznie w systemie",
       "statuses": {
         "pending_confirmation": "Oczekujące",
         "scheduled": "Zaplanowane",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -1434,9 +1434,9 @@ function GabinetReports() {
         />
         <StatisticsImpressionCard
           title={t("gabinet.reports.totalPatients")}
-          description={rangeLabel}
+          description={t("gabinet.reports.allClientsInSystem")}
           value={totalPatients.toLocaleString()}
-          changePercentage={rangeLabel}
+          changePercentage={t("gabinet.reports.allClientsInSystem")}
           chartData={revenueChartPoints.map((d) => ({ month: String(d.index), impression: d.count }))}
         />
       </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2308.

Closes #2308

---

## Claude summary

Done. Here's a summary of what was changed and why:

**Root cause confirmed:** `totalPatients` is fetched via `useSupabaseGabinetPatientsList` with no date filter — it always returns the all-time count for the organization. But the card passed `rangeLabel` (e.g. "Ostatnie 30 dni") to both `description` and `changePercentage`, making it look like the count was filtered by the selected period.

**Changes made (3 files):**

- `src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx:1437,1439` — replaced `{rangeLabel}` with `{t("gabinet.reports.allClientsInSystem")}` for both props
- `public/locales/pl/translation.json` — added `"allClientsInSystem": "Łącznie w systemie"`
- `public/locales/en/translation.json` — added `"allClientsInSystem": "All clients in system"`