### PR TITLE
Fix `supabasedb\.insert` dead pattern in `GENERIC_ERROR_MAP`

### DIFF
--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -395,7 +395,7 @@ const TREATMENT_ERROR_MAP: Array<{
     fallback: "Nie udało się zapisać zabiegu — nieprawidłowe dane.",
   },
   {
-    test: (m) => /supabasedb\.(get|getmany|patch|delete|insert|query)/i.test(m),
+    test: (m) => /supabasedb\.(getmany|get|patch|delete|insert|query)/i.test(m),
     key: "gabinet.treatments.errors.storage",
     fallback: "Nie udało się zapisać zabiegu — błąd magazynu danych. Spróbuj ponownie.",
   },
@@ -515,7 +515,7 @@ const GENERIC_ERROR_MAP: Array<{
     fallback: "Nieprawidłowe dane. Sprawdź formularz i spróbuj ponownie.",
   },
   {
-    test: (m) => /supabasedb\.(get|getmany|patch|delete|insert|query)/i.test(m),
+    test: (m) => /supabasedb\.(getmany|get|patch|delete|insert|query)/i.test(m),
     key: "common.errors.storage",
     fallback: "Błąd magazynu danych. Spróbuj ponownie.",
   },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2426.

Closes #2426

---

## Claude summary

Done. The audit found exactly one dead branch: in both `TREATMENT_ERROR_MAP` and `GENERIC_ERROR_MAP`, the regex alternation `(get|getmany|...)` placed `get` before `getmany`. Because `get` is a prefix of `getMany`, the engine always matched `get` first, making `getmany` unreachable. Fixed by reordering to `(getmany|get|...)` — longest/most-specific first.

All other alternation legs (`patch`, `delete`, `insert`, `query`) are distinct and have no shadowing relationship with each other or with the reordered `get`/`getmany` pair.