### PR TITLE
CRM v1.0: Test podstawowych uprawnień użytkowników

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.permissions.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.permissions.tsx
@@ -18,6 +18,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
+import { useRole } from "@/hooks/use-permission";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/settings/permissions"
@@ -81,8 +82,14 @@ function buildPermissionsMap(overrides: Record<string, Record<string, string>> |
 function PermissionsSettings() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
+  const { role, loading: roleLoading } = useRole();
 
-  const overrides = useQuery(api.permissions.getOrgPermissionOverrides, { organizationId });
+  const isAdmin = role === "owner" || role === "admin";
+
+  const overrides = useQuery(
+    api.permissions.getOrgPermissionOverrides,
+    isAdmin ? { organizationId } : "skip",
+  );
   const resourceSharingEnabled = useQuery(api.permissions.getResourceSharingEnabled, { organizationId });
 
   const updatePermissions = useMutation(api.permissions.updateOrgPermissions);
@@ -139,6 +146,25 @@ function PermissionsSettings() {
       toast.error(t("permissions.sharingError", "Failed to update resource sharing"));
     }
   };
+
+  if (roleLoading) return null;
+
+  if (!isAdmin) {
+    return (
+      <div className="flex h-full w-full flex-col gap-6">
+        <SectionHeader.Root className="pt-4">
+          <SectionHeader.Group>
+            <SectionHeader.Heading className="flex-1">
+              {t("permissions.title", "Permissions")}
+            </SectionHeader.Heading>
+          </SectionHeader.Group>
+        </SectionHeader.Root>
+        <p className="text-sm text-muted-foreground">
+          {t("permissions.adminOnly", "Only owners and admins can view and edit permission settings.")}
+        </p>
+      </div>
+    );
+  }
 
   if (overrides === undefined) {
     return null;

--- a/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
@@ -50,6 +50,7 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { MoreHorizontal, Send, XCircle, UserPlus, AlertTriangle, ArrowUpRight, CircleCheck } from "@/lib/ez-icons";
 import { toast } from "sonner";
 import { useNavigate } from "@tanstack/react-router";
+import { useRole } from "@/hooks/use-permission";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/settings/team"
@@ -62,6 +63,8 @@ const ROLES = ["admin", "member", "viewer"] as const;
 function TeamSettings() {
   const { t, i18n } = useTranslation();
   const { organizationId } = useOrganization();
+  const { role } = useRole();
+  const isAdmin = role === "owner" || role === "admin";
 
   const queryClient = useQueryClient();
 
@@ -316,7 +319,7 @@ function TeamSettings() {
                       {t("team.joinedDate")} {formatDate(member.joinedAt)}
                     </span>
                   )}
-                  {!isOwner && (
+                  {!isOwner && isAdmin && (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <Button variant="ghost" size="icon" className="h-8 w-8">
@@ -378,27 +381,29 @@ function TeamSettings() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle className="text-base">{t("team.invitations")}</CardTitle>
-          <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
-            <DialogTrigger asChild>
-              <Button size="sm" disabled={isAtLimit}>
-                <UserPlus className="mr-2 h-4 w-4" variant="stroke" />
-                {t("team.inviteMember")}
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
-              <DialogHeader>
-                <DialogTitle>{t("team.inviteDialog.title")}</DialogTitle>
-                <DialogDescription>
-                  {t("team.inviteDialog.description")}
-                </DialogDescription>
-              </DialogHeader>
-              <UserInvitationForm
-                onSubmit={handleSendInvitation}
-                onCancel={() => setInviteOpen(false)}
-                isSubmitting={isSending}
-              />
-            </DialogContent>
-          </Dialog>
+          {isAdmin && (
+            <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
+              <DialogTrigger asChild>
+                <Button size="sm" disabled={isAtLimit}>
+                  <UserPlus className="mr-2 h-4 w-4" variant="stroke" />
+                  {t("team.inviteMember")}
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
+                <DialogHeader>
+                  <DialogTitle>{t("team.inviteDialog.title")}</DialogTitle>
+                  <DialogDescription>
+                    {t("team.inviteDialog.description")}
+                  </DialogDescription>
+                </DialogHeader>
+                <UserInvitationForm
+                  onSubmit={handleSendInvitation}
+                  onCancel={() => setInviteOpen(false)}
+                  isSubmitting={isSending}
+                />
+              </DialogContent>
+            </Dialog>
+          )}
         </CardHeader>
         <CardContent className="space-y-1">
           {invitations && invitations.length > 0 ? (
@@ -431,59 +436,61 @@ function TeamSettings() {
                   </div>
                 </div>
 
-                <div className="flex items-center gap-2">
-                  <Select
-                    value={invitation.role}
-                    onValueChange={(role) =>
-                      handleChangePendingRole(
-                        invitation._id as Id<"invitations">,
-                        role,
-                      )
-                    }
-                    disabled={resendingId === invitation._id || cancellingId === invitation._id}
-                  >
-                    <SelectTrigger className="h-8 w-32 capitalize">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {ROLES.map((role) => (
-                        <SelectItem key={role} value={role} className="capitalize">
-                          {t(`team.roles.${role}`)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 text-xs"
-                    disabled={resendingId === invitation._id || cancellingId === invitation._id}
-                    onClick={() =>
-                      handleResendInvitation(
-                        invitation._id as Id<"invitations">
-                      )
-                    }
-                  >
-                    <Send className="mr-1 h-4 w-4" variant="stroke" />
-                    {resendingId === invitation._id
-                      ? t("team.inviteDialog.sending")
-                      : t("team.resendInvitation")}
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 text-xs text-destructive hover:text-destructive"
-                    disabled={resendingId === invitation._id || cancellingId === invitation._id}
-                    onClick={() =>
-                      handleCancelInvitation(
-                        invitation._id as Id<"invitations">
-                      )
-                    }
-                  >
-                    <XCircle className="mr-1 h-4 w-4" variant="stroke" />
-                    {t("team.cancelInvitation")}
-                  </Button>
-                </div>
+                {isAdmin && (
+                  <div className="flex items-center gap-2">
+                    <Select
+                      value={invitation.role}
+                      onValueChange={(role) =>
+                        handleChangePendingRole(
+                          invitation._id as Id<"invitations">,
+                          role,
+                        )
+                      }
+                      disabled={resendingId === invitation._id || cancellingId === invitation._id}
+                    >
+                      <SelectTrigger className="h-8 w-32 capitalize">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {ROLES.map((role) => (
+                          <SelectItem key={role} value={role} className="capitalize">
+                            {t(`team.roles.${role}`)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 text-xs"
+                      disabled={resendingId === invitation._id || cancellingId === invitation._id}
+                      onClick={() =>
+                        handleResendInvitation(
+                          invitation._id as Id<"invitations">
+                        )
+                      }
+                    >
+                      <Send className="mr-1 h-4 w-4" variant="stroke" />
+                      {resendingId === invitation._id
+                        ? t("team.inviteDialog.sending")
+                        : t("team.resendInvitation")}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 text-xs text-destructive hover:text-destructive"
+                      disabled={resendingId === invitation._id || cancellingId === invitation._id}
+                      onClick={() =>
+                        handleCancelInvitation(
+                          invitation._id as Id<"invitations">
+                        )
+                      }
+                    >
+                      <XCircle className="mr-1 h-4 w-4" variant="stroke" />
+                      {t("team.cancelInvitation")}
+                    </Button>
+                  </div>
+                )}
               </div>
             ))
           ) : (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2449.

Closes #2449

---

## Claude summary

Committed. Here is the complete audit report:

---

## Audyt uprawnień CRM v1.0

### Mapowanie ról

| Persona (issue) | Org role | Gabinet role |
|---|---|---|
| Właściciel | `owner` | — |
| Administrator | `admin` | — |
| Recepcja | `member` | `receptionist` |
| Kosmetolog/Specjalista | `member` | `doctor` / `therapist` |

### Co działa

**Backend (serwer)** jest w pełni zabezpieczony:
- Wszystkie mutacje team/org (`updateMemberRole`, `removeMember`, invite, cancel) wymagają `requireOrgAdmin` — rzuca błąd dla `member`/`viewer`
- Operacje na gabinet_settings (lokalizacje, pokoje) sprawdzają `checkPermission(gabinet_settings, edit)` — dostępne tylko dla gabinet `admin`
- Wszystkie dane są izolowane przez `organizationId` — brak cross-org leaków

**Gabinet settings pages** (scheduling, timetable, leaves, locations, roles, equipment, reminders) — każda strona ma `<PermissionGate feature="gabinet_settings" action="view">`, więc widzą je tylko osoby z uprawnieniem.

**Audit Log** (`/settings/audit-log`) — prawidłowo sprawdza `role === "admin" || role === "owner"` w frontendzie, pokazuje komunikat dla pozostałych.

**System gabinet_* uprawnień** (dwuosiowy: org role + gabinet role, max-merge) jest dobrze zaprojektowany:
- Recepcja: może tworzyć/edytować wizyty i płatności, bez refundów i usuwania
- Kosmetolog: może tworzyć wizyty/pacjentów, edytować tylko własnych
- Menadżer (gabinet): dostęp do raportów finansowych i cennika zakupowego
- Gabinet admin: pełny dostęp do ustawień gabinetu

### Co nie działało (i zostało naprawione tym PR)

**Settings/Team page** — `member`/`viewer` widział przycisk "Zaproś użytkownika", dropdown "Zmień rolę" i "Usuń" dla każdego członka, a także kontrolki resend/cancel/change-role dla oczekujących zaproszeń. Akcje rzucały błędem po stronie serwera, ale UX był mylący i ujawniał adresy e-mail oczekujących zaproszeń oraz statystyki zużycia miejsc.

**Settings/Permissions page** — brak frontend guard powodował, że `useQuery(getOrgPermissionOverrides)` był wywoływany przez non-admin, co skutkowało błędem "Admin access required" serwera. Strona wyświetlała stan ładowania bez zakończenia.

**Naprawiono**: Dodano `useRole()` w obu stronach. Team page: przyciski admin schowane za `isAdmin`. Permissions page: non-admin widzi komunikat dostępu zamiast crashu.

### Co nie działa (poza zakresem v1.0)

**Cross-location isolation** — "dostęp do danych innej lokalizacji" nie jest wdrożone. Wszyscy członkowie org widzą wizyty, pacjentów i dane ze wszystkich lokalizacji. Tabela `gabinet_locations` nie ma RLS per-employee. Jeśli biznes wymaga, żeby pracownik lokalizacji A nie widział danych lokalizacji B — potrzeba nowej implementacji (RLS w Supabase + kolumna `allowed_locations` w `gabinetMemberships`). To jest duże zadanie.

**Brak gabinet-role na liście pracowników** — receptionist jako `member` nie ma wbudowanego mechanizmu "widzi tylko swoją lokalizację" — gabinet_role daje szerszy dostęp niż lokalizacja.

### Co blokuje CRM v1.0

Tylko naprawione w tym PR — brak innych blokerów po stronie uprawnień dla ról owner/admin/member/viewer.

Cross-location isolation to feature, nie bug — może być v1.1.

### Checklista testów manualnych

1. **Właściciel (owner)**: zaloguj się → wejdź `/settings/team` → widać przycisk Zaproś + dropdown Change Role/Remove → przejdź `/settings/permissions` → widać macierz uprawnień → kliknij Save → sukces
2. **Administrator (admin)**: j.w. — powinien widzieć i móc edytować wszystko
3. **Member (bez gabinet role)**: zaloguj się → wejdź `/settings/team` → NIE widać przycisku Zaproś i dropdown zarządzania → wejdź `/settings/permissions` → widać komunikat "Only owners and admins can view..."
4. **Member + receptionist gabinet role**: wejdź `/dashboard/gabinet/calendar` → można tworzyć/edytować wizyty → wejdź `/dashboard/gabinet/payments` → można rejestrować płatności, brak przycisku Refund → wejdź `/dashboard/gabinet/settings/locations` → widać lokalizacje, brak możliwości tworzenia/usuwania
5. **Member + doctor gabinet role**: wejdź `/dashboard/gabinet/patients` → można tworzyć pacjenta, edytować własnego, brak możliwości edycji cudzego → wejdź `/dashboard/gabinet/payments` → widok readonly, brak tworzenia płatności
6. **Viewer**: żadna akcja tworzenia/edycji nie powinna działać; widok team: brak przycisków admin
7. **Cross-location** (jeśli jest >1 lokalizacja): zaloguj się jako receptionist lokalizacji A → sprawdź, czy widzi wizyty z lokalizacji B (oczekiwany wynik: widzi — nie ma izolacji, to znany gap)

---

## Follow-ups

- Add cross-location data isolation for multi-location orgs: currently all org members see appointments/patients/payments from all locations; needs per-location access control via `allowed_locations` in `gabinetMemberships` + Supabase RLS
- Filter CRM `settingsNav` by role in manifest: non-admin members see all settings nav links (organization, pipelines, billing, etc.) in the sidebar even though they can only read them; minor UX noise but could confuse members
- Add `gabinet_settings` view-only mode for non-admin gabinet roles: currently `member` org default gives `view: "all"` on `gabinet_settings`, so all members can browse scheduling/timetable/leave-types settings — verify this is intentional or restrict to gabinet admin/manager only