### PR TITLE
Gate inventory reads/writes in `convex/inventory.ts` behind `gabinet_inventory`

### DIFF
--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -51,7 +51,7 @@ export const getStockSummary = action({
     });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
-      { organizationId: args.organizationId, feature: "products", action: "view" },
+      { organizationId: args.organizationId, feature: "gabinet_inventory", action: "view" },
     ) as { allowed: boolean; scope: string };
     if (!perm.allowed) throw new Error("Permission denied");
 
@@ -71,7 +71,7 @@ export const listMovements = action({
     });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
-      { organizationId: args.organizationId, feature: "products", action: "view" },
+      { organizationId: args.organizationId, feature: "gabinet_inventory", action: "view" },
     ) as { allowed: boolean; scope: string };
     if (!perm.allowed) throw new Error("Permission denied");
 
@@ -108,7 +108,7 @@ export const adjustStock = action({
     );
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
-      { organizationId: args.organizationId, feature: "products", action: "edit" },
+      { organizationId: args.organizationId, feature: "gabinet_inventory", action: "edit" },
     ) as { allowed: boolean; scope: string };
     if (!perm.allowed) throw new Error("Permission denied");
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2387.

Closes #2387

---

## Claude summary

The fix is committed. Here's a summary of what was done:

The report was accurate. In `convex/inventory.ts`, all three action handlers (`getStockSummary`, `listMovements`, `adjustStock`) were calling `checkPermission` with `feature: "products"` instead of the dedicated `feature: "gabinet_inventory"` permission that was introduced in #2383. This meant that anyone with CRM product-view/edit access could read and write inventory stock, bypassing the intended gabinet-scoped permission boundary.

The fix replaces the feature string in all three permission checks:
- `getStockSummary`: `products / view` → `gabinet_inventory / view`
- `listMovements`: `products / view` → `gabinet_inventory / view`  
- `adjustStock`: `products / edit` → `gabinet_inventory / edit`

The `gabinet_inventory` feature is confirmed registered in `convex/_helpers/permissionTypes.ts:28` and has default role assignments in `convex/_helpers/gabinetRolePermissions.ts`.