### PR TITLE
Add per-employee permission overrides table

### DIFF
--- a/convex/_helpers/authAction.ts
+++ b/convex/_helpers/authAction.ts
@@ -107,6 +107,19 @@ export const checkPermission = internalQuery({
           gabinetScope = defaultGabinetScope(gRole, feature, action);
         }
         effectiveScope = maxScope(orgScope, gabinetScope);
+
+        // Layer 3: per-employee overrides (MAX-merge on top of role-level scope)
+        const membershipOverride = await ctx.db
+          .query("gabinetMembershipPermissions")
+          .withIndex("by_orgAndUser", (q) =>
+            q.eq("organizationId", args.organizationId).eq("userId", user._id),
+          )
+          .unique();
+        if (membershipOverride) {
+          const mPerms = membershipOverride.permissions as Record<string, Record<string, string>>;
+          const membershipScope = (mPerms?.[feature]?.[action] ?? "none") as Scope;
+          effectiveScope = maxScope(effectiveScope, membershipScope);
+        }
       }
     }
 

--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -188,6 +188,19 @@ export async function checkPermission(
             ?? defaultGabinetScope(gRole, feature, action)) as Scope
         : defaultGabinetScope(gRole, feature, action);
       effectiveScope = maxScope(orgScope, gabinetScope);
+
+      // Layer 3: per-employee overrides (MAX-merge on top of role-level scope)
+      const membershipOverride = await ctx.db
+        .query("gabinetMembershipPermissions")
+        .withIndex("by_orgAndUser", (q) =>
+          q.eq("organizationId", orgId).eq("userId", user._id),
+        )
+        .unique();
+      if (membershipOverride) {
+        const mPerms = membershipOverride.permissions as Record<string, Record<string, string>>;
+        const membershipScope = (mPerms?.[feature]?.[action] ?? "none") as Scope;
+        effectiveScope = maxScope(effectiveScope, membershipScope);
+      }
     }
   }
 
@@ -286,6 +299,26 @@ export async function getEffectivePermissions(
         mergedActions[action] = maxScope(mergedActions[action], gabinetScope);
       }
       merged[feature] = mergedActions;
+    }
+
+    // Layer 3: per-employee overrides (MAX-merge on top of role-level scope)
+    const membershipOverride = await ctx.db
+      .query("gabinetMembershipPermissions")
+      .withIndex("by_orgAndUser", (q) =>
+        q.eq("organizationId", orgId).eq("userId", user._id),
+      )
+      .unique();
+    if (membershipOverride) {
+      const mPerms = membershipOverride.permissions as Partial<FeaturePermissions>;
+      for (const feature of ALL_FEATURES) {
+        if (!feature.startsWith("gabinet_")) continue;
+        const mergedActions = { ...merged[feature] };
+        for (const action of ACTIONS) {
+          const membershipScope: Scope = mPerms?.[feature as Feature]?.[action] ?? "none";
+          mergedActions[action] = maxScope(mergedActions[action], membershipScope);
+        }
+        merged[feature] = mergedActions;
+      }
     }
   }
 

--- a/convex/gabinetRoles.ts
+++ b/convex/gabinetRoles.ts
@@ -11,7 +11,7 @@
  * "none" everywhere until overrides land).
  */
 
