### PR TITLE
Schowaj grafike w produktach

### DIFF
--- a/src/components/sidebar-widgets/crm/products-widgets.tsx
+++ b/src/components/sidebar-widgets/crm/products-widgets.tsx
@@ -45,13 +45,6 @@ export function ProductsWidgets({ organizationId }: { organizationId: Id<"organi
             </span>
           </CardHeader>
           <CardContent className="px-4">
-            <div className="mt-2 flex justify-center">
-              <img
-                src="/images/best-selling-bg.png"
-                alt=""
-                className="w-full"
-              />
-            </div>
             <div className="bg-card flex flex-col gap-5 rounded-xl p-4">
               {topProducts.map((product, i) => {
                 const color = PRODUCT_COLORS[i % PRODUCT_COLORS.length];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2845.

Closes #2845

---

## Claude summary

Done. The decorative `<img src="/images/best-selling-bg.png">` and its wrapper `<div>` were removed from the "Najlepsze produkty" (Best Selling Products) sidebar card in `src/components/sidebar-widgets/crm/products-widgets.tsx:49-55`. The product list and progress bar chart remain intact.