### PR TITLE
Wrap `upsertWithFkRetry` errors in other direct callers

### DIFF
--- a/convex/supabase/activities.ts
+++ b/convex/supabase/activities.ts
@@ -36,7 +36,11 @@ export const writeActivityToSupabase = internalAction({
       created_at: args.createdAt,
     };
 
-    const data = await upsertWithFkRetry(client, "activities", row);
+    const data = await upsertWithFkRetry(client, "activities", row)
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`supabaseDb.insert(activities): ${msg}`);
+      });
 
     console.info(`Activity written to Supabase id=${data.id} org=${args.organizationId}`);
     return { success: true, id: data.id };

--- a/convex/supabase/auditLog.ts
+++ b/convex/supabase/auditLog.ts
@@ -33,7 +33,11 @@ export const writeAuditLogToSupabase = internalAction({
       created_at: args.createdAt,
     };
 
-    const data = await upsertWithFkRetry(client, "audit_log", row);
+    const data = await upsertWithFkRetry(client, "audit_log", row)
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`supabaseDb.insert(audit_log): ${msg}`);
+      });
 
     console.info(`AuditLog written to Supabase id=${data.id}`);
     return { success: true, id: data.id };

--- a/convex/supabase/automationRunSteps.ts
+++ b/convex/supabase/automationRunSteps.ts
@@ -62,7 +62,11 @@ export const writeRunStep = internalAction({
       updated_at: args.updatedAt,
     };
 
-    const data = await upsertWithFkRetry(client, "automation_run_steps", row);
+    const data = await upsertWithFkRetry(client, "automation_run_steps", row)
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`supabaseDb.insert(automation_run_steps): ${msg}`);
+      });
 
     console.info(`Automation run step written to Supabase id=${data.id} org=${args.organizationId}`);
     return { success: true, id: data.id };

--- a/convex/supabase/automationRuns.ts
+++ b/convex/supabase/automationRuns.ts
@@ -54,7 +54,11 @@ export const writeRun = internalAction({
       updated_at: args.updatedAt,
     };
 
-    const data = await upsertWithFkRetry(client, "automation_runs", row);
+    const data = await upsertWithFkRetry(client, "automation_runs", row)
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`supabaseDb.insert(automation_runs): ${msg}`);
+      });
 
     console.info(`Automation run written to Supabase id=${data.id} org=${args.organizationId}`);
     return { success: true, id: data.id };

--- a/convex/supabase/emailEventLog.ts
+++ b/convex/supabase/emailEventLog.ts
@@ -58,7 +58,11 @@ export const writeEmailEventLogToSupabase = internalAction({
       created_at: args.createdAt,
     };
 
-    const data = await upsertWithFkRetry(client, "email_event_log", row);
+    const data = await upsertWithFkRetry(client, "email_event_log", row)
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`supabaseDb.insert(email_event_log): ${msg}`);
+      });
 
     console.info(`EmailEventLog written to Supabase id=${data.id} org=${args.organizationId}`);
     return { success: true, id: data.id };

--- a/convex/supabase/emails.ts
+++ b/convex/supabase/emails.ts
@@ -82,7 +82,11 @@ export const writeEmailToSupabase = internalAction({
       updated_at: args.updatedAt,
     };
 
-    const data = await upsertWithFkRetry(client, "emails", row);
+    const data = await upsertWithFkRetry(client, "emails", row)
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`supabaseDb.insert(emails): ${msg}`);
+      });
 
     console.info(`Email written to Supabase id=${data.id} org=${args.organizationId}`);
     return { success: true, id: data.id };

--- a/convex/supabase/formDocuments.ts
+++ b/convex/supabase/formDocuments.ts
@@ -72,7 +72,11 @@ export const writeFormDocumentToSupabase = internalAction({
       updated_at: args.updatedAt,
     };
 
-    const data = await upsertWithFkRetry(client, "form_documents", row);
+    const data = await upsertWithFkRetry(client, "form_documents", row)
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`supabaseDb.insert(form_documents): ${msg}`);
+      });
 
     console.info(`Form document written to Supabase id=${data.id} org=${args.organizationId}`);
     return { success: true, id: data.id };

--- a/convex/supabase/organizations.ts
+++ b/convex/supabase/organizations.ts
@@ -36,7 +36,11 @@ export const writeOrganizationToSupabase = internalAction({
       onboarding_completed: args.onboardingCompleted ?? null,
     };
 
-    const data = await upsertWithFkRetry(client, "organizations", row);
+    const data = await upsertWithFkRetry(client, "organizations", row)
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`supabaseDb.insert(organizations): ${msg}`);
+      });
 
     console.info(`Organization written to Supabase id=${data.id}`);
     return { success: true, id: data.id };
@@ -139,7 +143,11 @@ export const writeTeamMembershipToSupabase = internalAction({
       joined_at: args.joinedAt,
     };
 
-    const data = await upsertWithFkRetry(client, "team_memberships", row);
+    const data = await upsertWithFkRetry(client, "team_memberships", row)
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`supabaseDb.insert(team_memberships): ${msg}`);
+      });
 
     console.info(`TeamMembership written to Supabase id=${data.id}`);
     return { success: true, id: data.id };

--- a/convex/supabase/subscriptions.ts
+++ b/convex/supabase/subscriptions.ts
@@ -38,7 +38,11 @@ export const writeSubscriptionToSupabase = internalAction({
       cancel_at_period_end: args.cancelAtPeriodEnd,
     };
 
-    const data = await upsertWithFkRetry(client, "subscriptions", row);
+    const data = await upsertWithFkRetry(client, "subscriptions", row)
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`supabaseDb.insert(subscriptions): ${msg}`);
+      });
 
     console.info(`Subscription written to Supabase id=${data.id}`);
     return { success: true, id: data.id };


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2427.

Closes #2427

---

## Claude summary

The fix is committed. Here's a summary:

**Root cause confirmed:** Nine `internalAction` files in `convex/supabase/` called `upsertWithFkRetry` directly, letting the raw `"Supabase write failed for <table>: ..."` error propagate unwrapped. The error maps in `format-action-error.ts` only match the `supabaseDb.insert(...)` prefix pattern, so these errors fell through to the generic fallback instead of being classified as storage errors.

**Fix:** Added a `.catch()` wrapper on every direct `upsertWithFkRetry` call in all 9 files (`activities.ts`, `auditLog.ts`, `automationRuns.ts`, `automationRunSteps.ts`, `emailEventLog.ts`, `emails.ts`, `formDocuments.ts`, `organizations.ts` × 2, `subscriptions.ts`). The catch re-throws with `supabaseDb.insert(<table>): <msg>` — identical to what `supabaseDb.insert` itself does — so both `TREATMENT_ERROR_MAP` and `GENERIC_ERROR_MAP` storage entries now match these errors.

**Note:** `backfill.ts` mentioned in the issue does not call `upsertWithFkRetry` — it uses a local `upsertBatch` helper that calls `.upsert()` directly and returns errors in its result object rather than throwing, so it didn't need changes.

## Follow-ups

- Wrap `updateRun`/`updateRunStep` non-upsert errors in automationRuns.ts and automationRunSteps.ts: both files use a custom `"Supabase update failed for ..."` message format for their `.update()` paths (lines 92–94 and 116–118), which also won't match the `supabaseDb.(get|insert|...)` error-map patterns.