### PR TITLE
Add durable org selection persistence once intentional

### DIFF
--- a/src/components/org-context.tsx
+++ b/src/components/org-context.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useState, useCallback, ReactNode } from "react";
 import { Id } from "@cvx/_generated/dataModel";
 
-export const LS_ACTIVE_ORG_KEY = "quera-active-org-id";
+export const getOrgStorageKey = (userId: string) => `quera-active-org-${userId}`;
 
 interface OrgContextType {
   organizationId: Id<"organizations"> | null;
@@ -13,17 +13,21 @@ const OrgContext = createContext<OrgContextType | null>(null);
 export function OrgProvider({
   children,
   initialOrgId,
+  userId,
 }: {
   children: ReactNode;
   initialOrgId?: Id<"organizations">;
+  userId?: string;
 }) {
   const [organizationId, _setOrganizationId] =
     useState<Id<"organizations"> | null>(initialOrgId ?? null);
 
   const setOrganizationId = useCallback((id: Id<"organizations">) => {
-    localStorage.setItem(LS_ACTIVE_ORG_KEY, id);
+    if (userId) {
+      localStorage.setItem(getOrgStorageKey(userId), id);
+    }
     _setOrganizationId(id);
-  }, []);
+  }, [userId]);
 
   return (
     <OrgContext.Provider value={{ organizationId, setOrganizationId }}>

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -12,7 +12,7 @@ import { useSupabaseCustomFieldDefinitions } from "@/hooks/use-supabase-custom-f
 import { AppSidebar } from "@/components/layout/app-sidebar";
 import { AppFooter } from "@/components/layout/app-footer";
 import { RouteErrorBoundary } from "@/components/layout/route-error-boundary";
-import { OrgProvider, LS_ACTIVE_ORG_KEY } from "@/components/org-context";
+import { OrgProvider, getOrgStorageKey } from "@/components/org-context";
 import { SupabaseProvider } from "@/components/supabase-provider";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { Separator } from "@/components/ui/separator";
@@ -1064,19 +1064,19 @@ function DashboardLayout() {
   const [activeOrgId, setActiveOrgId] = useState<string | null>(null);
 
   if (!user || !orgs) return null;
-  const savedOrgId = activeOrgId ?? localStorage.getItem(LS_ACTIVE_ORG_KEY);
+  const savedOrgId = activeOrgId ?? localStorage.getItem(getOrgStorageKey(user._id));
   const firstOrg =
     (savedOrgId && orgs.find((o) => o._id === savedOrgId)) || orgs[0];
   if (!firstOrg) return null;
 
   const handleOrgSwitch = (orgId: string) => {
-    localStorage.setItem(LS_ACTIVE_ORG_KEY, orgId);
+    localStorage.setItem(getOrgStorageKey(user._id), orgId);
     setActiveOrgId(orgId);
   };
 
   return (
     <DateRangeProvider>
-      <OrgProvider key={firstOrg._id} initialOrgId={firstOrg._id}>
+      <OrgProvider key={firstOrg._id} initialOrgId={firstOrg._id} userId={user._id}>
         <SupabaseProvider>
           <NudgesProvider>
             <MiniCalendarProvider>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2618.

Closes #2618

---

## Claude summary

Done. Here's a summary of what was changed and why:

The localStorage key `quera-active-org-id` was a fixed string shared across all browser sessions regardless of which account is logged in. If user A switched orgs and then user B logged in on the same browser, user B would inherit user A's last-selected org.

The fix is in two files:

`src/components/org-context.tsx` — replaced the exported constant `LS_ACTIVE_ORG_KEY` with a function `getOrgStorageKey(userId)` that returns `` `quera-active-org-${userId}` ``. The `OrgProvider` now accepts a `userId` prop and uses the user-scoped key in its `setOrganizationId` callback.

`src/routes/_app/_auth/dashboard/_layout.tsx` — updated all three localStorage touch-points (initial read, `handleOrgSwitch` write, and the `OrgProvider` prop) to use `getOrgStorageKey(user._id)`. Since `user` is already resolved before any of these calls, no async changes were needed.

Existing users' old `quera-active-org-id` preference is silently abandoned on next login — they'll fall back to their first org, which is the correct safe default.