### PR TITLE
Add backfill cron for migrateGotoweContactEntityTypes

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -18,6 +18,15 @@ crons.daily(
   internal.documents.seed.backfillFilledByAllOrgs,
 );
 
+// Backfill "contact" entityType on the five "Gotowe" ready-made templates for all
+// onboarded orgs. Covers orgs that completed setup before issue #2532 was fixed.
+// Idempotent — becomes a no-op once all templates are already correct.
+crons.daily(
+  "backfill-gotowe-contact-entity-types",
+  { hourUTC: 3, minuteUTC: 30 },
+  internal.documents.seed.backfillGotoweContactEntityTypesAllOrgs,
+);
+
 // Mark formDocuments whose signing token has passed its 48h TTL as "expired".
 // Runs hourly so the DB status stays in sync with what the signing page shows.
 crons.hourly(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2534.

Closes #2534

---

## Claude summary

Done. The fix is a single change to `convex/crons.ts`: added a `crons.daily` entry at 03:30 UTC that calls `internal.documents.seed.backfillGotoweContactEntityTypesAllOrgs`. This mirrors the pattern of the existing `backfill-form-field-filled-by` job. Because the action is idempotent (skips templates that already have "contact" in `entityTypes`), it will run daily and become a harmless no-op once all existing orgs are patched.