### PR TITLE
`_acceptInternal` schedules `writeTeamMembershipToSupabase` before `writeUserToS

### DIFF
--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -427,7 +427,7 @@ export const _acceptInternal = internalMutation({
     // Convex teamMemberships but is invisible to the UI's permission
     // checks — UI shows empty / 403 on protected actions.
     await ctx.scheduler.runAfter(
-      0,
+      500, // delay so writeUserToSupabase lands first (avoids 23503 FK violation)
       internal.supabase.organizations.writeTeamMembershipToSupabase,
       {
         membershipId: String(membershipId),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2859.

Closes #2859

---

## Claude summary

The bug was real. In `_acceptInternal` (convex/invitations.ts:429), `writeTeamMembershipToSupabase` was scheduled with `runAfter(0, ...)` before `writeUserToSupabase` which was also `runAfter(0, ...)`. Since both have the same delay, the Convex scheduler can execute them in either order — and when the membership write runs first, Supabase rejects it with a `23503 FK violation` because the user row doesn't exist yet.

The fix changes `writeTeamMembershipToSupabase` from delay 0 to 500ms, exactly matching the pattern already used for `_createFromInvitation` (gabinet employee creation) at line 500–509, which has the same dependency on the user row.