### PR TITLE
Add location-scoped filtering to existing gabinet queries

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -375,6 +375,7 @@ export const list = action({
   args: {
     organizationId: v.id("organizations"),
     paginationOpts: paginationOptsValidator,
+    locationId: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<SupabasePaginationResult<GabinetAppointmentRow>> => {
     const authResult = await ctx.runQuery(
@@ -392,11 +393,13 @@ export const list = action({
     const orgIdStr = String(args.organizationId);
     const userIdStr = String(authResult.userId);
 
-    let page = (await db
+    let q = db
       .query("gabinetAppointments")
-      .eq("organizationId", orgIdStr)
-      .order("createdAt", false)
-      .collect()) as GabinetAppointmentRow[];
+      .eq("organizationId", orgIdStr);
+    if (args.locationId) {
+      q = q.eq("locationId", args.locationId);
+    }
+    let page = (await q.order("createdAt", false).collect()) as GabinetAppointmentRow[];
     if (perm.scope === "own") {
       page = page.filter((r) => String(r.employeeId) === userIdStr);
     }
@@ -437,6 +440,7 @@ export const listByDate = action({
   args: {
     organizationId: v.id("organizations"),
     date: v.string(),
+    locationId: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<GabinetAppointmentRow[]> => {
     const authResult = await ctx.runQuery(
@@ -451,11 +455,14 @@ export const listByDate = action({
     if (!perm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
-    let results = (await db
+    let q = db
       .query("gabinetAppointments")
       .eq("organizationId", String(args.organizationId))
-      .eq("date", args.date)
-      .collect()) as GabinetAppointmentRow[];
+      .eq("date", args.date);
+    if (args.locationId) {
+      q = q.eq("locationId", args.locationId);
+    }
+    let results = (await q.collect()) as GabinetAppointmentRow[];
     if (perm.scope === "own") {
       results = results.filter((r) => String(r.employeeId) === String(authResult.userId));
     }
@@ -469,6 +476,7 @@ export const listByDateRange = action({
     startDate: v.string(),
     endDate: v.string(),
     employeeId: v.optional(v.string()),
+    locationId: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<GabinetAppointmentRow[]> => {
     const authResult = await ctx.runQuery(
@@ -490,6 +498,9 @@ export const listByDateRange = action({
       .lte("date", args.endDate);
     if (args.employeeId) {
       builder = builder.eq("employeeId", args.employeeId);
+    }
+    if (args.locationId) {
+      builder = builder.eq("locationId", args.locationId);
     }
     let results = (await builder.collect()) as GabinetAppointmentRow[];
     if (perm.scope === "own") {

--- a/src/hooks/use-supabase-gabinet-appointments.ts
+++ b/src/hooks/use-supabase-gabinet-appointments.ts
@@ -20,11 +20,12 @@ import {
 interface UseSupabaseGabinetAppointmentsByDateRangeOptions {
   enabled?: boolean;
   employeeId?: string;
+  locationId?: string;
 }
 
 /**
  * Fetches appointments within a date range for an organization.
- * Supports optional employee filter for per-employee calendar views.
+ * Supports optional employee and location filters.
  */
 export function useSupabaseGabinetAppointmentsByDateRange(
   organizationId: string,
@@ -33,7 +34,7 @@ export function useSupabaseGabinetAppointmentsByDateRange(
   options: UseSupabaseGabinetAppointmentsByDateRangeOptions = {},
 ) {
   const { client, isReady } = useSupabase();
-  const { enabled = true, employeeId } = options;
+  const { enabled = true, employeeId, locationId } = options;
 
   return useQuery<MappedGabinetAppointment[], Error>({
     queryKey: [
@@ -42,6 +43,7 @@ export function useSupabaseGabinetAppointmentsByDateRange(
       startDate,
       endDate,
       employeeId ?? "",
+      locationId ?? "",
     ],
     queryFn: async (): Promise<MappedGabinetAppointment[]> => {
       if (!client) throw new Error("Supabase client not ready");
@@ -55,6 +57,9 @@ export function useSupabaseGabinetAppointmentsByDateRange(
 
       if (employeeId) {
         query = query.eq("employee_id", employeeId);
+      }
+      if (locationId) {
+        query = query.eq("location_id", locationId);
       }
 
       const { data, error } = await query.order("date").order("start_time");

--- a/supabase/migrations/00027_gabinet_appointments_location_idx.sql
+++ b/supabase/migrations/00027_gabinet_appointments_location_idx.sql
@@ -1,0 +1,6 @@
+-- Add composite index to support location-scoped appointment queries.
+-- gabinet_appointments.location_id is nullable (no location assigned);
+-- the index covers both filtered list and date-range calendar queries.
+CREATE INDEX IF NOT EXISTS gabinet_appointments_org_location_idx
+  ON gabinet_appointments (organization_id, location_id)
+  WHERE location_id IS NOT NULL;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2384.

Closes #2384

---

## Claude summary

Done. Here's a summary of what I found and changed:

**Triage result**: The issue is partially correct. The `gabinet_appointments` table has a `location_id` column in Supabase, but none of the list queries exposed it as a filter. However, the issue's claims about `patients.ts` and `payments.ts` are wrong — `gabinet_patients` and `payments` don't have a `location_id` column in the schema, so there's nothing to filter there.

**Changes made** (3 files):

`convex/gabinet/appointments.ts` — Added optional `locationId: v.optional(v.string())` to `list`, `listByDate`, and `listByDateRange`. When provided, the filter is pushed down to the Supabase query builder (`.eq("locationId", args.locationId)`).

`src/hooks/use-supabase-gabinet-appointments.ts` — Added optional `locationId` to `UseSupabaseGabinetAppointmentsByDateRangeOptions` and wired it into the Supabase query (`.eq("location_id", locationId)`). Also included `locationId` in the React Query cache key so per-location results are cached separately.

`supabase/migrations/00027_gabinet_appointments_location_idx.sql` — Adds a partial composite index `(organization_id, location_id) WHERE location_id IS NOT NULL` for efficient location-scoped queries.

## Follow-ups
- Add locationId filter to `useSupabaseGabinetAppointmentsByPatient` hook: if a patient can have appointments at multiple locations, callers may want to filter to a specific location when viewing patient history
- Add locationId filter to Supabase dashboard hooks in `use-supabase-gabinet-dashboard.ts`: KPI cards and revenue charts count all appointments org-wide; multi-location clinics will want per-location analytics