### PR TITLE
The "Total Patients" KPI card in reports always shows org-wide count regardless 

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3531,6 +3531,7 @@
       "last90days": "Last 90 days",
       "lastYear": "Last year",
       "allClientsInSystem": "All clients in system",
+      "allClientsOrgWide": "All clients · org-wide",
       "statuses": {
         "pending_confirmation": "Pending",
         "scheduled": "Scheduled",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3553,6 +3553,7 @@
       "last90days": "Ostatnie 90 dni",
       "lastYear": "Ostatni rok",
       "allClientsInSystem": "Łącznie w systemie",
+      "allClientsOrgWide": "Wszyscy klienci · cały gabinet",
       "statuses": {
         "pending_confirmation": "Oczekujące",
         "scheduled": "Zaplanowane",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -1460,9 +1460,9 @@ function GabinetReports() {
         />
         <StatisticsImpressionCard
           title={t("gabinet.reports.totalPatients")}
-          description={t("gabinet.reports.allClientsInSystem")}
+          description={selectedLocationId ? t("gabinet.reports.allClientsOrgWide") : t("gabinet.reports.allClientsInSystem")}
           value={totalPatients.toLocaleString()}
-          changePercentage={t("gabinet.reports.allClientsInSystem")}
+          changePercentage={selectedLocationId ? t("gabinet.reports.allClientsOrgWide") : t("gabinet.reports.allClientsInSystem")}
           chartData={revenueChartPoints.map((d) => ({ month: String(d.index), impression: d.count }))}
         />
       </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2403.

Closes #2403

---

## Claude summary

Done. Here's a summary of the fix:

**Root cause confirmed:** `useSupabaseGabinetPatientsList` is called without `locationId` because patients have no `location_id` column — this is intentional. When a location filter is active, all other KPI cards (appointments, completed, cancelled) update, but the Total Patients card stays at the org-wide count, which was misleading without a clear label.

**Changes made (3 files):**

- `public/locales/en/translation.json` — added `"allClientsOrgWide": "All clients · org-wide"`
- `public/locales/pl/translation.json` — added `"allClientsOrgWide": "Wszyscy klienci · cały gabinet"`  
- `_layout.gabinet.reports.lazy.tsx:1461-1467` — when `selectedLocationId` is set, both the `description` and `changePercentage` props on `StatisticsImpressionCard` now use the new `allClientsOrgWide` key; when no filter is active they continue using the existing `allClientsInSystem` label