### PR TITLE
PatientForm used for both create and edit with no `mode` prop

### DIFF
--- a/src/components/forms/patient-form.tsx
+++ b/src/components/forms/patient-form.tsx
@@ -61,6 +61,7 @@ interface PatientFormData {
 }
 
 interface PatientFormProps {
+  mode?: "create" | "edit";
   initialData?: Partial<PatientFormData>;
   onSubmit: (data: PatientFormData) => void;
   onCancel: () => void;
@@ -73,6 +74,7 @@ interface PatientFormProps {
 const ADD_NEW_REFERRAL_SOURCE = "__add_new__";
 
 export function PatientForm({
+  mode,
   initialData,
   onSubmit,
   onCancel,
@@ -81,6 +83,7 @@ export function PatientForm({
   categoryDefinitions = [],
   organizationId,
 }: PatientFormProps) {
+  const isEditMode = mode === "edit" || (!mode && !!initialData);
   const { t } = useTranslation();
   const [firstName, setFirstName] = useState(initialData?.firstName ?? "");
   const [lastName, setLastName] = useState(initialData?.lastName ?? "");
@@ -260,7 +263,7 @@ export function PatientForm({
             </SelectContent>
           </Select>
         </div>
-        {initialData && (
+        {isEditMode && (
           <div className="space-y-1.5">
             <Label>{t("gabinet.patients.bloodType")}</Label>
             <Input
@@ -433,7 +436,7 @@ export function PatientForm({
         >
           {isSubmitting
             ? t("common.saving")
-            : initialData
+            : isEditMode
               ? t("common.save")
               : t("gabinet.patients.createPatient")}
         </Button>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -1813,6 +1813,7 @@ function PatientDetail() {
           title={t("common.edit")}
         >
           <PatientForm
+            mode="edit"
             initialData={{
               firstName: patient.firstName,
               lastName: patient.lastName,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2641.

Closes #2641

---

## Claude summary

Done. Here's a summary of what was changed:

`src/components/forms/patient-form.tsx`: Added `mode?: "create" | "edit"` to `PatientFormProps` and derived `isEditMode` from it (`mode === "edit" || (!mode && !!initialData)`). Replaced the two implicit `initialData &&` / `initialData ?` guards with `isEditMode` — one for the `bloodType` field (line 266) and one for the submit button label (line ~437).

`src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx`: Added `mode="edit"` to the one `PatientForm` call that is genuinely in edit context (line 1815), making the intent explicit.

All three create-mode callers (`patients/index.tsx`, `_layout.tsx`, `appointment-dialog.tsx`) are untouched — they omit `mode` and the fallback preserves existing behaviour.