### PR TITLE
Załaduj tylko jeden szablon testowy RODO

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -572,7 +572,7 @@ export function FormTemplatesListPage() {
   const createTemplate = useAction(api.documents.templates.create);
   const duplicateTemplate = useAction(api.documents.templates.duplicate);
   const removeTemplate = useAction(api.documents.templates.remove);
-  const seedTemplates = useMutation(api.documents.seed.seedBeautyDocumentTemplates);
+  const seedTemplates = useMutation(api.documents.seed.seedSingleBeautyDocumentTemplate);
   const migrateFolders = useMutation(api.documents.seed.migrateFolderPaths);
 
   const allTemplates = useMemo<FormTemplateRecord[]>(
@@ -933,7 +933,7 @@ export function FormTemplatesListPage() {
             <AlertDialogAction
               onClick={async () => {
                 try {
-                  const result = await seedTemplates({ organizationId });
+                  const result = await seedTemplates({ organizationId, templateName: "Gotowe – RODO" });
                   await invalidateTemplates();
                   if (result.count === 0) {
                     toast(t("settings.formTemplates.seedAlreadyLoaded"));


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2555.

Closes #2555

---

## Claude summary

Done. The change is minimal and surgical:

- **File changed:** `src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx`
- The mutation called by "Załaduj przykłady" switched from `seedBeautyDocumentTemplates` (all templates) to `seedSingleBeautyDocumentTemplate` with `templateName: "Gotowe – RODO"`.
- The backend already handles idempotency — if "Gotowe – RODO" already exists for the org, it skips creation and returns `count: 0`, which triggers the existing "already loaded" toast.
- No backend changes needed; `seedSingleBeautyDocumentTemplate` was already there from issue #2552.