### PR TITLE
Surface `saveTreatmentProductLinks` delete/insert errors with `supabaseDb.` pref

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -253,8 +253,13 @@ export function createSupabaseDb(): SupabaseDb {
     const id = row._id ? String(row._id) : crypto.randomUUID();
     const snakeRow = mapRowToSnake(row);
     snakeRow.id = id;
-    const result = await upsertWithFkRetry(client, resolveTable(table), snakeRow);
-    return result.id;
+    try {
+      const result = await upsertWithFkRetry(client, resolveTable(table), snakeRow);
+      return result.id;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`supabaseDb.insert(${table}): ${msg}`);
+    }
   }
 
   async function patch(

--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -558,7 +558,7 @@ async function saveTreatmentProductLinks(
     .delete()
     .eq("treatment_id", treatmentId);
   if (delError) {
-    throw new Error(`Failed to clear existing treatment products: ${delError.message}`);
+    throw new Error(`supabaseDb.delete(gabinet_treatment_products): ${delError.message}`);
   }
 
   const now = Date.now();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2423.

Closes #2423

---

## Claude summary

The bug is confirmed and fixed. Here's the summary:

**Root cause:** Two error paths in `saveTreatmentProductLinks` produced messages that didn't match the `supabasedb\.(get|getmany|patch|delete|insert|query)` pattern in `TREATMENT_ERROR_MAP` and `GENERIC_ERROR_MAP`:

1. **Insert failures** — `db.insert()` internally calls `upsertWithFkRetry`, which on failure throws `"Supabase write failed for <table>: ..."`. This message never matched the `supabasedb\.insert` part of the pattern (despite the pattern listing `insert`), so insert errors across the entire codebase were silently falling through to the generic fallback.

2. **Delete failures** — the `db.raw()` delete in `saveTreatmentProductLinks` threw `"Failed to clear existing treatment products: ..."`, a one-off message that matched nothing.

**Fix (2 files):**
- `convex/_helpers/supabaseDb.ts`: wrapped `upsertWithFkRetry` in a try/catch inside `insert()` that rethrows as `"supabaseDb.insert(<table>): <original>"` — consistent with every other `supabaseDb.*` method and now matchable by both error maps.
- `convex/gabinet/treatments.ts`: changed the raw-delete error message from `"Failed to clear existing treatment products: ..."` to `"supabaseDb.delete(gabinet_treatment_products): ..."`.

## Follow-ups

- Fix `supabasedb\.insert` dead pattern in `GENERIC_ERROR_MAP`: before this fix, the `insert` leg of the pattern `supabasedb\.(get|getmany|patch|delete|insert|query)` in `GENERIC_ERROR_MAP` was unreachable — all insert errors used a different prefix. Now it works, but the pattern in `GENERIC_ERROR_MAP` and `TREATMENT_ERROR_MAP` should be audited for any other dead branches.
- Wrap `upsertWithFkRetry` errors in other direct callers: `convex/supabase/backfill.ts` and any other file that calls `upsertWithFkRetry` directly (bypassing `supabaseDb.insert`) will still throw the raw `"Supabase write failed for ..."` format, which won't match the error maps.