### PR TITLE
Add deduplication logic in autoGenerateDocuments

### DIFF
--- a/convex/gabinet/_helpers/autoGenerateDocuments.ts
+++ b/convex/gabinet/_helpers/autoGenerateDocuments.ts
@@ -98,6 +98,20 @@ export async function autoGenerateAppointmentDocuments(
 
   for (const entry of requiredTemplates) {
     try {
+      // Skip if a document for this template+appointment already exists
+      const existing = await supabaseDb
+        .query("formDocuments")
+        .eq("templateId", String(entry.templateId))
+        .eq("entityType", "appointment")
+        .eq("entityId", args.appointmentId as string)
+        .first();
+      if (existing) {
+        createdDocIds.push(
+          (existing as Record<string, unknown>)._id as Id<"formDocuments">,
+        );
+        continue;
+      }
+
       const template = await supabaseDb.get(
         "formTemplates",
         String(entry.templateId),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2339.

Closes #2339

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Problem confirmed:** `autoGenerateAppointmentDocuments` in `convex/gabinet/_helpers/autoGenerateDocuments.ts` iterated over required templates and inserted a `formDocument` row for each one with no prior existence check — calling the function twice for the same appointment (e.g. on reschedule or retry) would silently create duplicate documents.

**Fix:** Added a deduplication query at the top of each loop iteration (lines 101–113) using the existing `supabaseDb.query().eq().first()` pattern. It checks for an existing `formDocument` with matching `templateId`, `entityType="appointment"`, and `entityId`. If found, the existing document's id is added to the return list and the insert is skipped. The check hits the existing `form_documents_template_idx` and `form_documents_entity_idx` indexes, so there's no performance concern.