### PR TITLE
Multi-org switcher UI is missing

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2183,7 +2183,8 @@
     "logOut": "Log Out",
     "openDeals": "Open Deals",
     "notifications": "Notifications",
-    "createNew": "Create new"
+    "createNew": "Create new",
+    "organizations": "Organizations"
   },
   "profile": {
     "title": "Settings",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2196,7 +2196,8 @@
     "logOut": "Wyloguj",
     "openDeals": "Otwarte transakcje",
     "notifications": "Powiadomienia",
-    "createNew": "Utwórz nowy"
+    "createNew": "Utwórz nowy",
+    "organizations": "Organizacje"
   },
   "profile": {
     "title": "Ustawienia",

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -28,6 +28,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu";
@@ -48,6 +49,7 @@ import {
   UserPlus,
   CalendarCheck,
   BarChart3,
+  Check,
 } from "@/lib/ez-icons";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
@@ -207,9 +209,12 @@ interface DashboardLayoutInnerProps {
   user: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   firstOrg: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  orgs: any[];
+  onOrgSwitch: (orgId: string) => void;
 }
 
-function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
+function DashboardLayoutInner({ user, firstOrg, orgs, onOrgSwitch }: DashboardLayoutInnerProps) {
   const { t } = useTranslation();
   const quickCreateRef = useRef<QuickCreateMenuHandle>(null);
   const signOut = useSignOut();
@@ -916,6 +921,27 @@ function DashboardLayoutInner({ user, firstOrg }: DashboardLayoutInnerProps) {
                         <p className="text-xs text-muted-foreground">{user.email}</p>
                       </div>
                       <DropdownMenuSeparator className="sm:hidden" />
+                      {orgs.length > 1 && (
+                        <>
+                          <DropdownMenuLabel className="text-xs font-medium text-muted-foreground">
+                            {t("layout.organizations")}
+                          </DropdownMenuLabel>
+                          {orgs.map((org: any) => (
+                            <DropdownMenuItem
+                              key={org._id}
+                              onClick={() => onOrgSwitch(org._id)}
+                              className="gap-2"
+                            >
+                              <Building2 className="h-4 w-4 shrink-0" variant="stroke" />
+                              <span className="flex-1 truncate">{org.name}</span>
+                              {org._id === firstOrg._id && (
+                                <Check className="h-4 w-4 shrink-0 text-primary" variant="stroke" />
+                              )}
+                            </DropdownMenuItem>
+                          ))}
+                          <DropdownMenuSeparator />
+                        </>
+                      )}
                       <DropdownMenuItem onClick={() => navigate({ to: "/dashboard/settings" })}>
                         <Settings className="mr-2 h-4 w-4" variant="stroke" />
                         {t("layout.settings")}
@@ -1035,22 +1061,28 @@ function DashboardLayout() {
   const { data: orgs } = useQuery(
     convexQuery(api.organizations.getMyOrganizations, {})
   );
+  const [activeOrgId, setActiveOrgId] = useState<string | null>(null);
 
   if (!user || !orgs) return null;
-  const savedOrgId = localStorage.getItem(LS_ACTIVE_ORG_KEY);
+  const savedOrgId = activeOrgId ?? localStorage.getItem(LS_ACTIVE_ORG_KEY);
   const firstOrg =
     (savedOrgId && orgs.find((o) => o._id === savedOrgId)) || orgs[0];
   if (!firstOrg) return null;
 
+  const handleOrgSwitch = (orgId: string) => {
+    localStorage.setItem(LS_ACTIVE_ORG_KEY, orgId);
+    setActiveOrgId(orgId);
+  };
+
   return (
     <DateRangeProvider>
-      <OrgProvider initialOrgId={firstOrg._id}>
+      <OrgProvider key={firstOrg._id} initialOrgId={firstOrg._id}>
         <SupabaseProvider>
           <NudgesProvider>
             <MiniCalendarProvider>
               <SidebarSlotProvider>
                 <HeaderSlotProvider>
-                  <DashboardLayoutInner user={user} firstOrg={firstOrg} />
+                  <DashboardLayoutInner user={user} firstOrg={firstOrg} orgs={orgs} onOrgSwitch={handleOrgSwitch} />
                 </HeaderSlotProvider>
               </SidebarSlotProvider>
             </MiniCalendarProvider>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2613.

Closes #2613

---

## Claude summary

The bug was confirmed and fixed. Here's what was done:

**Root cause**: `setOrganizationId` was defined in `OrgContext` and persisted to `localStorage`, but no component ever called it — users with multiple org memberships had no UI to switch between them.

**Fix** (3 files, 40 lines):

`src/routes/_app/_auth/dashboard/_layout.tsx`:
- Added `useState<string | null>(null)` in `DashboardLayout` to track the active org reactively
- Added `handleOrgSwitch(orgId)` that writes to localStorage and updates state
- Added `key={firstOrg._id}` to `OrgProvider` so the full provider subtree remounts when the org changes, ensuring all Supabase/Convex queries pick up the new org context
- Passed `orgs` (full list) and `onOrgSwitch` down to `DashboardLayoutInner`
- Added an "Organizations" section in the user avatar dropdown (only rendered when `orgs.length > 1`) with a checkmark on the active org

`public/locales/{pl,en}/translation.json`:
- Added `layout.organizations` translation key ("Organizacje" / "Organizations")

Single-org users see no UI change. Multi-org users see the switcher in the header dropdown.