### PR TITLE
Remove gabinet_employees.location_id after join table adoption

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -350,7 +350,6 @@ export const _createFromInvitation = internalAction({
       showInCalendar: typeof d.showInCalendar === "boolean" ? d.showInCalendar : true,
       tagIds: asStringArray(d.tagIds),
       categoryId: asString(d.categoryId),
-      locationId: asString(d.locationId),
       createdBy: args.invitedBy,
       createdAt: now,
       updatedAt: now,

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -336,7 +336,6 @@ export function createGabinetTables({
     showInCalendar: v.optional(v.boolean()),
     tagIds: v.optional(v.array(v.id("tagDefinitions"))),
     categoryId: v.optional(v.id("categoryDefinitions")),
-    locationId: v.optional(v.string()),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),
@@ -349,7 +348,7 @@ export function createGabinetTables({
   // Many-to-many join between employees and locations.
   // An employee may work across multiple locations (multi-site clinic chains).
   // isPrimary marks the employee's default location for scheduling defaults and
-  // calendar filtering. Backfilled from gabinetEmployees.locationId on deploy.
+  // calendar filtering.
   gabinetEmployeeLocations: defineTable({
     organizationId: v.id("organizations"),
     employeeId: v.id("gabinetEmployees"),

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -34,6 +34,10 @@
  *   • 00027_gabinet_appointments_location_idx.sql
  *   • 00028_gabinet_payment_methods.sql
  *   • 00029_gabinet_employees_location.sql
+ *   • 00030_gabinet_employee_locations.sql
+ *   • 00031_add_current_user_id_helper.sql
+ *   • 00032_gabinet_patients_preferred_location.sql
+ *   • 00033_drop_gabinet_employees_location_id.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -3967,7 +3971,6 @@ export interface Database {
           bank_account: string | null;
           tag_ids: string[] | null;
           category_id: string | null;
-          location_id: string | null;
           created_by: string;
           created_at: number;
           updated_at: number;
@@ -4005,7 +4008,6 @@ export interface Database {
           bank_account?: string | null;
           tag_ids?: string[] | null;
           category_id?: string | null;
-          location_id?: string | null;
           created_by: string;
           created_at: number;
           updated_at: number;
@@ -4043,7 +4045,6 @@ export interface Database {
           bank_account?: string | null;
           tag_ids?: string[] | null;
           category_id?: string | null;
-          location_id?: string | null;
           created_by?: string;
           created_at?: number;
           updated_at?: number;
@@ -4077,13 +4078,6 @@ export interface Database {
             columns: ["created_by"];
             isOneToOne: false;
             referencedRelation: "users";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "gabinet_employees_location_id_fkey";
-            columns: ["location_id"];
-            isOneToOne: false;
-            referencedRelation: "gabinet_locations";
             referencedColumns: ["id"];
           },
         ];

--- a/supabase/migrations/00033_drop_gabinet_employees_location_id.sql
+++ b/supabase/migrations/00033_drop_gabinet_employees_location_id.sql
@@ -1,0 +1,14 @@
+-- Drop gabinet_employees.location_id after join table adoption (#2460).
+--
+-- migration 00029 added a single location_id FK on gabinet_employees as a
+-- convenience denormalization. Migration 00030 introduced the
+-- gabinet_employee_locations join table as the authoritative many-to-many
+-- source, and backfilled all existing location_id values into that table.
+--
+-- All read paths now go through gabinet_employee_locations; the column on
+-- gabinet_employees is unused stale state.
+
+DROP INDEX IF EXISTS gabinet_employees_org_location_idx;
+
+ALTER TABLE gabinet_employees
+  DROP COLUMN IF EXISTS location_id;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2460.

Closes #2460

---

## Claude summary

The changes are committed. Here's a summary of what was done:

**Migration `00033_drop_gabinet_employees_location_id.sql`** — drops the `gabinet_employees_org_location_idx` index and the `location_id` column from `gabinet_employees`. The backfill in migration 00030 already moved all data to `gabinet_employee_locations`, so nothing is lost.

**`convex/schema/gabinet.ts`** — removed `locationId: v.optional(v.string())` from the `gabinetEmployees` table definition and cleaned up the stale backfill note in the `gabinetEmployeeLocations` comment.

**`convex/gabinet/employees.ts`** — removed `locationId: asString(d.locationId)` from `_createFromInvitation`, the only write path that still populated the column.

**`src/lib/supabase/database.types.ts`** — removed `location_id` from the `gabinet_employees` Row/Insert/Update types, dropped the `gabinet_employees_location_id_fkey` FK relationship entry, and updated the migration header to include migrations 00030–00033.