### PR TITLE
CRM v1.0: Połącz opcję „Nadaj dostęp do systemu” z wysyłką zaproszenia

### DIFF
--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -73,6 +73,9 @@ export interface EmployeeFormData {
   qualifiedTreatmentIds: Id<"gabinetTreatments">[];
   tagIds?: Id<"tagDefinitions">[];
   categoryId?: Id<"categoryDefinitions">;
+  grantSystemAccess?: boolean;
+  accessEmail?: string;
+  accessRole?: "admin" | "member" | "viewer";
 }
 
 interface EmployeeFormProps {
@@ -159,7 +162,7 @@ export function EmployeeForm({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (requireUserSelection && !userId) return;
+    if (requireUserSelection && !userId && !(grantSystemAccess && accessEmail.trim())) return;
 
     const isClinicalRole = role !== "receptionist" && role !== "manager";
 
@@ -177,6 +180,9 @@ export function EmployeeForm({
         : [],
       tagIds: tagIds.length > 0 ? tagIds : undefined,
       categoryId: categoryId || undefined,
+      grantSystemAccess: grantSystemAccess || undefined,
+      accessEmail: grantSystemAccess ? (accessEmail.trim() || undefined) : undefined,
+      accessRole: grantSystemAccess ? accessRole : undefined,
     });
   };
 
@@ -531,7 +537,11 @@ export function EmployeeForm({
         </Button>
         <Button
           type="submit"
-          disabled={(requireUserSelection && !userId) || isSubmitting}
+          disabled={
+            isSubmitting ||
+            (grantSystemAccess && !accessEmail.trim()) ||
+            (!grantSystemAccess && requireUserSelection && !userId)
+          }
         >
           {isSubmitting
             ? t("common.saving")

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -527,6 +527,7 @@ function CreateEmployeeSheet({
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const createEmployee = useAction(api.gabinet.employees.create);
+  const createInvitation = useAction(api.invitations.create);
   const [saving, setSaving] = useState(false);
 
   return (
@@ -544,18 +545,47 @@ function CreateEmployeeSheet({
             isSubmitting={saving}
             onCancel={onClose}
             onSubmit={async (data) => {
-              if (!data.userId) return;
+              const shouldInvite = !!(data.grantSystemAccess && data.accessEmail);
+              if (!data.userId && !shouldInvite) return;
               setSaving(true);
               try {
-                await createEmployee({
-                  organizationId,
-                  ...data,
-                  userId: data.userId,
-                });
-                toast.success(t("common.created"));
-                void queryClient.invalidateQueries({
-                  queryKey: supabaseKeys.gabinetEmployees.list(organizationId),
-                });
+                if (data.userId) {
+                  await createEmployee({
+                    organizationId,
+                    ...data,
+                    userId: data.userId,
+                  });
+                  toast.success(t("common.created"));
+                  void queryClient.invalidateQueries({
+                    queryKey: supabaseKeys.gabinetEmployees.list(organizationId),
+                  });
+                }
+                if (shouldInvite) {
+                  await createInvitation({
+                    organizationId,
+                    email: data.accessEmail!,
+                    role: data.accessRole ?? "member",
+                    module: "gabinet",
+                    moduleData: {
+                      firstName: data.firstName,
+                      lastName: data.lastName,
+                      role: data.role,
+                      specialization: data.specialization,
+                      color: data.color,
+                      showInCalendar: data.showInCalendar,
+                      qualifiedTreatmentIds: data.qualifiedTreatmentIds,
+                      tagIds: data.tagIds,
+                      categoryId: data.categoryId,
+                    },
+                  });
+                  toast.success(t("team.invitationSent"));
+                  void queryClient.invalidateQueries({
+                    queryKey: supabaseKeys.invitations.list(organizationId),
+                  });
+                  void queryClient.invalidateQueries({
+                    queryKey: supabaseKeys.teamMemberships.list(organizationId),
+                  });
+                }
                 onClose();
               } catch (e) {
                 toast.error(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2595.

Closes #2595

---

## Claude summary

Done. Here's a summary of what was changed:

**Problem**: The "Grant system access" checkbox and its email/role fields in the employee form were purely cosmetic — saving the form did nothing with those values.

**Changes in `src/components/forms/employee-form.tsx`:**
- Added `grantSystemAccess`, `accessEmail`, and `accessRole` to `EmployeeFormData` so the parent receives them
- Updated `handleSubmit` to allow submission without a userId when `grantSystemAccess + accessEmail` are filled
- Updated the submit button disabled condition: disables when "Grant system access" is checked but email is empty, or when it's not checked and no user is selected

**Changes in `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx`:**
- Added `createInvitation = useAction(api.invitations.create)` to `CreateEmployeeSheet`
- The `onSubmit` handler now:
  - If a userId was selected: creates the employee record as before
  - If "Grant system access" is checked with an email: calls `createInvitation` with `module: "gabinet"` and the employee form data as `moduleData` — exactly the same payload the "Invite team member" form sends. When the invitee accepts, `_createFromInvitation` auto-creates their gabinet employee record (idempotent, so no duplicate if a userId was also selected)
  - Invalidates invitation and team membership caches on success