### PR TITLE
Add reactivate option on treatment detail page

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2623,6 +2623,7 @@
       "description": "Description",
       "instructions": "Instructions",
       "deactivate": "Deactivate",
+      "reactivate": "Reactivate",
       "recentAppointments": "Recent Appointments",
       "noAppointments": "No appointments for this treatment",
       "overview": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2640,6 +2640,7 @@
       "description": "Opis",
       "instructions": "Instrukcje",
       "deactivate": "Dezaktywuj",
+      "reactivate": "Reaktywuj",
       "recentAppointments": "Ostatnie wizyty",
       "noAppointments": "Brak wizyt dla tego zabiegu",
       "overview": {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -442,6 +442,17 @@ function TreatmentDetail() {
     }
   };
 
+  const handleReactivate = async () => {
+    await updateTreatment({
+      organizationId,
+      treatmentId: treatmentId as Id<"gabinetTreatments">,
+      isActive: true,
+    });
+    void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatments.detail(organizationId, treatmentId) });
+    void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatments.list(organizationId) });
+    toast.success(t("common.saved"));
+  };
+
   const handleEditSubmit = async (formData: TreatmentFormData) => {
     setIsSubmitting(true);
     try {
@@ -1313,13 +1324,17 @@ function TreatmentDetail() {
           setEditPanelOpen(true);
         }}
         secondaryActions={[
-          {
-            label: treatment?.isActive
-              ? t("gabinet.treatmentDetail.deactivate")
-              : t("common.delete"),
-            onClick: handleDeactivate,
-            variant: "destructive" as const,
-          },
+          treatment?.isActive === false
+            ? {
+                label: t("gabinet.treatmentDetail.reactivate"),
+                onClick: handleReactivate,
+                variant: "outline" as const,
+              }
+            : {
+                label: t("gabinet.treatmentDetail.deactivate"),
+                onClick: handleDeactivate,
+                variant: "destructive" as const,
+              },
         ]}
         fields={detailFields}
         expandedFieldCount={5}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2849.

Closes #2849

---

## Claude summary

The bug was confirmed and fixed. Here's a summary:

**Root cause**: `$treatmentId.tsx:1315-1323` had `secondaryActions` that showed "Deactivate" for active treatments and "Delete" for inactive treatments, but both cases called `handleDeactivate` which called `removeTreatment` (soft-delete) and navigated away. There was no way to reactivate from the detail page.

**Fix** (3 files changed):
- Added `handleReactivate` handler that calls `updateTreatment({ isActive: true })`, invalidates queries, and shows a success toast — staying on the page (consistent with the list view toggle)
- Updated `secondaryActions` to conditionally render either "Reactivate" (outline, for inactive treatments) or "Deactivate" (destructive, for active treatments)
- Added `gabinet.treatmentDetail.reactivate` i18n key in both EN ("Reactivate") and PL ("Reaktywuj") locale files