### PR TITLE
fix(supabase): wrap updateRun/updateRunStep errors with supabaseDb. prefix (closes #2431)

### DIFF
--- a/convex/supabase/automationRunSteps.ts
+++ b/convex/supabase/automationRunSteps.ts
@@ -117,7 +117,7 @@ export const updateRunStep = internalAction({
       .maybeSingle();
 
     if (error) {
-      const msg = `Supabase update failed for automation run step ${args.stepId}: ${error.message} (code=${error.code})`;
+      const msg = `supabaseDb.update(automation_run_steps): ${error.message} (code=${error.code})`;
       console.error(msg);
       throw new Error(msg);
     }

--- a/convex/supabase/automationRuns.ts
+++ b/convex/supabase/automationRuns.ts
@@ -93,7 +93,7 @@ export const updateRun = internalAction({
       .maybeSingle();
 
     if (error) {
-      const msg = `Supabase update failed for automation run ${args.runId}: ${error.message} (code=${error.code})`;
+      const msg = `supabaseDb.update(automation_runs): ${error.message} (code=${error.code})`;
       console.error(msg);
       throw new Error(msg);
     }


### PR DESCRIPTION
## Summary
- `updateRun` in `automationRuns.ts` was throwing `Supabase update failed for automation run <id>: ...` instead of `supabaseDb.update(automation_runs): ...`
- `updateRunStep` in `automationRunSteps.ts` was throwing `Supabase update failed for automation run step <id>: ...` instead of `supabaseDb.update(automation_run_steps): ...`
- Both error messages now use the `supabaseDb.<operation>(<table>): <message>` prefix that matches the storage error-map patterns in `format-action-error.ts`

## Test plan
- [ ] Confirm error messages from `updateRun` and `updateRunStep` match the `supabaseDb.update(...)` pattern
- [ ] Verify no regressions in automation run/step write paths

Fixes #2431 (auto-discovered during #2427)

🤖 Generated with [Claude Code](https://claude.com/claude-code)