### PR TITLE
Backfill scopeEntities for existing appointment documents

### DIFF
--- a/supabase/migrations/00045_backfill_scope_entities_appointment_docs.sql
+++ b/supabase/migrations/00045_backfill_scope_entities_appointment_docs.sql
@@ -1,0 +1,16 @@
+-- Backfill scope_entities for existing appointment form_documents.
+--
+-- Documents auto-generated after #2823 already have scope_entities populated.
+-- Rows created before that fix have scope_entities IS NULL, so the JSONB
+-- containment query (scope_entities @> '{"patient":"<id>"}') used by the
+-- patient card intake summary cannot find them.
+--
+-- This is a one-time UPDATE: only rows with entity_type='appointment' and
+-- scope_entities IS NULL are touched. Rows already populated are left alone.
+
+UPDATE form_documents fd
+SET    scope_entities = jsonb_build_object('patient', ga.patient_id)
+FROM   gabinet_appointments ga
+WHERE  fd.entity_id      = ga.id
+  AND  fd.entity_type    = 'appointment'
+  AND  fd.scope_entities IS NULL;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2825.

Closes #2825

---

## Claude summary

The fix is committed. Here's what was done:

Added `supabase/migrations/00045_backfill_scope_entities_appointment_docs.sql` — a one-time `UPDATE` that joins `form_documents` with `gabinet_appointments` and sets `scope_entities = jsonb_build_object('patient', ga.patient_id)` for every row where `entity_type = 'appointment'` and `scope_entities IS NULL`. Rows already patched by the #2823 fix or auto-generated documents are left untouched (the `IS NULL` guard prevents double-writes). Once this migration runs, the existing GIN index on `scope_entities` (added in migration 00044) will make those historical documents visible to the patient card's JSONB containment query.