### PR TITLE
CRM v1.0: Audyt modułu Klienci

### DIFF
--- a/session_state.json
+++ b/session_state.json
@@ -1,9 +1,9 @@
 {
-  "session_id": "S0103",
-  "started_at": "2026-06-12T16:00:00Z",
-  "last_updated": "2026-06-12T16:30:00Z",
-  "status": "active",
-  "focus": "Issue #1700 PR-A: Product inventory foundation (track_stock, stock_levels, stock_movements)",
+  "session_id": "S0104",
+  "started_at": "2026-06-30T00:00:00Z",
+  "last_updated": "2026-06-30T00:10:00Z",
+  "status": "completed",
+  "focus": "Issue #2475: CRM v1.0 audit of Klienci (patients) module",
   "tasks_snapshot": {
     "total": 1,
     "not_started": 0,
@@ -12,7 +12,7 @@
     "failing": 0,
     "blocked": 0
   },
-  "active_task_ids": ["INV-A"],
+  "active_task_ids": ["2475-AUDIT"],
   "blockers": [],
-  "notes": "S0103: Reviewed and shipped PR-A from an in-progress worktree state. Schema adds trackStock/stockUnit to products plus productStockLevels and productStockMovements tables (location-aware via gabinetLocations FK). Convex action `inventory.adjustStock` writes movements + level updates and returns negative_stock warning. Products list shows Stan column, create form has track-stock toggle + initial stock seed. PR-B (module feature flags) and PR-C/D (treatment defaults + visit settle + dealProducts stock deduction) are still ahead."
+  "notes": "S0104: Audited gabinet patients module end-to-end. All 9 checklist areas functional. Found and fixed one blocking bug: allergies field was a plain const (no useState, no <Input> rendered) so users could not view or edit allergies on any patient form. Fixed by converting to useState and adding Input element. All other features (create, edit, search, history, appointments, packages, payments, documents, delete) are fully implemented."
 }

--- a/src/components/forms/patient-form.tsx
+++ b/src/components/forms/patient-form.tsx
@@ -95,7 +95,7 @@ export function PatientForm({
   const [city, setCity] = useState(initialData?.address?.city ?? "");
   const [postalCode, setPostalCode] = useState(initialData?.address?.postalCode ?? "");
   const [medicalNotes, setMedicalNotes] = useState(initialData?.medicalNotes ?? "");
-  const allergies = initialData?.allergies ?? "";
+  const [allergies, setAllergies] = useState(initialData?.allergies ?? "");
   const [bloodType, setBloodType] = useState(initialData?.bloodType ?? "");
   const [emergencyContactName, setEmergencyContactName] = useState(initialData?.emergencyContactName ?? "");
   const [emergencyContactPhone, setEmergencyContactPhone] = useState(initialData?.emergencyContactPhone ?? "");
@@ -265,6 +265,13 @@ export function PatientForm({
           <Input
             value={bloodType}
             onChange={(e) => setBloodType(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1.5 sm:col-span-2">
+          <Label>{t("gabinet.patients.allergies")}</Label>
+          <Input
+            value={allergies}
+            onChange={(e) => setAllergies(e.target.value)}
           />
         </div>
       </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2475.

Closes #2475

---

## Claude summary

Here's the full audit result:

---

## Audit: Klienci module — CRM v1.0 readiness

### Co działa (what works)

**1. Dodawanie klienta** — pełna implementacja. Formularz z walidacją (imię, nazwisko, e-mail, telefon wymagane), opcjonalne pola medyczne, tagi, kategorie, źródło polecenia z własnym wpisem.

**2. Edycja danych klienta** — pełna implementacja. Drawer z prefillowanym formularzem, invalidacja cache po zapisie.

**3. Wyszukiwanie klienta** — pełna implementacja. Full-text po imieniu/nazwisku/e-mailu/telefonie, zaawansowane filtry, zapisane widoki (aktywni/nieaktywni/wszyscy), wykrywanie duplikatów.

**4. Historia klienta** — tab "Aktywność" z chronologicznym feedem. Rejestruje: created, updated, deleted, merged, SMS-sent, SMS-received.

**5. Powiązanie z wizytami** — tab "Wizyty" z podziałem na nadchodzące/minione, liczniki wizyt w pakiecie (X/Y), link do szczegółów wizyty.

**6. Widoczność pakietów** — karta boczna z listą pakietów, statusem, zużyciem, datą ważności, historią płatności.

**7. Saldo i płatności** — tab "Wpłaty" z 4 kartami podsumowującymi, historią transakcji, edycją/anulowaniem/zwrotem, wolnostojącymi płatnościami.

**8. Dokumenty i zgody** — tab "Dokumenty" z `EntityDocumentsTab` (paginacja, typy, statusy).

**9. Usuwanie klienta** — soft-delete (isActive=false), potwierdzenie, powrót do listy.

---

### Co zostało naprawione

**BUG (blocking): pole "Alergie" nieedytowalne** — `src/components/forms/patient-form.tsx:98`

`const allergies = initialData?.allergies ?? ""` było zwykłą stałą bez settera i bez elementu `<Input>` w JSX. Użytkownik nie mógł ani zobaczyć, ani edytować alergii pacjenta ani przy tworzeniu, ani przy edycji. Wartość była "przepychana" przez formularz bez zmian.

Naprawiono przez konwersję na `useState` + dodanie pola `<Input>` w sekcji danych medycznych (obok grupy krwi). Commit `2c4be97`.

---

### Co blokuje CRM v1.0

Po naprawie — brak blokerów. Moduł Klienci jest gotowy do v1.0.

---

### Checklista testów manualnych

- [ ] Dodaj klienta z imieniem, nazwiskiem, e-mailem, telefonem → pojawia się na liście
- [ ] Edytuj klienta → zmień pole "Alergie" → zapisz → sprawdź czy wartość się zapisała
- [ ] Edytuj klienta → zmień imię, e-mail → zapisz → sprawdź dane na karcie
- [ ] Wyszukaj klienta po nazwisku i po e-mailu → wyniki zgodne
- [ ] Otwórz szczegóły klienta → tab Wizyty → sprawdź listę wizyt i liczniki X/Y
- [ ] Tab Wpłaty → sprawdź saldo, dodaj wpłatę bez wizyty → saldo wzrośnie
- [ ] Tab Dokumenty → lista dokumentów widoczna
- [ ] Tab Aktywność → historia zdarzeń po edycji klienta
- [ ] Usuń klienta → potwierdzenie → powrót do listy → klient widoczny w widoku "Nieaktywni"
- [ ] Karta boczna → sekcja Pakiety → sprawdź dostępność jeśli klient ma pakiety

## Follow-ups

- Add Supabase-side pagination for patient list: the `list` action loads all patients then filters in-memory (limit 50 client-side), which will time out for orgs with thousands of patients — needs server-side filtering + cursor pagination
- Add GDPR hard-delete path for patients: currently only soft-delete (isActive=false) with all records intact; for RODO right-to-erasure a proper anonymization/hard-delete flow is needed
- Add duplicate-email/phone guard on patient create: backend accepts duplicate emails/phones silently, relying on a UI nudge to prompt merging; a backend uniqueness warning would catch this earlier