### PR TITLE
Zabiegi ↔ Magazyn — tabela relacji zabieg–produkt

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -53,6 +53,7 @@ const TABLE_MAP: Record<string, string> = {
   gabinetAppointments: "gabinet_appointments",
   gabinetTreatments: "gabinet_treatments",
   gabinetTreatmentVariants: "gabinet_treatment_variants",
+  gabinetTreatmentProducts: "gabinet_treatment_products",
   gabinetEmployees: "gabinet_employees",
   gabinetLocations: "gabinet_locations",
   gabinetRooms: "gabinet_rooms",

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -168,6 +168,25 @@ export function createGabinetTables({
     .index("by_treatment", ["treatmentId"])
     .index("by_org", ["organizationId"]),
 
+  // Junction table: treatment definition → warehouse product (#2318).
+  // Records which products (preparations and disposables) are standardly
+  // consumed during one visit of this treatment, and in what quantity.
+  // product_section mirrors products.productSection: "treatment" | "disposable".
+  // unit is a snapshot of products.stockUnit at link time.
+  gabinetTreatmentProducts: defineTable({
+    organizationId: v.id("organizations"),
+    treatmentId: v.id("gabinetTreatments"),
+    productId: v.id("products"),
+    productSection: v.string(), // "treatment" | "disposable"
+    quantity: v.number(),
+    unit: v.optional(v.string()), // snapshot of products.stockUnit
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_org", ["organizationId"])
+    .index("by_treatment", ["treatmentId"])
+    .index("by_product", ["productId"]),
+
   // --- Gabinet: Employee Scheduling (Phase 2) ---
 
   gabinetWorkingHours: defineTable({

--- a/src/lib/supabase/database.columns.ts
+++ b/src/lib/supabase/database.columns.ts
@@ -126,7 +126,8 @@ export type TableName =
   | "automation_run_steps"
   | "document_components"
   | "product_stock_levels"
-  | "product_stock_movements";
+  | "product_stock_movements"
+  | "gabinet_treatment_products";
 
 /**
  * Column names per table, as a runtime-checkable Set.
@@ -226,4 +227,5 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   document_components: new Set(["id", "organization_id", "scope", "created_by", "name", "description", "category", "content_json", "protected", "position_constraint", "version", "is_active", "created_at", "updated_at"]),
   product_stock_levels: new Set(["id", "organization_id", "product_id", "location_id", "quantity", "updated_at"]),
   product_stock_movements: new Set(["id", "organization_id", "product_id", "location_id", "delta", "balance_after", "reason", "source_type", "source_id", "note", "performed_by", "created_at"]),
+  gabinet_treatment_products: new Set(["id", "organization_id", "treatment_id", "product_id", "product_section", "quantity", "unit", "created_at", "updated_at"]),
 };

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -3929,6 +3929,64 @@ export interface Database {
           },
         ];
       };
+      gabinet_treatment_products: {
+        Row: {
+          id: string;
+          organization_id: string;
+          treatment_id: string;
+          product_id: string;
+          product_section: string;
+          quantity: number;
+          unit: string | null;
+          created_at: number;
+          updated_at: number;
+        };
+        Insert: {
+          id?: string;
+          organization_id: string;
+          treatment_id: string;
+          product_id: string;
+          product_section: string;
+          quantity: number;
+          unit?: string | null;
+          created_at: number;
+          updated_at: number;
+        };
+        Update: {
+          id?: string;
+          organization_id?: string;
+          treatment_id?: string;
+          product_id?: string;
+          product_section?: string;
+          quantity?: number;
+          unit?: string | null;
+          created_at?: number;
+          updated_at?: number;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "gabinet_treatment_products_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organizations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gabinet_treatment_products_treatment_id_fkey";
+            columns: ["treatment_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_treatments";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gabinet_treatment_products_product_id_fkey";
+            columns: ["product_id"];
+            isOneToOne: false;
+            referencedRelation: "products";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       gabinet_employees: {
         Row: {
           id: string;
@@ -6720,6 +6778,9 @@ export type GabinetTreatmentUpdate = Database["public"]["Tables"]["gabinet_treat
 export type GabinetTreatmentVariantRow = Database["public"]["Tables"]["gabinet_treatment_variants"]["Row"];
 export type GabinetTreatmentVariantInsert = Database["public"]["Tables"]["gabinet_treatment_variants"]["Insert"];
 export type GabinetTreatmentVariantUpdate = Database["public"]["Tables"]["gabinet_treatment_variants"]["Update"];
+export type GabinetTreatmentProductRow = Database["public"]["Tables"]["gabinet_treatment_products"]["Row"];
+export type GabinetTreatmentProductInsert = Database["public"]["Tables"]["gabinet_treatment_products"]["Insert"];
+export type GabinetTreatmentProductUpdate = Database["public"]["Tables"]["gabinet_treatment_products"]["Update"];
 export type GabinetEmployeeRow = Database["public"]["Tables"]["gabinet_employees"]["Row"];
 export type GabinetEmployeeInsert = Database["public"]["Tables"]["gabinet_employees"]["Insert"];
 export type GabinetEmployeeUpdate = Database["public"]["Tables"]["gabinet_employees"]["Update"];

--- a/supabase/migrations/00025_gabinet_treatment_products.sql
+++ b/supabase/migrations/00025_gabinet_treatment_products.sql
@@ -1,0 +1,64 @@
+-- Gabinet treatment → product junction table (#2318).
+--
+-- Stores the standard "inventory recipe" for a treatment definition:
+-- which products from the Magazyn (warehouse) are typically consumed
+-- during a single visit of this treatment, and in what quantity.
+--
+-- Two item types are supported via `product_section`, matching the
+-- existing product_section values on the products table:
+--
+--   • treatment   — Preparaty zabiegowe (preparations / serums)
+--   • disposable  — Materiały jednorazowe (single-use consumables)
+--
+-- `unit` is a snapshot of products.stock_unit at link time. Snapshots are
+-- the established project pattern (cf. price_at_booking on appointments)
+-- and ensure the recipe stays consistent even if the product unit changes.
+--
+-- Unique scope is (treatment_id, product_id, product_section): the same
+-- product could theoretically appear in both the "treatment" and "disposable"
+-- sections (e.g. a gel used both as preparation and disposable pad), so a
+-- stricter (treatment_id, product_id) unique would incorrectly block that.
+--
+-- This migration is intentionally data-only (no UI, no stock deduction,
+-- no appointment_use movements). Those are separate future steps.
+
+CREATE TABLE IF NOT EXISTS gabinet_treatment_products (
+  id              TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  treatment_id    TEXT NOT NULL REFERENCES gabinet_treatments(id) ON DELETE CASCADE,
+  product_id      TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  -- "treatment" | "disposable"  (mirrors products.product_section)
+  product_section TEXT NOT NULL,
+  quantity        NUMERIC NOT NULL,
+  -- snapshot of products.stock_unit at link time; NULL when product has no unit
+  unit            TEXT,
+  created_at      BIGINT NOT NULL,
+  updated_at      BIGINT NOT NULL
+);
+
+-- ---------------------------------------------------------------------------
+-- Indexes
+-- ---------------------------------------------------------------------------
+
+CREATE INDEX IF NOT EXISTS gabinet_treatment_products_org_idx
+  ON gabinet_treatment_products (organization_id);
+
+CREATE INDEX IF NOT EXISTS gabinet_treatment_products_treatment_idx
+  ON gabinet_treatment_products (treatment_id);
+
+CREATE INDEX IF NOT EXISTS gabinet_treatment_products_product_idx
+  ON gabinet_treatment_products (product_id);
+
+-- Prevent the same product appearing twice in the same section for the same
+-- treatment (but allow it to appear in both "treatment" and "disposable").
+CREATE UNIQUE INDEX IF NOT EXISTS gabinet_treatment_products_unique_idx
+  ON gabinet_treatment_products (treatment_id, product_id, product_section);
+
+-- ---------------------------------------------------------------------------
+-- RLS: org-scoped access, same pattern as all other gabinet tables.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE gabinet_treatment_products ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY org_isolation ON gabinet_treatment_products
+  USING (organization_id = current_org_id());


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2318.

Closes #2318

---

## Claude summary

Done. Here's a summary of what was implemented:

## What was done

Added the `gabinet_treatment_products` junction table that links a treatment definition to warehouse products (the "inventory recipe" for a treatment visit). Five files changed:

**`supabase/migrations/00025_gabinet_treatment_products.sql`** — the actual table with:
- `treatment_id` FK → `gabinet_treatments` (CASCADE DELETE, so removing a treatment cleans up its recipe)
- `product_id` FK → `products` (CASCADE DELETE, so removing a product cleans up all recipes referencing it)
- `product_section TEXT NOT NULL` — discriminates "treatment" (preparaty) vs "disposable" (materiały jednorazowe), mirroring `products.product_section`
- `quantity NUMERIC NOT NULL` — standard amount per visit
- `unit TEXT` — snapshot of `products.stock_unit` at link time (same pattern as `price_at_booking` on appointments)
- Unique index on `(treatment_id, product_id, product_section)` — allows the same product in both sections, but prevents duplicates within a section
- Indexes on `organization_id`, `treatment_id`, `product_id`
- RLS policy via `current_org_id()` (same pattern as all other tables)

**`convex/schema/gabinet.ts`** — `gabinetTreatmentProducts` table with `by_org`, `by_treatment`, `by_product` indexes.

**`convex/_helpers/supabaseDb.ts`** — `gabinetTreatmentProducts: "gabinet_treatment_products"` entry in TABLE_MAP.

**`src/lib/supabase/database.types.ts`** — full Row/Insert/Update types + `GabinetTreatmentProductRow/Insert/Update` export aliases.

**`src/lib/supabase/database.columns.ts`** — table name added to the `TableName` union and column Set added.

No UI changes, no treatment form changes, no stock deduction logic — exactly as scoped.