### PR TITLE
Naprawa błędu przy dodawaniu klienta na koncie WP

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -304,6 +304,37 @@ export const create = action({
     const now = Date.now();
     const db = createSupabaseDb();
     const orgIdStr = String(args.organizationId);
+
+    // Self-heal: if the organization row is missing from Supabase (can happen
+    // for orgs created before the Supabase migration or during a failed async
+    // sync), upsert it now so the gabinet_patients FK constraint doesn't fire.
+    const client = db.raw();
+    const { data: existingOrg } = await client
+      .from("organizations")
+      .select("id")
+      .eq("id", orgIdStr)
+      .maybeSingle();
+    if (!existingOrg) {
+      const org = await ctx.runQuery(internal.supabase.backfill._getOrganization, {
+        organizationId: orgIdStr,
+      });
+      if (org) {
+        await client.from("organizations").upsert(
+          {
+            id: orgIdStr,
+            name: org.name,
+            slug: org.slug,
+            owner_id: String(org.ownerId),
+            logo: org.logo ?? null,
+            website: org.website ?? null,
+            created_at: org.createdAt ?? now,
+            updated_at: org.updatedAt ?? now,
+          },
+          { onConflict: "id" },
+        );
+      }
+    }
+
     // Normalize phone to digits-only so "600-100-200" and "600100200" are
     // treated as the same number in both the duplicate guard and stored value.
     const normalizedPhone = normalizePhone(args.phone);

--- a/convex/supabase/backfill.ts
+++ b/convex/supabase/backfill.ts
@@ -39,6 +39,18 @@ async function upsertBatch<T extends SupabaseTable>(
 // Internal queries — single record (for self-healing FK deps)
 // ---------------------------------------------------------------------------
 
+export const _getOrganization = internalQuery({
+  args: { organizationId: v.string() },
+  handler: async (ctx, args) => {
+    try {
+      return await ctx.db.get(args.organizationId as Id<"organizations">);
+    } catch {
+      const all = await ctx.db.query("organizations").collect();
+      return all.find((o) => o._id === args.organizationId) ?? null;
+    }
+  },
+});
+
 export const _getUser = internalQuery({
   args: { userId: v.string() },
   handler: async (ctx, args) => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2644.

Closes #2644

---

## Claude summary

The fix is committed. Here's a summary of what was found and fixed:

**Root cause:** The organization for `a.slocka@wp.pl` exists in Convex but is missing from Supabase's `organizations` table. This happens when the async scheduler job `writeOrganizationToSupabase` (which runs "best-effort" with `runAfter(0, ...)` after signup) fails — either because the user row hadn't been written to Supabase yet (race condition), or during the period before the Supabase migration. Supabase's FK constraint `gabinet_patients_organization_id_fkey` then rejects the INSERT because `organization_id` references a non-existent row in `organizations`.

**Fix (2 files):**

`convex/supabase/backfill.ts` — Added `_getOrganization` internal query alongside the existing `_getUser` / `_getPatient` helpers.

`convex/gabinet/patients.ts` — In `patients.create`, before inserting the patient, check if the org exists in Supabase and upsert it if missing. This follows the exact pattern already used in `backfillSinglePatient` for the `created_by` FK. The check is a lightweight `SELECT id` and only does the repair write when the org is actually absent.

## Follow-ups

- Extend org self-heal to `gabinet/treatments.ts` create action: same `organization_id_fkey` FK violation can occur when creating treatments for orgs missing from Supabase
- Extend org self-heal to `gabinet/appointments.ts` create action: same pattern, same risk
- `backfillSinglePatient` and `backfillSingleTreatment` don't heal a missing org FK: if the org is missing from Supabase, the backfill upsert will fail with the same FK error they're supposed to recover from
- `writeOrganizationToSupabase` retries the upsert 3× immediately with no delay: if `owner_id` FK fails (user not yet in Supabase), all 3 retries fail instantly — add a short delay or chain user-write first