### PR TITLE
Add locationId filter to `useSupabaseGabinetPatientNudges` via appointment join

### DIFF
--- a/src/hooks/use-supabase-gabinet-dashboard.ts
+++ b/src/hooks/use-supabase-gabinet-dashboard.ts
@@ -459,11 +459,11 @@ export function useSupabaseGabinetLeaveNudges(organizationId: string) {
 }
 
 /** Patient nudges: patients missing contact info + no recent visit */
-export function useSupabaseGabinetPatientNudges(organizationId: string) {
+export function useSupabaseGabinetPatientNudges(organizationId: string, locationId?: string) {
   const { client, isReady } = useSupabase();
 
   return useQuery<NudgeData[], Error>({
-    queryKey: [...supabaseKeys.gabinetPatients.list(organizationId), "nudges"],
+    queryKey: [...supabaseKeys.gabinetPatients.list(organizationId), "nudges", locationId ?? ""],
     queryFn: async () => {
       if (!client) throw new Error("Supabase client not ready");
       const nudges: NudgeData[] = [];
@@ -486,14 +486,18 @@ export function useSupabaseGabinetPatientNudges(organizationId: string) {
         });
       }
 
-      // Patients with no recent visit (90 days)
+      // Patients with no recent visit (90 days), optionally scoped to a location
       const ninetyDaysAgo = dateNDaysAgo(90);
-      const { data: recentAppts, error: aErr } = await client
+      let apptQuery = client
         .from("gabinet_appointments")
         .select("patient_id")
         .eq("organization_id", organizationId)
         .gte("date", ninetyDaysAgo)
         .not("status", "in", '("cancelled","no_show")');
+
+      if (locationId) apptQuery = apptQuery.eq("location_id", locationId);
+
+      const { data: recentAppts, error: aErr } = await apptQuery;
 
       if (aErr) throw aErr;
       const recentPatientIds = new Set(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2402.

Closes #2402

---

## Claude summary

NOT_A_BUG: This issue was already fixed. PR #2411 (commit `0eef531` on `main`) added the `locationId?: string` parameter to `useSupabaseGabinetPatientNudges` in `src/hooks/use-supabase-gabinet-dashboard.ts:434`, included it in the React Query cache key, and applied `.eq("location_id", locationId)` to the "no recent visit" appointment query.

This branch (`claude/issue-2402`) was created from an older state of `main` before that PR was squash-merged. The fix is already in the codebase on `main` — there is nothing left to implement.