### PR TITLE
Apply self-heal pattern to `convex/gabinet/rooms.ts` create action

### DIFF
--- a/convex/gabinet/locations.ts
+++ b/convex/gabinet/locations.ts
@@ -305,8 +305,40 @@ export const createRoom = action({
     }
 
     const now = Date.now();
+    const orgIdStr = String(args.organizationId);
+
+    // Self-heal: upsert the org row in Supabase if it is missing (can happen
+    // for orgs created before the Supabase migration or during a failed async
+    // sync), so the gabinet_rooms_organization_id_fkey FK doesn't fire.
+    const client = db.raw();
+    const { data: existingOrg } = await client
+      .from("organizations")
+      .select("id")
+      .eq("id", orgIdStr)
+      .maybeSingle();
+    if (!existingOrg) {
+      const org = await ctx.runQuery(internal.supabase.backfill._getOrganization, {
+        organizationId: orgIdStr,
+      });
+      if (org) {
+        await client.from("organizations").upsert(
+          {
+            id: orgIdStr,
+            name: org.name,
+            slug: org.slug,
+            owner_id: String(org.ownerId),
+            logo: org.logo ?? null,
+            website: org.website ?? null,
+            created_at: org.createdAt ?? now,
+            updated_at: org.updatedAt ?? now,
+          },
+          { onConflict: "id" },
+        );
+      }
+    }
+
     const roomId = await db.insert("gabinetRooms", {
-      organizationId: String(args.organizationId),
+      organizationId: orgIdStr,
       locationId: args.locationId,
       name: args.name,
       description: args.description ?? null,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2668.

Closes #2668

---

## Claude summary

The fix is committed. The rooms functionality lives in `convex/gabinet/locations.ts` (not a separate `rooms.ts`), and the `createRoom` action now has the same self-heal pattern applied to `createLocation` and `createEquipment`: it checks whether the org row exists in Supabase before inserting into `gabinetRooms`, and if missing, fetches the org from Convex and upserts it — preventing the `gabinet_rooms_organization_id_fkey` FK violation for orgs created before the Supabase migration or during a failed async sync.