### PR TITLE
ukrycie w tworzeniu zabiegu pola wymaga zatwierdzenia

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -910,7 +910,7 @@ export function TreatmentForm({
         </div>
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="hidden">
         <Checkbox
           checked={requiresApproval}
           onCheckedChange={(checked) => setRequiresApproval(!!checked)}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2435.

Closes #2435

---

## Claude summary

Done. Changed `className="flex items-center gap-2"` to `className="hidden"` on the wrapper div in `src/components/gabinet/treatment-form.tsx:913`. The checkbox and its state/submission logic are fully intact — the field is just invisible in the UI. The value will continue to default to `false` for new treatments and will be preserved correctly when editing existing ones.