### PR TITLE
Gotowe – RODO Gotowe – Wywiad zdrowotny

### DIFF
--- a/convex/documents/seed.ts
+++ b/convex/documents/seed.ts
@@ -1697,6 +1697,12 @@ function buildRodoV2Template(c: ComponentMap): BeautyTemplate {
       p(),
       p(
         txt(
+          "Gabinet prowadzi dokumentację wizyt i zabiegów klienta w systemie, w zakresie niezbędnym do zapewnienia ciągłości obsługi, bezpieczeństwa zabiegów, prawidłowego prowadzenia terapii oraz rozliczenia wykonanych usług.",
+        ),
+      ),
+      p(),
+      p(
+        txt(
           "Podstawą przetwarzania danych jest wykonanie usługi lub podjęcie działań przed jej wykonaniem, obowiązki prawne administratora, prawnie uzasadniony interes administratora oraz zgoda klienta tam, gdzie jest wymagana.",
         ),
       ),
@@ -1704,6 +1710,12 @@ function buildRodoV2Template(c: ComponentMap): BeautyTemplate {
       p(
         txt(
           "Dane mogą być przekazywane wyłącznie w niezbędnym zakresie podmiotom wspierającym administratora, takim jak dostawca systemu CRM, hosting, poczta e-mail, SMS, operator płatności, księgowość, obsługa IT lub obsługa prawna.",
+        ),
+      ),
+      p(),
+      p(
+        txt(
+          "Gabinet może kontaktować się z klientem SMS-em lub e-mailem w sprawach organizacyjnych dotyczących umówionej wizyty, w szczególności w celu potwierdzenia utworzenia wizyty oraz przypomnienia o zbliżającym się terminie.",
         ),
       ),
       p(),
@@ -1761,6 +1773,24 @@ function buildRodoV2Template(c: ComponentMap): BeautyTemplate {
           "rodo2_confirm_contact",
           "checkbox",
           "Przyjmuję do wiadomości, że podane przeze mnie dane kontaktowe mogą być wykorzystywane do kontaktu organizacyjnego związanego z wizytą, np. potwierdzenia terminu, przypomnienia o wizycie, zmiany lub odwołania wizyty.",
+          { required: true },
+        ),
+      ),
+      p(),
+      p(
+        formField(
+          "rodo2_confirm_records",
+          "checkbox",
+          "Rozumiem, że gabinet prowadzi dokumentację moich wizyt i zabiegów w systemie, aby zapewnić ciągłość obsługi, bezpieczeństwo zabiegów i prawidłowe prowadzenie terapii.",
+          { required: true },
+        ),
+      ),
+      p(),
+      p(
+        formField(
+          "rodo2_confirm_reminders",
+          "checkbox",
+          "Rozumiem, że gabinet może wysłać mi SMS lub e-mail z potwierdzeniem utworzenia wizyty oraz przypomnieniem o jej terminie.",
           { required: true },
         ),
       ),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2357.

Closes #2357

---

## Claude summary

NOT_A_BUG: all requested changes from issue #2357 are already fully implemented and merged to `main`.

The `git diff origin/main HEAD` for `convex/documents/seed.ts` is empty — the branch and main are content-identical. Here's what's already done:

**Template renames** (merged via PR #2361, `convex/documents/seed.ts`):
- Line 1658: `name: "Gotowe – Wywiad zdrowotny"`
- Line 1842: `name: "Gotowe – RODO"`

**RODO body additions** (merged via PR #2368, `convex/documents/seed.ts`):
- Line 1700: Clinic documentation clause ("Gabinet prowadzi dokumentację wizyt i zabiegów...")
- Line 1718: SMS/email reminders clause ("Gabinet może kontaktować się z klientem SMS-em lub e-mailem...")

**Required checkboxes** (merged via PR #2368, `convex/documents/seed.ts`):
- Line 1782: `rodo2_confirm_records` — client acknowledges visit documentation in system
- Line 1791: `rodo2_confirm_reminders` — client acknowledges appointment SMS/email

**`renameReadyTemplates` mutation** (line 2368): available for any already-seeded org via `convex run documents/seed:renameReadyTemplates '{"organizationId":"<id>"}'`.

The last comment on the issue from @aleksanderem at 18:55 confirms: "There is nothing left to implement on this issue." No code changes are needed.