### PR TITLE
Apply self-heal pattern to `convex/gabinet/locations.ts` create action

### DIFF
--- a/convex/gabinet/locations.ts
+++ b/convex/gabinet/locations.ts
@@ -83,9 +83,40 @@ export const createLocation = action({
 
     const now = Date.now();
     const db = createSupabaseDb();
+    const orgIdStr = String(args.organizationId);
+
+    // Self-heal: upsert the org row in Supabase if it is missing (can happen
+    // for orgs created before the Supabase migration or during a failed async
+    // sync), so the gabinet_locations_organization_id_fkey FK doesn't fire.
+    const client = db.raw();
+    const { data: existingOrg } = await client
+      .from("organizations")
+      .select("id")
+      .eq("id", orgIdStr)
+      .maybeSingle();
+    if (!existingOrg) {
+      const org = await ctx.runQuery(internal.supabase.backfill._getOrganization, {
+        organizationId: orgIdStr,
+      });
+      if (org) {
+        await client.from("organizations").upsert(
+          {
+            id: orgIdStr,
+            name: org.name,
+            slug: org.slug,
+            owner_id: String(org.ownerId),
+            logo: org.logo ?? null,
+            website: org.website ?? null,
+            created_at: org.createdAt ?? now,
+            updated_at: org.updatedAt ?? now,
+          },
+          { onConflict: "id" },
+        );
+      }
+    }
 
     const locationId = await db.insert("gabinetLocations", {
-      organizationId: String(args.organizationId),
+      organizationId: orgIdStr,
       name: args.name,
       address: args.address ?? null,
       phone: args.phone ?? null,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2667.

Closes #2667

---

## Claude summary

Done. The `createLocation` action in `convex/gabinet/locations.ts` now has the same self-heal pattern as `createEquipment` (#2665) and `createCategoryDefinition` (#2663). Before inserting a location row, it checks whether the org row exists in Supabase and upserts it from Convex data if not, preventing the `gabinet_locations_organization_id_fkey` FK violation on fresh gabinets.