### PR TITLE
Add "Zaplanowana / najbliższa wizyta" column to gabinet patients table

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2462,6 +2462,7 @@
         "compareVisit": "Compare",
         "compareTitle": "Before / after photo comparison"
       },
+      "nextAppointment": "Scheduled appointment",
       "byDay": "Clients by Day",
       "bySource": "Clients by Source",
       "appointmentHistory": "Appointment history",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2477,6 +2477,7 @@
         "compareVisit": "Porównaj",
         "compareTitle": "Porównanie zdjęć przed i po"
       },
+      "nextAppointment": "Zaplanowana wizyta",
       "byDay": "Klienci wg dnia",
       "bySource": "Klienci wg źródła",
       "appointmentHistory": "Historia wizyt",

--- a/src/hooks/use-supabase-gabinet-appointments.ts
+++ b/src/hooks/use-supabase-gabinet-appointments.ts
@@ -505,6 +505,71 @@ export function useSupabaseGabinetAppointmentPaymentTotals(
 }
 
 // ---------------------------------------------------------------------------
+// Next Appointment per Patient (for patients table column)
+// ---------------------------------------------------------------------------
+
+export interface NextAppointmentInfo {
+  id: string;
+  date: string;
+  startTime: string;
+}
+
+/**
+ * Returns the earliest upcoming non-cancelled, non-no-show appointment for
+ * each patient in the organization. Used by the patients list to render the
+ * "Zaplanowana wizyta" column without N+1 queries.
+ */
+export function useSupabaseGabinetNextAppointmentByPatient(
+  organizationId: string,
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  const today = new Date().toISOString().split("T")[0];
+
+  return useQuery<Map<string, NextAppointmentInfo>, Error>({
+    queryKey: [
+      ...supabaseKeys.gabinetAppointments.list(organizationId),
+      "nextByPatient",
+      today,
+    ],
+    queryFn: async (): Promise<Map<string, NextAppointmentInfo>> => {
+      if (!client) throw new Error("Supabase client not ready");
+
+      const { data, error } = await client
+        .from("gabinet_appointments")
+        .select("id, patient_id, date, start_time")
+        .eq("organization_id", organizationId)
+        .gte("date", today)
+        .not("status", "in", '("cancelled","no_show")')
+        .order("date", { ascending: true })
+        .order("start_time", { ascending: true });
+
+      if (error) throw error;
+
+      const result = new Map<string, NextAppointmentInfo>();
+      for (const row of (data ?? []) as {
+        id: string;
+        patient_id: string;
+        date: string;
+        start_time: string;
+      }[]) {
+        if (!result.has(row.patient_id)) {
+          result.set(row.patient_id, {
+            id: row.id,
+            date: row.date,
+            startTime: row.start_time,
+          });
+        }
+      }
+      return result;
+    },
+    enabled: enabled && isReady && !!organizationId,
+  } satisfies UseQueryOptions<Map<string, NextAppointmentInfo>, Error>);
+}
+
+// ---------------------------------------------------------------------------
 // Single Appointment
 // ---------------------------------------------------------------------------
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { formatActionError, extractActionErrorMessage } from "@/lib/format-action-error";
 import { api } from "@cvx/_generated/api";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
-import { useSupabaseGabinetRecentVisitPatientIds } from "@/hooks/use-supabase-gabinet-appointments";
+import { useSupabaseGabinetRecentVisitPatientIds, useSupabaseGabinetNextAppointmentByPatient } from "@/hooks/use-supabase-gabinet-appointments";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { useOrganization } from "@/components/org-context";
 import { PageHeader } from "@/components/layout/page-header";
@@ -216,6 +216,7 @@ function PatientsIndex() {
     90,
     { enabled: nudgeFilter === "no-recent-visit" },
   );
+  const { data: nextAppointmentByPatient } = useSupabaseGabinetNextAppointmentByPatient(organizationId);
 
   const {
     views,
@@ -374,6 +375,25 @@ function PatientsIndex() {
         getSortValue: (item) => item.phone ?? "",
       },
       {
+        id: "nextAppointment",
+        label: t("gabinet.patients.nextAppointment"),
+        sortable: true,
+        render: (item) => {
+          const appt = nextAppointmentByPatient?.get(item._id);
+          if (!appt) return "—";
+          const [year, month, day] = appt.date.split("-");
+          return (
+            <span className="whitespace-nowrap">
+              {day}.{month}.{year} {appt.startTime.slice(0, 5)}
+            </span>
+          );
+        },
+        getSortValue: (item) => {
+          const appt = nextAppointmentByPatient?.get(item._id);
+          return appt ? appt.date + "T" + appt.startTime : "";
+        },
+      },
+      {
         id: "pesel",
         label: t("gabinet.patients.pesel"),
         sortable: true,
@@ -430,7 +450,7 @@ function PatientsIndex() {
         getSortValue: (item) => item.createdAt,
       },
     ],
-    [t],
+    [t, nextAppointmentByPatient],
   );
 
   const { allColumns, defaultHidden } = useAllColumns(columns, filterableFields);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2727.

Closes #2727

---

## Claude summary

Done. Here's a summary of what was implemented:

**Changes made (4 files):**

1. `src/hooks/use-supabase-gabinet-appointments.ts` — Added `useSupabaseGabinetNextAppointmentByPatient` hook that fetches all upcoming non-cancelled/no-show appointments for the organization in a single batch query, then returns a `Map<patientId, { id, date, startTime }>` with only the earliest appointment per patient.

2. `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx` — Imported and called the new hook, added a `nextAppointment` column definition between "Telefon" and "PESEL". The column renders as `DD.MM.YYYY HH:MM`, is sortable, and is visible by default (not in the hidden set).

3. `public/locales/pl/translation.json` — Added `"nextAppointment": "Zaplanowana wizyta"`

4. `public/locales/en/translation.json` — Added `"nextAppointment": "Scheduled appointment"`

The approach uses a single org-wide query for upcoming appointments (ordered by date+time ASC) and picks the first result per patient client-side — identical to the pattern already used for `useSupabaseGabinetRecentVisitPatientIds`.