### PR TITLE
Uprość domyślny widok tabeli klientów

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -434,7 +434,14 @@ function PatientsIndex() {
   );
 
   const { allColumns, defaultHidden } = useAllColumns(columns, filterableFields);
-  const { hiddenColumnIds, toggleColumn, setHiddenColumns } = useColumnVisibility(defaultHidden, "gabinet-patients");
+  const patientsDefaultHidden = useMemo(() => {
+    const hidden = new Set(defaultHidden);
+    for (const id of ["email", "pesel", "dateOfBirth", "gender", "referralSource", "allergies", "bloodType", "medicalNotes", "createdAt"]) {
+      hidden.add(id);
+    }
+    return hidden;
+  }, [defaultHidden]);
+  const { hiddenColumnIds, toggleColumn, setHiddenColumns } = useColumnVisibility(patientsDefaultHidden, "gabinet-patients");
 
   const handleCreate = useCallback(
     async (formData: {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2724.

Closes #2724

---

## Claude summary

Done. The change is a single file, 8 lines added. Here's what was done:

After `useAllColumns` returns `defaultHidden` (which covers auto-generated filterable-field columns), a new `useMemo` builds an extended set that also marks `email`, `pesel`, `dateOfBirth`, `gender`, `referralSource`, `allergies`, `bloodType`, `medicalNotes`, and `createdAt` as hidden by default. That extended set is passed to `useColumnVisibility`. The default only applies on a user's first visit — anyone with an existing `col-vis:gabinet-patients` entry in localStorage keeps their saved preferences. All columns remain accessible via the column-visibility toggle.

One item from the issue wasn't addressed: the "Zaplanowana / najbliższa wizyta" (next appointment) column. It doesn't exist in the current table — the `MappedGabinetPatient` type carries no appointment data and no such column is defined. Adding it would require fetching appointment data in the list view, which is beyond the guardrail "change only the default set of displayed columns".

## Follow-ups

- Add "Zaplanowana / najbliższa wizyta" column to gabinet patients table: the issue requests a next-appointment column but it doesn't exist; it would need fetching the earliest upcoming appointment per patient and adding it to `MappedGabinetPatient` or as a separate query