### PR TITLE
Przycisk historia 

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -545,12 +545,6 @@ function AppointmentDetail() {
                   {t("gabinet.patients.viewProfile", "Profil klienta")}
                 </Link>
               </DropdownMenuItem>
-              <DropdownMenuItem asChild>
-                <Link to="/dashboard/gabinet/patients/$patientId" params={{ patientId: pat?._id ?? "" }} search={{ tab: "history" }}>
-                  <History size={14} variant="stroke" className="mr-2" />
-                  {t("gabinet.patients.history", "Historia wizyt")}
-                </Link>
-              </DropdownMenuItem>
               <DropdownMenuSeparator />
               {pat?.phone && (
                 <DropdownMenuItem asChild>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2741.

Closes #2741

---

## Claude summary

The fix was already applied as a working-tree change — I've now committed it.

The "Historia wizyt" dropdown item in the patient card's kebab menu (in the appointment detail sidebar) was a deeplink to `/dashboard/gabinet/patients/$patientId?tab=history`. The "Profil klienta" item directly above it navigates to the same patient profile page, making "Historia" redundant. Removed those 6 lines; the `History` icon import remains valid because it's still used in the "Historia wizyt" card heading within the Historia tab content.