### PR TITLE
Add migration guard check in `saveTreatmentProductLinks`

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -558,6 +558,16 @@ async function saveTreatmentProductLinks(
     .delete()
     .eq("treatment_id", treatmentId);
   if (delError) {
+    // PostgreSQL error code 42P01 = undefined_table (relation does not exist).
+    // Surface a clear diagnostic instead of an opaque Postgres message.
+    if (
+      (delError as { code?: string }).code === "42P01" ||
+      delError.message?.includes("does not exist")
+    ) {
+      throw new Error(
+        "gabinet_treatment_products table missing — run migrations (supabase/migrations/)",
+      );
+    }
     throw new Error(`supabaseDb.delete(gabinet_treatment_products): ${delError.message}`);
   }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2424.

Closes #2424

---

## Claude summary

Done. In `convex/gabinet/treatments.ts:560-570`, the `saveTreatmentProductLinks` function now checks the Supabase delete error before re-throwing. If the error carries PostgreSQL code `42P01` (undefined_table) or the message contains "does not exist", it throws:

```
gabinet_treatment_products table missing — run migrations (supabase/migrations/)
```

Otherwise it falls through to the existing generic error. This gives developers a clear, actionable message when the table hasn't been created yet, rather than an opaque Postgres error.