### PR TITLE
Implement "Dodaj dostawę" (warehouse delivery) flow in Gabinet

### DIFF
--- a/src/components/gabinet/add-delivery-panel.tsx
+++ b/src/components/gabinet/add-delivery-panel.tsx
@@ -1,0 +1,188 @@
+import { useCallback, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAction } from "convex/react";
+import { api } from "@cvx/_generated/api";
+import type { Id } from "@cvx/_generated/dataModel";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { SidePanel } from "@/components/crm/side-panel";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Loader2 } from "@/lib/ez-icons";
+import { useSupabaseProductsList } from "@/hooks/use-supabase-products";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
+import { formatActionError } from "@/lib/format-action-error";
+
+interface AddDeliveryPanelProps {
+  organizationId: Id<"organizations">;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function AddDeliveryPanel({
+  organizationId,
+  open,
+  onOpenChange,
+}: AddDeliveryPanelProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const adjustStock = useAction(api.inventory.adjustStock);
+
+  const { data: productsData } = useSupabaseProductsList(String(organizationId));
+
+  const [productId, setProductId] = useState<string>("");
+  const [quantity, setQuantity] = useState<string>("");
+  const [note, setNote] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const stockableProducts = useMemo(
+    () => (productsData ?? []).filter((p) => p.isActive && p.trackStock),
+    [productsData],
+  );
+
+  const selectedProduct = useMemo(
+    () => stockableProducts.find((p) => p._id === productId),
+    [stockableProducts, productId],
+  );
+
+  const parsedQuantity = Math.max(0, Number.parseFloat(quantity.replace(",", ".")) || 0);
+
+  const reset = useCallback(() => {
+    setProductId("");
+    setQuantity("");
+    setNote("");
+  }, []);
+
+  const handleSubmit = async () => {
+    if (!selectedProduct || parsedQuantity <= 0) return;
+    setSubmitting(true);
+    try {
+      await adjustStock({
+        organizationId,
+        productId: selectedProduct._id,
+        delta: parsedQuantity,
+        reason: "warehouse_receive",
+        note: note.trim() || null,
+      });
+
+      toast.success(
+        t("gabinet.inventory.deliveryAdded", "Dostawa przyjęta pomyślnie"),
+      );
+      void queryClient.invalidateQueries({
+        queryKey: supabaseKeys.productStockLevels.list(String(organizationId)),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: supabaseKeys.productStockMovements.list(String(organizationId)),
+      });
+      onOpenChange(false);
+      reset();
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.inventory.errors.deliveryFailed",
+          defaultValue: "Nie udało się przyjąć dostawy.",
+        }),
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SidePanel
+      open={open}
+      onOpenChange={(o) => {
+        onOpenChange(o);
+        if (!o) reset();
+      }}
+      title={t("sidebar.gabinet.addDelivery", "Dodaj dostawę")}
+    >
+      <div className="space-y-4">
+        <div className="space-y-1.5">
+          <Label>{t("gabinet.inventory.selectProduct", "Produkt")}</Label>
+          <Select value={productId} onValueChange={setProductId}>
+            <SelectTrigger>
+              <SelectValue
+                placeholder={t(
+                  "gabinet.inventory.selectProductPlaceholder",
+                  "Wybierz produkt...",
+                )}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {stockableProducts.map((p) => (
+                <SelectItem key={p._id} value={p._id}>
+                  {p.name}
+                  {p.sku ? ` (${p.sku})` : ""}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {(productsData ?? []).filter((p) => p.isActive).length > 0 &&
+            stockableProducts.length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                {t(
+                  "gabinet.inventory.noStockableProducts",
+                  "Brak produktów ze śledzeniem stanów magazynowych. Włącz śledzenie w ustawieniach produktu.",
+                )}
+              </p>
+            )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="delivery-quantity">
+            {t("gabinet.inventory.quantity", "Ilość")}
+            {selectedProduct?.stockUnit ? ` (${selectedProduct.stockUnit})` : ""}
+          </Label>
+          <Input
+            id="delivery-quantity"
+            type="text"
+            inputMode="decimal"
+            placeholder="0"
+            value={quantity}
+            onChange={(e) => {
+              const v = e.target.value;
+              if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                setQuantity(v);
+              }
+            }}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="delivery-note">
+            {t("gabinet.inventory.note", "Notatka (opcjonalnie)")}
+          </Label>
+          <Textarea
+            id="delivery-note"
+            rows={3}
+            placeholder={t(
+              "gabinet.inventory.notePlaceholder",
+              "Nr faktury, dostawca, uwagi...",
+            )}
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+          />
+        </div>
+
+        <Button
+          className="w-full"
+          disabled={!productId || parsedQuantity <= 0 || submitting}
+          onClick={handleSubmit}
+        >
+          {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" variant="stroke" />}
+          {t("gabinet.inventory.confirmDelivery", "Przyjmij dostawę")}
+        </Button>
+      </div>
+    </SidePanel>
+  );
+}

--- a/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
+++ b/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
@@ -22,6 +22,7 @@ import { useSidebarActions } from "@/components/layout/sidebar-context";
 import { usePermission } from "@/hooks/use-permission";
 import { useOrganization } from "@/components/org-context";
 import { SellTreatmentPanel } from "@/components/gabinet/sell-treatment-panel";
+import { AddDeliveryPanel } from "@/components/gabinet/add-delivery-panel";
 
 export function GabinetQuickActionsDropdown() {
   const { t } = useTranslation();
@@ -30,6 +31,7 @@ export function GabinetQuickActionsDropdown() {
   const { allowed: canManageLeaves } = usePermission("gabinet_settings", "edit");
   const { organizationId } = useOrganization();
   const [sellTreatmentOpen, setSellTreatmentOpen] = useState(false);
+  const [addDeliveryOpen, setAddDeliveryOpen] = useState(false);
 
   // "Umów wizytę" routes through the calendar so every appointment entry
   // point opens the same AppointmentDialog (issue #1506).
@@ -98,14 +100,12 @@ export function GabinetQuickActionsDropdown() {
             {t("sidebar.gabinet.addLeave", "Dodaj nieobecność")}
           </DropdownMenuItem>
         )}
-        <DropdownMenuItem className="px-3 py-2.5 text-sm" disabled>
+        <DropdownMenuItem
+          className="px-3 py-2.5 text-sm"
+          onSelect={() => setAddDeliveryOpen(true)}
+        >
           <TruckIcon className="text-foreground size-5 shrink-0" />
-          <span className="flex flex-col gap-0.5">
-            <span>{t("sidebar.gabinet.addDelivery", "Dodaj dostawę")}</span>
-            <span className="text-muted-foreground text-xs font-normal">
-              {t("common.featureInProgress", "Funkcja w przygotowaniu")}
-            </span>
-          </span>
+          {t("sidebar.gabinet.addDelivery", "Dodaj dostawę")}
         </DropdownMenuItem>
         <DropdownMenuItem
           className="px-3 py-2.5 text-sm"
@@ -120,6 +120,11 @@ export function GabinetQuickActionsDropdown() {
       organizationId={organizationId}
       open={sellTreatmentOpen}
       onOpenChange={setSellTreatmentOpen}
+    />
+    <AddDeliveryPanel
+      organizationId={organizationId}
+      open={addDeliveryOpen}
+      onOpenChange={setAddDeliveryOpen}
     />
     </>
   );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2707.

Closes #2707

---

## Claude summary

The implementation is complete. Here's what was done:

**What the issue reported:** The "Dodaj dostawę" quick-action in the Gabinet sidebar was disabled with "Funkcja w przygotowaniu" placeholder text.

**What was found:** The inventory backend was already fully implemented in `convex/inventory.ts` with an `adjustStock` action supporting `reason: "warehouse_receive"`. The product schema has `trackStock` and `stockUnit` fields. Product stock hooks in `useSupabaseProductsList` were ready. Only the frontend panel was missing.

**What was implemented:**

1. `src/components/gabinet/add-delivery-panel.tsx` — a `SidePanel`-based drawer following the same pattern as `SellTreatmentPanel`. It lets staff:
   - Pick a tracked product (filtered to `isActive && trackStock === true`)
   - Enter a quantity received (with the product's stock unit shown in the label)
   - Add an optional note (invoice number, supplier, remarks)
   - Submit — calls `api.inventory.adjustStock` with `delta = quantity` and `reason = "warehouse_receive"`, then invalidates `productStockLevels` and `productStockMovements` React Query caches
   - Shows a helpful message if no stockable products exist yet

2. `src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx` — removed the disabled state and "Funkcja w przygotowaniu" text; wired the item to open `AddDeliveryPanel`.