### PR TITLE
Seat limit progress bar on team settings page will now correctly include pending

### DIFF
--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -96,14 +96,11 @@ export function UserInvitationForm({
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
 
-  const { data: members } = useQuery(
-    convexQuery(api.organizations.getMembers, { organizationId })
-  );
+  const { data: seatUsage } = useQuery(
+    convexQuery(api.organizations.getSeatUsage, { organizationId })
+  ) as { data: { currentSeats: number; seatLimit: number; canAddMore: boolean } | undefined };
   const { data: pendingInvitations } = useQuery(
     convexQuery(api.invitations.listPending, { organizationId })
-  );
-  const { data: subscription } = useQuery(
-    convexQuery(api.productSubscriptions.getSubscription, { organizationId })
   );
 
   // Gabinet-specific data sources — only fetched lazily once Gabinet is picked.
@@ -177,12 +174,13 @@ export function UserInvitationForm({
   const [customFieldValues, setCustomFieldValues] = useState<Record<string, unknown>>({});
   const [treatmentSearch, setTreatmentSearch] = useState("");
 
-  const memberCount = members?.length ?? 0;
   const pendingCount = pendingInvitations?.length ?? 0;
-  const totalUsers = memberCount + pendingCount;
-  const seatLimit = subscription?.seatLimit ?? 10;
-  const isNearLimit = totalUsers >= seatLimit - 2;
-  const isAtLimit = totalUsers >= seatLimit;
+  const totalUsers = seatUsage?.currentSeats ?? 0;
+  const seatLimit = seatUsage?.seatLimit ?? 5;
+  const isNearLimit = seatUsage
+    ? seatUsage.currentSeats >= seatUsage.seatLimit - 2 && seatUsage.canAddMore
+    : false;
+  const isAtLimit = seatUsage ? !seatUsage.canAddMore : false;
 
   const filteredTreatments = useMemo(() => {
     if (!treatments) return [];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2442.

Closes #2442

---

## Claude summary

The fix is committed. Here's a summary of what was wrong and what changed:

**Root cause**: `user-invitation-form.tsx` fetched seat data via three separate Convex queries that were inconsistent with the authoritative `getSeatUsage → checkSeatLimit` path used on the settings page progress bar:

1. `getSubscription` queried subscriptions by the **calling user's ID** — wrong for non-owner admins who'd see their own subscription limit instead of the org owner's.
2. `getSubscription` only filtered `status == "active"`, missing `trialing` subscriptions that `checkSeatLimit` includes.
3. Default fallback: `getSubscription` used `10` as the plan-not-found default vs `5` in `checkSeatLimit`.

**Fix**: Replace the three queries (`getMembers`, `getSubscription`, and the computed `memberCount`) with a single `getSeatUsage` call — the same query the settings page uses. `listPending` is retained because the form shows the parenthetical "(N pending invites)" count separately from the total. `isAtLimit` now uses `canAddMore` directly from the authoritative source, and `isNearLimit` checks `canAddMore` to avoid showing a warning when already at the limit.

## Follow-ups

- Replace `getSubscription` in other callers: `productSubscriptions.getSubscription` looks up subscriptions by calling user rather than org owner — audit all callers to ensure none make seat or plan decisions based on it
- `getSubscription` omits trialing status: `productSubscriptions.getSubscription` filters only `status == "active"` while `checkSeatLimit` also accepts `trialing` — unify the filter or deprecate `getSubscription`