### PR TITLE
`_removeMemberInternal` missing Supabase sync

### DIFF
--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -419,6 +419,14 @@ export const _removeMemberInternal = internalMutation({
 
     await ctx.db.delete(args.membershipId);
 
+    // Mirror deletion to Supabase — UI reads team_memberships from there, and
+    // RLS / seat-count queries would see a ghost row without this.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.supabase.organizations.deleteTeamMembershipFromSupabase,
+      { membershipId: String(args.membershipId) },
+    );
+
     await logActivity(ctx, {
       organizationId: args.organizationId,
       entityType: "organization",

--- a/convex/supabase/organizations.ts
+++ b/convex/supabase/organizations.ts
@@ -122,6 +122,23 @@ export const _listAllTeamMemberships = internalQuery({
   },
 });
 
+export const deleteTeamMembershipFromSupabase = internalAction({
+  args: { membershipId: v.string() },
+  returns: v.null_(),
+  handler: async (_ctx, args) => {
+    const client = createServiceRoleClient();
+    const { error } = await client
+      .from("team_memberships")
+      .delete()
+      .eq("id", args.membershipId);
+    if (error) {
+      throw new Error(`supabaseDb.delete(team_memberships, ${args.membershipId}): ${error.message}`);
+    }
+    console.info(`TeamMembership deleted from Supabase id=${args.membershipId}`);
+    return null;
+  },
+});
+
 export const writeTeamMembershipToSupabase = internalAction({
   args: {
     membershipId: v.string(),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2604.

Closes #2604

---

## Claude summary

The bug was real and is now fixed. Here's what was done:

**Root cause**: `_removeMemberInternal` in `convex/organizations.ts:420` called `ctx.db.delete(args.membershipId)` which removes the Convex row, but never touched the corresponding `team_memberships` row in Supabase. Since the UI reads team memberships from Supabase (via `useSupabaseOrganizationMembers`), removed members would still appear, seat counts would be inflated, and RLS could grant access to users who should have been removed.

**Fix**: Added a `deleteTeamMembershipFromSupabase` internal action in `convex/supabase/organizations.ts` and scheduled it via `ctx.scheduler.runAfter(0, ...)` in `_removeMemberInternal` — exactly matching the pattern used by `_updateMemberRoleInternal` for role changes (fixed in #2602).