### PR TITLE
Push `gabinetLeaves` date-range filter to DB in `getAvailableSlotsSupabase` and 

### DIFF
--- a/convex/gabinet/_availability_supabase.ts
+++ b/convex/gabinet/_availability_supabase.ts
@@ -181,18 +181,14 @@ export async function getAvailableSlotsSupabase(
     breakEnd = clinicHours.breakEnd;
   }
 
-  const leaves = await db
+  const activeLeaves = await db
     .query("gabinetLeaves")
     .eq("organizationId", args.organizationId)
     .eq("userId", args.userId)
+    .eq("status", "approved")
+    .lte("startDate", args.date)
+    .gte("endDate", args.date)
     .collect();
-
-  const activeLeaves = (leaves as any[]).filter(
-    (l) =>
-      l.status === "approved" &&
-      l.startDate <= args.date &&
-      l.endDate >= args.date,
-  );
 
   if (activeLeaves.some((l) => !l.startTime)) {
     return { slots: [], reason: "on_leave" };
@@ -353,12 +349,12 @@ export async function checkConflictSupabase(
     .query("gabinetLeaves")
     .eq("organizationId", args.organizationId)
     .eq("userId", args.userId)
+    .eq("status", "approved")
+    .lte("startDate", args.date)
+    .gte("endDate", args.date)
     .collect();
 
   for (const leave of leaves as any[]) {
-    if (leave.status !== "approved") continue;
-    if (leave.startDate > args.date || leave.endDate < args.date) continue;
-
     if (!leave.startTime) {
       return { hasConflict: true, reason: "Employee is on leave" };
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2515.

Closes #2515

---

## Claude summary

Fixed. Both `getAvailableSlotsSupabase` and `checkConflictSupabase` in `convex/gabinet/_availability_supabase.ts` were fetching the entire `gabinetLeaves` set for an employee and filtering in JS. The fix chains `.eq("status", "approved").lte("startDate", args.date).gte("endDate", args.date)` directly on the query, so Supabase returns only the rows that actually overlap the requested date. The JS-side `filter()` call and the two `continue` guards in the loop are removed since the DB now enforces those predicates.