### PR TITLE
Lista dokumentów – uproszczenie kolumn i dodanie informacji o podpisującym oraz dacie podpisu/wygaśnięcia

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -22,7 +22,6 @@ import { DataListFilterBar } from "@/components/crm/data-list-filter-bar";
 import { MiniChartsRow, type MiniChartData } from "@/components/crm/mini-charts";
 import { SidePanel } from "@/components/crm/side-panel";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -507,22 +506,12 @@ function GabinetDocumentsPage() {
         ),
       },
       {
-        id: "category",
-        label: t("gabinet.formDocuments.colCategory", "Kategoria"),
-        className: "min-w-[120px]",
-        render: (item) => (
-          <Badge variant="secondary" className="text-xs">
-            {getCategoryLabel(item.templateId)}
-          </Badge>
-        ),
-      },
-      {
-        id: "entityType",
-        label: t("gabinet.formDocuments.colEntityType", "Typ"),
-        className: "min-w-[100px]",
+        id: "signedBy",
+        label: t("gabinet.formDocuments.colSignedBy", "Podpisał/a"),
+        className: "min-w-[140px]",
         render: (item) => (
           <span className="text-sm text-muted-foreground">
-            {getEntityTypeLabel(item.entityType)}
+            {item.signedByName ?? "—"}
           </span>
         ),
       },
@@ -541,6 +530,26 @@ function GabinetDocumentsPage() {
         render: (item) => (
           <span className="text-sm text-muted-foreground">
             {formatDate(item.createdAt)}
+          </span>
+        ),
+      },
+      {
+        id: "signedAt",
+        label: t("gabinet.formDocuments.colSignedAt", "Data podpisania"),
+        className: "min-w-[130px]",
+        render: (item) => (
+          <span className="text-sm text-muted-foreground">
+            {item.signedAt ? formatDate(item.signedAt) : "—"}
+          </span>
+        ),
+      },
+      {
+        id: "expiresAt",
+        label: t("gabinet.formDocuments.colExpiresAt", "Data wygaśnięcia"),
+        className: "min-w-[130px]",
+        render: (item) => (
+          <span className="text-sm text-muted-foreground">
+            {item.signingTokenExpiresAt ? formatDate(item.signingTokenExpiresAt) : "—"}
           </span>
         ),
       },
@@ -599,7 +608,7 @@ function GabinetDocumentsPage() {
       },
     ];
     return result;
-  }, [t, getCategoryLabel, getEntityTypeLabel, getUserName, formatDate]);
+  }, [t, getUserName, formatDate]);
 
   // --- Column visibility ---
   const { allColumns, defaultHidden } = useAllColumns(columns, filterableFields);
@@ -733,6 +742,7 @@ function GabinetDocumentsPage() {
 
       {/* Data Table */}
       {!docsLoading && filteredDocuments.length > 0 && (
+        <div className="md:[&_th:first-child]:w-[72px] md:[&_td:first-child]:w-[72px]">
         <DocumentsGroupedView
           documents={filteredDocuments}
           columns={allColumns}
@@ -770,6 +780,7 @@ function GabinetDocumentsPage() {
             },
           ]}
         />
+        </div>
       )}
 
       {/* Document viewer side panel */}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2770.

Closes #2770

---

## Claude summary

Done. Here's a summary of what was changed in `src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx`:

**Columns removed:** "Kategoria" (`category`) and "Typ" (`entityType`) — both deleted from the column definitions.

**Columns added:**
- "Podpisał/a" (`signedBy`) — shows `item.signedByName`, replacing the "Typ" slot. Displays "—" when not yet signed. The `signedByName` field was already fetched and mapped from Supabase.
- "Data podpisania" (`signedAt`) — shows the signing timestamp when present, "—" otherwise. Uses the existing `signedAt` field from the mapper.
- "Data wygaśnięcia" (`expiresAt`) — shows `signingTokenExpiresAt` when present, "—" otherwise. Uses the existing field from the mapper.

**Checkbox column width:** Wrapped `DocumentsGroupedView` in a `<div className="md:[&_th:first-child]:w-[72px] md:[&_td:first-child]:w-[72px]">` that overrides the checkbox column to 72px on desktop (was 146px — ~50% reduction). This applies only to the documents list table and doesn't touch the shared `Table` component used by other tables.

**No database changes needed** — all three new data fields (`signedByName`, `signedAt`, `signingTokenExpiresAt`) were already stored in `form_documents` and fetched via `select("*")`.