### PR TITLE
Seed templates on gabinet onboarding

### DIFF
--- a/convex/gabinet/onboarding.ts
+++ b/convex/gabinet/onboarding.ts
@@ -93,6 +93,9 @@ export const completeSetup = action({
   },
   handler: async (ctx, args) => {
     // Auth + permissions via internal query
+    const { userId } = await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
     await ctx.runQuery(internal._helpers.authAction.checkPermission, {
       organizationId: args.organizationId,
       feature: "settings",
@@ -106,6 +109,13 @@ export const completeSetup = action({
       internal.gabinet.onboarding._completeSetupSideEffects,
       { organizationId: args.organizationId },
     );
+
+    // Seed default beauty document templates for this organization.
+    // Idempotent — skips any template whose name already exists.
+    await ctx.runMutation(internal.documents.seed.seedBeautyDocumentTemplatesInternal, {
+      organizationId: args.organizationId,
+      userId,
+    });
 
     // Backfill filledBy on any existing formField templates that pre-date
     // the filledBy feature. Idempotent — no-op when values are already correct.


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2528.

Closes #2528

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Bug confirmed.** `completeSetup` in `convex/gabinet/onboarding.ts` patched the `onboardingCompleted` flag and ran a `migrateFormFieldFilledByInternal` backfill, but never called `seedBeautyDocumentTemplatesInternal`. New organizations completing the onboarding wizard ended up with no default document templates.

**Fix:** Added two things to `completeSetup`:
1. A `verifyOrgAccess` query at the start to retrieve the `userId` (needed by the seed mutation).
2. A call to `internal.documents.seed.seedBeautyDocumentTemplatesInternal` after marking onboarding complete. The seed handler is idempotent — it checks for existing template names and skips any that already exist, so re-triggering onboarding (or running the Settings UI seed button afterward) is safe.