### PR TITLE
Po zalogowaniu domyślnie otwieraj Gabinet zamiast CRM

### DIFF
--- a/src/routes/_app/login/_layout.index.tsx
+++ b/src/routes/_app/login/_layout.index.tsx
@@ -14,6 +14,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Route as OnboardingUsernameRoute } from "@/routes/_app/_auth/onboarding/_layout.username";
 import { Route as DashboardRoute } from "@/routes/_app/_auth/dashboard/_layout.index";
+import { Route as GabinetRoute } from "@/routes/_app/_auth/dashboard/_layout.gabinet.index";
 import { useQuery } from "@tanstack/react-query";
 import { convexQuery, useConvexAuth } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
@@ -80,7 +81,7 @@ function Login() {
       navigate({ to: OnboardingUsernameRoute.fullPath, replace: true });
       return;
     }
-    navigate({ to: DashboardRoute.fullPath, replace: true });
+    navigate({ to: GabinetRoute.fullPath, replace: true });
   }, [isLoading, isAuthenticated, user, navigate, inviteToken]);
 
   // Optional banner rendered above every step when in invite flow


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2661.

Closes #2661

---

## Claude summary

Done. The fix is a 2-line change in `src/routes/_app/login/_layout.index.tsx`:

- Added import for `GabinetRoute` from `@/routes/_app/_auth/dashboard/_layout.gabinet.index`
- Changed the final post-login `navigate` call to use `GabinetRoute.fullPath` (`/dashboard/gabinet`) instead of `DashboardRoute.fullPath` (`/dashboard`)

The edge cases are preserved as-is: unauthenticated users still get bounced to the login guard, invite-flow users still get redirected to their invite token, and users without a username still go through the onboarding flow.