### PR TITLE
Backfill existing phones to digits-only format

### DIFF
--- a/supabase/migrations/00038_backfill_gabinet_patients_phone_digits_only.sql
+++ b/supabase/migrations/00038_backfill_gabinet_patients_phone_digits_only.sql
@@ -1,0 +1,21 @@
+-- Migration 00038: Backfill gabinet_patients.phone to digits-only format (#2508)
+--
+-- Patients created before #2496 may have formatted phone numbers (e.g.
+-- "600-100-200") stored in the phone column.  The duplicate-check guard
+-- introduced in #2496 normalises the incoming phone to digits before the
+-- equality comparison, so a formatted legacy value will never match and the
+-- dedup guard is silently bypassed for those existing rows.
+--
+-- This migration brings all existing rows in line with the new contract:
+--   • strip every non-digit character from phone (mirrors normalizePhone() in
+--     convex/gabinet/patients.ts)
+--   • set phone to NULL when stripping leaves an empty string
+--   • only touches rows that actually contain non-digit characters so that
+--     already-normalised rows are left completely unchanged
+
+UPDATE gabinet_patients
+SET
+  phone      = NULLIF(regexp_replace(phone, '[^0-9]', '', 'g'), ''),
+  updated_at = (extract(epoch from now()) * 1000)::bigint
+WHERE phone IS NOT NULL
+  AND phone ~ '[^0-9]';


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2508.

Closes #2508

---

## Claude summary

The fix is committed. Here's a summary of what was done and why.

---

**Triage:** The report is valid. `normalizePhone()` was added in #2496 to strip non-digit characters from phones before storing them and before the dedup equality check (`.eq("phone", normalizedPhone)`). Any patient created before that change and stored with a formatted phone like "600-100-200" would never match the dedup query for an incoming "600100200" submission — the old row is effectively invisible to the guard.

**Fix:** A single Supabase SQL migration (`00038_backfill_gabinet_patients_phone_digits_only.sql`) that runs:

```sql
UPDATE gabinet_patients
SET
  phone      = NULLIF(regexp_replace(phone, '[^0-9]', '', 'g'), ''),
  updated_at = (extract(epoch from now()) * 1000)::bigint
WHERE phone IS NOT NULL
  AND phone ~ '[^0-9]';
```

This mirrors exactly what `normalizePhone()` does in TypeScript — strip non-digits, and treat an all-non-digit string as `NULL`. The `WHERE` clause limits the update to only rows that actually need changing (rows already digits-only or NULL are untouched). After this migration runs, the existing dedup check will correctly detect formatted legacy phones as duplicates of new digits-only submissions.