### PR TITLE
Add server-side pagination to `listCustomReferralSources` in `convex/gabinet/pat

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -107,11 +107,14 @@ export const listCustomReferralSources = action({
     if (!perm.allowed) return [];
 
     const db = createSupabaseDb();
+    const client = db.raw();
     const orgIdStr = String(args.organizationId);
-    let patients = (await db
-      .query("gabinetPatients")
-      .eq("organizationId", orgIdStr)
-      .collect()) as GabinetPatientRow[];
+
+    let sourceQuery = client
+      .from("gabinet_patients")
+      .select("referral_source")
+      .eq("organization_id", orgIdStr)
+      .not("referral_source", "is", null);
 
     if (perm.scope === "own") {
       const userIdStr = String(authResult.userId);
@@ -120,14 +123,18 @@ export const listCustomReferralSources = action({
         .eq("organizationId", orgIdStr)
         .eq("employeeId", userIdStr)
         .collect()) as Array<{ patientId: unknown }>;
-      const ownPatientIds = new Set(ownAppts.map((a) => String(a.patientId)));
-      patients = patients.filter((r) => ownPatientIds.has(String(r._id)));
+      const ownPatientIds = [...new Set(ownAppts.map((a) => String(a.patientId)))];
+      if (ownPatientIds.length === 0) return [];
+      sourceQuery = sourceQuery.in("id", ownPatientIds);
     }
+
+    const { data, error } = await sourceQuery;
+    if (error) throw new Error(`listCustomReferralSources: ${error.message}`);
 
     const seen = new Set<string>();
     const custom: string[] = [];
-    for (const p of patients) {
-      const raw = p.referralSource;
+    for (const row of data ?? []) {
+      const raw = (row as { referral_source: unknown }).referral_source;
       if (typeof raw !== "string") continue;
       const trimmed = raw.trim();
       if (!trimmed) continue;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2489.

Closes #2489

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Root cause confirmed.** `listCustomReferralSources` in `convex/gabinet/patients.ts:93` was calling `.collect()` on every `gabinetPatient` row in the org — fetching all columns for every patient — just to extract unique `referralSource` strings.

**Fix applied** (lines 109–148):
- Replaced the `db.query("gabinetPatients").collect()` call with a targeted `SELECT referral_source` query via the raw Supabase client, fetching only that one column.
- Added a `.not("referral_source", "is", null)` filter so NULL rows are excluded at the DB level before any data is transferred.
- For the `own` scope, the patient-ID set from appointments is now applied as an `.in("id", ownPatientIds)` DB filter rather than a JS `.filter()` over full patient rows loaded into memory.
- Added an early-return for `own` scope when no appointments exist, avoiding the query entirely.

All 159 Convex unit tests pass.

## Follow-ups

- Optimize `searchUnlinkedContacts` in `convex/gabinet/patients.ts`: same load-all-then-filter pattern at lines 211–226 — fetches all contacts and all linked patients via `.collect()`, then filters in JS; should use DB-level search and a NOT IN / LEFT JOIN approach instead.
- Optimize `getByContact` in `convex/gabinet/patients.ts`: the `own` scope path at lines 1120–1127 loads all appointments via `.collect()` then filters patients in JS; the `ownPatientIds` set should be applied as an `.in()` DB filter matching the pattern now used in `list` and `listCustomReferralSources`.