### PR TITLE
Notatki medyczne: przygotowanie listy istotnych informacji z Wywiadu

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -7,6 +7,11 @@ import { formDocumentStatusValidator } from "../schema/documents";
 import { resolveComponentsInContent } from "./resolveComponents";
 import type { FormDocumentRow, FormTemplateRow } from "../_helpers/supabaseRows";
 import { Id } from "../_generated/dataModel";
+import {
+  extractFieldDefinitions,
+  extractIntakeSummary,
+  type IntakeFieldDefinition,
+} from "./intake-summary";
 
 // Dual-write refs removed — Supabase is now primary for document writes
 
@@ -206,6 +211,8 @@ export const getLatestSignedIntakeByPatient = action({
     id: string;
     responseData: string;
     formFieldValues: Record<string, string>;
+    fieldDefinitions: IntakeFieldDefinition[];
+    intakeSummary: string[];
     signedAt: number | null;
     templateId: string;
   } | null> => {
@@ -274,10 +281,27 @@ export const getLatestSignedIntakeByPatient = action({
       // Non-JSON responseData: formFieldValues stays empty
     }
 
+    // Extract field definitions from the template's TipTap contentJson
+    const matchedTemplate = intakeTemplates.find(
+      (t) => String(t._id) === String(latest.templateId),
+    );
+    let fieldDefinitions: IntakeFieldDefinition[] = [];
+    if (matchedTemplate?.contentJson) {
+      try {
+        fieldDefinitions = extractFieldDefinitions(
+          JSON.parse(matchedTemplate.contentJson as string),
+        );
+      } catch {
+        // contentJson not parseable — fieldDefinitions stays empty
+      }
+    }
+
     return {
       id: String(latest._id),
       responseData: latest.responseData as string,
       formFieldValues,
+      fieldDefinitions,
+      intakeSummary: extractIntakeSummary(fieldDefinitions, formFieldValues),
       signedAt: (latest.signedAt as number | null | undefined) ?? null,
       templateId: String(latest.templateId),
     };

--- a/convex/documents/intake-summary.ts
+++ b/convex/documents/intake-summary.ts
@@ -1,0 +1,79 @@
+/**
+ * Lightweight TipTap JSON node type — only the fields we need here.
+ */
+interface TipTapNode {
+  type: string;
+  attrs?: Record<string, unknown>;
+  content?: TipTapNode[];
+}
+
+export interface IntakeFieldDefinition {
+  fieldId: string;
+  /** "text" | "textarea" | "select" | "button_select" | "date" | "checkbox" */
+  fieldType: string;
+  label: string;
+}
+
+/** Walk TipTap JSON and collect every formField node's key metadata. */
+export function extractFieldDefinitions(contentJson: unknown): IntakeFieldDefinition[] {
+  const fields: IntakeFieldDefinition[] = [];
+  const walk = (node: TipTapNode) => {
+    if (node.type === "formField" && node.attrs) {
+      fields.push({
+        fieldId: (node.attrs.fieldId as string) || "",
+        fieldType: (node.attrs.fieldType as string) || "text",
+        label: (node.attrs.label as string) || "",
+      });
+    }
+    if (node.content) node.content.forEach(walk);
+  };
+  if (contentJson && typeof contentJson === "object") {
+    walk(contentJson as TipTapNode);
+  }
+  return fields;
+}
+
+const BOOLEAN_TRUE = new Set(["true", "tak", "yes", "1"]);
+const BOOLEAN_FALSE = new Set(["false", "nie", "no", "0"]);
+
+/**
+ * Build an ordered list of display strings from a signed Wywiad's field values.
+ *
+ * Rules:
+ * - Checkbox fields where the patient answered true/TAK → just the label, e.g. "Cukrzyca"
+ * - Non-empty text/textarea/select/button_select/date fields → "Label: value",
+ *   e.g. "Alergie: penicylina". Explicit false/NIE answers are skipped.
+ * - Empty values and unchecked checkboxes are always omitted.
+ *
+ * Field order matches the template's field order.
+ */
+export function extractIntakeSummary(
+  fieldDefinitions: IntakeFieldDefinition[],
+  formFieldValues: Record<string, string>,
+): string[] {
+  const result: string[] = [];
+
+  for (const field of fieldDefinitions) {
+    const raw = formFieldValues[field.fieldId];
+    if (raw === undefined || raw === null || raw === "") continue;
+
+    const trimmed = raw.trim();
+    if (trimmed === "") continue;
+
+    const normalized = trimmed.toLowerCase();
+    const displayLabel = field.label || field.fieldId;
+
+    if (field.fieldType === "checkbox") {
+      if (BOOLEAN_TRUE.has(normalized)) {
+        result.push(displayLabel);
+      }
+      // false / unchecked → skip
+    } else {
+      // text, textarea, select, button_select, date
+      if (BOOLEAN_FALSE.has(normalized)) continue;
+      result.push(`${displayLabel}: ${trimmed}`);
+    }
+  }
+
+  return result;
+}

--- a/tests/convex/extractIntakeSummary.test.ts
+++ b/tests/convex/extractIntakeSummary.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from "vitest";
+import {
+  extractFieldDefinitions,
+  extractIntakeSummary,
+  type IntakeFieldDefinition,
+} from "../../convex/documents/intake-summary";
+
+// ---------------------------------------------------------------------------
+// extractFieldDefinitions
+// ---------------------------------------------------------------------------
+
+describe("extractFieldDefinitions", () => {
+  test("returns empty array for null/undefined input", () => {
+    expect(extractFieldDefinitions(null)).toEqual([]);
+    expect(extractFieldDefinitions(undefined)).toEqual([]);
+  });
+
+  test("extracts formField nodes from flat TipTap JSON", () => {
+    const contentJson = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "formField",
+              attrs: {
+                fieldId: "diabetes",
+                fieldType: "checkbox",
+                label: "Cukrzyca",
+                required: false,
+                options: "",
+                placeholder: "",
+                filledBy: "client",
+              },
+            },
+            {
+              type: "formField",
+              attrs: {
+                fieldId: "allergies",
+                fieldType: "textarea",
+                label: "Alergie",
+                required: false,
+                options: "",
+                placeholder: "",
+                filledBy: "client",
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = extractFieldDefinitions(contentJson);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ fieldId: "diabetes", fieldType: "checkbox", label: "Cukrzyca" });
+    expect(result[1]).toEqual({ fieldId: "allergies", fieldType: "textarea", label: "Alergie" });
+  });
+
+  test("extracts formField nodes from nested TipTap JSON", () => {
+    const contentJson = {
+      type: "doc",
+      content: [
+        {
+          type: "table",
+          content: [
+            {
+              type: "tableRow",
+              content: [
+                {
+                  type: "tableCell",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [
+                        {
+                          type: "formField",
+                          attrs: { fieldId: "medications", fieldType: "text", label: "Przyjmowane leki" },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = extractFieldDefinitions(contentJson);
+    expect(result).toHaveLength(1);
+    expect(result[0].fieldId).toBe("medications");
+    expect(result[0].label).toBe("Przyjmowane leki");
+  });
+
+  test("uses fieldId as label fallback when label is missing", () => {
+    const contentJson = {
+      type: "doc",
+      content: [
+        {
+          type: "formField",
+          attrs: { fieldId: "pregnancy", fieldType: "checkbox", label: "" },
+        },
+      ],
+    };
+    const result = extractFieldDefinitions(contentJson);
+    expect(result[0].label).toBe("");
+    expect(result[0].fieldId).toBe("pregnancy");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractIntakeSummary
+// ---------------------------------------------------------------------------
+
+describe("extractIntakeSummary", () => {
+  const fields: IntakeFieldDefinition[] = [
+    { fieldId: "diabetes", fieldType: "checkbox", label: "Cukrzyca" },
+    { fieldId: "pregnancy", fieldType: "checkbox", label: "Ciąża" },
+    { fieldId: "pacemaker", fieldType: "checkbox", label: "Rozrusznik serca" },
+    { fieldId: "allergies", fieldType: "textarea", label: "Alergie" },
+    { fieldId: "medications", fieldType: "text", label: "Przyjmowane leki" },
+    { fieldId: "bloodPressure", fieldType: "select", label: "Ciśnienie tętnicze" },
+  ];
+
+  test("returns empty array when formFieldValues is empty", () => {
+    expect(extractIntakeSummary(fields, {})).toEqual([]);
+  });
+
+  test("includes checked checkboxes as plain label strings", () => {
+    const result = extractIntakeSummary(fields, {
+      diabetes: "true",
+      pregnancy: "true",
+    });
+    expect(result).toContain("Cukrzyca");
+    expect(result).toContain("Ciąża");
+  });
+
+  test("accepts TAK (Polish) as truthy checkbox value", () => {
+    const result = extractIntakeSummary(fields, { diabetes: "Tak", pregnancy: "TAK" });
+    expect(result).toContain("Cukrzyca");
+    expect(result).toContain("Ciąża");
+  });
+
+  test("omits unchecked (false) checkboxes", () => {
+    const result = extractIntakeSummary(fields, { diabetes: "false", pregnancy: "NIE" });
+    expect(result).not.toContain("Cukrzyca");
+    expect(result).not.toContain("Ciąża");
+  });
+
+  test("includes non-empty text fields as 'Label: value' strings", () => {
+    const result = extractIntakeSummary(fields, {
+      allergies: "penicylina",
+      medications: "Metformina",
+    });
+    expect(result).toContain("Alergie: penicylina");
+    expect(result).toContain("Przyjmowane leki: Metformina");
+  });
+
+  test("omits empty text fields", () => {
+    const result = extractIntakeSummary(fields, { allergies: "", medications: "  " });
+    expect(result).toHaveLength(0);
+  });
+
+  test("omits text fields whose value is NIE/false", () => {
+    const result = extractIntakeSummary(fields, {
+      bloodPressure: "Nie",
+      allergies: "nie",
+    });
+    expect(result).toHaveLength(0);
+  });
+
+  test("full example matching the issue specification", () => {
+    const values = {
+      diabetes: "true",
+      pregnancy: "tak",
+      pacemaker: "true",
+      allergies: "penicylina",
+      medications: "Metformina",
+      bloodPressure: "",
+    };
+    const result = extractIntakeSummary(fields, values);
+    expect(result).toEqual([
+      "Cukrzyca",
+      "Ciąża",
+      "Rozrusznik serca",
+      "Alergie: penicylina",
+      "Przyjmowane leki: Metformina",
+    ]);
+  });
+
+  test("preserves field order from fieldDefinitions", () => {
+    const values = { medications: "Aspiryna", diabetes: "true", allergies: "kurz" };
+    const result = extractIntakeSummary(fields, values);
+    // Order should follow fieldDefinitions array, not formFieldValues key order
+    const diabetesIdx = result.indexOf("Cukrzyca");
+    const allergiesIdx = result.findIndex((s) => s.startsWith("Alergie:"));
+    const medicationsIdx = result.findIndex((s) => s.startsWith("Przyjmowane leki:"));
+    expect(diabetesIdx).toBeLessThan(allergiesIdx);
+    expect(allergiesIdx).toBeLessThan(medicationsIdx);
+  });
+
+  test("uses fieldId as display label when label is empty", () => {
+    const fieldsNoLabel: IntakeFieldDefinition[] = [
+      { fieldId: "q_heart_disease", fieldType: "checkbox", label: "" },
+    ];
+    const result = extractIntakeSummary(fieldsNoLabel, { q_heart_disease: "true" });
+    expect(result).toEqual(["q_heart_disease"]);
+  });
+
+  test("ignores values for unknown field IDs", () => {
+    const result = extractIntakeSummary(fields, { unknown_field: "some value" });
+    expect(result).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2804.

Closes #2804

---

## Claude summary

Done. Here's a summary of what was implemented:

**New file: `convex/documents/intake-summary.ts`**

- `extractFieldDefinitions(contentJson)` — walks TipTap JSON and collects every `formField` node's `fieldId`, `fieldType`, and `label`. Server-safe (no DOM, no TipTap extensions needed).
- `extractIntakeSummary(fieldDefinitions, formFieldValues)` — the core logic: iterates field definitions in template order and produces display strings:
  - Checkbox where value is `"true"` / `"tak"` / `"yes"` → `"Cukrzyca"`
  - Non-empty text/textarea/select/button_select/date where value is not explicitly `"nie"`/`"false"` → `"Alergie: penicylina"`
  - Everything else (empty, `false`, unchecked) is omitted.

**Extended: `getLatestSignedIntakeByPatient`** — now parses the matched template's `contentJson` and returns two additional fields: `fieldDefinitions: IntakeFieldDefinition[]` and `intakeSummary: string[]`. Existing callers are unaffected.

**New test file: `tests/convex/extractIntakeSummary.test.ts`** — 15 unit tests covering the full spec including the Polish TAK/NIE synonyms, field ordering, empty values, unknown field IDs, and the exact example from the issue. All 21 tests (15 new + 6 existing) pass.