### PR TITLE
Walidacja dokumentów – po kliknięciu „Podpisz dokument” brak przejścia do niewypełnionego wymaganego pola

### DIFF
--- a/src/components/documents/inline-document-form.tsx
+++ b/src/components/documents/inline-document-form.tsx
@@ -19,6 +19,8 @@ interface InlineDocumentFormProps {
   /** Current client-filled values managed by the parent. */
   values: Record<string, string>;
   onValueChange: (fieldId: string, value: string) => void;
+  /** Field ID that failed validation — highlighted with a red outline. */
+  invalidFieldId?: string | null;
 }
 
 interface PortalTarget {
@@ -69,6 +71,7 @@ export function InlineDocumentForm({
   formFields,
   values,
   onValueChange,
+  invalidFieldId,
 }: InlineDocumentFormProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [portals, setPortals] = useState<PortalTarget[]>([]);
@@ -138,6 +141,7 @@ export function InlineDocumentForm({
             }
             onChange={(v) => onValueChange(field.fieldId, v)}
             isStandalone={isStandalone}
+            isInvalid={field.fieldId === invalidFieldId}
           />,
           element,
         ),
@@ -155,12 +159,16 @@ export function InlineFieldControl({
   value,
   onChange,
   isStandalone,
+  isInvalid,
 }: {
   field: ExtractedFormField;
   value: string;
   onChange: (value: string) => void;
   isStandalone?: boolean;
+  isInvalid?: boolean;
 }) {
+  const invalidOutline = isInvalid ? "2px solid #ef4444" : undefined;
+
   // Show the field label as a visible question prompt for standalone fields
   // where the label IS the question (not just a blank inside a sentence).
   // Checkboxes are excluded — they always show their label inline.
@@ -201,6 +209,8 @@ export function InlineFieldControl({
           userSelect: "none",
           width: "100%",
           padding: "6px 0",
+          outline: invalidOutline,
+          borderRadius: "4px",
         }}
       >
         <input
@@ -239,12 +249,13 @@ export function InlineFieldControl({
           style={{
             display: "block",
             width: "100%",
-            border: "1px solid #d1d5db",
+            border: isInvalid ? "1px solid #ef4444" : "1px solid #d1d5db",
             borderRadius: "4px",
             padding: "6px 10px",
             fontSize: "14px",
             color: "#111827",
             background: "#fff",
+            outline: isInvalid ? "1px solid #ef4444" : undefined,
           }}
         />
         {inlineRequiredMarker}
@@ -266,13 +277,14 @@ export function InlineFieldControl({
           required={field.required}
           style={{
             display: "inline-block",
-            border: "1px solid #d1d5db",
+            border: isInvalid ? "1px solid #ef4444" : "1px solid #d1d5db",
             borderRadius: "4px",
             padding: "4px 8px",
             fontSize: "14px",
             color: "#111827",
             background: "#fff",
             minWidth: "140px",
+            outline: isInvalid ? "1px solid #ef4444" : undefined,
           }}
         >
           <option value="">{field.placeholder || "Wybierz..."}</option>
@@ -293,7 +305,7 @@ export function InlineFieldControl({
       .map((o) => o.trim())
       .filter(Boolean);
     return (
-      <span style={{ display: "block", width: "100%" }}>
+      <span style={{ display: "block", width: "100%", outline: invalidOutline, borderRadius: "4px" }}>
         {labelNode}
         <span
           style={{
@@ -347,13 +359,14 @@ export function InlineFieldControl({
         required={field.required}
         style={{
           display: "inline-block",
-          border: "1px solid #d1d5db",
+          border: isInvalid ? "1px solid #ef4444" : "1px solid #d1d5db",
           borderRadius: "4px",
           padding: "4px 8px",
           fontSize: "14px",
           color: "#111827",
           background: "#fff",
           minWidth: "140px",
+          outline: isInvalid ? "1px solid #ef4444" : undefined,
         }}
       />
       {inlineRequiredMarker}

--- a/src/routes/sign.form.$token.tsx
+++ b/src/routes/sign.form.$token.tsx
@@ -425,10 +425,12 @@ function DocumentSigningFlow({ token, document, template }: FlowProps) {
     return init;
   });
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [invalidFieldId, setInvalidFieldId] = useState<string | null>(null);
 
   const handleValueChange = useCallback((fieldId: string, value: string) => {
     setFormValues((prev) => ({ ...prev, [fieldId]: value }));
     setValidationError(null);
+    setInvalidFieldId(null);
   }, []);
 
   // Document preview rendered from the template + scope + any employee-filled
@@ -486,30 +488,48 @@ function DocumentSigningFlow({ token, document, template }: FlowProps) {
   const handleSubmitFormValues = useCallback(async () => {
     // Validate required client fields before proceeding to signature step.
     // Checkboxes require value === "true"; other field types require non-empty.
+    let firstInvalidId: string | null = null;
+    let hasConsentsError = false;
+
     for (const field of formFields) {
       if (!field.required) continue;
       const val = formValues[field.fieldId];
       if (field.fieldType === "checkbox") {
         if (val !== "true") {
-          setValidationError(
-            t(
-              "documents.signing.requiredConsents",
-              "Zaznacz wszystkie wymagane zgody przed podpisaniem dokumentu.",
-            ),
-          );
-          return;
+          firstInvalidId = field.fieldId;
+          hasConsentsError = true;
+          break;
         }
       } else if (!val?.trim()) {
-        setValidationError(
-          t(
-            "documents.signing.requiredFields",
-            "Uzupełnij wszystkie wymagane pola przed podpisaniem dokumentu.",
-          ),
-        );
-        return;
+        firstInvalidId = field.fieldId;
+        break;
       }
     }
+
+    if (firstInvalidId !== null) {
+      setValidationError(
+        hasConsentsError
+          ? t(
+              "documents.signing.requiredConsents",
+              "Zaznacz wszystkie wymagane zgody przed podpisaniem dokumentu.",
+            )
+          : t(
+              "documents.signing.requiredFields",
+              "Uzupełnij wszystkie wymagane pola przed podpisaniem dokumentu.",
+            ),
+      );
+      setInvalidFieldId(firstInvalidId);
+      const el = document.getElementById(`ff_portal_${firstInvalidId}`);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+        const focusable = el.querySelector("input, textarea, select");
+        (focusable as HTMLElement | null)?.focus({ preventScroll: true });
+      }
+      return;
+    }
+
     setValidationError(null);
+    setInvalidFieldId(null);
     await handleFormComplete(formValues);
   }, [formFields, formValues, handleFormComplete, t]);
 
@@ -557,6 +577,7 @@ function DocumentSigningFlow({ token, document, template }: FlowProps) {
                   formFields={formFields}
                   values={formValues}
                   onValueChange={handleValueChange}
+                  invalidFieldId={invalidFieldId}
                 />
               </div>
             </CardContent>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2746.

Closes #2746

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Bug confirmed:** `handleSubmitFormValues` in `sign.form.$token.tsx` correctly caught missing required fields but only set an error message — it never directed the user to the problematic field.

**Changes made (2 files, minimal scope):**

`src/routes/sign.form.$token.tsx`:
- Added `invalidFieldId` state (cleared when user changes any field value).
- Rewrote `handleSubmitFormValues` to track the first failing field ID, then use `document.getElementById('ff_portal_' + fieldId)` to scroll it into view and focus the input inside it.

`src/components/documents/inline-document-form.tsx`:
- Added `invalidFieldId` prop to `InlineDocumentFormProps`.
- Passes `isInvalid` boolean to each `InlineFieldControl`.
- Each field type (checkbox, textarea, select, button_select, text/date input) applies a red `2px solid #ef4444` outline/border when `isInvalid` is true.

**Behavior after fix:** clicking "Podpisz dokument" with an unset required field scrolls the document to that field, focuses it, and highlights it with a red outline. The outline disappears as soon as the user interacts with the field.