### PR TITLE
fix(gabinet): add loadingFallback skeleton to all gabinet PermissionGates missing it (closes #2634)

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -107,15 +107,30 @@ import type { AppointmentFullDetailNote } from "@cvx/gabinet/appointments";
 import { useTranslation } from "react-i18next";
 import { Link } from "@tanstack/react-router";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
 
+function AppointmentDetailSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-8 w-64" />
+      <Skeleton className="h-48 w-full" />
+      <Skeleton className="h-48 w-full" />
+    </div>
+  );
+}
+
 export const Route = createLazyFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/appointments/$appointmentId",
 )({
-  component: () => <PermissionGate feature="gabinet_appointments" action="view"><AppointmentDetail /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_appointments" action="view" loadingFallback={<AppointmentDetailSkeleton />}>
+      <AppointmentDetail />
+    </PermissionGate>
+  ),
 });
 
 // All statuses can transition to any other status. Lets staff correct mistakes

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -86,11 +86,28 @@ import { EventDialog } from "@/components/gabinet/calendar/event-dialog";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatAppointmentError } from "@/lib/format-action-error";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function CalendarSkeleton() {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-7 w-32" />
+        <Skeleton className="h-9 w-48" />
+      </div>
+      <Skeleton className="h-[600px] w-full" />
+    </div>
+  );
+}
 
 export const Route = createLazyFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/calendar/",
 )({
-  component: () => <PermissionGate feature="gabinet_appointments" action="view"><GabinetCalendarPage /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_appointments" action="view" loadingFallback={<CalendarSkeleton />}>
+      <GabinetCalendarPage />
+    </PermissionGate>
+  ),
 });
 
 type ViewMode = "day" | "week" | "month";

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.document-templates.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.document-templates.tsx
@@ -1,12 +1,29 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { FormTemplatesListPage } from "./_layout.settings.form-templates.index";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function DocumentTemplatesSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-9 w-28" />
+      </div>
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/document-templates",
 )({
   component: () => (
-    <PermissionGate feature="document_templates" action="view">
+    <PermissionGate feature="document_templates" action="view" loadingFallback={<DocumentTemplatesSkeleton />}>
       <FormTemplatesListPage />
     </PermissionGate>
   ),

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -58,11 +58,28 @@ import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 // Route
 // ---------------------------------------------------------------------------
 
+function GabinetDocumentsSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-9 w-28" />
+      </div>
+      <Skeleton className="h-10 w-full" />
+      <div className="space-y-2">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/documents/",
 )({
   component: () => (
-    <PermissionGate feature="document_instances" action="view">
+    <PermissionGate feature="document_instances" action="view" loadingFallback={<GabinetDocumentsSkeleton />}>
       <GabinetDocumentsPage />
     </PermissionGate>
   ),

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -90,10 +90,24 @@ import { useSidebarSlot } from "@/components/layout/sidebar-slot-context";
 import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
 import { PermissionGate, useRole } from "@/hooks/use-permission";
 
+function EmployeeDetailSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-8 w-64" />
+      <Skeleton className="h-48 w-full" />
+      <Skeleton className="h-48 w-full" />
+    </div>
+  );
+}
+
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/employees/$employeeId"
 )({
-  component: () => <PermissionGate feature="gabinet_employees" action="view"><EmployeeDetail /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_employees" action="view" loadingFallback={<EmployeeDetailSkeleton />}>
+      <EmployeeDetail />
+    </PermissionGate>
+  ),
 });
 
 const ROLES = ["doctor", "cosmetologist", "nurse", "therapist", "receptionist", "manager", "admin", "other"] as const;

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -40,6 +40,7 @@ import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { EmployeeForm } from "@/components/forms/employee-form";
 import { EventDialog } from "@/components/gabinet/calendar/event-dialog";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   FlexibleScheduleEditor,
   groupSchedulesIntoPeriods,
@@ -50,10 +51,36 @@ import StatisticsOrderCard from "@/components/shadcn-studio/blocks/statistics-or
 import StatisticsProfitCard from "@/components/shadcn-studio/blocks/statistics-profit-card";
 import StatisticsImpressionCard from "@/components/shadcn-studio/blocks/statistics-impression-card";
 
+function EmployeesIndexSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-9 w-28" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Skeleton className="h-28" />
+        <Skeleton className="h-28" />
+        <Skeleton className="h-28" />
+      </div>
+      <Skeleton className="h-10 w-full" />
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/employees/"
 )({
-  component: () => <PermissionGate feature="gabinet_employees" action="view"><EmployeesIndex /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_employees" action="view" loadingFallback={<EmployeesIndexSkeleton />}>
+      <EmployeesIndex />
+    </PermissionGate>
+  ),
 });
 
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -56,16 +56,42 @@ import StatisticsOrderCard from "@/components/shadcn-studio/blocks/statistics-or
 import StatisticsProfitCard from "@/components/shadcn-studio/blocks/statistics-profit-card";
 import StatisticsImpressionCard from "@/components/shadcn-studio/blocks/statistics-impression-card";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
 
 // Type alias for Convex mutation compatibility (Knowledge Pattern #9/#12)
 type TreatmentPackage = MappedGabinetTreatmentPackage;
 
 type PackagesNudgeFilter = "expiring" | "no-usage";
 
