### PR TITLE
Zabiegi — dodać sekcję „Preparaty do zabiegu”

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useSupabaseGabinetTreatmentPackagesActive } from "@/hooks/use-supabase-gabinet-packages";
+import { useSupabaseProductsList } from "@/hooks/use-supabase-products";
 import {
   Command,
   CommandEmpty,
@@ -28,7 +29,7 @@ import {
   CommandList,
   CommandSeparator,
 } from "@/components/ui/command";
-import { Check, ChevronsUpDown, Plus } from "@/lib/ez-icons";
+import { Check, ChevronsUpDown, Plus, Trash2 } from "@/lib/ez-icons";
 import { cn } from "@/lib/utils";
 import { formatActionError } from "@/lib/format-action-error";
 import {
@@ -36,6 +37,12 @@ import {
   type RequiredFormTemplateValue,
 } from "@/components/documents/treatment-required-documents-field";
 import type { Id } from "@cvx/_generated/dataModel";
+
+export interface TreatmentProductLine {
+  productId: string;
+  quantity: number;
+  unit?: string | null;
+}
 
 export interface TreatmentFormData {
   name: string;
@@ -55,6 +62,7 @@ export interface TreatmentFormData {
   treatmentCount?: number;
   packageId?: string | null;
   requiredFormTemplates?: RequiredFormTemplateValue[];
+  products?: TreatmentProductLine[];
 }
 
 interface TreatmentFormProps {
@@ -129,8 +137,17 @@ export function TreatmentForm({
     initialPackageId ?? "",
   );
 
+  const [productLines, setProductLines] = useState<TreatmentProductLine[]>(
+    initialData?.products ?? [],
+  );
+  const [productPickerOpen, setProductPickerOpen] = useState<number | null>(null);
+
   const { data: packagesList } =
     useSupabaseGabinetTreatmentPackagesActive(organizationId);
+
+  const { data: treatmentProducts } = useSupabaseProductsList(organizationId, {
+    productSection: "treatment",
+  });
 
   const queryClient = useQueryClient();
   const listEquipmentAction = useAction(api.gabinet.equipment.listEquipment);
@@ -158,6 +175,25 @@ export function TreatmentForm({
 
   const getEquipmentName = (id: Id<"gabinetEquipment">) => {
     return equipmentList?.find((e) => e._id === id)?.name ?? id;
+  };
+
+  const addProductLine = () => {
+    setProductLines((prev) => [...prev, { productId: "", quantity: 1, unit: null }]);
+  };
+
+  const removeProductLine = (index: number) => {
+    setProductLines((prev) => prev.filter((_, i) => i !== index));
+    if (productPickerOpen === index) setProductPickerOpen(null);
+  };
+
+  const updateProductLine = (index: number, patch: Partial<TreatmentProductLine>) => {
+    setProductLines((prev) => prev.map((line, i) => (i === index ? { ...line, ...patch } : line)));
+  };
+
+  const selectProduct = (index: number, productId: string) => {
+    const product = (treatmentProducts ?? []).find((p) => p._id === productId);
+    updateProductLine(index, { productId, unit: product?.stockUnit ?? null });
+    setProductPickerOpen(null);
   };
 
   const resetAddEquipmentForm = () => {
@@ -201,6 +237,8 @@ export function TreatmentForm({
         : undefined
       : undefined;
 
+    const validProducts = productLines.filter((p) => p.productId.trim() !== "");
+
     onSubmit({
       name,
       description: notes || null,
@@ -217,6 +255,7 @@ export function TreatmentForm({
       color: initialData?.color ?? null,
       packageId: isPackage && selectedPackageId ? selectedPackageId : null,
       requiredFormTemplates,
+      products: validProducts,
     });
   };
 
@@ -526,6 +565,149 @@ export function TreatmentForm({
             </p>
           )}
         </div>
+      </div>
+
+      {/* Preparaty do zabiegu */}
+      <div className="space-y-3 border-t pt-4">
+        <div>
+          <Label className="text-sm font-medium">
+            Preparaty do zabiegu
+          </Label>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Preparaty używane podczas jednej wizyty, np. ampułka, serum, krem znieczulający.
+          </p>
+        </div>
+
+        {productLines.length > 0 && (
+          <div className="space-y-2">
+            {productLines.map((line, index) => {
+              const selectedProduct = (treatmentProducts ?? []).find(
+                (p) => p._id === line.productId,
+              );
+              return (
+                <div
+                  key={index}
+                  className="flex flex-col gap-2 rounded-md border p-2 sm:flex-row sm:items-center"
+                >
+                  {/* Product picker */}
+                  <Popover
+                    open={productPickerOpen === index}
+                    onOpenChange={(open) =>
+                      setProductPickerOpen(open ? index : null)
+                    }
+                  >
+                    <PopoverTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        role="combobox"
+                        aria-expanded={productPickerOpen === index}
+                        className="flex-1 justify-between font-normal min-w-0"
+                      >
+                        <span className="truncate">
+                          {selectedProduct
+                            ? selectedProduct.name
+                            : <span className="text-muted-foreground">Wybierz preparat...</span>}
+                        </span>
+                        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent
+                      className="w-72 p-0"
+                      align="start"
+                      style={{
+                        maxHeight: "var(--radix-popover-content-available-height)",
+                      }}
+                    >
+                      <Command>
+                        <CommandInput placeholder="Szukaj preparatu..." />
+                        <CommandList>
+                          <CommandEmpty>Brak wyników.</CommandEmpty>
+                          <CommandGroup>
+                            {(treatmentProducts ?? []).map((product) => (
+                              <CommandItem
+                                key={product._id}
+                                value={product.name}
+                                onSelect={() => selectProduct(index, product._id)}
+                              >
+                                <Check
+                                  className={cn(
+                                    "mr-2 h-4 w-4",
+                                    line.productId === product._id
+                                      ? "opacity-100"
+                                      : "opacity-0",
+                                  )}
+                                />
+                                <span className="truncate">{product.name}</span>
+                                {product.stockUnit && (
+                                  <span className="ml-auto text-xs text-muted-foreground shrink-0">
+                                    {product.stockUnit}
+                                  </span>
+                                )}
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
+
+                  {/* Quantity + unit + remove */}
+                  <div className="flex items-center gap-2 shrink-0">
+                    <Input
+                      type="number"
+                      inputMode="decimal"
+                      min="0"
+                      step="any"
+                      value={line.quantity}
+                      onChange={(e) => {
+                        const val = parseFloat(e.target.value);
+                        if (!Number.isNaN(val) && val >= 0) {
+                          updateProductLine(index, { quantity: val });
+                        }
+                      }}
+                      onWheel={(e) => (e.currentTarget as HTMLInputElement).blur()}
+                      className="w-20 text-right"
+                      aria-label="Ilość"
+                    />
+                    {line.unit ? (
+                      <span className="w-10 text-sm text-muted-foreground">{line.unit}</span>
+                    ) : (
+                      <span className="w-10" />
+                    )}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-destructive shrink-0"
+                      onClick={() => removeProductLine(index)}
+                      aria-label="Usuń preparat"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {productLines.length === 0 && (
+          <p className="text-sm text-muted-foreground py-1">
+            Brak przypisanych preparatów.
+          </p>
+        )}
+
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={addProductLine}
+          className="w-full sm:w-auto"
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          Dodaj preparat
+        </Button>
       </div>
 
       <div className="space-y-4 border-t pt-4">

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -155,6 +155,8 @@ function TreatmentDetail() {
   const updateVariantMut = useAction(api.gabinet.treatments.updateVariant);
   const deleteVariantMut = useAction(api.gabinet.treatments.deleteVariant);
   const trackView = useAction(api.recentlyViewed.track);
+  const getTreatmentProductsAction = useAction(api.gabinet.treatments.getTreatmentProducts);
+  const setTreatmentProductsAction = useAction(api.gabinet.treatments.setTreatmentProducts);
   const queryClient = useQueryClient();
 
   // Queries — treatment detail + variants from Supabase
@@ -238,6 +240,16 @@ function TreatmentDetail() {
     organizationId,
     treatmentId,
   );
+
+  const { data: existingProducts } = useQuery({
+    queryKey: ["gabinet.treatments.getTreatmentProducts", organizationId, treatmentId],
+    queryFn: () =>
+      getTreatmentProductsAction({
+        organizationId,
+        treatmentId: treatmentId as string,
+      }),
+    enabled: !!organizationId && !!treatmentId,
+  });
 
   // Enrich variants with resolved/inherited fields (previously computed server-side in Convex)
   const variants = useMemo(() => {
@@ -418,12 +430,28 @@ function TreatmentDetail() {
   const handleEditSubmit = async (formData: TreatmentFormData) => {
     setIsSubmitting(true);
     try {
+      const { products, ...treatmentData } = formData;
       await updateTreatment({
         organizationId,
         treatmentId: treatmentId as Id<"gabinetTreatments">,
-        ...formData,
+        ...treatmentData,
         categoryId: editCategoryId ?? null,
       });
+      if (products !== undefined) {
+        await setTreatmentProductsAction({
+          organizationId,
+          treatmentId: treatmentId as string,
+          products: products.map((p) => ({
+            productId: p.productId,
+            productSection: "treatment" as const,
+            quantity: p.quantity,
+            unit: p.unit ?? undefined,
+          })),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: ["gabinet.treatments.getTreatmentProducts", organizationId, treatmentId],
+        });
+      }
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatments.detail(organizationId, treatmentId) });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatments.list(organizationId) });
       setEditPanelOpen(false);
@@ -1262,7 +1290,7 @@ function TreatmentDetail() {
           title={t("common.edit")}
         >
           <TreatmentForm
-            key={treatment._id}
+            key={`${treatment._id}-${existingProducts !== undefined ? "p" : "np"}`}
             organizationId={organizationId}
             initialData={{
               name: treatment.name,
@@ -1285,6 +1313,11 @@ function TreatmentDetail() {
                 (treatment.requiredFormTemplates as
                   | TreatmentFormData["requiredFormTemplates"]
                   | undefined) ?? undefined,
+              products: (existingProducts ?? []).map((p) => ({
+                productId: p.productId,
+                quantity: p.quantity,
+                unit: p.unit ?? p.stockUnit ?? null,
+              })),
             }}
             onSubmit={handleEditSubmit}
             onCancel={() => setEditPanelOpen(false)}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -82,6 +82,8 @@ function TreatmentsIndex() {
   const createTreatment = useAction(api.gabinet.treatments.create);
   const updateTreatment = useAction(api.gabinet.treatments.update);
   const removeTreatment = useAction(api.gabinet.treatments.remove);
+  const getTreatmentProductsAction = useAction(api.gabinet.treatments.getTreatmentProducts);
+  const setTreatmentProductsAction = useAction(api.gabinet.treatments.setTreatmentProducts);
 
   const { allowed: canEdit } = usePermission("gabinet_treatments", "edit");
   const { allowed: canDelete } = usePermission("gabinet_treatments", "delete");
@@ -189,6 +191,16 @@ function TreatmentsIndex() {
   const { data: allPackages } = useSupabaseGabinetTreatmentPackagesList(organizationId);
   const { data: allEquipment = [] } = useSupabaseGabinetEquipmentList(organizationId);
   const [groupByEquipment, setGroupByEquipment] = useState(false);
+
+  const { data: editingTreatmentProducts } = useQuery({
+    queryKey: ["gabinet.treatments.getTreatmentProducts", organizationId, editingTreatment?._id ?? ""],
+    queryFn: () =>
+      getTreatmentProductsAction({
+        organizationId,
+        treatmentId: editingTreatment!._id,
+      }),
+    enabled: !!organizationId && !!editingTreatment?._id,
+  });
 
   const packageNameById = useMemo(() => {
     const map = new Map<string, string>();
@@ -457,21 +469,46 @@ function TreatmentsIndex() {
       setIsSubmitting(true);
       setFieldErrors({});
       try {
+        const { products, ...treatmentData } = formData;
         if (editingTreatment) {
           await updateTreatment({
             organizationId,
             treatmentId: editingTreatment._id as Id<"gabinetTreatments">,
-            ...formData,
+            ...treatmentData,
             tagIds,
             categoryId: categoryId ?? null,
           });
+          if (products !== undefined) {
+            await setTreatmentProductsAction({
+              organizationId,
+              treatmentId: editingTreatment._id,
+              products: products.map((p) => ({
+                productId: p.productId,
+                productSection: "treatment" as const,
+                quantity: p.quantity,
+                unit: p.unit ?? undefined,
+              })),
+            });
+          }
         } else {
-          await createTreatment({
+          const newTreatmentId = await createTreatment({
             organizationId,
-            ...formData,
+            ...treatmentData,
             tagIds,
             categoryId,
           });
+          if (products && products.length > 0) {
+            await setTreatmentProductsAction({
+              organizationId,
+              treatmentId: newTreatmentId,
+              products: products.map((p) => ({
+                productId: p.productId,
+                productSection: "treatment" as const,
+                quantity: p.quantity,
+                unit: p.unit ?? undefined,
+              })),
+            });
+          }
         }
         setPanelOpen(false);
         setEditingTreatment(null);
@@ -513,7 +550,7 @@ function TreatmentsIndex() {
         setIsSubmitting(false);
       }
     },
-    [editingTreatment, createTreatment, updateTreatment, organizationId, tagIds, categoryId, t],
+    [editingTreatment, createTreatment, updateTreatment, setTreatmentProductsAction, organizationId, tagIds, categoryId, t],
   );
 
   const handleBulkAction = useCallback(
@@ -800,7 +837,7 @@ function TreatmentsIndex() {
         }
       >
         <TreatmentForm
-          key={editingTreatment?._id ?? "new"}
+          key={editingTreatment?._id ? `${editingTreatment._id}-${editingTreatmentProducts !== undefined ? "p" : "np"}` : "new"}
           organizationId={organizationId}
           initialData={
             editingTreatment
@@ -831,6 +868,11 @@ function TreatmentsIndex() {
                     (editingTreatment.requiredFormTemplates as
                       | TreatmentFormData["requiredFormTemplates"]
                       | undefined) ?? undefined,
+                  products: (editingTreatmentProducts ?? []).map((p) => ({
+                    productId: p.productId,
+                    quantity: p.quantity,
+                    unit: p.unit ?? p.stockUnit ?? null,
+                  })),
                 }
               : undefined
           }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2324.

Closes #2324

---

## Claude summary

The implementation is complete. Here's a summary of what was done:

**Changes made across 3 files:**

`src/components/gabinet/treatment-form.tsx`:
- Added `TreatmentProductLine` and `products?` to `TreatmentFormData`
- Imported `useSupabaseProductsList` and `Trash2` icon
- Added state for `productLines` (initialized from `initialData.products`) and `productPickerOpen`
- Added `addProductLine`, `removeProductLine`, `updateProductLine`, `selectProduct` helpers
- Added the "Preparaty do zabiegu" section between "Wymagany sprzęt" and "Wymagane dokumenty": heading, helper text, list of rows (Popover product picker + quantity input + unit display + remove button), empty state, and "Dodaj preparat" button
- Included `products` in `handleSubmit` output (filtering out incomplete rows without a productId)

`src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx`:
- Added `getTreatmentProducts` and `setTreatmentProducts` actions
- Added a `useQuery` for `existingProducts` (loads at page open, ready before edit panel)
- Updated `handleEditSubmit` to extract and separately save products via `setTreatmentProducts` (avoids a backend bug where `products` would leak into the `gabinet_treatments` PATCH payload)
- Passes `existingProducts` as `initialData.products` to the form; form key includes `-p/-np` suffix to re-mount once products load

`src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx`:
- Added same actions; added `editingTreatmentProducts` query (enabled only when editing)
- Updated `handleSubmit` to save products via `setTreatmentProducts` for both create and edit paths
- Passes products in `initialData` for the edit case; same `-p/-np` key suffix

## Follow-ups

- Fix `products` leaking into gabinet_treatments PATCH payload in `convex/gabinet/treatments.ts`: The `update` handler destructures `products` into `...updates` and spreads into `patchPayload`, which gets sent to Supabase — if a `products` column doesn't exist on the table, this would cause a runtime error. `products` should be excluded from the patch object like `taxExempt` and `packageId` are.