### PR TITLE
Ukrycie pola na dole kalendarza

### DIFF
--- a/src/components/layout/app-footer.tsx
+++ b/src/components/layout/app-footer.tsx
@@ -83,10 +83,8 @@ const defaultGabinetActions: FooterAction[] = [
 
 const gabinetRouteActions: Record<string, FooterAction[]> = {
   calendar: [
-    { labelKey: "nav.actions.bookAppointment", icon: CalendarCheck, action: "openCreateAppointment" },
     { labelKey: "nav.actions.filters", icon: Filter, action: "openFilter" },
     { labelKey: "nav.actions.addPatient", icon: UserPlus, quickCreate: "patient" },
-    { labelKey: "nav.actions.manageTags", icon: Tag, action: "manageTags" },
     { labelKey: "nav.actions.printSchedule", icon: Download, action: "printSchedule" },
   ],
   patients: [


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2739.

Closes #2739

---

## Claude summary

Done. Removed the "Umów wizytę" (`openCreateAppointment`) and "Tagi" (`manageTags`) entries from the `gabinetRouteActions.calendar` array in `src/components/layout/app-footer.tsx:85-91`. The calendar footer now shows only Filters, Add Patient, and Print Schedule. The `CalendarCheck` and `Tag` icon imports are retained since they're still used in other route action arrays.