### PR TITLE
Add `gabinet_settings` view-only mode for non-admin gabinet roles

### DIFF
--- a/convex/_helpers/gabinetRolePermissions.ts
+++ b/convex/_helpers/gabinetRolePermissions.ts
@@ -148,6 +148,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
   // Manager: operational access without financial-admin powers.
   // Can manage catalog (treatments/packages) and view reports — unlike receptionist.
   // Cannot delete core records, issue refunds, or change gabinet settings — unlike admin.
+  // Gets view-only on gabinet_settings for operational awareness (issue #2453).
   manager: buildGabinet({
     gabinet_patients: { view: "all", create: "all", edit: "all" },
     gabinet_appointments: { view: "all", create: "all", edit: "all", delete: "all" },
@@ -161,7 +162,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_photos: { view: "all" },
     gabinet_online_booking: { view: "all", edit: "all" },
     gabinet_inventory: { view: "all", create: "all", edit: "all" },
-    gabinet_settings: {},
+    gabinet_settings: { view: "all" },
   }),
   admin: buildGabinet({
     gabinet_patients: { view: "all", create: "all", edit: "all", delete: "all" },

--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -91,6 +91,17 @@ DEFAULT_PERMISSIONS.viewer.gabinet_online_booking = {
   view: "none", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
 };
 
+// --- Per-feature overrides for gabinet_settings ---
+// Scheduling / timetable / leave-types / equipment config — admin-only.
+// Gabinet-role layer grants view to manager and full access to gabinet admin;
+// org member/viewer must not see these pages by default. (issue #2453)
+DEFAULT_PERMISSIONS.member.gabinet_settings = {
+  view: "none", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
+};
+DEFAULT_PERMISSIONS.viewer.gabinet_settings = {
+  view: "none", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
+};
+
 // --- Per-feature overrides for document_templates ---
 // owner/admin: all actions allowed (approve/sign not applicable to templates)
 // member: view only (no create/edit/delete)


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2453.

Closes #2453

---

## Claude summary

Done. Here's a summary of what was fixed and why:

**Root cause:** `buildDefaults` in `permissions.ts` gives every feature `view: "all"` for the `member` org role by default. `gabinet_settings` had no explicit override (unlike `gabinet_online_booking` which already had one), so all org members could browse scheduling, timetable, leave-types, and other admin settings pages.

**Changes made (12 files):**

`convex/_helpers/permissions.ts` — Added explicit `none` overrides for `member` and `viewer` on `gabinet_settings`, matching the identical pattern already used for `gabinet_online_booking`.

`convex/_helpers/gabinetRolePermissions.ts` — Changed `manager.gabinet_settings` from `{}` to `{ view: "all" }`. The issue calls out "gabinet admin/manager only", and a manager needs read access to verify operational config (working hours, leave types, schedules) without being able to change it.

`src/components/gabinet/no-access.tsx` (new) — A `GabinetNoAccess` component with a shield icon and the existing `permissions.noAccess` i18n key, used as the `PermissionGate` fallback.

9 gabinet settings route files — Added `fallback={<GabinetNoAccess />}` to each `PermissionGate` so unauthorized users see an informative message instead of a blank page.

**Resulting access matrix:**
- Org `owner`/`admin`: full access (unchanged, fast-path)
- Org `member`/`viewer` without gabinet employee record: no access (fixed)
- Gabinet `admin` role: full CRUD (unchanged)
- Gabinet `manager` role: view-only (new)
- Clinical roles (`doctor`, `nurse`, `therapist`, `receptionist`, `other`): no access (unchanged, `{}` already meant all-none)

**Manual test checklist:**
1. Log in as org `member` → navigate to `/dashboard/gabinet/settings/scheduling` → should see the "no access" shield message, not the settings form
2. Log in as org `admin` → same URL → should see and be able to edit scheduling settings
3. Log in as a user with gabinet `manager` role (org `member`) → same URL → should see the settings form (view), but Save button should fail with a permission error from the Convex mutation
4. Log in as a user with gabinet `admin` role → should see full CRUD on all settings pages
5. Log in as org `member` with gabinet `doctor`/`nurse`/`therapist` role → should see the "no access" message (doctor's `gabinet_settings: {}` means none, and org member override is now none → max(none,none)=none)

## Follow-ups

- Hide gabinet settings nav items from unauthorized users: the sidebar renders all `settingsNav` items from `gabinetManifest` without checking `gabinet_settings` permission, so users who can't access settings still see the nav links (they now show a "no access" message after clicking instead of crashing, but hiding them would be cleaner). Requires adding permission-aware filtering to `app-sidebar.tsx`'s `settingsNav` map or adding a `permissionFeature` mechanism to the manifest type.
- Gate gabinet settings Convex mutations for `manager` view-only: a `manager` who can view settings could still call mutations directly if no backend check exists for create/edit/delete on `gabinet_settings`. Audit `convex/gabinet/scheduling.ts` and related files to ensure `checkPermission(ctx, orgId, "gabinet_settings", "edit")` is called before any mutating operation.