### PR TITLE
Add locationId filter to `useSupabaseGabinetPatientNudges` via appointment join

### DIFF
--- a/src/hooks/use-supabase-gabinet-dashboard.ts
+++ b/src/hooks/use-supabase-gabinet-dashboard.ts
@@ -459,11 +459,11 @@ export function useSupabaseGabinetLeaveNudges(organizationId: string) {
 }
 
 /** Patient nudges: patients missing contact info + no recent visit */
-export function useSupabaseGabinetPatientNudges(organizationId: string) {
+export function useSupabaseGabinetPatientNudges(organizationId: string, locationId?: string) {
   const { client, isReady } = useSupabase();
 
   return useQuery<NudgeData[], Error>({
-    queryKey: [...supabaseKeys.gabinetPatients.list(organizationId), "nudges"],
+    queryKey: [...supabaseKeys.gabinetPatients.list(organizationId), "nudges", locationId ?? ""],
     queryFn: async () => {
       if (!client) throw new Error("Supabase client not ready");
       const nudges: NudgeData[] = [];
@@ -486,14 +486,18 @@ export function useSupabaseGabinetPatientNudges(organizationId: string) {
         });
       }
 
-      // Patients with no recent visit (90 days)
+      // Patients with no recent visit (90 days), optionally scoped to a location
       const ninetyDaysAgo = dateNDaysAgo(90);
-      const { data: recentAppts, error: aErr } = await client
+      let apptQuery = client
         .from("gabinet_appointments")
         .select("patient_id")
         .eq("organization_id", organizationId)
         .gte("date", ninetyDaysAgo)
         .not("status", "in", '("cancelled","no_show")');
+
+      if (locationId) apptQuery = apptQuery.eq("location_id", locationId);
+
+      const { data: recentAppts, error: aErr } = await apptQuery;
 
       if (aErr) throw aErr;
       const recentPatientIds = new Set(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2402.

Closes #2402

---

## Claude summary

Done. The fix adds `locationId?: string` to `useSupabaseGabinetPatientNudges` in `src/hooks/use-supabase-gabinet-dashboard.ts:462`, includes it in the React Query cache key, and applies `.eq("location_id", locationId)` to the "no recent visit" appointment query when a location is active. The "missing contact" sub-nudge intentionally stays unfiltered — patients are an org-level concept, not location-scoped.

## Follow-ups

- Add locationId filter to Convex `getPatientNudges` action: `convex/gabinet/nudges.ts:127` has the same gap — its `recentAppointments` query (line 175) fetches all org appointments with no location scope; if the Convex action path is ever wired to a location-aware caller it will show inflated nudge counts.
- Add locationId filter to Convex `getAll` nudges action: `convex/gabinet/nudges.ts:233` inlines the same unscoped `recentAppointments` fetch (line 264–268); needs the same treatment as the standalone `getPatientNudges`.