### PR TITLE
CRM v1.0: Dodaj opcję „Nadaj dostęp do systemu” w formularzu „Dodaj pracownika”

### DIFF
--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -146,6 +146,7 @@ export function EmployeeForm({
   const [tagIds, setTagIds] = useState<Id<"tagDefinitions">[]>(initialData?.tagIds ?? []);
   const [categoryId, setCategoryId] = useState<Id<"categoryDefinitions"> | undefined>(initialData?.categoryId);
   const [treatmentSearch, setTreatmentSearch] = useState("");
+  const [grantSystemAccess, setGrantSystemAccess] = useState(false);
 
   const filteredTreatments = useMemo(() => {
     if (!treatments) return [];
@@ -467,6 +468,23 @@ export function EmployeeForm({
           />
         </div>
       )}
+
+      {/* System access */}
+      <div className="space-y-2 rounded-md border p-4">
+        <p className="text-sm font-medium">
+          {t("gabinet.employees.systemAccess", { defaultValue: "Dostęp do systemu" })}
+        </p>
+        <label className="flex items-start gap-3 cursor-pointer">
+          <Checkbox
+            className="mt-0.5 h-5 w-5"
+            checked={grantSystemAccess}
+            onCheckedChange={(checked) => setGrantSystemAccess(checked === true)}
+          />
+          <span className="text-sm leading-none pt-0.5">
+            {t("gabinet.employees.grantSystemAccess", { defaultValue: "Nadaj dostęp do systemu" })}
+          </span>
+        </label>
+      </div>
 
       <div className="flex justify-end gap-2 pt-2">
         <Button type="button" variant="outline" onClick={onCancel}>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2591.

Closes #2591

---

## Claude summary

Done. Here's what was changed in `src/components/forms/employee-form.tsx`:

1. Added `grantSystemAccess` state variable initialised to `false` (line ~149).
2. Added a new "Dostęp do systemu" section with a bordered card just above the action buttons (lines 472–487). The section contains a checkbox labelled "Nadaj dostęp do systemu", unchecked by default.

The checkbox uses the already-imported `Checkbox` component and follows the exact same pattern as the existing `showInCalendar` checkbox. It does not affect `handleSubmit`, the backend, schema, or any invitation logic — purely a UI placeholder for the next stage.