### PR TITLE
Optimize `getByContact` in `convex/gabinet/patients.ts`

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -1201,21 +1201,28 @@ export const getByContact = action({
     if (!perm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
-    let results = (await db
-      .query("gabinetPatients")
-      .eq("organizationId", String(args.organizationId))
-      .eq("contactId", String(args.contactId))
-      .collect()) as GabinetPatientRow[];
+    const orgIdStr = String(args.organizationId);
 
+    let ownPatientIds: string[] | null = null;
     if (perm.scope === "own") {
       const ownAppts = (await db
         .query("gabinetAppointments")
-        .eq("organizationId", String(args.organizationId))
+        .eq("organizationId", orgIdStr)
         .eq("employeeId", String(authResult.userId))
         .collect()) as Array<{ patientId: unknown }>;
-      const ownPatientIds = new Set(ownAppts.map((a) => String(a.patientId)));
-      results = results.filter((r) => ownPatientIds.has(String(r._id)));
+      ownPatientIds = [...new Set(ownAppts.map((a) => String(a.patientId)))];
+      if (ownPatientIds.length === 0) return [];
     }
-    return results;
+
+    let query = db
+      .query("gabinetPatients")
+      .eq("organizationId", orgIdStr)
+      .eq("contactId", String(args.contactId));
+
+    if (ownPatientIds !== null) {
+      query = query.in("id", ownPatientIds);
+    }
+
+    return (await query.collect()) as GabinetPatientRow[];
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2499.

Closes #2499

---

## Claude summary

The fix is committed. The issue was real: `getByContact` in the `own` scope path was doing two queries to Supabase and then filtering in JS rather than in the database.

The change (`convex/gabinet/patients.ts:1203-1226`) now follows the exact same pattern as `list` and `listCustomReferralSources`:
1. Resolve `ownPatientIds` from appointments before querying patients
2. Return early with `[]` when the employee has no appointments (avoids a needless patient query)
3. Push the ID list into the patients query as `.in("id", ownPatientIds)` so Postgres does the filtering