### PR TITLE
Komunikacja jako nadrzędna pozycja menu dla Wygenerowanych Dokumentów

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -128,7 +128,7 @@
       "patients": "Clients",
       "treatments": "Treatments",
       "packages": "Packages",
-      "documents": "Generated Documents",
+      "documents": "Communication",
       "employees": "Employees",
       "reports": "Reports",
       "scheduling": "Working Hours",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -128,7 +128,7 @@
       "patients": "Klienci",
       "treatments": "Zabiegi",
       "packages": "Pakiety",
-      "documents": "Wygenerowane Dokumenty",
+      "documents": "Komunikacja",
       "employees": "Pracownicy",
       "reports": "Raporty",
       "scheduling": "Godziny pracy",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2723.

Closes #2723

---

## Claude summary

Done. Two translation files changed, one commit.

The sidebar nav item in the Gabinet module now reads "Komunikacja" (PL) / "Communication" (EN) instead of "Wygenerowane Dokumenty". The route (`/dashboard/gabinet/documents`), page heading ("Dokumenty"), and all existing functionality are untouched. The change touches only:

- `public/locales/pl/translation.json` — key `nav.gabinet.documents`: "Wygenerowane Dokumenty" → "Komunikacja"
- `public/locales/en/translation.json` — key `nav.gabinet.documents`: "Generated Documents" → "Communication"