### PR TITLE
Nie można utworzyć nowej wizyty z formularza umawiania

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -920,12 +920,14 @@ export function AppointmentDialog({
         allowPast: recordWalkIn || undefined,
         allowConflict: hasBookingConflict || undefined,
         sendReminder: anyReminderEnabled,
-        reminderOverrides: JSON.stringify({
-          sms48h: reminderSms48h,
-          sms24h: reminderSms24h,
-          email48h: reminderEmail48h,
-          email24h: reminderEmail24h,
-        }),
+        reminderOverrides: anyReminderEnabled
+          ? JSON.stringify({
+              sms48h: reminderSms48h,
+              sms24h: reminderSms24h,
+              email48h: reminderEmail48h,
+              email24h: reminderEmail24h,
+            })
+          : undefined,
       });
       // Refresh the calendar immediately — Convex actions don't invalidate
       // the Supabase React Query cache automatically.
@@ -969,6 +971,10 @@ export function AppointmentDialog({
     onOpenChange,
     queryClient,
     t,
+    reminderSms48h,
+    reminderSms24h,
+    reminderEmail48h,
+    reminderEmail24h,
   ]);
 
   const handleSubmit = useCallback(() => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2712.

Closes #2712

---

## Claude summary

The fix is committed. Here's what was wrong and what was fixed:

**Root cause:** `performCreate` (via `useCallback`) was missing `reminderSms48h`, `reminderSms24h`, `reminderEmail48h`, and `reminderEmail24h` from its dependency array. This meant the callback closed over the initial `false` values of all four reminder booleans — even after org settings loaded and potentially set them to `true`. As a result:

- `anyReminderEnabled` was always stale (computed as `false || false || false || false = false`)
- `reminderOverrides` was always sent as an all-false JSON string (`{"sms48h":false,...}`) regardless of user toggle state
- `sendReminder: false` was always sent even when reminder channels were enabled in UI

**Fix:** Two changes to `appointment-dialog.tsx:performCreate`:
1. Added the 4 reminder booleans to the `useCallback` deps array so the closure is recreated when org settings load or the user changes toggles
2. Made `reminderOverrides` conditional on `anyReminderEnabled` — no need to send a JSON payload when no channels are active

## Follow-ups
- Add `reminderOverrides` handling to `formatAppointmentError`: if the backend rejects due to reminder config issues, the error falls through to the generic "Nie udało się utworzyć wizyty" fallback with no actionable detail for the user