### PR TITLE
Performance

### DIFF
--- a/supabase/migrations/00046_form_documents_org_entity_type_idx.sql
+++ b/supabase/migrations/00046_form_documents_org_entity_type_idx.sql
@@ -1,0 +1,11 @@
+-- Add composite index on form_documents(organization_id, entity_type).
+--
+-- getLatestSignedIntakeByPatient runs two queries that both filter on
+-- organization_id + entity_type. The existing single-column org index forces
+-- Postgres to scan all org rows before filtering by entity_type. This index
+-- lets the planner narrow to the exact (org, entity_type) slice first, after
+-- which the GIN scope_entities containment check operates on a much smaller
+-- working set. Closes #2831.
+
+CREATE INDEX form_documents_org_entity_type_idx
+  ON form_documents (organization_id, entity_type);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2831.

Closes #2831

---

## Claude summary

The fix is committed. Here's a summary of what was done and the current state:

**Triage result:** The report is valid. The issue originally described three problems in `getLatestSignedIntakeByPatient`, two of which were already resolved in prior work on #2823:
- The `.contains()` PostgREST filter was already added to push the `scopeEntities.patient` check to the database (`documents.ts:255`).
- Migration 00044 already converted `scope_entities` to JSONB and added a GIN index on it.

The one remaining item was the composite index on `form_documents(organization_id, entity_type)`. Without it, Postgres uses the single-column `form_documents_org_idx` and must scan all rows for the org before filtering by entity type.

**Fix:** Added migration `00046_form_documents_org_entity_type_idx.sql` which creates `form_documents_org_entity_type_idx ON form_documents (organization_id, entity_type)`. Both queries in `getLatestSignedIntakeByPatient` (one for `entity_type = 'patient'`, one for `entity_type = 'appointment'`) benefit from this index as the first narrowing step before any GIN lookup.