### PR TITLE
Guard `leaveTypes.getBalances` and `leaveTypes.getAllBalances` with `gabinet_set

### DIFF
--- a/convex/gabinet/leaveTypes.ts
+++ b/convex/gabinet/leaveTypes.ts
@@ -239,6 +239,11 @@ export const getBalances = action({
       organizationId: args.organizationId,
     });
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_settings", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
     return await db
@@ -260,6 +265,11 @@ export const getAllBalances = action({
       organizationId: args.organizationId,
     });
     await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_settings", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
     return await db


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2691.

Closes #2691

---

## Claude summary

The issue is confirmed and fixed. Both `getBalances` (line 231) and `getAllBalances` (line 253) in `convex/gabinet/leaveTypes.ts` were only checking org membership and gabinet product access, but not the `gabinet_settings:view` permission — meaning any org member could read sensitive HR leave balance data regardless of their role.

The fix adds the same `checkPermission` guard already present in `list` and `getById` to both functions, so they now throw `"Permission denied"` for users without `gabinet_settings:view`.