### PR TITLE
Add `.eq()` date-range push-down in `_availability_supabase.ts` `resolveSchedule

### DIFF
--- a/convex/gabinet/_availability_supabase.ts
+++ b/convex/gabinet/_availability_supabase.ts
@@ -50,18 +50,14 @@ async function resolveScheduleForDate(
   dayOfWeek: number,
   date: string,
 ): Promise<Record<string, any> | null> {
-  const candidates = await db
+  const matching = await db
     .query("gabinetEmployeeSchedules")
     .eq("organizationId", organizationId)
     .eq("userId", userId)
     .eq("dayOfWeek", dayOfWeek)
+    .or(`effective_from.is.null,effective_from.lte.${date}`)
+    .or(`effective_to.is.null,effective_to.gte.${date}`)
     .collect();
-
-  const matching = candidates.filter((c: any) => {
-    if (c.effectiveFrom && date < c.effectiveFrom) return false;
-    if (c.effectiveTo && date > c.effectiveTo) return false;
-    return true;
-  });
 
   matching.sort((a: any, b: any) => {
     if (a.effectiveFrom && b.effectiveFrom) return b.effectiveFrom.localeCompare(a.effectiveFrom);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2502.

Closes #2502

---

## Claude summary

The fix is committed. Here's what changed and why it works:

`resolveScheduleForDate` previously fetched every `gabinetEmployeeSchedules` row for the given employee+dayOfWeek combination, then filtered `effectiveFrom`/`effectiveTo` in JavaScript. The tricky part was null handling: a null `effectiveFrom` means "valid from the beginning of time" and a null `effectiveTo` means "valid indefinitely."

The `SupabaseQueryBuilder` already exposes an `.or()` method that passes a PostgREST filter string directly to the database. Two chained `.or()` calls (which are AND-combined by PostgREST) express the same null-tolerant logic:

- `.or("effective_from.is.null,effective_from.lte.DATE")` → keep rows where `effectiveFrom IS NULL OR effectiveFrom <= date`
- `.or("effective_to.is.null,effective_to.gte.DATE")` → keep rows where `effectiveTo IS NULL OR effectiveTo >= date`

This is semantically identical to the removed JS filter but executes entirely in Postgres, reducing the number of rows fetched over the network on every appointment availability check.

## Follow-ups

- Push `gabinetLeaves` date-range filter to DB in `getAvailableSlotsSupabase` and `checkConflictSupabase`: both functions call `.collect()` on all leaves for an employee then filter `startDate`/`endDate` in JS (lines 188-199 and 356-376) — same pattern as this fix, can use `.or("start_date.lte.DATE").or("end_date.gte.DATE")` with an `eq("status","approved")` push-down.
- Push `scheduledActivities` date filter to DB in availability helpers: lines 238-255 and 396-418 fetch all resource activities then filter by matching date string in JS — could push down using a `.gte`/`.lte` on the `due_date` column to avoid pulling the entire calendar into application memory.