### PR TITLE
Add loadingFallback to PermissionGate on patients route

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -38,13 +38,42 @@ import { formatBirthDate } from "@/lib/format-date";
 import { plateJsonToText } from "@/components/gabinet/rich-text-editor";
 import { displayReferralSource } from "@/lib/options";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
 
 type PatientNudgeFilter = "missing-contact" | "no-recent-visit" | "duplicates";
+
+function PatientListSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-7 w-40" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        <Skeleton className="h-9 w-32" />
+      </div>
+      <Skeleton className="h-10 w-full" />
+      <div className="space-y-2">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/patients/",
 )({
-  component: () => <PermissionGate feature="gabinet_patients" action="view"><PatientsIndex /></PermissionGate>,
+  component: () => (
+    <PermissionGate
+      feature="gabinet_patients"
+      action="view"
+      loadingFallback={<PatientListSkeleton />}
+    >
+      <PatientsIndex />
+    </PermissionGate>
+  ),
   validateSearch: (search: Record<string, unknown>): { nudge?: PatientNudgeFilter } => {
     const nudge =
       search.nudge === "missing-contact" ||


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2633.

Closes #2633

---

## Claude summary

Done. Here's a summary of what was done:

The issue was real: `_layout.gabinet.patients.index.tsx:47` had `<PermissionGate feature="gabinet_patients" action="view">` with no `loadingFallback`. While the permission query was pending, `PermissionGate` returned `null` (its default), producing a blank page that looked like an empty list.

The fix adds a `PatientListSkeleton` component — a page header + filter bar + 8 table row skeletons — matching the data-table pattern used in `_layout.gabinet.index.tsx`, and passes it as `loadingFallback` to `PermissionGate`.