### PR TITLE
Add `reminderOverrides` handling to `formatAppointmentError`

### DIFF
--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -27,6 +27,9 @@ const COLUMN_LABEL_MAP: Record<string, string> = {
   package_id: "Powiązany pakiet",
   organization_id: "Organizacja",
   created_by: "Utworzone przez",
+  reminder_overrides: "Konfiguracja przypomnień",
+  send_reminder: "Przypomnienia",
+  reminder_hours_before: "Czas przypomnienia",
 };
 
 function humanFieldLabel(rawField: string): string {
@@ -369,6 +372,16 @@ export function formatAppointmentError(
   const inner = extractActionErrorMessage(err);
   for (const entry of APPOINTMENT_ERROR_MAP) {
     if (entry.test(inner)) {
+      if (entry.key === "gabinet.appointments.errors.invalidArguments") {
+        const detail = extractFieldValidationDetail(inner);
+        if (detail) {
+          return t("gabinet.appointments.errors.invalidField", {
+            field: detail.fieldLabel,
+            reason: detail.reason,
+            defaultValue: `Nieprawidłowe dane: ${detail.fieldLabel} — ${detail.reason}.`,
+          });
+        }
+      }
       return t(entry.key, { defaultValue: entry.fallback });
     }
   }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2714.

Closes #2714

---

## Claude summary

The fix is in. Here's a summary of what was wrong and what changed:

Two gaps in `src/lib/format-action-error.ts` caused reminder-config validator errors to silently produce the generic "Nie udało się utworzyć wizyty." toast:

1. `formatAppointmentError` never called `extractFieldValidationDetail` when the `invalidArguments` entry matched — unlike `formatTreatmentError` and `formatActionError`, which both do. The fix adds the same field-level extraction branch so the user sees e.g. "Nieprawidłowe dane: Konfiguracja przypomnień — nieprawidłowa wartość." instead of the generic fallback.

2. `COLUMN_LABEL_MAP` had no entries for reminder-related fields (`reminderOverrides` → `reminder_overrides`, `sendReminder` → `send_reminder`, `reminderHoursBefore` → `reminder_hours_before`). Without these, even if extraction ran, the label would have been the raw camelCase identifier. Added Polish translations for all three.