### PR TITLE
Nie można dodać zabiegu – sprawdzenie dokumentów i magazynu

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -552,6 +552,13 @@ async function saveTreatmentProductLinks(
     });
   }
 
+  // Deduplicate by (productId, productSection): last entry wins, matching upsert semantics.
+  const seen = new Map<string, typeof resolved[number]>();
+  for (const r of resolved) {
+    seen.set(`${r.productId}:${r.productSection}`, r);
+  }
+  const deduped = Array.from(seen.values());
+
   // Replace: delete existing links, then insert new ones.
   const { error: delError } = await db.raw()
     .from("gabinet_treatment_products")
@@ -572,7 +579,7 @@ async function saveTreatmentProductLinks(
   }
 
   const now = Date.now();
-  for (const p of resolved) {
+  for (const p of deduped) {
     const row: Record<string, unknown> = {
       organizationId,
       treatmentId,

--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -266,8 +266,8 @@ export function TreatmentForm({
         : undefined
       : undefined;
 
-    const validProducts = productLines.filter((p) => p.productId.trim() !== "");
-    const validMaterials = materialLines.filter((m) => m.productId.trim() !== "");
+    const validProducts = productLines.filter((p) => p.productId.trim() !== "" && p.quantity > 0);
+    const validMaterials = materialLines.filter((m) => m.productId.trim() !== "" && m.quantity > 0);
 
     onSubmit({
       name,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2540.

Closes #2540

---

## Claude summary

Two bugs fixed and committed.

**What was wrong (issue #2540):** Adding a treatment appeared to succeed but product/material links silently failed, triggering only a warning toast. There were two independent failure paths in `saveTreatmentProductLinks`:

1. **Zero-quantity products** — the form allowed `quantity = 0` (both via `min="0"` and the `val >= 0` guard in the change handler), but the backend throws on `quantity <= 0`. Fix: `validProducts`/`validMaterials` filters in `treatment-form.tsx:269-270` now additionally require `quantity > 0`.

2. **Duplicate product selection** — adding the same product twice in the same section caused a UNIQUE constraint violation (`23505`) on `gabinet_treatment_products(treatment_id, product_id, product_section)`. The `upsertWithFkRetry` client only retries FK errors (`23503`), so `23505` propagated and killed the entire product-link save. Fix: `saveTreatmentProductLinks` in `treatments.ts:555-560` now deduplicates `resolved` by `(productId, productSection)` before inserting; last entry wins.