### PR TITLE
Implement `email_otp` delivery path in `requestOtp`

### DIFF
--- a/convex/signingEmails.ts
+++ b/convex/signingEmails.ts
@@ -60,6 +60,41 @@ export const sendSigningRequestEmail = action({
 });
 
 // ---------------------------------------------------------------------------
+// Send OTP code via email for email_otp verification
+// ---------------------------------------------------------------------------
+
+export const sendOtpEmail = action({
+  args: {
+    signerEmail: v.string(),
+    code: v.string(),
+  },
+  handler: async (_ctx, args): Promise<{ sent: boolean }> => {
+    if (!RESEND_API_KEY) {
+      console.warn("RESEND_API_KEY not set — skipping OTP email");
+      return { sent: false };
+    }
+
+    const resend = new Resend(RESEND_API_KEY);
+
+    await resend.emails.send({
+      from: RESEND_FROM ?? "noreply@example.com",
+      to: args.signerEmail,
+      subject: `Twój kod weryfikacyjny: ${args.code}`,
+      html: `
+        <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+          <h2 style="color: #333;">Kod weryfikacyjny</h2>
+          <p>Twój jednorazowy kod do podpisania dokumentu:</p>
+          <p style="font-size: 32px; font-weight: 700; letter-spacing: 8px; color: #111; margin: 24px 0;">${args.code}</p>
+          <p style="color: #666; font-size: 14px;">Kod jest ważny przez 10 minut. Jeśli nie próbowałeś podpisać dokumentu, zignoruj tę wiadomość.</p>
+        </div>
+      `,
+    });
+
+    return { sent: true };
+  },
+});
+
+// ---------------------------------------------------------------------------
 // Notify document author when a slot is signed
 // ---------------------------------------------------------------------------
 

--- a/convex/sms.ts
+++ b/convex/sms.ts
@@ -411,6 +411,8 @@ export const requestOtp = action({
     const organizationId = String(result.organizationId ?? "");
     const signerPhone =
       typeof result.signerPhone === "string" ? result.signerPhone : undefined;
+    const signerEmail =
+      typeof result.signerEmail === "string" ? result.signerEmail : undefined;
 
     if (verificationMethod === "sms") {
       if (!signerPhone) throw new Error("No phone number for SMS delivery");
@@ -419,8 +421,13 @@ export const requestOtp = action({
         phone: signerPhone,
         code: result.code,
       });
+    } else if (verificationMethod === "email_otp") {
+      if (!signerEmail) throw new Error("No email address for OTP delivery");
+      await ctx.runAction(api.signingEmails.sendOtpEmail, {
+        signerEmail,
+        code: result.code,
+      });
     }
-    // email_otp: TODO — will use Resend in Phase E
 
     return { sent: true, method: verificationMethod };
   },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2350.

Closes #2350

---

## Claude summary

Done. Here's what was implemented:

**`convex/signingEmails.ts`** — added `sendOtpEmail` action that sends the OTP code via Resend in a simple Polish-language email. Follows the exact same guard (`RESEND_API_KEY` check + graceful `{ sent: false }` fallback) and from-address pattern as the existing `sendSigningRequestEmail` action.

**`convex/sms.ts`** — in `requestOtp`, extracted `signerEmail` from the `createOtp` result (it was already returned but unused) and added an `else if (verificationMethod === "email_otp")` branch that calls `api.signingEmails.sendOtpEmail`. The TODO comment is removed.

`createOtp` already stored `signerEmail` in its return value (`signatureRequests.ts:424`), so no schema or data-layer changes were needed.