### PR TITLE
`backfillSinglePatient` and `backfillSingleTreatment` don't heal a missing org F

### DIFF
--- a/convex/supabase/backfill.ts
+++ b/convex/supabase/backfill.ts
@@ -101,6 +101,33 @@ export const backfillSinglePatient = internalAction({
 
     const client = createServiceRoleClient();
 
+    const orgIdStr = String(p.organizationId);
+    const { data: existingOrg } = await client
+      .from("organizations")
+      .select("id")
+      .eq("id", orgIdStr)
+      .maybeSingle();
+    if (!existingOrg) {
+      const org = await ctx.runQuery(internal.supabase.backfill._getOrganization, {
+        organizationId: orgIdStr,
+      });
+      if (org) {
+        await client.from("organizations").upsert(
+          {
+            id: orgIdStr,
+            name: org.name,
+            slug: org.slug,
+            owner_id: String(org.ownerId),
+            logo: org.logo ?? null,
+            website: org.website ?? null,
+            created_at: org.createdAt ?? Date.now(),
+            updated_at: org.updatedAt ?? Date.now(),
+          },
+          { onConflict: "id" },
+        );
+      }
+    }
+
     const createdByExists = await client
       .from("users")
       .select("id")
@@ -183,6 +210,33 @@ export const backfillSingleTreatment = internalAction({
     if (!t) return { synced: 0, errors: ["Treatment not found in Convex"] };
 
     const client = createServiceRoleClient();
+
+    const orgIdStr = String(t.organizationId);
+    const { data: existingOrg } = await client
+      .from("organizations")
+      .select("id")
+      .eq("id", orgIdStr)
+      .maybeSingle();
+    if (!existingOrg) {
+      const org = await ctx.runQuery(internal.supabase.backfill._getOrganization, {
+        organizationId: orgIdStr,
+      });
+      if (org) {
+        await client.from("organizations").upsert(
+          {
+            id: orgIdStr,
+            name: org.name,
+            slug: org.slug,
+            owner_id: String(org.ownerId),
+            logo: org.logo ?? null,
+            website: org.website ?? null,
+            created_at: org.createdAt ?? Date.now(),
+            updated_at: org.updatedAt ?? Date.now(),
+          },
+          { onConflict: "id" },
+        );
+      }
+    }
 
     const createdByExists = await client
       .from("users")


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2648.

Closes #2648

---

## Claude summary

The bug was real and is now fixed.

**Root cause:** Both `backfillSinglePatient` and `backfillSingleTreatment` in `convex/supabase/backfill.ts` already self-healed the `createdBy` user FK before upserting, but skipped the `organization_id` FK check entirely. Since `gabinet_patients` and `gabinet_treatments` both reference `organizations(id)`, any org missing from Supabase would cause the upsert to fail with the same FK error these functions are supposed to recover from.

**Fix applied:** Added the identical org self-heal block (check → fetch from Convex → upsert to Supabase) to both functions, placed before the user check, matching the pattern already used in the write actions (`gabinet/patients.ts:create`, `gabinet/treatments.ts:create`). One file changed: `convex/supabase/backfill.ts`.