### PR TITLE
Link z e-maila do dokumentu początkowo pokazuje „Nie znaleziono dokumentu lub link wygasł”

### DIFF
--- a/src/routes/sign.form.$token.tsx
+++ b/src/routes/sign.form.$token.tsx
@@ -43,7 +43,14 @@ function FormSigningPage() {
     queryKey: ["documents.documents.getBySigningToken", token],
     queryFn: () => getBySigningToken({ token }),
     enabled: !!token,
-    retry: false,
+    // Retry on transient Convex client init failures (cold start from email link),
+    // but not on permanent errors like "Document not found" or "Signing link expired".
+    retry: (failureCount, error) => {
+      if (failureCount >= 2) return false;
+      const msg = error instanceof Error ? error.message : "";
+      return msg !== "Document not found" && msg !== "Signing link expired";
+    },
+    retryDelay: 500,
   });
 
   if (isLoading) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2840.

Closes #2840

---

## Claude summary

The fix is committed. Here's a summary:

**Root cause**: `sign.form.$token.tsx` uses TanStack Query's `useQuery` with a Convex action as the `queryFn`. On a cold start (first-ever page load from an email link), there's a race between the Convex client initializing and TanStack Query firing the `queryFn`. With `retry: false`, a single failed action dispatch immediately transitions the query to error state — `isLoading` becomes `false` and `data` stays `undefined` — so the `!data?.document` branch shows "Nie znaleziono dokumentu lub link wygasł". On refresh the JS bundle is cached, startup is faster, Convex wins the race, and the action succeeds.

**Fix** (`src/routes/sign.form.$token.tsx:42`): Replace `retry: false` with a smart retry function that retries up to 2 times (500 ms apart) for transient errors, but short-circuits immediately for the two permanent error messages the action explicitly throws (`"Document not found"`, `"Signing link expired"`). During retries `isLoading` remains `true`, so the user sees the loading spinner instead of the error card.

The contrast with `sign.$token.tsx` is instructive: that route uses Convex's native `useQuery` from `convex/react`, which handles the client's loading state internally and returns `undefined` until ready — no race condition possible. The form-signing route chose TanStack Query + Convex action and needed this guard.