### PR TITLE
CRM v1.0: Dodaj opcję „Pokazuj w kalendarzu” przy zapraszaniu pracownika

### DIFF
--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -78,6 +78,7 @@ export interface GabinetModuleData {
   categoryId?: string;
   locationId?: string;
   customFields?: Array<{ fieldDefinitionId: string; value: unknown }>;
+  showInCalendar?: boolean;
 }
 
 interface UserInvitationFormProps {
@@ -172,6 +173,7 @@ export function UserInvitationForm({
   const [categoryId, setCategoryId] = useState<Id<"categoryDefinitions"> | undefined>(undefined);
   const [locationId, setLocationId] = useState<string | undefined>(undefined);
   const [customFieldValues, setCustomFieldValues] = useState<Record<string, unknown>>({});
+  const [showInCalendar, setShowInCalendar] = useState(true);
   const [treatmentSearch, setTreatmentSearch] = useState("");
 
   const pendingCount = pendingInvitations?.length ?? 0;
@@ -232,6 +234,7 @@ export function UserInvitationForm({
         categoryId: categoryId || undefined,
         locationId: locationId || undefined,
         customFields: customFields.length > 0 ? customFields : undefined,
+        showInCalendar,
       };
     }
 
@@ -397,6 +400,24 @@ export function UserInvitationForm({
                   />
                 ))}
               </div>
+            </div>
+
+            <div className="space-y-1.5 sm:col-span-2">
+              <label className="flex items-start gap-3 cursor-pointer">
+                <Checkbox
+                  className="mt-0.5 h-5 w-5"
+                  checked={showInCalendar}
+                  onCheckedChange={(checked) => setShowInCalendar(checked === true)}
+                />
+                <span className="flex flex-col gap-0.5">
+                  <span className="text-sm font-medium leading-none">
+                    {t("gabinet.employees.showInCalendar")}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {t("gabinet.employees.showInCalendarHint")}
+                  </span>
+                </span>
+              </label>
             </div>
 
             {locations && locations.filter((l) => l.isActive).length > 0 && (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2570.

Closes #2570

---

## Claude summary

The fix is in. Here's what changed and why it works end-to-end:

**Root cause:** `GabinetModuleData` interface in `user-invitation-form.tsx` was missing the `showInCalendar` field. The backend (`convex/gabinet/employees.ts` → `_createFromInvitation`) already handled it — it was just never passed from the invite form.

**Changes to `src/components/forms/user-invitation-form.tsx`:**
1. Added `showInCalendar?: boolean` to the `GabinetModuleData` interface (line 81)
2. Added `const [showInCalendar, setShowInCalendar] = useState(true)` state, defaulting to `true` (line 176)
3. Added `showInCalendar` to the `moduleData` object built in `handleSubmit` (line 237)
4. Added the checkbox in the calendar-color section of the Gabinet form block, reusing the same i18n keys (`gabinet.employees.showInCalendar` / `gabinet.employees.showInCalendarHint`) and the same visual pattern as the existing employee edit form

No schema changes, no migration, no new i18n keys, no calendar logic touched — exactly as scoped in the issue.