### PR TITLE
Extend org self-heal to `gabinet/treatments.ts` create action

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -144,6 +144,37 @@ export const create = action({
 
       const now = Date.now();
       const db = createSupabaseDb();
+      const orgIdStr = String(args.organizationId);
+
+      // Self-heal: if the organization row is missing from Supabase (can happen
+      // for orgs created before the Supabase migration or during a failed async
+      // sync), upsert it now so the gabinet_treatments FK constraint doesn't fire.
+      const client = db.raw();
+      const { data: existingOrg } = await client
+        .from("organizations")
+        .select("id")
+        .eq("id", orgIdStr)
+        .maybeSingle();
+      if (!existingOrg) {
+        const org = await ctx.runQuery(internal.supabase.backfill._getOrganization, {
+          organizationId: orgIdStr,
+        });
+        if (org) {
+          await client.from("organizations").upsert(
+            {
+              id: orgIdStr,
+              name: org.name,
+              slug: org.slug,
+              owner_id: String(org.ownerId),
+              logo: org.logo ?? null,
+              website: org.website ?? null,
+              created_at: org.createdAt ?? now,
+              updated_at: org.updatedAt ?? now,
+            },
+            { onConflict: "id" },
+          );
+        }
+      }
 
       // --- INSERT treatment directly to Supabase ---
       // Only include taxExempt when true — omitting it avoids a "column does
@@ -152,7 +183,7 @@ export const create = action({
       // Only include packageId when non-null — same reasoning for migration
       // 00010.
       const insertRow: Record<string, unknown> = {
-        organizationId: String(args.organizationId),
+        organizationId: orgIdStr,
         name: args.name,
         description: args.description ?? null,
         duration: args.duration,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2646.

Closes #2646

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Triage:** The issue is real. The `create` action in `convex/gabinet/treatments.ts` writes directly to Supabase's `gabinet_treatments` table, which has an `organization_id_fkey` FK constraint. For organizations created before the Supabase migration or where the async sync failed, the `organizations` row may be absent in Supabase — causing the FK violation on insert. The identical bug was fixed for patients in #2644.

**Fix:** Added the same self-heal guard from `patients.ts` (lines 308-336) into the `treatments.ts` `create` action (after `createSupabaseDb()`). Before inserting the treatment row, it checks whether the org exists in Supabase and upserts it from Convex data if missing, using `internal.supabase.backfill._getOrganization`. The change is 31 lines in one file.