### PR TITLE
Refactor org switching to use setOrganizationId via context instead of key-remou

### DIFF
--- a/src/components/org-context.tsx
+++ b/src/components/org-context.tsx
@@ -5,6 +5,7 @@ export const getOrgStorageKey = (userId: string) => `quera-active-org-${userId}`
 
 interface OrgContextType {
   organizationId: Id<"organizations"> | null;
+  setOrganizationId: (id: Id<"organizations">) => void;
 }
 
 const OrgContext = createContext<OrgContextType | null>(null);
@@ -16,11 +17,11 @@ export function OrgProvider({
   children: ReactNode;
   initialOrgId?: Id<"organizations">;
 }) {
-  const [organizationId] =
+  const [organizationId, setOrganizationId] =
     useState<Id<"organizations"> | null>(initialOrgId ?? null);
 
   return (
-    <OrgContext.Provider value={{ organizationId }}>
+    <OrgContext.Provider value={{ organizationId, setOrganizationId }}>
       {children}
     </OrgContext.Provider>
   );
@@ -32,5 +33,6 @@ export function useOrganization() {
   if (!ctx.organizationId) throw new Error("No organization selected");
   return {
     organizationId: ctx.organizationId,
+    setOrganizationId: ctx.setOrganizationId,
   };
 }

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -208,13 +208,12 @@ interface DashboardLayoutInnerProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   user: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  firstOrg: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   orgs: any[];
-  onOrgSwitch: (orgId: string) => void;
 }
 
-function DashboardLayoutInner({ user, firstOrg, orgs, onOrgSwitch }: DashboardLayoutInnerProps) {
+function DashboardLayoutInner({ user, orgs }: DashboardLayoutInnerProps) {
+  const { organizationId, setOrganizationId } = useOrganization();
+  const firstOrg = orgs.find((o: any) => o._id === organizationId) ?? orgs[0];
   const { t } = useTranslation();
   const quickCreateRef = useRef<QuickCreateMenuHandle>(null);
   const signOut = useSignOut();
@@ -929,7 +928,10 @@ function DashboardLayoutInner({ user, firstOrg, orgs, onOrgSwitch }: DashboardLa
                           {orgs.map((org: any) => (
                             <DropdownMenuItem
                               key={org._id}
-                              onClick={() => onOrgSwitch(org._id)}
+                              onClick={() => {
+                                localStorage.setItem(getOrgStorageKey(user._id), org._id);
+                                setOrganizationId(org._id as Id<"organizations">);
+                              }}
                               className="gap-2"
                             >
                               <Building2 className="h-4 w-4 shrink-0" variant="stroke" />
@@ -1061,28 +1063,21 @@ function DashboardLayout() {
   const { data: orgs } = useQuery(
     convexQuery(api.organizations.getMyOrganizations, {})
   );
-  const [activeOrgId, setActiveOrgId] = useState<string | null>(null);
-
   if (!user || !orgs) return null;
-  const savedOrgId = activeOrgId ?? localStorage.getItem(getOrgStorageKey(user._id));
+  const savedOrgId = localStorage.getItem(getOrgStorageKey(user._id));
   const firstOrg =
     (savedOrgId && orgs.find((o) => o._id === savedOrgId)) || orgs[0];
   if (!firstOrg) return null;
 
-  const handleOrgSwitch = (orgId: string) => {
-    localStorage.setItem(getOrgStorageKey(user._id), orgId);
-    setActiveOrgId(orgId);
-  };
-
   return (
     <DateRangeProvider>
-      <OrgProvider key={firstOrg._id} initialOrgId={firstOrg._id}>
+      <OrgProvider initialOrgId={firstOrg._id}>
         <SupabaseProvider>
           <NudgesProvider>
             <MiniCalendarProvider>
               <SidebarSlotProvider>
                 <HeaderSlotProvider>
-                  <DashboardLayoutInner user={user} firstOrg={firstOrg} orgs={orgs} onOrgSwitch={handleOrgSwitch} />
+                  <DashboardLayoutInner user={user} orgs={orgs} />
                 </HeaderSlotProvider>
               </SidebarSlotProvider>
             </MiniCalendarProvider>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2622.

Closes #2622

---

## Claude summary

Changes committed. Here's a summary of what was done:

**`src/components/org-context.tsx`** — added `setOrganizationId` to `OrgContextType`, exposed the `useState` setter in the provider value, and returned it from `useOrganization()`.

**`src/routes/_app/_auth/dashboard/_layout.tsx`** — three related changes:
- `DashboardLayout`: removed `activeOrgId` state, removed `handleOrgSwitch`, and dropped `key={firstOrg._id}` from `<OrgProvider>`. The initial org is still read from localStorage on mount (unchanged behavior).
- `DashboardLayoutInner`: removed the `firstOrg` and `onOrgSwitch` props; the component now calls `useOrganization()` to get both `organizationId` and `setOrganizationId`, then derives `firstOrg` from the context value + `orgs` array.
- Dropdown handler: directly writes localStorage and calls `setOrganizationId(org._id)` — no more prop callbacks.

The net effect: switching orgs now just updates a single React state in `OrgContext`. `SupabaseProvider` (which reads `organizationId` via `useOrganization()` and passes it to `useSupabaseToken`) picks up the change and re-mints the JWT reactively, with no provider remount.