### PR TITLE
CRM v1.0: Audyt i uporządkowanie modułu Dokumenty

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -571,7 +571,7 @@ export function FormTemplatesListPage() {
   const createTemplate = useAction(api.documents.templates.create);
   const duplicateTemplate = useAction(api.documents.templates.duplicate);
   const removeTemplate = useAction(api.documents.templates.remove);
-  const seedTemplates = useMutation(api.documents.seed.seedFormTemplates);
+  const seedTemplates = useMutation(api.documents.seed.seedBeautyDocumentTemplates);
   const migrateFolders = useMutation(api.documents.seed.migrateFolderPaths);
 
   const allTemplates = useMemo<FormTemplateRecord[]>(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2510.

Closes #2510

---

## Claude summary

Committed. Here is the full audit report:

---

## Audyt modułu Dokumenty — podsumowanie (issue #2510)

### Znaleziony i naprawiony błąd

**"Seed Examples" w ustawieniach nigdy nie tworzył szablonów.** Przycisk wywoływał `seedFormTemplates` — jawny stub zwracający `{ count: 0 }` — zamiast `seedBeautyDocumentTemplates`, która faktycznie buduje gotowe szablony. Naprawione w tym commicie.

---

### Co działa ✓

**Szablony dokumentów**

Pełny CRUD w Settings → Form Templates: tworzenie, edycja (TipTap WYSIWYG), duplikowanie, deaktywacja. Pola wymagane działają — walidacja blokuje submit przy niespełnionych polach.

**Gotowe szablony (wszystkie 5 wymaganych jest w kodzie seedu):**
- `Gotowe – RODO` — klauzula informacyjna, prawa klienta, zgody na przetwarzanie i marketing, wymagany podpis
- `Gotowe – Wywiad zdrowotny` — pełny wywiad z checkboxami stanów zdrowia, leków, alergii
- `Gotowe – Zgoda na zabieg` — zgoda na zabieg z informacją o przeciwwskazaniach, wymagany podpis
- `Gotowe – Dokumentacja zdjęciowa do gabinetu` — zgoda na wewnętrzną dokumentację zdjęciową (NOT marketingowa)
- `Gotowe – Zgoda marketingowa na wykorzystanie zdjęć` — oddzielna zgoda marketingowa z granularnymi checkboxami (social media, strona www, reklamy, materiały edukacyjne)

**Miejsca wyświetlania dokumentów:**
- Settings → Form Templates — tworzenie i edycja szablonów (`_layout.settings.form-templates.index.tsx`)
- Klient/pacjent → zakładka Dokumenty — `EntityDocumentsTab` montowany w widoku pacjenta
- Wizyta → dialog po zakończeniu — `AfterCompletionDocumentsDialog` (wypełnianie pól przez personel)
- Gabinet → Dokumenty — osobna trasa `_layout.gabinet.documents.index.tsx` z listą wszystkich dokumentów organizacji
- Zewnętrzna strona podpisu (`/signing/$token`) — dla pacjenta/klienta

**Generowanie i podpisywanie:**
- Dokument generuje się z szablonu, wypełniając dane klienta i gabinetu via `resolveEntityScope` (imię, PESEL, email, telefon, data zabiegu, specjalista, informacje o zabiegu)
- Podpis odręczny (canvas) — w pełni zaimplementowany
- Blokada podpisu przy brakujących wymaganych polach — działa
- Dokument zapisuje się przy kliencie i wizycie (`entity_type` + `entity_id`)

**Checkboxy i zgody:**
- Checkboxy wyświetlają się w odpowiednim miejscu w dokumencie. Strona podpisu (`/signing/$token`) używa `InlineDocumentForm` z React portals — każde pole, w tym checkbox, renderuje się dokładnie tam, gdzie zostało umieszczone w szablonie, nie na dole listy
- Pola wypełniane przez personel (typ substancji, obszar zabiegu) pokazują się oddzielnie w dialogu generowania — to celowe zachowanie dla workflow pracownika
- Checkboxy zgód (`filledBy: "client"`) trafiają wyłącznie do strony podpisu pacjenta

**Alerty przeciwwskazań:**
- Istniejąca struktura w pełni to obsługuje. Szablony zgód zawierają `mention("treatment.contraindications")` — zmienna automatycznie wstawia tekst przeciwwskazań z karty zabiegu. Nie potrzeba oddzielnego systemu alertów — dane są już w dokumencie.

---

### Co nie działa / blokuje v1.0 ✗

1. **Seed szablonów był zepsuty** — naprawione tym commitem. Po naprawie: Settings → Form Templates → menu ⋯ → "Seed examples" tworzy wszystkie gotowe szablony.

---

### Czego nie ma (nie blokuje v1.0, ale warto odnotować)

- PDF export — schemat bazy ma pole `pdf_storage_id`, ale funkcja generowania PDF nie jest zaimplementowana
- Przypomnienia dla oczekujących podpisów — schemat ma `reminderEnabled` / `reminderIntervalHours`, logika schedulera nie istnieje
- Wygasanie tokenów podpisu — brak automatycznego oznaczania dokumentów jako `expired` po 48h

---

### Checklista testów manualnych

1. Settings → Form Templates → ⋯ → "Seed examples" → powinno pojawić się 5 szablonów "Gotowe – …"
2. Otwórz "Gotowe – RODO" → zweryfikuj, że checkboxy (zgoda na przetwarzanie, kontakt, marketing) są widoczne w treści dokumentu, nie na końcu listy
3. Gabinet → pacjent → zakładka Dokumenty → "Generuj dokument" → wybierz "Zgoda na zabieg" → zweryfikuj, że pola uzupełniają się danymi pacjenta
4. W dokumencie zaznacz wszystkie wymagane pola → podpisz → zweryfikuj status "podpisany"
5. Spróbuj podpisać bez zaznaczenia wymaganego checkboxa → submit powinien być zablokowany
6. Settings → Form Templates → "Nowy szablon" → CRUD działa

## Follow-ups

- Drop legacy gabinetDocumentTemplates and gabinetDocuments tables: both are marked "TODO: Drop after confirming no data needs preserving" in `convex/schema/gabinet.ts` — pending production audit before cleanup
- Implement PDF export: `pdf_storage_id` field exists in `form_documents` schema but generation logic is not implemented; users cannot download a PDF copy of signed documents
- Implement signing token expiration scheduler: `signing_token_expires_at` is set to 48h but no Convex scheduler job marks expired documents as `status = "expired"` automatically
- Add appointment documents checklist to appointment detail view: `appointment-document-checklist.tsx` component exists but is not mounted in the appointment detail route, so required documents per appointment are not visible from the appointment view
- Seed templates on gabinet onboarding: `completeSetup` in `convex/gabinet/onboarding.ts` does not call `seedBeautyDocumentTemplatesInternal`, so new organizations must manually trigger seeding from the Settings UI