### PR TITLE
Add locationId filter to Convex `getPatientNudges` action

### DIFF
--- a/convex/gabinet/nudges.ts
+++ b/convex/gabinet/nudges.ts
@@ -128,7 +128,7 @@ export const getPackageNudges = action({
 
 // --- Patient nudges ---
 export const getPatientNudges = action({
-  args: { organizationId: v.id("organizations") },
+  args: { organizationId: v.id("organizations"), locationId: v.optional(v.id("gabinetLocations")) },
   handler: async (ctx, args): Promise<NudgeData[]> => {
     await verify(ctx, args.organizationId);
     const db = createSupabaseDb();
@@ -175,11 +175,12 @@ export const getPatientNudges = action({
     const ninetyDaysAgoStr = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000)
       .toISOString()
       .split("T")[0];
-    const recentAppointments = (await db
+    let recentApptQuery = db
       .query("gabinetAppointments")
       .eq("organizationId", orgId)
-      .gte("date", ninetyDaysAgoStr)
-      .collect()) as any[];
+      .gte("date", ninetyDaysAgoStr);
+    if (args.locationId) recentApptQuery = recentApptQuery.eq("locationId", args.locationId);
+    const recentAppointments = (await recentApptQuery.collect()) as any[];
 
     const recentPatientIds = new Set(
       recentAppointments
@@ -234,7 +235,7 @@ export const getTreatmentNudges = action({
 
 // --- Get all Gabinet nudges ---
 export const getAll = action({
-  args: { organizationId: v.id("organizations") },
+  args: { organizationId: v.id("organizations"), locationId: v.optional(v.id("gabinetLocations")) },
   handler: async (ctx, args): Promise<NudgeData[]> => {
     await verify(ctx, args.organizationId);
     const nudges: NudgeData[] = [];
@@ -250,6 +251,12 @@ export const getAll = action({
       .toISOString()
       .split("T")[0];
 
+    let todayApptQuery = db.query("gabinetAppointments").eq("organizationId", orgId).eq("date", todayStr);
+    if (args.locationId) todayApptQuery = todayApptQuery.eq("locationId", args.locationId);
+
+    let recentApptQuery = db.query("gabinetAppointments").eq("organizationId", orgId).gte("date", ninetyDaysAgoStr);
+    if (args.locationId) recentApptQuery = recentApptQuery.eq("locationId", args.locationId);
+
     const [
       todayAppointments,
       pendingLeaves,
@@ -259,16 +266,12 @@ export const getAll = action({
       recentAppointments,
       treatments,
     ] = await Promise.all([
-      db.query("gabinetAppointments").eq("organizationId", orgId).eq("date", todayStr).collect(),
+      todayApptQuery.collect(),
       db.query("gabinetLeaves").eq("organizationId", orgId).eq("status", "pending").collect(),
       db.query("gabinetTreatmentPackages").eq("organizationId", orgId).eq("isActive", true).collect(),
       db.query("gabinetPackageUsage").eq("organizationId", orgId).eq("status", "active").collect(),
       db.query("gabinetPatients").eq("organizationId", orgId).collect(),
-      db
-        .query("gabinetAppointments")
-        .eq("organizationId", orgId)
-        .gte("date", ninetyDaysAgoStr)
-        .collect(),
+      recentApptQuery.collect(),
       db.query("gabinetTreatments").eq("organizationId", orgId).collect(),
     ]);
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2412.

Closes #2412

---

## Claude summary

The fix is committed. Here's a summary of what was done:

The issue was confirmed real. `getPatientNudges` (and `getAll`) in `convex/gabinet/nudges.ts` queried `gabinetAppointments` for "recent visits" without any location scope, while the Supabase-based equivalent hook `useSupabaseGabinetPatientNudges` already applied a `location_id` filter for the same query.

The changes add an optional `locationId: v.optional(v.id("gabinetLocations"))` arg to both `getPatientNudges` and `getAll`, and conditionally apply `.eq("locationId", args.locationId)` to the relevant appointment queries. Callers that don't pass `locationId` (including the current `global-nudges.tsx` component) see no behavioral change.

## Follow-ups

- Add locationId filter to `getAppointmentNudges` action: `convex/gabinet/nudges.ts:23` has the same gap — its query for today's unconfirmed appointments has no location scope, while `useSupabaseGabinetAppointmentNudges` (line 396 in `use-supabase-gabinet-dashboard.ts`) already applies the filter.