### PR TITLE
Do czego przycisk migruj foldery

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1596,7 +1596,7 @@
       "newTemplateName": "New template",
       "seedExamples": "Load examples",
       "seedSuccess": "Loaded {{count}} templates",
-      "migrateFolders": "Migrate folders",
+      "migrateFolders": "Assign folders to templates",
       "migrateSuccess": "Assigned folders to {{count}} templates"
     },
     "documentComponents": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1599,7 +1599,7 @@
       "newTemplateName": "Nowy szablon",
       "seedExamples": "Załaduj przykłady",
       "seedSuccess": "Załadowano {{count}} szablonów",
-      "migrateFolders": "Migruj foldery",
+      "migrateFolders": "Przypisz foldery do szablonów",
       "migrateSuccess": "Przypisano foldery do {{count}} szablonów"
     },
     "documentComponents": {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2544.

Closes #2544

---

## Claude summary

Here's what "Migruj foldery" / "Migrate folders" does, and what changed:

**What the button does:** It's a one-time data backfill utility found in the "Więcej" dropdown on the Form Templates settings page (`/dashboard/settings/form-templates`). When clicked, it scans all the organization's form templates that have no `folderPath` set yet, and automatically assigns each one to the correct folder based on its category and module — e.g. a `gabinet/consent` template gets placed in `Gabinet/Zgody`, a `crm/contract` template goes into `CRM/Umowy`, etc. It was introduced to organize templates that existed before the folder feature was added.

**Why the name was confusing:** "Migruj foldery" is developer-speak for a database migration. A regular user has no way to know from that label what will happen when they click it. The success toast already used clearer language: "Przypisano foldery do {{count}} szablonów" (Assigned folders to {{count}} templates).

**What was changed:** Both translation files were updated to use the same phrasing as the success toast:
- PL: "Migruj foldery" → "Przypisz foldery do szablonów"
- EN: "Migrate folders" → "Assign folders to templates"

The button lives at `src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx:860` inside the "Więcej" dropdown.