### PR TITLE
Add `ilike`/`or`/`in` usage audit across other Convex actions

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -43,34 +43,26 @@ export const list = action({
         .query("gabinetEmployees")
         .eq("organizationId", orgIdStr)
         .eq("role", args.role);
-      let all = (await q.collect()) as GabinetEmployeeRow[];
-      let filtered = args.activeOnly ? all.filter((e) => e.isActive) : all;
-      if (perm.scope === "own") {
-        filtered = filtered.filter((e) => String(e.userId) === userIdStr);
-      }
-      return filtered;
+      if (args.activeOnly) q = q.eq("isActive", true);
+      if (perm.scope === "own") q = q.eq("userId", userIdStr);
+      return (await q.collect()) as GabinetEmployeeRow[];
     }
 
     if (args.activeOnly) {
-      let results = (await db
+      let q = db
         .query("gabinetEmployees")
         .eq("organizationId", orgIdStr)
-        .eq("isActive", true)
-        .collect()) as GabinetEmployeeRow[];
-      if (perm.scope === "own") {
-        results = results.filter((e) => String(e.userId) === userIdStr);
-      }
-      return results;
+        .eq("isActive", true);
+      if (perm.scope === "own") q = q.eq("userId", userIdStr);
+      return (await q.collect()) as GabinetEmployeeRow[];
     }
 
-    let page = (await db
+    let q = db
       .query("gabinetEmployees")
       .eq("organizationId", orgIdStr)
-      .order("createdAt", false)
-      .collect()) as GabinetEmployeeRow[];
-    if (perm.scope === "own") {
-      page = page.filter((e) => String(e.userId) === userIdStr);
-    }
+      .order("createdAt", false);
+    if (perm.scope === "own") q = q.eq("userId", userIdStr);
+    const page = (await q.collect()) as GabinetEmployeeRow[];
     return { page, isDone: true, continueCursor: "" };
   },
 });
@@ -101,11 +93,10 @@ export const listAll = action({
     if (args.activeOnly) {
       q = q.eq("isActive", true);
     }
-    let results = (await q.collect()) as GabinetEmployeeRow[];
     if (perm.scope === "own") {
-      results = results.filter((e) => String(e.userId) === userIdStr);
+      q = q.eq("userId", userIdStr);
     }
-    return results;
+    return (await q.collect()) as GabinetEmployeeRow[];
   },
 });
 

--- a/convex/gabinet/leaveTypes.ts
+++ b/convex/gabinet/leaveTypes.ts
@@ -200,12 +200,12 @@ export const getBalances = action({
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
 
     const db = createSupabaseDb();
-    const all = await db
+    return await db
       .query("gabinetLeaveBalances")
       .eq("organizationId", String(args.organizationId))
       .eq("employeeId", args.employeeId)
+      .eq("year", args.year)
       .collect();
-    return all.filter((b) => (b as { year?: number }).year === args.year);
   },
 });
 
@@ -221,11 +221,11 @@ export const getAllBalances = action({
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
 
     const db = createSupabaseDb();
-    const all = await db
+    return await db
       .query("gabinetLeaveBalances")
       .eq("organizationId", String(args.organizationId))
+      .eq("year", args.year)
       .collect();
-    return all.filter((b) => (b as { year?: number }).year === args.year);
   },
 });
 

--- a/convex/gabinet/nudges.ts
+++ b/convex/gabinet/nudges.ts
@@ -30,11 +30,10 @@ export const getAppointmentNudges = action({
     let q = db
       .query("gabinetAppointments")
       .eq("organizationId", String(args.organizationId))
-      .eq("date", todayStr);
+      .eq("date", todayStr)
+      .eq("status", "scheduled");
     if (args.locationId) q = q.eq("locationId", args.locationId);
-    const unconfirmed = (await q.collect()) as Array<{ status: string }>;
-
-    const count = unconfirmed.filter((a) => a.status === "scheduled").length;
+    const count = (await q.collect()).length;
     if (count === 0) return [];
 
     return [

--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -210,26 +210,26 @@ export const searchUnlinkedContacts = action({
     if (!perm.allowed) return [];
 
     if (!args.search.trim()) return [];
-    const term = args.search.trim().toLowerCase();
+    const term = args.search.trim();
 
     const db = createSupabaseDb();
     const orgIdStr = String(args.organizationId);
 
-    const allContacts = (await db
+    const pattern = `%${term}%`;
+    const matched = (await db
       .query("contacts")
       .eq("organizationId", orgIdStr)
+      .or(`first_name.ilike.${pattern},last_name.ilike.${pattern},email.ilike.${pattern},phone.ilike.${pattern}`)
+      .take(20)
       .collect()) as Array<Record<string, any>>;
-    const matched = allContacts.filter((c) => {
-      const fn = String(c.firstName ?? "").toLowerCase();
-      const ln = String(c.lastName ?? "").toLowerCase();
-      const em = String(c.email ?? "").toLowerCase();
-      const ph = String(c.phone ?? "").toLowerCase();
-      return fn.includes(term) || ln.includes(term) || em.includes(term) || ph.includes(term);
-    }).slice(0, 20);
 
+    if (matched.length === 0) return [];
+
+    const matchedIds = matched.map((c) => String(c.id ?? c._id));
     const linkedPatients = (await db
       .query("gabinetPatients")
       .eq("organizationId", orgIdStr)
+      .in("contactId", matchedIds)
       .collect()) as Array<Record<string, any>>;
 
     const linkedContactIds = new Set(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2490.

Closes #2490

---

## Claude summary

The fixes are committed. Here's a summary of what was done:

**`convex/gabinet/patients.ts` — `searchUnlinkedContacts`**
The most important fix: instead of fetching all contacts for the org and filtering in JS, the search now uses `.or()` with `ilike` patterns server-side (same pattern already used in `listPatients`). The linked-patient check also improved: instead of fetching *all* gabinet patients for the org, it now queries only the patients whose `contactId` is in the matched set via `.in("contactId", matchedIds)`.

**`convex/gabinet/leaveTypes.ts` — `getBalances` and `getAllBalances`**
Both functions were fetching all leave balances and filtering by `year` in JS. Fixed by adding `.eq("year", args.year)` directly to the DB query.

**`convex/gabinet/employees.ts` — `list` and `listAll`**
Three code paths in `list` were filtering `activeOnly` and `scope === "own"` in JS after a full collect. Replaced with `.eq("isActive", true)` and `.eq("userId", userIdStr)` pushed to the DB query. Same for `listAll`.

**`convex/gabinet/nudges.ts` — `getAppointmentNudges`**
Was fetching all today's appointments then filtering by `status === "scheduled"` in JS. Moved to `.eq("status", "scheduled")` server-side.

## Follow-ups

- Push `qualifiedTreatmentIds` array containment filter to DB in `employees.ts` `listByTreatment`: currently fetches all active employees and filters with `Array.includes()` in JS; Postgres supports `@> ARRAY[id]` containment but `SupabaseQueryBuilder` has no `.contains()` method yet — needs a new builder method and PostgREST syntax
- Add `.eq()` date-range push-down in `_availability_supabase.ts` `resolveScheduleForDate`: fetches all schedule rows for an employee+dayOfWeek then filters `effectiveFrom`/`effectiveTo` in JS; could use `.gte("effectiveTo", date)` / `.lte("effectiveFrom", date)` but null handling makes this non-trivial