### PR TITLE
Align `EMPLOYEE_ROLES` in `src/lib/options.ts` with new role list

### DIFF
--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -16,7 +16,7 @@ export const COMPANY_SIZES = ["1-10", "11-50", "51-200", "201-500", "501-1000", 
 
 export const GENDERS = ["male", "female", "other"] as const;
 
-export const EMPLOYEE_ROLES = ["doctor", "nurse", "therapist", "receptionist", "admin", "other"] as const;
+export const EMPLOYEE_ROLES = ["doctor", "cosmetologist", "nurse", "therapist", "receptionist", "manager", "admin", "other"] as const;
 
 export const APPOINTMENT_STATUSES = ["scheduled", "confirmed", "in_progress", "completed", "cancelled", "no_show"] as const;
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2584.

Closes #2584

---

## Claude summary

The fix is committed. `EMPLOYEE_ROLES` in `src/lib/options.ts:19` now has all 8 roles — `cosmetologist` and `manager` were missing from the old 6-role array. The updated array matches `gabinetEmployeeRoleValidator` in `convex/schema.ts` and `SYSTEM_GABINET_ROLES` in `convex/_helpers/gabinetRolePermissions.ts`. Translation keys for both new roles already existed in both PL and EN, so the timetable filter and employee list filters will display them correctly.

## Follow-ups

- Align `ROLES` in `employee-form.tsx` and `$employeeId.tsx` with the full 8-role list: both files define a local 4-role `ROLES = ["cosmetologist", "doctor", "receptionist", "manager"]` that omits `nurse`, `therapist`, `admin`, and `other`, meaning those roles can't be assigned via the UI even though the schema accepts them
- Fix stale `allowedRoles` array in `convex/gabinet/employees.ts:320`: still uses the old 6-role list `["doctor", "nurse", "therapist", "receptionist", "admin", "other"]`, missing `cosmetologist` and `manager`, so server-side validation would reject those roles even if the form sends them