### PR TITLE
Missing Supabase-side search for form documents by patient appointments

### DIFF
--- a/convex/gabinet/_helpers/autoGenerateDocuments.ts
+++ b/convex/gabinet/_helpers/autoGenerateDocuments.ts
@@ -99,22 +99,29 @@ export async function autoGenerateAppointmentDocuments(
 
   for (const entry of requiredTemplates) {
     try {
-      // Skip if this is a one-time document and the patient has already signed it
+      // Skip if this is a one-time document and the patient has already signed it.
+      // Uses a two-step query: fetch the patient's appointment IDs (indexed on
+      // organization_id, patient_id), then check form_documents by entity_id IN
+      // (those IDs). This avoids the previous O(N-org) scan + in-memory JSON parse
+      // that was needed because scope_entities is TEXT, not JSONB.
       if (entry.isOneTime) {
-        const signedForPatient = await supabaseDb
-          .query("formDocuments")
-          .eq("templateId", String(entry.templateId))
+        const patientAppointments = await supabaseDb
+          .query("gabinetAppointments")
+          .eq("patientId", String(args.patientId))
           .eq("organizationId", String(args.organizationId))
-          .eq("status", "signed")
           .collect();
-        const alreadySigned = signedForPatient.some((doc) => {
-          const scope =
-            typeof doc.scopeEntities === "string"
-              ? (JSON.parse(doc.scopeEntities as string) as Record<string, unknown>)
-              : (doc.scopeEntities as Record<string, unknown> | null);
-          return scope?.patient === String(args.patientId);
-        });
-        if (alreadySigned) continue;
+        if (patientAppointments.length > 0) {
+          const appointmentIds = patientAppointments.map((a) => String(a._id));
+          const alreadySigned = await supabaseDb
+            .query("formDocuments")
+            .eq("templateId", String(entry.templateId))
+            .eq("organizationId", String(args.organizationId))
+            .eq("entityType", "appointment")
+            .eq("status", "signed")
+            .in("entityId", appointmentIds)
+            .first();
+          if (alreadySigned) continue;
+        }
       }
 
       // Skip if a document for this template+appointment already exists


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2788.

Closes #2788

---

## Claude summary

The issue is fixed. Here's a summary of what I found and did:

**Triage**: The issue was real. The `getLatestSignedInterview` name was a forward-looking label coined during issue #2784 work, but the underlying problem existed concretely in `convex/gabinet/_helpers/autoGenerateDocuments.ts`.

**Root cause**: The `isOneTime` deduplication check (which prevents re-generating a consent form a patient has already signed across any previous appointment) was:
1. Fetching ALL signed `form_documents` for the given template across the entire org
2. Parsing each `scope_entities` TEXT column as JSON in memory to find the patient match

This is O(N) over all patients who ever signed that template — gets slower as the org grows.

**Why the direct Supabase filter wasn't possible**: `scope_entities` is stored as `TEXT`, not `JSONB`, in Postgres. The existing `SupabaseQueryBuilder` has no containment filter method, and `@>` requires `JSONB` type.

**Fix** (`convex/gabinet/_helpers/autoGenerateDocuments.ts`): Two-step indexed query:
1. Fetch the patient's appointment IDs using the existing `(organization_id, patient_id)` index on `gabinet_appointments` — typically a small set
2. Query `form_documents` with `entity_id IN (appointment_ids)` + template + `status = 'signed'` + `entity_type = 'appointment'` → exits after the first match

Both queries use existing Postgres indexes and no schema changes are needed.

## Follow-ups

- Migrate `scope_entities` column from TEXT to JSONB in Supabase: Would enable direct Postgres containment queries (`scope_entities @> '{"patient":"..."}'`) and a GIN index, eliminating the need for the two-step appointment fetch when scope_entities filtering is needed elsewhere
- Add `.contains()` method to `SupabaseQueryBuilder`: Once `scope_entities` is JSONB, a `.contains(field, value)` builder method would allow pushing JSONB containment queries to Postgres without needing raw client access