### PR TITLE
Ujednolicenie nazwy „Umów wizytę”

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3516,6 +3516,7 @@
       "noAppointmentsToday": "No appointments scheduled today",
       "pendingLeaveRequests": "Pending Leave Requests",
       "noPendingLeaves": "No pending leave requests",
+      "addAppointment": "Book Appointment",
       "goToCalendar": "Open Calendar",
       "goToPatients": "View Clients",
       "goToPackages": "View Packages",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3538,6 +3538,7 @@
       "noAppointmentsToday": "Brak zaplanowanych wizyt na dziś",
       "pendingLeaveRequests": "Oczekujące wnioski urlopowe",
       "noPendingLeaves": "Brak oczekujących wniosków",
+      "addAppointment": "Umów wizytę",
       "goToCalendar": "Otwórz kalendarz",
       "goToPatients": "Klienci",
       "goToPackages": "Pakiety",

--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -97,7 +97,7 @@ export const gabinetManifest: ModuleManifest = {
       matches: [{ to: "/dashboard/gabinet/calendar", fuzzy: true }],
       actions: [
         {
-          labelKey: "nav.actions.addAppointment",
+          labelKey: "nav.actions.bookAppointment",
           icon: CalendarCheck,
           dispatch: "openCreateAppointment",
           permissionFeature: "gabinet_appointments",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
@@ -391,7 +391,7 @@ function GabinetDashboard() {
         <Button asChild variant="outline" className="justify-start gap-2 h-auto py-3 px-3">
           <Link to="/dashboard/gabinet/calendar" search={{ action: "create-appointment" }}>
             <Plus className="size-4 shrink-0 text-muted-foreground" />
-            {t("gabinet.dashboard.addAppointment", "Dodaj wizytę")}
+            {t("gabinet.dashboard.addAppointment", "Umów wizytę")}
           </Link>
         </Button>
         <Button asChild variant="outline" className="justify-start gap-2 h-auto py-3 px-3">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2679.

Closes #2679

---

## Claude summary

Done. Three places were inconsistently showing "Dodaj wizytę" instead of "Umów wizytę":

1. **`gabinet.dashboard.addAppointment` i18n key was missing** — added it with the correct value "Umów wizytę" (PL) / "Book Appointment" (EN) in both translation files, so the quick-action button on the Gabinet dashboard now resolves correctly.

2. **`src/modules/gabinet/manifest.ts:100`** — the Calendar page's sidebar action was using `nav.actions.addAppointment` ("Dodaj wizytę"); switched to `nav.actions.bookAppointment` ("Umów wizytę"). The Dashboard page's sidebar action (line 77) was already using the correct key.

3. **`_layout.gabinet.index.tsx:394`** — updated the fallback string from "Dodaj wizytę" to "Umów wizytę" to stay consistent even if the translation key were ever missing.