### PR TITLE
`viewer` role missing from invitation form role options

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -995,7 +995,8 @@
       "invitationInfo": "We'll send an invitation email. Recipient will have 7 days to accept.",
       "roles": {
         "admin": "Administrator",
-        "member": "Member"
+        "member": "Member",
+        "viewer": "Viewer"
       },
       "module": "Module",
       "moduleNone": "None (invitation only)",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -996,7 +996,8 @@
       "invitationInfo": "Zaproszenie wyślemy e-mailem. Odbiorca będzie miał 7 dni na jego przyjęcie.",
       "roles": {
         "admin": "Administrator",
-        "member": "Członek"
+        "member": "Członek",
+        "viewer": "Przeglądający"
       },
       "module": "Moduł",
       "moduleNone": "Brak (tylko zaproszenie)",

--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -24,7 +24,7 @@ import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { AlertCircle, Search, Users } from "@/lib/ez-icons";
 
-type OrgRole = "owner" | "admin" | "member";
+type OrgRole = "owner" | "admin" | "member" | "viewer";
 type InviteModule = "none" | "gabinet";
 type GabinetRole =
   | "doctor"
@@ -37,6 +37,7 @@ type GabinetRole =
 const ROLES: { value: OrgRole; labelKey: string }[] = [
   { value: "admin", labelKey: "settings.team.roles.admin" },
   { value: "member", labelKey: "settings.team.roles.member" },
+  { value: "viewer", labelKey: "settings.team.roles.viewer" },
 ];
 
 const GABINET_ROLES: GabinetRole[] = [


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2441.

Closes #2441

---

## Claude summary

The bug was real and the fix is clean. Three changes were made:

1. `src/components/forms/user-invitation-form.tsx:27` — added `"viewer"` to the `OrgRole` type union
2. `src/components/forms/user-invitation-form.tsx:40` — added `{ value: "viewer", labelKey: "settings.team.roles.viewer" }` to the `ROLES` array
3. `public/locales/en/translation.json` and `public/locales/pl/translation.json` — added the missing `settings.team.roles.viewer` translation keys ("Viewer" / "Przeglądający")

The team settings change-role dropdown already included `viewer` (line 60 of `_layout.settings.team.tsx`), but the invitation form didn't — this makes them consistent.