### PR TITLE
Fix `products` leaking into gabinet_treatments PATCH payload in `convex/gabinet/

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -316,7 +316,7 @@ export const update = action({
       }
 
       // --- Build updates and PATCH to Supabase ---
-      const { organizationId, treatmentId, taxExempt, packageId, ...updates } = args;
+      const { organizationId, treatmentId, taxExempt, packageId, products, ...updates } = args;
       // taxExempt and packageId were added by migrations 00005 and 00010.
       // Use the "field in record" probe so null/false can clear the field once
       // the column exists, while keeping pre-migration environments safe.
@@ -334,12 +334,12 @@ export const update = action({
 
       // --- Optional: replace treatment product ingredients ---
       // Only when `products` was explicitly passed (even if empty = clear all).
-      if (args.products !== undefined) {
+      if (products !== undefined) {
         await saveTreatmentProductLinks(
           db,
           String(organizationId),
           treatmentId,
-          args.products,
+          products,
         );
       }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2326.

Closes #2326

---

## Claude summary

The bug was real and is now fixed. The `update` handler in `convex/gabinet/treatments.ts` was destructuring `taxExempt` and `packageId` out of `args` before spreading into `patchPayload`, but forgot to do the same for `products`. Since `gabinet_treatments` has no `products` column (product associations live in the `gabinet_treatment_products` junction table), sending `products` in the PATCH would cause a Supabase runtime error whenever a user updated a treatment and included product data.

The fix adds `products` to the destructuring at line 319, so it's excluded from the spread — and also updates the downstream references on lines 337/341 to use the destructured `products` variable directly.