### PR TITLE
feat(documents): add getLatestSignedIntakeByPatient action (closes #2802)

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -188,6 +188,102 @@ export const listByStatus = action({
   },
 });
 
+/**
+ * Returns the most recently signed "Wywiad" (intake) document for a patient.
+ *
+ * Searches both entity types:
+ *  - documents linked directly to the patient (entityType = "patient")
+ *  - documents linked to the patient's appointments via scopeEntities.patient
+ *
+ * Returns null when the patient has no completed intake document.
+ */
+export const getLatestSignedIntakeByPatient = action({
+  args: {
+    organizationId: v.id("organizations"),
+    patientId: v.string(),
+  },
+  handler: async (ctx, args): Promise<{
+    id: string;
+    responseData: string;
+    formFieldValues: Record<string, string>;
+    signedAt: number | null;
+    templateId: string;
+  } | null> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+
+    const db = createSupabaseDb();
+    const orgIdStr = String(args.organizationId);
+
+    // Collect all "intake" ("Wywiad") template IDs for this org
+    const intakeTemplates = await db
+      .query("formTemplates")
+      .eq("organizationId", orgIdStr)
+      .eq("category", "intake")
+      .collect();
+
+    if (intakeTemplates.length === 0) return null;
+
+    const intakeTemplateIds = intakeTemplates.map((t) => String(t._id));
+
+    // Query 1: documents linked directly to the patient
+    const directDocs = await db
+      .query("formDocuments")
+      .eq("organizationId", orgIdStr)
+      .eq("entityType", "patient")
+      .eq("entityId", args.patientId)
+      .in("templateId", intakeTemplateIds)
+      .in("status", ["signed", "completed"])
+      .collect();
+
+    // Query 2: documents linked to the patient's appointments.
+    // Uses the GIN index on scope_entities JSONB (migration 00044).
+    const appointmentDocs = await db
+      .query("formDocuments")
+      .eq("organizationId", orgIdStr)
+      .eq("entityType", "appointment")
+      .in("templateId", intakeTemplateIds)
+      .in("status", ["signed", "completed"])
+      .contains("scopeEntities", { patient: args.patientId })
+      .collect();
+
+    const allDocs = [...directDocs, ...appointmentDocs];
+    if (allDocs.length === 0) return null;
+
+    // Most recent first: prefer signedAt, fall back to updatedAt/createdAt
+    allDocs.sort((a, b) => {
+      const aTime = ((a.signedAt ?? a.updatedAt ?? a.createdAt) as number) ?? 0;
+      const bTime = ((b.signedAt ?? b.updatedAt ?? b.createdAt) as number) ?? 0;
+      return bTime - aTime;
+    });
+
+    const latest = allDocs[0];
+
+    // Extract formFieldValues from the stored responseData JSON
+    let formFieldValues: Record<string, string> = {};
+    try {
+      const parsed = JSON.parse(latest.responseData as string);
+      const raw = parsed?.formFieldValues;
+      if (raw && typeof raw === "object") {
+        for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+          formFieldValues[k] = String(v);
+        }
+      }
+    } catch {
+      // Non-JSON responseData: formFieldValues stays empty
+    }
+
+    return {
+      id: String(latest._id),
+      responseData: latest.responseData as string,
+      formFieldValues,
+      signedAt: (latest.signedAt as number | null | undefined) ?? null,
+      templateId: String(latest.templateId),
+    };
+  },
+});
+
 export const create = action({
   args: {
     organizationId: v.id("organizations"),

--- a/tests/convex/getLatestSignedIntakeByPatient.test.ts
+++ b/tests/convex/getLatestSignedIntakeByPatient.test.ts
@@ -1,0 +1,352 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+describe("documents.getLatestSignedIntakeByPatient", () => {
+  async function setup() {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const db = createSupabaseDb();
+    const now = Date.now();
+
+    const patientId = await t.run(async (ctx) => {
+      return await ctx.db.insert("gabinetPatients", {
+        organizationId,
+        firstName: "Anna",
+        lastName: "Kowalska",
+        email: "anna@example.com",
+        isActive: true,
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    await db.insert("gabinetPatients", {
+      _id: patientId,
+      organizationId: String(organizationId),
+      firstName: "Anna",
+      lastName: "Kowalska",
+      email: "anna@example.com",
+      isActive: true,
+      createdBy: String(userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Seed an intake form template
+    const templateId = await t.run(async (ctx) => {
+      return await ctx.db.insert("formTemplates", {
+        organizationId,
+        name: "Wywiad lekarki",
+        category: "intake",
+        formJson: "{}",
+        modules: ["gabinet"],
+        entityTypes: ["patient", "appointment"],
+        requiresSignature: true,
+        version: 1,
+        isActive: true,
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    await db.insert("formTemplates", {
+      _id: templateId,
+      organizationId: String(organizationId),
+      name: "Wywiad lekarki",
+      category: "intake",
+      formJson: "{}",
+      modules: ["gabinet"],
+      entityTypes: ["patient", "appointment"],
+      requiresSignature: true,
+      version: 1,
+      isActive: true,
+      createdBy: String(userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return { t, organizationId, userId, identity, patientId, templateId, db, now };
+  }
+
+  test("returns null when no intake documents exist", async () => {
+    const { t, organizationId, identity, patientId } = await setup();
+
+    const result = await t.withIdentity(identity).action(
+      api.documents.documents.getLatestSignedIntakeByPatient,
+      { organizationId, patientId: String(patientId) },
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null when intake exists but is not signed/completed", async () => {
+    const { t, organizationId, userId, identity, patientId, templateId, db, now } = await setup();
+
+    const docId = await t.run(async (ctx) => {
+      return await ctx.db.insert("formDocuments", {
+        organizationId,
+        templateId,
+        title: "Wywiad",
+        responseData: JSON.stringify({ formFieldValues: { q1: "a1" } }),
+        entityType: "patient",
+        entityId: String(patientId),
+        status: "pending_signature",
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    await db.insert("formDocuments", {
+      _id: docId,
+      organizationId: String(organizationId),
+      templateId: String(templateId),
+      title: "Wywiad",
+      responseData: JSON.stringify({ formFieldValues: { q1: "a1" } }),
+      entityType: "patient",
+      entityId: String(patientId),
+      status: "pending_signature",
+      createdBy: String(userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await t.withIdentity(identity).action(
+      api.documents.documents.getLatestSignedIntakeByPatient,
+      { organizationId, patientId: String(patientId) },
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("returns signed intake document linked directly to patient", async () => {
+    const { t, organizationId, userId, identity, patientId, templateId, db, now } = await setup();
+
+    const signedAt = now + 1000;
+    const responseData = JSON.stringify({ formFieldValues: { name: "Anna", age: "30" } });
+
+    const docId = await t.run(async (ctx) => {
+      return await ctx.db.insert("formDocuments", {
+        organizationId,
+        templateId,
+        title: "Wywiad",
+        responseData,
+        entityType: "patient",
+        entityId: String(patientId),
+        status: "signed",
+        signedAt,
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    await db.insert("formDocuments", {
+      _id: docId,
+      organizationId: String(organizationId),
+      templateId: String(templateId),
+      title: "Wywiad",
+      responseData,
+      entityType: "patient",
+      entityId: String(patientId),
+      status: "signed",
+      signedAt,
+      createdBy: String(userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await t.withIdentity(identity).action(
+      api.documents.documents.getLatestSignedIntakeByPatient,
+      { organizationId, patientId: String(patientId) },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(String(docId));
+    expect(result!.signedAt).toBe(signedAt);
+    expect(result!.responseData).toBe(responseData);
+    expect(result!.formFieldValues).toEqual({ name: "Anna", age: "30" });
+    expect(result!.templateId).toBe(String(templateId));
+  });
+
+  test("returns intake document linked to appointment via scopeEntities", async () => {
+    const { t, organizationId, userId, identity, patientId, templateId, db, now } = await setup();
+
+    const signedAt = now + 2000;
+    const responseData = JSON.stringify({ formFieldValues: { condition: "healthy" } });
+
+    const docId = await t.run(async (ctx) => {
+      return await ctx.db.insert("formDocuments", {
+        organizationId,
+        templateId,
+        title: "Wywiad — wizyta",
+        responseData,
+        entityType: "appointment",
+        entityId: "appt-uuid-123",
+        scopeEntities: JSON.stringify({ patient: String(patientId) }),
+        status: "signed",
+        signedAt,
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    await db.insert("formDocuments", {
+      _id: docId,
+      organizationId: String(organizationId),
+      templateId: String(templateId),
+      title: "Wywiad — wizyta",
+      responseData,
+      entityType: "appointment",
+      entityId: "appt-uuid-123",
+      scopeEntities: { patient: String(patientId) },
+      status: "signed",
+      signedAt,
+      createdBy: String(userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await t.withIdentity(identity).action(
+      api.documents.documents.getLatestSignedIntakeByPatient,
+      { organizationId, patientId: String(patientId) },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(String(docId));
+    expect(result!.signedAt).toBe(signedAt);
+    expect(result!.formFieldValues).toEqual({ condition: "healthy" });
+  });
+
+  test("returns the most recently signed document when multiple exist", async () => {
+    const { t, organizationId, userId, identity, patientId, templateId, db, now } = await setup();
+
+    const olderSignedAt = now + 1000;
+    const newerSignedAt = now + 5000;
+    const responseOld = JSON.stringify({ formFieldValues: { visit: "first" } });
+    const responseNew = JSON.stringify({ formFieldValues: { visit: "second" } });
+
+    const [oldDocId, newDocId] = await t.run(async (ctx) => {
+      const a = await ctx.db.insert("formDocuments", {
+        organizationId,
+        templateId,
+        title: "Wywiad 1",
+        responseData: responseOld,
+        entityType: "patient",
+        entityId: String(patientId),
+        status: "signed",
+        signedAt: olderSignedAt,
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const b = await ctx.db.insert("formDocuments", {
+        organizationId,
+        templateId,
+        title: "Wywiad 2",
+        responseData: responseNew,
+        entityType: "patient",
+        entityId: String(patientId),
+        status: "signed",
+        signedAt: newerSignedAt,
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      });
+      return [a, b];
+    });
+
+    await db.insert("formDocuments", {
+      _id: oldDocId,
+      organizationId: String(organizationId),
+      templateId: String(templateId),
+      title: "Wywiad 1",
+      responseData: responseOld,
+      entityType: "patient",
+      entityId: String(patientId),
+      status: "signed",
+      signedAt: olderSignedAt,
+      createdBy: String(userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert("formDocuments", {
+      _id: newDocId,
+      organizationId: String(organizationId),
+      templateId: String(templateId),
+      title: "Wywiad 2",
+      responseData: responseNew,
+      entityType: "patient",
+      entityId: String(patientId),
+      status: "signed",
+      signedAt: newerSignedAt,
+      createdBy: String(userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await t.withIdentity(identity).action(
+      api.documents.documents.getLatestSignedIntakeByPatient,
+      { organizationId, patientId: String(patientId) },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(String(newDocId));
+    expect(result!.formFieldValues).toEqual({ visit: "second" });
+  });
+
+  test("ignores intake documents belonging to a different patient", async () => {
+    const { t, organizationId, userId, identity, patientId, templateId, db, now } = await setup();
+
+    const otherPatientId = "other-patient-uuid";
+    const responseData = JSON.stringify({ formFieldValues: { note: "other" } });
+
+    const docId = await t.run(async (ctx) => {
+      return await ctx.db.insert("formDocuments", {
+        organizationId,
+        templateId,
+        title: "Wywiad",
+        responseData,
+        entityType: "patient",
+        entityId: otherPatientId,
+        status: "signed",
+        signedAt: now + 1000,
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    await db.insert("formDocuments", {
+      _id: docId,
+      organizationId: String(organizationId),
+      templateId: String(templateId),
+      title: "Wywiad",
+      responseData,
+      entityType: "patient",
+      entityId: otherPatientId,
+      status: "signed",
+      signedAt: now + 1000,
+      createdBy: String(userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await t.withIdentity(identity).action(
+      api.documents.documents.getLatestSignedIntakeByPatient,
+      { organizationId, patientId: String(patientId) },
+    );
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `documents.documents.getLatestSignedIntakeByPatient` Convex action to `convex/documents/documents.ts`
- For a given patient, returns the most recently signed "Wywiad" (category: `intake`) form document
- Handles both directly patient-linked docs (`entityType = "patient"`) and appointment-linked docs via `scopeEntities.patient` JSONB containment (uses the GIN index from migration 00044)
- Returns `null` when no signed/completed intake document exists — no errors thrown

## What is returned

```ts
{
  id: string;           // document ID
  responseData: string; // raw JSON string stored in form_documents.response_data
  formFieldValues: Record<string, string>; // parsed from responseData.formFieldValues
  signedAt: number | null;  // epoch ms, null if not available
  templateId: string;
}
```

## Guardrails respected

- No database schema changes
- No UI changes
- No changes to signing logic
- No changes to existing functions

## Test plan

- [ ] Returns `null` when no intake templates exist for the org
- [ ] Returns `null` when an intake document exists but is not signed (`pending_signature`)
- [ ] Returns the signed document for direct patient linkage (`entityType = "patient"`)
- [ ] Returns the signed document for appointment linkage (`entityType = "appointment"`, via `scopeEntities.patient`)
- [ ] Returns the **most recently signed** document when multiple signed intake docs exist
- [ ] Does not return intake docs belonging to a different patient

Tests: `tests/convex/getLatestSignedIntakeByPatient.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)