### PR TITLE
GDPR erasure for appointment interview notes

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -1069,6 +1069,19 @@ export const gdprErase = action({
       .eq("organization_id", orgStr)
       .eq("entity_type", "gabinetPatient")
       .eq("entity_id", args.patientId);
+    // Null out free-text clinical fields on appointments linked to this patient
+    await client
+      .from("gabinet_appointments")
+      .update({
+        interview_notes: null,
+        notes: null,
+        internal_notes: null,
+        clinical_remarks: null,
+        body_chart_data: null,
+        treatment_parameter_values: null,
+      })
+      .eq("organization_id", orgStr)
+      .eq("patient_id", args.patientId);
 
     try {
       await ctx.runMutation(internal.gabinet.patients._gdprEraseSideEffects, {
@@ -1116,6 +1129,24 @@ export const _gdprEraseSideEffects = internalMutation({
       .collect();
     for (const note of existingNotes) {
       await ctx.db.patch(note._id, { content: GDPR_REDACTED, updatedAt: Date.now() });
+    }
+
+    // Null out free-text clinical fields on all appointments linked to this patient
+    const existingAppointments = await ctx.db
+      .query("gabinetAppointments")
+      .withIndex("by_orgAndPatient", (q) =>
+        q.eq("organizationId", args.organizationId).eq("patientId", args.patientId as Id<"gabinetPatients">)
+      )
+      .collect();
+    for (const appointment of existingAppointments) {
+      await ctx.db.patch(appointment._id, {
+        interviewNotes: undefined,
+        notes: undefined,
+        internalNotes: undefined,
+        clinicalRemarks: undefined,
+        bodyChartData: undefined,
+        treatmentParameterValues: undefined,
+      });
     }
 
     // Audit log retains original name as compliance record

--- a/tests/convex/gdprErase.test.ts
+++ b/tests/convex/gdprErase.test.ts
@@ -101,6 +101,59 @@ describe("gabinet/patients.gdprErase — activity and note anonymization", () =>
     expect(notes[0].content).toBe("[RODO: dane usunięte]");
   });
 
+  test("nulls out clinical text fields on appointments for the erased patient", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(t, organizationId, userId);
+    const patientIdStr = String(patientId);
+
+    await t.run(async (ctx) => {
+      const now = Date.now();
+      await ctx.db.insert("gabinetAppointments", {
+        organizationId,
+        patientId,
+        treatmentId,
+        employeeId: userId,
+        date: "2026-01-15",
+        startTime: "09:00",
+        endTime: "10:00",
+        status: "completed",
+        notes: "Jan Kowalski wymaga specjalnej opieki.",
+        internalNotes: "Historia choroby Jana Kowalskiego.",
+        interviewNotes: "Pacjent Jan Kowalski skarżył się na ból pleców.",
+        clinicalRemarks: "Kowalski ma alergię na lateks.",
+        bodyChartData: JSON.stringify({ marks: ["lower_back"] }),
+        treatmentParameterValues: JSON.stringify([{ name: "Waga", value: "85kg" }]),
+        isRecurring: false,
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    await t.withIdentity(identity).action(api.gabinet.patients.gdprErase, {
+      organizationId,
+      patientId: patientIdStr,
+    });
+
+    const appointments = await t.run(async (ctx) =>
+      ctx.db
+        .query("gabinetAppointments")
+        .withIndex("by_orgAndPatient", (q) =>
+          q.eq("organizationId", organizationId).eq("patientId", patientId)
+        )
+        .collect()
+    );
+
+    expect(appointments).toHaveLength(1);
+    expect(appointments[0].interviewNotes).toBeUndefined();
+    expect(appointments[0].notes).toBeUndefined();
+    expect(appointments[0].internalNotes).toBeUndefined();
+    expect(appointments[0].clinicalRemarks).toBeUndefined();
+    expect(appointments[0].bodyChartData).toBeUndefined();
+    expect(appointments[0].treatmentParameterValues).toBeUndefined();
+  });
+
   test("new erasure activity entry does not contain original patient name", async () => {
     const t = createTestCtx();
     const { organizationId, userId, identity } = await seedTestUser(t);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2493.

Closes #2493

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Root cause confirmed:** `gdprErase` in `convex/gabinet/patients.ts` anonymized the patient row, portal sessions, activities, and notes — but never touched the free-text clinical fields on linked `gabinetAppointments` rows (`interviewNotes`, `notes`, `internalNotes`, `clinicalRemarks`, `bodyChartData`, `treatmentParameterValues`), all of which can hold patient PII.

**Fix applied in two paths:**

1. `gdprErase` action (Supabase primary path) — added a `.update(...)` call against `gabinet_appointments` filtering by `organization_id` + `patient_id`, setting all six text columns to `null`.

2. `_gdprEraseSideEffects` internalMutation (Convex in-memory path used by tests) — queries `gabinetAppointments` via the `by_orgAndPatient` index and patches each record to `undefined` for the same six fields.

**Test added:** `tests/convex/gdprErase.test.ts` — seeds an appointment with PII in all six clinical fields, runs `gdprErase`, then asserts every field is `undefined` on the resulting record. All 4 tests pass.