### PR TITLE
Nieczytelny komunikat błędu przy podpisywaniu dokumentu

### DIFF
--- a/src/lib/format-action-error.test.ts
+++ b/src/lib/format-action-error.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractFieldValidationDetail,
   extractTreatmentFieldError,
+  formatActionError,
   formatTreatmentError,
 } from "./format-action-error";
 
@@ -123,6 +124,19 @@ describe("extractFieldValidationDetail", () => {
     );
     expect(detail?.fieldLabel).toContain("string");
     expect(detail?.reason).toContain("null");
+  });
+});
+
+describe("formatActionError", () => {
+  it("maps Convex 'Connection lost' to a Polish connection error message (issue #2745)", () => {
+    const err = new Error(
+      "[CONVEX A(documents/documents:submitDocumentFormFields)] Connection lost while action was in flight. Called by client",
+    );
+    const msg = formatActionError(err, t, {
+      key: "documents.signing.submitError",
+      defaultValue: "Nie udało się dokończyć podpisywania dokumentu.",
+    });
+    expect(msg).toBe("Wystąpił chwilowy problem z połączeniem. Spróbuj ponownie za moment.");
   });
 });
 

--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -528,6 +528,11 @@ const GENERIC_ERROR_MAP: Array<{
   fallback: string;
 }> = [
   {
+    test: (m) => /connection lost while action was in flight|connection reset|websocket.*closed|network.*error/i.test(m),
+    key: "common.errors.connectionLost",
+    fallback: "Wystąpił chwilowy problem z połączeniem. Spróbuj ponownie za moment.",
+  },
+  {
     test: (m) => /permission denied/i.test(m),
     key: "common.errors.permissionDenied",
     fallback: "Brak uprawnień do tej operacji.",

--- a/src/routes/sign.$token.tsx
+++ b/src/routes/sign.$token.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useQuery, useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useState, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -14,6 +15,7 @@ import {
   ShieldCheck,
   AlertTriangle,
 } from "@/lib/ez-icons";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute("/sign/$token")({
   component: SigningPage,
@@ -126,6 +128,7 @@ function SigningFlow({
   document,
   organizationName,
 }: SigningFlowProps) {
+  const { t } = useTranslation();
   const signExternal = useAction(api.signatureRequests.signExternal);
   const verifyOtp = useAction(api.signatureRequests.verifyOtp);
   const requestOtp = useAction(api.sms.requestOtp);
@@ -152,7 +155,7 @@ function SigningFlow({
       await requestOtp({ token });
       setOtpSent(true);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Nie udało się wysłać kodu");
+      setError(formatActionError(err, t, { key: "documents.signing.otpSendError", defaultValue: "Nie udało się wysłać kodu weryfikacyjnego. Spróbuj ponownie." }));
     } finally {
       setLoading(false);
     }
@@ -166,7 +169,7 @@ function SigningFlow({
       setOtpVerified(true);
       setStep("sign");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Nieprawidłowy kod");
+      setError(formatActionError(err, t, { key: "documents.signing.otpVerifyError", defaultValue: "Nieprawidłowy kod lub błąd połączenia. Spróbuj ponownie." }));
     } finally {
       setLoading(false);
     }
@@ -180,7 +183,7 @@ function SigningFlow({
         await signExternal({ token, signatureData });
         setStep("done");
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Nie udało się podpisać dokumentu");
+        setError(formatActionError(err, t, { key: "documents.signing.signError", defaultValue: "Nie udało się podpisać dokumentu. Sprawdź połączenie z Internetem i spróbuj ponownie." }));
       } finally {
         setLoading(false);
       }

--- a/src/routes/sign.form.$token.tsx
+++ b/src/routes/sign.form.$token.tsx
@@ -20,6 +20,7 @@ import {
   AlertTriangle,
   Loader2,
 } from "@/lib/ez-icons";
+import { formatActionError } from "@/lib/format-action-error";
 
 // ---------------------------------------------------------------------------
 // Route definition — public page, no auth required
@@ -184,14 +185,15 @@ function SignatureSection({
         });
         onDone();
       } catch (err: unknown) {
-        const message =
-          err instanceof Error ? err.message : "Wystąpił nieoczekiwany błąd";
-        setError(message);
+        setError(formatActionError(err, t, {
+          key: "documents.signing.signError",
+          defaultValue: "Nie udało się podpisać dokumentu. Sprawdź połączenie z Internetem i spróbuj ponownie.",
+        }));
       } finally {
         setLoading(false);
       }
     },
-    [recordSignature, token, resolvedHtml, onDone],
+    [recordSignature, token, resolvedHtml, onDone, t],
   );
 
   const handleClickSign = useCallback(async () => {
@@ -470,14 +472,15 @@ function DocumentSigningFlow({ token, document, template }: FlowProps) {
         setRenderedHtml(html);
         setStep("sign");
       } catch (err: unknown) {
-        const message =
-          err instanceof Error ? err.message : "Wystąpił nieoczekiwany błąd";
-        setError(message);
+        setError(formatActionError(err, t, {
+          key: "documents.signing.submitError",
+          defaultValue: "Nie udało się dokończyć podpisywania dokumentu. Sprawdź połączenie z Internetem i spróbuj ponownie.",
+        }));
       } finally {
         setSubmitting(false);
       }
     },
-    [template.contentJson, prefilledData, existingFormFieldValues, submitFormFields, token],
+    [template.contentJson, prefilledData, existingFormFieldValues, submitFormFields, token, t],
   );
 
   const handleSubmitFormValues = useCallback(async () => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2745.

Closes #2745

---

## Claude summary

The fix is committed. Here's what was done:

**Root cause:** Both public signing routes (`sign.$token.tsx` and `sign.form.$token.tsx`) were extracting `err.message` directly and passing it to the UI, so Convex framework messages like `[CONVEX A(documents/documents:submitDocumentFormFields)] Connection lost while action was in flight. Called by client` were shown verbatim to patients.

**Changes (4 files):**

1. **`src/lib/format-action-error.ts`** — Added a `"Connection lost while action was in flight"` pattern to `GENERIC_ERROR_MAP` that maps to `"Wystąpił chwilowy problem z połączeniem. Spróbuj ponownie za moment."`. This is the central place all error formatting flows through.

2. **`src/routes/sign.form.$token.tsx`** — Replaced both raw `err.message` catch blocks (`handleFormComplete` and `SignatureSection.handleSign`) with `formatActionError(err, t, { fallback: "Nie udało się..." })`. The fallback message is signing-specific and Polish.

3. **`src/routes/sign.$token.tsx`** — Same fix for all three error handlers (`handleSendOtp`, `handleVerifyOtp`, `handleSign`). Added `useTranslation` and `formatActionError` imports.

4. **`src/lib/format-action-error.test.ts`** — Added a test proving the exact Convex error from the issue report maps to the friendly Polish message.