### PR TITLE
Add missing `in` method to `InMemoryQueryBuilder` in `tests/convex/_supabase_inm

### DIFF
--- a/tests/convex/_supabase_inmemory.ts
+++ b/tests/convex/_supabase_inmemory.ts
@@ -259,6 +259,12 @@ class InMemoryQueryBuilder<T = Record<string, unknown>> {
     return this;
   }
 
+  in(field: string, values: unknown[]) {
+    const set = new Set(values);
+    this.filters.push((r) => set.has(r[field]));
+    return this;
+  }
+
   contains(field: string, value: Record<string, unknown> | unknown[]) {
     this.filters.push((row) => {
       const col = row[field];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2796.

Closes #2796

---

## Claude summary

The bug was real and the fix is simple. `InMemoryQueryBuilder` in `tests/convex/_supabase_inmemory.ts` was missing the `in(field, values)` method, even though `SupabaseQueryBuilder` in `convex/_helpers/supabaseDb.ts` has one (line 372) and it's called in `autoGenerateDocuments.ts`, `gabinet/patients.ts`, and `documents/documents.ts`. The `InMemoryRawQuery` class in the same file already had `in()` — only the higher-level `InMemoryQueryBuilder` was missing it.

Added the method at line 262 using a `Set` for O(1) lookup, matching the pattern used in `InMemoryRawQuery`.