### PR TITLE
Resolve signer name for appointment-linked documents

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -520,8 +520,19 @@ function GabinetDocumentsPage() {
         label: t("gabinet.formDocuments.colSignedBy", "Podpisał/a"),
         className: "min-w-[140px]",
         render: (item) => {
-          const name = item.signedByName ||
-            (item.entityType === "patient" ? patientMap.get(item.entityId) : undefined);
+          let name = item.signedByName;
+          if (!name) {
+            if (item.entityType === "patient") {
+              name = patientMap.get(item.entityId);
+            } else if (item.entityType === "appointment" && item.scopeEntities) {
+              try {
+                const scope = JSON.parse(item.scopeEntities) as { patient?: string };
+                if (scope.patient) name = patientMap.get(scope.patient);
+              } catch {
+                // malformed scopeEntities — fall through to "—"
+              }
+            }
+          }
           return (
             <span className="text-sm text-muted-foreground">
               {name || "—"}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2775.

Closes #2775

---

## Claude summary

The fix is committed. Here's what was done:

**Root cause:** The "Podpisał/a" (signed-by) column in the documents list only resolved patient names for documents directly linked to patients (`entityType === "patient"`). For appointment-linked documents (`entityType === "appointment"`), `entityId` holds the appointment ID, not the patient ID — so the existing `patientMap` lookup returned nothing and the column showed "—".

**Fix:** When `entityType === "appointment"` and `signedByName` is absent, parse the `scopeEntities` JSON field (which is already stored on the document at creation time as `{ patient: patientId, treatment: treatmentId }`), extract the patient ID, and look it up in the existing `patientMap`. No additional API calls or data fetching needed — all the data was already available.

**File changed:** `src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx:522–541`