### PR TITLE
Guard `listLeaves` and `getLeavesByDateRange` with `gabinet_settings

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -459,6 +459,11 @@ export const listLeaves = action({
       organizationId: args.organizationId,
     });
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_settings", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
     const db = createSupabaseDb();
     let q = db.query("gabinetLeaves").eq("organizationId", String(args.organizationId));
     if (args.status) {
@@ -631,6 +636,11 @@ export const getLeavesByDateRange = action({
       organizationId: args.organizationId,
     });
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_settings", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
     const db = createSupabaseDb();
     const leaves = (await db
       .query("gabinetLeaves")


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2687.

Closes #2687

---

## Claude summary

The fix is committed. Here's what was done:

Both `listLeaves` (line 452) and `getLeavesByDateRange` (line 628) in `convex/gabinet/scheduling.ts` were only checking org membership and Gabinet product access — they were missing the `gabinet_settings:view` permission check. This was inconsistent with every write operation in the same file (and in `leaveTypes.ts`), which all enforce `gabinet_settings:edit`.

I added the same `checkPermission` call pattern to both handlers:
```typescript
const perm = await ctx.runQuery(
  internal._helpers.authAction.checkPermission,
  { organizationId: args.organizationId, feature: "gabinet_settings", action: "view" },
) as { allowed: boolean; scope: string };
if (!perm.allowed) throw new Error("Permission denied");
```

This means only users whose role grants `gabinet_settings:view` (e.g. `gabinet_supervisor` and `gabinet_admin`) can now read leave data, matching the permission model defined in `convex/_helpers/gabinetRolePermissions.ts`.

## Follow-ups

- Guard `leaveTypes.list` and `leaveTypes.getById` with `gabinet_settings:view`: These two read actions in `convex/gabinet/leaveTypes.ts` have the same gap — they only check org membership and product access, not the feature-level view permission, unlike all write operations in that file.
- Guard `leaveTypes.getBalances` and `leaveTypes.getAllBalances` with `gabinet_settings:view`: Similarly, `getBalances` and `getAllBalances` in `convex/gabinet/leaveTypes.ts` (lines 221–260) are missing the `gabinet_settings:view` check despite being sensitive HR data.