### PR TITLE
Sprawdzenie widoczności gotowych dokumentów po zmianie entityTypes

### DIFF
--- a/convex/documents/seed.ts
+++ b/convex/documents/seed.ts
@@ -193,6 +193,21 @@ export const _listOnboardedOrgIds = internalQuery({
 });
 
 /**
+ * Internal: return the userId of the first team member found for an org.
+ * Used by backfill actions that need a createdBy userId when seeding templates.
+ */
+export const _getOrgFirstMemberId = internalQuery({
+  args: { organizationId: v.id("organizations") },
+  handler: async (ctx, args): Promise<GenericId<"users"> | null> => {
+    const membership = await ctx.db
+      .query("teamMemberships")
+      .withIndex("by_organizationId", (q) => q.eq("organizationId", args.organizationId))
+      .first();
+    return membership?.userId ?? null;
+  },
+});
+
+/**
  * Backfill `filledBy` on form-field nodes for ALL onboarded organizations.
  * Runs as a daily cron so existing orgs (that completed setup before the
  * filledBy feature was introduced) get migrated automatically.
@@ -2442,21 +2457,39 @@ export const migrateGotoweContactEntityTypes = internalMutation({
 });
 
 /**
- * Backfill "contact" entityType on the five "Gotowe" templates for ALL onboarded orgs.
- * Idempotent — skips templates that already include "contact".
+ * Backfill the five "Gotowe" templates for ALL onboarded orgs.
+ *
+ * Two-phase, both phases are idempotent:
+ * 1. Seed any missing Gotowe templates (orgs onboarded before #2528 never had
+ *    them created — the old onboarding path didn't call seedBeautyHandler).
+ * 2. Patch entityTypes to include "contact" so the templates appear in the
+ *    CRM contact document picker (fix from #2532).
  */
 export const backfillGotoweContactEntityTypesAllOrgs = internalAction({
   args: {},
-  handler: async (ctx): Promise<{ totalPatched: number; orgsProcessed: number }> => {
+  handler: async (ctx): Promise<{ totalSeeded: number; totalPatched: number; orgsProcessed: number }> => {
     const orgIds = await ctx.runQuery(internal.documents.seed._listOnboardedOrgIds, {});
+    let totalSeeded = 0;
     let totalPatched = 0;
     for (const orgId of orgIds) {
+      // Phase 1: seed templates that don't exist yet. Skips existing ones by name.
+      const userId = await ctx.runQuery(internal.documents.seed._getOrgFirstMemberId, {
+        organizationId: orgId,
+      });
+      if (userId) {
+        const { count } = await ctx.runMutation(
+          internal.documents.seed.seedBeautyDocumentTemplatesInternal,
+          { organizationId: orgId, userId },
+        );
+        totalSeeded += count;
+      }
+      // Phase 2: ensure "contact" is in entityTypes on all five Gotowe templates.
       const { patched } = await ctx.runMutation(
         internal.documents.seed.migrateGotoweContactEntityTypes,
         { organizationId: orgId },
       );
       totalPatched += patched;
     }
-    return { totalPatched, orgsProcessed: orgIds.length };
+    return { totalSeeded, totalPatched, orgsProcessed: orgIds.length };
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2538.

Closes #2538

---

## Claude summary

The commit is in. Here's the summary of what was wrong and what was fixed.

**Root cause**: The daily cron `backfill-gotowe-contact-entity-types` (added in #2534) only patches `entityTypes` on templates that already exist. But the onboarding flow only started seeding the five Gotowe templates when #2528 was shipped — so any organization that completed gabinet setup before that deployment never had those templates created at all. For those orgs the cron was silently a no-op: it found 0 matching templates, patched nothing, and moved on.

**Fix** (`convex/documents/seed.ts`): `backfillGotoweContactEntityTypesAllOrgs` now runs two idempotent phases per org:

1. **Seed** — calls `seedBeautyDocumentTemplatesInternal` to create any of the five Gotowe templates that don't exist yet. Existing templates are skipped by name.
2. **Patch** — calls `migrateGotoweContactEntityTypes` as before, to add `"contact"` to `entityTypes` so templates appear in the CRM contact document picker.

A new `_getOrgFirstMemberId` internal query supplies the `userId` (used only as `createdBy`) by looking up the org's first team member. The cron already runs daily at 03:30 UTC, so all existing organizations will be covered on the next scheduled run without any manual intervention.