### PR TITLE
CRM v1.0: Zmień nazwy ról w zapraszaniu członka zespołu

### DIFF
--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -996,8 +996,8 @@
       "invitationInfo": "Zaproszenie wyślemy e-mailem. Odbiorca będzie miał 7 dni na jego przyjęcie.",
       "roles": {
         "admin": "Administrator",
-        "member": "Członek",
-        "viewer": "Przeglądający"
+        "member": "Pracownik",
+        "viewer": "Tylko podgląd"
       },
       "module": "Moduł",
       "moduleNone": "Brak (tylko zaproszenie)",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2569.

Closes #2569

---

## Claude summary

Done. Changed two Polish labels in `public/locales/pl/translation.json` under `settings.team.roles` (the keys used exclusively by the invite form):

- `"member": "Członek"` → `"member": "Pracownik"`
- `"viewer": "Przeglądający"` → `"viewer": "Tylko podgląd"`

No logic, schema, or permissions were touched.

## Follow-ups

- Align `team.roles` labels with invite-form labels for consistency: The team members management page (`_layout.settings.team.tsx`) uses a separate `team.roles.*` key set that still shows "Członek" / "Przeglądający" when displaying existing members' roles — after this change a user invited as "Pracownik" will appear as "Członek" in the member list, which is inconsistent.