### PR TITLE
Remove duplicate localStorage write on org switch

### DIFF
--- a/src/components/org-context.tsx
+++ b/src/components/org-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, ReactNode } from "react";
+import { createContext, useContext, useState, useCallback, ReactNode } from "react";
 import { Id } from "@cvx/_generated/dataModel";
 
 export const getOrgStorageKey = (userId: string) => `quera-active-org-${userId}`;
@@ -13,12 +13,22 @@ const OrgContext = createContext<OrgContextType | null>(null);
 export function OrgProvider({
   children,
   initialOrgId,
+  userId,
 }: {
   children: ReactNode;
   initialOrgId?: Id<"organizations">;
+  userId: string;
 }) {
-  const [organizationId, setOrganizationId] =
+  const [organizationId, setOrgId] =
     useState<Id<"organizations"> | null>(initialOrgId ?? null);
+
+  const setOrganizationId = useCallback(
+    (id: Id<"organizations">) => {
+      localStorage.setItem(getOrgStorageKey(userId), id);
+      setOrgId(id);
+    },
+    [userId]
+  );
 
   return (
     <OrgContext.Provider value={{ organizationId, setOrganizationId }}>

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -929,7 +929,6 @@ function DashboardLayoutInner({ user, orgs }: DashboardLayoutInnerProps) {
                             <DropdownMenuItem
                               key={org._id}
                               onClick={() => {
-                                localStorage.setItem(getOrgStorageKey(user._id), org._id);
                                 setOrganizationId(org._id as Id<"organizations">);
                               }}
                               className="gap-2"
@@ -1071,7 +1070,7 @@ function DashboardLayout() {
 
   return (
     <DateRangeProvider>
-      <OrgProvider initialOrgId={firstOrg._id}>
+      <OrgProvider initialOrgId={firstOrg._id} userId={user._id}>
         <SupabaseProvider>
           <NudgesProvider>
             <MiniCalendarProvider>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2623.

Closes #2623

---

## Claude summary

Done. Here's what changed:

`src/components/org-context.tsx` — `OrgProvider` now accepts a required `userId: string` prop and wraps the state setter in a `useCallback` that writes to localStorage before updating React state. This means any caller of `setOrganizationId` gets the persistence for free.

`src/routes/_app/_auth/dashboard/_layout.tsx` — the inline `onClick` handler in the org-switcher dropdown no longer calls `localStorage.setItem` directly; it just calls `setOrganizationId`. `OrgProvider` is passed `userId={user._id}` so it can construct the storage key. The `getOrgStorageKey` import remains since it's still used for the read path at line 1067.