### PR TITLE
Sync appointment date in formDocuments on appointment reschedule

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1588,6 +1588,40 @@ export const update = action({
       }
     }
 
+    // Sync appointment date/time pre-fill in linked formDocuments that are
+    // still editable. Terminal-state documents (signed/completed/expired/voided)
+    // retain the date that was visible at signing time — only draft and
+    // pending_signature documents get updated.
+    if (dateChanged) {
+      try {
+        const linkedDocs = await db
+          .query("formDocuments")
+          .eq("entityType", "appointment")
+          .eq("entityId", appointmentId)
+          .collect();
+        const EDITABLE_STATUSES = new Set(["draft", "pending_signature"]);
+        for (const doc of linkedDocs) {
+          const docRow = doc as Record<string, unknown>;
+          if (!EDITABLE_STATUSES.has(docRow.status as string)) continue;
+          let rd: Record<string, string> = {};
+          try {
+            rd = JSON.parse((docRow.responseData as string) ?? "{}");
+          } catch {
+            rd = {};
+          }
+          rd["appointment.date"] = newDate;
+          rd["appointment.startTime"] = newStart;
+          rd["appointment.endTime"] = newEnd;
+          await db.patch("formDocuments", docRow._id as string, {
+            responseData: JSON.stringify(rd),
+            updatedAt: now,
+          });
+        }
+      } catch (e) {
+        console.warn("[update] formDocuments date sync failed (non-fatal):", e);
+      }
+    }
+
     // --- Side effects (Convex-only: activity log, automation event) ---
     try {
       await ctx.runMutation(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2341.

Closes #2341

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Root cause confirmed**: `autoGenerateAppointmentDocuments` snapshots appointment date/time into `formDocument.responseData` at creation time (as `appointment.date`, `appointment.startTime`, `appointment.endTime` keys). The `update` action that handles reschedules patched the appointment row and the linked `scheduledActivity`, but never touched the `formDocuments`.

**Fix** (`convex/gabinet/appointments.ts`, after line ~1589): When `dateChanged` is true, the update action now queries all `formDocuments` linked to the appointment via `entityType='appointment'` + `entityId=appointmentId`, and for each document in an editable state (`draft` or `pending_signature`), parses their `responseData` JSON, updates the three appointment date/time keys in-place (preserving any user-filled fields), and patches the document back to Supabase. Documents in terminal states (`signed`, `completed`, `expired`, `voided`) are intentionally skipped — they represent a legal record of what was agreed at signing time. The whole block is wrapped in a non-fatal `try/catch` so a Supabase error doesn't abort the appointment update.