### PR TITLE
Index team_memberships (user_id, organization_id, role) for RLS subquery perform

### DIFF
--- a/supabase/migrations/00037_team_memberships_admin_role_idx.sql
+++ b/supabase/migrations/00037_team_memberships_admin_role_idx.sql
@@ -1,0 +1,22 @@
+-- Migration 00037: Partial index on team_memberships for RLS admin-role subquery (#2470)
+--
+-- Migrations 00034 and 00036 introduced location-scoped RLS policies on
+-- gabinet_appointments that include a team_memberships subquery on every row
+-- evaluation to check whether the current user is an org owner or admin:
+--
+--   EXISTS (
+--     SELECT 1 FROM team_memberships tm
+--     WHERE tm.user_id        = current_user_id()
+--       AND tm.organization_id = current_org_id()
+--       AND tm.role IN ('owner', 'admin')
+--   )
+--
+-- The existing unique index team_memberships_org_user_idx(organization_id, user_id)
+-- limits this to at most one row lookup before the role check, but a dedicated
+-- partial index covering only owner/admin rows is smaller (regular members are
+-- excluded) and lets Postgres resolve a negative result (user is not an admin)
+-- without touching any data pages.
+
+CREATE INDEX team_memberships_admin_role_idx
+  ON team_memberships (user_id, organization_id)
+  WHERE role IN ('owner', 'admin');


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2470.

Closes #2470

---

## Claude summary

Done. Added `supabase/migrations/00037_team_memberships_admin_role_idx.sql` with a partial index:

```sql
CREATE INDEX team_memberships_admin_role_idx
  ON team_memberships (user_id, organization_id)
  WHERE role IN ('owner', 'admin');
```

The fix is targeted and minimal. The existing unique index `(organization_id, user_id)` already prevents a full sequential scan, but this partial index is smaller (only owner/admin rows are indexed) and lets Postgres immediately return no-match for the very common case of a regular member without touching any index data pages. The index predicate `WHERE role IN ('owner', 'admin')` exactly matches the `AND tm.role IN ('owner', 'admin')` filter in the RLS subquery, so Postgres will recognize it as eligible for that query plan.