### PR TITLE
Add `productSection` filter to `useSupabaseProductsList`

### DIFF
--- a/src/hooks/use-supabase-products.ts
+++ b/src/hooks/use-supabase-products.ts
@@ -46,6 +46,7 @@ interface UseSupabaseProductsListOptions {
   limit?: number;
   search?: string;
   sortOrder?: "asc" | "desc";
+  productSection?: string;
 }
 
 export function useSupabaseProductsList(
@@ -53,10 +54,10 @@ export function useSupabaseProductsList(
   options: UseSupabaseProductsListOptions = {},
 ) {
   const { client, isReady } = useSupabase();
-  const { enabled = true, limit = 100, search, sortOrder = "desc" } = options;
+  const { enabled = true, limit = 100, search, sortOrder = "desc", productSection } = options;
 
   return useQuery<MappedProduct[], Error>({
-    queryKey: [...supabaseKeys.products.list(organizationId), search ?? ""],
+    queryKey: [...supabaseKeys.products.list(organizationId), search ?? "", productSection ?? ""],
     queryFn: async (): Promise<MappedProduct[]> => {
       if (!client) throw new Error("Supabase client not ready");
 
@@ -64,6 +65,10 @@ export function useSupabaseProductsList(
         .from("products")
         .select("*")
         .eq("organization_id", organizationId);
+
+      if (productSection) {
+        query = query.eq("product_section", productSection);
+      }
 
       if (search?.trim()) {
         query = query.textSearch("search_vector", search.trim(), {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2313.

Closes #2313

---

## Claude summary

Done. The change adds an optional `productSection` parameter to `UseSupabaseProductsListOptions` in `src/hooks/use-supabase-products.ts:49`. When provided, it pushes a `.eq("product_section", productSection)` filter onto the Supabase query before execution. The value is also included in the React Query cache key so calls with different sections (e.g. `"treatment"` vs `"disposable"`) cache independently without invalidating each other.