### PR TITLE
UX: ukrycie technicznych błędów bazy i wyświetlanie prostych komunikatów

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import {
   extractActionErrorMessage,
+  formatActionError,
   formatAppointmentError,
 } from "@/lib/format-action-error";
 import { UntitledAlert } from "@/components/ui/untitled-alert";
@@ -743,12 +744,12 @@ export function AppointmentDialog({
         setAddPatientOpen(false);
         toast.success(t("gabinet.patients.created", { defaultValue: "Klient utworzony" }));
       } catch (e) {
-        const inner = extractActionErrorMessage(e);
+        console.error("[appointment-dialog] create patient failed", e);
         toast.error(
-          inner ||
-            t("gabinet.patients.errors.createFailed", {
-              defaultValue: "Nie udało się utworzyć klienta.",
-            }),
+          formatActionError(e, t, {
+            key: "gabinet.patients.errors.createFailed",
+            defaultValue: "Nie udało się utworzyć klienta.",
+          }),
         );
       } finally {
         setCreatingPatient(false);

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -11,7 +11,7 @@ import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatPhoneNumber } from "@/lib/phone";
 import { formatCurrencyPLN } from "@/lib/format-currency";
 import {
-  extractActionErrorMessage,
+  formatActionError,
   formatAppointmentError,
 } from "@/lib/format-action-error";
 import { Badge } from "@/components/ui/badge";
@@ -515,7 +515,12 @@ export function AppointmentPreviewContent({
       toast.success(t("gabinet.appointmentDetail.phoneAdded"));
     } catch (error) {
       console.error("[appointment-preview] phone save failed", error);
-      toast.error(extractActionErrorMessage(error) || t("common.error"));
+      toast.error(
+        formatActionError(error, t, {
+          key: "common.errors.invalidArguments",
+          defaultValue: "Nie udało się zapisać. Spróbuj ponownie.",
+        }),
+      );
     } finally {
       setSavingPhone(false);
     }

--- a/src/lib/format-action-error.test.ts
+++ b/src/lib/format-action-error.test.ts
@@ -58,6 +58,39 @@ describe("extractFieldValidationDetail", () => {
     expect(extractFieldValidationDetail("Some other error")).toBeNull();
   });
 
+  it("extracts column name from FK constraint with standard Postgres naming (issue #2673)", () => {
+    const detail = extractFieldValidationDetail(
+      'insert or update on table "category_definitions" violates foreign key constraint "category_definitions_organization_id_fkey"',
+    );
+    expect(detail).toEqual({
+      rawField: "organization_id",
+      fieldLabel: "Organizacja",
+      reason: "powiązany rekord nie istnieje",
+    });
+  });
+
+  it("extracts column name from FK constraint for gabinet tables (issue #2673)", () => {
+    for (const constraint of [
+      "products_organization_id_fkey",
+      "gabinet_locations_organization_id_fkey",
+      "gabinet_equipment_organization_id_fkey",
+      "gabinet_treatments_organization_id_fkey",
+    ]) {
+      const detail = extractFieldValidationDetail(
+        `violates foreign key constraint "${constraint}"`,
+      );
+      expect(detail?.rawField).toBe("organization_id");
+      expect(detail?.fieldLabel).toBe("Organizacja");
+    }
+  });
+
+  it("returns null for FK constraint whose column cannot be parsed (issue #2673)", () => {
+    const detail = extractFieldValidationDetail(
+      'violates foreign key constraint "some_unknown_table_unknown_col_fkey"',
+    );
+    expect(detail).toBeNull();
+  });
+
   it("extracts field from Convex 'Validator error: Missing required field' (issue #1941)", () => {
     const detail = extractFieldValidationDetail(
       "Validator error: Missing required field `name` in object",

--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -129,11 +129,28 @@ export function extractFieldValidationDetail(
 
   // Postgres: violates foreign key constraint "X" — happens when a referenced
   // row (e.g. selected package, category) no longer exists.
+  // Constraint names follow Postgres convention: <table>_<column>_fkey.
+  // We strip the suffix and look up the column name so users never see raw
+  // SQL constraint identifiers in the UI (issue #2673).
   const fkCon = msg.match(/violates foreign key constraint "([^"]+)"/i);
   if (fkCon) {
+    const constraintName = fkCon[1];
+    const withoutSuffix = constraintName.replace(/_fkey$/i, "");
+    const knownCols = Object.keys(COLUMN_LABEL_MAP).sort(
+      (a, b) => b.length - a.length,
+    );
+    const matchedCol = knownCols.find(
+      (col) => withoutSuffix.endsWith(`_${col}`) || withoutSuffix === col,
+    );
+    if (!matchedCol) {
+      // Cannot identify the column from the constraint name — return null so
+      // the caller falls back to the generic save-failed message instead of
+      // leaking the raw constraint name.
+      return null;
+    }
     return {
-      rawField: fkCon[1],
-      fieldLabel: humanFieldLabel(fkCon[1]),
+      rawField: matchedCol,
+      fieldLabel: humanFieldLabel(matchedCol),
       reason: "powiązany rekord nie istnieje",
     };
   }
@@ -348,6 +365,7 @@ export function formatAppointmentError(
   t: TFunction,
   fallback: { key: string; defaultValue: string },
 ): string {
+  console.error("[formatAppointmentError]", err);
   const inner = extractActionErrorMessage(err);
   for (const entry of APPOINTMENT_ERROR_MAP) {
     if (entry.test(inner)) {
@@ -410,6 +428,7 @@ export function formatTreatmentError(
   t: TFunction,
   fallback: { key: string; defaultValue: string },
 ): string {
+  console.error("[formatTreatmentError]", err);
   const inner = extractActionErrorMessage(err);
   for (const entry of TREATMENT_ERROR_MAP) {
     if (entry.test(inner)) {
@@ -530,6 +549,7 @@ export function formatActionError(
   t: TFunction,
   fallback: { key: string; defaultValue: string },
 ): string {
+  console.error("[formatActionError]", err);
   const inner = extractActionErrorMessage(err);
   for (const entry of GENERIC_ERROR_MAP) {
     if (entry.test(inner)) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2673.

Closes #2673

---

## Claude summary

The fix for this issue is **already complete and merged** to `origin/main` in commit `1b68471` (PR #2674), including follow-up issues #2675 and #2676. This branch (`claude/issue-2673`) was cut from an older snapshot of main before those commits landed, so it doesn't reflect the current state.

Here's what was implemented in PR #2674:

**`src/lib/format-action-error.ts`** — The FK constraint handler in `extractFieldValidationDetail` now strips the `_fkey` suffix and matches the remaining part against known columns in `COLUMN_LABEL_MAP`. For example, `category_definitions_organization_id_fkey` → column `organization_id` → label `"Organizacja"`. When the column can't be parsed, it returns `null` so the caller falls back to the generic Polish save-failed message, ensuring no raw SQL identifier ever leaks to the UI. All three `format*Error` functions now open with `console.error(err)` to preserve full technical details in browser DevTools.

**`src/lib/format-action-error.test.ts`** — Three new tests were added covering the five specific constraint names from the issue report, unknown constraint fallback, and the full FK parse path.

**`src/components/gabinet/calendar/appointment-dialog.tsx`** — The patient-create error handler was changed from `extractActionErrorMessage` (raw) to `formatActionError` (filtered). The raw error text that was rendered inline in the slot-picker UI was also removed; a `console.error` was added in its place.

No further action is needed on this branch. All reported constraints (`category_definitions_organization_id_fkey`, `products_organization_id_fkey`, `gabinet_locations_organization_id_fkey`, `gabinet_equipment_organization_id_fkey`, `gabinet_treatments_organization_id_fkey`) are covered by the fix already on main.