### PR TITLE
Unify `current_user_id()` and `current_app_user_id()`

### DIFF
--- a/supabase/migrations/00035_drop_current_app_user_id.sql
+++ b/supabase/migrations/00035_drop_current_app_user_id.sql
@@ -1,0 +1,16 @@
+-- Migration 00035: Drop unused current_app_user_id() helper (closes #2464)
+--
+-- current_app_user_id() was introduced in 00001_initial_schema.sql as an early
+-- helper that extracted the caller's user ID via:
+--
+--   COALESCE(app.current_user_id GUC, jwt.claims->>'sub')
+--
+-- 00002_rls_policies.sql introduced current_user_id() with a simpler, JWT-only
+-- implementation (nullif(jwt.claims->>'sub', '')) and wired all RLS policies to
+-- use that function. current_app_user_id() was never referenced in any policy
+-- and became dead code.
+--
+-- Dropping it removes the ambiguity so future contributors have a single,
+-- clearly-named function to call: current_user_id().
+
+DROP FUNCTION IF EXISTS current_app_user_id();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2464.

Closes #2464

---

## Claude summary

Done. Here's a summary of what I found and fixed:

**Triage:** The report was accurate. Two functions for extracting `sub` from the JWT coexisted:

- `current_app_user_id()` (00001) — `COALESCE(app.current_user_id GUC, jwt->>'sub')`. Defined but never called in any policy.
- `current_user_id()` (00002, 00031) — `nullif(jwt->>'sub', '')`. The canonical function used in all policies in 00002 and 00034.

**Fix:** Added `supabase/migrations/00035_drop_current_app_user_id.sql` which drops `current_app_user_id()`. The function was dead code; removing it means future contributors have exactly one function to reach for: `current_user_id()`.