### PR TITLE
Aktywacja zabiegu

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -289,6 +289,7 @@ export const update = action({
     organizationId: v.id("organizations"),
     treatmentId: v.string(),
     name: v.optional(v.string()),
+    isActive: v.optional(v.boolean()),
     description: v.optional(v.union(v.string(), v.null())),
     duration: v.optional(v.number()),
     price: v.optional(v.number()),

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -631,19 +631,14 @@ function TreatmentsIndex() {
               onClick: () => openEditPanel(row),
             },
             {
-              label: row.isActive ? t("common.inactive") : t("common.active"),
+              label: row.isActive ? t("common.deactivate", "Dezaktywuj") : t("common.activate", "Aktywuj"),
               icon: <Power className="h-4 w-4" variant="stroke" />,
               onClick: async () => {
-                // Soft toggle by removing (deactivate) or updating
-                if (row.isActive) {
-                  await removeTreatment({ organizationId, treatmentId: row._id as Id<"gabinetTreatments"> });
-                } else {
-                  await updateTreatment({
-                    organizationId,
-                    treatmentId: row._id as Id<"gabinetTreatments">,
-                    name: row.name,
-                  });
-                }
+                await updateTreatment({
+                  organizationId,
+                  treatmentId: row._id as Id<"gabinetTreatments">,
+                  isActive: !row.isActive,
+                });
               },
             },
           ]


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2847.

Closes #2847

---

## Claude summary

Two files changed, committed. Here's the root cause and fix:

**Root cause:** The row action toggle for treatments had a broken activation path. Deactivation called `removeTreatment` (soft-delete), while reactivation called `updateTreatment({ name: row.name })` — but the `update` Convex action didn't accept an `isActive` argument at all, making reactivation a silent no-op.

**Fix:**
1. `convex/gabinet/treatments.ts` — added `isActive: v.optional(v.boolean())` to the `update` action args; it automatically flows through the `...updates` spread into the Supabase patch.
2. `treatments.index.tsx` — replaced the asymmetric `removeTreatment` / `updateTreatment(name)` branches with a single `updateTreatment({ isActive: !row.isActive })` call for both directions. Button labels updated to "Aktywuj" / "Dezaktywuj" for clarity.

**Side benefit:** Deactivation no longer goes through `removeTreatment`, which was also deleting the treatment's product ingredient links on deactivation (losing the recipe data on soft-delete).

## Follow-ups
- Add reactivate option on treatment detail page: `$treatmentId.tsx` shows "Deactivate" when active and "Delete" when inactive, but has no way to reactivate from the detail view — the button label and action should toggle to "Reactivate" for inactive treatments
- Deactivation via `removeTreatment` deletes product ingredient links: the `remove` action hard-deletes rows from `gabinet_treatment_products` on soft-delete, so reactivating via update doesn't restore the recipe — consider only soft-deleting without touching product links