### PR TITLE
Fix inline slots-load error display in appointment-dialog.tsx

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -14,7 +14,6 @@ import type { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import {
-  extractActionErrorMessage,
   formatActionError,
   formatAppointmentError,
 } from "@/lib/format-action-error";
@@ -553,6 +552,12 @@ export function AppointmentDialog({
   });
   const availableSlots = slotsResult?.slots;
   const noSlotsReason = slotsResult?.reason;
+
+  useEffect(() => {
+    if (slotsErrored && slotsError) {
+      console.error("[appointment-dialog] slots load failed", slotsError);
+    }
+  }, [slotsErrored, slotsError]);
 
   // Rooms query — enabled only when a location is selected
   const getLocationAction = useAction(api.gabinet.locations.getLocation);
@@ -1718,16 +1723,12 @@ export function AppointmentDialog({
                       // Issue #1429.
                       <div
                         role="alert"
-                        className="py-8 text-center space-y-1.5 px-3"
+                        className="py-8 text-center px-3"
                       >
                         <p className="text-sm font-medium text-destructive">
                           {t(
                             "gabinet.appointments.calendarDialog.slotsLoadError",
                           )}
-                        </p>
-                        <p className="text-xs text-muted-foreground break-words">
-                          {extractActionErrorMessage(slotsError) ||
-                            String((slotsError as Error)?.message ?? "")}
                         </p>
                       </div>
                     ) : availableSlots && availableSlots.length > 0 ? (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2675.

Closes #2675

---

## Claude summary

The fix is committed. Here's what was changed in `src/components/gabinet/calendar/appointment-dialog.tsx`:

1. **Removed** `extractActionErrorMessage` from the import (was only used in the offending line).
2. **Removed** the second `<p>` that rendered the raw error string directly in the UI — end users should never see raw `Error.message` or Convex action error strings.
3. **Added** a `useEffect` that `console.error`s the full `slotsError` whenever the query enters error state, preserving full diagnostic detail in DevTools for developers — the same pattern established in #2673.
4. **Simplified** the container `div` class by removing `space-y-1.5` (no longer needed with only one child element).