### PR TITLE
Naprawa dodawania sprzętu w nowym gabinecie

### DIFF
--- a/convex/gabinet/equipment.ts
+++ b/convex/gabinet/equipment.ts
@@ -119,9 +119,40 @@ export const createEquipment = action({
 
     const now = Date.now();
     const db = createSupabaseDb();
+    const orgIdStr = String(args.organizationId);
+
+    // Self-heal: upsert the org row in Supabase if it is missing (can happen
+    // for orgs created before the Supabase migration or during a failed async
+    // sync), so the gabinet_equipment_organization_id_fkey FK doesn't fire.
+    const client = db.raw();
+    const { data: existingOrg } = await client
+      .from("organizations")
+      .select("id")
+      .eq("id", orgIdStr)
+      .maybeSingle();
+    if (!existingOrg) {
+      const org = await ctx.runQuery(internal.supabase.backfill._getOrganization, {
+        organizationId: orgIdStr,
+      });
+      if (org) {
+        await client.from("organizations").upsert(
+          {
+            id: orgIdStr,
+            name: org.name,
+            slug: org.slug,
+            owner_id: String(org.ownerId),
+            logo: org.logo ?? null,
+            website: org.website ?? null,
+            created_at: org.createdAt ?? now,
+            updated_at: org.updatedAt ?? now,
+          },
+          { onConflict: "id" },
+        );
+      }
+    }
 
     const equipmentId = await db.insert("gabinetEquipment", {
-      organizationId: String(args.organizationId),
+      organizationId: orgIdStr,
       name: args.name,
       description: args.description ?? null,
       serialNumber: args.serialNumber ?? null,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2665.

Closes #2665

---

## Claude summary

The fix is committed. Here's a summary:

**Root cause:** `createEquipment` in `convex/gabinet/equipment.ts` directly inserted into the `gabinet_equipment` Supabase table without first ensuring the parent `organizations` row exists. For a fresh gabinet the org may not yet be synced to Supabase, so the FK constraint `gabinet_equipment_organization_id_fkey` fires.

**Fix:** Applied the identical self-heal pattern already used in `convex/categoryDefinitions.ts` (PR #2664) and `convex/gabinet/treatments.ts`:
1. Check if the org row exists in Supabase via `db.raw()`.
2. If missing, fetch the org from Convex via `internal.supabase.backfill._getOrganization` and upsert it into Supabase.
3. Then proceed with the equipment insert — the FK is now satisfied.

Only `convex/gabinet/equipment.ts` was changed (1 file, 32 lines added), scoped exactly to the create action.

## Follow-ups

- Apply self-heal pattern to `convex/gabinet/locations.ts` create action: the same FK violation would occur when creating a location on a fresh gabinet, for the same reason as equipment (#2665) and category definitions (#2663).
- Apply self-heal pattern to `convex/gabinet/rooms.ts` create action: same FK risk — rooms reference `organization_id` in Supabase and may be the first write for a new org.