### PR TITLE
Tekst (opis wizyty)

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -1614,11 +1614,11 @@ export function AppointmentPreviewContent({
           <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
             {t("gabinet.appointments.internalNotes")}
           </Label>
-          <Textarea
+          <RichTextEditor
             value={internalNotes}
-            onChange={(e) => setInternalNotes(e.target.value)}
+            onChange={(v) => setInternalNotes(v ?? "")}
             placeholder={t("gabinet.appointments.internalNotesPlaceholder")}
-            className="min-h-[104px] text-sm"
+            minHeight="104px"
           />
         </div>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2730.

Closes #2730

---

## Claude summary

The fix is committed. Here's the root cause and what changed:

**Root cause:** The "Opis wizyty" field (`internalNotes`) is edited via `RichTextEditor` on the appointment detail page (`/dashboard/gabinet/appointments/$appointmentId`), which serializes content as Plate.js JSON. However, the calendar preview popover (`appointment-preview-content.tsx`) was displaying that same field in a plain `<Textarea>`, which renders the raw JSON string verbatim — hence the "symbols" the user saw.

**Fix:** Replaced the `<Textarea>` with `<RichTextEditor>` in `appointment-preview-content.tsx:1617`. The `RichTextEditor` component already handles both Plate JSON and legacy plain text via its `parseValue()` helper, so existing data stored in either format displays correctly. The `onChange` handler is consistent with how the detail page saves it.

## Follow-ups
- Inconsistent internalNotes storage format: old appointments saved from the preview Textarea store plain text, while those saved from the detail page store Plate JSON — a migration or backward-compat read path may be needed to normalize the format across all existing records.