### PR TITLE
Podpowiedź przy ilości produktów i materiałów w zabiegu

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -610,6 +610,9 @@ export function TreatmentForm({
           <p className="text-xs text-muted-foreground mt-0.5">
             Preparaty używane podczas jednej wizyty, np. ampułka, serum, krem znieczulający.
           </p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Podaj ilość preparatu potrzebną do wykonania jednego zabiegu (np. 3 ml, 1 szt.). Pozycje z ilością 0 nie zostaną zapisane.
+          </p>
         </div>
 
         {productLines.length > 0 && (
@@ -753,6 +756,9 @@ export function TreatmentForm({
           </Label>
           <p className="text-xs text-muted-foreground mt-0.5">
             Materiały zużywane podczas jednej wizyty, np. igły, gaziki, rękawiczki.
+          </p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Podaj ilość materiału potrzebną do wykonania jednego zabiegu (np. 1 szt., 2 pary). Pozycje z ilością 0 nie zostaną zapisane.
           </p>
         </div>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2543.

Closes #2543

---

## Claude summary

Done. Here's a summary of what was found and changed:

The feature area exists in `src/components/gabinet/treatment-form.tsx`. Investigation found:

- **Default value of 1** — already implemented. Both `addProductLine` (line 191) and `addMaterialLine` (line 210) initialize new lines with `quantity: 1`, so no change was needed there.
- **Hint text** — was missing. Added a hint paragraph under each section header:
  - Under "Preparaty do zabiegu": "Podaj ilość preparatu potrzebną do wykonania jednego zabiegu (np. 3 ml, 1 szt.). Pozycje z ilością 0 nie zostaną zapisane."
  - Under "Materiały jednorazowe / zużywalne": "Podaj ilość materiału potrzebną do wykonania jednego zabiegu (np. 1 szt., 2 pary). Pozycje z ilością 0 nie zostaną zapisane."

Both hints appear as muted-foreground `text-xs` text consistent with the existing section descriptions, and are placed where users will see them before interacting with the quantity fields.