### PR TITLE
Add localStorage persistence for active org selection

### DIFF
--- a/src/components/org-context.tsx
+++ b/src/components/org-context.tsx
@@ -1,5 +1,7 @@
-import { createContext, useContext, useState, ReactNode } from "react";
+import { createContext, useContext, useState, useCallback, ReactNode } from "react";
 import { Id } from "@cvx/_generated/dataModel";
+
+export const LS_ACTIVE_ORG_KEY = "quera-active-org-id";
 
 interface OrgContextType {
   organizationId: Id<"organizations"> | null;
@@ -15,8 +17,14 @@ export function OrgProvider({
   children: ReactNode;
   initialOrgId?: Id<"organizations">;
 }) {
-  const [organizationId, setOrganizationId] =
+  const [organizationId, _setOrganizationId] =
     useState<Id<"organizations"> | null>(initialOrgId ?? null);
+
+  const setOrganizationId = useCallback((id: Id<"organizations">) => {
+    localStorage.setItem(LS_ACTIVE_ORG_KEY, id);
+    _setOrganizationId(id);
+  }, []);
+
   return (
     <OrgContext.Provider value={{ organizationId, setOrganizationId }}>
       {children}

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -12,7 +12,7 @@ import { useSupabaseCustomFieldDefinitions } from "@/hooks/use-supabase-custom-f
 import { AppSidebar } from "@/components/layout/app-sidebar";
 import { AppFooter } from "@/components/layout/app-footer";
 import { RouteErrorBoundary } from "@/components/layout/route-error-boundary";
-import { OrgProvider } from "@/components/org-context";
+import { OrgProvider, LS_ACTIVE_ORG_KEY } from "@/components/org-context";
 import { SupabaseProvider } from "@/components/supabase-provider";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { Separator } from "@/components/ui/separator";
@@ -1037,7 +1037,9 @@ function DashboardLayout() {
   );
 
   if (!user || !orgs) return null;
-  const firstOrg = orgs[0];
+  const savedOrgId = localStorage.getItem(LS_ACTIVE_ORG_KEY);
+  const firstOrg =
+    (savedOrgId && orgs.find((o) => o._id === savedOrgId)) || orgs[0];
   if (!firstOrg) return null;
 
   return (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2612.

Closes #2612

---

## Claude summary

Done. Here's a summary of what was changed and why:

**`src/components/org-context.tsx`** — `OrgProvider` now wraps the state setter with `useCallback` so that calling `setOrganizationId(id)` also writes to `localStorage` under the key `quera-active-org-id`. The key is exported as `LS_ACTIVE_ORG_KEY` so `DashboardLayout` can read it without string duplication.

**`src/routes/_app/_auth/dashboard/_layout.tsx`** — `DashboardLayout` now reads `LS_ACTIVE_ORG_KEY` from localStorage after loading the user's org list. The stored org ID is validated against the actual `orgs` array (so a stale or cross-user value can't cause an invalid state) before being used as the initial org. Falls back to `orgs[0]` if nothing is stored or the stored value doesn't match any membership.

When a multi-org switcher UI is eventually added and it calls `setOrganizationId`, the choice will be remembered automatically across sessions.