### PR TITLE
Push `qualifiedTreatmentIds` array containment filter to DB in `employees.ts` `l

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -809,15 +809,12 @@ export const getQualifiedForTreatment = action({
     if (!perm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
-    const employees = (await db
+    return (await db
       .query("gabinetEmployees")
       .eq("organizationId", String(args.organizationId))
       .eq("isActive", true)
+      .contains("qualifiedTreatmentIds", [args.treatmentId])
       .collect()) as GabinetEmployeeRow[];
-
-    return employees.filter((e) =>
-      (e.qualifiedTreatmentIds ?? []).includes(args.treatmentId as Id<"gabinetTreatments">)
-    );
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2501.

Closes #2501

---

## Claude summary

Committed. Here's a summary of the changes:

**Problem confirmed:** `getQualifiedForTreatment` in `convex/gabinet/employees.ts` fetched all active employees for the org and filtered them in JS with `Array.includes()`, which is O(n) in application memory rather than a DB-level predicate.

**Fix — 3 files changed:**

- `convex/_helpers/supabaseDb.ts` — added `contains(field, values)` to `SupabaseQueryBuilder`. It pushes a lambda that calls supabase-js's native `.contains()` method (PostgREST `cs` operator → Postgres `@>` array containment) with the snake_case column name.

- `tests/convex/_supabase_inmemory.ts` — added the same `contains()` method to `InMemoryQueryBuilder`. It checks that all elements in `values` appear in the row's array field, matching Postgres `@>` semantics.

- `convex/gabinet/employees.ts` — replaced the fetch-all + JS filter with `.contains("qualifiedTreatmentIds", [args.treatmentId])` chained on the query builder, so only matching rows are returned from the database.