### PR TITLE
fix(gabinet): separate product-link error from treatment create/update (closes #2422)

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -437,6 +437,15 @@ function TreatmentDetail() {
         ...treatmentData,
         categoryId: editCategoryId ?? null,
       });
+
+      // Update succeeded — close the panel and invalidate queries now so a
+      // product-link failure below does not make the update appear to have
+      // failed (#2422).
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatments.detail(organizationId, treatmentId) });
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatments.list(organizationId) });
+      setEditPanelOpen(false);
+      toast.success(t("common.saved"));
+
       const allProductLinks = [
         ...(products ?? []).map((p) => ({
           productId: p.productId,
@@ -451,18 +460,26 @@ function TreatmentDetail() {
           unit: m.unit ?? undefined,
         })),
       ];
-      await setTreatmentProductsAction({
-        organizationId,
-        treatmentId: treatmentId as string,
-        products: allProductLinks,
-      });
-      void queryClient.invalidateQueries({
-        queryKey: ["gabinet.treatments.getTreatmentProducts", organizationId, treatmentId],
-      });
-      void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatments.detail(organizationId, treatmentId) });
-      void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatments.list(organizationId) });
-      setEditPanelOpen(false);
-      toast.success(t("common.saved"));
+
+      // Save product/material links separately so their failure does not
+      // mask a successful treatment update.
+      try {
+        await setTreatmentProductsAction({
+          organizationId,
+          treatmentId: treatmentId as string,
+          products: allProductLinks,
+        });
+        void queryClient.invalidateQueries({
+          queryKey: ["gabinet.treatments.getTreatmentProducts", organizationId, treatmentId],
+        });
+      } catch (productErr) {
+        toast.warning(
+          t("gabinet.treatments.errors.productsSaveFailed", {
+            defaultValue:
+              "Zabieg zapisany. Nie udało się zapisać preparatów/materiałów — otwórz zabieg i spróbuj ponownie.",
+          }),
+        );
+      }
     } catch (e) {
       toast.error(
         formatTreatmentError(e, t, {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -484,6 +484,11 @@ function TreatmentsIndex() {
             unit: m.unit ?? undefined,
           })),
         ];
+        // treatmentId is set once the main write succeeds so the product-link
+        // step can reference it even if the main catch fires (it won't fire
+        // after this point because we close the panel before the product step).
+        let savedTreatmentId: string | null = null;
+
         if (editingTreatment) {
           await updateTreatment({
             organizationId,
@@ -492,11 +497,7 @@ function TreatmentsIndex() {
             tagIds,
             categoryId: categoryId ?? null,
           });
-          await setTreatmentProductsAction({
-            organizationId,
-            treatmentId: editingTreatment._id,
-            products: allProductLinks,
-          });
+          savedTreatmentId = editingTreatment._id;
         } else {
           const newTreatmentId = await createTreatment({
             organizationId,
@@ -504,18 +505,42 @@ function TreatmentsIndex() {
             tagIds,
             categoryId,
           });
-          if (allProductLinks.length > 0) {
-            await setTreatmentProductsAction({
-              organizationId,
-              treatmentId: newTreatmentId,
-              products: allProductLinks,
-            });
-          }
+          savedTreatmentId = newTreatmentId;
         }
+
+        // Main write succeeded — close the panel now so a product-link failure
+        // below does not mislead the user into thinking the treatment itself
+        // was not saved (which caused duplicate-creation retry loops, #2422).
         setPanelOpen(false);
         setEditingTreatment(null);
         setTagIds([]);
         setCategoryId(undefined);
+
+        // Save product/material links separately. Failure here does NOT mean
+        // the treatment was lost — only that the ingredient recipe needs to be
+        // set again via the edit panel.
+        if (savedTreatmentId && (editingTreatment || allProductLinks.length > 0)) {
+          try {
+            await setTreatmentProductsAction({
+              organizationId,
+              treatmentId: savedTreatmentId,
+              products: allProductLinks,
+            });
+          } catch (productErr) {
+            void reportError(productErr, {
+              scope: "gabinet.treatments",
+              fnName: "setTreatmentProducts",
+              argsJson: JSON.stringify({ treatmentId: savedTreatmentId, productCount: allProductLinks.length }),
+              organizationId,
+            });
+            toast.warning(
+              t("gabinet.treatments.errors.productsSaveFailed", {
+                defaultValue:
+                  "Zabieg zapisany. Nie udało się zapisać preparatów/materiałów — otwórz zabieg i spróbuj ponownie.",
+              }),
+            );
+          }
+        }
       } catch (e) {
         // Capture client-side so /admin/errors gets the failing payload.
         // ArgumentValidationError is thrown by the Convex wrapper before the


### PR DESCRIPTION
## Summary

- After `createTreatment`/`updateTreatment` succeeds, close the panel immediately so the treatment is never mistaken for lost
- Run `setTreatmentProductsAction` in its own inner `try/catch` — failure there shows a specific warning toast rather than a generic creation error
- Same fix applied to both the index route (create + update via side panel) and the treatment detail page edit handler

**Root cause:** both the main write and the product-link step were in a single `try/catch`. When `setTreatmentProductsAction` failed, the catch block showed "Nie udało się utworzyć zabiegu" even though the treatment was already in the database. The panel stayed open, users retried, and duplicate treatments were created in a loop.

## Test plan
- [ ] Create a treatment without products — panel closes, success toast shown, no duplicate
- [ ] Create a treatment with products/materials — panel closes on main write success; if product-link step fails, warning toast shown ("Zabieg zapisany. Nie udało się zapisać preparatów/materiałów — otwórz zabieg i spróbuj ponownie.") with treatment still present
- [ ] Edit an existing treatment — same error-handling applies: edit success shown even if product-link step fails
- [ ] Edit a treatment via the detail page — same behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)