### PR TITLE
Pre-existing TS7022/TS7023 circular inference errors in seed.ts

### DIFF
--- a/convex/documents/seed.ts
+++ b/convex/documents/seed.ts
@@ -201,7 +201,7 @@ export const _listOnboardedOrgIds = internalQuery({
  */
 export const backfillFilledByAllOrgs = internalAction({
   args: {},
-  handler: async (ctx) => {
+  handler: async (ctx): Promise<{ totalPatched: number; orgsProcessed: number }> => {
     const orgIds = await ctx.runQuery(internal.documents.seed._listOnboardedOrgIds, {});
     let totalPatched = 0;
     for (const orgId of orgIds) {
@@ -2447,7 +2447,7 @@ export const migrateGotoweContactEntityTypes = internalMutation({
  */
 export const backfillGotoweContactEntityTypesAllOrgs = internalAction({
   args: {},
-  handler: async (ctx) => {
+  handler: async (ctx): Promise<{ totalPatched: number; orgsProcessed: number }> => {
     const orgIds = await ctx.runQuery(internal.documents.seed._listOnboardedOrgIds, {});
     let totalPatched = 0;
     for (const orgId of orgIds) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2535.

Closes #2535

---

## Claude summary

The fix is confirmed and committed. Both `internalAction` handlers in `convex/documents/seed.ts` now have explicit `Promise<{ totalPatched: number; orgsProcessed: number }>` return type annotations on their `handler` functions, which breaks the circular type inference that TypeScript was failing on (TS7022/TS7023). The handlers reference `internal.documents.seed.*` — functions exported from the same file — which causes TypeScript to enter a circular inference loop when it tries to derive the handler's return type. The explicit annotation gives the compiler a fixed type to use without needing to recurse.