### PR TITLE
Add `deleteLeave` mutation to the backend

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -625,6 +625,62 @@ export const rejectLeave = action({
   },
 });
 
+export const deleteLeave = action({
+  args: {
+    organizationId: v.id("organizations"),
+    leaveId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_settings", action: "edit" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+    const db = createSupabaseDb();
+
+    const leave = await db.get("gabinetLeaves", args.leaveId);
+    if (!leave || String(leave.organizationId) !== String(args.organizationId)) {
+      throw new Error("Leave not found");
+    }
+
+    // If the leave was approved and had a leave type, reverse the balance deduction
+    if (leave.status === "approved" && leave.leaveTypeId) {
+      const startD = new Date(leave.startDate as string);
+      const endD = new Date(leave.endDate as string);
+      const days = Math.max(1, Math.ceil((endD.getTime() - startD.getTime()) / (1000 * 60 * 60 * 24)) + 1);
+      const year = startD.getFullYear();
+
+      const employee = await db.query("gabinetEmployees")
+        .eq("organizationId", String(args.organizationId))
+        .eq("userId", leave.userId as string)
+        .first();
+
+      if (employee) {
+        const balance = await db.query("gabinetLeaveBalances")
+          .eq("organizationId", String(args.organizationId))
+          .eq("employeeId", employee._id as string)
+          .eq("leaveTypeId", leave.leaveTypeId as string)
+          .eq("year", year)
+          .first();
+
+        if (balance) {
+          await db.patch("gabinetLeaveBalances", balance._id as string, {
+            usedDays: Math.max(0, (balance.usedDays as number) - days),
+            updatedAt: Date.now(),
+          });
+        }
+      }
+    }
+
+    await db.delete("gabinetLeaves", args.leaveId);
+  },
+});
+
 export const getLeavesByDateRange = action({
   args: {
     organizationId: v.id("organizations"),

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2798,13 +2798,18 @@
       },
       "approve": "Approve",
       "reject": "Reject",
+      "delete": "Delete",
+      "deleted": "Leave request deleted",
       "confirmApproveTitle": "Approve Leave Request",
       "confirmApproveDesc": "Are you sure you want to approve this leave request? The employee will be notified.",
       "confirmRejectTitle": "Reject Leave Request",
       "confirmRejectDesc": "Are you sure you want to reject this leave request? The employee will be notified.",
+      "confirmDeleteTitle": "Delete Leave Request",
+      "confirmDeleteDesc": "Are you sure you want to delete this leave request? This action cannot be undone.",
       "errors": {
         "createFailed": "Could not create the leave request.",
-        "statusChangeFailed": "Could not update the leave request status."
+        "statusChangeFailed": "Could not update the leave request status.",
+        "deleteFailed": "Could not delete the leave request."
       }
     },
     "employees": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2819,13 +2819,18 @@
       },
       "approve": "Zatwierdź",
       "reject": "Odrzuć",
+      "delete": "Usuń",
+      "deleted": "Wniosek urlopowy usunięty",
       "confirmApproveTitle": "Zatwierdź wniosek urlopowy",
       "confirmApproveDesc": "Czy na pewno chcesz zatwierdzić ten wniosek urlopowy? Pracownik zostanie powiadomiony.",
       "confirmRejectTitle": "Odrzuć wniosek urlopowy",
       "confirmRejectDesc": "Czy na pewno chcesz odrzucić ten wniosek urlopowy? Pracownik zostanie powiadomiony.",
