### PR TITLE
Add Supabase-side pagination for patient list

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -356,6 +356,26 @@ class SupabaseQueryBuilder<T = Record<string, unknown>> {
     return this;
   }
 
+  ilike(field: string, pattern: string) {
+    this.filters.push((q) => q.ilike(toSnakeCase(field), pattern));
+    return this;
+  }
+
+  /**
+   * PostgREST OR filter. `filterStr` must use snake_case column names and
+   * PostgREST filter syntax, e.g. `"first_name.ilike.%jo%,last_name.ilike.%jo%"`.
+   * Multiple `.or()` calls on the same builder are AND-combined by PostgREST.
+   */
+  or(filterStr: string) {
+    this.filters.push((q) => q.or(filterStr));
+    return this;
+  }
+
+  in(field: string, values: unknown[]) {
+    this.filters.push((q) => q.in(toSnakeCase(field), values));
+    return this;
+  }
+
   order(field: string, ascending = true) {
     this.orderBy.push({ field: toSnakeCase(field), ascending });
     return this;

--- a/convex/_helpers/supabaseRows.ts
+++ b/convex/_helpers/supabaseRows.ts
@@ -31,8 +31,8 @@ export type NoteRow = SupabaseRow<"notes">;
 export type EmailRow = SupabaseRow<"emails">;
 
 // Envelope returned by Supabase-backed list actions that imitate the Convex
-// pagination contract. The cursor is unused (Supabase-backed lists return
-// everything in one page), but kept for API-shape compatibility.
+// pagination contract. The cursor encodes the next page offset as a decimal
+// string; isDone=true and continueCursor="" signal the last page.
 export interface SupabasePaginationResult<TRow> {
   page: TRow[];
   isDone: boolean;

--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -33,46 +33,47 @@ export const list = action({
     const orgIdStr = String(args.organizationId);
     const userIdStr = String(authResult.userId);
 
-    if (args.search) {
-      const term = args.search.trim().toLowerCase();
-      let results = (await db
-        .query("gabinetPatients")
-        .eq("organizationId", orgIdStr)
-        .collect()) as GabinetPatientRow[];
-      results = results.filter((r) => {
-        const fn = String(r.firstName ?? "").toLowerCase();
-        const ln = String(r.lastName ?? "").toLowerCase();
-        const em = String(r.email ?? "").toLowerCase();
-        const ph = String(r.phone ?? "").toLowerCase();
-        return fn.includes(term) || ln.includes(term) || em.includes(term) || ph.includes(term);
-      }).slice(0, 50);
-      if (perm.scope === "own") {
-        const ownAppts = (await db
-          .query("gabinetAppointments")
-          .eq("organizationId", orgIdStr)
-          .eq("employeeId", userIdStr)
-          .collect()) as Array<{ patientId: unknown }>;
-        const ownPatientIds = new Set(ownAppts.map((a) => String(a.patientId)));
-        results = results.filter((r) => ownPatientIds.has(String(r._id)));
-      }
-      return { page: results, isDone: true, continueCursor: "" };
-    }
+    const pageSize = args.paginationOpts?.numItems ?? 50;
+    const cursorStr = args.paginationOpts?.cursor ?? null;
+    const offset = cursorStr && /^\d+$/.test(cursorStr) ? parseInt(cursorStr, 10) : 0;
 
-    let page = (await db
-      .query("gabinetPatients")
-      .eq("organizationId", orgIdStr)
-      .order("createdAt", false)
-      .collect()) as GabinetPatientRow[];
+    // For "own" scope, resolve the set of patient IDs the employee can see
+    // via their appointments before applying the paged query.
+    let ownPatientIds: string[] | null = null;
     if (perm.scope === "own") {
       const ownAppts = (await db
         .query("gabinetAppointments")
         .eq("organizationId", orgIdStr)
         .eq("employeeId", userIdStr)
         .collect()) as Array<{ patientId: unknown }>;
-      const ownPatientIds = new Set(ownAppts.map((a) => String(a.patientId)));
-      page = page.filter((r) => ownPatientIds.has(String(r._id)));
+      ownPatientIds = [...new Set(ownAppts.map((a) => String(a.patientId)))];
+      if (ownPatientIds.length === 0) {
+        return { page: [], isDone: true, continueCursor: "" };
+      }
     }
-    return { page, isDone: true, continueCursor: "" };
+
+    let query = db
+      .query("gabinetPatients")
+      .eq("organizationId", orgIdStr)
+      .order("createdAt", false);
+
+    if (ownPatientIds !== null) {
+      query = query.in("id", ownPatientIds);
+    }
+
+    if (args.search?.trim()) {
+      for (const token of args.search.trim().split(/\s+/).filter(Boolean)) {
+        const pattern = `%${token}%`;
+        query = query.or(
+          `first_name.ilike.${pattern},last_name.ilike.${pattern},email.ilike.${pattern},phone.ilike.${pattern}`,
+        );
+      }
+    }
+
+    query = query.range(offset, offset + pageSize - 1);
+    const page = (await query.collect()) as GabinetPatientRow[];
+    const isDone = page.length < pageSize;
+    return { page, isDone, continueCursor: isDone ? "" : String(offset + pageSize) };
   },
 });
 

--- a/src/hooks/use-supabase-gabinet-patients.ts
+++ b/src/hooks/use-supabase-gabinet-patients.ts
@@ -26,7 +26,7 @@ export function useSupabaseGabinetPatientsList(
   options: UseSupabaseGabinetPatientsListOptions = {},
 ) {
   const { client, isReady } = useSupabase();
-  const { enabled = true, limit = 100, search, sortOrder = "desc" } = options;
+  const { enabled = true, limit, search, sortOrder = "desc" } = options;
 
   return useQuery<MappedGabinetPatient[], Error>({
     queryKey: [
@@ -56,9 +56,11 @@ export function useSupabaseGabinetPatientsList(
         }
       }
 
-      const { data, error } = await query
-        .order("created_at", { ascending: sortOrder === "asc" })
-        .limit(limit);
+      let orderedQuery = query.order("created_at", { ascending: sortOrder === "asc" });
+      if (limit !== undefined) {
+        orderedQuery = orderedQuery.limit(limit);
+      }
+      const { data, error } = await orderedQuery;
 
       if (error) throw error;
       return (data ?? []).map(mapGabinetPatientFromSupabase);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2485.

Closes #2485

---

## Claude summary

The fix is committed. Here's a summary of what was done and why:

**Root cause confirmed:** The `list` action in `convex/gabinet/patients.ts` called `.collect()` to load the entire `gabinet_patients` table for the org, then sliced/filtered in Node memory. The Supabase read hook used by the frontend had a separate bug: a hard `limit: 100` default that silently truncated the patient list, so any org with >100 patients would see incomplete data in the table, search results, and duplicate detection.

**Changes (4 files):**

`convex/_helpers/supabaseDb.ts` — added `ilike()`, `or()`, and `in()` to `SupabaseQueryBuilder` so filtering can be pushed to Postgres instead of done in memory.

`convex/gabinet/patients.ts` — rewrote the `list` action to use server-side filtering: ILIKE via `.or()` per search token, `.in()` for the "own" scope patient-ID set, and `.range()` for offset pagination. The cursor now encodes the next page offset as a decimal string; `isDone` is set when the returned page is smaller than the requested page size.

`src/hooks/use-supabase-gabinet-patients.ts` — removed the `limit: 100` default. The patient list page needs all patients for duplicate detection and mini-charts, so an artificial cap was actively wrong. Callers that genuinely want a cap can still pass `limit` explicitly.

`convex/_helpers/supabaseRows.ts` — updated the stale comment that said "cursor is unused."

## Follow-ups

- Add server-side pagination to `listCustomReferralSources` in `convex/gabinet/patients.ts`: same load-all-then-filter pattern as the fixed `list` action — it calls `.collect()` on every patient in the org to find custom referral source strings.
- Add `ilike`/`or`/`in` usage audit across other Convex actions: several other gabinet actions (e.g., `searchUnlinkedContacts` on line 209) call `.collect()` on the full contacts table and filter in memory — each should use ILIKE server-side.