### PR TITLE
Nie można utworzyć pierwszej kategorii zabiegów w nowym gabinecie

### DIFF
--- a/convex/categoryDefinitions.ts
+++ b/convex/categoryDefinitions.ts
@@ -45,6 +45,38 @@ export const create = action({
     if (!perm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
+    const orgIdStr = String(args.organizationId);
+    const now = Date.now();
+
+    // Self-heal: if the organization row is missing from Supabase (can happen
+    // for orgs created before the Supabase migration or during a failed async
+    // sync), upsert it now so the category_definitions FK constraint doesn't fire.
+    const client = db.raw();
+    const { data: existingOrg } = await client
+      .from("organizations")
+      .select("id")
+      .eq("id", orgIdStr)
+      .maybeSingle();
+    if (!existingOrg) {
+      const org = await ctx.runQuery(internal.supabase.backfill._getOrganization, {
+        organizationId: orgIdStr,
+      });
+      if (org) {
+        await client.from("organizations").upsert(
+          {
+            id: orgIdStr,
+            name: org.name,
+            slug: org.slug,
+            owner_id: String(org.ownerId),
+            logo: org.logo ?? null,
+            website: org.website ?? null,
+            created_at: org.createdAt ?? now,
+            updated_at: org.updatedAt ?? now,
+          },
+          { onConflict: "id" },
+        );
+      }
+    }
 
     // Validate 2-level constraint
     if (args.parentId) {
@@ -57,7 +89,7 @@ export const create = action({
     // Get next sortOrder within same level
     const siblings = await db
       .query("categoryDefinitions")
-      .eq("organizationId", String(args.organizationId))
+      .eq("organizationId", orgIdStr)
       .eq("entityType", args.entityType)
       .collect();
     const sameLevelSiblings = siblings.filter((c: any) =>
@@ -65,9 +97,8 @@ export const create = action({
     );
     const maxOrder = sameLevelSiblings.reduce((max: number, c: any) => Math.max(max, c.sortOrder ?? 0), -1);
 
-    const now = Date.now();
     const catId = await db.insert("categoryDefinitions", {
-      organizationId: String(args.organizationId),
+      organizationId: orgIdStr,
       entityType: args.entityType,
       name: args.name.trim(),
       parentId: args.parentId ?? null,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2663.

Closes #2663

---

## Claude summary

The bug is confirmed real and is now fixed. Here's what was happening:

**Root cause:** `convex/categoryDefinitions.ts` `create` action was missing the organization self-heal block. On a freshly created gabinet, when the user tried to add their first treatment category, the `category_definitions` table's FK constraint (`category_definitions_organization_id_fkey`) fired because the organization row hadn't been synced to Supabase yet. This is the same class of bug that was previously fixed for `gabinet/treatments.ts` (lines 149–177), but `categoryDefinitions.ts` never got the same treatment.

**Fix:** Added the identical self-heal pattern to `categoryDefinitions.ts`'s `create` action — it checks if the org row exists in Supabase, and if not, fetches it from Convex via `internal.supabase.backfill._getOrganization` and upserts it before attempting the insert.