### PR TITLE
Add `.contains()` method to `SupabaseQueryBuilder`

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -374,6 +374,16 @@ class SupabaseQueryBuilder<T = Record<string, unknown>> {
     return this;
   }
 
+  /**
+   * JSONB containment filter (`@>` operator). Checks whether the column value
+   * contains all key-value pairs in `value` (for objects) or all elements in
+   * `value` (for arrays). Only meaningful for JSONB / array columns in Postgres.
+   */
+  contains(field: string, value: Record<string, unknown> | unknown[]) {
+    this.filters.push((q) => q.contains(toSnakeCase(field), value));
+    return this;
+  }
+
   order(field: string, ascending = true) {
     this.orderBy.push({ field: toSnakeCase(field), ascending });
     return this;

--- a/tests/convex/_supabase_inmemory.ts
+++ b/tests/convex/_supabase_inmemory.ts
@@ -259,6 +259,22 @@ class InMemoryQueryBuilder<T = Record<string, unknown>> {
     return this;
   }
 
+  contains(field: string, value: Record<string, unknown> | unknown[]) {
+    this.filters.push((row) => {
+      const col = row[field];
+      if (col === null || col === undefined) return false;
+      if (Array.isArray(value)) {
+        if (!Array.isArray(col)) return false;
+        const colArr = col as unknown[];
+        return value.every((v) => colArr.includes(v));
+      }
+      if (typeof col !== "object") return false;
+      const colObj = col as Record<string, unknown>;
+      return Object.entries(value).every(([k, v]) => colObj[k] === v);
+    });
+    return this;
+  }
+
   order(field: string, ascending = true) {
     this.orderBy.push({ field, ascending });
     return this;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2792.

Closes #2792

---

## Claude summary

Done. Here's a summary of what was added:

**`convex/_helpers/supabaseDb.ts`** — `SupabaseQueryBuilder.contains(field, value)` delegates to the Supabase JS client's `.contains()` method, which maps to the Postgres `@>` JSONB containment operator. The field name is converted to snake_case like all other builder methods.

**`tests/convex/_supabase_inmemory.ts`** — `InMemoryQueryBuilder.contains(field, value)` implements the equivalent in-memory logic: for object values it checks that all key-value pairs exist in the stored object; for array values it checks that all elements are present in the stored array.

Callers can now write:
```ts
db.query("formDocuments")
  .contains("scopeEntities", { patient: patientId })
  .collect()
```
instead of pulling the raw client for JSONB containment queries.

## Follow-ups

- Add missing `in` method to `InMemoryQueryBuilder` in `tests/convex/_supabase_inmemory.ts`: `SupabaseQueryBuilder.in()` was added (used in `autoGenerateDocuments.ts`) but the in-memory stub never received the matching method, so any test that exercises the one-time-doc code path with `.in()` would throw at runtime
- Add missing `or` method to `InMemoryQueryBuilder` in `tests/convex/_supabase_inmemory.ts`: same gap — `SupabaseQueryBuilder.or()` exists but has no in-memory equivalent, leaving any test that hits an `.or()` query uncovered