### PR TITLE
Ukrycie paska

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -808,21 +808,6 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
   return (
     <>
       <div className="flex h-dvh w-full flex-col overflow-hidden">
-        {/* Beta strip */}
-        <div
-          className="relative z-40 flex h-[30px] shrink-0 items-center overflow-hidden px-4 text-xs font-medium text-white"
-          style={{
-            background: "repeating-linear-gradient(-45deg, #7c3aed, #7c3aed 10px, #6d28d9 10px, #6d28d9 20px)",
-          }}
-        >
-          <span className="drop-shadow-sm">
-            Quera — v. active beta{" "}
-            <span className="mx-1.5 opacity-50">|</span>{" "}
-            <button onClick={() => setDevInfoOpen(true)} className="underline underline-offset-2 opacity-80 hover:opacity-100">
-              co to znaczy?
-            </button>
-          </span>
-        </div>
         {(firstOrg?.role === "owner" || firstOrg?.role === "admin") && (
           <MigrationHealthBanner />
         )}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2567.

Closes #2567

---

## Claude summary

Done. Removed the purple diagonal "active beta" banner strip from `src/routes/_app/_auth/dashboard/_layout.tsx:811-825`. It was a 30px-tall decorative bar rendered at the very top of every dashboard page. The `DevInfoDialog` it linked to is still wired up via `useEffect` and will still appear once for first-time visitors — only the persistent visible strip is gone.