### PR TITLE
Add `current_user_id()` SQL helper to RLS migration

### DIFF
--- a/supabase/migrations/00002_rls_policies.sql
+++ b/supabase/migrations/00002_rls_policies.sql
@@ -18,6 +18,7 @@
 --
 -- Helper functions
 --   current_org_id()  – extracts org_id from the JWT
+--   current_user_id() – extracts sub (user id) from the JWT
 --   is_service_role() – true when called by the backend service role
 --
 -- Observability
@@ -34,6 +35,17 @@ STABLE
 AS $$
   SELECT nullif(
     current_setting('request.jwt.claims', true)::json->>'org_id',
+    ''
+  )
+$$;
+
+CREATE OR REPLACE FUNCTION current_user_id()
+RETURNS TEXT
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT nullif(
+    current_setting('request.jwt.claims', true)::json->>'sub',
     ''
   )
 $$;
@@ -1012,11 +1024,11 @@ CREATE POLICY users_insert ON users
 CREATE POLICY users_update ON users
   FOR UPDATE
   USING (
-    id = nullif(current_setting('request.jwt.claims', true)::json->>'sub', '')
+    id = current_user_id()
     OR is_service_role()
   )
   WITH CHECK (
-    id = nullif(current_setting('request.jwt.claims', true)::json->>'sub', '')
+    id = current_user_id()
     OR is_service_role()
   );
 CREATE POLICY users_delete ON users
@@ -1047,7 +1059,7 @@ CREATE POLICY platform_products_delete ON platform_products
 CREATE POLICY subscriptions_select ON subscriptions
   FOR SELECT
   USING (
-    user_id = nullif(current_setting('request.jwt.claims', true)::json->>'sub', '')
+    user_id = current_user_id()
     OR is_service_role()
   );
 CREATE POLICY subscriptions_insert ON subscriptions

--- a/supabase/migrations/00031_add_current_user_id_helper.sql
+++ b/supabase/migrations/00031_add_current_user_id_helper.sql
@@ -1,0 +1,23 @@
+-- Migration 00031: Add current_user_id() SQL helper function
+--
+-- Adds the missing JWT helper that extracts the `sub` claim (Convex user ID)
+-- from the request JWT. Mirrors current_org_id() from 00002_rls_policies.sql.
+--
+-- Needed to resolve the JWT sub claim to users.id in RLS policies that scope
+-- access by user identity (e.g. location-join lookups, employee self-access
+-- policies). Previously these policies inlined the extraction expression;
+-- the helper centralises it and makes future policies easier to write.
+--
+-- Uses CREATE OR REPLACE so this migration is safe to apply to databases
+-- that already have the function from a re-run of 00002_rls_policies.sql.
+
+CREATE OR REPLACE FUNCTION current_user_id()
+RETURNS TEXT
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT nullif(
+    current_setting('request.jwt.claims', true)::json->>'sub',
+    ''
+  )
+$$;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2455.

Closes #2455

---

## Claude summary

Done. Here's what was changed:

`supabase/migrations/00002_rls_policies.sql` — added `current_user_id()` to the helpers section (alongside `current_org_id()` and `is_service_role()`) and replaced the two inline `nullif(current_setting('request.jwt.claims', true)::json->>'sub', '')` expressions in the `users_update` and `subscriptions_select` policies with `current_user_id()`.

`supabase/migrations/00031_add_current_user_id_helper.sql` — new migration that installs the function on already-running databases via `CREATE OR REPLACE FUNCTION` (idempotent).

The function reads only from the JWT `sub` claim, mirroring the `current_org_id()` pattern. This is distinct from the existing `current_app_user_id()` in `00001_initial_schema.sql`, which has a `coalesce` fallback to a local `app.current_user_id` setting for service-role contexts — the new helper is the appropriate one for standard JWT-authenticated RLS policies.

## Follow-ups

- Unify `current_user_id()` and `current_app_user_id()`: two functions extract `sub` from the JWT (`current_user_id()` in 00002 and `current_app_user_id()` in 00001 with a coalesce fallback); consider whether policies that currently call the inline expression or `current_app_user_id()` should be migrated to `current_user_id()` for consistency, or document the distinction so future contributors pick the right one.