### PR TITLE
Add location-scoped query filtering to gabinet patients/payments/reports

### DIFF
--- a/src/hooks/use-supabase-payments.ts
+++ b/src/hooks/use-supabase-payments.ts
@@ -143,15 +143,19 @@ export interface PaymentRevenueSummary {
  * the gabinet reports page to show actual collected revenue alongside the
  * appointment-based estimate. Only payments with a non-null `paid_at` are
  * included; `paid_at` timestamps are compared as milliseconds UTC.
+ *
+ * When `locationId` is provided, payments are scoped to those linked to
+ * appointments at that location in the date range. The payments table has no
+ * direct location_id column, so this requires a two-step query.
  */
 export function useSupabasePaymentsRevenueByDateRange(
   organizationId: string,
   startDate: string, // YYYY-MM-DD
   endDate: string,   // YYYY-MM-DD
-  options: { enabled?: boolean } = {},
+  options: { enabled?: boolean; locationId?: string } = {},
 ) {
   const { client, isReady } = useSupabase();
-  const { enabled = true } = options;
+  const { enabled = true, locationId } = options;
 
   return useQuery<PaymentRevenueSummary[], Error>({
     queryKey: [
@@ -159,6 +163,7 @@ export function useSupabasePaymentsRevenueByDateRange(
       "revenueByDateRange",
       startDate,
       endDate,
+      locationId ?? "",
     ],
     queryFn: async (): Promise<PaymentRevenueSummary[]> => {
       if (!client) throw new Error("Supabase client not ready");
@@ -166,7 +171,7 @@ export function useSupabasePaymentsRevenueByDateRange(
       const startTs = new Date(startDate + "T00:00:00.000Z").getTime();
       const endTs = new Date(endDate + "T23:59:59.999Z").getTime();
 
-      const { data, error } = await client
+      let paymentsQuery = client
         .from("payments")
         .select("amount, paid_at, currency, payment_method")
         .eq("organization_id", organizationId)
@@ -176,6 +181,25 @@ export function useSupabasePaymentsRevenueByDateRange(
         .not("paid_at", "is", null)
         .gte("paid_at", startTs)
         .lte("paid_at", endTs);
+
+      if (locationId) {
+        const { data: apptData, error: apptError } = await client
+          .from("gabinet_appointments")
+          .select("id")
+          .eq("organization_id", organizationId)
+          .eq("location_id", locationId)
+          .gte("date", startDate)
+          .lte("date", endDate);
+
+        if (apptError) throw apptError;
+
+        const apptIds = (apptData ?? []).map((a: { id: string }) => a.id);
+        if (apptIds.length === 0) return [];
+
+        paymentsQuery = paymentsQuery.in("appointment_id", apptIds);
+      }
+
+      const { data, error } = await paymentsQuery;
 
       if (error) throw error;
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -9,6 +9,7 @@ import {
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
+import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
 import { useOrganization } from "@/components/org-context";
 import { usePermission } from "@/hooks/use-permission";
 import { formatCurrencyPLN } from "@/lib/format-currency";
@@ -948,6 +949,7 @@ function GabinetReports() {
   const { allowed: canViewReports, loading: permLoading } = usePermission("gabinet_reports", "view");
 
   const [dateRange, setDateRange] = useState<DateRangeKey>("30d");
+  const [selectedLocationId, setSelectedLocationId] = useState<string | undefined>(undefined);
   const [dateFilterPanelOpen, setDateFilterPanelOpen] = useState(false);
   const todayIso = new Date().toISOString().split("T")[0];
   const defaultCustomStart = useMemo(() => {
@@ -1000,8 +1002,12 @@ function GabinetReports() {
     setDateFilterPanelOpen(false);
   }, [customStart, customEnd, t]);
 
+  const { data: locations } = useSupabaseGabinetLocationsList(organizationId, { activeOnly: true });
+
   const { data: appointments, isLoading: loadingAppointments } =
-    useSupabaseGabinetAppointmentsByDateRange(organizationId, startDate, endDate);
+    useSupabaseGabinetAppointmentsByDateRange(organizationId, startDate, endDate, {
+      locationId: selectedLocationId,
+    });
 
   const { data: treatments, isLoading: loadingTreatments } =
     useSupabaseGabinetTreatmentsList(organizationId);
@@ -1023,7 +1029,9 @@ function GabinetReports() {
     useSupabaseGratisBarterAppointmentIds(organizationId, completedAppointmentIds);
 
   const { data: actualPayments, isLoading: loadingActualPayments } =
-    useSupabasePaymentsRevenueByDateRange(organizationId, startDate, endDate);
+    useSupabasePaymentsRevenueByDateRange(organizationId, startDate, endDate, {
+      locationId: selectedLocationId,
+    });
 
   const isLoading =
     loadingAppointments || loadingTreatments || loadingPatients || loadingEmployees || loadingGratisBarter || loadingActualPayments;
@@ -1379,29 +1387,47 @@ function GabinetReports() {
           title={t("gabinet.reports.title")}
           description={t("gabinet.reports.description")}
         />
-        <Select
-          value={dateRange}
-          onValueChange={(v) => {
-            if (v === "custom") {
-              setDateFilterPanelOpen(true);
-              return;
-            }
-            setDateRange(v as DateRangeKey);
-          }}
-        >
-          <SelectTrigger className="w-40 shrink-0" aria-label={t("gabinet.reports.dateRange")}>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="today">{t("gabinet.reports.today")}</SelectItem>
-            <SelectItem value="yesterday">{t("gabinet.reports.yesterday")}</SelectItem>
-            <SelectItem value="7d">{t("gabinet.reports.last7days")}</SelectItem>
-            <SelectItem value="30d">{t("gabinet.reports.last30days")}</SelectItem>
-            <SelectItem value="90d">{t("gabinet.reports.last90days")}</SelectItem>
-            <SelectItem value="365d">{t("gabinet.reports.lastYear")}</SelectItem>
-            <SelectItem value="custom">{t("common.custom", "Custom")}</SelectItem>
-          </SelectContent>
-        </Select>
+        <div className="flex gap-2 shrink-0">
+          {locations && locations.length > 0 && (
+            <Select
+              value={selectedLocationId ?? "all"}
+              onValueChange={(v) => setSelectedLocationId(v === "all" ? undefined : v)}
+            >
+              <SelectTrigger className="w-40" aria-label={t("gabinet.reports.location", "Location")}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{t("gabinet.reports.allLocations", "All locations")}</SelectItem>
+                {locations.map((loc) => (
+                  <SelectItem key={loc._id} value={loc._id}>{loc.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          <Select
+            value={dateRange}
+            onValueChange={(v) => {
+              if (v === "custom") {
+                setDateFilterPanelOpen(true);
+                return;
+              }
+              setDateRange(v as DateRangeKey);
+            }}
+          >
+            <SelectTrigger className="w-40" aria-label={t("gabinet.reports.dateRange")}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="today">{t("gabinet.reports.today")}</SelectItem>
+              <SelectItem value="yesterday">{t("gabinet.reports.yesterday")}</SelectItem>
+              <SelectItem value="7d">{t("gabinet.reports.last7days")}</SelectItem>
+              <SelectItem value="30d">{t("gabinet.reports.last30days")}</SelectItem>
+              <SelectItem value="90d">{t("gabinet.reports.last90days")}</SelectItem>
+              <SelectItem value="365d">{t("gabinet.reports.lastYear")}</SelectItem>
+              <SelectItem value="custom">{t("common.custom", "Custom")}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
       </div>
 
       {/* KPI Cards */}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2397.

Closes #2397

---

## Claude summary

The commit is clean. Here's a summary of what was done:

**Triage:** The issue was legitimate — the gabinet reports page and `useSupabasePaymentsRevenueByDateRange` hook had no location-based filtering. (The patients part of the report is not applicable since `gabinet_patients` has no `location_id` column — patients are org-wide entities by design. Dashboard analytics got locationId support in the earlier PRs #2391/#2395.)

**Changes made:**

`src/hooks/use-supabase-payments.ts` — `useSupabasePaymentsRevenueByDateRange` now accepts an optional `locationId`. Since the `payments` table has no `location_id` column, a two-step query is used: first fetch appointment IDs at that location in the date range, then filter payments by those IDs. Returns early with `[]` when a location is selected but no appointments exist there (which correctly zeros out the payment revenue).

`src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx` — Added `selectedLocationId` state, imported `useSupabaseGabinetLocationsList`, and added a location dropdown to the filter header (only shown when the org has more than one active location). Both `useSupabaseGabinetAppointmentsByDateRange` and `useSupabasePaymentsRevenueByDateRange` now receive the selected `locationId`, so all appointment-based metrics (completions, revenue, treatment stats, employee utilization) and actual payment revenue are scoped to the chosen location.

## Follow-ups
- Add locationId filter to `useSupabaseGabinetPatientNudges` via appointment join: the nudge "no recent visit" in `use-supabase-gabinet-dashboard.ts` fetches all org appointments without location scope; it should optionally filter by location when a location context is active
- The "Total Patients" KPI card in reports always shows org-wide count regardless of location filter: this is by design (patients have no location_id), but it could be misleading — consider relabelling it to make clear it's always org-wide