### PR TITLE
fix(gabinet): anonymize activity/note descriptions on GDPR patient erase

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -1054,6 +1054,22 @@ export const gdprErase = action({
       .eq("organization_id", String(args.organizationId))
       .eq("patient_id", args.patientId);
 
+    // Anonymize PII in Supabase activity descriptions and note contents
+    const orgStr = String(args.organizationId);
+    const GDPR_REDACTED = "[RODO: dane usunięte]";
+    await client
+      .from("activities")
+      .update({ description: GDPR_REDACTED })
+      .eq("organization_id", orgStr)
+      .eq("entity_type", "gabinetPatient")
+      .eq("entity_id", args.patientId);
+    await client
+      .from("notes")
+      .update({ content: GDPR_REDACTED, updated_at: Date.now() })
+      .eq("organization_id", orgStr)
+      .eq("entity_type", "gabinetPatient")
+      .eq("entity_id", args.patientId);
+
     try {
       await ctx.runMutation(internal.gabinet.patients._gdprEraseSideEffects, {
         patientId: args.patientId,
@@ -1078,16 +1094,31 @@ export const _gdprEraseSideEffects = internalMutation({
   },
   handler: async (ctx, args) => {
     const erasedByUserId = args.erasedBy as Id<"users">;
+    const GDPR_REDACTED = "[RODO: dane usunięte]";
 
-    await logActivity(ctx, {
-      organizationId: args.organizationId,
-      entityType: "gabinetPatient",
-      entityId: args.patientId as Id<"gabinetPatients">,
-      action: "deleted",
-      description: `RODO: usunięto dane klienta "${args.originalName}"`,
-      performedBy: erasedByUserId,
-    });
+    // Anonymize all existing Convex activity descriptions for this patient
+    const existingActivities = await ctx.db
+      .query("activities")
+      .withIndex("by_entity", (q) =>
+        q.eq("entityType", "gabinetPatient").eq("entityId", args.patientId)
+      )
+      .collect();
+    for (const activity of existingActivities) {
+      await ctx.db.patch(activity._id, { description: GDPR_REDACTED });
+    }
 
+    // Anonymize all existing Convex note contents for this patient
+    const existingNotes = await ctx.db
+      .query("notes")
+      .withIndex("by_entity", (q) =>
+        q.eq("entityType", "gabinetPatient").eq("entityId", args.patientId)
+      )
+      .collect();
+    for (const note of existingNotes) {
+      await ctx.db.patch(note._id, { content: GDPR_REDACTED, updatedAt: Date.now() });
+    }
+
+    // Audit log retains original name as compliance record
     await logAudit(ctx, {
       organizationId: args.organizationId,
       userId: erasedByUserId,
@@ -1095,6 +1126,16 @@ export const _gdprEraseSideEffects = internalMutation({
       entityType: "gabinetPatient",
       entityId: args.patientId,
       details: `GDPR erasure performed on patient "${args.originalName}" (ID: ${args.patientId})`,
+    });
+
+    // Activity entry without PII marks the erasure in the patient timeline
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetPatient",
+      entityId: args.patientId as Id<"gabinetPatients">,
+      action: "deleted",
+      description: "RODO: dane klienta zostały usunięte",
+      performedBy: erasedByUserId,
     });
   },
 });

--- a/tests/convex/gdprErase.test.ts
+++ b/tests/convex/gdprErase.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import {
+  createTestCtx,
+  seedTestUser,
+  seedGabinetPrereqs,
+} from "../../convex/_test_helpers";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+describe("gabinet/patients.gdprErase — activity and note anonymization", () => {
+  test("anonymizes descriptions of existing activities referencing the erased patient", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
+    const patientIdStr = String(patientId);
+
+    // Seed two activity entries referencing this patient in Convex
+    await t.run(async (ctx) => {
+      const now = Date.now();
+      await ctx.db.insert("activities", {
+        organizationId,
+        entityType: "gabinetPatient",
+        entityId: patientIdStr,
+        action: "created",
+        description: "Utworzono pacjenta Jan Kowalski",
+        performedBy: userId,
+        createdAt: now,
+      });
+      await ctx.db.insert("activities", {
+        organizationId,
+        entityType: "gabinetPatient",
+        entityId: patientIdStr,
+        action: "updated",
+        description: "Zaktualizowano dane Jana Kowalskiego",
+        performedBy: userId,
+        createdAt: now + 1,
+      });
+    });
+
+    await t.withIdentity(identity).action(api.gabinet.patients.gdprErase, {
+      organizationId,
+      patientId: patientIdStr,
+    });
+
+    const activities = await t.run(async (ctx) =>
+      ctx.db
+        .query("activities")
+        .withIndex("by_entity", (q) =>
+          q.eq("entityType", "gabinetPatient").eq("entityId", patientIdStr)
+        )
+        .collect()
+    );
+
+    for (const activity of activities) {
+      expect(activity.description).not.toContain("Kowalski");
+      expect(activity.description).not.toContain("Jan");
+    }
+    // At least the two seeded entries plus the erasure entry should exist
+    expect(activities.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("anonymizes content of existing notes referencing the erased patient", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
+    const patientIdStr = String(patientId);
+
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("notes", {
+        organizationId,
+        entityType: "gabinetPatient",
+        entityId: patientIdStr,
+        content: "Pacjent Jan Kowalski skarżył się na ból głowy.",
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    await t.withIdentity(identity).action(api.gabinet.patients.gdprErase, {
+      organizationId,
+      patientId: patientIdStr,
+    });
+
+    const notes = await t.run(async (ctx) =>
+      ctx.db
+        .query("notes")
+        .withIndex("by_entity", (q) =>
+          q.eq("entityType", "gabinetPatient").eq("entityId", patientIdStr)
+        )
+        .collect()
+    );
+
+    expect(notes).toHaveLength(1);
+    expect(notes[0].content).not.toContain("Kowalski");
+    expect(notes[0].content).not.toContain("Jan");
+    expect(notes[0].content).toBe("[RODO: dane usunięte]");
+  });
+
+  test("new erasure activity entry does not contain original patient name", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
+    const patientIdStr = String(patientId);
+
+    await t.withIdentity(identity).action(api.gabinet.patients.gdprErase, {
+      organizationId,
+      patientId: patientIdStr,
+    });
+
+    const activities = await t.run(async (ctx) =>
+      ctx.db
+        .query("activities")
+        .withIndex("by_entity", (q) =>
+          q.eq("entityType", "gabinetPatient").eq("entityId", patientIdStr)
+        )
+        .collect()
+    );
+
+    // Every activity entry — including the new deletion event — must be PII-free
+    for (const activity of activities) {
+      expect(activity.description).not.toContain("Kowalski");
+      expect(activity.description).not.toContain("Jan");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- During `gdprErase`, all `activities` rows with `entityType = 'gabinetPatient'` and `entityId = patientId` now have their `description` replaced with `"[RODO: dane usunięte]"` — both in Convex (via `ctx.db.patch`) and in Supabase (via the raw service-role client UPDATE).
- All `notes` rows for the same patient have their `content` similarly anonymized.
- The new erasure activity entry no longer embeds the original patient name in its description (it now uses a fixed PII-free string; the audit log record still retains the name for compliance).

## Test plan

- [x] 3 new unit tests in `tests/convex/gdprErase.test.ts` covering: activity descriptions anonymized, note content anonymized, new erasure entry is PII-free.
- [x] All 167 existing unit tests still pass.
- [x] TypeScript type check clean.

Closes #2492

🤖 Generated with [Claude Code](https://claude.com/claude-code)