### PR TITLE
Add "one-time document" flag to formTemplates/requiredFormTemplates

### DIFF
--- a/convex/gabinet/_helpers/autoGenerateDocuments.ts
+++ b/convex/gabinet/_helpers/autoGenerateDocuments.ts
@@ -60,6 +60,7 @@ export async function autoGenerateAppointmentDocuments(
     | Array<{
         templateId: string;
         timing?: "before_start" | "during_visit" | "after_completion";
+        isOneTime?: boolean;
       }>
     | undefined) ?? [];
   if (requiredTemplates.length === 0) return [];
@@ -98,6 +99,24 @@ export async function autoGenerateAppointmentDocuments(
 
   for (const entry of requiredTemplates) {
     try {
+      // Skip if this is a one-time document and the patient has already signed it
+      if (entry.isOneTime) {
+        const signedForPatient = await supabaseDb
+          .query("formDocuments")
+          .eq("templateId", String(entry.templateId))
+          .eq("organizationId", String(args.organizationId))
+          .eq("status", "signed")
+          .collect();
+        const alreadySigned = signedForPatient.some((doc) => {
+          const scope =
+            typeof doc.scopeEntities === "string"
+              ? (JSON.parse(doc.scopeEntities as string) as Record<string, unknown>)
+              : (doc.scopeEntities as Record<string, unknown> | null);
+          return scope?.patient === String(args.patientId);
+        });
+        if (alreadySigned) continue;
+      }
+
       // Skip if a document for this template+appointment already exists
       const existing = await supabaseDb
         .query("formDocuments")

--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -113,6 +113,7 @@ export const create = action({
         v.literal("during_visit"),
         v.literal("after_completion"),
       ),
+      isOneTime: v.optional(v.boolean()),
     }))),
     tagIds: v.optional(v.array(v.string())),
     categoryId: v.optional(v.union(v.string(), v.null())),
@@ -277,6 +278,7 @@ export const update = action({
         v.literal("during_visit"),
         v.literal("after_completion"),
       ),
+      isOneTime: v.optional(v.boolean()),
     }))),
     tagIds: v.optional(v.array(v.string())),
     categoryId: v.optional(v.union(v.string(), v.null())),
@@ -1178,6 +1180,7 @@ export const getRequiredFormTemplates = action({
     const entries = (treatment.requiredFormTemplates as Array<{
       templateId: string;
       timing: "before_start" | "during_visit" | "after_completion";
+      isOneTime?: boolean;
     }> | null) ?? [];
     if (entries.length === 0) return [];
 
@@ -1195,6 +1198,7 @@ export const getRequiredFormTemplates = action({
         return {
           templateId: String(entry.templateId),
           timing: entry.timing,
+          isOneTime: entry.isOneTime ?? false,
           templateName: (template.name as string | null) ?? "",
           templateCategory: (template.category as string | null) ?? "",
           requiresSignature: (template.requiresSignature as boolean | null) ?? false,
@@ -1216,6 +1220,7 @@ export const setRequiredFormTemplates = action({
         v.literal("during_visit"),
         v.literal("after_completion"),
       ),
+      isOneTime: v.optional(v.boolean()),
     })),
   },
   handler: async (ctx, args) => {

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -141,6 +141,9 @@ export function createGabinetTables({
         v.literal("during_visit"),
         v.literal("after_completion"),
       ),
+      // When true, skip generation if the patient already has a signed copy of
+      // this template (e.g. RODO, terms — signed once per patient, not per visit)
+      isOneTime: v.optional(v.boolean()),
     }))),
     shortDescription: v.optional(v.string()),
     image: v.optional(v.id("_storage")),

