### PR TITLE
załaduj przykłady

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1595,6 +1595,10 @@
       "newFolder": "New folder",
       "newTemplateName": "New template",
       "seedExamples": "Load examples",
+      "seedConfirmTitle": "Load example templates",
+      "seedConfirmDescription": "This will add a ready-made set of document templates for beauty salons (consents, health questionnaires, treatment protocols, GDPR). Templates that already exist will not be overwritten.",
+      "seedConfirmAction": "Load templates",
+      "seedAlreadyLoaded": "All example templates are already loaded",
       "seedSuccess": "Loaded {{count}} templates",
       "migrateFolders": "Assign folders to templates",
       "migrateSuccess": "Assigned folders to {{count}} templates"

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1598,6 +1598,10 @@
       "newFolder": "Nowy folder",
       "newTemplateName": "Nowy szablon",
       "seedExamples": "Załaduj przykłady",
+      "seedConfirmTitle": "Załaduj przykładowe szablony",
+      "seedConfirmDescription": "Spowoduje to dodanie gotowego zestawu szablonów dokumentów dla salonu beauty (zgody, wywiady, protokoły zabiegów, RODO). Szablony, które już istnieją, nie zostaną nadpisane.",
+      "seedConfirmAction": "Załaduj szablony",
+      "seedAlreadyLoaded": "Wszystkie przykładowe szablony są już załadowane",
       "seedSuccess": "Załadowano {{count}} szablonów",
       "migrateFolders": "Przypisz foldery do szablonów",
       "migrateSuccess": "Przypisano foldery do {{count}} szablonów"

--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -545,6 +545,7 @@ export function FormTemplatesListPage() {
   const [search, setSearch] = useState("");
   const [deletingTemplate, setDeletingTemplate] =
     useState<FormTemplateRecord | null>(null);
+  const [seedConfirmOpen, setSeedConfirmOpen] = useState(false);
   const [newFolderDialogOpen, setNewFolderDialogOpen] = useState(false);
   const [newFolderName, setNewFolderName] = useState("");
   const [newFolderParent, setNewFolderParent] = useState("");
@@ -828,17 +829,7 @@ export function FormTemplatesListPage() {
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
-                  onClick={async () => {
-                    try {
-                      const result = await seedTemplates({ organizationId });
-                      await invalidateTemplates();
-                      toast.success(t("settings.formTemplates.seedSuccess", { count: result.count }));
-                    } catch (e) {
-                      toast.error(
-                        e instanceof Error ? e.message : t("common.error"),
-                      );
-                    }
-                  }}
+                  onClick={() => setSeedConfirmOpen(true)}
                 >
                   {t("settings.formTemplates.seedExamples")}
                 </DropdownMenuItem>
@@ -925,6 +916,44 @@ export function FormTemplatesListPage() {
           </div>
         )
       )}
+
+      {/* Load examples confirmation */}
+      <AlertDialog open={seedConfirmOpen} onOpenChange={setSeedConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("settings.formTemplates.seedConfirmTitle")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("settings.formTemplates.seedConfirmDescription")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async () => {
+                try {
+                  const result = await seedTemplates({ organizationId });
+                  await invalidateTemplates();
+                  if (result.count === 0) {
+                    toast(t("settings.formTemplates.seedAlreadyLoaded"));
+                  } else {
+                    toast.success(
+                      t("settings.formTemplates.seedSuccess", { count: result.count }),
+                    );
+                  }
+                } catch (e) {
+                  toast.error(
+                    e instanceof Error ? e.message : t("common.error"),
+                  );
+                }
+              }}
+            >
+              {t("settings.formTemplates.seedConfirmAction")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* Delete confirmation */}
       <AlertDialog


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2549.

Closes #2549

---

## Claude summary

The issue was real and is now fixed. Here's what was happening and what changed:

**Root cause:** The "Załaduj przykłady" dropdown item in `src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx` called `seedBeautyDocumentTemplates` directly with no explanation or confirmation. Users had no way to know what would be imported or that the action had any effect.

**Fix:** Added a confirmation `AlertDialog` that:
- Explains the action clearly: a ready-made set of beauty salon templates (consents, health questionnaires, treatment protocols, GDPR) will be added
- Notes that existing templates will not be overwritten (idempotent)
- Shows Cancel and "Załaduj szablony" action buttons
- If all templates are already loaded, shows a neutral toast instead of a confusing "Loaded 0 templates" success message

I chose a confirmation dialog over a per-template selection UI because the templates form a cohesive set designed to be used together, and the backend already implements an idempotent "skip existing" approach — per-template selection would require significant backend changes for little practical benefit.

**Files changed:**
- `src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx` — added `seedConfirmOpen` state, changed the dropdown item to open the dialog, added `AlertDialog` with description
- `public/locales/pl/translation.json` and `public/locales/en/translation.json` — added `seedConfirmTitle`, `seedConfirmDescription`, `seedConfirmAction`, `seedAlreadyLoaded` keys