### PR TITLE
Add SMS sending channel for document signing requests

### DIFF
--- a/convex/signatureRequests.ts
+++ b/convex/signatureRequests.ts
@@ -146,7 +146,9 @@ export const sendForSigning = action({
 
     for (const signer of args.signers) {
       if (signer.signerType === "external" && !signer.signerEmail) {
-        throw new Error(`Email required for external signer on slot ${signer.slotId}`);
+        if (signer.verificationMethod !== "sms" || !signer.signerPhone) {
+          throw new Error(`Email required for external signer on slot ${signer.slotId}`);
+        }
       }
       if (signer.verificationMethod === "sms" && !signer.signerPhone) {
         throw new Error(`Phone required for SMS verification on slot ${signer.slotId}`);
@@ -269,6 +271,17 @@ export const _sendSigningEmails = internalMutation({
         await ctx.scheduler.runAfter(0, api.signingEmails.sendSigningRequestEmail, {
           signerName: sig.signerName ?? sig.signerEmail,
           signerEmail: sig.signerEmail,
+          documentTitle: args.instanceTitle,
+          organizationName: orgName,
+          token: ct.token,
+          expiresAt: args.expiresAt,
+        });
+      }
+      if (sig?.signerPhone && sig?.verificationMethod === "sms") {
+        await ctx.scheduler.runAfter(0, internal.sms.sendSigningLinkSms, {
+          organizationId: args.organizationId as Id<"organizations">,
+          phone: sig.signerPhone,
+          signerName: sig.signerName ?? sig.signerPhone,
           documentTitle: args.instanceTitle,
           organizationName: orgName,
           token: ct.token,

--- a/convex/sms.ts
+++ b/convex/sms.ts
@@ -295,6 +295,47 @@ async function sendViaTwilio(
 }
 
 // ---------------------------------------------------------------------------
+// sendSigningLinkSms — internal action to deliver a document-signing URL via SMS
+// ---------------------------------------------------------------------------
+
+export const sendSigningLinkSms = internalAction({
+  args: {
+    organizationId: v.id("organizations"),
+    phone: v.string(),
+    signerName: v.string(),
+    documentTitle: v.string(),
+    organizationName: v.string(),
+    token: v.string(),
+    expiresAt: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const config = await ctx.runQuery(internal.sms.getConfigInternal, {
+      organizationId: args.organizationId,
+    });
+    if (!config || !config.isActive) {
+      console.warn("[sms.sendSigningLinkSms] SMS not configured or inactive — skipping");
+      return { sent: false };
+    }
+
+    const APP_URL = process.env.APP_URL ?? "https://app.example.com";
+    const signingUrl = `${APP_URL}/sign/${args.token}`;
+    const expiryDate = new Date(args.expiresAt).toLocaleDateString("pl-PL");
+    const message = `${args.organizationName} prosi o podpisanie dokumentu „${args.documentTitle}". Link: ${signingUrl} (ważny do: ${expiryDate})`;
+
+    if (config.provider === "smsapi") {
+      await sendViaSmsapi(config.apiToken, args.phone, message, config.senderId ?? undefined);
+    } else if (config.provider === "twilio") {
+      if (!config.apiSecret || !config.fromNumber) {
+        throw new Error("Twilio requires API secret and phone number");
+      }
+      await sendViaTwilio(config.apiToken, config.apiSecret, config.fromNumber, args.phone, message);
+    }
+
+    return { sent: true };
+  },
+});
+
+// ---------------------------------------------------------------------------
 // sendAppointmentSms — internal action for appointment lifecycle SMS
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2343.

Closes #2343

---

## Claude summary

Done. Here's what was changed:

**`convex/sms.ts`** — new `sendSigningLinkSms` internal action (lines 301-336). It loads the org's SMS config and sends the signing URL via SMSAPI or Twilio with a Polish-language message containing the link and expiry date.

**`convex/signatureRequests.ts`** — two fixes:

1. Validation (line 148-152): external signers without an email are now accepted when `verificationMethod === "sms"` and a `signerPhone` is provided. Previously this always threw, making SMS-only patients impossible to send to.

2. `_sendSigningEmails` dispatcher (line 280-290): after the existing email block, a new branch schedules `internal.sms.sendSigningLinkSms` for any signer who has a phone number and uses SMS verification. Email and SMS delivery are independent — a signer with both an email and a phone gets both.

The `resend` action re-creates the signing request but never triggered any notification even before this change (for email or SMS), so that remains a pre-existing gap.

## Follow-ups

- Send notification on signing request resend: `convex/signatureRequests.ts` `resend` action creates a fresh token but never dispatches an email or SMS to the signer — the recipient silently gets a new link they don't know about.
- Implement `email_otp` delivery path in `requestOtp`: `convex/sms.ts:382` has a `// TODO — will use Resend in Phase E` comment; the `email_otp` verification method is schema-valid but OTP delivery via email is never sent.