### PR TITLE
Fix stale `allowedRoles` array in `convex/gabinet/employees.ts

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -317,7 +317,7 @@ export const _createFromInvitation = internalAction({
       Array.isArray(v) ? (v.filter((x) => typeof x === "string") as string[]) : null;
 
     const role = asString(d.role) ?? "doctor";
-    const allowedRoles = ["doctor", "nurse", "therapist", "receptionist", "admin", "other"];
+    const allowedRoles = ["doctor", "cosmetologist", "nurse", "therapist", "receptionist", "manager", "admin", "other"];
     const safeRole = allowedRoles.includes(role) ? role : "doctor";
 
     const now = Date.now();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2588.

Closes #2588

---

## Claude summary

Bug confirmed and fixed. `convex/gabinet/employees.ts:320` had a hand-written `allowedRoles` array that missed `cosmetologist` and `manager` — the two roles added to `gabinetEmployeeRoleValidator` in the schema but never backported to this internal action. Any employee created via invitation with either of those roles would have silently had their role coerced to `"doctor"`. The fix adds both missing values to match the full 8-role schema.