### PR TITLE
Implement GABINET_MODULES catalog and checkModuleAccess helper

### DIFF
--- a/convex/_helpers/products.ts
+++ b/convex/_helpers/products.ts
@@ -1,5 +1,6 @@
 import { QueryCtx } from "../_generated/server";
 import { Id } from "../_generated/dataModel";
+import { GABINET_MODULES, type GabinetModule } from "../gabinet/_registry";
 
 /**
  * Verify that the organization has an active subscription for a specific product.
@@ -34,4 +35,21 @@ export async function verifyProductAccess(
   if (subscription.status !== "active" && subscription.status !== "trialing") {
     throw new Error(`Subscription for ${productId} is ${subscription.status}`);
   }
+}
+
+/**
+ * Verify that the organization has access to a specific gabinet sub-module.
+ * Resolves the module name to its required product ID via GABINET_MODULES and
+ * delegates to verifyProductAccess.
+ *
+ * Usage:
+ *   await checkModuleAccess(ctx, organizationId, "inventory");
+ *   await checkModuleAccess(ctx, organizationId, "patients");
+ */
+export async function checkModuleAccess(
+  ctx: QueryCtx,
+  organizationId: Id<"organizations">,
+  module: GabinetModule,
+): Promise<void> {
+  await verifyProductAccess(ctx, organizationId, GABINET_MODULES[module]);
 }

--- a/convex/gabinet/_registry.ts
+++ b/convex/gabinet/_registry.ts
@@ -41,3 +41,31 @@ export const GABINET_NAVIGATION = [
 
 /** Product ID for subscription gating */
 export const GABINET_PRODUCT_ID = "gabinet";
+
+/**
+ * Catalog mapping every gateable gabinet sub-module to the product ID whose
+ * active subscription grants access.  All standard features ship with the base
+ * "gabinet" plan.  Add-on features that require a separate purchase can point
+ * to a distinct product ID (e.g. "gabinet_online_booking") without changing
+ * call-sites — callers just pass the module name.
+ */
+export const GABINET_MODULES = {
+  dashboard:      "gabinet",
+  patients:       "gabinet",
+  appointments:   "gabinet",
+  treatments:     "gabinet",
+  packages:       "gabinet",
+  employees:      "gabinet",
+  documents:      "gabinet",
+  reports:        "gabinet",
+  payments:       "gabinet",
+  loyalty:        "gabinet",
+  scheduling:     "gabinet",
+  locations:      "gabinet",
+  equipment:      "gabinet",
+  inventory:      "gabinet",
+  online_booking: "gabinet",
+  settings:       "gabinet",
+} as const satisfies Record<string, string>;
+
+export type GabinetModule = keyof typeof GABINET_MODULES;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2398.

Closes #2398

---

## Claude summary

Done. Here's a summary of what was implemented:

**`convex/gabinet/_registry.ts`** — added `GABINET_MODULES` and `GabinetModule` type. The catalog maps 16 gabinet sub-module names (`dashboard`, `patients`, `appointments`, `treatments`, `packages`, `employees`, `documents`, `reports`, `payments`, `loyalty`, `scheduling`, `locations`, `equipment`, `inventory`, `online_booking`, `settings`) to their required product ID. All currently point to `"gabinet"` (base plan), but the structure lets future premium add-ons point to different product IDs without any call-site changes.

**`convex/_helpers/products.ts`** — added `checkModuleAccess(ctx, organizationId, module)` which resolves the module name through `GABINET_MODULES` and delegates to the existing `verifyProductAccess`. Callers can now write `await checkModuleAccess(ctx, organizationId, "inventory")` instead of manually stringing together the product ID.

## Follow-ups

- Adopt checkModuleAccess in all gabinet backend files: only `appointments.ts` (line 2024) currently calls `verifyProductAccess` for gabinet — the remaining ~20 gabinet convex files (`patients.ts`, `treatments.ts`, `packages.ts`, `employees.ts`, `loyalty.ts`, etc.) skip the product subscription check entirely and should each get a `checkModuleAccess` call after `verifyOrgAccess`.
- Add frontend `useModuleAccess` hook: the React side has no equivalent of `checkModuleAccess` — routes that render gabinet pages could use a hook backed by `productSubscriptions.getActiveProducts` to guard against direct URL access when a subscription lapses.