### PR TITLE
Case-insensitive email dedup in patient create

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -302,12 +302,14 @@ export const create = action({
     // Duplicate guard: reject creation if an active patient in this org
     // already has the same email or phone. Two queries to keep the in-memory
     // test stub compatible (it has no OR filter support).
+    // Email comparison is case-insensitive so jan@example.com and JAN@EXAMPLE.COM
+    // are treated as the same address.
     const [emailDupes, phoneDupes] = await Promise.all([
       (db
         .query("gabinetPatients")
         .eq("organizationId", orgIdStr)
         .eq("isActive", true)
-        .eq("email", args.email)
+        .ilike("email", args.email)
         .collect()) as Promise<Array<{ _id: unknown }>>,
       args.phone
         ? (db

--- a/tests/convex/_supabase_inmemory.ts
+++ b/tests/convex/_supabase_inmemory.ts
@@ -228,6 +228,17 @@ class InMemoryQueryBuilder<T = Record<string, unknown>> {
     return this;
   }
 
+  ilike(field: string, pattern: string) {
+    // Convert SQL LIKE pattern to a JS case-insensitive regex
+    const regexStr = pattern
+      .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+      .replace(/%/g, ".*")
+      .replace(/_/g, ".");
+    const re = new RegExp(`^${regexStr}$`, "i");
+    this.filters.push((r) => typeof r[field] === "string" && re.test(r[field] as string));
+    return this;
+  }
+
   gt(field: string, value: unknown) {
     this.filters.push((r) => (r[field] as any) > (value as any));
     return this;

--- a/tests/convex/patientsCreate.test.ts
+++ b/tests/convex/patientsCreate.test.ts
@@ -89,6 +89,22 @@ describe("gabinet/patients.create duplicate guard", () => {
     expect(typeof newId).toBe("string");
   });
 
+  test("rejects creation when another active patient has the same email in different case", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    // Seeds a patient with email "jan@example.com"
+    await seedGabinetPrereqs(t, organizationId, userId);
+
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.patients.create, {
+        organizationId,
+        firstName: "Duplicate",
+        lastName: "Patient",
+        email: "JAN@EXAMPLE.COM",
+      }),
+    ).rejects.toThrow(/Duplicate patient detected/);
+  });
+
   test("allows creation when only phone is provided and no match exists", async () => {
     const t = createTestCtx();
     const { organizationId, userId, identity } = await seedTestUser(t);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2495.

Closes #2495

---

## Claude summary

Done. Three files changed:

- `convex/gabinet/patients.ts` — swapped `.eq("email", args.email)` for `.ilike("email", args.email)` in the duplicate guard, so `jan@example.com` and `JAN@EXAMPLE.COM` collide correctly
- `tests/convex/_supabase_inmemory.ts` — added `.ilike()` to `InMemoryQueryBuilder`, converting the SQL LIKE pattern to a JS case-insensitive regex so tests exercise the same logic
- `tests/convex/patientsCreate.test.ts` — added a test case that attempts to create a patient with the same email in a different case and expects the duplicate error

All 6 tests in `patientsCreate.test.ts` pass.