### PR TITLE
Standardize `stock_unit` values

### DIFF
--- a/src/components/forms/product-form.tsx
+++ b/src/components/forms/product-form.tsx
@@ -30,6 +30,19 @@ export function generateSku(): string {
 // VAT-exempt ("zwolniony") is tracked as a separate boolean (taxExempt) on the
 // product. The "zw" option is selected when the boolean is true; otherwise the
 // numeric percentage is used. Mirrors the gabinet treatment form.
+const STOCK_UNIT_OPTIONS = [
+  { value: "szt.", label: "szt. (sztuka)" },
+  { value: "op.", label: "op. (opakowanie)" },
+  { value: "kpl.", label: "kpl. (komplet)" },
+  { value: "para", label: "para" },
+  { value: "ml", label: "ml (mililitr)" },
+  { value: "l", label: "l (litr)" },
+  { value: "g", label: "g (gram)" },
+  { value: "kg", label: "kg (kilogram)" },
+  { value: "m", label: "m (metr)" },
+  { value: "cm", label: "cm (centymetr)" },
+];
+
 const TAX_RATE_OPTIONS = [
   { value: "zw", label: "ZW" },
   { value: "0", label: "0%" },
@@ -299,7 +312,15 @@ export function ProductForm({
                     value={stockUnit}
                     onChange={(e) => setStockUnit(e.target.value)}
                     placeholder={t("products.stock.unitPlaceholder", { defaultValue: "szt., ml, g…" })}
+                    list="stock-unit-datalist"
                   />
+                  <datalist id="stock-unit-datalist">
+                    {STOCK_UNIT_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </datalist>
                 </div>
                 <div className="space-y-1.5">
                   <Label>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2314.

Closes #2314

---

## Claude summary

Done. Here's what changed:

**`src/components/forms/product-form.tsx`** — The `stockUnit` field was a free-text `Input` with no guidance, risking inconsistent values ("szt." vs "szt" vs "sztuk"). The fix adds a native HTML5 `<datalist>` with 10 predefined Polish-market units (`szt.`, `op.`, `kpl.`, `para`, `ml`, `l`, `g`, `kg`, `m`, `cm`) linked to the input via `list="stock-unit-datalist"`. The input still accepts free text, so custom units remain possible, but users are nudged toward consistent canonical values.

The approach is intentionally minimal — no new component, no forced constraint on the `string | null` schema type — just suggestions at the UI layer where the inconsistency originates.