### PR TITLE
Sprawdzenie pozostałych błędów tworzenia pierwszych danych w nowym gabinecie

### DIFF
--- a/convex/gabinet/employeeLocations.ts
+++ b/convex/gabinet/employeeLocations.ts
@@ -79,6 +79,38 @@ export const addLocation = action({
       if (existing) return String(existing._id);
 
       const makePrimary = args.isPrimary ?? false;
+      const orgIdStr = String(args.organizationId);
+      const now = Date.now();
+
+      // Self-heal: if the organization row is missing from Supabase (can happen
+      // for orgs created before the Supabase migration or during a failed async
+      // sync), upsert it now so the gabinet_employee_locations FK constraint doesn't fire.
+      const client = db.raw();
+      const { data: existingOrg } = await client
+        .from("organizations")
+        .select("id")
+        .eq("id", orgIdStr)
+        .maybeSingle();
+      if (!existingOrg) {
+        const org = await ctx.runQuery(internal.supabase.backfill._getOrganization, {
+          organizationId: orgIdStr,
+        });
+        if (org) {
+          await client.from("organizations").upsert(
+            {
+              id: orgIdStr,
+              name: org.name,
+              slug: org.slug,
+              owner_id: String(org.ownerId),
+              logo: org.logo ?? null,
+              website: org.website ?? null,
+              created_at: org.createdAt ?? now,
+              updated_at: org.updatedAt ?? now,
+            },
+            { onConflict: "id" },
+          );
+        }
+      }
 
       // If this should become primary, clear any existing primary for this employee.
       if (makePrimary) {
@@ -95,11 +127,11 @@ export const addLocation = action({
       }
 
       const grantId = await db.insert("gabinetEmployeeLocations", {
-        organizationId: String(args.organizationId),
+        organizationId: orgIdStr,
         employeeId: args.employeeId,
         locationId: args.locationId,
         isPrimary: makePrimary,
-        createdAt: Date.now(),
+        createdAt: now,
       });
 
       return grantId;

--- a/convex/gabinet/leaveTypes.ts
+++ b/convex/gabinet/leaveTypes.ts
@@ -70,9 +70,40 @@ export const create = action({
     if (!perm.allowed) throw new Error("Permission denied");
     const now = Date.now();
     const db = createSupabaseDb();
+    const orgIdStr = String(args.organizationId);
+
+    // Self-heal: if the organization row is missing from Supabase (can happen
+    // for orgs created before the Supabase migration or during a failed async
+    // sync), upsert it now so the gabinet_leave_types FK constraint doesn't fire.
+    const client = db.raw();
+    const { data: existingOrg } = await client
+      .from("organizations")
+      .select("id")
+      .eq("id", orgIdStr)
+      .maybeSingle();
+    if (!existingOrg) {
+      const org = await ctx.runQuery(internal.supabase.backfill._getOrganization, {
+        organizationId: orgIdStr,
+      });
+      if (org) {
+        await client.from("organizations").upsert(
+          {
+            id: orgIdStr,
+            name: org.name,
+            slug: org.slug,
+            owner_id: String(org.ownerId),
+            logo: org.logo ?? null,
+            website: org.website ?? null,
+            created_at: org.createdAt ?? now,
+            updated_at: org.updatedAt ?? now,
+          },
+          { onConflict: "id" },
+        );
+      }
+    }
 
     const leaveTypeId = await db.insert("gabinetLeaveTypes", {
-      organizationId: String(args.organizationId),
+      organizationId: orgIdStr,
       name: args.name,
       color: args.color ?? null,
       isPaid: args.isPaid,

--- a/convex/gabinet/loyalty.ts
+++ b/convex/gabinet/loyalty.ts
@@ -86,8 +86,39 @@ export const earnPoints = action({
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const now = Date.now();
     const db = createSupabaseDb();
+    const orgIdStr = String(args.organizationId);
 
-    const loyalty = await getOrCreateLoyalty(db, String(args.organizationId), args.patientId);
+    // Self-heal: if the organization row is missing from Supabase (can happen
+    // for orgs created before the Supabase migration or during a failed async
+    // sync), upsert it now so the gabinet_loyalty_points FK constraint doesn't fire.
+    const client = db.raw();
+    const { data: existingOrg } = await client
+      .from("organizations")
+      .select("id")
+      .eq("id", orgIdStr)
+      .maybeSingle();
+    if (!existingOrg) {
+      const org = await ctx.runQuery(internal.supabase.backfill._getOrganization, {
+        organizationId: orgIdStr,
+      });
+      if (org) {
+        await client.from("organizations").upsert(
+          {
+            id: orgIdStr,
+            name: org.name,
+            slug: org.slug,
+            owner_id: String(org.ownerId),
+            logo: org.logo ?? null,
+            website: org.website ?? null,
+            created_at: org.createdAt ?? now,
+            updated_at: org.updatedAt ?? now,
+          },
+          { onConflict: "id" },
+        );
+      }
+    }
+
+    const loyalty = await getOrCreateLoyalty(db, orgIdStr, args.patientId);
     const newBalance = (loyalty!.balance as number) + args.points;
     const newLifetimeEarned = (loyalty!.lifetimeEarned as number) + args.points;
 
@@ -98,7 +129,7 @@ export const earnPoints = action({
     });
 
     await db.insert("gabinetLoyaltyTransactions", {
-      organizationId: String(args.organizationId),
+      organizationId: orgIdStr,
       patientId: args.patientId,
       type: "earn",
       points: args.points,
@@ -129,8 +160,38 @@ export const spendPoints = action({
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const now = Date.now();
     const db = createSupabaseDb();
+    const orgIdStr = String(args.organizationId);
 
-    const loyalty = await getOrCreateLoyalty(db, String(args.organizationId), args.patientId);
+    // Self-heal: if the organization row is missing from Supabase, upsert it now
+    // so the gabinet_loyalty_transactions FK constraint doesn't fire.
+    const clientSpend = db.raw();
+    const { data: existingOrgSpend } = await clientSpend
+      .from("organizations")
+      .select("id")
+      .eq("id", orgIdStr)
+      .maybeSingle();
+    if (!existingOrgSpend) {
+      const org = await ctx.runQuery(internal.supabase.backfill._getOrganization, {
+        organizationId: orgIdStr,
+      });
+      if (org) {
+        await clientSpend.from("organizations").upsert(
+          {
+            id: orgIdStr,
+            name: org.name,
+            slug: org.slug,
+            owner_id: String(org.ownerId),
+            logo: org.logo ?? null,
+            website: org.website ?? null,
+            created_at: org.createdAt ?? now,
+            updated_at: org.updatedAt ?? now,
+          },
+          { onConflict: "id" },
+        );
+      }
+    }
+
+    const loyalty = await getOrCreateLoyalty(db, orgIdStr, args.patientId);
     if ((loyalty!.balance as number) < args.points) throw new Error("Insufficient loyalty points");
 
     const newBalance = (loyalty!.balance as number) - args.points;
@@ -143,7 +204,7 @@ export const spendPoints = action({
     });
 
     await db.insert("gabinetLoyaltyTransactions", {
-      organizationId: String(args.organizationId),
+      organizationId: orgIdStr,
       patientId: args.patientId,
       type: "spend",
       points: args.points,
@@ -172,8 +233,38 @@ export const adjustPoints = action({
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
     const now = Date.now();
     const db = createSupabaseDb();
+    const orgIdStr = String(args.organizationId);
 
-    const loyalty = await getOrCreateLoyalty(db, String(args.organizationId), args.patientId);
+    // Self-heal: if the organization row is missing from Supabase, upsert it now
+    // so the gabinet_loyalty_transactions FK constraint doesn't fire.
+    const clientAdjust = db.raw();
+    const { data: existingOrgAdjust } = await clientAdjust
+      .from("organizations")
+      .select("id")
+      .eq("id", orgIdStr)
+      .maybeSingle();
+    if (!existingOrgAdjust) {
+      const org = await ctx.runQuery(internal.supabase.backfill._getOrganization, {
+        organizationId: orgIdStr,
+      });
+      if (org) {
+        await clientAdjust.from("organizations").upsert(
+          {
+            id: orgIdStr,
+            name: org.name,
+            slug: org.slug,
+            owner_id: String(org.ownerId),
+            logo: org.logo ?? null,
+            website: org.website ?? null,
+            created_at: org.createdAt ?? now,
+            updated_at: org.updatedAt ?? now,
+          },
+          { onConflict: "id" },
+        );
+      }
+    }
+
+    const loyalty = await getOrCreateLoyalty(db, orgIdStr, args.patientId);
     const newBalance = (loyalty!.balance as number) + args.points;
     const newLifetimeEarned = args.points > 0
       ? (loyalty!.lifetimeEarned as number) + args.points
@@ -190,7 +281,7 @@ export const adjustPoints = action({
     });
 
     await db.insert("gabinetLoyaltyTransactions", {
-      organizationId: String(args.organizationId),
+      organizationId: orgIdStr,
       patientId: args.patientId,
       type: "adjust",
       points: args.points,

--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -144,9 +144,40 @@ export const create = action({
 
     const now = Date.now();
     const db = createSupabaseDb();
+    const orgIdStr = String(args.organizationId);
+
+    // Self-heal: if the organization row is missing from Supabase (can happen
+    // for orgs created before the Supabase migration or during a failed async
+    // sync), upsert it now so the gabinet_treatment_packages FK constraint doesn't fire.
+    const client = db.raw();
+    const { data: existingOrg } = await client
+      .from("organizations")
+      .select("id")
+      .eq("id", orgIdStr)
+      .maybeSingle();
+    if (!existingOrg) {
+      const org = await ctx.runQuery(internal.supabase.backfill._getOrganization, {
+        organizationId: orgIdStr,
+      });
+      if (org) {
+        await client.from("organizations").upsert(
+          {
+            id: orgIdStr,
+            name: org.name,
+            slug: org.slug,
+            owner_id: String(org.ownerId),
+            logo: org.logo ?? null,
+            website: org.website ?? null,
+            created_at: org.createdAt ?? now,
+            updated_at: org.updatedAt ?? now,
+          },
+          { onConflict: "id" },
+        );
+      }
+    }
 
     const packageId = await db.insert("gabinetTreatmentPackages", {
-      organizationId: String(args.organizationId),
+      organizationId: orgIdStr,
       name: args.name,
       description: args.description ?? null,
       treatments: args.treatments,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2671.

Closes #2671

---

## Claude summary

Done. Here's a summary of what was found and changed:

**Files changed (4):**

- `convex/gabinet/packages.ts` — `create` action: self-heal added before `gabinetTreatmentPackages` insert
- `convex/gabinet/leaveTypes.ts` — `create` action: self-heal added before `gabinetLeaveTypes` insert
- `convex/gabinet/employeeLocations.ts` — `addLocation` action: self-heal added before `gabinetEmployeeLocations` insert
- `convex/gabinet/loyalty.ts` — `earnPoints`, `spendPoints`, and `adjustPoints` actions: self-heal added in each before the `getOrCreateLoyalty` call (which can insert `gabinetLoyaltyPoints`) and before the `gabinetLoyaltyTransactions` insert

**Files checked and already correct (no changes needed):**

- `convex/gabinet/treatments.ts` — already had the self-heal
- `convex/gabinet/patients.ts` — already had the self-heal
- `convex/gabinet/appointments.ts` — already had the self-heal
- `convex/gabinet/employees.ts`, `scheduling.ts`, `appointmentWorkflow.ts`, `documentDataSources.ts`, `onboarding.ts`, `nudges.ts`, `patientAuth.ts` — no create actions inserting into FK-constrained tables that could be reached before the org exists