### PR TITLE
Add index on `gabinet_patients(organization_id, sms_consent)` for consent-based 

### DIFF
--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -66,6 +66,7 @@ export function createGabinetTables({
     referralSource: v.optional(v.string()),
     referredByPatientId: v.optional(v.id("gabinetPatients")),
     isActive: v.boolean(),
+    smsConsent: v.optional(v.boolean()),
     tags: v.optional(v.array(v.string())),
     tagIds: v.optional(v.array(v.id("tagDefinitions"))),
     categoryId: v.optional(v.id("categoryDefinitions")),
@@ -77,7 +78,8 @@ export function createGabinetTables({
     .index("by_org", ["organizationId"])
     .index("by_orgAndEmail", ["organizationId", "email"])
     .index("by_orgAndPesel", ["organizationId", "pesel"])
-    .index("by_orgAndContact", ["organizationId", "contactId"]),
+    .index("by_orgAndContact", ["organizationId", "contactId"])
+    .index("by_orgAndSmsConsent", ["organizationId", "smsConsent"]),
 
   gabinetTreatments: defineTable({
     organizationId: v.id("organizations"),

--- a/supabase/migrations/00039_gabinet_patients_sms_consent.sql
+++ b/supabase/migrations/00039_gabinet_patients_sms_consent.sql
@@ -1,0 +1,17 @@
+-- Migration 00039: Add sms_consent column and partial index to gabinet_patients (#2512)
+--
+-- Adds an opt-in SMS marketing-consent flag to patients.  When the org wants to
+-- send bulk SMS messages it needs to filter to patients who have explicitly
+-- consented; a partial index covering only consenting rows (sms_consent = true)
+-- keeps that query efficient even at large patient counts.
+--
+-- The column is nullable rather than NOT NULL DEFAULT false so that existing rows
+-- remain distinguishable from patients who actively declined consent (NULL =
+-- consent never asked; false = asked and declined; true = consented).
+
+ALTER TABLE gabinet_patients
+  ADD COLUMN sms_consent BOOLEAN;
+
+CREATE INDEX gabinet_patients_org_sms_consent_idx
+  ON gabinet_patients (organization_id)
+  WHERE sms_consent = true;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2512.

Closes #2512

---

## Claude summary

Done. Here's what was done:

**`convex/schema/gabinet.ts`** — added `smsConsent: v.optional(v.boolean())` to `gabinetPatients` and a corresponding `by_orgAndSmsConsent` Convex index.

**`supabase/migrations/00039_gabinet_patients_sms_consent.sql`** — adds the `sms_consent BOOLEAN` column (nullable, so NULL = never asked / false = declined / true = consented) and a partial index `ON gabinet_patients (organization_id) WHERE sms_consent = true`. The partial index is intentionally narrow — it only covers consenting rows, which is the only predicate a bulk-SMS query will ever filter on, keeping the index small.