### PR TITLE
Doprecyzowanie: przypomnienia przy wizytach umawianych z krótkim wyprzedzeniem + potwierdzanie wizyty SMS-em

### DIFF
--- a/convex/gabinet/appointmentSms.ts
+++ b/convex/gabinet/appointmentSms.ts
@@ -256,7 +256,7 @@ export const queueConfirmationRequest = internalMutation({
     organizationId: v.id("organizations"),
     appointmentId: v.string(),
     reminderId: v.optional(v.id("appointmentReminders")),
-    trigger: v.optional(v.union(v.literal("reminder"), v.literal("manual"))),
+    trigger: v.optional(v.union(v.literal("reminder"), v.literal("manual"), v.literal("booking"))),
   },
   handler: async (ctx, args) => {
     const db = createSupabaseDb();
@@ -301,9 +301,12 @@ export const queueConfirmationRequest = internalMutation({
     });
     const now = Date.now();
     const correlationKey = `appointment-confirmation:${appointmentId}`;
-    const idempotencyKey = args.reminderId
-      ? `outbound:${args.reminderId}`
-      : `${correlationKey}:${now}`;
+    const idempotencyKey =
+      args.trigger === "booking"
+        ? `outbound:booking:${appointmentId}`
+        : args.reminderId
+          ? `outbound:${args.reminderId}`
+          : `${correlationKey}:${now}`;
 
     const existingEvent = await db
       .query("appointmentSmsEvents")

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1037,10 +1037,10 @@ export const _createSideEffects = internalMutation({
           apptDate: string,
           apptStartTime: string,
           hoursAhead: number,
-        ) => {
+        ): Promise<boolean> => {
           const appointmentMs = new Date(`${apptDate}T${apptStartTime}:00`).getTime();
           const reminderMs = appointmentMs - hoursAhead * 60 * 60 * 1000;
-          if (reminderMs <= Date.now()) return;
+          if (reminderMs <= Date.now()) return false;
           const reminderId = await ctx.db.insert("appointmentReminders", {
             organizationId: args.organizationId,
             appointmentId: apptId as any,
@@ -1054,10 +1054,14 @@ export const _createSideEffects = internalMutation({
             internal.gabinet.appointmentReminders.sendReminder,
             { reminderId },
           );
+          return true;
         };
 
+        let baseApptScheduled = 0;
         for (const hours of timingsHours) {
-          await scheduleReminderFor(args.appointmentId, args.date, args.startTime, hours);
+          if (await scheduleReminderFor(args.appointmentId, args.date, args.startTime, hours)) {
+            baseApptScheduled++;
+          }
           for (const recur of recurringAppointments) {
             await scheduleReminderFor(
               recur.appointmentId,
@@ -1065,6 +1069,24 @@ export const _createSideEffects = internalMutation({
               recur.startTime ?? args.startTime,
               hours,
             );
+          }
+        }
+
+        // Short-notice appointment: all configured reminder slots are in the past.
+        // Send an immediate booking confirmation SMS so the patient still gets notified.
+        if (timingsHours.length > 0 && baseApptScheduled === 0 && args.patientPhone) {
+          const needSms = has4ToggleConfig
+            ? Boolean(
+                (apptOverrides.sms48h !== undefined ? apptOverrides.sms48h : supaOrgSettings?.reminderSms48h) ||
+                (apptOverrides.sms24h !== undefined ? apptOverrides.sms24h : supaOrgSettings?.reminderSms24h)
+              )
+            : true;
+          if (needSms) {
+            await ctx.runMutation(internal.gabinet.appointmentSms.queueConfirmationRequest, {
+              organizationId: args.organizationId,
+              appointmentId: args.appointmentId,
+              trigger: "booking",
+            });
           }
         }
       } catch (e) {

--- a/tests/convex/appointmentSms.test.ts
+++ b/tests/convex/appointmentSms.test.ts
@@ -551,4 +551,58 @@ describe("appointment SMS flow", () => {
       "Cannot transition from completed to confirmed",
     );
   });
+
+  test("queueConfirmationRequest with booking trigger uses stable idempotency key", async () => {
+    const t = createManagedTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    await setPatientPhone(t, patientId, "500600700");
+    await seedSmsConfig(t, organizationId);
+
+    const appointmentId = await createAppointment(t, identity, {
+      organizationId,
+      patientId,
+      treatmentId,
+      employeeId: userId,
+    });
+
+    // First call with booking trigger
+    const firstEventId = await t.mutation(
+      internal.gabinet.appointmentSms.queueConfirmationRequest,
+      {
+        organizationId,
+        appointmentId,
+        trigger: "booking",
+      },
+    );
+
+    // Second call with same booking trigger — must not create a duplicate
+    const secondEventId = await t.mutation(
+      internal.gabinet.appointmentSms.queueConfirmationRequest,
+      {
+        organizationId,
+        appointmentId,
+        trigger: "booking",
+      },
+    );
+
+    const db = createSupabaseDb();
+    const allEvents = await db
+      .query("appointmentSmsEvents")
+      .eq("appointmentId", appointmentId)
+      .collect();
+    const outboundEvents = allEvents.filter((e) => e.direction === "outbound");
+
+    expect(firstEventId).toBeTruthy();
+    expect(secondEventId).toBe(firstEventId);
+    expect(outboundEvents).toHaveLength(1);
+    expect(outboundEvents[0]?.idempotencyKey).toBe(
+      `outbound:booking:${appointmentId}`,
+    );
+  });
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2696.

Closes #2696

---

## Claude summary

Here's what I found and implemented:

## Triage

This is a real gap. The codebase already has a sophisticated SMS infrastructure (both providers: Twilio and SMSAPI), a complete `/sms/inbound` webhook in `convex/http.ts:460`, and full "TAK/NIE" reply processing via `processIncomingMessage` in `appointmentSms.ts`. The TAK-reply-confirms-appointment feature is **already fully implemented** — no new work needed there.

The missing piece was the short-notice scenario: in `_createSideEffects` (`appointments.ts:1043`), `scheduleReminderFor` already correctly skips past reminder slots with `if (reminderMs <= Date.now()) return;`, but when ALL slots are skipped (appointment booked within the last 24h), the patient received nothing.

## Changes made (3 files)

**`convex/gabinet/appointmentSms.ts`**
- Added `"booking"` as a valid trigger type for `queueConfirmationRequest`
- When trigger is `"booking"`, uses a stable idempotency key `outbound:booking:<appointmentId>` so repeated calls (retries, double-saves) produce exactly one SMS

**`convex/gabinet/appointments.ts`** (`_createSideEffects`)
- `scheduleReminderFor` now returns `boolean` (true = scheduled, false = skipped)
- Tracks how many reminders were actually scheduled for the base appointment
- If `timingsHours.length > 0` (reminders were desired) **and** `baseApptScheduled === 0` (all in the past) **and** SMS is enabled for this org **and** patient has a phone → calls `queueConfirmationRequest` with `trigger: "booking"`

**`tests/convex/appointmentSms.test.ts`**
- Added test verifying that calling `queueConfirmationRequest` with `trigger: "booking"` twice produces only one SMS event with the correct stable idempotency key. All 4 tests pass.

## Regarding the TAK reply webhook

The `/sms/inbound` POST endpoint already exists and is fully wired. To activate it, the operator (Twilio or SMSAPI) needs to be configured to POST incoming messages to `<convex-url>/sms/inbound` with a `provider` field. No code changes are needed — this is purely a provider configuration step documented in the org's SMS settings.