### PR TITLE
ci(supabase-migrations): add workflow_dispatch to apply migrations on demand

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -13,6 +13,11 @@ on:
     # migrations AND trigger the Netlify deploy. Path-filtering would let
     # pushes that touch only the frontend skip the deploy gate, defeating
     # the ordering this workflow exists to enforce (#951).
+  # Manual trigger to apply pending migrations on demand — e.g. to recover
+  # from drift after the SUPABASE_DB_URL secret was missing, without waiting
+  # for or forcing an unrelated push to main. Only the `apply` job runs on
+  # dispatch (the Netlify deploy stays push-gated).
+  workflow_dispatch:
 
 jobs:
   # On PR: verify that the migrations already on main are applied to the
@@ -42,7 +47,7 @@ jobs:
   # can't be applied, so a broken schema does not get a frontend in front of it.
   apply:
     name: Apply pending migrations
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## What

Adds a `workflow_dispatch` trigger to `.github/workflows/supabase-migrations.yml` and lets the **apply** job run on it. The Netlify **deploy** job stays push-gated, so a manual migration run does not trigger a production frontend deploy.

## Why

The apply job only ran on `push` to `main`. When the `SUPABASE_DB_URL` repo secret was unset, every merged migration silently failed to auto-apply and drift accumulated (DB stuck at `00040` while `main` reached `00043`). Recovering required forcing an unrelated push. With a manual trigger we can apply pending migrations on demand and verify the secret is working, without waiting for or faking a push.

## How to use after merge

1. Set the `SUPABASE_DB_URL` repo secret to a **psql-reachable** connection string (see note below).
2. Run: `gh workflow run supabase-migrations.yml --ref main` — the apply job applies all pending migrations (`00041`–`00043`) idempotently.

> Note: the connection string currently in `.env.local` uses the pooler port `:5433`, which previously failed `psql` with `Tenant or user not found`. The apply job shells to `psql`, so the secret should use a psql-working string (likely the direct `:5432` endpoint, or a Supavisor-compatible `postgres.<tenant>` username).

🤖 Generated with [Claude Code](https://claude.com/claude-code)