### PR TITLE
Deactivation via `removeTreatment` deletes product ingredient links

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -474,12 +474,6 @@ export const remove = action({
       updatedAt: Date.now(),
     });
 
-    // --- Hard-delete product ingredient links (orphaned by soft-delete) ---
-    await db.raw()
-      .from("gabinet_treatment_products")
-      .delete()
-      .eq("treatment_id", args.treatmentId);
-
     // --- Delegate post-write side effects ---
     try {
       await ctx.runMutation(internal.gabinet.treatments._removeSideEffects, {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2850.

Closes #2850

---

## Claude summary

Bug was real and the fix is in. Here's the summary:

The `remove` action in `convex/gabinet/treatments.ts` soft-deletes a treatment by setting `isActive=false`, but then immediately hard-deleted all rows from `gabinet_treatment_products` with a `.delete()` call (lines 477-481). Since reactivation via `update` only flips `isActive` back to `true` and doesn't restore product links, the ingredient recipe was permanently lost on deactivation.

The fix removes the hard-delete entirely. The product link rows are now preserved across the deactivation/reactivation cycle, matching the expected behavior for a soft-delete pattern.