### PR TITLE
Silent catch in `extractFieldDefinitions` hides parse errors

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -287,13 +287,9 @@ export const getLatestSignedIntakeByPatient = action({
     );
     let fieldDefinitions: IntakeFieldDefinition[] = [];
     if (matchedTemplate?.contentJson) {
-      try {
-        fieldDefinitions = extractFieldDefinitions(
-          JSON.parse(matchedTemplate.contentJson as string),
-        );
-      } catch {
-        // contentJson not parseable — fieldDefinitions stays empty
-      }
+      fieldDefinitions = extractFieldDefinitions(
+        JSON.parse(matchedTemplate.contentJson as string),
+      );
     }
 
     return {

--- a/tests/convex/getLatestSignedIntakeByPatient.test.ts
+++ b/tests/convex/getLatestSignedIntakeByPatient.test.ts
@@ -425,6 +425,86 @@ describe("documents.getLatestSignedIntakeByPatient", () => {
     ]);
   });
 
+  test("throws when template contentJson is malformed JSON", async () => {
+    const { t, organizationId, userId, identity, patientId, db, now } = await setup();
+
+    const malformedTemplateId = await t.run(async (ctx) => {
+      return await ctx.db.insert("formTemplates", {
+        organizationId,
+        name: "Malformed template",
+        category: "intake",
+        formJson: "{}",
+        contentJson: "{not valid json}",
+        modules: ["gabinet"],
+        entityTypes: ["patient"],
+        requiresSignature: true,
+        version: 1,
+        isActive: true,
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    await db.insert("formTemplates", {
+      _id: malformedTemplateId,
+      organizationId: String(organizationId),
+      name: "Malformed template",
+      category: "intake",
+      formJson: "{}",
+      contentJson: "{not valid json}",
+      modules: ["gabinet"],
+      entityTypes: ["patient"],
+      requiresSignature: true,
+      version: 1,
+      isActive: true,
+      createdBy: String(userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const signedAt = now + 1000;
+    const responseData = JSON.stringify({ formFieldValues: { q1: "a1" } });
+
+    const docId = await t.run(async (ctx) => {
+      return await ctx.db.insert("formDocuments", {
+        organizationId,
+        templateId: malformedTemplateId,
+        title: "Wywiad",
+        responseData,
+        entityType: "patient",
+        entityId: String(patientId),
+        status: "signed",
+        signedAt,
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    await db.insert("formDocuments", {
+      _id: docId,
+      organizationId: String(organizationId),
+      templateId: String(malformedTemplateId),
+      title: "Wywiad",
+      responseData,
+      entityType: "patient",
+      entityId: String(patientId),
+      status: "signed",
+      signedAt,
+      createdBy: String(userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await expect(
+      t.withIdentity(identity).action(
+        api.documents.documents.getLatestSignedIntakeByPatient,
+        { organizationId, patientId: String(patientId) },
+      ),
+    ).rejects.toThrow(SyntaxError);
+  });
+
   test("ignores intake documents belonging to a different patient", async () => {
     const { t, organizationId, userId, identity, patientId, templateId, db, now } = await setup();
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2815.

Closes #2815

---

## Claude summary

The fix is in. Here's a summary of what changed:

**Root cause:** `convex/documents/documents.ts:289-297` wrapped `JSON.parse(matchedTemplate.contentJson)` in a catch block that silently swallowed `SyntaxError`. A template with corrupt `contentJson` would return `fieldDefinitions: []`, which looks identical to a template with no `contentJson` at all.

**Fix:** Removed the try-catch entirely (`documents.ts:289-294`). The `JSON.parse` call now throws naturally on malformed input, propagating the error to the caller who can handle or observe it. The `extractFieldDefinitions` function itself never throws (it guards on `typeof obj === "object"`), so no other error path is introduced.

**Test added:** `getLatestSignedIntakeByPatient.test.ts` — "throws when template contentJson is malformed JSON" — seeds a template with `contentJson: "{not valid json}"`, seeds a signed document against it, and asserts the action rejects with `SyntaxError`.