### PR TITLE
Support restriction semantics in per-employee overrides

### DIFF
--- a/convex/_helpers/authAction.ts
+++ b/convex/_helpers/authAction.ts
@@ -108,7 +108,8 @@ export const checkPermission = internalQuery({
         }
         effectiveScope = maxScope(orgScope, gabinetScope);
 
-        // Layer 3: per-employee overrides (MAX-merge on top of role-level scope)
+        // Layer 3: per-employee overrides (REPLACE semantics — allows both
+        // elevation and restriction relative to the role-derived scope)
         const membershipOverride = await ctx.db
           .query("gabinetMembershipPermissions")
           .withIndex("by_orgAndUser", (q) =>
@@ -117,8 +118,10 @@ export const checkPermission = internalQuery({
           .unique();
         if (membershipOverride) {
           const mPerms = membershipOverride.permissions as Record<string, Record<string, string>>;
-          const membershipScope = (mPerms?.[feature]?.[action] ?? "none") as Scope;
-          effectiveScope = maxScope(effectiveScope, membershipScope);
+          const membershipScope = mPerms?.[feature]?.[action];
+          if (membershipScope !== undefined) {
+            effectiveScope = membershipScope as Scope;
+          }
         }
       }
     }

--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -189,7 +189,8 @@ export async function checkPermission(
         : defaultGabinetScope(gRole, feature, action);
       effectiveScope = maxScope(orgScope, gabinetScope);
 
-      // Layer 3: per-employee overrides (MAX-merge on top of role-level scope)
+      // Layer 3: per-employee overrides (REPLACE semantics — allows both
+      // elevation and restriction relative to the role-derived scope)
       const membershipOverride = await ctx.db
         .query("gabinetMembershipPermissions")
         .withIndex("by_orgAndUser", (q) =>
@@ -198,8 +199,10 @@ export async function checkPermission(
         .unique();
       if (membershipOverride) {
         const mPerms = membershipOverride.permissions as Record<string, Record<string, string>>;
-        const membershipScope = (mPerms?.[feature]?.[action] ?? "none") as Scope;
-        effectiveScope = maxScope(effectiveScope, membershipScope);
+        const membershipScope = mPerms?.[feature]?.[action];
+        if (membershipScope !== undefined) {
+          effectiveScope = membershipScope as Scope;
+        }
       }
     }
   }
@@ -301,7 +304,8 @@ export async function getEffectivePermissions(
       merged[feature] = mergedActions;
     }
 
-    // Layer 3: per-employee overrides (MAX-merge on top of role-level scope)
+    // Layer 3: per-employee overrides (REPLACE semantics — wins over role-derived
+    // scope, supporting both elevation and restriction)
     const membershipOverride = await ctx.db
       .query("gabinetMembershipPermissions")
       .withIndex("by_orgAndUser", (q) =>
@@ -314,8 +318,10 @@ export async function getEffectivePermissions(
         if (!feature.startsWith("gabinet_")) continue;
         const mergedActions = { ...merged[feature] };
         for (const action of ACTIONS) {
-          const membershipScope: Scope = mPerms?.[feature as Feature]?.[action] ?? "none";
-          mergedActions[action] = maxScope(mergedActions[action], membershipScope);
+          const membershipScope = mPerms?.[feature as Feature]?.[action];
+          if (membershipScope !== undefined) {
+            mergedActions[action] = membershipScope;
+          }
         }
         merged[feature] = mergedActions;
       }

--- a/convex/gabinetRoles.ts
+++ b/convex/gabinetRoles.ts
@@ -310,8 +310,9 @@ export const getEmployeePermissions = query({
   },
 });
 
-/** Upsert per-employee permission overrides. Overrides are MAX-merged on top
- *  of the employee's gabinet-role permissions, so only elevation is possible. */
+/** Upsert per-employee permission overrides. For each feature/action present in
+ *  the permissions blob, that value REPLACES the role-derived scope (supports
+ *  both elevation and restriction). Missing entries inherit from the role. */
 export const setEmployeePermissions = mutation({
   args: {
     organizationId: v.id("organizations"),

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -611,10 +611,11 @@ export function createCrmTables({
     .index("by_orgAndRole", ["organizationId", "gabinetRole"]),
 
   // --- RBAC: Gabinet Per-Employee Permission Overrides ---
-  // Optional per-user permission overrides, MAX-merged on top of the
-  // gabinetRolePermissions layer. Allows elevating a specific employee's
-  // access beyond what their gabinet role grants (e.g. giving one receptionist
-  // access to financial reports). Absent row → role-level permissions apply.
+  // Optional per-user permission overrides with REPLACE semantics: for each
+  // feature/action present in the blob the stored scope wins over the
+  // role-derived value, supporting both elevation (e.g. receptionist sees
+  // financial reports) and restriction (e.g. doctor cannot view payments).
+  // Missing entries inherit from the role. Absent row → role-level applies.
   gabinetMembershipPermissions: defineTable({
     organizationId: v.id("organizations"),
     userId: v.id("users"),

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -749,6 +749,7 @@ function EmployeeDetail() {
               <EmployeePermissionsTab
                 organizationId={organizationId}
                 userId={employee.userId as Id<"users">}
+                gabinetRole={employee.role}
                 t={t}
               />
             ),
@@ -2800,12 +2801,20 @@ const ALL_PERMS_FEATURES = [
 
 const ALL_PERMS_ACTIONS = ["view", "create", "edit", "delete", "approve", "sign", "refund"] as const;
 
-function buildEmpLocalPerms(raw: Record<string, Record<string, string>> | null): LocalPerms {
+function buildEmpLocalPerms(
+  raw: Record<string, Record<string, string>> | null,
+  roleDefaults?: Record<string, Record<string, string>> | null,
+): LocalPerms {
   const result: LocalPerms = {};
   for (const f of EMPLOYEE_PERMISSION_FEATURES) {
     result[f.key] = {};
     for (const action of f.actions) {
-      result[f.key]![action] = (raw?.[f.key]?.[action] as Scope) ?? "none";
+      // When no override row exists yet, pre-populate from the role-level defaults
+      // so the admin sees the current effective values rather than all-none.
+      const fallback = raw === null
+        ? ((roleDefaults?.[f.key]?.[action] as Scope) ?? "none")
+        : "none";
+      result[f.key]![action] = (raw?.[f.key]?.[action] as Scope) ?? fallback;
     }
   }
   return result;
@@ -2845,10 +2854,12 @@ function EmpScopeSelect({ value, onChange }: { value: Scope; onChange: (v: Scope
 function EmployeePermissionsTab({
   organizationId,
   userId,
+  gabinetRole,
   t,
 }: {
   organizationId: Id<"organizations">;
   userId: Id<"users">;
+  gabinetRole: string;
   t: TFunction;
 }) {
   const rawPerms = useConvexQuery(api.gabinetRoles.getEmployeePermissions, {
@@ -2856,20 +2867,30 @@ function EmployeePermissionsTab({
     userId,
   });
 
+  const rolePerms = useConvexQuery(api.gabinetRoles.getPermissions, {
+    organizationId,
+    gabinetRole,
+  });
+
   const setEmpPermissions = useMutation(api.gabinetRoles.setEmployeePermissions);
   const resetEmpPermissions = useMutation(api.gabinetRoles.resetEmployeePermissions);
 
-  const [local, setLocal] = useState<LocalPerms>(() => buildEmpLocalPerms(null));
+  const [local, setLocal] = useState<LocalPerms>(() => buildEmpLocalPerms(null, null));
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
   const [resetting, setResetting] = useState(false);
 
   useEffect(() => {
-    if (rawPerms !== undefined) {
-      setLocal(buildEmpLocalPerms(rawPerms as Record<string, Record<string, string>> | null));
+    if (rawPerms !== undefined && rolePerms !== undefined) {
+      setLocal(
+        buildEmpLocalPerms(
+          rawPerms as Record<string, Record<string, string>> | null,
+          rolePerms as Record<string, Record<string, string>> | null,
+        ),
+      );
       setDirty(false);
     }
-  }, [rawPerms]);
+  }, [rawPerms, rolePerms]);
 
   const handleChange = useCallback((feature: string, action: string, scope: Scope) => {
     setLocal((prev) => ({
@@ -2918,7 +2939,7 @@ function EmployeePermissionsTab({
     }
   };
 
-  if (rawPerms === undefined) {
+  if (rawPerms === undefined || rolePerms === undefined) {
     return <div className="py-8 text-center text-sm text-muted-foreground">{t("common.loading", "Ładowanie…")}</div>;
   }
 
@@ -2934,7 +2955,7 @@ function EmployeePermissionsTab({
           <p className="text-xs text-muted-foreground">
             {t(
               "gabinet.employees.permissions.description",
-              "Indywidualne nadpisania uprawnień dla tego pracownika. Uprawnienia są scalane z rolą pracownika — możliwe jest tylko podwyższenie poziomu dostępu."
+              "Indywidualne nadpisania uprawnień dla tego pracownika. Zapisane wartości zastępują uprawnienia roli — możliwe jest zarówno podwyższenie jak i ograniczenie dostępu. Brak nadpisania oznacza stosowanie uprawnień roli."
             )}
           </p>
           {hasOverride && (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2409.

Closes #2409

---

## Claude summary

Done. Here's a summary of what was implemented:

**Problem**: Per-employee gabinet permission overrides used MAX-merge semantics — setting a feature/action to "none" in the override was silently ignored because the role-level scope would always win. This made it impossible to restrict an employee below their role (e.g., blocking a specific doctor from viewing payments).

**Fix**: Changed the per-employee layer from MAX-merge to REPLACE semantics across all three permission-checking paths:

- `convex/_helpers/permissions.ts` — `checkPermission` and `getEffectivePermissions`
- `convex/_helpers/authAction.ts` — `checkPermission` (the action-context variant)

When a `gabinetMembershipPermissions` row exists, each `feature/action` value in the blob now **replaces** the role-derived scope instead of being MAX-merged. Entries absent from the blob still inherit from the role, so partial overrides only affect specified permissions.

**UI fix**: The `EmployeePermissionsTab` now fetches the employee's gabinet role permissions (`gabinetRoles.getPermissions`) and pre-populates the dropdowns with those values when no override exists yet. Without this, admins would see all-none as the starting point and accidentally restrict everything when saving the first override. The description text was updated from "only elevation is possible" to correctly describe replace semantics.