### PR TITLE
Add location picker to invitation form for gabinet module

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -350,6 +350,7 @@ export const _createFromInvitation = internalAction({
       showInCalendar: typeof d.showInCalendar === "boolean" ? d.showInCalendar : true,
       tagIds: asStringArray(d.tagIds),
       categoryId: asString(d.categoryId),
+      locationId: asString(d.locationId),
       createdBy: args.invitedBy,
       createdAt: now,
       updatedAt: now,

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -336,6 +336,7 @@ export function createGabinetTables({
     showInCalendar: v.optional(v.boolean()),
     tagIds: v.optional(v.array(v.id("tagDefinitions"))),
     categoryId: v.optional(v.id("categoryDefinitions")),
+    locationId: v.optional(v.string()),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1001,7 +1001,10 @@
       "moduleNone": "None (invitation only)",
       "moduleGabinet": "Gabinet — create employee profile",
       "moduleHint": "Pick a module to pre-fill the fields needed to provision a profile once the invitation is accepted.",
-      "gabinetSectionTitle": "Gabinet employee details"
+      "gabinetSectionTitle": "Gabinet employee details",
+      "gabinetLocation": "Primary location",
+      "gabinetLocationPlaceholder": "Select a location",
+      "gabinetLocationNone": "No specific location"
     },
     "pipelines": {
       "title": "Pipelines",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1002,7 +1002,10 @@
       "moduleNone": "Brak (tylko zaproszenie)",
       "moduleGabinet": "Gabinet — utwórz profil pracownika",
       "moduleHint": "Wybierz moduł, aby od razu wypełnić dane potrzebne do utworzenia profilu po akceptacji zaproszenia.",
-      "gabinetSectionTitle": "Dane pracownika Gabinetu"
+      "gabinetSectionTitle": "Dane pracownika Gabinetu",
+      "gabinetLocation": "Główna lokalizacja",
+      "gabinetLocationPlaceholder": "Wybierz lokalizację",
+      "gabinetLocationNone": "Brak konkretnej lokalizacji"
     },
     "pipelines": {
       "title": "Pipeline",

--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -75,6 +75,7 @@ export interface GabinetModuleData {
   qualifiedTreatmentIds?: string[];
   tagIds?: string[];
   categoryId?: string;
+  locationId?: string;
   customFields?: Array<{ fieldDefinitionId: string; value: unknown }>;
 }
 
@@ -113,6 +114,13 @@ export function UserInvitationForm({
     queryFn: () => listActiveTreatments({ organizationId }),
     enabled: !!organizationId && module === "gabinet",
   }) as { data: Array<{ _id: string; name: string; duration?: number }> | undefined };
+
+  const listLocationsAction = useAction(api.gabinet.locations.listLocations);
+  const { data: locations } = useQuery({
+    queryKey: ["gabinet.locations.listLocations", organizationId],
+    queryFn: () => listLocationsAction({ organizationId }),
+    enabled: !!organizationId && module === "gabinet",
+  }) as { data: Array<{ _id: string; name: string; isActive: boolean }> | undefined };
 
   const { tags: tagDefinitions } = useTagDefinitions(organizationId) as {
     tags: Array<{ _id: Id<"tagDefinitions">; name: string; color: string }>;
@@ -164,6 +172,7 @@ export function UserInvitationForm({
   const [selectedTreatments, setSelectedTreatments] = useState<string[]>([]);
   const [tagIds, setTagIds] = useState<Id<"tagDefinitions">[]>([]);
   const [categoryId, setCategoryId] = useState<Id<"categoryDefinitions"> | undefined>(undefined);
+  const [locationId, setLocationId] = useState<string | undefined>(undefined);
   const [customFieldValues, setCustomFieldValues] = useState<Record<string, unknown>>({});
   const [treatmentSearch, setTreatmentSearch] = useState("");
 
@@ -222,6 +231,7 @@ export function UserInvitationForm({
           : undefined,
         tagIds: tagIds.length > 0 ? tagIds : undefined,
         categoryId: categoryId || undefined,
+        locationId: locationId || undefined,
         customFields: customFields.length > 0 ? customFields : undefined,
       };
     }
@@ -389,6 +399,28 @@ export function UserInvitationForm({
                 ))}
               </div>
             </div>
+
+            {locations && locations.filter((l) => l.isActive).length > 0 && (
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label>{t("settings.team.gabinetLocation")}</Label>
+                <Select
+                  value={locationId ?? "none"}
+                  onValueChange={(v) => setLocationId(v === "none" ? undefined : v)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder={t("settings.team.gabinetLocationPlaceholder")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">{t("settings.team.gabinetLocationNone")}</SelectItem>
+                    {locations.filter((l) => l.isActive).map((loc) => (
+                      <SelectItem key={loc._id} value={loc._id}>
+                        {loc.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
           </div>
 
           {isClinicalRole && (

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -33,6 +33,7 @@
  *   • 00026_gabinet_treatment_products_rls.sql
  *   • 00027_gabinet_appointments_location_idx.sql
  *   • 00028_gabinet_payment_methods.sql
+ *   • 00029_gabinet_employees_location.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -3966,6 +3967,7 @@ export interface Database {
           bank_account: string | null;
           tag_ids: string[] | null;
           category_id: string | null;
+          location_id: string | null;
           created_by: string;
           created_at: number;
           updated_at: number;
@@ -4003,6 +4005,7 @@ export interface Database {
           bank_account?: string | null;
           tag_ids?: string[] | null;
           category_id?: string | null;
+          location_id?: string | null;
           created_by: string;
           created_at: number;
           updated_at: number;
@@ -4040,6 +4043,7 @@ export interface Database {
           bank_account?: string | null;
           tag_ids?: string[] | null;
           category_id?: string | null;
+          location_id?: string | null;
           created_by?: string;
           created_at?: number;
           updated_at?: number;
@@ -4073,6 +4077,13 @@ export interface Database {
             columns: ["created_by"];
             isOneToOne: false;
             referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gabinet_employees_location_id_fkey";
+            columns: ["location_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_locations";
             referencedColumns: ["id"];
           },
         ];

--- a/supabase/migrations/00029_gabinet_employees_location.sql
+++ b/supabase/migrations/00029_gabinet_employees_location.sql
@@ -1,0 +1,8 @@
+-- Add optional primary/default location to gabinet_employees.
+-- Nullable: employees without a fixed location remain unaffected.
+ALTER TABLE gabinet_employees
+  ADD COLUMN IF NOT EXISTS location_id TEXT REFERENCES gabinet_locations(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS gabinet_employees_org_location_idx
+  ON gabinet_employees (organization_id, location_id)
+  WHERE location_id IS NOT NULL;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2440.

Closes #2440

---

## Claude summary

Done. Here's a summary of what was implemented:

**7 files changed:**

- `supabase/migrations/00029_gabinet_employees_location.sql` — new migration adding nullable `location_id` column (FK → `gabinet_locations`) to `gabinet_employees`, with a partial index for org-scoped location queries
- `src/lib/supabase/database.types.ts` — added `location_id: string | null` to `gabinet_employees` Row/Insert/Update types and the corresponding FK relationship
- `convex/schema/gabinet.ts` — added `locationId: v.optional(v.string())` to the `gabinetEmployees` table definition
- `src/components/forms/user-invitation-form.tsx` — added `locationId` to `GabinetModuleData`, fetches locations lazily via `listLocations` action when `module=gabinet`, renders a location `<Select>` that only appears when active locations exist, and passes `locationId` in the submitted `moduleData`
- `convex/gabinet/employees.ts` — `_createFromInvitation` now extracts and stores `locationId: asString(d.locationId)` alongside the other employee fields
- `public/locales/en/translation.json` and `public/locales/pl/translation.json` — added three i18n keys each for the location picker label, placeholder, and "no location" option