### PR TITLE
Inconsistent internalNotes storage format

### DIFF
--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -18,6 +18,45 @@ import {
 // must hit Supabase rather than Convex ctx.db).
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Plate JSON helpers (backend-safe, no React imports)
+// ---------------------------------------------------------------------------
+
+type PlateNode = { type: string; children: Array<{ text: string }> };
+
+/**
+ * Append plain-text lines to an internalNotes field that may already be stored
+ * as Plate JSON or as legacy plain text.  Always returns valid Plate JSON so
+ * that subsequent reads by the RichTextEditor display correctly without any raw
+ * JSON leaking into the editor.
+ */
+function appendPlateNotes(existing: string | undefined, text: string): string {
+  const toNodes = (raw: string): PlateNode[] =>
+    raw.split("\n").map((line) => ({ type: "p", children: [{ text: line }] }));
+
+  let existingNodes: PlateNode[] = [];
+  if (existing) {
+    try {
+      const parsed = JSON.parse(existing);
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        existingNodes = parsed as PlateNode[];
+      } else {
+        existingNodes = toNodes(existing);
+      }
+    } catch {
+      existingNodes = toNodes(existing);
+    }
+  }
+
+  const separator: PlateNode = { type: "p", children: [{ text: "" }] };
+  const newNodes = toNodes(text);
+  const combined =
+    existingNodes.length > 0
+      ? [...existingNodes, separator, ...newNodes]
+      : newNodes;
+  return JSON.stringify(combined);
+}
+
 export const getMyProfile = action({
   args: { tokenHash: v.string() },
   handler: async (_ctx, args) => {
@@ -640,10 +679,10 @@ export const requestReschedule = action({
       ...(args.reason ? [`Reason: ${args.reason}`] : []),
     ].join("\n");
 
-    const existingNotes = (appt.internalNotes as string) ?? "";
-    const updatedNotes = existingNotes
-      ? `${existingNotes}\n\n${requestNote}`
-      : requestNote;
+    const updatedNotes = appendPlateNotes(
+      appt.internalNotes as string | undefined,
+      requestNote,
+    );
 
     // Patch appointment in Supabase
     await db.patch("gabinetAppointments", args.appointmentId, {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2735.

Closes #2735

---

## Claude summary

The fix is committed. Here's a summary of what was done:

The bug was real and isolated to `convex/gabinet/patientPortal.ts`. When a patient submits a reschedule request through the patient portal, the `requestReschedule` action appends a note to `internalNotes`. The old code did this with a plain string concatenation — which corrupts the field if it already contains Plate JSON (e.g., `[{"type":"p","children":[{"text":"..."}]}]\n\n[RESCHEDULE REQUEST]...`). The `RichTextEditor.parseValue()` would then fail to parse the result as JSON and display the raw JSON characters as text.

The fix adds an `appendPlateNotes()` helper that:
1. Tries to parse the existing value as Plate JSON — if it succeeds, uses those nodes as the starting point
2. If parsing fails (legacy plain text), converts each line into Plate paragraph nodes instead
3. Appends the new reschedule note as Plate paragraph nodes with an empty separator line
4. Always serializes the result back to Plate JSON

The backward-compat read path in `RichTextEditor.parseValue()` already handles displaying old plain-text records — this fix closes the write-side gap so the patient portal no longer produces mixed-format values.