### PR TITLE
Szablony e-mail — poprawa edycji na telefonie

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.email-templates.$templateId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.email-templates.$templateId.tsx
@@ -197,23 +197,23 @@ function EditEmailTemplatePage() {
   return (
     <div className="flex h-full flex-col">
       {/* Header bar */}
-      <div className="flex items-center gap-3 border-b px-4 py-2">
-        <Button variant="ghost" size="icon" className="h-8 w-8" asChild>
+      <div className="flex items-center gap-2 border-b px-4 py-2">
+        <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" asChild>
           <Link to="/dashboard/email-templates">
             <ArrowLeft className="h-4 w-4" />
           </Link>
         </Button>
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <div className="flex min-w-0 flex-1 items-center gap-2 text-sm text-muted-foreground">
           <Link
             to="/dashboard/email-templates"
-            className="hover:text-foreground"
+            className="hidden shrink-0 hover:text-foreground sm:inline"
           >
             {t("emailTemplates.title")}
           </Link>
-          <span>/</span>
-          <span className="text-foreground">{template.name}</span>
+          <span className="hidden sm:inline">/</span>
+          <span className="truncate text-foreground">{template.name}</span>
         </div>
-        <div className="ml-auto flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           <div className="flex items-center gap-1.5 text-sm">
             <span className="text-muted-foreground">
               {isActive ? t("common.active") : t("common.inactive")}
@@ -250,9 +250,9 @@ function EditEmailTemplatePage() {
       </div>
 
       {/* Form + Editor */}
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6">
         <div className="mx-auto max-w-[900px] space-y-4">
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
             <div className="space-y-1.5">
               <Label>{t("common.name")}</Label>
               <Input

--- a/src/routes/_app/_auth/dashboard/_layout.settings.email-templates.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.email-templates.tsx
@@ -314,7 +314,7 @@ function EmailTemplatesSettings() {
 
       {/* Create/Edit Dialog */}
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <DialogContent className="sm:max-w-[900px] max-h-[90vh] overflow-y-auto">
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[900px]">
           <DialogHeader>
             <DialogTitle>
               {editingId
@@ -324,7 +324,7 @@ function EmailTemplatesSettings() {
           </DialogHeader>
 
           <div className="space-y-4">
-            <div className="grid grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
               <div className="space-y-1.5">
                 <Label>{t("common.name")}</Label>
                 <Input


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2375.

Closes #2375

---

## Claude summary

The code on the current branch already contains all the fixes requested in this issue. Looking at the key indicators:

1. `_layout.email-templates.$templateId.tsx:255` — `grid-cols-1 gap-4 sm:grid-cols-3` (Name/Category/Module stack full-width on mobile)
2. `_layout.email-templates.$templateId.tsx:253` — `p-4 sm:p-6` (reduced padding on mobile)
3. `_layout.email-templates.$templateId.tsx:201` — back button has `shrink-0`
4. `_layout.email-templates.$templateId.tsx:206-216` — breadcrumb has `min-w-0 flex-1`, parent link is `hidden sm:inline`, template name has `truncate`, action bar has `shrink-0`
5. `_layout.settings.email-templates.tsx:327` — same `grid-cols-1 sm:grid-cols-3` fix in the dialog form
6. `template-editor.tsx:88` — editor container has `max-w-[600px]` (correctly caps at email width, shrinks below that), toolbar has `flex flex-wrap` for button wrapping on narrow screens

NOT_A_BUG: All the responsiveness fixes for the email template edit view were already implemented and squash-merged to `main` via PR #2376 and PR #2377 (referenced in the issue comments). The current branch `claude/issue-2375` was created from `main` after those merges, so it already contains the complete fix. The most recent commit on main — `00a1508 fix(email-templates): improve mobile responsiveness of edit view (#2375)` — confirms the work is done.

There is nothing left to implement for this issue.