### PR TITLE
Fix pre-existing `useRole` mock in `app-sidebar.test.tsx`

### DIFF
--- a/src/components/layout/app-sidebar.test.tsx
+++ b/src/components/layout/app-sidebar.test.tsx
@@ -7,6 +7,7 @@ const shellSidebarMode = vi.hoisted(() => ({ value: "default" as "default" | "ic
 vi.mock("@tanstack/react-router", () => ({
   Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
   useMatchRoute: () => ({ to }: { to: string }) => to === "/dashboard/leads",
+  useNavigate: () => vi.fn(),
 }));
 
 vi.mock("@tanstack/react-query", () => ({
@@ -74,6 +75,7 @@ vi.mock("@/components/layout/sidebar-slot-context", () => ({
 
 vi.mock("@/hooks/use-permission", () => ({
   usePermissions: () => ({ can: () => true }),
+  useRole: () => ({ role: null, loading: false }),
 }));
 
 vi.mock("@/components/layout/mini-calendar-context", () => ({


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2836.

Closes #2836

---

## Claude summary

Fixed. Two mocks were missing from `src/components/layout/app-sidebar.test.tsx`:

1. `useRole` was not exported from the `@/hooks/use-permission` mock (line 75-77), but `app-sidebar.tsx` imports and calls it at the component's top level (line 22, 93). Calling an undefined value throws `TypeError: useRole is not a function`, breaking both tests.

2. `useNavigate` was also absent from the `@tanstack/react-router` mock (line 7-10), but the component calls `useNavigate()` at the top level (line 52). Same root cause.

The fix adds `useRole: () => ({ role: null, loading: false })` and `useNavigate: () => vi.fn()` to their respective mocks — minimal stubs matching the shapes the component expects.