### PR TITLE
`writeOrganizationToSupabase` retries the upsert 3× immediately with no delay

### DIFF
--- a/convex/supabase/organizations.ts
+++ b/convex/supabase/organizations.ts
@@ -22,8 +22,48 @@ export const writeOrganizationToSupabase = internalAction({
     onboardingCompleted: v.optional(v.boolean()),
   },
   returns: v.object({ success: v.boolean(), id: v.string() }),
-  handler: async (_ctx, args) => {
+  handler: async (ctx, args) => {
     const client = createServiceRoleClient();
+
+    // Self-heal: writeUserToSupabase and writeOrganizationToSupabase are both
+    // scheduled with runAfter(0) from completeOnboarding. If the org action
+    // fires first the owner_id FK doesn't exist yet, and the immediate 3-retry
+    // loop in upsertWithFkRetry has no delay to let it appear. Ensure the owner
+    // user row is present before attempting the org upsert.
+    const { data: existingUser } = await client
+      .from("users")
+      .select("id")
+      .eq("id", args.ownerId)
+      .maybeSingle();
+    if (!existingUser) {
+      const user = await ctx.runQuery(internal.supabase.backfill._getUser, {
+        userId: args.ownerId,
+      });
+      if (user) {
+        await client.from("users").upsert(
+          {
+            id: user._id,
+            name: user.name ?? null,
+            username: user.username ?? null,
+            image_storage_id: user.imageId ?? null,
+            image: user.image ?? null,
+            email: user.email ?? null,
+            email_verification_time: user.emailVerificationTime ?? null,
+            phone: user.phone ?? null,
+            phone_verification_time: user.phoneVerificationTime ?? null,
+            is_anonymous: user.isAnonymous ?? false,
+            customer_id: user.customerId ?? null,
+            language: user.language ?? null,
+            theme: user.theme ?? null,
+            timezone: user.timezone ?? null,
+            created_at: Math.floor(user._creationTime),
+            updated_at: Math.floor(user._creationTime),
+          },
+          { onConflict: "id" },
+        );
+      }
+    }
+
     const row = {
       id: args.organizationId,
       name: args.name,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2649.

Closes #2649

---

## Claude summary

The bug is real and the fix is committed. Here's the summary:

**Root cause:** In `app.completeOnboarding`, both `writeUserToSupabase` and `writeOrganizationToSupabase` are scheduled with `runAfter(0, ...)`. They race, and when the org action fires first, the `owner_id` FK doesn't yet exist in Supabase's `users` table. `upsertWithFkRetry` retries 3× immediately (no delay) — all fail with `23503`.

**Fix in `convex/supabase/organizations.ts`:** Before the org upsert, check if the owner user row exists in Supabase. If not, fetch the user from Convex via `_getUser` and write them inline first. This is the same self-heal pattern applied in issues #2644–#2648 for missing org FKs.

## Follow-ups
- Apply same self-heal pattern to `writeTeamMembershipToSupabase`: it has both `user_id` and `organization_id` FKs and is scheduled with `runAfter(0)` alongside the user/org writes — the same race condition applies if either FK is missing