### PR TITLE
Regresja: w Szablonach formularzy pokazują się statystyki z dashboardu zamiast danych modułu

### DIFF
--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -190,6 +190,14 @@ export const gabinetManifest: ModuleManifest = {
       ],
     },
     {
+      key: "document-templates",
+      titleKey: "nav.gabinet.documentTemplates",
+      matches: [{ to: "/dashboard/gabinet/document-templates" }],
+      actions: [
+        { labelKey: "nav.actions.addTemplate", icon: PlusCircle, href: "/dashboard/document-editor/new" },
+      ],
+    },
+    {
       key: "reports",
       titleKey: "nav.gabinet.reports",
       widgets: GabinetReportsWidgets,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2789.

Closes #2789

---

## Claude summary

The fix is committed. Here's a summary of the bug and the resolution:

**Root cause**: `src/modules/gabinet/manifest.ts` had no `pageContext` entry matching the route `/dashboard/gabinet/document-templates`. Since `fallbackPageContextKey: "dashboard"` is set on the manifest, any unmatched route falls back to the `dashboard` page context — which renders `GabinetDashboardWidgets` (visits today, confirmed, clients, active employees, weekly overview, today's schedule) in the left sidebar panel.

**Fix**: Added a new `document-templates` page context entry (lines 192–199 in the manifest) that explicitly matches `/dashboard/gabinet/document-templates`. It has no `widgets` (consistent with the adjacent `documents` context), only a single action "Dodaj szablon" → `/dashboard/document-editor/new`. Now the sidebar panel correctly shows the template management title and action instead of the appointment dashboard widgets.

One file changed, 8 lines added.