### PR TITLE
Update ROLES array in employee detail page to use new role list

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -96,7 +96,7 @@ export const Route = createFileRoute(
   component: () => <PermissionGate feature="gabinet_employees" action="view"><EmployeeDetail /></PermissionGate>,
 });
 
-const ROLES = ["doctor", "nurse", "therapist", "receptionist", "admin", "other"] as const;
+const ROLES = ["cosmetologist", "doctor", "receptionist", "manager"] as const;
 
 function EmployeeDetail() {
   const { employeeId } = Route.useParams();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2581.

Closes #2581

---

## Claude summary

Done. The fix is a one-line change at `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx:99` — the old 6-role array `["doctor", "nurse", "therapist", "receptionist", "admin", "other"]` is replaced with the current 4-role list `["cosmetologist", "doctor", "receptionist", "manager"]` that matches `src/components/forms/employee-form.tsx:37`. Both selects in the detail page (the inline edit at line 1450 and the modal edit at line 2135) use this array, so both are fixed by the single change. All four roles have existing translations under `gabinet.employees.roles.*` in both `en` and `pl` locales.

## Follow-ups

- Align `EMPLOYEE_ROLES` in `src/lib/options.ts` with new role list: `src/lib/options.ts:19` still exports the old 6-role array and may be used elsewhere, creating a third source of truth that can drift again.