### PR TITLE
Audit remaining `extractActionErrorMessage` usages in `src/routes/_app/_auth/das

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.integrations.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.integrations.tsx
@@ -27,7 +27,8 @@ function IntegrationsSettings() {
       toast.success(t("integrations.connected"));
       window.history.replaceState({}, "", window.location.pathname);
     } else if (error) {
-      toast.error(`${t("integrations.notConnected")}: ${error}`);
+      console.error("[integrations] OAuth callback error:", error);
+      toast.error(t("integrations.oauthError"));
       window.history.replaceState({}, "", window.location.pathname);
     }
   }, [success, error, t]);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2676.

Closes #2676

---

## Claude summary

Fixed. The issue was real: `_layout.settings.integrations.tsx:30` was constructing a toast with the raw OAuth `error` URL query parameter interpolated in — which could expose internal OAuth error codes or messages to users.

The fix replaces the backtick interpolation with the already-existing `integrations.oauthError` translation key ("Failed to connect Google account. Please try again."), and logs the raw error to `console.error` so developers can still see it.