### PR TITLE
Add locationId filter to `getAppointmentNudges` action

### DIFF
--- a/convex/gabinet/nudges.ts
+++ b/convex/gabinet/nudges.ts
@@ -21,17 +21,18 @@ async function verify(ctx: any, organizationId: string) {
 
 // --- Appointment nudges ---
 export const getAppointmentNudges = action({
-  args: { organizationId: v.id("organizations") },
+  args: { organizationId: v.id("organizations"), locationId: v.optional(v.id("gabinetLocations")) },
   handler: async (ctx, args): Promise<NudgeData[]> => {
     await verify(ctx, args.organizationId);
     const db = createSupabaseDb();
     const todayStr = new Date().toISOString().split("T")[0];
 
-    const unconfirmed = (await db
+    let q = db
       .query("gabinetAppointments")
       .eq("organizationId", String(args.organizationId))
-      .eq("date", todayStr)
-      .collect()) as Array<{ status: string }>;
+      .eq("date", todayStr);
+    if (args.locationId) q = q.eq("locationId", args.locationId);
+    const unconfirmed = (await q.collect()) as Array<{ status: string }>;
 
     const count = unconfirmed.filter((a) => a.status === "scheduled").length;
     if (count === 0) return [];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2420.

Closes #2420

---

## Claude summary

The bug was real and the fix is committed. Here's what was wrong and what changed:

`getAppointmentNudges` accepted only `organizationId` and always fetched all of today's unconfirmed appointments across every location. Meanwhile, the `getAll` action (same file, line 254) and the Supabase hook `useSupabaseGabinetAppointmentNudges` both already applied an optional `locationId` filter, creating an inconsistency.

The fix adds `locationId: v.optional(v.id("gabinetLocations"))` to the action's `args` and applies the same conditional `.eq("locationId", args.locationId)` guard that the rest of the file already uses.