### PR TITLE
fix(gabinet): guard leaveTypes.list and getById with gabinet_settings:view permission

### DIFF
--- a/convex/gabinet/leaveTypes.ts
+++ b/convex/gabinet/leaveTypes.ts
@@ -17,6 +17,11 @@ export const list = action({
       organizationId: args.organizationId,
     });
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_settings", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
     const db = createSupabaseDb();
     let q = db.query("gabinetLeaveTypes").eq("organizationId", String(args.organizationId));
     if (args.activeOnly) {
@@ -36,6 +41,11 @@ export const getById = action({
       organizationId: args.organizationId,
     });
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_settings", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
     const db = createSupabaseDb();
     const lt = (await db.get("gabinetLeaveTypes", args.leaveTypeId)) as
       | GabinetLeaveTypeRow


### PR DESCRIPTION
## Summary
- `list` and `getById` in `convex/gabinet/leaveTypes.ts` only checked org membership and Gabinet product access, missing the `gabinet_settings:view` feature-level permission check
- All write operations in the same file (`create`, `update`, `remove`) already enforce `gabinet_settings:edit`; read ops were inconsistent
- Applied the identical 5-line `checkPermission` guard used by the #2687 fix for `listLeaves` / `getLeavesByDateRange`

## Test plan
- [ ] User with `gabinet_settings:view` can call `leaveTypes.list` and `leaveTypes.getById` successfully
- [ ] User without `gabinet_settings:view` receives `"Permission denied"` error from both actions
- [ ] Write operations (`create`, `update`, `remove`) are unaffected

Closes #2690

🤖 Generated with [Claude Code](https://claude.com/claude-code)