### PR TITLE
Add RLS policies for `gabinet_treatment_products` in Supabase

### DIFF
--- a/supabase/migrations/00026_gabinet_treatment_products_rls.sql
+++ b/supabase/migrations/00026_gabinet_treatment_products_rls.sql
@@ -1,0 +1,20 @@
+-- Upgrade RLS on gabinet_treatment_products to the per-command pattern
+-- established in 00002_rls_policies.sql.
+--
+-- Migration 00025 created this table with a single ALL-operation org_isolation
+-- policy (USING only, no WITH CHECK). That broad pattern was replaced project-
+-- wide by 00002, but gabinet_treatment_products was introduced afterwards and
+-- inherited the old shape. This migration brings it in line with every other
+-- table in the project (#2332).
+
+DROP POLICY IF EXISTS org_isolation ON gabinet_treatment_products;
+
+CREATE POLICY gabinet_treatment_products_select ON gabinet_treatment_products
+  FOR SELECT USING (current_org_id() = organization_id);
+CREATE POLICY gabinet_treatment_products_insert ON gabinet_treatment_products
+  FOR INSERT WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY gabinet_treatment_products_update ON gabinet_treatment_products
+  FOR UPDATE USING (current_org_id() = organization_id)
+  WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY gabinet_treatment_products_delete ON gabinet_treatment_products
+  FOR DELETE USING (current_org_id() = organization_id);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2332.

Closes #2332

---

## Claude summary

The issue was real. Migration `00025` created `gabinet_treatment_products` with the old-style `org_isolation` ALL-policy (USING clause only, no `WITH CHECK`). This meant INSERT and UPDATE operations were not checked against the org constraint on the inbound data — only that the row being read/deleted belonged to the current org.

The new migration `00026_gabinet_treatment_products_rls.sql`:
1. Drops the old `org_isolation` ALL-policy
2. Creates four granular per-command policies (SELECT, INSERT, UPDATE, DELETE) each with proper `WITH CHECK` on INSERT and UPDATE, exactly matching the pattern established in `00002_rls_policies.sql` for every other table in the project