+      "confirmDeleteTitle": "Usuń wniosek urlopowy",
+      "confirmDeleteDesc": "Czy na pewno chcesz usunąć ten wniosek urlopowy? Tej operacji nie można cofnąć.",
       "errors": {
         "createFailed": "Nie udało się utworzyć wniosku urlopowego.",
-        "statusChangeFailed": "Nie udało się zaktualizować statusu wniosku urlopowego."
+        "statusChangeFailed": "Nie udało się zaktualizować statusu wniosku urlopowego.",
+        "deleteFailed": "Nie udało się usunąć wniosku urlopowego."
       }
     },
     "employees": {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
@@ -41,7 +41,7 @@ import {
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
 import { PlateText } from "@/components/plate-text";
 import { Id } from "@cvx/_generated/dataModel";
-import { Plus, Check, X } from "@/lib/ez-icons";
+import { Plus, Check, X, Trash2 } from "@/lib/ez-icons";
 import { AlertTriangle } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -98,6 +98,8 @@ function LeavesPage() {
   const approveLeave = useAction(api.gabinet.scheduling.approveLeave);
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
   const rejectLeave = useAction(api.gabinet.scheduling.rejectLeave);
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
+  const deleteLeave = useAction(api.gabinet.scheduling.deleteLeave);
   const queryClient = useQueryClient();
 
   const [statusFilter, setStatusFilter] = useState<string>(
@@ -123,6 +125,7 @@ function LeavesPage() {
 
   const [confirmLeaveId, setConfirmLeaveId] = useState<Id<"gabinetLeaves"> | null>(null);
   const [confirmAction, setConfirmAction] = useState<"approve" | "reject" | null>(null);
+  const [deleteLeaveId, setDeleteLeaveId] = useState<Id<"gabinetLeaves"> | null>(null);
 
   // Existing appointments overlapping the requested leave range — warn the
   // user there are bookings they need to deal with before approving. Issue #652.
@@ -229,6 +232,24 @@ function LeavesPage() {
     } finally {
       setConfirmLeaveId(null);
       setConfirmAction(null);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteLeaveId) return;
+    try {
+      await deleteLeave({ organizationId, leaveId: deleteLeaveId });
+      toast.success(t("gabinet.leaves.deleted"));
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetLeaves.all });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.leaves.errors.deleteFailed",
+          defaultValue: "Nie udało się usunąć wniosku urlopowego.",
+        }),
+      );
+    } finally {
+      setDeleteLeaveId(null);
     }
   };
 
@@ -417,13 +438,20 @@ function LeavesPage() {
                     </Badge>
                   </td>
                   <td className="px-4 py-2 text-right">
-                    {leave.status === "pending" && canManageLeaves && (
+                    {canManageLeaves && (
                       <div className="flex justify-end gap-1">
-                        <Button size="sm" variant="ghost" onClick={() => handleApprove(leave._id as Id<"gabinetLeaves">)}>
-                          <Check className="h-4 w-4 text-green-600" variant="stroke" />
-                        </Button>
-                        <Button size="sm" variant="ghost" onClick={() => handleReject(leave._id as Id<"gabinetLeaves">)}>
-                          <X className="h-4 w-4 text-red-600" variant="stroke" />
+                        {leave.status === "pending" && (
+                          <>
+                            <Button size="sm" variant="ghost" onClick={() => handleApprove(leave._id as Id<"gabinetLeaves">)}>
+                              <Check className="h-4 w-4 text-green-600" variant="stroke" />
+                            </Button>
+                            <Button size="sm" variant="ghost" onClick={() => handleReject(leave._id as Id<"gabinetLeaves">)}>
+                              <X className="h-4 w-4 text-red-600" variant="stroke" />
+                            </Button>
+                          </>
+                        )}
+                        <Button size="sm" variant="ghost" onClick={() => setDeleteLeaveId(leave._id as Id<"gabinetLeaves">)}>
+                          <Trash2 className="h-4 w-4 text-muted-foreground" variant="stroke" />
                         </Button>
                       </div>
                     )}
@@ -486,6 +514,28 @@ function LeavesPage() {
               className={confirmAction === "reject" ? "bg-destructive text-destructive-foreground hover:bg-destructive/90" : undefined}
             >
               {confirmAction === "approve" ? t("gabinet.leaves.approve") : t("gabinet.leaves.reject")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+      <AlertDialog
+        open={!!deleteLeaveId}
+        onOpenChange={(open) => {
+          if (!open) setDeleteLeaveId(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("gabinet.leaves.confirmDeleteTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>{t("gabinet.leaves.confirmDeleteDesc")}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {t("gabinet.leaves.delete")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2688.

Closes #2688

---

## Claude summary

Done. Here's a summary of what was implemented:

**Backend (`convex/gabinet/scheduling.ts`):** Added `deleteLeave` action that verifies org membership, requires `gabinet_settings:edit` permission, and checks the leave belongs to the organization before deleting. If the leave was `approved` and had a `leaveTypeId`, the used days are reversed in `gabinetLeaveBalances` to keep accounting consistent.

**Frontend (`_layout.gabinet.settings.leaves.tsx`):** Added a trash icon delete button in the actions column (visible for all leave statuses, only to users with manage permission). Pending leaves still show the approve/reject buttons alongside the new delete button. A destructive `AlertDialog` confirms before deletion.

**i18n:** Added `delete`, `deleted`, `confirmDeleteTitle`, `confirmDeleteDesc`, and `errors.deleteFailed` keys to both Polish and English locales.