### PR TITLE
Align `team.roles` labels with invite-form labels for consistency

### DIFF
--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2302,8 +2302,8 @@
     "roles": {
       "owner": "Właściciel",
       "admin": "Administrator",
-      "member": "Członek",
-      "viewer": "Przeglądający"
+      "member": "Pracownik",
+      "viewer": "Tylko podgląd"
     },
     "invitedBy": "Zaproszony przez",
     "sentDate": "Wysłano",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2572.

Closes #2572

---

## Claude summary

The fix is clean and minimal. In `public/locales/pl/translation.json`, the `team.roles` block (used by `_layout.settings.team.tsx:315` to render badges for existing members) had stale Polish labels — "Członek" and "Przeglądający" — while the invite form updated in #2569 reads from `settings.team.roles` which already had "Pracownik" and "Tylko podgląd". The two lines are now aligned so a user invited as "Pracownik" will appear as "Pracownik" in the member list too.