### PR TITLE
Remove unused `GABINET_PRODUCT_ID` import in `convex/gabinet/appointments.ts

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -12,7 +12,6 @@ import { paginationOptsValidator } from "convex/server";
 import { verifyOrgAccess } from "../_helpers/auth";
 import { checkModuleAccess } from "../_helpers/products";
 import { logActivity } from "../_helpers/activities";
-import { GABINET_PRODUCT_ID } from "./_registry";
 import { gabinetAppointmentStatusValidator } from "../schema";
 import {
   checkConflict,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2628.

Closes #2628

---

## Claude summary

The fix was straightforward: `GABINET_PRODUCT_ID` was imported from `./_registry` at line 15 of `convex/gabinet/appointments.ts` but never referenced anywhere in the file, causing a TS6133 warning. Removed the unused import line. TypeScript confirms no errors after the removal.