### PR TITLE
Add previous-response prefill for health questionnaire templates

### DIFF
--- a/convex/documents/generate.ts
+++ b/convex/documents/generate.ts
@@ -177,6 +177,106 @@ export const generateDocument = action({
   },
 });
 
+/**
+ * Fetch form field values from the most recent completed questionnaire
+ * for the same template + patient. Returns null when no prior response
+ * exists so callers can skip prefilling entirely.
+ */
+export const getPriorResponseData = action({
+  args: {
+    organizationId: v.id("organizations"),
+    templateId: v.string(),
+    entityType: v.string(),
+    entityId: v.string(),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ formFieldValues: Record<string, string> } | null> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+
+    const db = createSupabaseDb();
+
+    // Resolve the patient id from the entity context
+    let patientId: string | null = null;
+    if (args.entityType === "patient") {
+      patientId = args.entityId;
+    } else if (args.entityType === "appointment") {
+      const appt = await db.get("gabinetAppointments", args.entityId);
+      if (appt && String(appt.organizationId) === String(args.organizationId)) {
+        patientId = appt.patientId ? String(appt.patientId) : null;
+      }
+    }
+
+    if (!patientId) return null;
+
+    // All signed/completed docs for this template in this org
+    const allDocs = await db
+      .query("formDocuments")
+      .eq("organizationId", String(args.organizationId))
+      .eq("templateId", args.templateId)
+      .collect();
+
+    const resolvedPatientId = patientId;
+    const patientDocs = allDocs.filter((doc) => {
+      if (doc.status !== "signed" && doc.status !== "completed") return false;
+      // Direct patient-entity link
+      if (
+        doc.entityType === "patient" &&
+        String(doc.entityId) === resolvedPatientId
+      )
+        return true;
+      // Appointment-linked doc with scopeEntities.patient
+      if (doc.scopeEntities) {
+        try {
+          const scope =
+            typeof doc.scopeEntities === "string"
+              ? (JSON.parse(doc.scopeEntities as string) as Record<
+                  string,
+                  unknown
+                >)
+              : (doc.scopeEntities as Record<string, unknown>);
+          return String(scope?.patient) === resolvedPatientId;
+        } catch {
+          return false;
+        }
+      }
+      return false;
+    });
+
+    if (patientDocs.length === 0) return null;
+
+    // Most recent first
+    patientDocs.sort(
+      (a, b) => (b.createdAt as number) - (a.createdAt as number),
+    );
+    const mostRecent = patientDocs[0];
+
+    try {
+      const responseData = JSON.parse(mostRecent.responseData as string);
+      const rawValues = responseData.formFieldValues;
+      if (
+        !rawValues ||
+        typeof rawValues !== "object" ||
+        Object.keys(rawValues).length === 0
+      ) {
+        return null;
+      }
+      const formFieldValues: Record<string, string> = {};
+      for (const [k, v] of Object.entries(
+        rawValues as Record<string, unknown>,
+      )) {
+        formFieldValues[k] = String(v);
+      }
+      return { formFieldValues };
+    } catch {
+      return null;
+    }
+  },
+});
+
 // Converted from internalMutation → internalAction so it can survive
 // transient Supabase retries. postgrest-js retries failed fetches via
 // `executeWithRetry → sleep → setTimeout`, which the Convex mutation runtime

--- a/src/components/documents/generate-document-dialog.tsx
+++ b/src/components/documents/generate-document-dialog.tsx
@@ -131,11 +131,13 @@ function countFormFields(formJson: string | null | undefined): number {
 function DocumentTemplateFormStep({
   contentJson,
   prefilledData,
+  previousValues,
   onComplete,
   onCancel,
 }: {
   contentJson: string;
   prefilledData: Record<string, string>;
+  previousValues?: Record<string, string>;
   onComplete: (data: Record<string, unknown>) => void;
   onCancel: () => void;
 }) {
@@ -188,6 +190,7 @@ function DocumentTemplateFormStep({
     <DocumentFormFiller
       formFields={allFormFields}
       filledByFilter="employee"
+      initialValues={previousValues}
       onComplete={(fieldValues) => {
         const resolvedHtml = renderDocument(
           contentJson,
@@ -683,6 +686,7 @@ export function GenerateDocumentDialog({
 
   const generateDocument = useAction(api.documents.generate.generateDocument);
   const completeMissingDataMutation = useAction(api.documents.completeMissingData.completeMissingData);
+  const getPriorResponseDataAction = useAction(api.documents.generate.getPriorResponseData);
 
   // --- Reset state on close ---
 
@@ -756,6 +760,24 @@ export function GenerateDocumentDialog({
     ],
     queryFn: () =>
       previewDocumentDataAction({
+        organizationId,
+        templateId: selectedTemplateId as unknown as string,
+        entityType,
+        entityId,
+      }),
+    enabled: !!selectedTemplateId && (step === "fill_form" || step === "complete_data"),
+  });
+
+  const { data: priorResponseData } = useQuery({
+    queryKey: [
+      "documents.generate.getPriorResponseData",
+      organizationId,
+      selectedTemplateId,
+      entityType,
+      entityId,
+    ],
+    queryFn: () =>
+      getPriorResponseDataAction({
         organizationId,
         templateId: selectedTemplateId as unknown as string,
         entityType,
@@ -1073,6 +1095,7 @@ export function GenerateDocumentDialog({
                     <DocumentTemplateFormStep
                       contentJson={previewData.contentJson}
                       prefilledData={previewData.prefilledData}
+                      previousValues={priorResponseData?.formFieldValues}
                       onComplete={handleComplete}
                       onCancel={handleBack}
                     />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2342.

Closes #2342

---

## Claude summary

The issue was real and is now fixed. Here's what was done:

**Root cause:** `DocumentFormFiller` already had an `initialValues` prop, but nothing ever populated it when generating a document from a template. For returning patients filling out the same health questionnaire (wywiad zdrowotny), every session started blank.

**Changes (2 files):**

`convex/documents/generate.ts` — new `getPriorResponseData` action:
- Resolves the patient from the entity context (direct `patient` entity, or via `appointment.patientId`)
- Queries `formDocuments` for all signed/completed documents for the same `templateId` in this org
- Matches patient by direct entity link OR `scopeEntities.patient` (how auto-generated appointment docs store patient reference)
- Returns `formFieldValues` from the most recent matching document

`src/components/documents/generate-document-dialog.tsx`:
- Adds `useAction` and `useQuery` for the new action, fired in parallel with `previewDocumentData`
- Passes `priorResponseData?.formFieldValues` as `previousValues` through `DocumentTemplateFormStep` → `initialValues` on `DocumentFormFiller`
- When no prior response exists, the action returns `null` and the form starts empty as before