### PR TITLE
Adopt checkModuleAccess in all gabinet backend files

### DIFF
--- a/convex/_helpers/products.ts
+++ b/convex/_helpers/products.ts
@@ -1,6 +1,7 @@
-import { QueryCtx } from "../_generated/server";
+import { QueryCtx, internalQuery } from "../_generated/server";
+import { v } from "convex/values";
 import { Id } from "../_generated/dataModel";
-import { GABINET_MODULES, type GabinetModule } from "../gabinet/_registry";
+import { GABINET_MODULES, GABINET_PRODUCT_ID, type GabinetModule } from "../gabinet/_registry";
 
 /**
  * Verify that the organization has an active subscription for a specific product.
@@ -53,3 +54,15 @@ export async function checkModuleAccess(
 ): Promise<void> {
   await verifyProductAccess(ctx, organizationId, GABINET_MODULES[module]);
 }
+
+/**
+ * Internal query that action handlers can call via ctx.runQuery() to verify
+ * gabinet product access. Actions receive ActionCtx (not QueryCtx) so they
+ * cannot call verifyProductAccess directly.
+ */
+export const verifyGabinetAccess = internalQuery({
+  args: { organizationId: v.id("organizations") },
+  handler: async (ctx, args) => {
+    await verifyProductAccess(ctx, args.organizationId, GABINET_PRODUCT_ID);
+  },
+});

--- a/convex/gabinet/appointmentReminders.ts
+++ b/convex/gabinet/appointmentReminders.ts
@@ -26,6 +26,7 @@ export const scheduleReminder = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
 
     const db = createSupabaseDb();
 
@@ -295,6 +296,7 @@ export const cancelReminders = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
 
     const db = createSupabaseDb();
 

