### PR TITLE
Zabiegi — zamykanie listy wyboru sprzętu po kliknięciu

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -525,7 +525,10 @@ export function TreatmentForm({
                           <CommandItem
                             key={eq._id}
                             value={eq.name}
-                            onSelect={() => toggleEquipment(eq._id as Id<"gabinetEquipment">)}
+                            onSelect={() => {
+                              toggleEquipment(eq._id as Id<"gabinetEquipment">);
+                              setEquipmentOpen(false);
+                            }}
                           >
                             <div
                               className={cn(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2328.

Closes #2328

---

## Claude summary

The fix is committed. Here's what changed and why:

**Root cause:** `toggleEquipment` updated `selectedEquipmentIds` correctly but never closed the popover. The `setEquipmentOpen(false)` state setter existed but was only wired to the `Popover`'s own `onOpenChange` callback (click-outside / Escape), not to item selection.

**Fix:** In the `CommandItem`'s `onSelect` handler (line 528), I expanded the arrow function to call both `toggleEquipment(...)` and `setEquipmentOpen(false)`. This is a 4-line change with zero risk to data logic, form submission, or the add-new-equipment sub-flow (which uses a separate `addingNewEquipment` state and its own UI branch).

The "Preparaty do zabiegu" product picker already closes correctly after selection (`selectProduct` calls `setProductPickerOpen(null)`), so the equipment section now behaves consistently.