### PR TITLE
CRM v1.0: Usuń obowiązkowy wybór członka zespołu z formularza „Dodaj pracownika”

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -162,7 +162,7 @@ export const getByUserId = action({
 export const create = action({
   args: {
     organizationId: v.id("organizations"),
-    userId: v.string(),
+    userId: v.optional(v.string()),
     firstName: v.optional(v.string()),
     lastName: v.optional(v.string()),
     role: gabinetEmployeeRoleValidator,
@@ -195,19 +195,21 @@ export const create = action({
     const now = Date.now();
     const db = createSupabaseDb();
 
-    // --- Check if employee already exists (via Supabase) ---
-    const existing = await db.query("gabinetEmployees")
-      .eq("organizationId", String(args.organizationId))
-      .eq("userId", args.userId)
-      .collect();
-    if (existing.length > 0) {
-      throw new Error("Employee profile already exists for this user");
+    // --- Check if employee already exists (only when a user is linked) ---
+    if (args.userId) {
+      const existing = await db.query("gabinetEmployees")
+        .eq("organizationId", String(args.organizationId))
+        .eq("userId", args.userId)
+        .collect();
+      if (existing.length > 0) {
+        throw new Error("Employee profile already exists for this user");
+      }
     }
 
     // --- INSERT employee directly to Supabase ---
     const employeeId = await db.insert("gabinetEmployees", {
       organizationId: String(args.organizationId),
-      userId: args.userId,
+      userId: args.userId ?? null,
       firstName: args.firstName ?? null,
       lastName: args.lastName ?? null,
       role: args.role,
@@ -239,15 +241,17 @@ export const create = action({
 
     // --- Mirror role into Convex `gabinetMemberships` so checkPermission
     //     can resolve the user's gabinet-role (it can't reach Supabase). ---
-    try {
-      await ctx.runMutation(internal.gabinet.employees._upsertMembership, {
-        organizationId: args.organizationId,
-        userId: args.userId,
-        gabinetRole: args.role,
-        isActive: true,
-      });
-    } catch (e) {
-      console.error("[employees.create] Membership mirror FAILED:", e);
+    if (args.userId) {
+      try {
+        await ctx.runMutation(internal.gabinet.employees._upsertMembership, {
+          organizationId: args.organizationId,
+          userId: args.userId,
+          gabinetRole: args.role,
+          isActive: true,
+        });
+      } catch (e) {
+        console.error("[employees.create] Membership mirror FAILED:", e);
+      }
     }
 
     return employeeId;

--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -1,9 +1,7 @@
 import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { convexQuery } from "@convex-dev/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { toast } from "sonner";
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
@@ -18,20 +16,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
-import {
-  UserInvitationForm,
-  type UserInvitationFormData,
-} from "@/components/forms/user-invitation-form";
-import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { Search } from "@/lib/ez-icons";
 
 const ROLES = ["doctor", "cosmetologist", "nurse", "therapist", "receptionist", "manager", "admin", "other"] as const;
@@ -83,8 +69,6 @@ interface EmployeeFormProps {
   onSubmit: (data: EmployeeFormData) => void;
   onCancel: () => void;
   isSubmitting?: boolean;
-  /** If true, user selection is required (create mode). If false, user is pre-selected (edit mode). */
-  requireUserSelection?: boolean;
   tagDefinitions?: TagDef[];
   categoryDefinitions?: CategoryDef[];
 }
@@ -94,23 +78,11 @@ export function EmployeeForm({
   onSubmit,
   onCancel,
   isSubmitting = false,
-  requireUserSelection = true,
   tagDefinitions = [],
   categoryDefinitions = [],
 }: EmployeeFormProps) {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
-
-  // Fetch organization members and existing employees
-  const { data: members } = useQuery(
-    convexQuery(api.organizations.getMembers, { organizationId })
-  );
-  const listEmployees = useAction(api.gabinet.employees.listAll);
-  const { data: employees } = useQuery({
-    queryKey: ["gabinet.employees.listAll", organizationId],
-    queryFn: () => listEmployees({ organizationId }),
-    enabled: !!organizationId,
-  });
 
   const listActiveTreatments = useAction(api.gabinet.treatments.listActive);
   const { data: treatments } = useQuery({
@@ -119,21 +91,6 @@ export function EmployeeForm({
     enabled: !!organizationId,
   });
 
-  // Users not yet registered as employees (for create mode)
-  const availableUsers = useMemo(() => {
-    if (!members || !employees) return [];
-    const empUserIds = new Set(employees.map((e) => e.userId));
-    return members
-      .filter((m) => m.user && !empUserIds.has(m.userId))
-      .map((m) => ({ _id: m.userId, name: m.user!.name, email: m.user!.email }));
-  }, [members, employees]);
-
-  const queryClient = useQueryClient();
-  const createInvitation = useAction(api.invitations.create);
-  const [inviteOpen, setInviteOpen] = useState(false);
-  const [isSendingInvite, setIsSendingInvite] = useState(false);
-
-  const [userId, setUserId] = useState<string>(initialData?.userId ?? "");
   const [firstName, setFirstName] = useState(initialData?.firstName ?? "");
   const [lastName, setLastName] = useState(initialData?.lastName ?? "");
   const [role, setRole] = useState<EmployeeRole>(initialData?.role ?? "doctor");
@@ -162,12 +119,10 @@ export function EmployeeForm({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (requireUserSelection && !userId && !(grantSystemAccess && accessEmail.trim())) return;
 
     const isClinicalRole = role !== "receptionist" && role !== "manager";
 
     onSubmit({
-      userId: userId as Id<"users"> | undefined,
       firstName: firstName || undefined,
       lastName: lastName || undefined,
       role,
@@ -196,86 +151,6 @@ export function EmployeeForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-5">
-      {/* User selection (only for create mode) */}
-      {requireUserSelection && (
-        <div className="space-y-1.5">
-          <Label>
-            {t("gabinet.employees.selectUser")} <span className="text-destructive">*</span>
-          </Label>
-          <Select value={userId} onValueChange={setUserId}>
-            <SelectTrigger>
-              <SelectValue placeholder={t("gabinet.employees.selectUserPlaceholder")} />
-            </SelectTrigger>
-            <SelectContent>
-              {availableUsers.map((u) => (
-                <SelectItem key={u._id} value={u._id}>
-                  {u.name || u.email}
-                </SelectItem>
-              ))}
-              {availableUsers.length === 0 && (
-                <SelectItem value="_none" disabled>
-                  {t("gabinet.employees.noAvailableUsers")}
-                </SelectItem>
-              )}
-            </SelectContent>
-          </Select>
-          <p className="text-xs text-muted-foreground">
-            {availableUsers.length === 0 && (
-              <>{t("gabinet.employees.allUsersRegistered")}{" "}</>
-            )}
-            <button
-              type="button"
-              onClick={() => setInviteOpen(true)}
-              className="text-brand-secondary underline hover:no-underline"
-            >
-              {t("gabinet.employees.inviteTeamMember", { defaultValue: "Zaproś nowego członka zespołu" })}
-            </button>
-          </p>
-        </div>
-      )}
-
-      {requireUserSelection && (
-        <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
-          <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
-            <DialogHeader>
-              <DialogTitle>{t("team.inviteDialog.title")}</DialogTitle>
-              <DialogDescription>
-                {t("team.inviteDialog.description")}
-              </DialogDescription>
-            </DialogHeader>
-            <UserInvitationForm
-              defaultModule="gabinet"
-              isSubmitting={isSendingInvite}
-              onCancel={() => setInviteOpen(false)}
-              onSubmit={async (data: UserInvitationFormData) => {
-                setIsSendingInvite(true);
-                try {
-                  await createInvitation({
-                    organizationId,
-                    email: data.email,
-                    role: data.role as "admin" | "member" | "viewer" | "owner",
-                    module: data.module,
-                    moduleData: data.moduleData,
-                  });
-                  toast.success(t("team.invitationSent"));
-                  void queryClient.invalidateQueries({
-                    queryKey: supabaseKeys.invitations.list(organizationId),
-                  });
-                  void queryClient.invalidateQueries({
-                    queryKey: supabaseKeys.teamMemberships.list(organizationId),
-                  });
-                  setInviteOpen(false);
-                } catch (e) {
-                  toast.error(e instanceof Error ? e.message : String(e));
-                } finally {
-                  setIsSendingInvite(false);
-                }
-              }}
-            />
-          </DialogContent>
-        </Dialog>
-      )}
-
       {/* Name fields */}
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="space-y-1.5">
@@ -539,8 +414,7 @@ export function EmployeeForm({
           type="submit"
           disabled={
             isSubmitting ||
-            (grantSystemAccess && !accessEmail.trim()) ||
-            (!grantSystemAccess && requireUserSelection && !userId)
+            (grantSystemAccess && !accessEmail.trim())
           }
         >
           {isSubmitting

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -546,10 +546,9 @@ function CreateEmployeeSheet({
             onCancel={onClose}
             onSubmit={async (data) => {
               const shouldInvite = !!(data.grantSystemAccess && data.accessEmail);
-              if (!data.userId && !shouldInvite) return;
               setSaving(true);
               try {
-                if (data.userId) {
+                if (!shouldInvite) {
                   await createEmployee({
                     organizationId,
                     ...data,

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -593,7 +593,6 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
           return (
             <EmployeeForm
               onSubmit={async (data) => {
-                if (!data.userId) return;
                 setIsCreating(true);
                 try {
                   await createEmployee({ organizationId: orgId, ...data, userId: data.userId });

--- a/supabase/migrations/00042_gabinet_employees_nullable_user_id.sql
+++ b/supabase/migrations/00042_gabinet_employees_nullable_user_id.sql
@@ -1,0 +1,5 @@
+-- Allow gabinet_employees to be created without a linked user account.
+-- When system access is not granted the user_id stays NULL; the unique index
+-- still prevents duplicate user→org links when user_id IS provided because
+-- Postgres treats each NULL as distinct in a unique index.
+ALTER TABLE gabinet_employees ALTER COLUMN user_id DROP NOT NULL;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2597.

Closes #2597

---

## Claude summary

Done. Here's a summary of what changed across 5 files:

**Problem confirmed:** The "Add Employee" form required selecting an existing team member (user account) before any other fields could be used, making it impossible to create a standalone employee record.

**Changes made:**

- `supabase/migrations/00042_gabinet_employees_nullable_user_id.sql` — drops the `NOT NULL` constraint on `gabinet_employees.user_id` so employees can exist without a linked user account
- `convex/gabinet/employees.ts` — `userId` argument is now `v.optional(v.string())`; the duplicate-user guard and `gabinetMemberships` mirror are skipped when no userId is provided
- `src/components/forms/employee-form.tsx` — removed the entire "Wybierz członka zespołu" section, the "Brak dostępnych użytkowników"/"Wszyscy zarejestrowani" messages, the "Zaproś nowego członka zespołu" link and its embedded dialog, and the `requireUserSelection` prop; ~120 lines of code removed
- `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx` — `CreateEmployeeSheet` now calls `createEmployee` for all non-invite paths (no longer gated on `data.userId`)
- `src/routes/_app/_auth/dashboard/_layout.tsx` — quick-create handler no longer bails when `data.userId` is absent

The workflow is now exactly as requested: fill in employee details → optionally check "Nadaj dostęp do systemu" → save. No team member pre-selection needed.

## Follow-ups

- Handle `grantSystemAccess` in the quick-create handler in `_layout.tsx`: the quick-create form shows the system access checkbox, but `_layout.tsx:595-611` only calls `createEmployee` and never sends an invitation — if a user fills in the email there, the invitation is silently dropped