### PR TITLE
Fix `TreatmentProductLine` missing `productSection` in quick-create `createTreat

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -229,6 +229,7 @@ function DashboardLayoutInner({ user, orgs }: DashboardLayoutInnerProps) {
   const createLead = useAction(api.leads.create);
   const createPatient = useAction(api.gabinet.patients.create);
   const createTreatment = useAction(api.gabinet.treatments.create);
+  const setTreatmentProducts = useAction(api.gabinet.treatments.setTreatmentProducts);
   const createPackage = useAction(api.gabinet.packages.create);
   const createEmployee = useAction(api.gabinet.employees.create);
   const createActivity = useAction(api.scheduledActivities.create);
@@ -551,7 +552,29 @@ function DashboardLayoutInner({ user, orgs }: DashboardLayoutInnerProps) {
               onSubmit={async (data) => {
                 setIsCreating(true);
                 try {
-                  await createTreatment({ organizationId: orgId, ...data });
+                  const { products, materials, ...treatmentData } = data;
+                  const newTreatmentId = await createTreatment({ organizationId: orgId, ...treatmentData });
+                  const allProductLinks = [
+                    ...(products ?? []).map((p) => ({
+                      productId: p.productId,
+                      productSection: "treatment" as const,
+                      quantity: p.quantity,
+                      unit: p.unit ?? undefined,
+                    })),
+                    ...(materials ?? []).map((m) => ({
+                      productId: m.productId,
+                      productSection: "disposable" as const,
+                      quantity: m.quantity,
+                      unit: m.unit ?? undefined,
+                    })),
+                  ];
+                  if (allProductLinks.length > 0) {
+                    await setTreatmentProducts({
+                      organizationId: orgId,
+                      treatmentId: newTreatmentId,
+                      products: allProductLinks,
+                    });
+                  }
                   void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatments.list(orgId) });
                   opts.onSuccess();
                 } catch (e) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2629.

Closes #2629

---

## Claude summary

Fixed. The bug was real: the quick-create `onSubmit` in `_layout.tsx:554` was spreading `TreatmentFormData` directly into `createTreatment`, but the backend action's validator requires `products` entries to have `productSection: "treatment" | "disposable"` — a field the frontend `TreatmentProductLine` type doesn't carry.

The fix (`_layout.tsx:232, 555–577`) mirrors the approach already used in the full treatments page:
1. Destructure `products` and `materials` out of the form data
2. Call `createTreatment` with only `treatmentData` (no products)
3. Build `allProductLinks` by adding the correct `productSection` discriminator to each list
4. Call `setTreatmentProducts` separately with the correctly typed array (only when non-empty)