### PR TITLE
Szablony dokumentów: uporządkowanie nazw oraz kolejności typów i kategorii

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1572,14 +1572,14 @@
         "employee": "Employee"
       },
       "categories": {
+        "intake": "Health Questionnaire",
         "consent": "Consent",
+        "protocol": "Treatment Protocol",
         "medical_record": "Medical Record",
         "prescription": "Prescription",
         "referral": "Referral",
         "contract": "Contract",
         "invoice": "Invoice",
-        "protocol": "Protocol",
-        "intake": "Intake Form",
         "custom": "Custom"
       },
       "signatureMethods": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1575,14 +1575,14 @@
         "employee": "Pracownik"
       },
       "categories": {
+        "intake": "Wywiad",
         "consent": "Zgoda",
+        "protocol": "Protokół zabiegu",
         "medical_record": "Karta medyczna",
         "prescription": "Recepta",
         "referral": "Skierowanie",
         "contract": "Umowa",
         "invoice": "Faktura",
-        "protocol": "Protokół",
-        "intake": "Formularz przyjęcia",
         "custom": "Własny"
       },
       "signatureMethods": {

--- a/src/components/documents/template-settings-sheet.tsx
+++ b/src/components/documents/template-settings-sheet.tsx
@@ -75,14 +75,14 @@ interface TemplateSettingsSheetProps {
 // ---------------------------------------------------------------------------
 
 const CATEGORY_OPTIONS: FormCategory[] = [
+  "intake",
   "consent",
+  "protocol",
   "medical_record",
   "prescription",
   "referral",
   "contract",
   "invoice",
-  "protocol",
-  "intake",
   "custom",
 ];
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2799.

Closes #2799

---

## Claude summary

Done. Here's a summary of the changes:

**3 files changed, minimal scope:**

`src/components/documents/template-settings-sheet.tsx` — reordered `CATEGORY_OPTIONS` to follow natural beauty-salon workflow: Wywiad → Zgoda → Protokół zabiegu → Karta medyczna → Recepta → Skierowanie → Umowa → Faktura → Własny.

`public/locales/pl/translation.json` — renamed `intake` → "Wywiad" and `protocol` → "Protokół zabiegu". Keys order updated to match the dropdown order.

`public/locales/en/translation.json` — renamed `intake` → "Health Questionnaire" and `protocol` → "Treatment Protocol".

**What stayed unchanged:** all schema values (string keys like `"intake"`, `"consent"`, etc. are intact), the `FormCategory` TypeScript type union, all signing/signature logic, and everything else unrelated to labels and display order.

The `intake` category is now "Wywiad" and appears first in the dropdown — ready to be the designated data source when medical-notes automation is implemented in a future issue.