### PR TITLE
Pola parametrów/wizyta

### DIFF
--- a/src/components/gabinet/documentation-tab.tsx
+++ b/src/components/gabinet/documentation-tab.tsx
@@ -440,7 +440,7 @@ export function DocumentationTab({
                 <div key={i} className="space-y-1.5">
                   {param.isCustom ? (
                     <div className="flex items-start gap-2">
-                      <div className="grid flex-1 gap-2 sm:grid-cols-[1fr_8rem]">
+                      <div className="grid flex-1 gap-2 sm:grid-cols-[1fr_8rem_1fr]">
                         <Input
                           value={param.name}
                           onChange={(e) =>
@@ -481,6 +481,18 @@ export function DocumentationTab({
                             ))}
                           </datalist>
                         )}
+                        <Input
+                          value={String(param.value ?? "")}
+                          onChange={(e) => handleParamChange(i, e.target.value)}
+                          placeholder={t(
+                            "gabinet.documentation.paramValuePlaceholder",
+                            "Wartość",
+                          )}
+                          aria-label={t(
+                            "gabinet.documentation.paramValue",
+                            "Wartość",
+                          )}
+                        />
                       </div>
                       <Button
                         type="button"
@@ -507,18 +519,11 @@ export function DocumentationTab({
                   {def?.description && (
                     <p className="text-xs text-muted-foreground">{def.description}</p>
                   )}
-                  {paramType === "text" && (
+                  {!param.isCustom && paramType === "text" && (
                     <Input
                       value={String(param.value ?? "")}
                       onChange={(e) => handleParamChange(i, e.target.value)}
-                      placeholder={
-                        param.isCustom
-                          ? t(
-                              "gabinet.documentation.paramValuePlaceholder",
-                              "Wartość",
-                            )
-                          : "—"
-                      }
+                      placeholder="—"
                     />
                   )}
                   {paramType === "number" && (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2740.

Closes #2740

---

## Claude summary

Done. The fix puts all 3 custom parameter fields (Name, Unit, Value) in a single horizontal row using a `sm:grid-cols-[1fr_8rem_1fr]` grid, with the delete button still aligned to the right. Previously the value input rendered below the name+unit row as a separate block.

Changed file: `src/components/gabinet/documentation-tab.tsx:443` — widened the grid from `[1fr_8rem]` to `[1fr_8rem_1fr]` and moved the value `<Input>` inside the custom-param branch. The separate text-value input below is now guarded with `!param.isCustom` so it only renders for template-defined (non-custom) parameters.