### PR TITLE
feat(gabinet): implement Sprzedaj produkt flow in quick actions (closes #2706)

### DIFF
--- a/src/components/gabinet/sell-treatment-panel.tsx
+++ b/src/components/gabinet/sell-treatment-panel.tsx
@@ -1,0 +1,572 @@
+import { useCallback, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAction } from "convex/react";
+import { api } from "@cvx/_generated/api";
+import type { Id } from "@cvx/_generated/dataModel";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { SidePanel } from "@/components/crm/side-panel";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Loader2 } from "@/lib/ez-icons";
+import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
+import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
+import { formatActionError } from "@/lib/format-action-error";
+import { formatCurrencyPLN } from "@/lib/format-currency";
+import { cn } from "@/lib/utils";
+
+type PaymentMethod = "cash" | "card" | "transfer" | "other";
+
+interface SellTreatmentPanelProps {
+  organizationId: Id<"organizations">;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function SellTreatmentPanel({
+  organizationId,
+  open,
+  onOpenChange,
+}: SellTreatmentPanelProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen for this action
+  const purchaseTreatment = useAction(api.gabinet.packages.purchaseTreatment);
+  const createPayment = useAction(api.payments.create);
+
+  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId);
+  const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId);
+
+  const [patientId, setPatientId] = useState<string>("");
+  const [treatmentId, setTreatmentId] = useState<string>("");
+  const [sessionCount, setSessionCount] = useState<string>("1");
+  const [paymentType, setPaymentType] = useState<"one_time" | "installment">("one_time");
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("cash");
+  const [splitPayment, setSplitPayment] = useState(false);
+  const [firstSplitMethod, setFirstSplitMethod] = useState<PaymentMethod>("cash");
+  const [secondSplitMethod, setSecondSplitMethod] = useState<PaymentMethod>("card");
+  const [firstSplitAmount, setFirstSplitAmount] = useState<string>("");
+  const [secondSplitAmount, setSecondSplitAmount] = useState<string>("");
+  const [installmentCount, setInstallmentCount] = useState<string>("2");
+  const [submitting, setSubmitting] = useState(false);
+
+  const activeTreatments = useMemo(
+    () => (treatmentsData ?? []).filter((tr) => tr.isActive),
+    [treatmentsData],
+  );
+  const selectedTreatment = useMemo(
+    () => activeTreatments.find((tr) => tr._id === treatmentId),
+    [activeTreatments, treatmentId],
+  );
+
+  const parsedSessionCount = Math.max(1, Number.parseInt(sessionCount, 10) || 1);
+  const totalPrice = useMemo(
+    () =>
+      selectedTreatment
+        ? Math.round((selectedTreatment.price ?? 0) * parsedSessionCount * 100) / 100
+        : 0,
+    [selectedTreatment, parsedSessionCount],
+  );
+  const currency = selectedTreatment?.currency ?? "PLN";
+
+  const isOneTime = paymentType === "one_time";
+  const isInstallment = paymentType === "installment";
+
+  const parsedInstallmentCount = Math.max(2, Math.min(4, Number.parseInt(installmentCount, 10) || 2));
+  const installmentAmount = selectedTreatment
+    ? Math.round((totalPrice / parsedInstallmentCount) * 100) / 100
+    : 0;
+  const installmentRemainder = selectedTreatment
+    ? Math.round((totalPrice - installmentAmount * parsedInstallmentCount) * 100) / 100
+    : 0;
+  const firstInstallmentAmount = selectedTreatment
+    ? Math.round((installmentAmount + installmentRemainder) * 100) / 100
+    : 0;
+
+  const parsedFirstSplit = Number.parseFloat(firstSplitAmount.replace(",", ".")) || 0;
+  const parsedSecondSplit = Number.parseFloat(secondSplitAmount.replace(",", ".")) || 0;
+  const splitTotal = Math.round((parsedFirstSplit + parsedSecondSplit) * 100) / 100;
+  const splitExpectedTotal = selectedTreatment
+    ? isInstallment
+      ? firstInstallmentAmount
+      : Math.round(totalPrice * 100) / 100
+    : 0;
+  const splitMismatch = splitPayment && !!selectedTreatment && splitTotal !== splitExpectedTotal;
+  const splitMissingAmount = splitPayment && parsedFirstSplit <= 0 && parsedSecondSplit <= 0;
+  const splitSameMethod = splitPayment && firstSplitMethod === secondSplitMethod;
+
+  const reset = useCallback(() => {
+    setPatientId("");
+    setTreatmentId("");
+    setSessionCount("1");
+    setPaymentType("one_time");
+    setPaymentMethod("cash");
+    setSplitPayment(false);
+    setFirstSplitMethod("cash");
+    setSecondSplitMethod("card");
+    setFirstSplitAmount("");
+    setSecondSplitAmount("");
+    setInstallmentCount("2");
+  }, []);
+
+  const handleSubmit = async () => {
+    if (!patientId || !selectedTreatment) return;
+    if (splitPayment) {
+      if (splitMissingAmount) {
+        toast.error(
+          t("gabinet.packages.splitMissingAmount", "Podaj kwotę co najmniej jednej metody płatności"),
+        );
+        return;
+      }
+      if (splitMismatch) {
+        toast.error(
+          t("gabinet.packages.splitMismatchError", "Suma rozdzielonych płatności musi być równa cenie"),
+        );
+        return;
+      }
+      if (splitSameMethod) {
+        toast.error(
+          t("gabinet.packages.splitSameMethodError", "Wybierz dwie różne metody płatności"),
+        );
+        return;
+      }
+    }
+    setSubmitting(true);
+    try {
+      let usagePaymentMethod: string = paymentMethod;
+      if (splitPayment) usagePaymentMethod = "split";
+      if (isInstallment) usagePaymentMethod = "installment";
+
+      const usageId = await purchaseTreatment({
+        organizationId,
+        patientId,
+        treatmentId: selectedTreatment._id,
+        sessionCount: parsedSessionCount,
+        paidAmount: totalPrice,
+        paymentMethod: usagePaymentMethod,
+      });
+
+      const treatmentName = selectedTreatment.name;
+
+      if (isInstallment) {
+        if (splitPayment) {
+          const parts: Array<{ method: PaymentMethod; amount: number }> = [];
+          if (parsedFirstSplit > 0)
+            parts.push({ method: firstSplitMethod, amount: parsedFirstSplit });
+          if (parsedSecondSplit > 0)
+            parts.push({ method: secondSplitMethod, amount: parsedSecondSplit });
+          for (const part of parts) {
+            await createPayment({
+              organizationId,
+              patientId: patientId as Id<"gabinetPatients">,
+              packageUsageId: usageId,
+              amount: part.amount,
+              currency,
+              paymentMethod: part.method,
+              notes: `Treatment: ${treatmentName} (installment 1/${parsedInstallmentCount} split: ${part.method})`,
+            });
+          }
+        } else {
+          await createPayment({
+            organizationId,
+            patientId: patientId as Id<"gabinetPatients">,
+            packageUsageId: usageId,
+            amount: firstInstallmentAmount,
+            currency,
+            paymentMethod,
+            notes: `Treatment: ${treatmentName} (installment 1/${parsedInstallmentCount})`,
+          });
+        }
+        for (let i = 2; i <= parsedInstallmentCount; i++) {
+          await createPayment({
+            organizationId,
+            patientId: patientId as Id<"gabinetPatients">,
+            packageUsageId: usageId,
+            amount: installmentAmount,
+            currency,
+            paymentMethod,
+            notes: `Treatment: ${treatmentName} (installment ${i}/${parsedInstallmentCount})`,
+            status: "pending",
+          });
+        }
+      } else if (splitPayment) {
+        const parts: Array<{ method: PaymentMethod; amount: number }> = [];
+        if (parsedFirstSplit > 0)
+          parts.push({ method: firstSplitMethod, amount: parsedFirstSplit });
+        if (parsedSecondSplit > 0)
+          parts.push({ method: secondSplitMethod, amount: parsedSecondSplit });
+        for (const part of parts) {
+          await createPayment({
+            organizationId,
+            patientId: patientId as Id<"gabinetPatients">,
+            packageUsageId: usageId,
+            amount: part.amount,
+            currency,
+            paymentMethod: part.method,
+            notes: `Treatment: ${treatmentName} (split: ${part.method})`,
+          });
+        }
+      } else {
+        await createPayment({
+          organizationId,
+          patientId: patientId as Id<"gabinetPatients">,
+          packageUsageId: usageId,
+          amount: totalPrice,
+          currency,
+          paymentMethod,
+          notes: `Treatment: ${treatmentName}`,
+        });
+      }
+
+      toast.success(t("gabinet.treatments.purchased", "Zabieg sprzedany pomyślnie"));
+      void queryClient.invalidateQueries({
+        queryKey: supabaseKeys.gabinetTreatments.list(organizationId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: supabaseKeys.gabinetPackageUsage.list(organizationId),
+      });
+      onOpenChange(false);
+      reset();
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.treatments.errors.purchaseFailed",
+          defaultValue: "Nie udało się sprzedać zabiegu.",
+        }),
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SidePanel
+      open={open}
+      onOpenChange={(o) => {
+        onOpenChange(o);
+        if (!o) reset();
+      }}
+      title={t("sidebar.gabinet.sellProduct", "Sprzedaj produkt")}
+    >
+      <div className="space-y-4">
+        <div className="space-y-1.5">
+          <Label>{t("gabinet.packages.selectPatient", "Klient")}</Label>
+          <Select value={patientId} onValueChange={setPatientId}>
+            <SelectTrigger>
+              <SelectValue
+                placeholder={t("gabinet.packages.selectPatientPlaceholder", "Wybierz klienta...")}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {(patientsData ?? []).map((p) => (
+                <SelectItem key={p._id} value={p._id}>
+                  {p.firstName} {p.lastName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>{t("gabinet.treatments.selectTreatment", "Zabieg")}</Label>
+          <Select value={treatmentId} onValueChange={setTreatmentId}>
+            <SelectTrigger>
+              <SelectValue
+                placeholder={t("gabinet.treatments.selectTreatmentPlaceholder", "Wybierz zabieg...")}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {activeTreatments.map((tr) => (
+                <SelectItem key={tr._id} value={tr._id}>
+                  {tr.name} — {formatCurrencyPLN(tr.price ?? 0, tr.currency ?? "PLN")}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="sell-treatment-session-count">
+            {t("gabinet.treatments.sessionCount", "Liczba sesji")}
+          </Label>
+          <Input
+            id="sell-treatment-session-count"
+            type="number"
+            inputMode="numeric"
+            min="1"
+            step="1"
+            value={sessionCount}
+            onChange={(e) => setSessionCount(e.target.value)}
+          />
+        </div>
+
+        {selectedTreatment && (
+          <div className="rounded-lg border p-3 space-y-2">
+            <p className="text-sm font-medium">{selectedTreatment.name}</p>
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-muted-foreground">
+                {t("gabinet.treatments.unitPrice", "Cena za sesję")}
+              </span>
+              <span>{formatCurrencyPLN(selectedTreatment.price ?? 0, currency)}</span>
+            </div>
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-muted-foreground">
+                {t("gabinet.treatments.sessionCount", "Liczba sesji")}
+              </span>
+              <span>&times;{parsedSessionCount}</span>
+            </div>
+            <div className="flex items-center justify-between pt-1 border-t text-sm">
+              <span className="font-medium">
+                {t("gabinet.packages.totalPrice", "Cena całkowita")}
+              </span>
+              <span className="font-bold">{formatCurrencyPLN(totalPrice, currency)}</span>
+            </div>
+          </div>
+        )}
+
+        <div
+          role="radiogroup"
+          aria-label={t("gabinet.packages.paymentType", "Rodzaj płatności")}
+          className="grid grid-cols-2 gap-2"
+        >
+          <button
+            type="button"
+            role="radio"
+            aria-checked={isOneTime}
+            onClick={() => setPaymentType("one_time")}
+            className={`rounded-lg border p-3 text-left transition-colors ${
+              isOneTime
+                ? "border-primary bg-primary/5 ring-1 ring-primary"
+                : "border-border hover:bg-accent"
+            }`}
+          >
+            <p className="text-sm font-medium">
+              {t("gabinet.packages.paymentTypeOneTime", "Płatność jednorazowa")}
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {t("gabinet.packages.paymentTypeOneTimeHint", "Zapłać całą kwotę teraz")}
+            </p>
+          </button>
+          <button
+            type="button"
+            role="radio"
+            aria-checked={isInstallment}
+            onClick={() => setPaymentType("installment")}
+            className={`rounded-lg border p-3 text-left transition-colors ${
+              isInstallment
+                ? "border-primary bg-primary/5 ring-1 ring-primary"
+                : "border-border hover:bg-accent"
+            }`}
+          >
+            <p className="text-sm font-medium">
+              {t("gabinet.packages.paymentTypeInstallment", "Płatność na raty")}
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {t("gabinet.packages.paymentTypeInstallmentHint", "Rozłóż płatność na raty")}
+            </p>
+          </button>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>{t("gabinet.packages.paymentMethod", "Metoda płatności")}</Label>
+          <Select
+            value={paymentMethod}
+            onValueChange={(v) => setPaymentMethod(v as PaymentMethod)}
+            disabled={isOneTime && splitPayment}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="cash">
+                {t("gabinet.packages.paymentMethods.cash", "Gotówka")}
+              </SelectItem>
+              <SelectItem value="card">
+                {t("gabinet.packages.paymentMethods.card", "Karta")}
+              </SelectItem>
+              <SelectItem value="transfer">
+                {t("gabinet.packages.paymentMethods.transfer", "Przelew")}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <Label
+          htmlFor="sell-treatment-split-payment"
+          className="-mx-2 flex min-h-11 select-none items-center gap-3 rounded-md px-2 py-2.5 cursor-pointer text-sm font-normal transition-colors hover:bg-accent/40 active:bg-accent"
+        >
+          <Checkbox
+            id="sell-treatment-split-payment"
+            checked={splitPayment}
+            onCheckedChange={(v) => setSplitPayment(v === true)}
+          />
+          {isInstallment
+            ? t("gabinet.packages.splitFirstInstallment", "Podziel pierwszą ratę")
+            : t("gabinet.packages.splitPayment", "Podziel płatność")}
+        </Label>
+
+        {isInstallment && selectedTreatment && (
+          <div className="rounded-lg border p-3 space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="sell-treatment-installment-count" className="text-xs font-medium">
+                {t("gabinet.packages.installmentCount", "Liczba rat")}
+              </Label>
+              <Select value={installmentCount} onValueChange={setInstallmentCount}>
+                <SelectTrigger id="sell-treatment-installment-count">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {[2, 3, 4].map((n) => (
+                    <SelectItem key={n} value={String(n)}>
+                      {n}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-muted-foreground">
+                {t("gabinet.packages.installmentAmount", "Kwota raty")}
+              </span>
+              <span className="font-medium">{formatCurrencyPLN(installmentAmount, currency)}</span>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {t(
+                "gabinet.packages.installmentNote",
+                "Pierwsza rata zostanie pobrana teraz; pozostałe raty zostaną zapisane jako oczekujące i można je oznaczyć jako opłacone później.",
+              )}
+            </p>
+          </div>
+        )}
+
+        {splitPayment && (
+          <div className="rounded-lg border p-3 space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded-md border p-2 space-y-2">
+                <Label className="text-xs font-medium">
+                  {t("gabinet.packages.firstMethod", "Pierwsza metoda")}
+                </Label>
+                <Select
+                  value={firstSplitMethod}
+                  onValueChange={(v) => setFirstSplitMethod(v as PaymentMethod)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="cash">
+                      {t("gabinet.packages.paymentMethods.cash", "Gotówka")}
+                    </SelectItem>
+                    <SelectItem value="card">
+                      {t("gabinet.packages.paymentMethods.card", "Karta")}
+                    </SelectItem>
+                    <SelectItem value="transfer">
+                      {t("gabinet.packages.paymentMethods.transfer", "Przelew")}
+                    </SelectItem>
+                    <SelectItem value="other">
+                      {t("gabinet.packages.paymentMethods.other", "Inna")}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <Input
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="0.00"
+                  value={firstSplitAmount}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                      setFirstSplitAmount(v);
+                    }
+                  }}
+                />
+              </div>
+              <div className="rounded-md border p-2 space-y-2">
+                <Label className="text-xs font-medium">
+                  {t("gabinet.packages.secondMethod", "Druga metoda")}
+                </Label>
+                <Select
+                  value={secondSplitMethod}
+                  onValueChange={(v) => setSecondSplitMethod(v as PaymentMethod)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="cash">
+                      {t("gabinet.packages.paymentMethods.cash", "Gotówka")}
+                    </SelectItem>
+                    <SelectItem value="card">
+                      {t("gabinet.packages.paymentMethods.card", "Karta")}
+                    </SelectItem>
+                    <SelectItem value="transfer">
+                      {t("gabinet.packages.paymentMethods.transfer", "Przelew")}
+                    </SelectItem>
+                    <SelectItem value="other">
+                      {t("gabinet.packages.paymentMethods.other", "Inna")}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <Input
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="0.00"
+                  value={secondSplitAmount}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                      setSecondSplitAmount(v);
+                    }
+                  }}
+                />
+              </div>
+            </div>
+            <div
+              className={cn(
+                "flex items-center justify-between text-xs",
+                splitMismatch || splitSameMethod ? "text-destructive" : "text-muted-foreground",
+              )}
+            >
+              <span>
+                {t("gabinet.packages.splitSum", "Suma")}: {splitTotal.toFixed(2)}
+                {selectedTreatment
+                  ? ` / ${formatCurrencyPLN(splitExpectedTotal, currency)}`
+                  : ""}
+              </span>
+              {splitSameMethod ? (
+                <span>{t("gabinet.packages.splitSameMethod", "Metody muszą się różnić")}</span>
+              ) : splitMismatch ? (
+                <span>{t("gabinet.packages.splitMismatch", "Musi się zgadzać z ceną")}</span>
+              ) : null}
+            </div>
+          </div>
+        )}
+
+        <Button
+          className="w-full"
+          disabled={
+            !patientId ||
+            !treatmentId ||
+            parsedSessionCount < 1 ||
+            submitting ||
+            (splitPayment && (splitMissingAmount || !!splitMismatch || splitSameMethod))
+          }
+          onClick={handleSubmit}
+        >
+          {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" variant="stroke" />}
+          {t("gabinet.packages.purchaseButton", "Dodaj sprzedaż")}
+        </Button>
+      </div>
+    </SidePanel>
+  );
+}

--- a/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
+++ b/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "@tanstack/react-router";
 import {
@@ -19,12 +20,16 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useSidebarActions } from "@/components/layout/sidebar-context";
 import { usePermission } from "@/hooks/use-permission";
+import { useOrganization } from "@/components/org-context";
+import { SellTreatmentPanel } from "@/components/gabinet/sell-treatment-panel";
 
 export function GabinetQuickActionsDropdown() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { openQuickCreate } = useSidebarActions();
   const { allowed: canManageLeaves } = usePermission("gabinet_settings", "edit");
+  const { organizationId } = useOrganization();
+  const [sellTreatmentOpen, setSellTreatmentOpen] = useState(false);
 
   // "Umów wizytę" routes through the calendar so every appointment entry
   // point opens the same AppointmentDialog (issue #1506).
@@ -35,6 +40,7 @@ export function GabinetQuickActionsDropdown() {
     });
 
   return (
+    <>
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
@@ -69,14 +75,12 @@ export function GabinetQuickActionsDropdown() {
           <UserPlus className="text-foreground size-5" />
           {t("sidebar.gabinet.addPatient", "Dodaj klienta")}
         </DropdownMenuItem>
-        <DropdownMenuItem className="px-3 py-2.5 text-sm" disabled>
+        <DropdownMenuItem
+          className="px-3 py-2.5 text-sm"
+          onSelect={() => setSellTreatmentOpen(true)}
+        >
           <ShoppingCart className="text-foreground size-5 shrink-0" />
-          <span className="flex flex-col gap-0.5">
-            <span>{t("sidebar.gabinet.sellProduct", "Sprzedaj produkt")}</span>
-            <span className="text-muted-foreground text-xs font-normal">
-              {t("common.featureInProgress", "Funkcja w przygotowaniu")}
-            </span>
-          </span>
+          {t("sidebar.gabinet.sellProduct", "Sprzedaj produkt")}
         </DropdownMenuItem>
         <DropdownMenuItem
           className="px-3 py-2.5 text-sm"
@@ -112,5 +116,11 @@ export function GabinetQuickActionsDropdown() {
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+    <SellTreatmentPanel
+      organizationId={organizationId}
+      open={sellTreatmentOpen}
+      onOpenChange={setSellTreatmentOpen}
+    />
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- Adds `SellTreatmentPanel` component (`src/components/gabinet/sell-treatment-panel.tsx`) — a side panel with patient selection, treatment selection, session count input, and full payment options (one-time, installment 2-4 rates, split payment across two methods)
- Wires up the previously-disabled "Sprzedaj produkt" quick action in `GabinetQuickActionsDropdown` to open this panel
- The panel follows the same architecture as `SellPackagePanel` (Supabase hooks for data, Convex action for the mutation, `SidePanel` shell)

## Test plan

- [ ] Open Gabinet module, click "Szybkie akcje" in the sidebar
- [ ] "Sprzedaj produkt" is no longer disabled and has no "Funkcja w przygotowaniu" subtitle
- [ ] Clicking it opens the sell treatment side panel
- [ ] Panel shows patient dropdown (populated from org patients) and treatment dropdown (active treatments only)
- [ ] Selecting a treatment shows price summary with session count multiplier
- [ ] One-time and installment payment types toggle correctly
- [ ] Split payment checkbox reveals split-method inputs with validation
- [ ] Submitting with valid inputs creates a package usage + payment record and shows success toast
- [ ] Panel closes and resets state after success

🤖 Generated with [Claude Code](https://claude.com/claude-code)