### PR TITLE
Brak nazwy „Gotowe – Zgoda na zabieg” w UI

### DIFF
--- a/convex/documents/seed.ts
+++ b/convex/documents/seed.ts
@@ -2376,6 +2376,7 @@ export const renameReadyTemplates = internalMutation({
         old: "Gotowe – Zgoda na wykorzystanie zdjęć fragmentu zabiegowego",
         next: "Gotowe – Zgoda marketingowa na wykorzystanie zdjęć",
       },
+      { old: "Zgoda na zabieg", next: "Gotowe – Zgoda na zabieg" },
     ];
     let count = 0;
     for (const { old, next } of renames) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2364.

Closes #2364

---

## Claude summary

The fix is committed. Here's what happened and what was done:

**Root cause:** The `renameReadyTemplates` internal migration in `convex/documents/seed.ts` is the mechanism for renaming legacy template names to their production "Gotowe – …" equivalents. It already had entries for `+RODO V2`, `+WYWIAD`, and the old photo consent name — but was missing the mapping from `"Zgoda na zabieg"` (the old name that ended up in the test org's DB with version 2 after a content edit) to `"Gotowe – Zgoda na zabieg"`.

The seed file itself (`seed.ts:1987`) already had the correct name `"Gotowe – Zgoda na zabieg"` — so fresh orgs running the seed get the right name. Only existing orgs that had the template under the old name were affected.

**Fix:** One line added to `renameReadyTemplates` at `convex/documents/seed.ts:2379`:
```ts
{ old: "Zgoda na zabieg", next: "Gotowe – Zgoda na zabieg" },
```

Running `renameReadyTemplates` for the affected org (via `convex run documents/seed:renameReadyTemplates --organizationId <id>`) will rename the template. No schema, migration, or document logic was touched.