### PR TITLE
fix(convex): v.null_() → v.null() (blocks Convex deploy)

### DIFF
--- a/convex/supabase/organizations.ts
+++ b/convex/supabase/organizations.ts
@@ -164,7 +164,7 @@ export const _listAllTeamMemberships = internalQuery({
 
 export const deleteTeamMembershipFromSupabase = internalAction({
   args: { membershipId: v.string() },
-  returns: v.null_(),
+  returns: v.null(),
   handler: async (_ctx, args) => {
     const client = createServiceRoleClient();
     const { error } = await client


### PR DESCRIPTION
`v.null_()` in `convex/supabase/organizations.ts` is not a validator function and threw `TypeError: e.null_ is not a function` at module analysis, blocking every Convex deploy. One-char fix to `v.null()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)