### PR TITLE
Wyszukiwarka

### DIFF
--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -359,16 +359,20 @@ export function DraggableAppointment({
       <PopoverAnchor asChild>{card}</PopoverAnchor>
       {/* Backdrop overlay (issue #1886): Radix Popover has no built-in
           overlay, so the preview previously visually merged with the calendar
-          grid underneath. A portaled dimmer sits between the calendar and
-          the popover content (z-40 vs the popover's z-50) so the preview
-          stands out. Clicking the overlay falls through to Radix's outside-
-          click detection and closes the popover. */}
+          grid underneath. The portaled dimmer uses z-50 (matching the sticky
+          header) so that at the same z-index level the header is covered by the
+          backdrop because the portal is appended to document.body later in DOM
+          order — this hides the header search bar while the preview is open
+          (issue #2729). The popover content also renders at z-50 but its portal
+          is appended after the backdrop, so DOM order keeps it on top.
+          Clicking the overlay falls through to Radix's outside-click detection
+          and closes the popover. */}
       {popoverOpen &&
         typeof document !== "undefined" &&
         createPortal(
           <div
             aria-hidden="true"
-            className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[1px] animate-in fade-in-0 duration-150"
+            className="fixed inset-0 z-50 bg-black/40 backdrop-blur-[1px] animate-in fade-in-0 duration-150"
           />,
           document.body,
         )}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2729.

Closes #2729

---

## Claude summary

Done. The fix was a one-line change in `src/components/gabinet/calendar/draggable-appointment.tsx`.

**Root cause**: The appointment preview backdrop used `z-40`, but the sticky dashboard header uses `z-50`. Since a higher z-index always wins, the header (including its "Szukaj" search button) remained visible above the backdrop.

**Fix**: Changed the backdrop from `z-40` to `z-50`. At the same z-index, DOM order determines stacking — the portaled backdrop is appended to `document.body` after the header, so it renders on top of and covers the header. The PopoverContent (also `z-50`) has its portal appended to `document.body` after the backdrop, so it correctly remains above the backdrop.