### PR TITLE
Załaduj tylko jeden szablon testowy RODO

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -572,7 +572,7 @@ export function FormTemplatesListPage() {
   const createTemplate = useAction(api.documents.templates.create);
   const duplicateTemplate = useAction(api.documents.templates.duplicate);
   const removeTemplate = useAction(api.documents.templates.remove);
-  const seedTemplates = useMutation(api.documents.seed.seedBeautyDocumentTemplates);
+  const seedTemplates = useMutation(api.documents.seed.seedSingleBeautyDocumentTemplate);
   const migrateFolders = useMutation(api.documents.seed.migrateFolderPaths);
 
   const allTemplates = useMemo<FormTemplateRecord[]>(
@@ -933,7 +933,7 @@ export function FormTemplatesListPage() {
             <AlertDialogAction
               onClick={async () => {
                 try {
-                  const result = await seedTemplates({ organizationId });
+                  const result = await seedTemplates({ organizationId, templateName: "Gotowe – RODO" });
                   await invalidateTemplates();
                   if (result.count === 0) {
                     toast(t("settings.formTemplates.seedAlreadyLoaded"));


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2555.

Closes #2555

---

## Claude summary

NOT_A_BUG: The code is fully correct — this is a Convex deployment lag on quera-dev, not a missing function.

Here is the exact state of the codebase:

`convex/documents/seed.ts:2427` exports `seedSingleBeautyDocumentTemplate` as a public `mutation` (not internal), with the correct signature accepting `organizationId`, `templateName`, and optional `force`. The handler function `seedBeautyHandler` at line 2256 accepts the optional `templateName` parameter and correctly filters to a single template when it is provided.

`src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx:574` calls exactly `useMutation(api.documents.seed.seedSingleBeautyDocumentTemplate)` — the name and module path match the backend export perfectly.

The error `Could not find public function documents/seed:seedSingleBeautyDocumentTemplate` is a Convex runtime error thrown by the Convex cloud instance when it cannot find a registered function. It does not mean the function is missing from the source code — it means the **quera-dev Convex deployment was not updated** after commit `5fe624b` (the squash-merge of PR #2557) was pushed to `main`.

To resolve this: whoever manages the quera-dev environment needs to run `npx convex deploy` (or trigger the CI/CD pipeline) pointing at the quera-dev Convex project. Once the deployment completes, the function will be registered and "Załaduj przykłady" will work — creating exactly one "Gotowe – RODO" template if it does not already exist, or showing a neutral toast if it does.

No code changes are needed.