+function PackagesIndexSkeleton() {
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-9 w-28" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Skeleton className="h-28" />
+        <Skeleton className="h-28" />
+        <Skeleton className="h-28" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-40" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/packages/"
 )({
-  component: () => <PermissionGate feature="gabinet_packages" action="view"><PackagesIndex /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_packages" action="view" loadingFallback={<PackagesIndexSkeleton />}>
+      <PackagesIndex />
+    </PermissionGate>
+  ),
   validateSearch: (
     search: Record<string, unknown>,
   ): { nudge?: PackagesNudgeFilter } => {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -76,6 +76,7 @@ import { cn } from "@/lib/utils";
 
 import { useTranslation } from "react-i18next";
 import { usePermission, useRole, PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
 import { PatientPackagesCard } from "@/components/gabinet/patient-packages-card";
 import { PatientTreatmentsCard } from "@/components/gabinet/patient-treatments-card";
 import { PatientPhotosTab } from "@/components/gabinet/patient-photos-tab";
@@ -86,10 +87,24 @@ import { formatPhoneNumber } from "@/lib/phone";
 import { formatCurrencyPLN } from "@/lib/format-currency";
 import { formatBirthDate } from "@/lib/format-date";
 
+function PatientDetailSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-8 w-64" />
+      <Skeleton className="h-48 w-full" />
+      <Skeleton className="h-48 w-full" />
+    </div>
+  );
+}
+
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/patients/$patientId",
 )({
-  component: () => <PermissionGate feature="gabinet_patients" action="view"><PatientDetail /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_patients" action="view" loadingFallback={<PatientDetailSkeleton />}>
+      <PatientDetail />
+    </PermissionGate>
+  ),
 });
 
 function PatientDetail() {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
@@ -42,11 +42,26 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function EquipmentSettingsSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-7 w-48" />
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-32 w-full" />
+    </div>
+  );
+}
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/equipment"
 )({
-  component: () => <PermissionGate feature="gabinet_settings" action="view"><EquipmentSettingsPage /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_settings" action="view" loadingFallback={<EquipmentSettingsSkeleton />}>
+      <EquipmentSettingsPage />
+    </PermissionGate>
+  ),
 });
 
 type EquipmentStatus = "available" | "in_use" | "maintenance" | "retired";

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-balances.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-balances.tsx
@@ -11,11 +11,26 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function LeaveBalancesSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-7 w-48" />
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-32 w-full" />
+    </div>
+  );
+}
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/leave-balances"
 )({
-  component: () => <PermissionGate feature="gabinet_settings" action="view"><LeaveBalancesPage /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_settings" action="view" loadingFallback={<LeaveBalancesSkeleton />}>
+      <LeaveBalancesPage />
+    </PermissionGate>
+  ),
 });
 
 function LeaveBalancesPage() {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
@@ -22,11 +22,26 @@ import { toast } from "sonner";
 import { Id } from "@cvx/_generated/dataModel";
 import { formatActionError } from "@/lib/format-action-error";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function LeaveTypesSettingsSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-7 w-48" />
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-32 w-full" />
+    </div>
+  );
+}
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/leave-types"
 )({
-  component: () => <PermissionGate feature="gabinet_settings" action="view"><LeaveTypesSettings /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_settings" action="view" loadingFallback={<LeaveTypesSettingsSkeleton />}>
+      <LeaveTypesSettings />
+    </PermissionGate>
+  ),
 });
 
 function LeaveTypesSettings() {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
@@ -48,13 +48,32 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
 
 type LeavesNudgeFilter = "pending";
+
+function LeavesPageSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-7 w-48" />
+      <Skeleton className="h-10 w-full" />
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/leaves"
 )({
-  component: () => <PermissionGate feature="gabinet_settings" action="view"><LeavesPage /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_settings" action="view" loadingFallback={<LeavesPageSkeleton />}>
+      <LeavesPage />
+    </PermissionGate>
+  ),
   validateSearch: (
     search: Record<string, unknown>,
   ): { nudge?: LeavesNudgeFilter } => ({

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
@@ -35,11 +35,26 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function LocationsSettingsSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-7 w-48" />
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-32 w-full" />
+    </div>
+  );
+}
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/locations"
 )({
-  component: () => <PermissionGate feature="gabinet_settings" action="view"><LocationsSettingsPage /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_settings" action="view" loadingFallback={<LocationsSettingsSkeleton />}>
+      <LocationsSettingsPage />
+    </PermissionGate>
+  ),
 });
 
 type LocationWithRooms = {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.reminders.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.reminders.tsx
@@ -13,11 +13,26 @@ import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function ReminderSettingsSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-7 w-48" />
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-32 w-full" />
+    </div>
+  );
+}
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/reminders"
 )({
-  component: () => <PermissionGate feature="gabinet_settings" action="view"><ReminderSettings /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_settings" action="view" loadingFallback={<ReminderSettingsSkeleton />}>
+      <ReminderSettings />
+    </PermissionGate>
+  ),
 });
 
 function ReminderSettings() {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.roles.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.roles.tsx
@@ -21,11 +21,26 @@ import { RotateCcw } from "@/lib/ez-icons";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function GabinetRolesSettingsSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-7 w-48" />
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-32 w-full" />
+    </div>
+  );
+}
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/roles"
 )({
-  component: () => <PermissionGate feature="gabinet_settings" action="view"><GabinetRolesSettingsPage /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_settings" action="view" loadingFallback={<GabinetRolesSettingsSkeleton />}>
+      <GabinetRolesSettingsPage />
+    </PermissionGate>
+  ),
 });
 
 type Scope = "none" | "own" | "all";

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
@@ -14,11 +14,26 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function SchedulingSettingsSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-7 w-48" />
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-32 w-full" />
+    </div>
+  );
+}
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/scheduling"
 )({
-  component: () => <PermissionGate feature="gabinet_settings" action="view"><SchedulingSettings /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_settings" action="view" loadingFallback={<SchedulingSettingsSkeleton />}>
+      <SchedulingSettings />
+    </PermissionGate>
+  ),
 });
 
 const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
