### PR TITLE
feat(hooks): add useModuleAccess hook for frontend subscription gating

### DIFF
--- a/src/hooks/use-module-access.ts
+++ b/src/hooks/use-module-access.ts
@@ -1,0 +1,61 @@
+import { useQuery } from "convex/react";
+import { api } from "@cvx/_generated/api";
+import { useOrganization } from "@/components/org-context";
+import { GABINET_MODULES, type GabinetModule } from "@cvx/gabinet/_registry";
+
+export type { GabinetModule };
+
+/**
+ * Returns whether the current organization has an active subscription for
+ * a given gabinet sub-module (or any product key string).
+ *
+ * Mirrors the server-side `checkModuleAccess` / `verifyProductAccess` logic:
+ * - During grace period (no subscriptions at all) access is granted.
+ * - Once subscriptions exist, the product must be present and active/trialing.
+ */
+export function useModuleAccess(module: GabinetModule | (string & {})): {
+  hasAccess: boolean;
+  loading: boolean;
+} {
+  const { organizationId } = useOrganization();
+
+  const activeProducts = useQuery(
+    api.productSubscriptions.getActiveProducts,
+    organizationId ? { organizationId } : "skip",
+  );
+
+  if (activeProducts === undefined) {
+    return { hasAccess: false, loading: true };
+  }
+
+  const productId =
+    module in GABINET_MODULES
+      ? GABINET_MODULES[module as GabinetModule]
+      : module;
+
+  return {
+    hasAccess: activeProducts.includes(productId),
+    loading: false,
+  };
+}
+
+/**
+ * Component-level guard that renders `children` only when the given module
+ * subscription is active, `fallback` otherwise. Renders nothing while loading.
+ */
+export function ModuleAccessGate({
+  module,
+  children,
+  fallback,
+  loadingFallback,
+}: {
+  module: GabinetModule | (string & {});
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+  loadingFallback?: React.ReactNode;
+}): React.ReactNode {
+  const { hasAccess, loading } = useModuleAccess(module);
+  if (loading) return loadingFallback ?? null;
+  if (!hasAccess) return fallback ?? null;
+  return children;
+}


### PR DESCRIPTION
## Summary

- Adds `src/hooks/use-module-access.ts` with a `useModuleAccess(module)` hook and a `ModuleAccessGate` component
- Hook is backed by `productSubscriptions.getActiveProducts` and mirrors the server-side `checkModuleAccess` / `verifyProductAccess` grace-period logic
- Accepts a `GabinetModule` name (resolved to product ID via `GABINET_MODULES`) or any raw product key string
- Returns `{ hasAccess, loading }` — same shape as `usePermission` so routes can guard against direct URL access when a subscription lapses

## Pattern

```tsx
// In any gabinet route or component:
const { hasAccess, loading } = useModuleAccess("patients");
if (!hasAccess) return <Redirect to="/dashboard" />;

// Or declaratively:
<ModuleAccessGate module="appointments" fallback={<AccessDenied />}>
  <AppointmentCalendar />
</ModuleAccessGate>
```

## Test plan

- [ ] Verify hook returns `{ hasAccess: true, loading: false }` for an org with an active gabinet subscription
- [ ] Verify hook returns `{ hasAccess: false, loading: false }` for an org whose gabinet subscription has lapsed
- [ ] Verify grace period: no subscriptions in DB → `hasAccess: true` (matches backend behavior)

Closes #2406

🤖 Generated with [Claude Code](https://claude.com/claude-code)