### PR TITLE
Poprawka listy dokumentów: podpisujący i data wygaśnięcia

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -50,6 +50,7 @@ import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
 import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
 import { useSupabaseFormDocumentsList } from "@/hooks/use-supabase-form-documents";
+import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { useSavedViews, applyFilterConditions } from "@/hooks/use-saved-views";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 
@@ -216,6 +217,15 @@ function GabinetDocumentsPage() {
     }
     return map;
   }, [members]);
+
+  const { data: patients } = useSupabaseGabinetPatientsList(organizationId);
+  const patientMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of patients ?? []) {
+      map.set(p._id, [p.firstName, p.lastName].filter(Boolean).join(" "));
+    }
+    return map;
+  }, [patients]);
 
   // Extract unique categories from loaded templates
   const availableCategories = useMemo(() => {
@@ -509,11 +519,15 @@ function GabinetDocumentsPage() {
         id: "signedBy",
         label: t("gabinet.formDocuments.colSignedBy", "Podpisał/a"),
         className: "min-w-[140px]",
-        render: (item) => (
-          <span className="text-sm text-muted-foreground">
-            {item.signedByName ?? "—"}
-          </span>
-        ),
+        render: (item) => {
+          const name = item.signedByName ||
+            (item.entityType === "patient" ? patientMap.get(item.entityId) : undefined);
+          return (
+            <span className="text-sm text-muted-foreground">
+              {name || "—"}
+            </span>
+          );
+        },
       },
       {
         id: "status",
@@ -549,7 +563,9 @@ function GabinetDocumentsPage() {
         className: "min-w-[130px]",
         render: (item) => (
           <span className="text-sm text-muted-foreground">
-            {item.signingTokenExpiresAt ? formatDate(item.signingTokenExpiresAt) : "—"}
+            {item.status !== "signed" && item.signingTokenExpiresAt
+              ? formatDate(item.signingTokenExpiresAt)
+              : "—"}
           </span>
         ),
       },
@@ -608,7 +624,7 @@ function GabinetDocumentsPage() {
       },
     ];
     return result;
-  }, [t, getUserName, formatDate]);
+  }, [t, getUserName, formatDate, patientMap]);
 
   // --- Column visibility ---
   const { allColumns, defaultHidden } = useAllColumns(columns, filterableFields);

--- a/src/routes/_app/patient/_layout.documents.tsx
+++ b/src/routes/_app/patient/_layout.documents.tsx
@@ -38,6 +38,13 @@ function PatientDocuments() {
     enabled: !!tokenHash,
   });
 
+  const getPortalSession = useAction(api.gabinet.patientAuth.getPortalSession);
+  const { data: portalSession } = useQuery({
+    queryKey: ["gabinet.patientAuth.getPortalSession", tokenHash],
+    queryFn: () => getPortalSession({ tokenHash }),
+    enabled: !!tokenHash,
+  });
+
   const recordSignature = useAction(
     api.documents.documents.recordSignature,
   );
@@ -55,7 +62,7 @@ function PatientDocuments() {
       await recordSignature({
         token: signDoc.signingToken,
         signatureData,
-        signedByName: t("patientPortal.documents.patientSigner", "Patient"),
+        signedByName: portalSession?.patientName ?? t("patientPortal.documents.patientSigner", "Patient"),
       });
       toast.success(t("patientPortal.documents.signed"));
       setSignDocId(null);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2772.

Closes #2772

---

## Claude summary

Done. Here's a summary of what was fixed and why:

**Issue 1 — "Podpisał/a" showing "—"**

Root cause: `form_documents.signed_by_name` was never populated with the actual patient name at signing time. The public signing page stored `""`, the patient portal stored a generic `"Patient"` translation string, and older documents had `null`.

Two-part fix:
1. **Documents page** (`_layout.gabinet.documents.index.tsx`): Added `useSupabaseGabinetPatientsList` to build a `patientMap` (ID → full name). The "Podpisał/a" column now falls back to this map when `signedByName` is empty — specifically for documents where `entityType === "patient"`. Documents linked to appointments still show "—" (name is one join deeper; see Follow-ups).
2. **Patient portal** (`_app/patient/_layout.documents.tsx`): The `getPortalSession` query is already cached by React Query in the parent layout, so re-calling it here costs nothing. Now passes `portalSession.patientName` to `recordSignature` for all future portal signings.

**Issue 2 — Expiry date shown for signed documents**

Fix: Added `item.status !== "signed"` guard to the `expiresAt` column render. Signed documents now show "—"; expired documents continue to show the date; drafts show "—" (already did, since `signingTokenExpiresAt` is null for drafts).

## Follow-ups

- Resolve signer name for appointment-linked documents: when `entityType === "appointment"`, the current fix shows "—" because the patient is one join deeper (`appointment.patientId → gabinetPatients`). Either denormalize the patient name into form_documents at document-creation time, or add an appointments lookup map similar to the patients map added here.
- Fix public signing page to store actual patient name: `src/routes/sign.form.$token.tsx:183` passes `signedByName: ""` because the page is unauthenticated and doesn't know who the signer is. The `recordSignature` Convex action (`convex/documents/documents.ts`) could resolve the patient name from `doc.entityType`/`doc.entityId` server-side and use it as a fallback when the caller passes an empty string.