### PR TITLE
`OrgContext.setOrganizationId` is exported and wired up but never called by any 

### DIFF
--- a/src/components/org-context.tsx
+++ b/src/components/org-context.tsx
@@ -1,11 +1,10 @@
-import { createContext, useContext, useState, useCallback, ReactNode } from "react";
+import { createContext, useContext, useState, ReactNode } from "react";
 import { Id } from "@cvx/_generated/dataModel";
 
 export const getOrgStorageKey = (userId: string) => `quera-active-org-${userId}`;
 
 interface OrgContextType {
   organizationId: Id<"organizations"> | null;
-  setOrganizationId: (id: Id<"organizations">) => void;
 }
 
 const OrgContext = createContext<OrgContextType | null>(null);
@@ -13,24 +12,15 @@ const OrgContext = createContext<OrgContextType | null>(null);
 export function OrgProvider({
   children,
   initialOrgId,
-  userId,
 }: {
   children: ReactNode;
   initialOrgId?: Id<"organizations">;
-  userId?: string;
 }) {
-  const [organizationId, _setOrganizationId] =
+  const [organizationId] =
     useState<Id<"organizations"> | null>(initialOrgId ?? null);
 
-  const setOrganizationId = useCallback((id: Id<"organizations">) => {
-    if (userId) {
-      localStorage.setItem(getOrgStorageKey(userId), id);
-    }
-    _setOrganizationId(id);
-  }, [userId]);
-
   return (
-    <OrgContext.Provider value={{ organizationId, setOrganizationId }}>
+    <OrgContext.Provider value={{ organizationId }}>
       {children}
     </OrgContext.Provider>
   );
@@ -42,6 +32,5 @@ export function useOrganization() {
   if (!ctx.organizationId) throw new Error("No organization selected");
   return {
     organizationId: ctx.organizationId,
-    setOrganizationId: ctx.setOrganizationId,
   };
 }

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -1076,7 +1076,7 @@ function DashboardLayout() {
 
   return (
     <DateRangeProvider>
-      <OrgProvider key={firstOrg._id} initialOrgId={firstOrg._id} userId={user._id}>
+      <OrgProvider key={firstOrg._id} initialOrgId={firstOrg._id}>
         <SupabaseProvider>
           <NudgesProvider>
             <MiniCalendarProvider>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2619.

Closes #2619

---

## Claude summary

The fix is committed. Here's what was done:

**Root cause confirmed**: `OrgContext.setOrganizationId` was defined, typed, and exposed via `useOrganization()` — but never called. All actual org switching happened through `DashboardLayout.handleOrgSwitch`, which writes to localStorage and updates a local `useState`, which remounts `OrgProvider` via the `key` prop. The context setter was completely bypassed.

**Changes** (2 files, -15/+4 lines):
- `src/components/org-context.tsx`: removed `setOrganizationId` from `OrgContextType`, removed the `useCallback` implementation, removed the `userId` prop (which only existed to support the localStorage write in that callback), dropped `useCallback` import, removed `setOrganizationId` from `useOrganization()` return.
- `src/routes/_app/_auth/dashboard/_layout.tsx`: removed `userId={user._id}` from `<OrgProvider>` (the prop no longer exists).

The org-switching behavior is unchanged — `handleOrgSwitch` + `key`-based remount continues to work exactly as before.

## Follow-ups

- Refactor org switching to use setOrganizationId via context instead of key-remount: `DashboardLayout.handleOrgSwitch` + `key={firstOrg._id}` forces a full subtree unmount/remount on every org switch; since `SupabaseProvider` already reactively re-mints the JWT when `organizationId` changes in context, a proper `setOrganizationId` wired to the dropdown would eliminate the heavy remount and the duplicate localStorage write
- Remove duplicate localStorage write on org switch: `handleOrgSwitch` in `_layout.tsx:1073` writes to localStorage, and `OrgProvider` previously also wrote in its setter — the setter is now gone, but the write in `handleOrgSwitch` remains the only path, which is correct; however if the key-remount refactor above is done, localStorage writes should be centralized back in the context setter