--- a/convex/gabinet/appointmentSms.ts
+++ b/convex/gabinet/appointmentSms.ts
@@ -147,6 +147,7 @@ export const listByAppointment = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_appointments",

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -10,7 +10,7 @@ import {
 import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { verifyOrgAccess } from "../_helpers/auth";
-import { verifyProductAccess } from "../_helpers/products";
+import { checkModuleAccess } from "../_helpers/products";
 import { logActivity } from "../_helpers/activities";
 import { GABINET_PRODUCT_ID } from "./_registry";
 import { gabinetAppointmentStatusValidator } from "../schema";
@@ -382,6 +382,7 @@ export const list = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_appointments",
@@ -417,6 +418,7 @@ export const getById = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_appointments",
@@ -447,6 +449,7 @@ export const listByDate = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_appointments",
@@ -483,6 +486,7 @@ export const listByDateRange = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_appointments",
@@ -520,6 +524,7 @@ export const listByPatient = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_appointments",
@@ -550,6 +555,7 @@ export const listByEmployee = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_appointments",
@@ -580,6 +586,7 @@ export const listPatientsForEmployee = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_appointments",
@@ -631,6 +638,7 @@ export const listPatientsWithStatsForEmployee = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_appointments",
@@ -697,6 +705,7 @@ export const getAvailableSlotsQuery = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_appointments",
@@ -727,6 +736,7 @@ export const checkQualification = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_appointments",
@@ -1089,6 +1099,7 @@ export const create = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_appointments",
@@ -1452,6 +1463,7 @@ export const update = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       {
@@ -1797,6 +1809,7 @@ export const updateStatus = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       {
@@ -2021,7 +2034,7 @@ export const getDocumentGateStatus = query({
   },
   handler: async (ctx, args) => {
     await verifyOrgAccess(ctx, args.organizationId);
-    await verifyProductAccess(ctx, args.organizationId, GABINET_PRODUCT_ID);
+    await checkModuleAccess(ctx, args.organizationId, "appointments");
 
     return await checkDocumentGate(
       ctx,
@@ -2142,6 +2155,7 @@ export const cancel = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       {
@@ -2559,6 +2573,7 @@ export const cancelRecurringSeries = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       {
@@ -2675,6 +2690,7 @@ export const getFullDetail = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_appointments",
@@ -2964,6 +2980,7 @@ export const getWarnings = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = (await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       {
@@ -3155,6 +3172,7 @@ export const getPhotoUrls = query({
   },
   handler: async (ctx, args) => {
     await verifyOrgAccess(ctx, args.organizationId);
+    await checkModuleAccess(ctx, args.organizationId, "appointments");
     return Promise.all(
       args.storageIds.map((id) => ctx.storage.getUrl(id)),
     );

--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -26,6 +26,7 @@ export const list = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_employees",
@@ -84,6 +85,7 @@ export const listAll = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_employees",
@@ -117,6 +119,7 @@ export const getById = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_employees",
@@ -146,6 +149,7 @@ export const getByUserId = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_employees",
@@ -188,6 +192,7 @@ export const create = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     // Require admin role (mirrors requireOrgAdmin)
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
@@ -595,6 +600,7 @@ export const update = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     // Require admin role (mirrors requireOrgAdmin)
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
@@ -723,6 +729,7 @@ export const remove = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     // Require admin role (mirrors requireOrgAdmin)
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
@@ -810,6 +817,7 @@ export const getQualifiedForTreatment = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_employees",
@@ -843,6 +851,7 @@ export const setQualifiedTreatments = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     // Require admin role (mirrors requireOrgAdmin)
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");

--- a/convex/gabinet/equipment.ts
+++ b/convex/gabinet/equipment.ts
@@ -4,6 +4,7 @@ import { Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { verifyOrgAccess } from "../_helpers/auth";
+import { checkModuleAccess } from "../_helpers/products";
 import { logError } from "../_helpers/logged";
 import type {
   GabinetEquipmentRow,
@@ -35,6 +36,7 @@ export const listEquipment = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const db = createSupabaseDb();
     let q = db.query("gabinetEquipment").eq("organizationId", String(args.organizationId));
     if (args.locationId) {
@@ -62,6 +64,7 @@ export const getEquipment = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const db = createSupabaseDb();
     const equipment = (await db.get("gabinetEquipment", args.equipmentId)) as
       | GabinetEquipmentRow
@@ -107,6 +110,7 @@ export const createEquipment = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_settings", action: "edit" },
@@ -167,6 +171,7 @@ export const updateEquipment = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_settings", action: "edit" },
@@ -220,6 +225,7 @@ export const transferEquipment = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_settings", action: "edit" },
@@ -270,6 +276,7 @@ export const listTransfers = query({
   },
   handler: async (ctx, args) => {
     await verifyOrgAccess(ctx, args.organizationId);
+    await checkModuleAccess(ctx, args.organizationId, "equipment");
     const equipment = await ctx.db.get(args.equipmentId);
     if (!equipment || equipment.organizationId !== args.organizationId) return [];
     return await ctx.db

--- a/convex/gabinet/leaveTypes.ts
+++ b/convex/gabinet/leaveTypes.ts
@@ -16,6 +16,7 @@ export const list = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const db = createSupabaseDb();
     let q = db.query("gabinetLeaveTypes").eq("organizationId", String(args.organizationId));
     if (args.activeOnly) {
@@ -34,6 +35,7 @@ export const getById = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const db = createSupabaseDb();
     const lt = (await db.get("gabinetLeaveTypes", args.leaveTypeId)) as
       | GabinetLeaveTypeRow
@@ -60,6 +62,7 @@ export const create = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
     }
@@ -109,6 +112,7 @@ export const update = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
     }
@@ -156,6 +160,7 @@ export const remove = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
     }
@@ -186,6 +191,7 @@ export const getBalances = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
 
     const db = createSupabaseDb();
     const all = await db
@@ -206,6 +212,7 @@ export const getAllBalances = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
 
     const db = createSupabaseDb();
     const all = await db
@@ -229,6 +236,7 @@ export const initializeBalance = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
     }
@@ -285,6 +293,7 @@ export const adjustBalance = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
     }
@@ -315,6 +324,7 @@ export const initializeAllBalances = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
     }

--- a/convex/gabinet/locations.ts
+++ b/convex/gabinet/locations.ts
@@ -18,6 +18,7 @@ export const listLocations = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const db = createSupabaseDb();
     const results = (await db
       .query("gabinetLocations")
@@ -36,6 +37,7 @@ export const getLocation = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const db = createSupabaseDb();
     const location = (await db.get("gabinetLocations", args.locationId)) as
       | GabinetLocationRow
@@ -72,6 +74,7 @@ export const createLocation = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_settings", action: "edit" },
@@ -138,6 +141,7 @@ export const updateLocation = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_settings", action: "edit" },
@@ -184,6 +188,7 @@ export const deleteLocation = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_settings", action: "edit" },
@@ -229,6 +234,7 @@ export const listRooms = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const db = createSupabaseDb();
     const location = await db.get("gabinetLocations", args.locationId);
     if (!location || String(location.organizationId) !== String(args.organizationId)) return [];
@@ -253,6 +259,7 @@ export const createRoom = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_settings", action: "edit" },
@@ -310,6 +317,7 @@ export const updateRoom = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_settings", action: "edit" },
@@ -355,6 +363,7 @@ export const deleteRoom = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_settings", action: "edit" },

--- a/convex/gabinet/loyalty.ts
+++ b/convex/gabinet/loyalty.ts
@@ -14,6 +14,7 @@ export const getBalance = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const db = createSupabaseDb();
     return await db
       .query("gabinetLoyaltyPoints")
@@ -32,6 +33,7 @@ export const getTransactions = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const db = createSupabaseDb();
     return await db
       .query("gabinetLoyaltyTransactions")
@@ -81,6 +83,7 @@ export const earnPoints = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const now = Date.now();
     const db = createSupabaseDb();
 
@@ -123,6 +126,7 @@ export const spendPoints = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const now = Date.now();
     const db = createSupabaseDb();
 
@@ -165,6 +169,7 @@ export const adjustPoints = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const now = Date.now();
     const db = createSupabaseDb();
 

--- a/convex/gabinet/nudges.ts
+++ b/convex/gabinet/nudges.ts
@@ -14,6 +14,9 @@ async function verify(ctx: any, organizationId: string) {
   await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
     organizationId,
   });
+  await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, {
+    organizationId,
+  });
 }
 
 // --- Appointment nudges ---

--- a/convex/gabinet/onboarding.ts
+++ b/convex/gabinet/onboarding.ts
@@ -48,6 +48,7 @@ export const getSetupStatus = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
 
     const db = createSupabaseDb();
     const orgIdStr = String(args.organizationId);

--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -28,6 +28,7 @@ export const list = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_packages",
@@ -58,6 +59,7 @@ export const listActive = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_packages",
@@ -91,6 +93,7 @@ export const getById = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_packages",
@@ -132,6 +135,7 @@ export const create = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_packages", action: "create" },
@@ -232,6 +236,7 @@ export const update = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_packages", action: "edit" },
@@ -279,6 +284,7 @@ export const remove = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_packages", action: "delete" },
@@ -313,6 +319,7 @@ export const purchaseTreatment = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_packages", action: "create" },
@@ -458,6 +465,7 @@ export const purchasePackage = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_packages", action: "create" },
@@ -621,6 +629,7 @@ export const usePackageTreatment = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_packages", action: "edit" },
@@ -674,6 +683,7 @@ export const usePackageTreatmentsBatch = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       { organizationId: args.organizationId, feature: "gabinet_packages", action: "edit" },
@@ -758,6 +768,7 @@ export const getActiveUsageCounts = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_packages",
@@ -791,6 +802,7 @@ export const getPatientPackages = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_packages",
@@ -818,6 +830,7 @@ export const getPatientPackagesEnriched = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_packages",
@@ -894,6 +907,7 @@ export const getActiveUsageDetails = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_packages",

--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -21,6 +21,7 @@ export const list = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_patients",
@@ -95,6 +96,7 @@ export const listCustomReferralSources = action({
     const authResult = await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_patients",
@@ -148,6 +150,7 @@ export const getById = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_patients",
@@ -189,6 +192,7 @@ export const searchUnlinkedContacts = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "contacts",
@@ -272,6 +276,7 @@ export const create = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_patients",
@@ -444,6 +449,7 @@ export const update = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       {
@@ -542,6 +548,7 @@ export const remove = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       {
@@ -680,6 +687,7 @@ export const merge = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       {
@@ -951,6 +959,7 @@ export const getByContact = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_patients",

--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -21,6 +21,7 @@ export const getWorkingHours = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const db = createSupabaseDb();
     return (await db
       .query("gabinetWorkingHours")
@@ -45,6 +46,7 @@ export const setWorkingHours = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
     }
@@ -106,6 +108,7 @@ export const bulkSetWorkingHours = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
     }
@@ -158,6 +161,7 @@ export const getEmployeeSchedule = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const db = createSupabaseDb();
     return (await db
       .query("gabinetEmployeeSchedules")
@@ -186,6 +190,7 @@ export const setEmployeeSchedule = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
     }
@@ -254,6 +259,7 @@ export const bulkSetEmployeeSchedule = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
     }
@@ -329,6 +335,7 @@ export const saveSchedulePeriod = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
     }
@@ -392,6 +399,7 @@ export const removeSchedulePeriod = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
     }
@@ -418,6 +426,7 @@ export const listEmployeeSchedules = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const db = createSupabaseDb();
     return (await db
       .query("gabinetEmployeeSchedules")
@@ -437,6 +446,7 @@ export const listLeaves = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const db = createSupabaseDb();
     let q = db.query("gabinetLeaves").eq("organizationId", String(args.organizationId));
     if (args.status) {
@@ -464,6 +474,7 @@ export const createLeave = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const now = Date.now();
     const db = createSupabaseDb();
 
@@ -506,6 +517,7 @@ export const approveLeave = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
     }
@@ -566,6 +578,7 @@ export const rejectLeave = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
     }
@@ -596,6 +609,7 @@ export const getLeavesByDateRange = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const db = createSupabaseDb();
     const leaves = (await db
       .query("gabinetLeaves")
@@ -620,6 +634,7 @@ export const removeEmployeeSchedule = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     if (authResult.role !== "owner" && authResult.role !== "admin") {
       throw new Error("Admin access required");
     }
@@ -653,6 +668,7 @@ export const findNextAvailableSlot = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
 
     const db = createSupabaseDb();
 

--- a/convex/gabinet/sidebarWidgets.ts
+++ b/convex/gabinet/sidebarWidgets.ts
@@ -12,6 +12,9 @@ async function verify(ctx: any, organizationId: string) {
   await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
     organizationId,
   });
+  await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, {
+    organizationId,
+  });
 }
 
 // --- Dashboard KPIs ---

--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -26,6 +26,7 @@ export const list = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_treatments",
@@ -66,6 +67,7 @@ export const getById = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_treatments",
@@ -131,6 +133,7 @@ export const create = action({
         internal._helpers.authAction.verifyOrgAccess,
         { organizationId: args.organizationId },
       );
+      await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
       await ctx.runQuery(internal._helpers.authAction.checkPermission, {
         organizationId: args.organizationId,
         feature: "gabinet_treatments",
@@ -296,6 +299,7 @@ export const update = action({
         internal._helpers.authAction.verifyOrgAccess,
         { organizationId: args.organizationId },
       );
+      await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
       const perm = await ctx.runQuery(
         internal._helpers.authAction.checkPermission,
         {
@@ -410,6 +414,7 @@ export const remove = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       {
@@ -590,6 +595,7 @@ export const getTreatmentProducts = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_treatments",
@@ -644,6 +650,7 @@ export const setTreatmentProducts = action({
         internal._helpers.authAction.verifyOrgAccess,
         { organizationId: args.organizationId },
       );
+      await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
       await ctx.runQuery(internal._helpers.authAction.checkPermission, {
         organizationId: args.organizationId,
         feature: "gabinet_treatments",
@@ -703,6 +710,7 @@ export const listActive = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_treatments",
@@ -742,6 +750,7 @@ export const getTreatmentStats = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_treatments",
@@ -817,6 +826,7 @@ export const getTreatmentDetailedStats = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_treatments",
@@ -1033,6 +1043,7 @@ export const listTreatmentAppointments = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_appointments",
@@ -1108,6 +1119,7 @@ export const getTreatmentEmployees = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_employees",
@@ -1163,6 +1175,7 @@ export const getRequiredFormTemplates = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_treatments",
@@ -1229,6 +1242,7 @@ export const setRequiredFormTemplates = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_treatments",
@@ -1295,6 +1309,7 @@ export const saveTreatmentParameters = action({
         internal._helpers.authAction.verifyOrgAccess,
         { organizationId: args.organizationId },
       );
+      await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
       await ctx.runQuery(internal._helpers.authAction.checkPermission, {
         organizationId: args.organizationId,
         feature: "gabinet_treatments",
@@ -1355,6 +1370,7 @@ export const migrateParametersToTyped = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
 
     const db = createSupabaseDb();
 
@@ -1435,6 +1451,7 @@ export const listVariants = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_treatments",
@@ -1475,6 +1492,7 @@ export const getVariant = action({
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_treatments",
@@ -1516,6 +1534,7 @@ export const createVariant = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_treatments",
@@ -1604,6 +1623,7 @@ export const updateVariant = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_treatments",
@@ -1687,6 +1707,7 @@ export const deleteVariant = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_treatments",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2405.

Closes #2405

---

## Claude summary

All files have the product access check added. The counts match the number of `verifyOrgAccess` calls in each file (verified earlier).

The implementation is complete and committed. Here's a summary of what was done:

**Infrastructure change** (`convex/_helpers/products.ts`): Added `verifyGabinetAccess` as an `internalQuery` — this is the key enabler, since most gabinet handlers run as Convex `action`s (which have `ActionCtx`, not `QueryCtx`) and therefore cannot call `checkModuleAccess` directly. Actions use `ctx.runQuery(...)` to call internal queries.

**Files with local `verify()` helpers** (`nudges.ts`, `sidebarWidgets.ts`): The single-line addition to the shared helper covers all 6+ exported actions in each file at once.

**All other public gabinet files** (11 files): Added `ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId })` immediately after every `verifyOrgAccess` call in public (non-internal) handlers. Internal handlers (`internalMutation`, `internalAction`, `internalQuery`) were intentionally left untouched — they're called from server-side code, not directly by clients.

**Direct query/mutation handlers** (`appointments.ts`, `equipment.ts`): These have `QueryCtx`/`MutationCtx` and call `checkModuleAccess` directly. The existing `verifyProductAccess` call in `getDocumentGateStatus` was converted to `checkModuleAccess(ctx, ..., "appointments")` for consistency.