### PR TITLE
Nie można dodać zabiegu – sprawdzenie dokumentów i magazynu

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -552,6 +552,13 @@ async function saveTreatmentProductLinks(
     });
   }
 
+  // Deduplicate by (productId, productSection): last entry wins, matching upsert semantics.
+  const seen = new Map<string, typeof resolved[number]>();
+  for (const r of resolved) {
+    seen.set(`${r.productId}:${r.productSection}`, r);
+  }
+  const deduped = Array.from(seen.values());
+
   // Replace: delete existing links, then insert new ones.
   const { error: delError } = await db.raw()
     .from("gabinet_treatment_products")
@@ -572,7 +579,7 @@ async function saveTreatmentProductLinks(
   }
 
   const now = Date.now();
-  for (const p of resolved) {
+  for (const p of deduped) {
     const row: Record<string, unknown> = {
       organizationId,
       treatmentId,

--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -266,8 +266,8 @@ export function TreatmentForm({
         : undefined
       : undefined;
 
-    const validProducts = productLines.filter((p) => p.productId.trim() !== "");
-    const validMaterials = materialLines.filter((m) => m.productId.trim() !== "");
+    const validProducts = productLines.filter((p) => p.productId.trim() !== "" && p.quantity > 0);
+    const validMaterials = materialLines.filter((m) => m.productId.trim() !== "" && m.quantity > 0);
 
     onSubmit({
       name,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2540.

Closes #2540

---

## Claude summary

I have all the information needed. This is a clarification question, not a new bug.

Here's what the code shows:

**The `quantity > 0` validation only checks the quantity entered in the treatment form — it has nothing to do with warehouse stock.**

Specifically:
- `TreatmentProductLine.quantity` (defined at `treatment-form.tsx:43`) is how many units of the product are needed to perform one treatment session (e.g., "3 ml of anesthetic"). This is what the user types into the form.
- The backend check at `treatments.ts:531` — `if (item.quantity <= 0)` — validates only this form-entered number.
- `saveTreatmentProductLinks` fetches products from the database only to verify they exist and belong to the org. It never reads any stock level, never touches `stockMovements`, and never compares against current inventory.

So treatment creation is completely independent of warehouse stock. You can create a treatment that requires 100 units of a product even if the warehouse has 0 in stock. The validation only prevents nonsensical entries like "this treatment uses 0 units of product X."

No code changes are needed — the existing fix already works the way you described (form quantity only, no stock blocking).