### PR TITLE
Zmiana roli członka zespołu dalej nie zapisuje się poprawnie w UI

### DIFF
--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -332,10 +332,20 @@ export const updateMemberRole = action({
     role: orgRoleValidator,
   },
   handler: async (ctx, args): Promise<string> => {
-    await ctx.runMutation(internal.organizations._updateMemberRoleInternal, {
+    const membershipData = await ctx.runMutation(internal.organizations._updateMemberRoleInternal, {
       organizationId: args.organizationId,
       membershipId: args.membershipId as any,
       role: args.role,
+    });
+    // Await the Supabase write directly so the UI sees the updated role when it
+    // refetches — scheduler.runAfter is fire-and-forget and loses the race.
+    await ctx.runAction(internal.supabase.organizations.writeTeamMembershipToSupabase, {
+      membershipId: args.membershipId,
+      userId: membershipData.userId,
+      organizationId: String(args.organizationId),
+      role: args.role,
+      invitedBy: membershipData.invitedBy,
+      joinedAt: membershipData.joinedAt,
     });
     return args.membershipId;
   },
@@ -360,22 +370,6 @@ export const _updateMemberRoleInternal = internalMutation({
 
     await ctx.db.patch(args.membershipId, { role: args.role });
 
-    // Mirror updated role to Supabase — the UI reads team_memberships from
-    // Supabase via useSupabaseOrganizationMembers, so without this the role
-    // badge stays stale after a role change.
-    await ctx.scheduler.runAfter(
-      0,
-      internal.supabase.organizations.writeTeamMembershipToSupabase,
-      {
-        membershipId: String(args.membershipId),
-        userId: String(membership.userId),
-        organizationId: String(args.organizationId),
-        role: args.role,
-        invitedBy: membership.invitedBy ? String(membership.invitedBy) : undefined,
-        joinedAt: membership.joinedAt ?? Date.now(),
-      },
-    );
-
     await logActivity(ctx, {
       organizationId: args.organizationId,
       entityType: "organization",
@@ -384,6 +378,12 @@ export const _updateMemberRoleInternal = internalMutation({
       description: `Updated member role to "${args.role}"`,
       performedBy: user._id,
     });
+
+    return {
+      userId: String(membership.userId),
+      invitedBy: membership.invitedBy ? String(membership.invitedBy) : undefined,
+      joinedAt: membership.joinedAt ?? Date.now(),
+    };
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2606.

Closes #2606

---

## Claude summary

The bug was a race condition. Here's what was happening:

**Root cause:** `_updateMemberRoleInternal` mutation used `ctx.scheduler.runAfter(0, writeTeamMembershipToSupabase, ...)` to mirror the role change to Supabase. `scheduler.runAfter` is fire-and-forget — it schedules the sync job to run after the mutation commits, but doesn't wait for it. The outer `updateMemberRole` action resolved immediately after the mutation, the UI got the success toast, invalidated its Supabase query, and refetched — but the sync job hadn't run yet, so Supabase still had the old role.

**Fix:** Moved the Supabase write from the mutation (where it has to use the scheduler) to the outer action, where it can be directly `await`-ed via `ctx.runAction(...)`. The mutation now returns the membership's `userId`/`invitedBy`/`joinedAt` fields so the action has everything it needs to call the Supabase write synchronously. The action only resolves — and the UI only shows the success toast — after the Supabase row is confirmed updated.

## Follow-ups

- Apply same fix to `removeMember` / `_removeMemberInternal`: the same `scheduler.runAfter` race condition exists when removing a member — the deleted row may still appear briefly in the UI after the toast fires. Same fix pattern applies: move the Supabase delete into the outer `removeMember` action and await it directly.