### PR TITLE
CRM v1.0: Zwiększ limit miejsc dla pracowników do 20

### DIFF
--- a/convex/_helpers/seatLimits.ts
+++ b/convex/_helpers/seatLimits.ts
@@ -57,7 +57,7 @@ export async function checkSeatLimit(
     .first();
 
   // Fail open: default to free tier limit if subscription data is unavailable.
-  let seatLimit = 5; // Default free tier
+  let seatLimit = 20; // Default free tier
   if (subscription) {
     const plan = await ctx.db.get(subscription.planId);
     if (plan) {

--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -178,7 +178,7 @@ export function UserInvitationForm({
 
   const pendingCount = pendingInvitations?.length ?? 0;
   const totalUsers = seatUsage?.currentSeats ?? 0;
-  const seatLimit = seatUsage?.seatLimit ?? 5;
+  const seatLimit = seatUsage?.seatLimit ?? 20;
   const isNearLimit = seatUsage
     ? seatUsage.currentSeats >= seatUsage.seatLimit - 2 && seatUsage.canAddMore
     : false;

--- a/tests/convex/seatLimits.test.ts
+++ b/tests/convex/seatLimits.test.ts
@@ -20,7 +20,7 @@ describe("checkSeatLimit via getSeatUsage", () => {
       .query(api.organizations.getSeatUsage, { organizationId });
 
     expect(usage.currentSeats).toBe(1);
-    expect(usage.seatLimit).toBe(5); // free tier default
+    expect(usage.seatLimit).toBe(20); // free tier default
     expect(usage.canAddMore).toBe(true);
   });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2575.

Closes #2575

---

## Claude summary

Done. Three files changed, all in the same one-line way:

- `convex/_helpers/seatLimits.ts:60` — default fallback limit `5 → 20` (used when no active subscription is found)
- `src/components/forms/user-invitation-form.tsx:181` — UI-side fallback `?? 5 → ?? 20` (used when the query hasn't resolved yet)
- `tests/convex/seatLimits.test.ts:23` — test expectation updated to match the new default

Organizations with an explicit plan (`seatLimit` on the `plans` row) are unaffected — only the free-tier / no-subscription fallback path changed.