### PR TITLE
Szablony e-mail — poprawa edycji na telefonie

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.email-templates.$templateId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.email-templates.$templateId.tsx
@@ -197,23 +197,23 @@ function EditEmailTemplatePage() {
   return (
     <div className="flex h-full flex-col">
       {/* Header bar */}
-      <div className="flex items-center gap-3 border-b px-4 py-2">
-        <Button variant="ghost" size="icon" className="h-8 w-8" asChild>
+      <div className="flex items-center gap-2 border-b px-4 py-2">
+        <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" asChild>
           <Link to="/dashboard/email-templates">
             <ArrowLeft className="h-4 w-4" />
           </Link>
         </Button>
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <div className="flex min-w-0 flex-1 items-center gap-2 text-sm text-muted-foreground">
           <Link
             to="/dashboard/email-templates"
-            className="hover:text-foreground"
+            className="hidden shrink-0 hover:text-foreground sm:inline"
           >
             {t("emailTemplates.title")}
           </Link>
-          <span>/</span>
-          <span className="text-foreground">{template.name}</span>
+          <span className="hidden sm:inline">/</span>
+          <span className="truncate text-foreground">{template.name}</span>
         </div>
-        <div className="ml-auto flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           <div className="flex items-center gap-1.5 text-sm">
             <span className="text-muted-foreground">
               {isActive ? t("common.active") : t("common.inactive")}
@@ -250,9 +250,9 @@ function EditEmailTemplatePage() {
       </div>
 
       {/* Form + Editor */}
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6">
         <div className="mx-auto max-w-[900px] space-y-4">
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
             <div className="space-y-1.5">
               <Label>{t("common.name")}</Label>
               <Input

--- a/src/routes/_app/_auth/dashboard/_layout.settings.email-templates.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.email-templates.tsx
@@ -314,7 +314,7 @@ function EmailTemplatesSettings() {
 
       {/* Create/Edit Dialog */}
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <DialogContent className="sm:max-w-[900px] max-h-[90vh] overflow-y-auto">
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[900px]">
           <DialogHeader>
             <DialogTitle>
               {editingId
@@ -324,7 +324,7 @@ function EmailTemplatesSettings() {
           </DialogHeader>
 
           <div className="space-y-4">
-            <div className="grid grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
               <div className="space-y-1.5">
                 <Label>{t("common.name")}</Label>
                 <Input


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2375.

Closes #2375

---

## Claude summary

Done. Here's what was changed in the two files:

**`_layout.email-templates.$templateId.tsx`** (edit page):
- Back button gets `shrink-0` so it stays reachable on narrow screens.
- Breadcrumb gets `min-w-0 flex-1` so it yields space to the action bar; the "Szablony e-mail / " link and separator are hidden on mobile (`hidden sm:inline`); the template name gets `truncate` so it clips instead of overflowing.
- Action bar gets `shrink-0` so Save/Trash/Switch are never pushed off-screen.
- Name/Category/Module row: `grid-cols-1` on mobile, `sm:grid-cols-3` on larger screens — all three fields go full-width on phones.
- Form padding: `p-4` on mobile, `sm:p-6` on desktop.

**`_layout.settings.email-templates.tsx`** (settings dialog):
- Same `grid-cols-1 sm:grid-cols-3` fix inside the create/edit dialog form.

No logic, data, backend, or component behavior was touched.