### PR TITLE
Check that admin error log page exists and is linked from settings

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1938,6 +1938,7 @@
     "team": "Team",
     "permissions": "Permissions",
     "auditLog": "Audit Log",
+    "errorLog": "Error Log",
     "email": "Email",
     "mail": "Mail",
     "sms": "SMS",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1941,6 +1941,7 @@
     "team": "Zespół",
     "permissions": "Uprawnienia",
     "auditLog": "Dziennik audytu",
+    "errorLog": "Dziennik błędów",
     "email": "Email",
     "mail": "Poczta",
     "sms": "SMS",

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -50,6 +50,7 @@ export function AppSidebar() {
 
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen (same pattern as dashboard layout)
   const { data: activeProducts } = useQuery(convexQuery(api.productSubscriptions.getActiveProducts, { organizationId }));
+  const { data: currentUser } = useQuery(convexQuery(api.app.getCurrentUser, {}));
 
   const visibleModules = getVisibleModules(activeProducts);
   const hasGabinet = visibleModules.some((module) => module.id === "gabinet");
@@ -77,6 +78,7 @@ export function AppSidebar() {
     .flatMap((module) => module.settingsNav)
     .filter((item) => {
       if (item.adminOnly && !isAdmin) return false;
+      if (item.platformAdminOnly && !currentUser?.isPlatformAdmin) return false;
       if (item.permissionFeature && !canView(item.permissionFeature)) return false;
       return true;
     });

--- a/src/modules/crm/manifest.ts
+++ b/src/modules/crm/manifest.ts
@@ -81,6 +81,7 @@ export const crmManifest: ModuleManifest = {
     { labelKey: "settingsNav.team", to: "/dashboard/settings/team" },
     { labelKey: "settingsNav.permissions", to: "/dashboard/settings/permissions", adminOnly: true },
     { labelKey: "settingsNav.auditLog", to: "/dashboard/settings/audit-log", adminOnly: true },
+    { labelKey: "settingsNav.errorLog", to: "/admin/errors", platformAdminOnly: true },
     { labelKey: "settingsNav.mail", to: "/dashboard/settings/mail", adminOnly: true },
     { labelKey: "settingsNav.automations", to: "/dashboard/settings/automations", adminOnly: true },
     { labelKey: "settingsNav.emailTemplates", to: "/dashboard/settings/email-templates" },

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -48,6 +48,7 @@ export interface ModuleSettingsNavItem {
   to: string;
   sectionKey?: string;
   adminOnly?: boolean;
+  platformAdminOnly?: boolean;
   permissionFeature?: Feature;
 }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2564.

Closes #2564

---

## Claude summary

The issue was real and has been fixed. Here's what was found and changed:

**Triage result:** The admin error log page at `/admin/errors` existed and was functional (with auto-refresh, filtering by source, expandable stack traces), and it was linked from the platform admin index at `/admin`. However, there was no way to discover the admin section from the normal app UI — no navigation item pointed to `/admin` for platform admins.

**Fix (5 files, 6 lines):**

- `src/modules/types.ts` — added `platformAdminOnly?: boolean` to `ModuleSettingsNavItem`
- `src/components/layout/app-sidebar.tsx` — queries `getCurrentUser` and filters settings nav items marked `platformAdminOnly` to only show them to platform admins
- `src/modules/crm/manifest.ts` — adds an "Error Log" entry in the settings nav (right after "Audit Log") pointing to `/admin/errors`, with `platformAdminOnly: true`
- `public/locales/en/translation.json` — adds `"errorLog": "Error Log"`
- `public/locales/pl/translation.json` — adds `"errorLog": "Dziennik błędów"`

Platform admins will now see an "Error Log" entry in the Settings sidebar next to the existing Audit Log link. Non-platform-admins don't see it. The admin page itself already enforces access control via `isPlatformAdmin`.