### PR TITLE
Przypomnienia wizyt – ustawienia SMS/e-mail (24h / 48h)

### DIFF
--- a/convex/gabinet/appointmentReminders.ts
+++ b/convex/gabinet/appointmentReminders.ts
@@ -157,6 +157,58 @@ export const sendReminder = internalMutation({
       : "Klient";
     const treatmentName = (treatment?.name as string) ?? "Wizyta";
 
+    // Resolve per-channel settings from org settings + per-appointment overrides.
+    // Org settings are read from Supabase (primary store). Per-appointment overrides
+    // are stored as JSON on the appointment and take priority.
+    const orgSettings = await db.query("orgSettings")
+      .eq("organizationId", String(reminder.organizationId))
+      .first();
+
+    let apptOverrides: Record<string, boolean> = {};
+    if (appointment.reminderOverrides) {
+      try { apptOverrides = JSON.parse(String(appointment.reminderOverrides)); } catch {}
+    }
+
+    const appointmentMs = new Date(
+      `${appointment.date}T${appointment.startTime}:00`,
+    ).getTime();
+    const reminderHoursAhead = Math.round(
+      (appointmentMs - (reminder.scheduledFor as number)) / (60 * 60 * 1000),
+    );
+
+    // Determine timing slot: >=36h ahead means this is a 48h-slot reminder.
+    const is48h = reminderHoursAhead >= 36;
+
+    // Check if 4-toggle mode is active (any channel setting explicitly configured).
+    const orgS = orgSettings as Record<string, unknown> | null;
+    const has4ToggleConfig =
+      orgS?.reminderSms48h !== null && orgS?.reminderSms48h !== undefined ||
+      orgS?.reminderSms24h !== null && orgS?.reminderSms24h !== undefined ||
+      orgS?.reminderEmail48h !== null && orgS?.reminderEmail48h !== undefined ||
+      orgS?.reminderEmail24h !== null && orgS?.reminderEmail24h !== undefined ||
+      Object.keys(apptOverrides).length > 0;
+
+    let sendSms = true;
+    let sendEmail = true;
+
+    if (has4ToggleConfig) {
+      if (is48h) {
+        sendSms = apptOverrides.sms48h !== undefined
+          ? apptOverrides.sms48h
+          : Boolean(orgS?.reminderSms48h ?? false);
+        sendEmail = apptOverrides.email48h !== undefined
+          ? apptOverrides.email48h
+          : Boolean(orgS?.reminderEmail48h ?? false);
+      } else {
+        sendSms = apptOverrides.sms24h !== undefined
+          ? apptOverrides.sms24h
+          : Boolean(orgS?.reminderSms24h ?? false);
+        sendEmail = apptOverrides.email24h !== undefined
+          ? apptOverrides.email24h
+          : Boolean(orgS?.reminderEmail24h ?? false);
+      }
+    }
+
     // Send in-app notification to the employee assigned to the appointment
     await createNotificationDirect(ctx, {
       organizationId: reminder.organizationId as Id<"organizations">,
@@ -179,10 +231,8 @@ export const sendReminder = internalMutation({
       });
     }
 
-    // Send appointment reminder email if patient has email.
-    // Pick the event type that matches the configured lead time so it
-    // resolves against the seeded gabinet.appointment.reminder_* bindings.
-    if (patient?.email) {
+    // Send appointment reminder email if enabled for this timing and patient has email.
+    if (sendEmail && patient?.email) {
       // appointment.employeeId references users(id), not gabinetEmployees(id),
       // so query the gabinet profile by userId and fall back to the linked user.
       const employeeUserId = String(appointment.employeeId);
@@ -202,18 +252,14 @@ export const sendReminder = internalMutation({
         (employeeUser?.email as string | undefined) ??
         "Specjalista";
 
-      const appointmentMs = new Date(
-        `${appointment.date}T${appointment.startTime}:00`,
-      ).getTime();
-      const reminderHoursAhead = Math.round(
-        (appointmentMs - (reminder.scheduledFor as number)) / (60 * 60 * 1000),
-      );
       const reminderEventType =
-        reminderHoursAhead === 24
-          ? "gabinet.appointment.reminder_24h"
-          : reminderHoursAhead === 1
-            ? "gabinet.appointment.reminder_1h"
-            : "gabinet.appointment.reminder_custom";
+        reminderHoursAhead === 48
+          ? "gabinet.appointment.reminder_48h"
+          : reminderHoursAhead === 24
+            ? "gabinet.appointment.reminder_24h"
+            : reminderHoursAhead === 1
+              ? "gabinet.appointment.reminder_1h"
+              : "gabinet.appointment.reminder_custom";
 
       await ctx.runMutation(internal.emailEventTrigger.triggerEmailEvent, {
         organizationId: reminder.organizationId as Id<"organizations">,
@@ -258,8 +304,8 @@ export const sendReminder = internalMutation({
       occurredAt: Date.now(),
     });
 
-    // Queue appointment confirmation SMS if patient has phone
-    if (patient?.phone) {
+    // Queue appointment confirmation SMS if enabled for this timing and patient has phone
+    if (sendSms && patient?.phone) {
       await ctx.runMutation(internal.gabinet.appointmentSms.queueConfirmationRequest, {
         organizationId: reminder.organizationId as Id<"organizations">,
         appointmentId: appointment._id as Id<"gabinetAppointments">,

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -887,6 +887,7 @@ export const _createSideEffects = internalMutation({
     isRecurring: v.boolean(),
     recurringGroupId: v.optional(v.string()),
     sendReminder: v.boolean(),
+    reminderOverrides: v.optional(v.string()), // JSON: per-appointment channel overrides
     createdBy: v.string(),
     createdAt: v.number(),
     // Resolved names for calendar title
@@ -989,19 +990,56 @@ export const _createSideEffects = internalMutation({
     // --- 6. Schedule reminders (inline — avoid DB read since appointment is in Supabase) ---
     if (args.sendReminder) {
       try {
-        const orgSettings = await ctx.db
-          .query("orgSettings")
-          .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-          .unique();
-        const reminderHours = (orgSettings as any)?.reminderHoursBefore ?? 24;
+        // Read org settings from Supabase (primary store) to get 4-toggle channel config.
+        const remDb = createSupabaseDb();
+        const supaOrgSettings = await remDb.query("orgSettings")
+          .eq("organizationId", String(args.organizationId))
+          .first() as Record<string, unknown> | null;
+
+        // Parse per-appointment overrides from dialog.
+        let apptOverrides: Record<string, boolean> = {};
+        if (args.reminderOverrides) {
+          try { apptOverrides = JSON.parse(args.reminderOverrides); } catch {}
+        }
+
+        // Determine which timings to schedule based on merged settings.
+        // If no 4-toggle settings exist (legacy orgs), fall back to single 24h reminder.
+        const has4ToggleConfig =
+          supaOrgSettings?.reminderSms48h !== null && supaOrgSettings?.reminderSms48h !== undefined ||
+          supaOrgSettings?.reminderSms24h !== null && supaOrgSettings?.reminderSms24h !== undefined ||
+          supaOrgSettings?.reminderEmail48h !== null && supaOrgSettings?.reminderEmail48h !== undefined ||
+          supaOrgSettings?.reminderEmail24h !== null && supaOrgSettings?.reminderEmail24h !== undefined ||
+          Object.keys(apptOverrides).length > 0;
+
+        let timingsHours: number[];
+        if (has4ToggleConfig) {
+          timingsHours = [];
+          const need48h =
+            (apptOverrides.sms48h !== undefined ? apptOverrides.sms48h : Boolean(supaOrgSettings?.reminderSms48h)) ||
+            (apptOverrides.email48h !== undefined ? apptOverrides.email48h : Boolean(supaOrgSettings?.reminderEmail48h));
+          const need24h =
+            (apptOverrides.sms24h !== undefined ? apptOverrides.sms24h : Boolean(supaOrgSettings?.reminderSms24h)) ||
+            (apptOverrides.email24h !== undefined ? apptOverrides.email24h : Boolean(supaOrgSettings?.reminderEmail24h));
+          if (need48h) timingsHours.push(48);
+          if (need24h) timingsHours.push(24);
+        } else {
+          // Legacy: single reminder at configured hours (default 24)
+          const orgSettings = await ctx.db
+            .query("orgSettings")
+            .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+            .unique();
+          const reminderHours = (orgSettings as any)?.reminderHoursBefore ?? 24;
+          timingsHours = [reminderHours];
+        }
 
         const scheduleReminderFor = async (
           apptId: string,
           apptDate: string,
           apptStartTime: string,
+          hoursAhead: number,
         ) => {
           const appointmentMs = new Date(`${apptDate}T${apptStartTime}:00`).getTime();
-          const reminderMs = appointmentMs - reminderHours * 60 * 60 * 1000;
+          const reminderMs = appointmentMs - hoursAhead * 60 * 60 * 1000;
           if (reminderMs <= Date.now()) return;
           const reminderId = await ctx.db.insert("appointmentReminders", {
             organizationId: args.organizationId,
@@ -1018,13 +1056,16 @@ export const _createSideEffects = internalMutation({
           );
         };
 
-        await scheduleReminderFor(args.appointmentId, args.date, args.startTime);
-        for (const recur of recurringAppointments) {
-          await scheduleReminderFor(
-            recur.appointmentId,
-            recur.date,
-            recur.startTime ?? args.startTime,
-          );
+        for (const hours of timingsHours) {
+          await scheduleReminderFor(args.appointmentId, args.date, args.startTime, hours);
+          for (const recur of recurringAppointments) {
+            await scheduleReminderFor(
+              recur.appointmentId,
+              recur.date,
+              recur.startTime ?? args.startTime,
+              hours,
+            );
+          }
         }
       } catch (e) {
         console.warn("Reminder scheduling failed (non-fatal):", e);
@@ -1076,6 +1117,7 @@ export const create = action({
     prepaymentAmount: v.optional(v.number()),
     packageUsageId: v.optional(v.string()),
     sendReminder: v.optional(v.boolean()),
+    reminderOverrides: v.optional(v.string()), // JSON: per-appointment channel overrides
     locationId: v.optional(v.string()),
     roomId: v.optional(v.string()),
     tagIds: v.optional(v.array(v.string())),
@@ -1256,6 +1298,7 @@ export const create = action({
       prepaymentStatus: args.prepaymentRequired ? "pending" : null,
       packageUsageId: resolvedPackageUsageId ?? null,
       sendReminder: shouldSendReminder,
+      reminderOverrides: args.reminderOverrides ?? null,
       locationId: resolvedLocationId ?? null,
       roomId: args.roomId ?? null,
       tagIds: args.tagIds ?? null,
@@ -1396,6 +1439,7 @@ export const create = action({
           isRecurring,
           recurringGroupId,
           sendReminder: shouldSendReminder,
+          reminderOverrides: args.reminderOverrides,
           createdBy: String(authResult.userId),
           createdAt: now,
           patientName,

--- a/convex/orgSettings.ts
+++ b/convex/orgSettings.ts
@@ -29,6 +29,10 @@ export const upsert = action({
     timezone: v.optional(v.string()),
     reminderEnabled: v.optional(v.boolean()),
     reminderHoursBefore: v.optional(v.number()),
+    reminderSms48h: v.optional(v.boolean()),
+    reminderSms24h: v.optional(v.boolean()),
+    reminderEmail48h: v.optional(v.boolean()),
+    reminderEmail24h: v.optional(v.boolean()),
     appointmentWorkflowConfig: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
@@ -52,6 +56,10 @@ export const upsert = action({
       if (args.timezone !== undefined) updates.timezone = args.timezone;
       if (args.reminderEnabled !== undefined) updates.reminderEnabled = args.reminderEnabled;
       if (args.reminderHoursBefore !== undefined) updates.reminderHoursBefore = args.reminderHoursBefore;
+      if (args.reminderSms48h !== undefined) updates.reminderSms48h = args.reminderSms48h;
+      if (args.reminderSms24h !== undefined) updates.reminderSms24h = args.reminderSms24h;
+      if (args.reminderEmail48h !== undefined) updates.reminderEmail48h = args.reminderEmail48h;
+      if (args.reminderEmail24h !== undefined) updates.reminderEmail24h = args.reminderEmail24h;
       if (args.appointmentWorkflowConfig !== undefined) updates.appointmentWorkflowConfig = args.appointmentWorkflowConfig;
 
       await db.patch("orgSettings", existing._id as string, updates);
@@ -66,6 +74,10 @@ export const upsert = action({
       timezone: args.timezone ?? null,
       reminderEnabled: args.reminderEnabled ?? null,
       reminderHoursBefore: args.reminderHoursBefore ?? null,
+      reminderSms48h: args.reminderSms48h ?? null,
+      reminderSms24h: args.reminderSms24h ?? null,
+      reminderEmail48h: args.reminderEmail48h ?? null,
+      reminderEmail24h: args.reminderEmail24h ?? null,
       appointmentWorkflowConfig: args.appointmentWorkflowConfig ?? null,
       createdAt: now,
       updatedAt: now,

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -552,6 +552,11 @@ export function createCrmTables({
     // Appointment reminder settings
     reminderEnabled: v.optional(v.boolean()),
     reminderHoursBefore: v.optional(v.number()), // default 24
+    // Per-channel/per-timing reminder toggles (issue #2685)
+    reminderSms48h: v.optional(v.boolean()),
+    reminderSms24h: v.optional(v.boolean()),
+    reminderEmail48h: v.optional(v.boolean()),
+    reminderEmail24h: v.optional(v.boolean()),
     appointmentWorkflowConfig: v.optional(v.string()),
     createdAt: v.number(),
     updatedAt: v.number(),

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -458,6 +458,7 @@ export function createGabinetTables({
     scheduledActivityId: v.optional(v.string()),
     reminderSentAt: v.optional(v.number()),
     sendReminder: v.optional(v.boolean()),
+    reminderOverrides: v.optional(v.string()), // JSON: {sms48h?,sms24h?,email48h?,email24h?}
     cancelledAt: v.optional(v.number()),
     cancelledBy: v.optional(v.id("users")),
     cancellationReason: v.optional(v.string()),

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2761,11 +2761,26 @@
     "reminders": {
       "title": "Appointment Reminders",
       "description": "Configure automatic reminders sent before appointments",
+      "sectionSms": "SMS",
+      "sectionEmail": "Email",
+      "sms48h": "SMS 48 hours before appointment",
+      "sms48hDesc": "Send an SMS to the client 48 hours before the appointment",
+      "sms24h": "SMS 24 hours before appointment",
+      "sms24hDesc": "Send an SMS to the client 24 hours before the appointment",
+      "email48h": "Email 48 hours before appointment",
+      "email48hDesc": "Send an email to the client 48 hours before the appointment",
+      "email24h": "Email 24 hours before appointment",
+      "email24hDesc": "Send an email to the client 24 hours before the appointment",
+      "noContactWarning": "A reminder will be skipped if the client has no phone number (SMS) or email address (email).",
+      "saved": "Reminder settings saved",
+      "appointmentSection": "Reminders",
+      "appointmentDescription": "Defaults from clinic settings. You can override for this appointment.",
+      "noPhone": "Client has no phone number — SMS will not be sent",
+      "noEmail": "Client has no email address — email will not be sent",
       "enabled": "Enable reminders",
       "enabledDescription": "Automatically send reminders about upcoming appointments",
       "hoursBefore": "Hours before appointment",
-      "hoursBeforeDescription": "How many hours before the appointment to send the reminder",
-      "saved": "Reminder settings saved"
+      "hoursBeforeDescription": "How many hours before the appointment to send the reminder"
     },
     "leaves": {
       "title": "Leave Management",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2782,11 +2782,26 @@
     "reminders": {
       "title": "Przypomnienia o wizytach",
       "description": "Konfiguruj automatyczne przypomnienia wysyłane przed wizytami",
+      "sectionSms": "SMS",
+      "sectionEmail": "E-mail",
+      "sms48h": "SMS 48 godzin przed wizytą",
+      "sms48hDesc": "Wyślij SMS do klienta 48 godzin przed wizytą",
+      "sms24h": "SMS 24 godziny przed wizytą",
+      "sms24hDesc": "Wyślij SMS do klienta 24 godziny przed wizytą",
+      "email48h": "E-mail 48 godzin przed wizytą",
+      "email48hDesc": "Wyślij e-mail do klienta 48 godzin przed wizytą",
+      "email24h": "E-mail 24 godziny przed wizytą",
+      "email24hDesc": "Wyślij e-mail do klienta 24 godziny przed wizytą",
+      "noContactWarning": "Przypomnienie zostanie pominięte, jeśli klient nie ma numeru telefonu (SMS) lub adresu e-mail (e-mail).",
+      "saved": "Ustawienia przypomnień zapisane",
+      "appointmentSection": "Przypomnienia",
+      "appointmentDescription": "Domyślnie na podstawie ustawień gabinetu. Możesz zmienić dla tej wizyty.",
+      "noPhone": "Klient nie ma numeru telefonu — SMS nie zostanie wysłany",
+      "noEmail": "Klient nie ma adresu e-mail — e-mail nie zostanie wysłany",
       "enabled": "Włącz przypomnienia",
       "enabledDescription": "Automatycznie wysyłaj przypomnienia o nadchodzących wizytach",
       "hoursBefore": "Godziny przed wizytą",
-      "hoursBeforeDescription": "Ile godzin przed wizytą wysłać przypomnienie",
-      "saved": "Ustawienia przypomnień zapisane"
+      "hoursBeforeDescription": "Ile godzin przed wizytą wysłać przypomnienie"
     },
     "leaves": {
       "title": "Zarządzanie urlopami",

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -95,6 +95,7 @@ import { TreatmentPicker } from "@/components/gabinet/appointment-shared/treatme
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { useSupabaseGabinetAppointmentsByDateRange } from "@/hooks/use-supabase-gabinet-appointments";
+import { useSupabaseOrgSettings } from "@/hooks/use-supabase-organizations";
 import { formatPhoneNumber } from "@/lib/phone";
 
 // ---------------------------------------------------------------------------
@@ -286,6 +287,12 @@ export function AppointmentDialog({
   const [locationId, setLocationId] = useState("");
   const [roomId, setRoomId] = useState("");
   const [packageUsageId, setPackageUsageId] = useState<string | null>(null);
+
+  // Per-appointment reminder channel overrides
+  const [reminderSms48h, setReminderSms48h] = useState(false);
+  const [reminderSms24h, setReminderSms24h] = useState(false);
+  const [reminderEmail48h, setReminderEmail48h] = useState(false);
+  const [reminderEmail24h, setReminderEmail24h] = useState(false);
 
   // Combobox open states
   const [treatmentOpen, setTreatmentOpen] = useState(false);
@@ -517,6 +524,21 @@ export function AppointmentDialog({
   const now = new Date();
   const nowDate = format(now, "yyyy-MM-dd");
   const nowTime = format(now, "HH:mm");
+
+  // Org reminder defaults — used to pre-populate reminder toggles
+  const { data: orgSettings } = useSupabaseOrgSettings(organizationId as string, {
+    enabled: open,
+  });
+
+  // Initialize reminder toggles from org settings when they load
+  useEffect(() => {
+    if (orgSettings) {
+      setReminderSms48h(orgSettings.reminderSms48h ?? false);
+      setReminderSms24h(orgSettings.reminderSms24h ?? false);
+      setReminderEmail48h(orgSettings.reminderEmail48h ?? false);
+      setReminderEmail24h(orgSettings.reminderEmail24h ?? false);
+    }
+  }, [orgSettings]);
 
   // Available slots — action reading from Supabase
   const getAvailableSlots = useAction(api.gabinet.appointments.getAvailableSlotsQuery);
@@ -876,6 +898,8 @@ export function AppointmentDialog({
           (o, i) =>
             o.startTime !== selectedSlot.start || o.date !== cycleDates[i],
         );
+      const anyReminderEnabled =
+        reminderSms48h || reminderSms24h || reminderEmail48h || reminderEmail24h;
       await createAppointment({
         organizationId,
         patientId: patientId as Id<"gabinetPatients">,
@@ -895,6 +919,13 @@ export function AppointmentDialog({
         packageUsageId: packageUsageId ?? undefined,
         allowPast: recordWalkIn || undefined,
         allowConflict: hasBookingConflict || undefined,
+        sendReminder: anyReminderEnabled,
+        reminderOverrides: JSON.stringify({
+          sms48h: reminderSms48h,
+          sms24h: reminderSms24h,
+          email48h: reminderEmail48h,
+          email24h: reminderEmail24h,
+        }),
       });
       // Refresh the calendar immediately — Convex actions don't invalidate
       // the Supabase React Query cache automatically.
@@ -1433,6 +1464,81 @@ export function AppointmentDialog({
                           "gabinet.appointments.notesPlaceholder",
                         )}
                       />
+                    </AccordionContent>
+                  </AccordionItem>
+                </Accordion>
+
+                {/* Reminders */}
+                <Accordion type="single" collapsible>
+                  <AccordionItem value="reminders" className="border-none">
+                    <AccordionTrigger className="py-0 text-xs text-muted-foreground hover:text-foreground hover:no-underline gap-1.5">
+                      <span className="flex items-center gap-1.5">
+                        <Clock className="size-3" />
+                        {t("gabinet.reminders.appointmentSection")}
+                      </span>
+                    </AccordionTrigger>
+                    <AccordionContent className="pb-0 pt-2">
+                      <div className="space-y-3">
+                        <p className="text-muted-foreground text-xs">
+                          {t("gabinet.reminders.appointmentDescription")}
+                        </p>
+                        <div className="space-y-2">
+                          <p className="text-xs font-medium">{t("gabinet.reminders.sectionSms")}</p>
+                          <Label className="-mx-1 flex min-h-9 select-none items-center gap-2.5 rounded-md px-1 py-1 text-sm cursor-pointer hover:bg-accent/40">
+                            <Checkbox
+                              checked={reminderSms48h}
+                              onCheckedChange={(v) => setReminderSms48h(v === true)}
+                              disabled={!selectedPatient?.phone}
+                            />
+                            <span className={!selectedPatient?.phone ? "text-muted-foreground" : ""}>
+                              {t("gabinet.reminders.sms48h")}
+                            </span>
+                          </Label>
+                          <Label className="-mx-1 flex min-h-9 select-none items-center gap-2.5 rounded-md px-1 py-1 text-sm cursor-pointer hover:bg-accent/40">
+                            <Checkbox
+                              checked={reminderSms24h}
+                              onCheckedChange={(v) => setReminderSms24h(v === true)}
+                              disabled={!selectedPatient?.phone}
+                            />
+                            <span className={!selectedPatient?.phone ? "text-muted-foreground" : ""}>
+                              {t("gabinet.reminders.sms24h")}
+                            </span>
+                          </Label>
+                          {selectedPatient && !selectedPatient.phone && (
+                            <p className="text-xs text-muted-foreground">
+                              {t("gabinet.reminders.noPhone")}
+                            </p>
+                          )}
+                        </div>
+                        <div className="space-y-2">
+                          <p className="text-xs font-medium">{t("gabinet.reminders.sectionEmail")}</p>
+                          <Label className="-mx-1 flex min-h-9 select-none items-center gap-2.5 rounded-md px-1 py-1 text-sm cursor-pointer hover:bg-accent/40">
+                            <Checkbox
+                              checked={reminderEmail48h}
+                              onCheckedChange={(v) => setReminderEmail48h(v === true)}
+                              disabled={!selectedPatient?.email}
+                            />
+                            <span className={!selectedPatient?.email ? "text-muted-foreground" : ""}>
+                              {t("gabinet.reminders.email48h")}
+                            </span>
+                          </Label>
+                          <Label className="-mx-1 flex min-h-9 select-none items-center gap-2.5 rounded-md px-1 py-1 text-sm cursor-pointer hover:bg-accent/40">
+                            <Checkbox
+                              checked={reminderEmail24h}
+                              onCheckedChange={(v) => setReminderEmail24h(v === true)}
+                              disabled={!selectedPatient?.email}
+                            />
+                            <span className={!selectedPatient?.email ? "text-muted-foreground" : ""}>
+                              {t("gabinet.reminders.email24h")}
+                            </span>
+                          </Label>
+                          {selectedPatient && !selectedPatient.email && (
+                            <p className="text-xs text-muted-foreground">
+                              {t("gabinet.reminders.noEmail")}
+                            </p>
+                          )}
+                        </div>
+                      </div>
                     </AccordionContent>
                   </AccordionItem>
                 </Accordion>

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -526,6 +526,10 @@ export interface Database {
           resource_sharing_enabled: boolean | null;
           reminder_enabled: boolean | null;
           reminder_hours_before: number | null;
+          reminder_sms_48h: boolean | null;
+          reminder_sms_24h: boolean | null;
+          reminder_email_48h: boolean | null;
+          reminder_email_24h: boolean | null;
           appointment_workflow_config: string | null;
           created_at: number;
           updated_at: number;
@@ -540,6 +544,10 @@ export interface Database {
           resource_sharing_enabled?: boolean | null;
           reminder_enabled?: boolean | null;
           reminder_hours_before?: number | null;
+          reminder_sms_48h?: boolean | null;
+          reminder_sms_24h?: boolean | null;
+          reminder_email_48h?: boolean | null;
+          reminder_email_24h?: boolean | null;
           appointment_workflow_config?: string | null;
           created_at: number;
           updated_at: number;
@@ -554,6 +562,10 @@ export interface Database {
           resource_sharing_enabled?: boolean | null;
           reminder_enabled?: boolean | null;
           reminder_hours_before?: number | null;
+          reminder_sms_48h?: boolean | null;
+          reminder_sms_24h?: boolean | null;
+          reminder_email_48h?: boolean | null;
+          reminder_email_24h?: boolean | null;
           appointment_workflow_config?: string | null;
           created_at?: number;
           updated_at?: number;
@@ -4678,6 +4690,7 @@ export interface Database {
           scheduled_activity_id: string | null;
           reminder_sent_at: number | null;
           send_reminder: boolean | null;
+          reminder_overrides: string | null;
           cancelled_at: number | null;
           cancelled_by: string | null;
           cancellation_reason: string | null;
@@ -4724,6 +4737,7 @@ export interface Database {
           scheduled_activity_id?: string | null;
           reminder_sent_at?: number | null;
           send_reminder?: boolean | null;
+          reminder_overrides?: string | null;
           cancelled_at?: number | null;
           cancelled_by?: string | null;
           cancellation_reason?: string | null;
@@ -4770,6 +4784,7 @@ export interface Database {
           scheduled_activity_id?: string | null;
           reminder_sent_at?: number | null;
           send_reminder?: boolean | null;
+          reminder_overrides?: string | null;
           cancelled_at?: number | null;
           cancelled_by?: string | null;
           cancellation_reason?: string | null;

--- a/src/lib/supabase/mappers/gabinet/appointments.ts
+++ b/src/lib/supabase/mappers/gabinet/appointments.ts
@@ -36,6 +36,7 @@ export interface MappedGabinetAppointment {
   scheduledActivityId?: string;
   reminderSentAt?: number;
   sendReminder?: boolean;
+  reminderOverrides?: string;
   cancelledAt?: number;
   cancelledBy?: string;
   cancellationReason?: string;

--- a/src/lib/supabase/mappers/org-settings.ts
+++ b/src/lib/supabase/mappers/org-settings.ts
@@ -16,6 +16,10 @@ export interface MappedOrgSettings {
   resourceSharingEnabled?: boolean;
   reminderEnabled?: boolean;
   reminderHoursBefore?: number;
+  reminderSms48h?: boolean;
+  reminderSms24h?: boolean;
+  reminderEmail48h?: boolean;
+  reminderEmail24h?: boolean;
   appointmentWorkflowConfig?: string;
   createdAt: number;
   updatedAt: number;

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -10,6 +10,7 @@ import { formatPhoneNumber } from "@/lib/phone";
 import { formatCurrencyPLN } from "@/lib/format-currency";
 import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
 import { useSupabaseGabinetEquipmentList } from "@/hooks/use-supabase-gabinet-equipment";
+import { useSupabaseOrgSettings } from "@/hooks/use-supabase-organizations";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -43,6 +44,7 @@ import { RichTextEditor, plateJsonToText } from "@/components/gabinet/rich-text-
 import { Avatar as UntitledAvatar } from "@untitled/base/avatar/avatar";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -101,6 +103,7 @@ import {
   Stethoscope,
   MapPin,
   Building2,
+  Clock,
 } from "@/lib/ez-icons";
 import { Id } from "@cvx/_generated/dataModel";
 import type { AppointmentFullDetailNote } from "@cvx/gabinet/appointments";
@@ -359,6 +362,13 @@ function AppointmentDetail() {
   const [treatmentSearch, setTreatmentSearch] = useState("");
   const [isSavingScheduling, setIsSavingScheduling] = useState(false);
 
+  // Reminder channel overrides — editable inline on this page
+  const [editReminderSms48h, setEditReminderSms48h] = useState(false);
+  const [editReminderSms24h, setEditReminderSms24h] = useState(false);
+  const [editReminderEmail48h, setEditReminderEmail48h] = useState(false);
+  const [editReminderEmail24h, setEditReminderEmail24h] = useState(false);
+  const [isSavingReminders, setIsSavingReminders] = useState(false);
+
   const { tags: tagDefinitions } = useTagDefinitions(organizationId);
 
 
@@ -517,6 +527,8 @@ function AppointmentDetail() {
     }),
   );
 
+  const { data: orgSettings } = useSupabaseOrgSettings(organizationId as string);
+
   // Equipment list used to surface parameter units on the Documentation tab —
   // when the appointment's treatment lists required equipment, the editor
   // pre-fills the unit field with that equipment's catalog. See #1847.
@@ -567,6 +579,24 @@ function AppointmentDetail() {
   useEffect(() => {
     setTagIds((detail?.appointment.tagIds as Id<"tagDefinitions">[] | undefined) ?? []);
   }, [detail?.appointment._id, detail?.appointment.tagIds]);
+
+  // Seed reminder toggles from per-appointment overrides (falling back to org defaults).
+  // Uses a ref guard so user edits are not overwritten by query refetches.
+  const reminderInitRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!detail || !orgSettings) return;
+    if (reminderInitRef.current === detail.appointment._id) return;
+    reminderInitRef.current = detail.appointment._id;
+    const appt = detail.appointment as Record<string, unknown>;
+    let overrides: Record<string, boolean> = {};
+    if (appt.reminderOverrides) {
+      try { overrides = JSON.parse(String(appt.reminderOverrides)); } catch {}
+    }
+    setEditReminderSms48h("sms48h" in overrides ? overrides.sms48h : (orgSettings.reminderSms48h ?? false));
+    setEditReminderSms24h("sms24h" in overrides ? overrides.sms24h : (orgSettings.reminderSms24h ?? false));
+    setEditReminderEmail48h("email48h" in overrides ? overrides.email48h : (orgSettings.reminderEmail48h ?? false));
+    setEditReminderEmail24h("email24h" in overrides ? overrides.email24h : (orgSettings.reminderEmail24h ?? false));
+  }, [detail, orgSettings]);
 
   // Initialize body chart data from appointment
   useEffect(() => {
@@ -1248,6 +1278,30 @@ function AppointmentDetail() {
     }
   };
 
+  const handleSaveReminders = async () => {
+    setIsSavingReminders(true);
+    try {
+      await updateAppointment({
+        organizationId,
+        appointmentId: appointment._id,
+        reminderOverrides: JSON.stringify({
+          sms48h: editReminderSms48h,
+          sms24h: editReminderSms24h,
+          email48h: editReminderEmail48h,
+          email24h: editReminderEmail24h,
+        }),
+      });
+      await invalidateAppointmentCaches();
+      refetch();
+      toast.success(t("gabinet.reminders.saved"));
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : t("common.error");
+      toast.error(msg);
+    } finally {
+      setIsSavingReminders(false);
+    }
+  };
+
   // Group notes by parent for threading
   const rootNotes = notes.filter((n) => !n.parentNoteId);
   const getReplies = (noteId: string) =>
@@ -1699,6 +1753,75 @@ function AppointmentDetail() {
                   </div>
                 );
               })()}
+            </CardContent>
+          </Card>
+
+          {/* Reminders Card */}
+          <Card>
+            <CardHeader className="px-6 py-3 border-b">
+              <CardTitle className="text-sm flex items-center gap-2">
+                <Clock className="h-4 w-4" variant="stroke" />
+                {t("gabinet.reminders.appointmentSection")}
+              </CardTitle>
+              <CardDescription className="text-xs">
+                {t("gabinet.reminders.appointmentDescription")}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4 px-6 py-4">
+              <div className="space-y-2">
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">{t("gabinet.reminders.sectionSms")}</p>
+                <Label className="-mx-1 flex min-h-9 select-none items-center gap-2.5 rounded-md px-1 py-1 text-sm cursor-pointer hover:bg-accent/40">
+                  <Checkbox
+                    checked={editReminderSms48h}
+                    onCheckedChange={(v) => setEditReminderSms48h(v === true)}
+                    disabled={!patient?.phone}
+                  />
+                  <span className={!patient?.phone ? "text-muted-foreground" : ""}>{t("gabinet.reminders.sms48h")}</span>
+                </Label>
+                <Label className="-mx-1 flex min-h-9 select-none items-center gap-2.5 rounded-md px-1 py-1 text-sm cursor-pointer hover:bg-accent/40">
+                  <Checkbox
+                    checked={editReminderSms24h}
+                    onCheckedChange={(v) => setEditReminderSms24h(v === true)}
+                    disabled={!patient?.phone}
+                  />
+                  <span className={!patient?.phone ? "text-muted-foreground" : ""}>{t("gabinet.reminders.sms24h")}</span>
+                </Label>
+                {patient && !patient.phone && (
+                  <p className="text-xs text-muted-foreground">{t("gabinet.reminders.noPhone")}</p>
+                )}
+              </div>
+              <div className="space-y-2">
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">{t("gabinet.reminders.sectionEmail")}</p>
+                <Label className="-mx-1 flex min-h-9 select-none items-center gap-2.5 rounded-md px-1 py-1 text-sm cursor-pointer hover:bg-accent/40">
+                  <Checkbox
+                    checked={editReminderEmail48h}
+                    onCheckedChange={(v) => setEditReminderEmail48h(v === true)}
+                    disabled={!patient?.email}
+                  />
+                  <span className={!patient?.email ? "text-muted-foreground" : ""}>{t("gabinet.reminders.email48h")}</span>
+                </Label>
+                <Label className="-mx-1 flex min-h-9 select-none items-center gap-2.5 rounded-md px-1 py-1 text-sm cursor-pointer hover:bg-accent/40">
+                  <Checkbox
+                    checked={editReminderEmail24h}
+                    onCheckedChange={(v) => setEditReminderEmail24h(v === true)}
+                    disabled={!patient?.email}
+                  />
+                  <span className={!patient?.email ? "text-muted-foreground" : ""}>{t("gabinet.reminders.email24h")}</span>
+                </Label>
+                {patient && !patient.email && (
+                  <p className="text-xs text-muted-foreground">{t("gabinet.reminders.noEmail")}</p>
+                )}
+              </div>
+              <div className="flex justify-end pt-1">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleSaveReminders}
+                  disabled={isSavingReminders}
+                >
+                  {isSavingReminders ? t("common.saving") : t("common.save")}
+                </Button>
+              </div>
             </CardContent>
           </Card>
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.reminders.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.reminders.tsx
@@ -6,9 +6,9 @@ import { useSupabaseOrgSettings } from "@/hooks/use-supabase-organizations";
 import { SectionHeader } from "@untitled/app/section-headers/section-headers";
 import { UntitledAlert } from "@/components/ui/untitled-alert";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -19,8 +19,8 @@ function ReminderSettingsSkeleton() {
   return (
     <div className="space-y-4">
       <Skeleton className="h-7 w-48" />
-      <Skeleton className="h-32 w-full" />
-      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-40 w-full" />
+      <Skeleton className="h-40 w-full" />
     </div>
   );
 }
@@ -35,6 +35,45 @@ export const Route = createFileRoute(
   ),
 });
 
+interface ChannelConfig {
+  sms48h: boolean;
+  sms24h: boolean;
+  email48h: boolean;
+  email24h: boolean;
+}
+
+function ChannelToggle({
+  id,
+  label,
+  description,
+  checked,
+  onCheckedChange,
+  disabled,
+}: {
+  id: string;
+  label: string;
+  description: string;
+  checked: boolean;
+  onCheckedChange: (v: boolean) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <Checkbox
+        id={id}
+        checked={checked}
+        onCheckedChange={(v) => onCheckedChange(v === true)}
+        disabled={disabled}
+        className="mt-0.5"
+      />
+      <div className="grid gap-1 leading-none">
+        <Label htmlFor={id}>{label}</Label>
+        <p className="text-muted-foreground text-sm">{description}</p>
+      </div>
+    </div>
+  );
+}
+
 function ReminderSettings() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
@@ -43,27 +82,37 @@ function ReminderSettings() {
 
   const { data: orgSettings } = useSupabaseOrgSettings(organizationId);
 
-  const [enabled, setEnabled] = useState(false);
-  const [hoursBefore, setHoursBefore] = useState(24);
+  const [config, setConfig] = useState<ChannelConfig>({
+    sms48h: false,
+    sms24h: false,
+    email48h: false,
+    email24h: false,
+  });
 
   useEffect(() => {
     if (orgSettings) {
-      setEnabled(orgSettings.reminderEnabled ?? false);
-      setHoursBefore(orgSettings.reminderHoursBefore ?? 24);
+      setConfig({
+        sms48h: orgSettings.reminderSms48h ?? false,
+        sms24h: orgSettings.reminderSms24h ?? false,
+        email48h: orgSettings.reminderEmail48h ?? false,
+        email24h: orgSettings.reminderEmail24h ?? false,
+      });
     }
   }, [orgSettings]);
 
+  const toggle = (key: keyof ChannelConfig) => (value: boolean) => {
+    setConfig((prev) => ({ ...prev, [key]: value }));
+  };
+
   const handleSave = async () => {
-    if (hoursBefore < 1 || hoursBefore > 168) {
-      toast.error(t("gabinet.reminders.hoursBeforeDescription"));
-      return;
-    }
     setSaving(true);
     try {
       await upsertSettings({
         organizationId,
-        reminderEnabled: enabled,
-        reminderHoursBefore: hoursBefore,
+        reminderSms48h: config.sms48h,
+        reminderSms24h: config.sms24h,
+        reminderEmail48h: config.email48h,
+        reminderEmail24h: config.email24h,
       });
       toast.success(t("gabinet.reminders.saved"));
     } catch (e) {
@@ -86,42 +135,47 @@ function ReminderSettings() {
       </SectionHeader.Root>
 
       <div className="max-w-lg space-y-6">
-        <div className="flex items-start gap-3">
-          <Checkbox
-            id="reminderEnabled"
-            checked={enabled}
-            onCheckedChange={(checked) => setEnabled(checked === true)}
+        <div className="space-y-4">
+          <p className="text-sm font-medium">{t("gabinet.reminders.sectionSms")}</p>
+          <ChannelToggle
+            id="sms48h"
+            label={t("gabinet.reminders.sms48h")}
+            description={t("gabinet.reminders.sms48hDesc")}
+            checked={config.sms48h}
+            onCheckedChange={toggle("sms48h")}
           />
-          <div className="grid gap-1 leading-none">
-            <Label htmlFor="reminderEnabled">
-              {t("gabinet.reminders.enabled")}
-            </Label>
-            <p className="text-muted-foreground text-sm">
-              {t("gabinet.reminders.enabledDescription")}
-            </p>
-          </div>
+          <ChannelToggle
+            id="sms24h"
+            label={t("gabinet.reminders.sms24h")}
+            description={t("gabinet.reminders.sms24hDesc")}
+            checked={config.sms24h}
+            onCheckedChange={toggle("sms24h")}
+          />
         </div>
 
-        {enabled && (
-          <div className="space-y-2">
-            <Label htmlFor="hoursBefore">
-              {t("gabinet.reminders.hoursBefore")}
-            </Label>
-            <Input
-              id="hoursBefore"
-              type="number"
-              inputMode="numeric"
-              className="w-32"
-              min={1}
-              max={168}
-              value={hoursBefore}
-              onChange={(e) => setHoursBefore(Number(e.target.value))}
-            />
-            <p className="text-muted-foreground text-xs">
-              {t("gabinet.reminders.hoursBeforeDescription")}
-            </p>
-          </div>
-        )}
+        <Separator />
+
+        <div className="space-y-4">
+          <p className="text-sm font-medium">{t("gabinet.reminders.sectionEmail")}</p>
+          <ChannelToggle
+            id="email48h"
+            label={t("gabinet.reminders.email48h")}
+            description={t("gabinet.reminders.email48hDesc")}
+            checked={config.email48h}
+            onCheckedChange={toggle("email48h")}
+          />
+          <ChannelToggle
+            id="email24h"
+            label={t("gabinet.reminders.email24h")}
+            description={t("gabinet.reminders.email24hDesc")}
+            checked={config.email24h}
+            onCheckedChange={toggle("email24h")}
+          />
+        </div>
+
+        <p className="text-muted-foreground text-xs">
+          {t("gabinet.reminders.noContactWarning")}
+        </p>
 
         <div className="flex justify-end">
           <Button onClick={handleSave} disabled={saving}>

--- a/supabase/migrations/00043_reminder_channel_settings.sql
+++ b/supabase/migrations/00043_reminder_channel_settings.sql
@@ -1,0 +1,10 @@
+-- Add per-channel and per-timing reminder settings to org_settings (issue #2685)
+ALTER TABLE org_settings
+  ADD COLUMN IF NOT EXISTS reminder_sms_48h   BOOLEAN,
+  ADD COLUMN IF NOT EXISTS reminder_sms_24h   BOOLEAN,
+  ADD COLUMN IF NOT EXISTS reminder_email_48h BOOLEAN,
+  ADD COLUMN IF NOT EXISTS reminder_email_24h BOOLEAN;
+
+-- Add per-appointment reminder overrides (JSON) to gabinet_appointments (issue #2685)
+ALTER TABLE gabinet_appointments
+  ADD COLUMN IF NOT EXISTS reminder_overrides TEXT;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2685.

Closes #2685

---

## Claude summary

The feature is fully implemented and committed. Here's a summary of what was done:

**Triage:** The issue is a real feature request — the reminder system partially existed (some fields in orgSettings, a basic sendReminder mechanism) but lacked the 4-channel UI, per-appointment overrides, and proper scheduling logic.

**Implementation covers all 5 requirements:**

1. **Gabinet settings page** (`_layout.gabinet.settings.reminders.tsx`) — 4 toggles for SMS 48h, SMS 24h, email 48h, email 24h, backed by `orgSettings.reminderSms48h/24h/email48h/24h`.

2. **Appointment create dialog** (`appointment-dialog.tsx`) — collapsible Reminders section pre-populated from org defaults; user can override per-appointment. Overrides serialized as JSON and sent as `reminderOverrides` to the backend.

3. **Appointment detail/edit page** (`_layout.gabinet.appointments.$appointmentId.lazy.tsx`) — new Reminders card with 4 editable toggles initialized from the appointment's saved overrides (falling back to org defaults). Save calls `updateAppointment` with updated `reminderOverrides`.

4. **Patient contact awareness** — SMS checkboxes disabled when patient has no phone; email checkboxes disabled when no email. Backend also guards at send time.

5. **Backend** (`appointmentReminders.ts`, `appointments.ts`) — schedules both 48h and 24h reminders at creation; at send time merges org settings with per-appointment overrides to decide which channels fire.

6. **DB migration** (`00043_reminder_channel_settings.sql`) — adds 4 channel columns to `org_settings` and `reminder_overrides` TEXT to `gabinet_appointments`.