### PR TITLE
Komunikat przed przejściem z Gabinetu do wspólnego modułu CRM

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -4609,5 +4609,11 @@
       "duplicateSection": "Duplicate section",
       "deleteSection": "Delete section"
     }
+  },
+  "crossModuleDialog": {
+    "title": "Shared CRM Module",
+    "description": "This module is shared across the entire CRM system and is not directly part of the Gabinet section.\n\nYou will be taken to the relevant CRM module.",
+    "confirm": "Go to module",
+    "dontShowAgain": "Don't show again"
   }
 }

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -4635,5 +4635,11 @@
       "duplicateSection": "Duplikuj sekcję",
       "deleteSection": "Usuń sekcję"
     }
+  },
+  "crossModuleDialog": {
+    "title": "Moduł wspólny CRM",
+    "description": "Ten moduł jest wspólny dla całego systemu CRM i nie znajduje się bezpośrednio w części Gabinet.\n\nZa chwilę otworzymy odpowiedni moduł CRM.",
+    "confirm": "Przejdź do modułu",
+    "dontShowAgain": "Nie pokazuj ponownie"
   }
 }

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -1,4 +1,5 @@
-import { Link, useMatchRoute } from "@tanstack/react-router";
+import { Link, useMatchRoute, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { convexQuery } from "@convex-dev/react-query";
 import { useAction } from "convex/react";
@@ -24,6 +25,16 @@ import { CalendarMiniMonth } from "@untitled/app/calendar/base-components/calend
 import { WorkspaceSwitcher } from "@/components/layout/workspace-switcher";
 import { cn } from "@/utils/misc";
 import Logo from "@/assets/svg/logo";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { DayTimeline } from "@/components/sidebar-widgets/day-timeline";
 import { getModuleById, getVisibleModules, moduleRegistry } from "@/modules/registry";
 
@@ -31,13 +42,47 @@ const routeAwareModules = [...moduleRegistry].sort(
   (left, right) => right.workspaceRoot.length - left.workspaceRoot.length,
 );
 
+const CROSS_MODULE_DISMISSED_KEY = "gabinet.crossModuleWarningDismissed";
+
 export function AppSidebar() {
   const matchRoute = useMatchRoute();
   const { t } = useTranslation();
   const { openQuickCreate, navigateTo, dispatch } = useSidebarActions();
   const { isMobile, setOpenMobile } = useSidebar();
+  const navigate = useNavigate();
+  const [pendingNavHref, setPendingNavHref] = useState<string | null>(null);
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
   const closeMobile = () => {
     if (isMobile) setOpenMobile(false);
+  };
+
+  const handleCrossModuleClick = (href: string) => {
+    const dismissed = localStorage.getItem(CROSS_MODULE_DISMISSED_KEY) === "true";
+    if (dismissed) {
+      void navigate({ to: href });
+      closeMobile();
+    } else {
+      setPendingNavHref(href);
+    }
+  };
+
+  const handleCrossModuleConfirm = () => {
+    if (dontShowAgain) {
+      localStorage.setItem(CROSS_MODULE_DISMISSED_KEY, "true");
+    }
+    const href = pendingNavHref;
+    setPendingNavHref(null);
+    setDontShowAgain(false);
+    if (href) {
+      void navigate({ to: href });
+      closeMobile();
+    }
+  };
+
+  const handleCrossModuleCancel = () => {
+    setPendingNavHref(null);
+    setDontShowAgain(false);
   };
   const { organizationId } = useOrganization();
   const { state: miniCalState } = useMiniCalendar();
@@ -138,17 +183,29 @@ export function AppSidebar() {
 
                   return (
                     <SidebarMenuItem key={item.href}>
-                      <SidebarMenuButton
-                        className="[&>svg]:text-primary [&>easier-icon]:text-primary group-data-[collapsible=icon]:size-10! [&>svg]:size-4 [&>easier-icon]:size-4"
-                        tooltip={t(item.labelKey)}
-                        isActive={isActive}
-                        asChild
-                      >
-                        <Link to={item.href} onClick={closeMobile}>
+                      {item.crossModule ? (
+                        <SidebarMenuButton
+                          className="[&>svg]:text-primary [&>easier-icon]:text-primary group-data-[collapsible=icon]:size-10! [&>svg]:size-4 [&>easier-icon]:size-4"
+                          tooltip={t(item.labelKey)}
+                          isActive={isActive}
+                          onClick={() => handleCrossModuleClick(item.href)}
+                        >
                           <item.icon variant="stroke" />
                           <span>{t(item.labelKey)}</span>
-                        </Link>
-                      </SidebarMenuButton>
+                        </SidebarMenuButton>
+                      ) : (
+                        <SidebarMenuButton
+                          className="[&>svg]:text-primary [&>easier-icon]:text-primary group-data-[collapsible=icon]:size-10! [&>svg]:size-4 [&>easier-icon]:size-4"
+                          tooltip={t(item.labelKey)}
+                          isActive={isActive}
+                          asChild
+                        >
+                          <Link to={item.href} onClick={closeMobile}>
+                            <item.icon variant="stroke" />
+                            <span>{t(item.labelKey)}</span>
+                          </Link>
+                        </SidebarMenuButton>
+                      )}
                     </SidebarMenuItem>
                   );
                 })}
