### PR TITLE
Uprawnienia nieobecności – pracownik nie może sam wpisywać wolnego

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -487,6 +487,11 @@ export const createLeave = action({
       { organizationId: args.organizationId },
     );
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_settings", action: "edit" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
     const now = Date.now();
     const db = createSupabaseDb();
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
@@ -21,7 +21,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Id } from "@cvx/_generated/dataModel";
 import { formatActionError } from "@/lib/format-action-error";
-import { PermissionGate } from "@/hooks/use-permission";
+import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { Skeleton } from "@/components/ui/skeleton";
 
 function LeaveTypesSettingsSkeleton() {
@@ -47,6 +47,7 @@ export const Route = createFileRoute(
 function LeaveTypesSettings() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
+  const { allowed: canEdit } = usePermission("gabinet_settings", "edit");
   const [showCreate, setShowCreate] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -84,6 +85,7 @@ function LeaveTypesSettings() {
           <SectionHeader.Heading className="flex-1">
             {t("gabinet.leaveTypes.title")}
           </SectionHeader.Heading>
+          {canEdit && (
           <SectionHeader.Actions>
             <div className="flex gap-2">
               <Button variant="outline" onClick={handleInitBalances}>
@@ -95,6 +97,7 @@ function LeaveTypesSettings() {
               </Button>
             </div>
           </SectionHeader.Actions>
+          )}
         </SectionHeader.Group>
         <UntitledAlert>{t("gabinet.leaveTypes.description")}</UntitledAlert>
       </SectionHeader.Root>
@@ -133,6 +136,7 @@ function LeaveTypesSettings() {
                   <Badge variant="outline">{t("common.inactive")}</Badge>
                 )}
               </div>
+              {canEdit && (
               <Button
                 variant="ghost"
                 size="icon"
@@ -141,6 +145,7 @@ function LeaveTypesSettings() {
               >
                 <Pencil className="h-4 w-4" variant="stroke" />
               </Button>
+              )}
             </CardContent>
           </Card>
         ))}
@@ -171,9 +176,7 @@ function LeaveTypesSettings() {
             void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetLeaveTypes.list(organizationId) });
             setEditingId(null);
           }}
-          onDelete={async () => {
-            setDeleteDialogOpen(true);
-          }}
+          onDelete={canEdit ? async () => { setDeleteDialogOpen(true); } : undefined}
           t={t}
         />
       )}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
@@ -47,7 +47,7 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
-import { PermissionGate } from "@/hooks/use-permission";
+import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { Skeleton } from "@/components/ui/skeleton";
 
 type LeavesNudgeFilter = "pending";
@@ -90,6 +90,7 @@ function LeavesPage() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
   const { nudge: nudgeFilter } = useSearch({ from: Route.id });
+  const { allowed: canManageLeaves } = usePermission("gabinet_settings", "edit");
   const routeNavigate = useNavigate();
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
   const createLeave = useAction(api.gabinet.scheduling.createLeave);
@@ -254,6 +255,7 @@ function LeavesPage() {
               {t("gabinet.leaves.title")}
             </SectionHeader.Heading>
             <SectionHeader.Actions>
+              {canManageLeaves && (
               <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
                 <DialogTrigger asChild>
                   <Button size="sm">
@@ -337,6 +339,7 @@ function LeavesPage() {
                   </div>
                 </DialogContent>
               </Dialog>
+              )}
             </SectionHeader.Actions>
           </SectionHeader.Group>
           <UntitledAlert>{t("gabinet.leaves.description")}</UntitledAlert>
@@ -414,7 +417,7 @@ function LeavesPage() {
                     </Badge>
                   </td>
                   <td className="px-4 py-2 text-right">
-                    {leave.status === "pending" && (
+                    {leave.status === "pending" && canManageLeaves && (
                       <div className="flex justify-end gap-1">
                         <Button size="sm" variant="ghost" onClick={() => handleApprove(leave._id as Id<"gabinetLeaves">)}>
                           <Check className="h-4 w-4 text-green-600" variant="stroke" />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2684.

Closes #2684

---

## Claude summary

Commit succeeded (exit 1 is a post-commit shell cleanup artifact, not a git error — the hash `cd31e98` confirms it).

Here's a summary of what was done and why:

---

**Root cause**: The issue is real. The system had a permission gap in two places:

1. **Backend** (`convex/gabinet/scheduling.ts`): `createLeave` had no permission check at all — any org member with Gabinet access could call it directly. Meanwhile `approveLeave` and `rejectLeave` already checked `gabinet_settings:edit`. Added the same check to `createLeave`.

2. **Frontend** (both settings pages): The pages are gated at page level with `gabinet_settings:view`, meaning managers (who have view-only) could reach the pages and see all action buttons — but would get backend errors on click. The permission matrix was already correct (managers get only `view`, gabinet admins get full CRUD), but the action buttons weren't individually gated. Added `usePermission("gabinet_settings", "edit")` calls and wrapped the action buttons conditionally:
   - Leaves page: "Request Leave" button and Approve/Reject row buttons hidden unless `canManageLeaves`
   - Leave-types page: Add, Init Balances, and per-card Edit buttons hidden unless `canEdit`; Delete option only passed to dialog when `canEdit`

Clinical roles (doctor, cosmetologist, nurse, therapist, receptionist) already had `gabinet_settings: {}` (no permissions at all), so they couldn't reach these pages before either. The fix primarily closes the gap for the `manager` gabinet role and the raw API surface.

## Follow-ups

- Guard `listLeaves` and `getLeavesByDateRange` with `gabinet_settings:view` permission check: These read-only actions currently only verify org membership and Gabinet product access, not feature-level view permission — inconsistent with the leaveTypes mutations which all check permission.
- Add `deleteLeave` mutation to the backend: Currently there is no way to delete a leave record (only approve/reject status changes), which may be a missing operation for correcting data entry errors.