### PR TITLE
Add `gabinet_settings` view-only mode for non-admin gabinet roles

### DIFF
--- a/convex/_helpers/gabinetRolePermissions.ts
+++ b/convex/_helpers/gabinetRolePermissions.ts
@@ -148,6 +148,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
   // Manager: operational access without financial-admin powers.
   // Can manage catalog (treatments/packages) and view reports — unlike receptionist.
   // Cannot delete core records, issue refunds, or change gabinet settings — unlike admin.
+  // Gets view-only on gabinet_settings for operational awareness (issue #2453).
   manager: buildGabinet({
     gabinet_patients: { view: "all", create: "all", edit: "all" },
     gabinet_appointments: { view: "all", create: "all", edit: "all", delete: "all" },
@@ -161,7 +162,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_photos: { view: "all" },
     gabinet_online_booking: { view: "all", edit: "all" },
     gabinet_inventory: { view: "all", create: "all", edit: "all" },
-    gabinet_settings: {},
+    gabinet_settings: { view: "all" },
   }),
   admin: buildGabinet({
     gabinet_patients: { view: "all", create: "all", edit: "all", delete: "all" },

--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -91,6 +91,17 @@ DEFAULT_PERMISSIONS.viewer.gabinet_online_booking = {
   view: "none", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
 };
 
+// --- Per-feature overrides for gabinet_settings ---
+// Scheduling / timetable / leave-types / equipment config — admin-only.
+// Gabinet-role layer grants view to manager and full access to gabinet admin;
+// org member/viewer must not see these pages by default. (issue #2453)
+DEFAULT_PERMISSIONS.member.gabinet_settings = {
+  view: "none", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
+};
+DEFAULT_PERMISSIONS.viewer.gabinet_settings = {
+  view: "none", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
+};
+
 // --- Per-feature overrides for document_templates ---
 // owner/admin: all actions allowed (approve/sign not applicable to templates)
 // member: view only (no create/edit/delete)


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2453.

Closes #2453

---

## Claude summary

Done. Here's a summary of what was fixed and why.

**Root cause:** `buildDefaults` in `permissions.ts` applies `view: "all"` to every feature for the `member` org role. Unlike `gabinet_online_booking`, `gabinet_financial_reports`, and other sensitive features that have explicit overrides dropping `member` to `none`, `gabinet_settings` had no such override — so any org member could browse the scheduling, timetable, and leave-types settings pages.

**Changes made (2 files):**

`convex/_helpers/permissions.ts` — Added explicit `none` overrides for `member` and `viewer` on `gabinet_settings`, matching the identical pattern already used for `gabinet_online_booking`.

`convex/_helpers/gabinetRolePermissions.ts` — Gave the gabinet `manager` role `view: "all"` on `gabinet_settings` (previously `{}`). The issue calls out "restrict to gabinet admin/manager only", and a manager needs read access to verify operational config (working hours, leave types, schedules) without being able to change it.

**Resulting access matrix:**
- Org `owner`/`admin`: full access (unchanged, fast-path in `checkPermission`)
- Org `member`/`viewer` without a gabinet employee record: no access (fixed)
- Gabinet `admin` role: full access (unchanged)
- Gabinet `manager` role: view-only (new)
- Other gabinet roles (`doctor`, `nurse`, etc.): no access (unchanged)