### PR TITLE
CRM v1.0: Napraw zmianę roli członka zespołu

### DIFF
--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -360,6 +360,22 @@ export const _updateMemberRoleInternal = internalMutation({
 
     await ctx.db.patch(args.membershipId, { role: args.role });
 
+    // Mirror updated role to Supabase — the UI reads team_memberships from
+    // Supabase via useSupabaseOrganizationMembers, so without this the role
+    // badge stays stale after a role change.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.supabase.organizations.writeTeamMembershipToSupabase,
+      {
+        membershipId: String(args.membershipId),
+        userId: String(membership.userId),
+        organizationId: String(args.organizationId),
+        role: args.role,
+        invitedBy: membership.invitedBy ? String(membership.invitedBy) : undefined,
+        joinedAt: membership.joinedAt ?? Date.now(),
+      },
+    );
+
     await logActivity(ctx, {
       organizationId: args.organizationId,
       entityType: "organization",

--- a/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
@@ -108,12 +108,18 @@ function TeamSettings() {
     membershipId: Id<"teamMemberships">,
     role: string
   ) => {
-    await updateRole({
-      organizationId,
-      membershipId,
-      role: role as "admin" | "member" | "viewer" | "owner",
-    });
-    void queryClient.invalidateQueries({ queryKey: supabaseKeys.teamMemberships.list(organizationId) });
+    try {
+      await updateRole({
+        organizationId,
+        membershipId,
+        role: role as "admin" | "member" | "viewer" | "owner",
+      });
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.teamMemberships.list(organizationId) });
+      toast.success(t("team.roleUpdated", { defaultValue: "Rola została zmieniona" }));
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      toast.error(message);
+    }
   };
 
   const handleChangePendingRole = async (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2602.

Closes #2602

---

## Claude summary

The bug was real and the root cause was clear. Here's what happened:

**Root cause:** `_updateMemberRoleInternal` patched the Convex DB via `ctx.db.patch` but never wrote the updated role to Supabase. The team settings page reads members via `useSupabaseOrganizationMembers` (which hits Supabase directly), so the role badge always reflected the old value after a change. Query invalidation had no effect since Supabase still held the stale role.

**Fix (2 files):**

`convex/organizations.ts` — after `ctx.db.patch`, schedule `writeTeamMembershipToSupabase` with the new role. This action uses upsert semantics so it overwrites the existing row with the correct role, following the identical pattern used when memberships are created (invitation accept, org creation).

`src/routes/_app/_auth/dashboard/_layout.settings.team.tsx` — wrapped `handleChangeRole` in try/catch and added `toast.success`/`toast.error` so the user gets feedback, consistent with how `handleChangePendingRole` already worked.

## Follow-ups

- `_removeMemberInternal` missing Supabase sync: `ctx.db.delete` removes the Convex row but the `team_memberships` row in Supabase is never deleted, leaving a ghost membership that could cause incorrect permission reads and seat count discrepancies.