### PR TITLE
Apply same fix to `removeMember` / `_removeMemberInternal`

### DIFF
--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -397,6 +397,11 @@ export const removeMember = action({
       organizationId: args.organizationId,
       membershipId: args.membershipId as any,
     });
+    // Await the Supabase delete directly so the UI sees the removal when it
+    // refetches — scheduler.runAfter is fire-and-forget and loses the race.
+    await ctx.runAction(internal.supabase.organizations.deleteTeamMembershipFromSupabase, {
+      membershipId: args.membershipId,
+    });
     return args.membershipId;
   },
 });
@@ -418,14 +423,6 @@ export const _removeMemberInternal = internalMutation({
     }
 
     await ctx.db.delete(args.membershipId);
-
-    // Mirror deletion to Supabase — UI reads team_memberships from there, and
-    // RLS / seat-count queries would see a ghost row without this.
-    await ctx.scheduler.runAfter(
-      0,
-      internal.supabase.organizations.deleteTeamMembershipFromSupabase,
-      { membershipId: String(args.membershipId) },
-    );
 
     await logActivity(ctx, {
       organizationId: args.organizationId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2609.

Closes #2609

---

## Claude summary

The fix is in. Here's what changed:

`convex/organizations.ts` — `_removeMemberInternal` was using `ctx.scheduler.runAfter(0, deleteTeamMembershipFromSupabase, ...)`, which enqueues the Supabase DELETE as a background job. The outer `removeMember` action returned immediately after the Convex row was deleted, so the UI refetched before the background job ran and saw a ghost membership row.

The fix moves `deleteTeamMembershipFromSupabase` out of the internal mutation and into `removeMember` action as a direct `await ctx.runAction(...)`. Now the action only returns (and the UI only refetches) after the Supabase row is gone — the same pattern used in #2606 for `updateMemberRole`.