### PR TITLE
Godziny pracy – możliwość ręcznego wpisania godziny i szybkie kopiowanie na inne dni

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2753,7 +2753,10 @@
       "errors": {
         "saveFailed": "Could not save working hours.",
         "deleteFailed": "Could not delete the schedule."
-      }
+      },
+      "applyToWeekdays": "Apply to weekdays",
+      "applyToAllDays": "Apply to all days",
+      "copyHours": "Copy hours"
     },
     "reminders": {
       "title": "Appointment Reminders",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2774,7 +2774,10 @@
       "errors": {
         "saveFailed": "Nie udało się zapisać godzin pracy.",
         "deleteFailed": "Nie udało się usunąć harmonogramu."
-      }
+      },
+      "applyToWeekdays": "Zastosuj do dni roboczych",
+      "applyToAllDays": "Zastosuj do wszystkich dni",
+      "copyHours": "Kopiuj godziny"
     },
     "reminders": {
       "title": "Przypomnienia o wizytach",

--- a/src/components/gabinet/calendar/time-picker-5min.tsx
+++ b/src/components/gabinet/calendar/time-picker-5min.tsx
@@ -17,11 +17,20 @@ interface TimePicker5MinProps {
   id?: string;
   stepMinutes?: number;
   "aria-label"?: string;
+  allowTyping?: boolean;
 }
 
 // `<input type="time" step={300}>` shows a per-minute wheel on iOS Safari
 // because iOS ignores the step attribute on time inputs (#1789, #1822, #1827).
 // This Select-based picker enforces the configured grid in the UI itself.
+function snapToGrid(raw: string, step: number): string {
+  const [h, m] = raw.split(":").map(Number);
+  if (!Number.isFinite(h) || !Number.isFinite(m)) return "";
+  const total = Math.min(Math.max(h * 60 + m, 0), 24 * 60 - step);
+  const grid = Math.min(Math.round(total / step) * step, 24 * 60 - step);
+  return `${String(Math.floor(grid / 60)).padStart(2, "0")}:${String(grid % 60).padStart(2, "0")}`;
+}
+
 export const TimePicker5Min = forwardRef<HTMLButtonElement, TimePicker5MinProps>(
   function TimePicker5Min(
     {
@@ -32,6 +41,7 @@ export const TimePicker5Min = forwardRef<HTMLButtonElement, TimePicker5MinProps>
       id,
       stepMinutes = 5,
       "aria-label": ariaLabel,
+      allowTyping = false,
     },
     ref,
   ) {
@@ -51,12 +61,33 @@ export const TimePicker5Min = forwardRef<HTMLButtonElement, TimePicker5MinProps>
 
     const snapped = (() => {
       if (!value) return "";
-      const [h, m] = value.split(":").map(Number);
-      if (!Number.isFinite(h) || !Number.isFinite(m)) return "";
-      const total = Math.min(Math.max(h * 60 + m, 0), 24 * 60 - step);
-      const grid = Math.min(Math.round(total / step) * step, 24 * 60 - step);
-      return `${String(Math.floor(grid / 60)).padStart(2, "0")}:${String(grid % 60).padStart(2, "0")}`;
+      return snapToGrid(value, step);
     })();
+
+    if (allowTyping) {
+      return (
+        <input
+          type="time"
+          id={id}
+          step={step * 60}
+          value={snapped}
+          onChange={(e) => {
+            const raw = e.target.value;
+            if (!raw) return;
+            const s = snapToGrid(raw, step);
+            if (s) onChange(s);
+          }}
+          disabled={disabled}
+          aria-label={ariaLabel}
+          className={cn(
+            "flex rounded-md border border-input bg-background px-2 py-1 text-sm tabular-nums",
+            "focus-visible:outline-none focus-visible:border-primary",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+            className,
+          )}
+        />
+      );
+    }
 
     return (
       <Select value={snapped} onValueChange={onChange} disabled={disabled}>

--- a/src/components/gabinet/flexible-schedule-editor.tsx
+++ b/src/components/gabinet/flexible-schedule-editor.tsx
@@ -19,7 +19,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Clock, Pencil, Plus, Trash2 } from "@/lib/ez-icons";
+import { Clock, Pencil, Plus, Trash2, MoreHorizontal } from "@/lib/ez-icons";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { formatActionError } from "@/lib/format-action-error";
 import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
 
@@ -307,6 +313,18 @@ export function FlexibleScheduleEditor({
       prev.map((h) =>
         h.dayOfWeek === dayOfWeek ? { ...h, [field]: value } : h,
       ),
+    );
+  };
+
+  const copyHoursTo = (sourceDayOfWeek: number, target: "weekdays" | "all") => {
+    const src = periodHours.find((h) => h.dayOfWeek === sourceDayOfWeek);
+    if (!src) return;
+    setPeriodHours((prev) =>
+      prev.map((h) => {
+        const isTarget = target === "all" || (h.dayOfWeek >= 1 && h.dayOfWeek <= 5);
+        if (!isTarget || h.dayOfWeek === sourceDayOfWeek) return h;
+        return { ...h, startTime: src.startTime, endTime: src.endTime, isWorking: src.isWorking, breakStart: src.breakStart, breakEnd: src.breakEnd };
+      }),
     );
   };
 
@@ -610,14 +628,15 @@ export function FlexibleScheduleEditor({
             </div>
 
             <div className="overflow-x-auto">
-            <div className="rounded-lg border min-w-[600px]">
-              <div className="grid grid-cols-[180px_50px_1fr_1fr_2fr_1fr] gap-2 border-b bg-muted/50 px-3 py-2 text-xs font-medium text-muted-foreground">
+            <div className="rounded-lg border min-w-[640px]">
+              <div className="grid grid-cols-[180px_50px_1fr_1fr_2fr_1fr_32px] gap-2 border-b bg-muted/50 px-3 py-2 text-xs font-medium text-muted-foreground">
                 <span>{t("gabinet.scheduling.day")}</span>
                 <span>{t("gabinet.scheduling.open")}</span>
                 <span>{t("gabinet.scheduling.start")}</span>
                 <span>{t("gabinet.scheduling.end")}</span>
                 <span>{t("gabinet.schedules.break")}</span>
                 <span>{t("gabinet.appointments.location")}</span>
+                <span />
               </div>
 
               {DISPLAY_ORDER.map((dayOfWeek) => {
@@ -627,7 +646,7 @@ export function FlexibleScheduleEditor({
                 return (
                   <div
                     key={h.dayOfWeek}
-                    className="grid grid-cols-[180px_50px_1fr_1fr_2fr_1fr] items-center gap-2 border-b px-3 py-1.5 last:border-b-0"
+                    className="grid grid-cols-[180px_50px_1fr_1fr_2fr_1fr_32px] items-center gap-2 border-b px-3 py-1.5 last:border-b-0"
                   >
                     <div className="flex flex-col gap-0.5">
                       <span className="text-sm font-medium">
@@ -641,6 +660,7 @@ export function FlexibleScheduleEditor({
                       }
                     />
                     <TimePicker5Min
+                      allowTyping
                       stepMinutes={15}
                       className="h-7 w-22"
                       value={h.startTime}
@@ -650,6 +670,7 @@ export function FlexibleScheduleEditor({
                       disabled={!h.isWorking}
                     />
                     <TimePicker5Min
+                      allowTyping
                       stepMinutes={15}
                       className="h-7 w-22"
                       value={h.endTime}
@@ -661,6 +682,7 @@ export function FlexibleScheduleEditor({
                     {hasBreak ? (
                       <div className="flex items-center gap-1">
                         <TimePicker5Min
+                          allowTyping
                           stepMinutes={15}
                           className="h-7 w-22"
                           value={h.breakStart}
@@ -671,6 +693,7 @@ export function FlexibleScheduleEditor({
                         />
                         <span className="text-xs text-muted-foreground">–</span>
                         <TimePicker5Min
+                          allowTyping
                           stepMinutes={15}
                           className="h-7 w-22"
                           value={h.breakEnd}
@@ -738,6 +761,27 @@ export function FlexibleScheduleEditor({
                           ))}
                       </SelectContent>
                     </Select>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 text-muted-foreground"
+                          aria-label={t("gabinet.scheduling.copyHours", "Kopiuj godziny")}
+                        >
+                          <MoreHorizontal className="h-4 w-4" variant="stroke" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={() => copyHoursTo(h.dayOfWeek, "weekdays")}>
+                          {t("gabinet.scheduling.applyToWeekdays", "Zastosuj do dni roboczych")}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => copyHoursTo(h.dayOfWeek, "all")}>
+                          {t("gabinet.scheduling.applyToAllDays", "Zastosuj do wszystkich dni")}
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </div>
                 );
               })}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
@@ -8,7 +8,13 @@ import { UntitledAlert } from "@/components/ui/untitled-alert";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
-import { Plus, Trash2 } from "@/lib/ez-icons";
+import { Plus, Trash2, MoreHorizontal } from "@/lib/ez-icons";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -94,6 +100,18 @@ function SchedulingSettings() {
     );
   };
 
+  const copyHoursTo = (sourceDayOfWeek: number, target: "weekdays" | "all") => {
+    const src = hours.find((h) => h.dayOfWeek === sourceDayOfWeek);
+    if (!src) return;
+    setHours((prev) =>
+      prev.map((h) => {
+        const isTarget = target === "all" || (h.dayOfWeek >= 1 && h.dayOfWeek <= 5);
+        if (!isTarget || h.dayOfWeek === sourceDayOfWeek) return h;
+        return { ...h, startTime: src.startTime, endTime: src.endTime, isOpen: src.isOpen, breakStart: src.breakStart, breakEnd: src.breakEnd };
+      }),
+    );
+  };
+
   const validationErrors = hours
     .filter((h) => h.isOpen && h.endTime <= h.startTime)
     .map((h) => dayNames[h.dayOfWeek]);
@@ -164,13 +182,14 @@ function SchedulingSettings() {
         <UntitledAlert>{t("gabinet.scheduling.description")}</UntitledAlert>
       </SectionHeader.Root>
 
-      <div className="rounded-lg border">
-        <div className="grid grid-cols-[180px_80px_1fr_1fr_2fr] gap-2 border-b bg-muted/50 px-4 py-2 text-xs font-medium text-muted-foreground">
+      <div className="rounded-lg border overflow-x-auto">
+        <div className="grid grid-cols-[180px_80px_1fr_1fr_2fr_32px] gap-2 border-b bg-muted/50 px-4 py-2 text-xs font-medium text-muted-foreground min-w-[620px]">
           <span>{t("gabinet.scheduling.day")}</span>
           <span>{t("gabinet.scheduling.open")}</span>
           <span>{t("gabinet.scheduling.start")}</span>
           <span>{t("gabinet.scheduling.end")}</span>
           <span>{t("gabinet.schedules.break")}</span>
+          <span />
         </div>
 
         {DISPLAY_ORDER.map((dayOfWeek) => {
@@ -182,7 +201,7 @@ function SchedulingSettings() {
           return (
           <div
             key={h.dayOfWeek}
-            className={`grid grid-cols-[180px_80px_1fr_1fr_2fr] items-center gap-2 border-b px-4 py-2 last:border-b-0 ${hasTimeError || hasBreakError ? "bg-red-50 dark:bg-red-950/20" : ""}`}
+            className={`grid grid-cols-[180px_80px_1fr_1fr_2fr_32px] items-center gap-2 border-b px-4 py-2 last:border-b-0 min-w-[620px] ${hasTimeError || hasBreakError ? "bg-red-50 dark:bg-red-950/20" : ""}`}
           >
             <span className="text-sm font-medium">{dayNames[h.dayOfWeek]}</span>
             <Checkbox
@@ -190,12 +209,14 @@ function SchedulingSettings() {
               onCheckedChange={(checked) => updateDay(h.dayOfWeek, "isOpen", checked as boolean)}
             />
             <TimePicker5Min
+              allowTyping
               className="h-8 w-24"
               value={h.startTime}
               onChange={(v) => updateDay(h.dayOfWeek, "startTime", v)}
               disabled={!h.isOpen}
             />
             <TimePicker5Min
+              allowTyping
               className="h-8 w-24"
               value={h.endTime}
               onChange={(v) => updateDay(h.dayOfWeek, "endTime", v)}
@@ -204,6 +225,7 @@ function SchedulingSettings() {
             {hasBreak ? (
               <div className="flex items-center gap-1">
                 <TimePicker5Min
+                  allowTyping
                   className="h-8 w-24"
                   value={h.breakStart}
                   onChange={(v) => updateDay(h.dayOfWeek, "breakStart", v)}
@@ -211,6 +233,7 @@ function SchedulingSettings() {
                 />
                 <span className="text-xs text-muted-foreground">–</span>
                 <TimePicker5Min
+                  allowTyping
                   className="h-8 w-24"
                   value={h.breakEnd}
                   onChange={(v) => updateDay(h.dayOfWeek, "breakEnd", v)}
@@ -248,6 +271,27 @@ function SchedulingSettings() {
                 {t("gabinet.scheduling.addBreak")}
               </Button>
             )}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-muted-foreground"
+                  aria-label={t("gabinet.scheduling.copyHours", "Kopiuj godziny")}
+                >
+                  <MoreHorizontal className="h-4 w-4" variant="stroke" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => copyHoursTo(h.dayOfWeek, "weekdays")}>
+                  {t("gabinet.scheduling.applyToWeekdays", "Zastosuj do dni roboczych")}
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => copyHoursTo(h.dayOfWeek, "all")}>
+                  {t("gabinet.scheduling.applyToAllDays", "Zastosuj do wszystkich dni")}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         );
         })}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2682.

Closes #2682

---

## Claude summary

Changes are committed. Here's a summary of what was done:

**Issue confirmed real** — `TimePicker5Min` was a pure `<Select>` dropdown with no keyboard input, and neither working hours editor had copy functionality.

**Changes made across 5 files:**

1. `src/components/gabinet/calendar/time-picker-5min.tsx` — Added `allowTyping?: boolean` prop. When true, renders a native `<input type="time">` that accepts keyboard entry (e.g., `09:00`, `17:30`) and snaps the typed value to the nearest step on change. The Select-based picker is preserved for all other callsites (appointment dialogs, leave forms, activity forms) to keep the iOS grid-enforcement behavior described in the existing comment.

2. `src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx` — All `TimePicker5Min` instances now use `allowTyping`. Added a `copyHoursTo` function and a per-row `⋯` dropdown menu (DropdownMenu) with two actions: "Zastosuj do dni roboczych" (Mon–Fri) and "Zastosuj do wszystkich dni".

3. `src/components/gabinet/flexible-schedule-editor.tsx` — Same changes as above for the employee-level schedule editor (used in the Timetable settings sheet).

4. `public/locales/pl/translation.json` and `public/locales/en/translation.json` — Added `applyToWeekdays`, `applyToAllDays`, and `copyHours` under `gabinet.scheduling`.