@@ -272,6 +329,35 @@ export function AppSidebar() {
             )}
         </div>
       )}
+
+      <Dialog open={pendingNavHref !== null} onOpenChange={(open) => { if (!open) handleCrossModuleCancel(); }}>
+        <DialogContent hideClose>
+          <DialogHeader>
+            <DialogTitle>{t("crossModuleDialog.title")}</DialogTitle>
+            <DialogDescription className="whitespace-pre-line">
+              {t("crossModuleDialog.description")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="cross-module-dont-show"
+              checked={dontShowAgain}
+              onCheckedChange={(checked) => setDontShowAgain(!!checked)}
+            />
+            <label htmlFor="cross-module-dont-show" className="cursor-pointer text-sm">
+              {t("crossModuleDialog.dontShowAgain")}
+            </label>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={handleCrossModuleCancel}>
+              {t("common.cancel")}
+            </Button>
+            <Button onClick={handleCrossModuleConfirm}>
+              {t("crossModuleDialog.confirm")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -55,8 +55,8 @@ export const gabinetManifest: ModuleManifest = {
     { labelKey: "nav.gabinet.employees", href: "/dashboard/gabinet/employees", icon: UserCog },
     { labelKey: "nav.gabinet.documents", href: "/dashboard/gabinet/documents", icon: ClipboardList },
     { labelKey: "nav.gabinet.documentTemplates", href: "/dashboard/gabinet/document-templates", icon: FilePlus },
-    { labelKey: "nav.emailTemplates", href: "/dashboard/email-templates", icon: MailOpen },
-    { labelKey: "nav.products", href: "/dashboard/products", icon: Package },
+    { labelKey: "nav.emailTemplates", href: "/dashboard/email-templates", icon: MailOpen, crossModule: true },
+    { labelKey: "nav.products", href: "/dashboard/products", icon: Package, crossModule: true },
     { labelKey: "nav.gabinet.reports", href: "/dashboard/gabinet/reports", icon: PieChart },
   ],
   settingsNav: [

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -23,6 +23,7 @@ export interface ModuleNavItem {
   href: string;
   icon: ElementType;
   activeMatch?: "exact" | "fuzzy";
+  crossModule?: boolean;
 }
 
 export interface ModuleContextAction {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2656.

Closes #2656

---

## Claude summary

The implementation is complete. Here's a summary of what was done:

**Changes across 5 files:**

`src/modules/types.ts` — Added `crossModule?: boolean` to the `ModuleNavItem` interface so nav items can be flagged as cross-module links.

`src/modules/gabinet/manifest.ts` — Added `crossModule: true` to the "Szablony e-mail" and "Produkty / Magazyn" nav items so they trigger the dialog.

`src/components/layout/app-sidebar.tsx` — Added the full dialog flow: `handleCrossModuleClick` checks `localStorage` and either navigates directly (if already dismissed) or opens the dialog; `handleCrossModuleConfirm` saves the preference and navigates; the Dialog renders with a `Checkbox` for "Nie pokazuj ponownie". The dismissal is persisted under the key `gabinet.crossModuleWarningDismissed` in `localStorage`.

`public/locales/pl/translation.json` & `public/locales/en/translation.json` — Added the `crossModuleDialog` translation keys in both Polish and English with the exact wording from the issue.