### PR TITLE
Fix public signing page to store actual patient name

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -462,12 +462,39 @@ export const recordSignature = action({
     if (doc.status !== "pending_signature")
       throw new Error("Document is not awaiting signature");
 
+    // When the public signing page submits an empty name (unauthenticated flow),
+    // resolve the patient name server-side from the document's entity reference.
+    let resolvedSignedByName = args.signedByName;
+    if (!resolvedSignedByName) {
+      const entityType = doc.entityType as string | undefined;
+      const entityId = doc.entityId as string | undefined;
+      if (entityType === "appointment" && entityId) {
+        const appointment = await db.get("gabinetAppointments", entityId);
+        if (appointment && typeof appointment === "object") {
+          const appt = appointment as { patientId?: string };
+          if (appt.patientId) {
+            const patient = await db.get("gabinetPatients", String(appt.patientId));
+            if (patient && typeof patient === "object") {
+              const p = patient as { firstName?: string; lastName?: string };
+              resolvedSignedByName = [p.firstName, p.lastName].filter(Boolean).join(" ");
+            }
+          }
+        }
+      } else if (entityType === "patient" && entityId) {
+        const patient = await db.get("gabinetPatients", entityId);
+        if (patient && typeof patient === "object") {
+          const p = patient as { firstName?: string; lastName?: string };
+          resolvedSignedByName = [p.firstName, p.lastName].filter(Boolean).join(" ");
+        }
+      }
+    }
+
     const now = Date.now();
     const patch: Record<string, unknown> = {
       status: "signed",
       signatureData: args.signatureData,
       signedAt: now,
-      signedByName: args.signedByName,
+      signedByName: resolvedSignedByName,
       signedByEmail: args.signedByEmail ?? null,
       signedByIp: args.signedByIp ?? null,
       updatedAt: now,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2776.

Closes #2776

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Bug confirmed:** `src/routes/sign.form.$token.tsx:183` passes `signedByName: ""` because the public signing page is unauthenticated and has no knowledge of who the signer is.

**Fix:** In `convex/documents/documents.ts`, the `recordSignature` action now resolves the patient name server-side when `args.signedByName` is empty. It follows the identical pattern already used by `sendForSignature` (lines 405-425): check `doc.entityType` — if it's `"appointment"`, look up the appointment then follow `patientId` to `gabinetPatients`; if it's `"patient"`, look up `gabinetPatients` directly. The resolved full name (`firstName + lastName`) is stored in `signedByName` on the `formDocuments` row. The fallback is graceful — if the patient lookup fails for any reason, `resolvedSignedByName` stays as `""` (no error thrown).