### PR TITLE
Zmiana nazwy z edytuj na szczegóły

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -1799,7 +1799,9 @@ export function AppointmentPreviewContent({
             params={{ appointmentId: appointment._id }}
           >
             <ExternalLink className="mr-1 size-3.5" />
-            {t("gabinet.appointmentDetail.edit", "Edytuj")}
+            {isSettled
+              ? t("gabinet.appointmentDetail.viewDetails", "Szczegóły wizyty")
+              : t("gabinet.appointmentDetail.edit", "Edytuj")}
           </Link>
         </Button>
         <Button


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2737.

Closes #2737

---

## Claude summary

Done. The fix is in `src/components/gabinet/calendar/appointment-preview-content.tsx:1802`. When `isSettled` is true (appointment status is "completed" and the full payment has been received), the button now reads "Szczegóły wizyty" instead of "Edytuj". The `isSettled` flag was already computed at line 728 and used elsewhere in the same component (the "Rozlicz" button), so this was a one-line conditional addition.