### PR TITLE
fix(gabinet): add duplicate email/phone guard on patient create

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -290,6 +290,40 @@ export const create = action({
 
     const now = Date.now();
     const db = createSupabaseDb();
+    const orgIdStr = String(args.organizationId);
+
+    // Duplicate guard: reject creation if an active patient in this org
+    // already has the same email or phone. Two queries to keep the in-memory
+    // test stub compatible (it has no OR filter support).
+    const [emailDupes, phoneDupes] = await Promise.all([
+      (db
+        .query("gabinetPatients")
+        .eq("organizationId", orgIdStr)
+        .eq("isActive", true)
+        .eq("email", args.email)
+        .collect()) as Promise<Array<{ _id: unknown }>>,
+      args.phone
+        ? (db
+            .query("gabinetPatients")
+            .eq("organizationId", orgIdStr)
+            .eq("isActive", true)
+            .eq("phone", args.phone)
+            .collect()) as Promise<Array<{ _id: unknown }>>
+        : Promise.resolve([] as Array<{ _id: unknown }>),
+    ]);
+
+    const duplicateIds = [
+      ...new Set([
+        ...emailDupes.map((p) => String(p._id)),
+        ...phoneDupes.map((p) => String(p._id)),
+      ]),
+    ];
+
+    if (duplicateIds.length > 0) {
+      throw new Error(
+        `Duplicate patient detected. Existing patient IDs: ${duplicateIds.join(",")}`,
+      );
+    }
 
     // --- INSERT patient directly to Supabase ---
     const patientId = await db.insert("gabinetPatients", {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, useNavigate, useSearch, Link } from "@tanstack/react-r
 import { useAction } from "convex/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { formatActionError } from "@/lib/format-action-error";
+import { formatActionError, extractActionErrorMessage } from "@/lib/format-action-error";
 import { api } from "@cvx/_generated/api";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseGabinetRecentVisitPatientIds } from "@/hooks/use-supabase-gabinet-appointments";
@@ -434,12 +434,21 @@ function PatientsIndex() {
         });
         setPanelOpen(false);
       } catch (e) {
-        toast.error(
-          formatActionError(e, t, {
-            key: "gabinet.patients.errors.createFailed",
-            defaultValue: "Nie udało się dodać klienta.",
-          }),
-        );
+        const inner = extractActionErrorMessage(e);
+        if (/duplicate patient detected/i.test(inner)) {
+          toast.warning(
+            t("gabinet.patients.errors.duplicatePatient", {
+              defaultValue: "Klient z tym e-mailem lub telefonem już istnieje. Sprawdź listę klientów i rozważ scalenie.",
+            }),
+          );
+        } else {
+          toast.error(
+            formatActionError(e, t, {
+              key: "gabinet.patients.errors.createFailed",
+              defaultValue: "Nie udało się dodać klienta.",
+            }),
+          );
+        }
       } finally {
         setIsCreating(false);
       }

--- a/tests/convex/patientsCreate.test.ts
+++ b/tests/convex/patientsCreate.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import {
+  createTestCtx,
+  seedTestUser,
+  seedGabinetPrereqs,
+} from "../../convex/_test_helpers";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+describe("gabinet/patients.create duplicate guard", () => {
+  test("rejects creation when another active patient has the same email", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    // Seeds a patient with email "jan@example.com"
+    await seedGabinetPrereqs(t, organizationId, userId);
+
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.patients.create, {
+        organizationId,
+        firstName: "Duplicate",
+        lastName: "Patient",
+        email: "jan@example.com",
+      }),
+    ).rejects.toThrow(/Duplicate patient detected/);
+  });
+
+  test("rejects creation when another active patient has the same phone", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedGabinetPrereqs(t, organizationId, userId);
+
+    // First create a patient with a phone number
+    await t.withIdentity(identity).action(api.gabinet.patients.create, {
+      organizationId,
+      firstName: "First",
+      lastName: "Patient",
+      email: "first@example.com",
+      phone: "600100200",
+    });
+
+    // Second creation with same phone should be rejected
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.patients.create, {
+        organizationId,
+        firstName: "Second",
+        lastName: "Patient",
+        email: "second@example.com",
+        phone: "600100200",
+      }),
+    ).rejects.toThrow(/Duplicate patient detected/);
+  });
+
+  test("allows creation when a patient with the same email exists but is inactive", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    // Soft-delete the seeded patient (email: "jan@example.com")
+    await t.withIdentity(identity).action(api.gabinet.patients.remove, {
+      organizationId,
+      patientId: String(patientId),
+    });
+
+    // Creating a new patient with the same email should now succeed
+    const newId = await t.withIdentity(identity).action(api.gabinet.patients.create, {
+      organizationId,
+      firstName: "New",
+      lastName: "Patient",
+      email: "jan@example.com",
+    });
+    expect(typeof newId).toBe("string");
+  });
+
+  test("allows creation when email and phone are unique", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedGabinetPrereqs(t, organizationId, userId);
+
+    const newId = await t.withIdentity(identity).action(api.gabinet.patients.create, {
+      organizationId,
+      firstName: "Unique",
+      lastName: "Patient",
+      email: "unique@example.com",
+      phone: "700200300",
+    });
+    expect(typeof newId).toBe("string");
+  });
+
+  test("allows creation when only phone is provided and no match exists", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedGabinetPrereqs(t, organizationId, userId);
+
+    const newId = await t.withIdentity(identity).action(api.gabinet.patients.create, {
+      organizationId,
+      firstName: "Phone",
+      lastName: "Only",
+      email: "phoneonly@example.com",
+      phone: "999888777",
+    });
+    expect(typeof newId).toBe("string");
+  });
+});


### PR DESCRIPTION
## Summary

- Added a backend duplicate check in `convex/gabinet/patients.create`: before inserting, two queries run against active patients in the same org — one for matching email, one for matching phone. If any match is found the action throws `Duplicate patient detected. Existing patient IDs: <ids>` and no row is written.
- Updated the `handleCreate` error handler in the patients index route to detect this specific error and show a Polish warning toast (`"Klient z tym e-mailem lub telefonem już istnieje..."`) instead of the generic failure toast.
- Added 5 unit tests covering: email duplicate rejection, phone duplicate rejection, soft-deleted patient not blocking re-creation, and two happy-path cases.

Closes #2487

## Test plan

- [x] `node_modules/.bin/vitest run tests/convex/patientsCreate.test.ts` — 5 tests pass
- [x] Existing patient suite (`patientsMerge`, `patientsUpdate`, `patientAuth`) — 28 tests still pass
- [x] TypeScript typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)