-import { query, action, internalMutation } from "./_generated/server";
+import { query, mutation, action, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import { Id } from "./_generated/dataModel";
@@ -283,6 +283,81 @@ export const _resetPermissionsInternal = internalMutation({
       .query("gabinetRolePermissions")
       .withIndex("by_orgAndRole", (q) =>
         q.eq("organizationId", args.organizationId).eq("gabinetRole", args.gabinetRole),
+      )
+      .unique();
+    if (existing) await ctx.db.delete(existing._id);
+  },
+});
+
+// --- Per-employee permission overrides ---
+
+/** Return the per-employee permission override blob for a given user, or null
+ *  if no override exists (i.e. role-level permissions apply). */
+export const getEmployeePermissions = query({
+  args: {
+    organizationId: v.id("organizations"),
+    userId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    await requireOrgAdmin(ctx, args.organizationId);
+    const override = await ctx.db
+      .query("gabinetMembershipPermissions")
+      .withIndex("by_orgAndUser", (q) =>
+        q.eq("organizationId", args.organizationId).eq("userId", args.userId),
+      )
+      .unique();
+    return override?.permissions ?? null;
+  },
+});
+
+/** Upsert per-employee permission overrides. Overrides are MAX-merged on top
+ *  of the employee's gabinet-role permissions, so only elevation is possible. */
+export const setEmployeePermissions = mutation({
+  args: {
+    organizationId: v.id("organizations"),
+    userId: v.id("users"),
+    permissions: v.any(),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireOrgAdmin(ctx, args.organizationId);
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("gabinetMembershipPermissions")
+      .withIndex("by_orgAndUser", (q) =>
+        q.eq("organizationId", args.organizationId).eq("userId", args.userId),
+      )
+      .unique();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        permissions: args.permissions,
+        updatedBy: user._id,
+        updatedAt: now,
+      });
+    } else {
+      await ctx.db.insert("gabinetMembershipPermissions", {
+        organizationId: args.organizationId,
+        userId: args.userId,
+        permissions: args.permissions,
+        updatedBy: user._id,
+        updatedAt: now,
+      });
+    }
+  },
+});
+
+/** Remove the per-employee permission override, reverting the employee to
+ *  role-level permissions. */
+export const resetEmployeePermissions = mutation({
+  args: {
+    organizationId: v.id("organizations"),
+    userId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    await requireOrgAdmin(ctx, args.organizationId);
+    const existing = await ctx.db
+      .query("gabinetMembershipPermissions")
+      .withIndex("by_orgAndUser", (q) =>
+        q.eq("organizationId", args.organizationId).eq("userId", args.userId),
       )
       .unique();
     if (existing) await ctx.db.delete(existing._id);

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -610,6 +610,21 @@ export function createCrmTables({
     .index("by_org", ["organizationId"])
     .index("by_orgAndRole", ["organizationId", "gabinetRole"]),
 
+  // --- RBAC: Gabinet Per-Employee Permission Overrides ---
+  // Optional per-user permission overrides, MAX-merged on top of the
+  // gabinetRolePermissions layer. Allows elevating a specific employee's
+  // access beyond what their gabinet role grants (e.g. giving one receptionist
+  // access to financial reports). Absent row → role-level permissions apply.
+  gabinetMembershipPermissions: defineTable({
+    organizationId: v.id("organizations"),
+    userId: v.id("users"),
+    permissions: v.any(), // FeaturePermissions JSON
+    updatedBy: v.id("users"),
+    updatedAt: v.number(),
+  })
+    .index("by_org", ["organizationId"])
+    .index("by_orgAndUser", ["organizationId", "userId"]),
+
   // --- RBAC: Gabinet Membership Mirror ---
   // Slim Convex mirror of gabinet_employees.{userId, role, isActive} so that
   // checkPermission (which runs in QueryCtx and can't reach Supabase) can


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2400.

Closes #2400

---

## Claude summary

The implementation is committed. Here's a summary of what was done:

**Triage**: This is a genuine gap. The existing RBAC system has two layers for gabinet features — org-role permissions (`orgPermissions`) and gabinet-role permissions (`gabinetRolePermissions`) — but no way to set permissions per individual employee. The issue correctly identified the missing `gabinetMembershipPermissions` table.

**Implementation** (4 files, 137 lines added):

1. `convex/schema/crm.ts` — New `gabinetMembershipPermissions` table with `(organizationId, userId)` composite index, following the same shape as `gabinetRolePermissions`.

2. `convex/gabinetRoles.ts` — Three new public functions: `getEmployeePermissions` (query, admin-only), `setEmployeePermissions` (mutation, upsert), `resetEmployeePermissions` (mutation, deletes the override row).

3. `convex/_helpers/permissions.ts` — Both `checkPermission` and `getEffectivePermissions` now apply a third MAX-merge layer from `gabinetMembershipPermissions` after the gabinet-role layer.

4. `convex/_helpers/authAction.ts` — The action-level `checkPermission` gets the same third MAX-merge layer to keep mutation/query/action enforcement in sync.

**Semantics**: Per-employee overrides are MAX-merged (can only elevate above role level). This is consistent with how gabinet-role permissions work relative to org-role permissions.

## Follow-ups

- Add per-employee permissions UI in employee detail page: The `gabinetMembershipPermissions` backend is fully wired but there's no UI in `_layout.gabinet.employees.$employeeId.tsx` for admins to configure these overrides — a "Permissions" tab reusing the `RolePermissionPanel` pattern from `_layout.gabinet.settings.roles.tsx` would complete the feature.
- Support restriction semantics in per-employee overrides: Current MAX-merge semantics mean individual employees can only be elevated beyond their role, not restricted below it; a separate "deny list" or replace-semantics mode may be needed for some clinic workflows (e.g., restricting a doctor from financial reports).