### PR TITLE
Gate `PatientPhotosTab` behind `gabinet_photos` permission

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -268,6 +268,10 @@ function PatientDetail() {
     "gabinet_payments",
     "view",
   );
+  const { allowed: canViewPhotos } = usePermission(
+    "gabinet_photos",
+    "view",
+  );
 
   const getPaymentForLabel = (payment: {
     appointmentId?: string;
@@ -1176,7 +1180,7 @@ function PatientDetail() {
         </div>
       ),
     },
-    {
+    ...(canViewPhotos ? [{
       label: t("gabinet.patients.tabs.photos", "Zdjęcia"),
       count: (patientAppointments ?? []).reduce(
         (sum, apt) =>
@@ -1190,7 +1194,7 @@ function PatientDetail() {
           treatments={treatmentsData}
         />
       ),
-    },
+    }] : []),
     ...(canViewPayments ? [{
       // Issue #1690: one merged tab — wpłaty, saldo, naliczenia, zwroty in
       // a single chronological table with a "Typ" column.


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2386.

Closes #2386

---

## Claude summary

The fix is committed. Here's what was done:

The `PatientPhotosTab` was rendered unconditionally inside the patient detail tabs array — any user with `gabinet_patients` view permission could see it. The `gabinet_photos` permission feature already existed in the RBAC system (`convex/_helpers/gabinetRolePermissions.ts`, `convex/_helpers/permissionTypes.ts`) but was never checked at the tab level.

The fix adds `const { allowed: canViewPhotos } = usePermission("gabinet_photos", "view")` and conditionally spreads the photos tab entry using the same `...(canViewPhotos ? [{ ... }] : [])` pattern already used for the payments tab (`canViewPayments`). The tab is now invisible to users whose role does not grant `gabinet_photos.view`.