### PR TITLE
Orphaned `appointment.notes` display gap

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -326,6 +326,7 @@ export function AppointmentPreviewContent({
     const em = newEnd % 60;
     setEndTime(`${String(eh).padStart(2, "0")}:${String(em).padStart(2, "0")}`);
   };
+  const [notes, setNotes] = useState("");
   const [internalNotes, setInternalNotes] = useState("");
   const [treatmentId, setTreatmentId] = useState("");
   const [treatmentOpen, setTreatmentOpen] = useState(false);
@@ -427,6 +428,7 @@ export function AppointmentPreviewContent({
     setDate(appt.date);
     setStartTime(appt.startTime.slice(0, 5));
     setEndTime(appt.endTime.slice(0, 5));
+    setNotes(appt.notes ?? "");
     setInternalNotes(appt.internalNotes ?? "");
     setTreatmentId(appt.treatmentId ? String(appt.treatmentId) : "");
     setTagIds(
@@ -482,6 +484,7 @@ export function AppointmentPreviewContent({
     date !== appointment.date ||
     startTime !== appointment.startTime.slice(0, 5) ||
     endTime !== appointment.endTime.slice(0, 5) ||
+    notes !== (appointment.notes ?? "") ||
     internalNotes !== (appointment.internalNotes ?? "") ||
     treatmentId !== initialTreatmentId ||
     tagsDirty;
@@ -661,6 +664,8 @@ export function AppointmentPreviewContent({
         if (startTime !== appointment.startTime.slice(0, 5))
           args.startTime = startTime;
         if (endTime !== appointment.endTime.slice(0, 5)) args.endTime = endTime;
+        if (notes !== (appointment.notes ?? ""))
+          args.notes = notes || null;
         if (internalNotes !== (appointment.internalNotes ?? ""))
           args.internalNotes = internalNotes || null;
         if (treatmentId && treatmentId !== initialTreatmentId)
@@ -1608,6 +1613,18 @@ export function AppointmentPreviewContent({
               })}
             </button>
           </div>
+        </div>
+
+        <div className="space-y-1">
+          <Label className="text-[11px] uppercase tracking-wide text-muted-foreground">
+            {t("gabinet.appointments.notes")}
+          </Label>
+          <RichTextEditor
+            value={notes}
+            onChange={(v) => setNotes(v ?? "")}
+            placeholder={t("gabinet.appointments.notesPlaceholder")}
+            minHeight="80px"
+          />
         </div>
 
         <div className="space-y-1">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2750.

Closes #2750

---

## Claude summary

The bug was real and is now fixed. Here's a summary of what was wrong and what changed:

**Root cause:** In `appointment-preview-content.tsx`, the edit panel for appointment details only wired up `internalNotes` (staff-only). The `notes` field (patient-visible, set at creation via `appointment-dialog.tsx`) was never read from the appointment, never shown in the UI, and never included in save calls — so staff had no way to see or edit it after creation, even though patients could read it in the portal.

**Fix in `src/components/gabinet/calendar/appointment-preview-content.tsx`:**
1. Added `const [notes, setNotes] = useState("")` state (line 329)
2. Seeded it from `appt.notes ?? ""` in the initialization `useEffect` (line 431)
3. Added `notes !== (appointment.notes ?? "")` to the `apptDirty` check (line 487)
4. Added `args.notes = notes || null` to the save handler when notes changed (lines 667–668)
5. Rendered a `RichTextEditor` for `notes` in the UI, above the existing `internalNotes` editor, using the pre-existing translation keys `gabinet.appointments.notes` / `gabinet.appointments.notesPlaceholder` (lines 1618–1629)