### PR TITLE
Send notification on signing request resend

### DIFF
--- a/convex/signatureRequests.ts
+++ b/convex/signatureRequests.ts
@@ -500,6 +500,26 @@ export const resend = action({
       createdAt: now,
     });
 
+    // Dispatch email/SMS notification with the new token
+    const instance = await db.get("documentInstances", String(request.instanceId));
+    try {
+      await ctx.runMutation(internal.signatureRequests._sendSigningEmails, {
+        organizationId: String(request.organizationId),
+        instanceTitle: String(instance?.title ?? ""),
+        createdTokens: JSON.stringify([{ slotId: request.slotId, token, requestId: newId }]),
+        signatures: JSON.stringify([{
+          slotId: request.slotId,
+          signerEmail: request.signerEmail,
+          signerName: request.signerName,
+          signerPhone: request.signerPhone,
+          verificationMethod: request.verificationMethod,
+        }]),
+        expiresAt,
+      });
+    } catch (e) {
+      console.error("[signatureRequests.resend] Notification side effects FAILED:", e);
+    }
+
     return { requestId: newId, token };
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2349.

Closes #2349

---

## Claude summary

The fix is committed. Here's what was wrong and what was done:

**Root cause:** `convex/signatureRequests.ts:resend` (line 468) was generating a fresh token and creating a new `signatureRequests` row, but returned immediately without notifying the signer — so the recipient never learned their link had changed.

**Fix:** After inserting the new request, fetch the document instance (for its title) and call the existing `_sendSigningEmails` internal mutation, exactly mirroring the pattern used by `sendForSigning` (line 228). This schedules the appropriate email (if `signerEmail` is set) or SMS (if `signerPhone` + `verificationMethod === "sms"`) via `ctx.scheduler`, wrapped in the same fault-tolerant try/catch so a notification failure never blocks the resend itself.