### PR TITLE
Informacje medyczne: wyświetl automatyczne podsumowanie Wywiadu w istniejącym komponencie

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -907,7 +907,9 @@ function PatientDetail() {
   // stacked above the tabs on mobile) — see #1927. Keep the "medical info" card
   // dedicated to emergency contact so the same data isn't presented twice.
   const hasMedicalInfo = Boolean(
-    patient?.emergencyContactName || patient?.emergencyContactPhone,
+    patient?.emergencyContactName ||
+      patient?.emergencyContactPhone ||
+      (latestIntake && latestIntake.intakeSummary.length > 0),
   );
 
   // Issue #1894: Beauty plan history — chronological list of `interviewNotes`
@@ -1120,6 +1122,36 @@ function PatientDetail() {
                 </p>
               ) : (
                 <div className="grid gap-3 sm:grid-cols-2">
+                  {latestIntake && latestIntake.intakeSummary.length > 0 && (
+                    <div className="sm:col-span-2 space-y-1.5">
+                      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                        {t("gabinet.patients.intakeSummarySection")}
+                      </p>
+                      <div className="space-y-2">
+                        {groupIntakeSummary(latestIntake.intakeSummary).map(
+                          (group) => (
+                            <div key={group.key}>
+                              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+                                {t(
+                                  `gabinet.patients.intakeGroups.${group.key}`,
+                                )}
+                              </p>
+                              <ul className="space-y-0.5">
+                                {group.items.map((item, i) => (
+                                  <li
+                                    key={i}
+                                    className="text-sm text-muted-foreground"
+                                  >
+                                    {item}
+                                  </li>
+                                ))}
+                              </ul>
+                            </div>
+                          ),
+                        )}
+                      </div>
+                    </div>
+                  )}
                   {(patient?.emergencyContactName ||
                     patient?.emergencyContactPhone) && (
                     <div className="sm:col-span-2">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2811.

Closes #2811

---

## Claude summary

Done. Here's what changed in a single file (`_layout.gabinet.patients.$patientId.tsx`):

1. `hasMedicalInfo` (line 909) now also returns `true` when `latestIntake` has summary items, so the card shows content instead of "Brak informacji medycznych" for patients who have a signed intake but no emergency contact.

2. Inside the "Informacje medyczne" card's content branch, a new block renders `groupIntakeSummary(latestIntake.intakeSummary)` — the exact same data and helper already used by the "Notatki medyczne" sidebar. The existing emergency contact display is unchanged and still renders below it.

No new endpoints, no new queries, no schema changes, no changes to the "Notatki medyczne" section.