### PR TITLE
Delete cascade for `gabinet_treatment_products` on treatment deactivation

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -435,6 +435,12 @@ export const remove = action({
       updatedAt: Date.now(),
     });
 
+    // --- Hard-delete product ingredient links (orphaned by soft-delete) ---
+    await db.raw()
+      .from("gabinet_treatment_products")
+      .delete()
+      .eq("treatment_id", args.treatmentId);
+
     // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.treatments._removeSideEffects, {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2322.

Closes #2322

---

## Claude summary

The fix is in. Here's what happened and why:

The `gabinet_treatment_products` table has `ON DELETE CASCADE` on its `treatment_id` FK, but that only fires when the parent row is hard-deleted from the database. The `treatments.remove` action performs a soft-delete (patches `isActive=false`), leaving the treatment row — and its product links — intact.

The fix adds a `db.raw().from("gabinet_treatment_products").delete().eq("treatment_id", ...)` call in the `remove` action immediately after the soft-delete patch. This is the same pattern already used by `saveTreatmentProductLinks` to clear links during an update. The treatment is already deactivated at that point, so cleaning up its product recipe is safe.