### PR TITLE
Załaduj tylko jeden szablon testowy RODO

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -572,7 +572,7 @@ export function FormTemplatesListPage() {
   const createTemplate = useAction(api.documents.templates.create);
   const duplicateTemplate = useAction(api.documents.templates.duplicate);
   const removeTemplate = useAction(api.documents.templates.remove);
-  const seedTemplates = useMutation(api.documents.seed.seedBeautyDocumentTemplates);
+  const seedTemplates = useMutation(api.documents.seed.seedSingleBeautyDocumentTemplate);
   const migrateFolders = useMutation(api.documents.seed.migrateFolderPaths);
 
   const allTemplates = useMemo<FormTemplateRecord[]>(
@@ -933,7 +933,7 @@ export function FormTemplatesListPage() {
             <AlertDialogAction
               onClick={async () => {
                 try {
-                  const result = await seedTemplates({ organizationId });
+                  const result = await seedTemplates({ organizationId, templateName: "Gotowe – RODO" });
                   await invalidateTemplates();
                   if (result.count === 0) {
                     toast(t("settings.formTemplates.seedAlreadyLoaded"));


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2555.

Closes #2555

---

## Claude summary

NOT_A_BUG: Issue #2555 is already fully implemented. Commit `5fe624b` (the HEAD of this branch) is the squash-merge of PR #2557, which:

1. Added `seedSingleBeautyDocumentTemplate` as a public mutation in `convex/documents/seed.ts:2427` — accepts `organizationId`, `templateName`, and optional `force`.
2. Updated the frontend at `src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx:574` to call that mutation with `templateName: "Gotowe – RODO"`.
3. The template itself is defined at `convex/documents/seed.ts:1842`.
4. Idempotency is baked in: if "Gotowe – RODO" already exists for the org, the handler skips insertion and returns `count: 0`, which triggers the "already loaded" toast on the frontend (`line 835`).

Everything is working as designed. Clicking "Załaduj przykłady" → dropdown → that menu item will create exactly one template ("Gotowe – RODO") if it doesn't already exist, or show a neutral toast if it does.