### PR TITLE
`gabinetTreatments.description` label inconsistency

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2548,7 +2548,7 @@
       "preparationInstructions": "Preparation Instructions",
       "aftercareInstructions": "Aftercare Instructions",
       "requiredDocuments": "Required Documents",
-      "notes": "Notes",
+      "notes": "Description",
       "requiresApproval": "Requires Approval",
       "treatmentCount": "Sessions per course",
       "treatmentCountHint": "Number of sessions in a course (e.g. 20). Auto-creates a package on first booking.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2563,7 +2563,7 @@
       "preparationInstructions": "Instrukcje przygotowania",
       "aftercareInstructions": "Instrukcje po zabiegu",
       "requiredDocuments": "Wymagane dokumenty",
-      "notes": "Uwagi / Notatki",
+      "notes": "Opis",
       "requiresApproval": "Wymaga zatwierdzenia",
       "treatmentCount": "Liczba zabiegów",
       "treatmentCountHint": "Ilość zabiegów w cyklu (np. 20). Automatycznie tworzy pakiet przy pierwszej wizycie.",

--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -907,7 +907,7 @@ export function TreatmentForm({
           />
         </div>
         <div className="space-y-1.5">
-          <Label>{t("gabinet.treatments.notes", "Uwagi / Notatki")}</Label>
+          <Label>{t("gabinet.treatments.notes", "Opis")}</Label>
           <RichTextEditor
             value={notes}
             onChange={(v) => setNotes(v ?? "")}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2751.

Closes #2751

---

## Claude summary

Fixed. The `gabinetTreatments.description` field is now labeled consistently as "Opis" (PL) / "Description" (EN) everywhere:

- `treatment-form.tsx:910` — was "Uwagi / Notatki", now "Opis"
- `pl/translation.json` `gabinet.treatments.notes` — was "Uwagi / Notatki", now "Opis"
- `en/translation.json` `gabinet.treatments.notes` — was "Notes", now "Description"

The detail view's variants section already used "Opis" via `gabinet.treatmentDetail.variants.description`, so no changes were needed there.