### PR TITLE
Phone normalization in patient create guard

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -250,6 +250,12 @@ export const searchUnlinkedContacts = action({
   },
 });
 
+function normalizePhone(phone: string | null | undefined): string | null {
+  if (!phone) return null;
+  const digits = phone.replace(/\D/g, "");
+  return digits || null;
+}
+
 export const create = action({
   args: {
     organizationId: v.id("organizations"),
@@ -298,6 +304,9 @@ export const create = action({
     const now = Date.now();
     const db = createSupabaseDb();
     const orgIdStr = String(args.organizationId);
+    // Normalize phone to digits-only so "600-100-200" and "600100200" are
+    // treated as the same number in both the duplicate guard and stored value.
+    const normalizedPhone = normalizePhone(args.phone);
 
     // Duplicate guard: reject creation if an active patient in this org
     // already has the same email or phone. Two queries to keep the in-memory
@@ -311,12 +320,12 @@ export const create = action({
         .eq("isActive", true)
         .ilike("email", args.email)
         .collect()) as Promise<Array<{ _id: unknown }>>,
-      args.phone
+      normalizedPhone
         ? (db
             .query("gabinetPatients")
             .eq("organizationId", orgIdStr)
             .eq("isActive", true)
-            .eq("phone", args.phone)
+            .eq("phone", normalizedPhone)
             .collect()) as Promise<Array<{ _id: unknown }>>
         : Promise.resolve([] as Array<{ _id: unknown }>),
     ]);
@@ -344,7 +353,7 @@ export const create = action({
       dateOfBirth: args.dateOfBirth ?? null,
       gender: args.gender ?? null,
       email: args.email,
-      phone: args.phone ?? null,
+      phone: normalizedPhone,
       address: args.address ?? null,
       medicalNotes: args.medicalNotes ?? null,
       allergies: args.allergies ?? null,
@@ -373,7 +382,7 @@ export const create = action({
         firstName: args.firstName,
         lastName: args.lastName,
         email: args.email,
-        phone: args.phone ?? undefined,
+        phone: normalizedPhone ?? undefined,
         referralSource: args.referralSource ?? undefined,
         createdBy: String(authResult.userId),
         createdAt: now,

--- a/tests/convex/patientsCreate.test.ts
+++ b/tests/convex/patientsCreate.test.ts
@@ -119,4 +119,50 @@ describe("gabinet/patients.create duplicate guard", () => {
     });
     expect(typeof newId).toBe("string");
   });
+
+  test("rejects creation when phone matches existing patient after non-digit normalization", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedGabinetPrereqs(t, organizationId, userId);
+
+    // Create first patient with formatted phone
+    await t.withIdentity(identity).action(api.gabinet.patients.create, {
+      organizationId,
+      firstName: "First",
+      lastName: "Patient",
+      email: "first-normed@example.com",
+      phone: "600-100-200",
+    });
+
+    // Second patient with digits-only equivalent should be rejected
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.patients.create, {
+        organizationId,
+        firstName: "Second",
+        lastName: "Patient",
+        email: "second-normed@example.com",
+        phone: "600100200",
+      }),
+    ).rejects.toThrow(/Duplicate patient detected/);
+  });
+
+  test("normalizes phone to digits-only when storing a new patient", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedGabinetPrereqs(t, organizationId, userId);
+
+    const patientId = await t.withIdentity(identity).action(api.gabinet.patients.create, {
+      organizationId,
+      firstName: "Normed",
+      lastName: "Patient",
+      email: "normed-phone@example.com",
+      phone: "700 200 300",
+    });
+
+    const patient = await t.withIdentity(identity).action(api.gabinet.patients.getById, {
+      organizationId,
+      patientId: String(patientId),
+    });
+    expect(patient.phone).toBe("700200300");
+  });
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2496.

Closes #2496

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Root cause confirmed:** In `convex/gabinet/patients.ts:319`, the phone duplicate check used `.eq("phone", args.phone)` — an exact string match. The frontend's `normalizePhoneKey` strips non-digits before comparing, so `600-100-200` stored in the DB and `600100200` submitted as a new patient would not be caught as duplicates by the backend.

**Fix applied:**
- Added a `normalizePhone` helper at `convex/gabinet/patients.ts:253` that strips all non-digit characters from a phone string
- Applied it to the incoming phone before the duplicate check (so the `.eq()` query uses the normalized form)
- Applied it when storing the patient (so all new phones are digits-only in the DB, making future comparisons reliable)
- Added 2 new tests: one verifying a formatted phone (`600-100-200`) is caught as a duplicate of its digits-only equivalent, and one verifying the stored value is digits-only

All 8 tests in `patientsCreate.test.ts` pass.

## Follow-ups

- Normalize phone on patient update path: `patients.update` patches the phone field as-is (`args.phone`) without normalization — the same `normalizePhone` helper should be applied there so edited phones are also stored in a consistent digits-only format
- Backfill existing phones to digits-only format: patients created before this fix may have formatted phones (e.g. "600-100-200") in the DB that will not be caught by the now-normalized duplicate check against newly submitted digits-only phones