### PR TITLE
Replace `getSubscription` in other callers

### DIFF
--- a/convex/productSubscriptions.ts
+++ b/convex/productSubscriptions.ts
@@ -21,36 +21,3 @@ export const getActiveProducts = query({
       .map((s) => s.productId);
   },
 });
-
-export const getSubscription = query({
-  args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
-    const { user } = await verifyOrgAccess(ctx, args.organizationId);
-
-    // Check for user's subscription (plans are per-user, not per-org)
-    const subscription = await ctx.db
-      .query("subscriptions")
-      .withIndex("userId", (q) => q.eq("userId", user._id))
-      .filter((q) => q.eq(q.field("status"), "active"))
-      .first();
-
-    if (!subscription) {
-      // No active subscription - return default free tier
-      return {
-        seatLimit: 5,
-        status: "free" as const,
-        productId: null,
-      };
-    }
-
-    // Get plan details for seat limit
-    const plan = await ctx.db.get(subscription.planId);
-    const seatLimit = plan?.seatLimit ?? 10;
-
-    return {
-      seatLimit,
-      status: subscription.status as "active" | "trialing",
-      productId: null,
-    };
-  },
-});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2446.

Closes #2446

---

## Claude summary

The fix is committed. Here's a summary of what was found and done:

**Audit result:** `productSubscriptions.getSubscription` had zero callers anywhere in the codebase (neither frontend nor other Convex functions). It was dead code.

**The bug:** The function queried subscriptions by the calling user's ID (`user._id`) instead of the org owner's ID (`org.ownerId`). This means any non-owner member calling it would get their own (likely non-existent) subscription, fall through to the free tier default (5 seats), and return a wrong seat limit. The correct pattern already existed in `convex/_helpers/seatLimits.ts:50` — it reads `org.ownerId` and is used by `getSeatUsage`.

**Fix:** Deleted `getSubscription` entirely. Since it had no callers, there's no migration or frontend update needed. The correct query for seat/plan decisions is `api.organizations.getSeatUsage`.