### PR TITLE
Notatki medyczne: wyświetlenie informacji z Wywiadu w karcie pacjenta

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2412,7 +2412,10 @@
         "female": "Female",
         "other": "Other"
       },
-      "medicalNotes": "Client Note",
+      "medicalNotes": "Medical Notes",
+      "intakeSummarySection": "Key Intake Information",
+      "noIntakeSummary": "No key information from the last intake.",
+      "staffNotesSection": "Additional Staff Notes",
       "allergies": "Allergies",
       "bloodType": "Blood Type",
       "emergencyContact": "Emergency Contact",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2427,7 +2427,10 @@
         "female": "Kobieta",
         "other": "Inna"
       },
-      "medicalNotes": "Notatka o kliencie",
+      "medicalNotes": "Notatki medyczne",
+      "intakeSummarySection": "Istotne informacje z Wywiadu",
+      "noIntakeSummary": "Brak istotnych informacji z ostatniego Wywiadu.",
+      "staffNotesSection": "Dodatkowe notatki personelu",
       "allergies": "Alergie",
       "bloodType": "Grupa krwi",
       "emergencyContact": "Kontakt awaryjny",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -128,6 +128,8 @@ function PatientDetail() {
   );
   const trackView = useAction(api.recentlyViewed.track);
   const listDocumentsByEntity = useAction(api.documents.documents.listByEntity);
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen for this action
+  const getLatestSignedIntakeByPatientAction = useAction(api.documents.documents.getLatestSignedIntakeByPatient);
   const queryClient = useQueryClient();
 
   const [editDrawerOpen, setEditDrawerOpen] = useState(false);
@@ -252,6 +254,12 @@ function PatientDetail() {
         entityType: "patient",
         entityId: patientId,
       }),
+    enabled: !!organizationId && !!patientId,
+  });
+
+  const { data: latestIntake } = useQuery({
+    queryKey: ["documents.getLatestSignedIntakeByPatient", organizationId, patientId],
+    queryFn: () => getLatestSignedIntakeByPatientAction({ organizationId, patientId }),
     enabled: !!organizationId && !!patientId,
   });
 
@@ -454,22 +462,49 @@ function PatientDetail() {
           })()}
         </div>
       </div>
-      {(() => {
-        const medicalNotesText = plateJsonToText(patient.medicalNotes ?? undefined).trim();
-        if (!medicalNotesText) return null;
-        return (
-          <div className="space-y-2">
-            <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
-              {t("gabinet.patients.medicalNotes")}
-            </p>
+      <div className="space-y-3">
+        <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+          {t("gabinet.patients.medicalNotes")}
+        </p>
+        <div className="space-y-1.5">
+          <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+            {t("gabinet.patients.intakeSummarySection")}
+          </p>
+          {latestIntake && latestIntake.intakeSummary.length > 0 ? (
             <div className="rounded-md border p-2.5">
-              <p className="text-xs text-muted-foreground whitespace-pre-wrap">
-                {medicalNotesText}
+              <ul className="space-y-1">
+                {latestIntake.intakeSummary.map((item, i) => (
+                  <li key={i} className="text-xs text-muted-foreground">
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : (
+            <div className="rounded-md border p-2.5">
+              <p className="text-xs text-muted-foreground italic">
+                {t("gabinet.patients.noIntakeSummary")}
               </p>
             </div>
-          </div>
-        );
-      })()}
+          )}
+        </div>
+        {(() => {
+          const medicalNotesText = plateJsonToText(patient.medicalNotes ?? undefined).trim();
+          if (!medicalNotesText) return null;
+          return (
+            <div className="space-y-1.5">
+              <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+                {t("gabinet.patients.staffNotesSection")}
+              </p>
+              <div className="rounded-md border p-2.5">
+                <p className="text-xs text-muted-foreground whitespace-pre-wrap">
+                  {medicalNotesText}
+                </p>
+              </div>
+            </div>
+          );
+        })()}
+      </div>
       <PatientPackagesCard
         patientId={patientId}
         organizationId={organizationId}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2806.

Closes #2806

---

## Claude summary

Done. Here's a summary of what was implemented:

**3 files changed:**

1. `src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx`
   - Added `useAction(api.documents.documents.getLatestSignedIntakeByPatient)` hook
   - Added `useQuery` to fetch the latest signed intake for the patient
   - Replaced the single "medical notes" block with a two-subsection structure under the "Notatki medyczne" heading:
     - **Section A** (always visible): "Istotne informacje z Wywiadu" — renders `intakeSummary` as a list, or shows "Brak istotnych informacji z ostatniego Wywiadu." when empty/absent
     - **Section B** (conditional): "Dodatkowe notatki personelu" — renders the existing manual staff notes only when non-empty; never touched by intake data

2. `public/locales/pl/translation.json` — added `intakeSummarySection`, `noIntakeSummary`, `staffNotesSection` keys; renamed `medicalNotes` to "Notatki medyczne"

3. `public/locales/en/translation.json` — same keys in English