### PR TITLE
Remove bloodType from the create-patient form (SidePanel on patients list)

### DIFF
--- a/src/components/forms/patient-form.tsx
+++ b/src/components/forms/patient-form.tsx
@@ -260,13 +260,15 @@ export function PatientForm({
             </SelectContent>
           </Select>
         </div>
-        <div className="space-y-1.5">
-          <Label>{t("gabinet.patients.bloodType")}</Label>
-          <Input
-            value={bloodType}
-            onChange={(e) => setBloodType(e.target.value)}
-          />
-        </div>
+        {initialData && (
+          <div className="space-y-1.5">
+            <Label>{t("gabinet.patients.bloodType")}</Label>
+            <Input
+              value={bloodType}
+              onChange={(e) => setBloodType(e.target.value)}
+            />
+          </div>
+        )}
         <div className="space-y-1.5 sm:col-span-2">
           <Label>{t("gabinet.patients.allergies")}</Label>
           <Input


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2640.

Closes #2640

---

## Claude summary

Done. The `bloodType` field in `src/components/forms/patient-form.tsx` (line 263) is now wrapped in `{initialData && (...)}`, so it only renders in edit mode. When the SidePanel opens for a new patient (no `initialData`), the blood type field is hidden. It remains visible and editable when opening the form to edit an existing patient.