### PR TITLE
Add locationId filter to `useSupabaseGabinetAppointmentsByPatient` hook

### DIFF
--- a/src/hooks/use-supabase-gabinet-appointments.ts
+++ b/src/hooks/use-supabase-gabinet-appointments.ts
@@ -78,6 +78,7 @@ export function useSupabaseGabinetAppointmentsByDateRange(
 interface UseSupabaseGabinetAppointmentsByPatientOptions {
   enabled?: boolean;
   limit?: number;
+  locationId?: string;
 }
 
 export function useSupabaseGabinetAppointmentsByPatient(
@@ -86,22 +87,29 @@ export function useSupabaseGabinetAppointmentsByPatient(
   options: UseSupabaseGabinetAppointmentsByPatientOptions = {},
 ) {
   const { client, isReady } = useSupabase();
-  const { enabled = true, limit = 100 } = options;
+  const { enabled = true, limit = 100, locationId } = options;
 
   return useQuery<MappedGabinetAppointment[], Error>({
     queryKey: [
       ...supabaseKeys.gabinetAppointments.list(organizationId),
       "patient",
       patientId ?? "",
+      locationId ?? "",
     ],
     queryFn: async (): Promise<MappedGabinetAppointment[]> => {
       if (!client || !patientId) return [];
 
-      const { data, error } = await client
+      let query = client
         .from("gabinet_appointments")
         .select("*")
         .eq("organization_id", organizationId)
-        .eq("patient_id", patientId)
+        .eq("patient_id", patientId);
+
+      if (locationId) {
+        query = query.eq("location_id", locationId);
+      }
+
+      const { data, error } = await query
         .order("date", { ascending: false })
         .order("start_time", { ascending: false })
         .limit(limit);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2390.

Closes #2390

---

## Claude summary

Done. The fix adds `locationId?: string` to `UseSupabaseGabinetAppointmentsByPatientOptions` in `src/hooks/use-supabase-gabinet-appointments.ts`, includes it in the React Query cache key (so different locations get separate cache entries), and conditionally applies `.eq("location_id", locationId)` to the Supabase query when a `locationId` is passed. The existing two callers (`_layout.gabinet.patients.$patientId.tsx` and `patient-packages-card.tsx`) are unaffected since the option is optional and defaults to undefined.