### PR TITLE
`gabinetEmployees.notes` field vs `notes` table tab name collision

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2875,6 +2875,7 @@
         "detailedData": "Detailed Data",
         "schedule": "Schedule",
         "assignedItems": "Materials",
+        "notes": "Notes",
         "noPatients": "No clients seen yet."
       },
       "agenda": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2896,6 +2896,7 @@
         "detailedData": "Dane szczegółowe",
         "schedule": "Grafik",
         "assignedItems": "Materiały",
+        "notes": "Notatki",
         "noPatients": "Brak obsługiwanych klientów."
       },
       "agenda": {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -527,7 +527,7 @@ function EmployeeDetail() {
       {employee.notes && (
         <Card>
           <CardHeader className="pb-3">
-            <CardTitle className="text-base">{t("gabinet.employees.notes")}</CardTitle>
+            <CardTitle className="text-base">{t("gabinet.employees.detailedData.notesComments")}</CardTitle>
           </CardHeader>
           <CardContent>
             <p className="text-sm text-muted-foreground whitespace-pre-wrap">
@@ -733,7 +733,7 @@ function EmployeeDetail() {
       ),
     },
     {
-      label: t("gabinet.employees.notes"),
+      label: t("gabinet.employees.tabs.notes"),
       content: (
         <NotesTabContent
           notesData={notesData}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2753.

Closes #2753

---

## Claude summary

The fix is in. Here's a summary of what changed:

**Problem:** In the employee detail view, two elements simultaneously showed the label "Notatki" — a sidebar card rendering `employee.notes` (the HR free-text profile field) and a tab for the CRM-style threaded notes system.

**Fix (3 files):**

1. `_layout.gabinet.employees.$employeeId.tsx:530` — sidebar card title now uses `gabinet.employees.detailedData.notesComments` ("Uwagi / Komentarze" / "Notes / Comments"), which is the same key already used for this field in `DetailedDataTab`. No new string invented.

2. `_layout.gabinet.employees.$employeeId.tsx:736` — tab now uses `gabinet.employees.tabs.notes` instead of the bare `gabinet.employees.notes`, making it consistent with all other tab labels that live under the `tabs.*` namespace.

3. Both locale files — added `"notes": "Notatki"` / `"notes": "Notes"` to the `employees.tabs` object.

The edit drawer field at line 1527 (`gabinet.employees.notes`) was left unchanged — it's inside the SidePanel edit form, a separate context where there's no collision.