### PR TITLE
Zaproszenie

### DIFF
--- a/src/routes/_app/invite.$token.tsx
+++ b/src/routes/_app/invite.$token.tsx
@@ -36,28 +36,41 @@ function InviteAcceptPage() {
   const [isAccepting, setIsAccepting] = useState(false);
   const [isDeclining, setIsDeclining] = useState(false);
   const [result, setResult] = useState<"accepted" | "declined" | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const isLoading = authLoading || inviteLoading;
 
   const handleAccept = async () => {
     setIsAccepting(true);
+    setActionError(null);
     try {
       await acceptInvitation({ token });
       setResult("accepted");
       setTimeout(() => {
         navigate({ to: "/dashboard" });
       }, 1500);
-    } catch {
+    } catch (err) {
+      setActionError(
+        err instanceof Error
+          ? err.message
+          : t("invite.acceptError", { defaultValue: "Coś poszło nie tak. Spróbuj ponownie." })
+      );
       setIsAccepting(false);
     }
   };
 
   const handleDecline = async () => {
     setIsDeclining(true);
+    setActionError(null);
     try {
       await declineInvitation({ token });
       setResult("declined");
-    } catch {
+    } catch (err) {
+      setActionError(
+        err instanceof Error
+          ? err.message
+          : t("invite.declineError", { defaultValue: "Coś poszło nie tak. Spróbuj ponownie." })
+      );
       setIsDeclining(false);
     }
   };
@@ -220,6 +233,13 @@ function InviteAcceptPage() {
               </Badge>
             </div>
           </div>
+
+          {actionError && (
+            <div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              <span>{actionError}</span>
+            </div>
+          )}
 
           <div className="flex gap-3">
             <Button

--- a/src/routes/_app/login/_layout.index.tsx
+++ b/src/routes/_app/login/_layout.index.tsx
@@ -66,15 +66,16 @@ function Login() {
 
   useEffect(() => {
     if (isLoading || !isAuthenticated) return;
+    // Redirect back to the invite page before any other check. The invite
+    // page handles its own auth/loading state, and checking !user first would
+    // send new sign-ups to /dashboard, silently dropping the invite token.
+    if (inviteToken) {
+      navigate({ to: "/invite/$token", params: { token: inviteToken }, replace: true });
+      return;
+    }
     if (!user) {
       // No user record yet — let the dashboard's auth gate handle it
       navigate({ to: DashboardRoute.fullPath, replace: true });
-      return;
-    }
-    // If user came from /invite/<token>, send them back so the invitation
-    // gets accepted automatically.
-    if (inviteToken) {
-      navigate({ to: "/invite/$token", params: { token: inviteToken }, replace: true });
       return;
     }
     if (!user.username) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2854.

Closes #2854

---

## Claude summary

Two bugs were found and fixed.

**Bug 1 — silent failure on accept/decline** (`src/routes/_app/invite.$token.tsx`): The `handleAccept` and `handleDecline` catch blocks were swallowing all errors — the server could throw (email mismatch, seat limit reached, invitation already used, not authenticated, etc.) and the only visible effect was the button briefly disabling then re-enabling. Added `actionError` state that captures and displays the server error message in a red alert box above the buttons.

**Bug 2 — new users redirected away from invite** (`src/routes/_app/login/_layout.index.tsx`): After OTP verification, the `useEffect` checked `!user` before `inviteToken`. When a brand-new user signs up via an invite link, `isAuthenticated` becomes true but the `getCurrentUser` query result is still `undefined` (pending). The `!user` branch ran first and redirected to `/dashboard`, dropping the invite token. The user would land on an empty dashboard with no organization. Fixed by moving the `inviteToken` check before the `!user` check — the invite page handles its own auth state, so it's always safe to redirect there immediately after auth succeeds.

## Follow-ups

- Add error display to `handleAccept`/`handleDecline` in patient portal invite flow if one exists: the same silent-catch pattern may be present in other invitation acceptance paths
- `_acceptInternal` schedules `writeTeamMembershipToSupabase` before `writeUserToSupabase` with the same `runAfter(0, ...)` delay — a race condition where the membership FK write arrives before the user row lands in Supabase, causing `23503` FK violations; `writeUserToSupabase` should run with delay 0 and `writeTeamMembershipToSupabase` with delay 500 (or the membership write should depend on the user write)
- `writeUserToSupabase` is called with `username: user.username` which is still `null` at that point even though `ctx.db.patch` just set it — the Supabase `users` row ends up with a null username; fix by capturing the generated `candidate` and passing it explicitly to the scheduled job