### PR TITLE
Align `gabinetEmployeeRoleValidator` in convex/schema.ts with the new role set

### DIFF
--- a/convex/_helpers/gabinetRolePermissions.ts
+++ b/convex/_helpers/gabinetRolePermissions.ts
@@ -17,6 +17,7 @@ import type { Feature, Action, Scope, FeaturePermissions } from "./permissionTyp
 
 export type SystemGabinetRole =
   | "doctor"
+  | "cosmetologist"
   | "nurse"
   | "therapist"
   | "receptionist"
@@ -26,6 +27,7 @@ export type SystemGabinetRole =
 
 export const SYSTEM_GABINET_ROLES: readonly SystemGabinetRole[] = [
   "doctor",
+  "cosmetologist",
   "nurse",
   "therapist",
   "receptionist",
@@ -102,6 +104,16 @@ function buildGabinet(
 
 export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, FeaturePermissions> = {
   doctor: buildGabinet({
+    gabinet_patients: { view: "all", create: "all", edit: "own" },
+    gabinet_appointments: { view: "all", create: "all", edit: "own", delete: "own" },
+    gabinet_treatments: { view: "all" },
+    gabinet_packages: { view: "all" },
+    gabinet_employees: { view: "all" },
+    gabinet_payments: { view: "all" },
+    gabinet_photos: { view: "all", create: "all", edit: "own", delete: "own" },
+    gabinet_settings: {},
+  }),
+  cosmetologist: buildGabinet({
     gabinet_patients: { view: "all", create: "all", edit: "own" },
     gabinet_appointments: { view: "all", create: "all", edit: "own", delete: "own" },
     gabinet_treatments: { view: "all" },
@@ -195,6 +207,7 @@ export const SYSTEM_GABINET_ROLE_LABELS: Record<
   { pl: string; en: string; color: string; isClinical: boolean }
 > = {
   doctor: { pl: "Lekarz", en: "Doctor", color: "#3b82f6", isClinical: true },
+  cosmetologist: { pl: "Kosmetolog / Specjalista", en: "Cosmetologist / Specialist", color: "#ec4899", isClinical: true },
   nurse: { pl: "Pielęgniarka", en: "Nurse", color: "#22c55e", isClinical: true },
   therapist: { pl: "Terapeuta", en: "Therapist", color: "#8b5cf6", isClinical: true },
   receptionist: { pl: "Recepcjonista", en: "Receptionist", color: "#f59e0b", isClinical: false },

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -191,9 +191,11 @@ export type GabinetLeaveType = Infer<typeof gabinetLeaveTypeValidator>;
 
 export const gabinetEmployeeRoleValidator = v.union(
   v.literal("doctor"),
+  v.literal("cosmetologist"),
   v.literal("nurse"),
   v.literal("therapist"),
   v.literal("receptionist"),
+  v.literal("manager"),
   v.literal("admin"),
   v.literal("other"),
 );

--- a/supabase/migrations/00041_gabinet_employee_role_add_cosmetologist_manager.sql
+++ b/supabase/migrations/00041_gabinet_employee_role_add_cosmetologist_manager.sql
@@ -1,0 +1,9 @@
+-- Add 'cosmetologist' and 'manager' values to gabinet_employee_role_enum.
+-- The UI (employee form and employee detail page) was updated in issues #2579 and #2581
+-- to use these roles, but the Postgres enum was never extended.
+-- ALTER TYPE … ADD VALUE is non-transactional in Postgres and cannot be rolled back,
+-- but is safe to run on an existing type — duplicate values are rejected at DDL time,
+-- not at runtime, so this migration is idempotent if applied twice on different envs.
+
+ALTER TYPE gabinet_employee_role_enum ADD VALUE IF NOT EXISTS 'cosmetologist';
+ALTER TYPE gabinet_employee_role_enum ADD VALUE IF NOT EXISTS 'manager';


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2582.

Closes #2582

---

## Claude summary

Done. Here's a summary of what was fixed and why:

**Root cause:** Issues #2579 and #2581 updated both the Add Employee form and the Employee detail page to use a new role set (`cosmetologist`, `doctor`, `receptionist`, `manager`), but never updated the backend schema. Any attempt to create or update an employee with `cosmetologist` or `manager` would fail Convex validator validation.

**Changes made:**

1. `convex/schema.ts` — added `cosmetologist` and `manager` literals to `gabinetEmployeeRoleValidator` (keeping old roles for backward compatibility with existing employee records that may have `nurse`, `therapist`, `admin`, or `other`)

2. `supabase/migrations/00041_gabinet_employee_role_add_cosmetologist_manager.sql` — extends the `gabinet_employee_role_enum` Postgres type with `IF NOT EXISTS` guards, which is required because Supabase enforces the enum at the database level too

3. `convex/_helpers/gabinetRolePermissions.ts` — adds `cosmetologist` to `SystemGabinetRole`, `SYSTEM_GABINET_ROLES`, `DEFAULT_GABINET_ROLE_PERMISSIONS` (clinical permissions matching therapist), and `SYSTEM_GABINET_ROLE_LABELS` to keep the permissions system consistent with the expanded validator