### PR TITLE
fix(ci): apply migrations over HTTP (pg/query), not psql

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -35,6 +35,10 @@ jobs:
       - name: Verify base-branch migrations are applied
         run: node scripts/supabase-migrations.mjs check
         env:
+          # HTTP transport (preferred) — works over 443, no Postgres port needed.
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # psql fallback.
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
 
   # On push to main: apply any pending migrations to the deployed database
@@ -54,13 +58,19 @@ jobs:
 
       - name: Apply pending migrations
         env:
+          # HTTP transport (preferred) — works over 443, no Postgres port needed.
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # psql fallback.
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
-          if [ -z "${SUPABASE_DB_URL:-}" ]; then
-            echo "::error::SUPABASE_DB_URL repository secret is not set."
-            echo "::error::Configure it in Settings -> Secrets and variables -> Actions"
-            echo "::error::so this workflow can apply migrations to the deployed database."
-            exit 1
+          if [ -z "${SUPABASE_URL:-}" ] || [ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
+            if [ -z "${SUPABASE_DB_URL:-}" ]; then
+              echo "::error::No migration transport configured."
+              echo "::error::Set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (HTTP, preferred),"
+              echo "::error::or SUPABASE_DB_URL (psql), in Settings -> Secrets and variables -> Actions."
+              exit 1
+            fi
           fi
           node scripts/supabase-migrations.mjs apply
 

--- a/scripts/supabase-migrations.mjs
+++ b/scripts/supabase-migrations.mjs
@@ -1,25 +1,26 @@
 #!/usr/bin/env node
-// Check / apply Supabase SQL migrations against the database in $SUPABASE_DB_URL.
+// Check / apply Supabase SQL migrations against the deployed database.
 //
 // Tracks applied migrations in `supabase_migrations.schema_migrations` (the same
 // schema the Supabase CLI uses), keyed by the filename version prefix
 // (e.g. `00005` for `00005_gabinet_treatment_tax_exempt.sql`).
 //
+// Two transports, auto-selected:
+//   1. HTTP (preferred) — POST ${SUPABASE_URL}/pg/query with the service-role
+//      key. Works over 443 (no Postgres port needed), which is why it succeeds
+//      where psql to the pooler fails. Needs SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY.
+//   2. psql (fallback) — raw Postgres connection via SUPABASE_DB_URL. Needs the
+//      DB/pooler port reachable from the runner.
+//
 // Modes:
 //   check               — print pending migrations, exit non-zero if any (default)
-//   apply               — apply pending migrations in order, each wrapped in
-//                         BEGIN/COMMIT, recording success in schema_migrations
-//   mark <ver> [<ver>…] — record the given versions as applied without running
-//                         them. One-time bootstrap when the deployed database
-//                         already has migrations that were applied manually
-//                         (e.g. 00001-00004 in this repo).
+//   apply               — apply pending migrations in order, recording success
+//   mark <ver> [<ver>…] — record versions as applied without running them
 //
-// Requires `psql` on PATH (preinstalled on ubuntu-latest GitHub runners).
-//
-// Why this exists: issue #935 — migration 00005 was merged 2 days before being
-// flagged as missing from quera-dev because nothing in CI/CD applies migrations.
+// Why this exists: issue #935 — nothing in CI/CD applied migrations, so merged
+// migrations silently never reached the DB.
 
-import { readdirSync, existsSync } from "node:fs";
+import { readdirSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 
@@ -31,18 +32,25 @@ if (!["check", "apply", "mark"].includes(MODE)) {
   process.exit(2);
 }
 
-const dbUrl = process.env.SUPABASE_DB_URL;
-if (!dbUrl) {
+// ---------------------------------------------------------------------------
+// Transport selection
+// ---------------------------------------------------------------------------
+
+const httpUrl = (process.env.SUPABASE_URL ?? "").replace(/\/+$/u, "");
+const httpKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+const dbUrl = process.env.SUPABASE_DB_URL ?? "";
+
+const useHttp = Boolean(httpUrl && httpKey);
+const usePsql = !useHttp && Boolean(dbUrl);
+
+if (!useHttp && !usePsql) {
   // Emit a GitHub Actions warning annotation so the missing-secret state is
-  // visible in the PR checks UI instead of being silently green. Plain text
-  // outside Actions, parsed as an annotation when GITHUB_ACTIONS=true (#1651,
-  // surfaced during #1284 PR review where this had silently skipped).
+  // visible in the PR checks UI instead of being silently green.
   console.log(
-    `::warning::SUPABASE_DB_URL is not set — skipping migration ${MODE}. ` +
-      `Configure the SUPABASE_DB_URL repository secret to enable this check.`,
+    `::warning::No migration transport configured — skipping ${MODE}. ` +
+      `Set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (HTTP, preferred) or ` +
+      `SUPABASE_DB_URL (psql) as repository secrets.`,
   );
-  // Exit 0 so callers that haven't configured the secret aren't blocked.
-  // The CI workflow gates the apply job on the secret separately for stricter enforcement.
   process.exit(0);
 }
 
@@ -50,6 +58,42 @@ if (!existsSync(MIGRATIONS_DIR)) {
   console.error(`No ${MIGRATIONS_DIR} directory found.`);
   process.exit(0);
 }
+
+// ---------------------------------------------------------------------------
+// HTTP transport (POST ${SUPABASE_URL}/pg/query)
+// ---------------------------------------------------------------------------
+
+async function httpQuery(sql) {
+  const res = await fetch(`${httpUrl}/pg/query`, {
+    method: "POST",
+    headers: {
+      apikey: httpKey,
+      Authorization: `Bearer ${httpKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query: sql }),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`pg/query HTTP ${res.status}: ${text.slice(0, 600)}`);
+  }
+  let json;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    return [];
+  }
+  // The endpoint returns a JSON array of rows on success, or an object carrying
+  // Postgres error fields (severity/code/message) on failure — even with 200.
+  if (json && !Array.isArray(json) && (json.error || json.severity || json.code)) {
+    throw new Error(`pg/query error: ${(json.message ?? JSON.stringify(json)).toString().slice(0, 600)}`);
+  }
+  return Array.isArray(json) ? json : [];
+}
+
+// ---------------------------------------------------------------------------
+// psql transport (fallback)
+// ---------------------------------------------------------------------------
 
 function ensurePsql(result) {
   if (result.error && result.error.code === "ENOENT") {
@@ -63,22 +107,13 @@ function ensurePsql(result) {
 function runPsql(sql, { captureStdout = false } = {}) {
   const result = spawnSync(
     "psql",
-    [
-      dbUrl,
-      "-v",
-      "ON_ERROR_STOP=1",
-      "--no-psqlrc",
-      "--quiet",
-      ...(captureStdout ? ["-tA"] : []),
-      "-c",
-      sql,
-    ],
+    [dbUrl, "-v", "ON_ERROR_STOP=1", "--no-psqlrc", "--quiet",
+      ...(captureStdout ? ["-tA"] : []), "-c", sql],
     { encoding: "utf8" },
   );
   ensurePsql(result);
   if (result.status !== 0) {
-    const stderr = result.stderr ?? "";
-    throw new Error(`psql failed (exit ${result.status}): ${stderr.trim()}`);
+    throw new Error(`psql failed (exit ${result.status}): ${(result.stderr ?? "").trim()}`);
   }
   return result.stdout ?? "";
 }
@@ -86,24 +121,86 @@ function runPsql(sql, { captureStdout = false } = {}) {
 function runPsqlFile(path) {
   const result = spawnSync(
     "psql",
-    [
-      dbUrl,
-      "-v",
-      "ON_ERROR_STOP=1",
-      "--no-psqlrc",
-      "--quiet",
-      "--single-transaction",
-      "-f",
-      path,
-    ],
+    [dbUrl, "-v", "ON_ERROR_STOP=1", "--no-psqlrc", "--quiet", "--single-transaction", "-f", path],
     { encoding: "utf8" },
   );
   ensurePsql(result);
   if (result.status !== 0) {
-    const stderr = result.stderr ?? "";
-    throw new Error(`psql failed applying ${path} (exit ${result.status}): ${stderr.trim()}`);
+    throw new Error(`psql failed applying ${path} (exit ${result.status}): ${(result.stderr ?? "").trim()}`);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Transport-agnostic operations
+// ---------------------------------------------------------------------------
+
+const versionInsertSql = (version, name) =>
+  `INSERT INTO supabase_migrations.schema_migrations (version, name) ` +
+  `VALUES ('${version}', '${name.replace(/'/gu, "''")}') ON CONFLICT (version) DO NOTHING;`;
+
+// Statements that cannot run inside an explicit transaction block, so the file
+// must be sent as-is (implicit / autocommit) rather than wrapped in BEGIN/COMMIT.
+const NON_TX = /concurrently|alter\s+type[\s\S]*?add\s+value/iu;
+
+async function ensureTrackingTable() {
+  const sql = `
+    CREATE SCHEMA IF NOT EXISTS supabase_migrations;
+    CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (
+      version TEXT PRIMARY KEY,
+      name TEXT,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );`;
+  if (useHttp) await httpQuery(sql);
+  else runPsql(sql);
+}
+
+async function fetchAppliedVersions() {
+  if (useHttp) {
+    const rows = await httpQuery(
+      "SELECT version FROM supabase_migrations.schema_migrations ORDER BY version;",
+    );
+    return rows.map((r) => String(r.version)).filter(Boolean);
+  }
+  const raw = runPsql(
+    "SELECT version FROM supabase_migrations.schema_migrations ORDER BY version;",
+    { captureStdout: true },
+  );
+  return raw.split("\n").map((l) => l.trim()).filter(Boolean);
+}
+
+async function markVersion(m) {
+  const sql = versionInsertSql(m.version, m.name);
+  if (useHttp) await httpQuery(sql);
+  else runPsql(sql);
+}
+
+async function applyMigration(m) {
+  const path = join(MIGRATIONS_DIR, m.file);
+  if (useHttp) {
+    const body = readFileSync(path, "utf8");
+    if (NON_TX.test(body)) {
+      // Cannot wrap: run the file as-is, then record the version separately.
+      await httpQuery(body);
+      await httpQuery(versionInsertSql(m.version, m.name));
+    } else {
+      // Atomic: migration + version insert commit together (or not at all).
+      await httpQuery(`BEGIN;\n${body}\n${versionInsertSql(m.version, m.name)}\nCOMMIT;`);
+    }
+  } else {
+    runPsqlFile(path);
+    runPsql(versionInsertSql(m.version, m.name));
+  }
+}
+
+async function notifyPostgrestReload() {
+  const sql = "NOTIFY pgrst, 'reload schema';";
+  if (useHttp) await httpQuery(sql);
+  else runPsql(sql);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
 
 function parseFile(name) {
   const match = /^(\d+)_(.+)\.sql$/u.exec(name);
@@ -121,26 +218,10 @@ if (localMigrations.length === 0) {
   process.exit(0);
 }
 
-// Ensure tracking table exists
-runPsql(`
-  CREATE SCHEMA IF NOT EXISTS supabase_migrations;
-  CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (
-    version TEXT PRIMARY KEY,
-    name TEXT,
-    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-  );
-`);
+console.log(`Using ${useHttp ? "HTTP (pg/query)" : "psql"} transport.`);
 
-const appliedRaw = runPsql(
-  "SELECT version FROM supabase_migrations.schema_migrations ORDER BY version;",
-  { captureStdout: true },
-);
-const applied = new Set(
-  appliedRaw
-    .split("\n")
-    .map((l) => l.trim())
-    .filter(Boolean),
-);
+await ensureTrackingTable();
+const applied = new Set(await fetchAppliedVersions());
 
 if (MODE === "mark") {
   const versions = process.argv.slice(3);
@@ -158,12 +239,7 @@ if (MODE === "mark") {
   }
   for (const v of versions) {
     const m = localMigrations.find((x) => x.version === v);
-    const sanitizedName = m.name.replace(/'/gu, "''");
-    runPsql(
-      `INSERT INTO supabase_migrations.schema_migrations (version, name) ` +
-        `VALUES ('${m.version}', '${sanitizedName}') ` +
-        `ON CONFLICT (version) DO NOTHING;`,
-    );
+    await markVersion(m);
     console.log(`marked ${m.version} as applied`);
   }
   process.exit(0);
@@ -184,36 +260,22 @@ for (const m of pending) console.log(`  - ${m.file}`);
 if (MODE === "check") {
   console.error(
     "\nThe deployed database is missing the migrations above. Run\n" +
-      "`npm run migrations:apply` (with SUPABASE_DB_URL set) to apply them, or wait\n" +
-      "for the CI workflow on main to do it.",
+      "`npm run migrations:apply` to apply them, or wait for the CI workflow on main.",
   );
   process.exit(1);
 }
 
 // apply
 for (const m of pending) {
-  const path = join(MIGRATIONS_DIR, m.file);
   console.log(`Applying ${m.file}...`);
-  runPsqlFile(path);
-  // Record after success. We do this in a separate statement because some
-  // migrations contain statements that cannot run inside a transaction
-  // (e.g. CREATE INDEX CONCURRENTLY). psql --single-transaction will already
-  // have committed if all statements ran successfully.
-  const sanitizedName = m.name.replace(/'/gu, "''");
-  runPsql(
-    `INSERT INTO supabase_migrations.schema_migrations (version, name) ` +
-      `VALUES ('${m.version}', '${sanitizedName}') ` +
-      `ON CONFLICT (version) DO NOTHING;`,
-  );
+  await applyMigration(m);
   console.log(`  applied ${m.version}`);
 }
 
 console.log(`\nApplied ${pending.length} migration(s).`);
 
-// Reload PostgREST schema cache so newly-added columns/tables are visible
-// without waiting for the periodic refresh. Safe no-op if pgrst isn't listening.
 try {
-  runPsql("NOTIFY pgrst, 'reload schema';");
+  await notifyPostgrestReload();
   console.log("Notified PostgREST to reload schema cache.");
 } catch (err) {
   console.warn(`Could not notify PostgREST: ${err.message}`);


### PR DESCRIPTION
The Supabase Migrations `apply` job has failed on every push to main: `SUPABASE_DB_URL` was unset, and the Postgres/pooler port isn't reachable from GitHub runners regardless. Migrations never auto-applied and drifted.

This rewires `scripts/supabase-migrations.mjs` to apply over HTTP — `POST ${SUPABASE_URL}/pg/query` with the service-role key (port 443, the same channel used for manual remediation). `psql`/`SUPABASE_DB_URL` remains as an automatic fallback. The workflow now provides `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` (both set as repo secrets) and gates on either transport being present.

Transaction semantics preserved; `CONCURRENTLY` / `ALTER TYPE ... ADD VALUE` files are sent unwrapped. Verified locally: `check` over HTTP reports "All 46 migrations applied".

🤖 Generated with [Claude Code](https://claude.com/claude-code)