### PR TITLE
Remove redundant raw role checks in `employees.ts` and `employeeLocations.ts`

### DIFF
--- a/convex/gabinet/employeeLocations.ts
+++ b/convex/gabinet/employeeLocations.ts
@@ -43,15 +43,12 @@ export const addLocation = action({
   },
   handler: async (ctx, args): Promise<string> => {
     try {
-      const authResult = await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
         organizationId: args.organizationId,
       });
       await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, {
         organizationId: args.organizationId,
       });
-      if (authResult.role !== "owner" && authResult.role !== "admin") {
-        throw new Error("Admin access required");
-      }
       const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
         organizationId: args.organizationId,
         feature: "gabinet_employees",
@@ -132,15 +129,12 @@ export const removeLocation = action({
   },
   handler: async (ctx, args): Promise<void> => {
     try {
-      const authResult = await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
         organizationId: args.organizationId,
       });
       await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, {
         organizationId: args.organizationId,
       });
-      if (authResult.role !== "owner" && authResult.role !== "admin") {
-        throw new Error("Admin access required");
-      }
       const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
         organizationId: args.organizationId,
         feature: "gabinet_employees",
@@ -194,15 +188,12 @@ export const setPrimary = action({
   },
   handler: async (ctx, args): Promise<void> => {
     try {
-      const authResult = await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
         organizationId: args.organizationId,
       });
       await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, {
         organizationId: args.organizationId,
       });
-      if (authResult.role !== "owner" && authResult.role !== "admin") {
-        throw new Error("Admin access required");
-      }
       const perm = await ctx.runQuery(internal._helpers.authAction.checkPermission, {
         organizationId: args.organizationId,
         feature: "gabinet_employees",

--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -193,10 +193,6 @@ export const create = action({
       { organizationId: args.organizationId },
     );
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
-    // Require admin role (mirrors requireOrgAdmin)
-    if (authResult.role !== "owner" && authResult.role !== "admin") {
-      throw new Error("Admin access required");
-    }
     await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_employees",
@@ -601,10 +597,6 @@ export const update = action({
       { organizationId: args.organizationId },
     );
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
-    // Require admin role (mirrors requireOrgAdmin)
-    if (authResult.role !== "owner" && authResult.role !== "admin") {
-      throw new Error("Admin access required");
-    }
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       {
@@ -730,10 +722,6 @@ export const remove = action({
       { organizationId: args.organizationId },
     );
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
-    // Require admin role (mirrors requireOrgAdmin)
-    if (authResult.role !== "owner" && authResult.role !== "admin") {
-      throw new Error("Admin access required");
-    }
     const perm = await ctx.runQuery(
       internal._helpers.authAction.checkPermission,
       {
@@ -852,10 +840,6 @@ export const setQualifiedTreatments = action({
       { organizationId: args.organizationId },
     );
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
-    // Require admin role (mirrors requireOrgAdmin)
-    if (authResult.role !== "owner" && authResult.role !== "admin") {
-      throw new Error("Admin access required");
-    }
     await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "gabinet_employees",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2482.

Closes #2482

---

## Claude summary

Done. The fix removes 7 redundant raw role checks (4 in `employees.ts`, 3 in `employeeLocations.ts`) across all write mutations, leaving `checkPermission` as the sole RBAC gate. Gabinet admins and managers with "member" org roles will no longer be incorrectly blocked before `checkPermission` can evaluate their gabinet-level permissions.