### PR TITLE
Align `ROLES` in `employee-form.tsx` and `$employeeId.tsx` with the full 8-role 

### DIFF
--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -34,7 +34,7 @@ import {
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { Search } from "@/lib/ez-icons";
 
-const ROLES = ["cosmetologist", "doctor", "receptionist", "manager"] as const;
+const ROLES = ["doctor", "cosmetologist", "nurse", "therapist", "receptionist", "manager", "admin", "other"] as const;
 type EmployeeRole = (typeof ROLES)[number];
 
 interface TagDef {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -96,7 +96,7 @@ export const Route = createFileRoute(
   component: () => <PermissionGate feature="gabinet_employees" action="view"><EmployeeDetail /></PermissionGate>,
 });
 
-const ROLES = ["cosmetologist", "doctor", "receptionist", "manager"] as const;
+const ROLES = ["doctor", "cosmetologist", "nurse", "therapist", "receptionist", "manager", "admin", "other"] as const;
 
 function EmployeeDetail() {
   const { employeeId } = Route.useParams();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2587.

Closes #2587

---

## Claude summary

The bug was real and is now fixed. Both files had a 4-role `ROLES` array `["cosmetologist", "doctor", "receptionist", "manager"]` that omitted `nurse`, `therapist`, `admin`, and `other`. Both are now updated to the full 8-role list matching `gabinetEmployeeRoleValidator` in `convex/schema.ts:192-201`.

Files changed:
- `src/components/forms/employee-form.tsx:37` — the Add Employee form's role select
- `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx:99` — the employee detail page's role selects (used in two places within that file at lines 1450 and 2135)