### PR TITLE
Design gabinet_employee_locations join table + backfill migration

### DIFF
--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -346,6 +346,22 @@ export function createGabinetTables({
     .index("by_orgAndActive", ["organizationId", "isActive"])
     .index("by_orgAndRole", ["organizationId", "role"]),
 
+  // Many-to-many join between employees and locations.
+  // An employee may work across multiple locations (multi-site clinic chains).
+  // isPrimary marks the employee's default location for scheduling defaults and
+  // calendar filtering. Backfilled from gabinetEmployees.locationId on deploy.
+  gabinetEmployeeLocations: defineTable({
+    organizationId: v.id("organizations"),
+    employeeId: v.id("gabinetEmployees"),
+    locationId: v.id("gabinetLocations"),
+    isPrimary: v.boolean(),
+    createdAt: v.number(),
+  })
+    .index("by_org", ["organizationId"])
+    .index("by_employee", ["employeeId"])
+    .index("by_location", ["locationId"])
+    .index("by_employeeAndLocation", ["employeeId", "locationId"]),
+
   // --- Gabinet: Leave Types & Balances (HR) ---
 
   gabinetLeaveTypes: defineTable({

--- a/supabase/migrations/00030_gabinet_employee_locations.sql
+++ b/supabase/migrations/00030_gabinet_employee_locations.sql
@@ -1,0 +1,83 @@
+-- gabinet_employee_locations join table (#2454).
+--
+-- Records which locations each gabinet employee is authorized to work at.
+-- An employee can be assigned to multiple locations (multi-location clinics /
+-- salon chains). The `is_primary` flag marks the employee's default location —
+-- used for scheduling defaults and calendar filtering.
+--
+-- Relationship to gabinet_employees.location_id (added in migration 00029):
+-- That column is a convenience denormalization for "primary location" and
+-- remains valid for simple single-location use cases. This table is the
+-- authoritative source for multi-location access grants and is what future RLS
+-- policies that scope appointment access by location should read from.
+--
+-- Backfill: existing employees that already have a location_id are granted
+-- membership to that location with is_primary = TRUE so they do not lose
+-- appointment access when location-scoped RLS is enabled. Employees without
+-- a location_id are not backfilled; they will gain access once assigned via
+-- the UI or a subsequent migration.
+
+CREATE TABLE IF NOT EXISTS gabinet_employee_locations (
+  id              TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  employee_id     TEXT NOT NULL REFERENCES gabinet_employees(id) ON DELETE CASCADE,
+  location_id     TEXT NOT NULL REFERENCES gabinet_locations(id) ON DELETE CASCADE,
+  is_primary      BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at      BIGINT NOT NULL DEFAULT (extract(epoch from now()) * 1000)::bigint
+);
+
+-- ---------------------------------------------------------------------------
+-- Indexes
+-- ---------------------------------------------------------------------------
+
+CREATE INDEX IF NOT EXISTS gabinet_employee_locations_org_idx
+  ON gabinet_employee_locations (organization_id);
+
+CREATE INDEX IF NOT EXISTS gabinet_employee_locations_employee_idx
+  ON gabinet_employee_locations (employee_id);
+
+CREATE INDEX IF NOT EXISTS gabinet_employee_locations_location_idx
+  ON gabinet_employee_locations (location_id);
+
+-- Prevents the same (employee, location) pair from appearing more than once.
+CREATE UNIQUE INDEX IF NOT EXISTS gabinet_employee_locations_unique_idx
+  ON gabinet_employee_locations (employee_id, location_id);
+
+-- ---------------------------------------------------------------------------
+-- RLS: per-command org-scoped policies (pattern established in
+-- 00002_rls_policies.sql, per-command split per 00026).
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE gabinet_employee_locations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY gabinet_employee_locations_select ON gabinet_employee_locations
+  FOR SELECT USING (current_org_id() = organization_id);
+CREATE POLICY gabinet_employee_locations_insert ON gabinet_employee_locations
+  FOR INSERT WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY gabinet_employee_locations_update ON gabinet_employee_locations
+  FOR UPDATE USING (current_org_id() = organization_id)
+  WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY gabinet_employee_locations_delete ON gabinet_employee_locations
+  FOR DELETE USING (current_org_id() = organization_id);
+
+-- ---------------------------------------------------------------------------
+-- Backfill: seed from existing gabinet_employees.location_id.
+--
+-- Backfill IDs are UUID-style strings (not Convex IDs) because these rows are
+-- created outside the Convex mutation path. Future inserts via Convex mutations
+-- will use proper Convex-generated IDs. The UUID backfill rows are treated as
+-- opaque TEXT PKs — Supabase and RLS policies only care that they are unique.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO gabinet_employee_locations
+  (id, organization_id, employee_id, location_id, is_primary, created_at)
+SELECT
+  gen_random_uuid()::text,
+  e.organization_id,
+  e.id,
+  e.location_id,
+  TRUE,
+  (extract(epoch from now()) * 1000)::bigint
+FROM gabinet_employees e
+WHERE e.location_id IS NOT NULL
+ON CONFLICT (employee_id, location_id) DO NOTHING;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2454.

Closes #2454

---

## Claude summary

Done. Here's what was implemented:

**`convex/schema/gabinet.ts`** — added `gabinetEmployeeLocations` table definition with fields `organizationId`, `employeeId`, `locationId`, `isPrimary`, `createdAt` and four indexes (`by_org`, `by_employee`, `by_location`, `by_employeeAndLocation`).

**`supabase/migrations/00030_gabinet_employee_locations.sql`** — creates the `gabinet_employee_locations` table with:
- FK constraints to `organizations`, `gabinet_employees`, and `gabinet_locations` (all with `ON DELETE CASCADE`)
- A unique index on `(employee_id, location_id)` preventing duplicate grants
- Per-command RLS policies (SELECT/INSERT/UPDATE/DELETE) scoped to `current_org_id()`, matching the established project pattern from migration 00026
- A backfill `INSERT … SELECT` that reads all employees with an existing `location_id` and creates a primary-location grant for each, with `ON CONFLICT DO NOTHING` as a safety guard

The backfill ensures existing employees keep appointment access the moment this migration runs, before any location-scoped RLS enforcement is added.

## Follow-ups

- Remove gabinet_employees.location_id after join table adoption: migration 00029 added a single `location_id` FK on `gabinet_employees`; now that the join table is the authoritative source for location grants, this column is a stale denormalization that should be dropped in a follow-up migration once all read paths use `gabinet_employee_locations`
- Add Convex mutations for managing gabinetEmployeeLocations: the join table has no Convex mutation layer yet (create/delete grants, toggle isPrimary) — needed before the UI can manage multi-location assignments
- Design location-scoped RLS for gabinet_appointments: the original motivation for this table (issue #2451) was to scope appointment visibility to the employee's authorized locations; that RLS policy still needs to be written now that the prerequisite join table exists