### PR TITLE
Expose error message in toast when setTreatmentProducts fails

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -478,6 +478,12 @@ function TreatmentDetail() {
             defaultValue:
               "Zabieg zapisany. Nie udało się zapisać preparatów/materiałów — otwórz zabieg i spróbuj ponownie.",
           }),
+          {
+            description: formatTreatmentError(productErr, t, {
+              key: "gabinet.treatments.errors.productsSaveFailedDetail",
+              defaultValue: "Nie udało się zapisać preparatów/materiałów.",
+            }),
+          },
         );
       }
     } catch (e) {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -538,6 +538,12 @@ function TreatmentsIndex() {
                 defaultValue:
                   "Zabieg zapisany. Nie udało się zapisać preparatów/materiałów — otwórz zabieg i spróbuj ponownie.",
               }),
+              {
+                description: formatTreatmentError(productErr, t, {
+                  key: "gabinet.treatments.errors.productsSaveFailedDetail",
+                  defaultValue: "Nie udało się zapisać preparatów/materiałów.",
+                }),
+              },
             );
           }
         }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2563.

Closes #2563

---

## Claude summary

Done. The bug was real and in two places.

In both `_layout.gabinet.treatments.$treatmentId.tsx` and `_layout.gabinet.treatments.index.tsx`, the `catch (productErr)` block after `setTreatmentProducts` showed an identical hardcoded Polish string regardless of whether the failure was a permission error, a validation error, a missing treatment, or anything else.

The fix adds the sanitized error as a Sonner `description` via the existing `formatTreatmentError` helper (already imported in both files). The main toast message is unchanged (keeping backward-compatible i18n keys and the "Zabieg zapisany" context), while the `description` now shows the categorized Polish error detail — e.g. "Brak uprawnień do tej operacji na zabiegu." for permission failures or field-specific messages for validation errors.