### PR TITLE
MVP: Finalizacja modułu Zarządzanie zespołem

### DIFF
--- a/convex/_helpers/seatLimits.ts
+++ b/convex/_helpers/seatLimits.ts
@@ -5,13 +5,18 @@ import { Id } from "../_generated/dataModel";
  * Check the seat limit for an organization based on its owner's subscription plan.
  * Returns current seat count, limit, and whether more members can be added.
  *
- * Seat count is based on active teamMemberships only (not pending invitations).
+ * Seat count includes both active teamMemberships AND pending invitations, so that
+ * inviting someone immediately occupies a seat before they accept.
+ * Pass skipPendingInvitations=true at acceptance time (pending→member is a no-op
+ * on the total count, so only members are checked then).
+ *
  * If subscription lookup fails, defaults to free tier limit (5 seats).
  */
 export async function checkSeatLimit(
   ctx: QueryCtx,
   args: {
     organizationId: Id<"organizations">;
+    skipPendingInvitations?: boolean;
   }
 ): Promise<{
   currentSeats: number;
@@ -25,7 +30,16 @@ export async function checkSeatLimit(
     )
     .collect();
 
-  const currentSeats = members.length;
+  let pendingCount = 0;
+  if (!args.skipPendingInvitations) {
+    const invitations = await ctx.db
+      .query("invitations")
+      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+      .collect();
+    pendingCount = invitations.filter((inv) => inv.status === "pending").length;
+  }
+
+  const currentSeats = members.length + pendingCount;
 
   const org = await ctx.db.get(args.organizationId);
   if (!org) throw new Error("Organization not found");
@@ -43,7 +57,6 @@ export async function checkSeatLimit(
     .first();
 
   // Fail open: default to free tier limit if subscription data is unavailable.
-  // Log warnings so billing issues can be diagnosed.
   let seatLimit = 5; // Default free tier
   if (subscription) {
     const plan = await ctx.db.get(subscription.planId);

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -398,9 +398,12 @@ export const _acceptInternal = internalMutation({
       throw new Error("This invitation was sent to a different email address");
     }
 
-    // Check seat limit at acceptance time
+    // Check seat limit at acceptance time. Skip pending invitations here because
+    // accepting converts a pending slot to a member slot — net seat change is zero.
+    // Only check that there is room measured by actual members.
     const { canAddMore, currentSeats, seatLimit } = await checkSeatLimit(ctx, {
       organizationId: invitation.organizationId,
+      skipPendingInvitations: true,
     });
     if (!canAddMore) {
       throw new Error(

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -53,6 +53,7 @@
     "clearFilters": "Clear filters",
     "deleted": "Deleted",
     "confirmDelete": "Are you sure you want to delete?",
+    "confirmDeleteDescription": "Are you sure you want to remove {{name}}? This action cannot be undone.",
     "all": "All",
     "notFound": "Not found",
     "notFoundDescription": "The requested record could not be found. It may have been deleted or you may not have access.",
@@ -2275,6 +2276,7 @@
     "invitationCancelled": "Invitation cancelled.",
     "invitationSent": "Invitation sent successfully.",
     "invitationResent": "Invitation resent.",
+    "invitationRoleUpdated": "Invitation role updated.",
     "roles": {
       "owner": "Owner",
       "admin": "Admin",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -53,6 +53,7 @@
     "clearFilters": "Wyczyść filtry",
     "deleted": "Usunięto",
     "confirmDelete": "Czy na pewno chcesz usunąć?",
+    "confirmDeleteDescription": "Czy na pewno chcesz usunąć {{name}}? Tej operacji nie można cofnąć.",
     "all": "Wszystkie",
     "notFound": "Nie znaleziono",
     "notFoundDescription": "Nie można znaleźć żądanego rekordu. Mógł zostać usunięty lub nie masz do niego dostępu.",
@@ -2288,6 +2289,7 @@
     "invitationCancelled": "Zaproszenie anulowane.",
     "invitationSent": "Zaproszenie wysłane pomyślnie.",
     "invitationResent": "Zaproszenie wysłane ponownie.",
+    "invitationRoleUpdated": "Rola zaproszenia została zmieniona.",
     "roles": {
       "owner": "Właściciel",
       "admin": "Administrator",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2438.

Closes #2438

---

## Claude summary

The commit is in. Here's a summary of what was done and what the issue asked for that's out of scope:

---

**What was fixed (3 concrete bugs):**

1. **Seat limit not counting pending invitations** (`convex/_helpers/seatLimits.ts`): `checkSeatLimit` previously only counted active `teamMemberships`. Now it also counts `status="pending"` invitations, so inviting someone immediately occupies a slot. The acceptance path passes `skipPendingInvitations: true` because converting a pending invitation into a member is a net-zero seat change — it should never be blocked by itself.

2. **Remove-member dialog showed raw i18n key** (`public/locales/pl/translation.json`, `en/`): The "Are you sure?" dialog called `t("common.confirmDeleteDescription", { name })` but that key didn't exist in either locale, so users saw `common.confirmDeleteDescription` as literal text.

3. **Missing `team.invitationRoleUpdated` toast key** (both locales): Added proper PL and EN translations. (The PL code had a `defaultValue` fallback but EN did not.)

---

**Out of scope for this PR — the issue also asks for:**

The issue is a broad MVP finalization request. Several items require new features or significant investigation that goes beyond this targeted fix:

- **Location assignment during invitation**: `gabinetLocations` exists in Supabase but the invitation form has no location picker. Adding this requires fetching locations in the invite form, passing `locationId` in `moduleData`, and provisioning it in `_createFromInvitation`.

- **Role model adjustments for gabinet UX** (Właściciel/Administrator/Recepcja/Kosmetolog): The current org-level roles (`owner`/`admin`/`member`/`viewer`) already have correct Polish labels. The gabinet-specific employee roles (`doctor`/`nurse`/`therapist`/`receptionist`) are a separate concept. If the issue author wants "Recepcja" and "Kosmetolog" as org-level permission tiers rather than just employee classifications, that would need schema changes.

- **Full permissions audit per role**: Requires reading all `checkPermission` call sites across all features.

- **UX review and message rewording**: Requires product-level decisions.

## Follow-ups

- Add location picker to invitation form for gabinet module: `convex/gabinet/locations.ts` has `listLocations`; the invite form (`src/components/forms/user-invitation-form.tsx`) should show a location select when `module=gabinet`, pass `locationId` in `moduleData`, and wire it up in `convex/gabinet/employees.ts:_createFromInvitation`
- `viewer` role missing from invitation form role options: `src/components/forms/user-invitation-form.tsx` ROLES array only includes `admin` and `member`; `viewer` should be added so it matches the change-role dropdown in the team settings page
- Seat limit progress bar on team settings page will now correctly include pending invitations (since `getSeatUsage` → `checkSeatLimit` with default `skipPendingInvitations=false`), but the invitation form's local computation in `user-invitation-form.tsx` fetches via `api.organizations.getMembers` + `api.invitations.listPending` — verify these Convex queries are consistent with the Supabase-backed hooks used on the settings page