### PR TITLE
Handle `grantSystemAccess` in the quick-create handler in `_layout.tsx`

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -594,9 +594,32 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
             <EmployeeForm
               onSubmit={async (data) => {
                 setIsCreating(true);
+                const shouldInvite = !!(data.grantSystemAccess && data.accessEmail);
                 try {
-                  await createEmployee({ organizationId: orgId, ...data, userId: data.userId });
-                  void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetEmployees.list(orgId) });
+                  if (!shouldInvite) {
+                    await createEmployee({ organizationId: orgId, ...data, userId: data.userId });
+                    void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetEmployees.list(orgId) });
+                  } else {
+                    await createInvitation({
+                      organizationId: orgId,
+                      email: data.accessEmail!,
+                      role: data.accessRole ?? "member",
+                      module: "gabinet",
+                      moduleData: {
+                        firstName: data.firstName,
+                        lastName: data.lastName,
+                        role: data.role,
+                        specialization: data.specialization,
+                        color: data.color,
+                        showInCalendar: data.showInCalendar,
+                        qualifiedTreatmentIds: data.qualifiedTreatmentIds,
+                        tagIds: data.tagIds,
+                        categoryId: data.categoryId,
+                      },
+                    });
+                    void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(orgId) });
+                    void queryClient.invalidateQueries({ queryKey: supabaseKeys.teamMemberships.list(orgId) });
+                  }
                   opts.onSuccess();
                 } catch (e) {
                   toast.error(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2599.

Closes #2599

---

## Claude summary

The bug was real and is now fixed. Here's a summary:

**Root cause:** `_layout.tsx:595-611` — the quick-create `onSubmit` handler for the `"employee"` case always called `createEmployee`, completely ignoring `data.grantSystemAccess` and `data.accessEmail`. Any invitation the user filled in was silently dropped.

**Fix:** Mirrored the exact logic already present in `CreateEmployeeSheet` (`_layout.gabinet.employees.index.tsx:548-587`): compute `shouldInvite = !!(data.grantSystemAccess && data.accessEmail)`, then branch — if no invitation needed, call `createEmployee` as before; otherwise call `createInvitation` with the `moduleData` payload and invalidate the invitations/teamMemberships caches.

Both `createEmployee` and `createInvitation` were already wired up in the component (lines 229 and 234), so no new imports were needed.