### PR TITLE
Użytkownik jest członkiem organizacji, ale po zalogowaniu otwiera się inna organizacja

### DIFF
--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -128,6 +128,10 @@ export const getMyOrganizations = query({
       .withIndex("by_userId", (q) => q.eq("userId", user._id))
       .collect();
 
+    // Sort most-recently-joined first so the UI picks the right org on login
+    // when a user belongs to multiple orgs (e.g. their own + an invited org).
+    memberships.sort((a, b) => b.joinedAt - a.joinedAt);
+
     const orgs = await Promise.all(
       memberships.map(async (m) => {
         const org = await ctx.db.get(m.organizationId);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2607.

Closes #2607

---

## Claude summary

Committed. Here's a summary of the investigation and fix.

---

**Root cause found and fixed.**

`getMyOrganizations` in `convex/organizations.ts` collected `teamMemberships` via `.collect()` with no ordering. Convex returns documents in internal database order, which is non-deterministic. `DashboardLayout` always picks `orgs[0]` as the active organization on login, with no localStorage persistence of any prior selection.

The user `a.slocka@wp.pl` has two memberships:
- Their own personal org (created first, role: owner, 0 other members)
- Aleksander's org (joined later, role: member/admin, 5 members)

Because the personal org happened to be returned first by the DB, `orgs[0]` was the personal org — explaining the exact symptom: "1 of 5 seats, 0 team members, Organization Owner".

**Fix** (`convex/organizations.ts:133`): sort the memberships array by `joinedAt` descending before mapping to org objects. The most-recently-joined org now appears first, which is always the invited org in the described scenario.

## Follow-ups

- Add localStorage persistence for active org selection: `OrgProvider` and `DashboardLayout` have no mechanism to remember the last selected org across sessions — sorting by `joinedAt` is a reasonable default but the correct long-term fix is to persist the user's explicit choice, especially once a multi-org switcher UI is added (note: `setOrganizationId` is defined in context but never called anywhere).
- Multi-org switcher UI is missing: `setOrganizationId` exists in `OrgContext` but no component ever calls it — users with multiple organizations have no way to switch between them in the UI.