### PR TITLE
Show unpaid appointments count in patient sidebar stats

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3685,6 +3685,7 @@
       "summary": "Summary",
       "totalPaid": "Total paid",
       "totalSpent": "Total spent",
+      "unpaidAppointments": "Unpaid visits",
       "treatmentPrice": "Treatment price",
       "creditBalance": "Credit balance",
       "useCredit": "Use credit balance",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3707,6 +3707,7 @@
       "summary": "Podsumowanie",
       "totalPaid": "Zapłacono łącznie",
       "totalSpent": "Wydano łącznie",
+      "unpaidAppointments": "Zaległe wizyty",
       "treatmentPrice": "Cena zabiegu",
       "creditBalance": "Saldo nadpłat",
       "useCredit": "Użyj salda nadpłat",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -64,6 +64,7 @@ import {
   Minus,
   ArrowUpRight,
   ArrowDownRight,
+  AlertCircle,
   CreditCard,
   Pencil,
   WalletIcon,
@@ -419,6 +420,23 @@ function PatientDetail() {
               )}
             </span>
           </div>
+          {(() => {
+            const unpaidCount = (patientPayments ?? []).filter(
+              (p) => p.status === "pending" && p.kind !== "credit_refund",
+            ).length;
+            if (!unpaidCount) return null;
+            return (
+              <div className="flex items-center justify-between">
+                <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <AlertCircle size={12} variant="stroke" />
+                  {t("gabinet.payments.unpaidAppointments")}
+                </span>
+                <span className="text-xs font-semibold tabular-nums text-destructive">
+                  {unpaidCount}
+                </span>
+              </div>
+            );
+          })()}
         </div>
       </div>
       {(() => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2513.

Closes #2513

---

## Claude summary

Done. Here's a summary of what was done:

The feature request was real and straightforward. The patient sidebar stats card already showed Total Appointments, Loyalty Balance, and Total Spent — but was missing the "zaległe wizyty" (unpaid visits) count.

Changes made to 3 files:

`src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx` — added `AlertCircle` to the icon imports, then appended a new stat row after "Total Spent". It counts `patientPayments` with `status === "pending"` and `kind !== "credit_refund"` (to exclude credit-refund ledger rows). The row is hidden when the count is zero and renders the number in `text-destructive` (red) so staff immediately notice outstanding balances.

`public/locales/en/translation.json` — added `gabinet.payments.unpaidAppointments: "Unpaid visits"`

`public/locales/pl/translation.json` — added `gabinet.payments.unpaidAppointments: "Zaległe wizyty"`