### PR TITLE
Nie można dodać zabiegu – sprawdzenie dokumentów i magazynu

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -552,6 +552,13 @@ async function saveTreatmentProductLinks(
     });
   }
 
+  // Deduplicate by (productId, productSection): last entry wins, matching upsert semantics.
+  const seen = new Map<string, typeof resolved[number]>();
+  for (const r of resolved) {
+    seen.set(`${r.productId}:${r.productSection}`, r);
+  }
+  const deduped = Array.from(seen.values());
+
   // Replace: delete existing links, then insert new ones.
   const { error: delError } = await db.raw()
     .from("gabinet_treatment_products")
@@ -572,7 +579,7 @@ async function saveTreatmentProductLinks(
   }
 
   const now = Date.now();
-  for (const p of resolved) {
+  for (const p of deduped) {
     const row: Record<string, unknown> = {
       organizationId,
       treatmentId,

--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -266,8 +266,8 @@ export function TreatmentForm({
         : undefined
       : undefined;
 
-    const validProducts = productLines.filter((p) => p.productId.trim() !== "");
-    const validMaterials = materialLines.filter((m) => m.productId.trim() !== "");
+    const validProducts = productLines.filter((p) => p.productId.trim() !== "" && p.quantity > 0);
+    const validMaterials = materialLines.filter((m) => m.productId.trim() !== "" && m.quantity > 0);
 
     onSubmit({
       name,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2540.

Closes #2540

---

## Claude summary

Two bugs in `saveTreatmentProductLinks` caused treatment creation to appear to succeed but then silently fail on product/material linking. Both are now fixed:

**Bug 1 — Zero-quantity products** (`treatment-form.tsx:269-270`): The quantity input used `min="0"` and accepted `val >= 0`, so entering 0 was valid in the UI. The frontend filter only checked `productId.trim() !== ""`, letting zero-quantity items through to the backend, which throws on `quantity <= 0`. Fixed by adding `&& p.quantity > 0` to both `validProducts` and `validMaterials` filters — zero-quantity entries are now silently dropped before submission (same as leaving a product row empty).

**Bug 2 — Duplicate products** (`treatments.ts:555-560`): Adding the same product twice in a section would hit a UNIQUE constraint violation on `gabinet_treatment_products(treatment_id, product_id, product_section)`, killing the entire link save. Fixed by deduplicating the `resolved` array by `(productId, productSection)` before the insert loop — last entry wins.

**Regarding the warehouse stock question**: The `quantity > 0` validation only checks the number the user types into the form (how many units of a product are needed per treatment session). The backend never reads stock levels, never touches `stockMovements`, and never compares against current inventory. Treatment creation works regardless of whether the warehouse has 0 or 1000 units of the product in stock.