--- a/src/components/documents/treatment-required-documents.tsx
+++ b/src/components/documents/treatment-required-documents.tsx
@@ -23,7 +23,9 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { FileText, Plus, X, Search } from "@/lib/ez-icons";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { FileText, Plus, X, Search, RotateCcw } from "@/lib/ez-icons";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -58,6 +60,7 @@ type RequiredFormTemplateTiming =
 interface RequiredFormTemplate {
   templateId: Id<"formTemplates">;
   timing: RequiredFormTemplateTiming;
+  isOneTime?: boolean;
 }
 
 interface TreatmentRequiredDocumentsProps {
@@ -89,6 +92,7 @@ export function TreatmentRequiredDocuments({
     useState<Id<"formTemplates"> | null>(null);
   const [selectedTiming, setSelectedTiming] =
     useState<RequiredFormTemplateTiming>("before_start");
+  const [selectedIsOneTime, setSelectedIsOneTime] = useState(false);
 
   const updateTreatment = useAction(api.gabinet.treatments.update);
 
@@ -127,7 +131,7 @@ export function TreatmentRequiredDocuments({
 
     const updated: RequiredFormTemplate[] = [
       ...requiredFormTemplates,
-      { templateId: selectedTemplateId, timing: selectedTiming },
+      { templateId: selectedTemplateId, timing: selectedTiming, isOneTime: selectedIsOneTime || undefined },
     ];
 
     try {
@@ -142,6 +146,7 @@ export function TreatmentRequiredDocuments({
       setAddDialogOpen(false);
       setSelectedTemplateId(null);
       setSearch("");
+      setSelectedIsOneTime(false);
     } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
@@ -149,6 +154,7 @@ export function TreatmentRequiredDocuments({
   }, [
     selectedTemplateId,
     selectedTiming,
+    selectedIsOneTime,
     requiredFormTemplates,
     updateTreatment,
     organizationId,
@@ -174,6 +180,25 @@ export function TreatmentRequiredDocuments({
       } catch (error) {
         const msg =
           error instanceof Error ? error.message : t("common.error");
+        toast.error(msg);
+      }
+    },
+    [requiredFormTemplates, updateTreatment, organizationId, treatmentId, t],
+  );
+
+  const handleOneTimeChange = useCallback(
+    async (templateId: Id<"formTemplates">, isOneTime: boolean) => {
+      const updated = requiredFormTemplates.map((r) =>
+        r.templateId === templateId ? { ...r, isOneTime: isOneTime || undefined } : r,
+      );
+      try {
+        await updateTreatment({
+          organizationId,
+          treatmentId,
+          requiredFormTemplates: updated,
+        });
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : t("common.error");
         toast.error(msg);
       }
     },
@@ -255,6 +280,33 @@ export function TreatmentRequiredDocuments({
                         }
                         t={t as (key: string, fallback?: string) => string}
                       />
+                      <button
+                        type="button"
+                        onClick={() =>
+                          handleOneTimeChange(req.templateId, !req.isOneTime)
+                        }
+                        title={
+                          req.isOneTime
+                            ? t("documents.requiredDocs.oneTimeOn", "Jednorazowy – kliknij, aby wyłączyć")
+                            : t("documents.requiredDocs.oneTimeOff", "Wymagany per-wizyta – kliknij, aby ustawić jako jednorazowy")
+                        }
+                        className="cursor-pointer"
+                      >
+                        <Badge
+                          variant="outline"
+                          className={cn(
+                            "text-xs select-none",
+                            req.isOneTime
+                              ? "bg-purple-100 text-purple-800 border-purple-200 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800"
+                              : "bg-muted text-muted-foreground border-border hover:bg-accent",
+                          )}
+                        >
+                          <RotateCcw className="h-3 w-3 mr-1" />
+                          {req.isOneTime
+                            ? t("documents.requiredDocs.oneTime", "Jednorazowy")
+                            : t("documents.requiredDocs.perVisit", "Per wizyta")}
+                        </Badge>
+                      </button>
                       <Button
                         variant="ghost"
                         size="icon"
@@ -404,6 +456,26 @@ export function TreatmentRequiredDocuments({
                 </SelectContent>
               </Select>
             </div>
+
+            {/* One-time toggle */}
+            <div className="flex items-center justify-between rounded-lg border p-3">
+              <div className="space-y-0.5">
+                <Label htmlFor="one-time-toggle" className="text-sm font-medium cursor-pointer">
+                  {t("documents.requiredDocs.oneTimeLabel", "Dokument jednorazowy")}
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  {t(
+                    "documents.requiredDocs.oneTimeDescription",
+                    "Podpisywany raz na pacjenta (np. RODO, regulamin). Nie generuje nowej kopii, jeśli pacjent już podpisał.",
+                  )}
+                </p>
+              </div>
+              <Switch
+                id="one-time-toggle"
+                checked={selectedIsOneTime}
+                onCheckedChange={setSelectedIsOneTime}
+              />
+            </div>
           </div>
 
           {/* Footer */}
@@ -414,6 +486,7 @@ export function TreatmentRequiredDocuments({
                 setAddDialogOpen(false);
                 setSelectedTemplateId(null);
                 setSearch("");
+                setSelectedIsOneTime(false);
               }}
             >
               {t("common.cancel", "Anuluj")}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2340.

Closes #2340

---

## Claude summary

Done. Here's a summary of what was implemented:

**4 files changed:**

- `convex/schema/gabinet.ts` — added `isOneTime?: v.optional(v.boolean())` to the `requiredFormTemplates` array item in `gabinetTreatments`. No SQL migration needed (stored as JSONB).

- `convex/gabinet/treatments.ts` — added `isOneTime` to the validators in the `create`, `update`, and `setRequiredFormTemplates` actions, and included it in the `getRequiredFormTemplates` return shape.

- `convex/gabinet/_helpers/autoGenerateDocuments.ts` — before generating a document for any template entry with `isOneTime: true`, the function now queries `formDocuments` for all signed copies of that template in the org and skips generation if the patient already appears in `scopeEntities`.

- `src/components/documents/treatment-required-documents.tsx` — adds a clickable "Per wizyta / Jednorazowy" badge on each entry in the list (toggleable in-place), and a labeled Switch in the "add document" dialog explaining the one-time semantics (RODO, regulamin etc.).