### PR TITLE
Normalize phone on patient update path

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -536,6 +536,9 @@ export const update = action({
 
     // --- Build updates and PATCH to Supabase ---
     const { organizationId, patientId, ...updates } = args;
+    if ("phone" in updates) {
+      updates.phone = normalizePhone(updates.phone);
+    }
     await db.patch("gabinetPatients", patientId, { ...updates, updatedAt: Date.now() });
 
     // --- Delegate post-write side effects ---


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2507.

Closes #2507

---

## Claude summary

The fix is committed. The bug was real: in `convex/gabinet/patients.ts`, the `update` action at line 538 spread `args` directly into the Supabase patch without normalizing `phone`, while the `create` action correctly called `normalizePhone(args.phone)` at line 309. The fix adds a 3-line guard before the patch: if `phone` is included in the update payload, it's passed through `normalizePhone` so formatted numbers like `"600-100-200"` are stored as `"600100200"`, matching the create-path behavior.