### PR TITLE
fix(gabinet): self-heal missing org in Supabase before appointment insert (closes #2647)

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1109,6 +1109,37 @@ export const create = action({
 
     const now = Date.now();
     const db = createSupabaseDb();
+    const orgIdStr = String(args.organizationId);
+
+    // Self-heal: if the organization row is missing from Supabase (can happen
+    // for orgs created before the Supabase migration or during a failed async
+    // sync), upsert it now so the gabinet_appointments FK constraint doesn't fire.
+    const client = db.raw();
+    const { data: existingOrg } = await client
+      .from("organizations")
+      .select("id")
+      .eq("id", orgIdStr)
+      .maybeSingle();
+    if (!existingOrg) {
+      const org = await ctx.runQuery(internal.supabase.backfill._getOrganization, {
+        organizationId: orgIdStr,
+      });
+      if (org) {
+        await client.from("organizations").upsert(
+          {
+            id: orgIdStr,
+            name: org.name,
+            slug: org.slug,
+            owner_id: String(org.ownerId),
+            logo: org.logo ?? null,
+            website: org.website ?? null,
+            created_at: org.createdAt ?? now,
+            updated_at: org.updatedAt ?? now,
+          },
+          { onConflict: "id" },
+        );
+      }
+    }
 
     // --- Past-time guard (issue #1414) ---
     // Reject appointments whose start is already in the past unless the


### PR DESCRIPTION
## Summary
- Adds the org self-heal pattern to `gabinet/appointments.ts` `create` action, matching the identical fix already applied to `patients.ts` (#2644) and `treatments.ts` (#2646)
- Before inserting a `gabinet_appointments` row, the action now checks whether the `organizations` row exists in Supabase and upserts it if missing — preventing FK constraint failures for orgs created before the Supabase migration

## Test plan
- [ ] Create an appointment for an org whose row is absent from Supabase — should succeed (org is auto-upserted) rather than throwing an FK violation
- [ ] Create an appointment for a normal org (row already present) — fast path, no extra DB round-trip visible in behavior
- [ ] Existing appointment creation tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)