### PR TITLE
Extend column settings side panel to gabinet list views

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -10,7 +10,9 @@ import { useSupabaseOrganizationMembers } from "@/hooks/use-supabase-organizatio
 import { useOrganization } from "@/components/org-context";
 import { PageHeader } from "@/components/layout/page-header";
 import { CrmDataTable, useColumnVisibility, useAllColumns, type CrmColumn } from "@/components/crm/enhanced-data-table";
+import { SidePanel } from "@/components/crm/side-panel";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import {
   Sheet,
@@ -302,6 +304,7 @@ function EmployeesIndex() {
 
   const { allColumns, defaultHidden } = useAllColumns(columns, filterableFields);
   const { hiddenColumnIds, toggleColumn, setHiddenColumns } = useColumnVisibility(defaultHidden, "gabinet-employees");
+  const [columnSettingsOpen, setColumnSettingsOpen] = useState(false);
 
   const editingSchedulePeriods = useMemo(() => {
     if (!editingScheduleEmployee) return [];
@@ -441,6 +444,7 @@ function EmployeesIndex() {
         hiddenColumnIds={hiddenColumnIds}
         onToggleColumn={toggleColumn}
         onSetHiddenColumns={setHiddenColumns}
+        onColumnSettingsOpen={() => setColumnSettingsOpen(true)}
         onFiltersChange={setActiveFilters}
         onTagsManage={() => setTagsSlideoutOpen(true)}
         onCategoriesManage={() => setCategoriesSlideoutOpen(true)}
@@ -476,6 +480,29 @@ function EmployeesIndex() {
         entityType="gabinetEmployee"
         categories={categories}
       />
+
+      <SidePanel
+        open={columnSettingsOpen}
+        onOpenChange={setColumnSettingsOpen}
+        title={t("common.columnSettings", "Ustawienia kolumn")}
+      >
+        <div className="space-y-1 py-2">
+          {allColumns.map((col) => {
+            const isVisible = !hiddenColumnIds.has(col.id);
+            return (
+              <button
+                key={col.id}
+                type="button"
+                className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left hover:bg-muted/50 transition-colors"
+                onClick={() => toggleColumn(col.id)}
+              >
+                <Checkbox checked={isVisible} className="pointer-events-none" aria-hidden />
+                <span className="text-sm font-medium">{col.label ?? col.id}</span>
+              </button>
+            );
+          })}
+        </div>
+      </SidePanel>
 
       <CreateEmployeeSheet
         open={showCreate}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -13,6 +13,7 @@ import { CrmDataTable, useColumnVisibility, useAllColumns, type CrmColumn } from
 import { DataListFilterBar } from "@/components/crm/data-list-filter-bar";
 import { MiniChartsRow, useChartsToggleState, ChartsToggleButton } from "@/components/crm/mini-charts";
 import { SidePanel } from "@/components/crm/side-panel";
+import { Checkbox } from "@/components/ui/checkbox";
 import { PatientForm } from "@/components/forms/patient-form";
 import { MergePatientsDialog } from "@/components/gabinet/merge-patients-dialog";
 import { Button } from "@/components/ui/button";
@@ -462,6 +463,7 @@ function PatientsIndex() {
     return hidden;
   }, [defaultHidden]);
   const { hiddenColumnIds, toggleColumn, setHiddenColumns } = useColumnVisibility(patientsDefaultHidden, "gabinet-patients");
+  const [columnSettingsOpen, setColumnSettingsOpen] = useState(false);
 
   const handleCreate = useCallback(
     async (formData: {
@@ -627,6 +629,7 @@ function PatientsIndex() {
         hiddenColumnIds={hiddenColumnIds}
         onToggleColumn={toggleColumn}
         onSetHiddenColumns={setHiddenColumns}
+        onColumnSettingsOpen={() => setColumnSettingsOpen(true)}
         onTagsManage={() => setTagsSlideoutOpen(true)}
         onCategoriesManage={() => setCategoriesSlideoutOpen(true)}
         onFiltersChange={setActiveFilters}
@@ -680,6 +683,29 @@ function PatientsIndex() {
           navigate({ to: `/dashboard/gabinet/patients/${patientId}` })
         }
       />
+
+      <SidePanel
+        open={columnSettingsOpen}
+        onOpenChange={setColumnSettingsOpen}
+        title={t("common.columnSettings", "Ustawienia kolumn")}
+      >
+        <div className="space-y-1 py-2">
+          {allColumns.map((col) => {
+            const isVisible = !hiddenColumnIds.has(col.id);
+            return (
+              <button
+                key={col.id}
+                type="button"
+                className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left hover:bg-muted/50 transition-colors"
+                onClick={() => toggleColumn(col.id)}
+              >
+                <Checkbox checked={isVisible} className="pointer-events-none" aria-hidden />
+                <span className="text-sm font-medium">{col.label ?? col.id}</span>
+              </button>
+            );
+          })}
+        </div>
+      </SidePanel>
 
       <SidePanel
         open={panelOpen}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -13,6 +13,7 @@ import { CrmDataTable, useColumnVisibility, useAllColumns } from "@/components/c
 import type { CrmColumn } from "@/components/crm/enhanced-data-table";
 import { DataListFilterBar } from "@/components/crm/data-list-filter-bar";
 import { SidePanel } from "@/components/crm/side-panel";
+import { Checkbox } from "@/components/ui/checkbox";
 import { TreatmentForm } from "@/components/gabinet/treatment-form";
 import type { TreatmentFormData } from "@/components/gabinet/treatment-form";
 import { Button } from "@/components/ui/button";
@@ -429,6 +430,7 @@ function TreatmentsIndex() {
 
   const { allColumns, defaultHidden } = useAllColumns(columns, filterableFields);
   const { hiddenColumnIds, toggleColumn, setHiddenColumns } = useColumnVisibility(defaultHidden, "gabinet-treatments");
+  const [columnSettingsOpen, setColumnSettingsOpen] = useState(false);
 
   const treatmentGroups = useMemo(() => {
     if (!groupByEquipment) return null;
@@ -731,6 +733,7 @@ function TreatmentsIndex() {
         hiddenColumnIds={hiddenColumnIds}
         onToggleColumn={toggleColumn}
         onSetHiddenColumns={setHiddenColumns}
+        onColumnSettingsOpen={() => setColumnSettingsOpen(true)}
         onTagsManage={() => setTagsSlideoutOpen(true)}
         onCategoriesManage={() => setCategoriesSlideoutOpen(true)}
         onFiltersChange={setActiveFilters}
@@ -869,6 +872,29 @@ function TreatmentsIndex() {
           }
         />
       )}
+
+      <SidePanel
+        open={columnSettingsOpen}
+        onOpenChange={setColumnSettingsOpen}
+        title={t("common.columnSettings", "Ustawienia kolumn")}
+      >
+        <div className="space-y-1 py-2">
+          {allColumns.map((col) => {
+            const isVisible = !hiddenColumnIds.has(col.id);
+            return (
+              <button
+                key={col.id}
+                type="button"
+                className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left hover:bg-muted/50 transition-colors"
+                onClick={() => toggleColumn(col.id)}
+              >
+                <Checkbox checked={isVisible} className="pointer-events-none" aria-hidden />
+                <span className="text-sm font-medium">{col.label ?? col.id}</span>
+              </button>
+            );
+          })}
+        </div>
+      </SidePanel>
 
       <SidePanel
         open={panelOpen}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2786.

Closes #2786

---

## Claude summary

Done. The issue was real — all three gabinet list views were using the inline Popover (old approach) for column visibility instead of the SidePanel approach introduced for CRM views in #2783.

Changes made to all three files:
- `_layout.gabinet.patients.index.tsx` — added `Checkbox` import, `columnSettingsOpen` state, `onColumnSettingsOpen` on `DataListFilterBar`, and a new `SidePanel` with column checkboxes
- `_layout.gabinet.treatments.index.tsx` — same additions
- `_layout.gabinet.employees.index.tsx` — same additions, plus `SidePanel` and `Checkbox` imports (employees didn't previously import `SidePanel`)