### PR TITLE
Implement signing token expiration scheduler

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -18,4 +18,12 @@ crons.daily(
   internal.documents.seed.backfillFilledByAllOrgs,
 );
 
+// Mark formDocuments whose signing token has passed its 48h TTL as "expired".
+// Runs hourly so the DB status stays in sync with what the signing page shows.
+crons.hourly(
+  "expire-signing-tokens",
+  { minuteUTC: 15 },
+  internal.documents.documents.expireSigningTokens,
+);
+
 export default crons;

--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -1,4 +1,4 @@
-import { action } from "../_generated/server";
+import { action, internalAction } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { v } from "convex/values";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
@@ -595,6 +595,38 @@ export const remove = action({
 
     await db.delete("formDocuments", args.documentId);
     return args.documentId;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Scheduled job — marks documents whose signing token has expired as "expired".
+// Runs hourly (see convex/crons.ts). Supabase NULL values are naturally
+// excluded by the lt() filter (NULL < X evaluates to NULL in Postgres, not
+// true), so only rows with an actual expiry timestamp in the past are matched.
+// ---------------------------------------------------------------------------
+
+export const expireSigningTokens = internalAction({
+  args: {},
+  handler: async (_ctx, _args): Promise<void> => {
+    const db = createSupabaseDb();
+    const now = Date.now();
+
+    const docs = await db
+      .query("formDocuments")
+      .in("status", ["draft", "pending_signature"])
+      .lt("signingTokenExpiresAt", now)
+      .collect();
+
+    if (docs.length === 0) return;
+
+    for (const doc of docs) {
+      await db.patch("formDocuments", String(doc._id), {
+        status: "expired",
+        updatedAt: now,
+      });
+    }
+
+    console.info(`[expireSigningTokens] Marked ${docs.length} document(s) as expired`);
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2526.

Closes #2526

---

## Claude summary

The fix is committed. Here's a summary of what was done and why:

**Root cause confirmed.** `formDocuments` has `signing_token_expires_at` set to `Date.now() + 48h` when a signing email is sent, and the `"expired"` status already exists in the schema validator. However, expiry was only enforced at read time — when a patient visits the signing page, the handler throws "Signing link expired". The database row stayed `"draft"` or `"pending_signature"` forever.

**Fix: two changes.**

`convex/documents/documents.ts` — added `expireSigningTokens` (`internalAction`). It queries Supabase for `formDocuments` with status `draft` or `pending_signature` and `signingTokenExpiresAt < now`, then patches each matching row to `status: "expired"`. The `lt()` filter naturally excludes NULL expiry values in Postgres (NULL comparisons return NULL, not true), so documents without a signing token are unaffected.

`convex/crons.ts` — registered the action as `crons.hourly("expire-signing-tokens", { minuteUTC: 15 }, ...)`. Running hourly means the worst-case drift between actual expiry and database status is under one hour.