### PR TITLE
Dokumenty: poprawa widoczności Szablonów, statystyk i tłumaczeń

### DIFF
--- a/src/components/crm/data-list-filter-bar.tsx
+++ b/src/components/crm/data-list-filter-bar.tsx
@@ -116,6 +116,8 @@ export interface DataListFilterBarProps {
   hiddenColumnIds?: Set<string>;
   onToggleColumn?: (columnId: string) => void;
   onSetHiddenColumns?: (ids: Set<string>) => void;
+  /** When provided, clicking the columns icon calls this instead of opening the built-in popover. */
+  onColumnSettingsOpen?: () => void;
 
   // Extra dropdown actions
   dropdownActions?: Array<{
@@ -173,6 +175,7 @@ export function DataListFilterBar({
   hiddenColumnIds,
   onToggleColumn,
   onSetHiddenColumns: _onSetHiddenColumns,
+  onColumnSettingsOpen,
   onFiltersChange,
   dropdownActions = [],
   onTagsManage: _onTagsManage,
@@ -480,7 +483,12 @@ export function DataListFilterBar({
             </span>
           </Button>
         )}
-        {columnDefs && columnDefs.length > 0 && onToggleColumn && (
+        {onColumnSettingsOpen && (
+          <button type="button" className="group relative inline-flex h-max cursor-pointer items-center justify-center rounded-lg border border-border-primary bg-bg-primary px-2 py-1.5 text-fg-quaternary shadow-xs hover:bg-bg-primary_hover hover:text-fg-tertiary" onClick={onColumnSettingsOpen}>
+            <Columns03 className="size-4 stroke-[2px]" />
+          </button>
+        )}
+        {!onColumnSettingsOpen && columnDefs && columnDefs.length > 0 && onToggleColumn && (
           <Popover>
             <PopoverTrigger asChild>
               <button type="button" className="group relative inline-flex h-max cursor-pointer items-center justify-center rounded-lg border border-border-primary bg-bg-primary px-2 py-1.5 text-fg-quaternary shadow-xs hover:bg-bg-primary_hover hover:text-fg-tertiary">

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -33,6 +33,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { FileText, Send, Download, Menu, Trash2, Calendar, User, Tag, FileSignature, Pencil } from "@/lib/ez-icons";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -127,6 +128,7 @@ function GabinetDocumentsPage() {
   const [tagsSlideoutOpen, setTagsSlideoutOpen] = useState(false);
   const [categoriesSlideoutOpen, setCategoriesSlideoutOpen] = useState(false);
   const [filterSlideoutOpen, setFilterSlideoutOpen] = useState(false);
+  const [columnSettingsOpen, setColumnSettingsOpen] = useState(false);
 
   useSidebarDispatch("openFilter", () => setFilterSlideoutOpen(true));
   useSidebarDispatch("createFromTemplate", () =>
@@ -550,6 +552,7 @@ function GabinetDocumentsPage() {
       },
       {
         id: "actions",
+        label: t("common.actions", "Akcje"),
         render: (item) => (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -655,7 +658,7 @@ function GabinetDocumentsPage() {
             onClick={() =>
               navigate({ to: "/dashboard/gabinet/document-templates" })
             }
-            variant="outline"
+            variant="default"
           >
             <FileText className="mr-2 h-4 w-4" />
             {t("gabinet.formDocuments.manageTemplates", "Szablony")}
@@ -684,10 +687,7 @@ function GabinetDocumentsPage() {
         onFiltersChange={setActiveFilters}
         onTagsManage={() => setTagsSlideoutOpen(true)}
         onCategoriesManage={() => setCategoriesSlideoutOpen(true)}
-        columnDefs={allColumns.map(c => ({ id: c.id, label: c.label ?? c.id }))}
-        hiddenColumnIds={hiddenColumnIds}
-        onToggleColumn={toggleColumn}
-        onSetHiddenColumns={setHiddenColumns}
+        onColumnSettingsOpen={() => setColumnSettingsOpen(true)}
       />
 
       {/* Loading state */}
@@ -699,19 +699,7 @@ function GabinetDocumentsPage() {
         </div>
       )}
 
-      {/* Mini charts */}
-      {!docsLoading && documents && documents.length > 0 && (
-        <MiniChartsRow
-          leftChart={{
-            title: t("gabinet.formDocuments.byDay", "Dokumenty w czasie"),
-            data: documentsByDay,
-          }}
-          rightChart={{
-            title: t("gabinet.formDocuments.byStatus", "Dokumenty według statusu"),
-            data: documentsByStatus,
-          }}
-        />
-      )}
+      {/* Statistics — collapsed by default, user can expand */}
 
       {/* Empty state */}
       {!docsLoading && filteredDocuments.length === 0 && (
@@ -767,6 +755,52 @@ function GabinetDocumentsPage() {
         />
         </div>
       )}
+
+      {/* Statistics — below the list so the document list stays primary */}
+      {!docsLoading && documents && documents.length > 0 && (
+        <MiniChartsRow
+          storageKey="gabinetDocuments"
+          leftChart={{
+            title: t("gabinet.formDocuments.byDay", "Dokumenty w czasie"),
+            data: documentsByDay,
+          }}
+          rightChart={{
+            title: t("gabinet.formDocuments.byStatus", "Dokumenty według statusu"),
+            data: documentsByStatus,
+          }}
+        />
+      )}
+
+      {/* Column settings side panel */}
+      <SidePanel
+        open={columnSettingsOpen}
+        onOpenChange={setColumnSettingsOpen}
+        title={t("common.columnSettings", "Ustawienia kolumn")}
+      >
+        <div className="space-y-1 py-2">
+          {/* TODO: entityType and category columns hidden per #2780 — restore here if needed */}
+          {allColumns
+            .filter((col) => !["entityType", "category", "actions"].includes(col.id))
+            .map((col) => {
+              const isVisible = !hiddenColumnIds.has(col.id);
+              return (
+                <button
+                  key={col.id}
+                  type="button"
+                  className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left hover:bg-muted/50 transition-colors"
+                  onClick={() => toggleColumn(col.id)}
+                >
+                  <Checkbox
+                    checked={isVisible}
+                    className="pointer-events-none"
+                    aria-hidden
+                  />
+                  <span className="text-sm font-medium">{col.label ?? col.id}</span>
+                </button>
+              );
+            })}
+        </div>
+      </SidePanel>
 
       {/* Document viewer side panel */}
       <SidePanel


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2780.

Closes #2780

---

## Claude summary

All five changes from issue #2780 are implemented and committed. Here's a summary of what was done:

**1. "Szablony" button** — Changed from `variant="outline"` to `variant="default"` (primary style) in the `PageHeader` actions area, making it immediately visible.

**2. Statistics** — Moved `MiniChartsRow` to below the document list (so the list is always the first thing visible) and added `storageKey="gabinetDocuments"` to make it collapsible, defaulting to collapsed on first load.

**3. Column settings side panel** — Added an optional `onColumnSettingsOpen` prop to `DataListFilterBar` (`src/components/crm/data-list-filter-bar.tsx`). When provided, the columns icon calls the callback instead of opening the popover. The documents page now opens a `SidePanel` from the right with column visibility controls.

**4. Polish translations** — Added `label: t("common.actions", "Akcje")` to the actions column so it shows "Akcje" (instead of "actions") in the column settings panel.

**5. Typ and Kategoria hidden** — The column settings side panel filters out `entityType`, `category`, and `actions` columns from the user-configurable list. They remain in code with a `TODO` comment referencing #2780 for easy restoration.

## Follow-ups

- Translate "actions" column label in other modules using DataListFilterBar: the same English "actions" issue may exist in contacts, companies, leads, activities, and other list pages that use the column popover.
- Extend `onColumnSettingsOpen` to other modules needing a side panel: CRM modules (contacts, leads, etc.) could benefit from the same side panel UX for column settings — currently only gabinet/documents uses it.