@@ -61,11 +61,26 @@ import type { MappedGabinetEmployeeSchedule } from "@/lib/supabase/mappers/gabin
 import type { MappedGabinetWorkingHours } from "@/lib/supabase/mappers/gabinet/working-hours";
 import type { MappedGabinetLeave } from "@/lib/supabase/mappers/gabinet/leaves";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function TimetablePageSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-7 w-48" />
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-32 w-full" />
+    </div>
+  );
+}
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/settings/timetable"
 )({
-  component: () => <PermissionGate feature="gabinet_settings" action="view"><TimetablePage /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_settings" action="view" loadingFallback={<TimetablePageSkeleton />}>
+      <TimetablePage />
+    </PermissionGate>
+  ),
 });
 
 const DAY_NAMES_EN = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -66,11 +66,26 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatTreatmentError } from "@/lib/format-action-error";
 import { PermissionGate } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function TreatmentDetailSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-8 w-64" />
+      <Skeleton className="h-48 w-full" />
+      <Skeleton className="h-48 w-full" />
+    </div>
+  );
+}
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/treatments/$treatmentId",
 )({
-  component: () => <PermissionGate feature="gabinet_treatments" action="view"><TreatmentDetail /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_treatments" action="view" loadingFallback={<TreatmentDetailSkeleton />}>
+      <TreatmentDetail />
+    </PermissionGate>
+  ),
 });
 
 function formatCurrency(amount: number, currency?: string): string {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -42,6 +42,7 @@ import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { formatTreatmentError, extractTreatmentFieldError } from "@/lib/format-action-error";
 import { reportError } from "@/lib/error-reporter";
 import { PermissionGate, usePermission } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
 
 // shadcn/studio statistics blocks
 import StatisticsOrderCard from "@/components/shadcn-studio/blocks/statistics-order-card";
@@ -50,10 +51,31 @@ import StatisticsSalesGrowthCard from "@/components/shadcn-studio/blocks/statist
 
 type TreatmentsNudgeFilter = "no-price";
 
+function TreatmentsIndexSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-9 w-28" />
+      </div>
+      <Skeleton className="h-10 w-full" />
+      <div className="space-y-2">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/treatments/",
 )({
-  component: () => <PermissionGate feature="gabinet_treatments" action="view"><TreatmentsIndex /></PermissionGate>,
+  component: () => (
+    <PermissionGate feature="gabinet_treatments" action="view" loadingFallback={<TreatmentsIndexSkeleton />}>
+      <TreatmentsIndex />
+    </PermissionGate>
+  ),
   validateSearch: (
     search: Record<string, unknown>,
   ): { nudge?: TreatmentsNudgeFilter } => {


### PR DESCRIPTION
## Summary

- Added `loadingFallback` skeleton components to all 19 gabinet route-level `PermissionGate` usages that were missing them, eliminating blank pages during initial permission resolution
- Follows the same pattern established in #2633 for the patients index route
- Skeleton designs are appropriate per page type: list pages show header + table rows, detail pages show header + content blocks, settings pages show a compact form skeleton, the calendar shows a large grid placeholder

## Fixes

Closes #2634

## Test plan

- [ ] Navigate to each gabinet route as a user whose permissions haven't loaded yet — should see a skeleton instead of a blank page
- [ ] Verify the skeleton disappears and the real content loads once permissions resolve
- [ ] Confirm no regressions on already-working routes (patients/index and gabinet dashboard which already had skeletons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)