### PR TITLE
`writeUserToSupabase` is called with `username

### DIFF
--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -445,6 +445,7 @@ export const _acceptInternal = internalMutation({
     // address like "john.doe@x.com" would fail it, leaving the invitee
     // stuck. Slug derivation downstream tolerates anything (already strips
     // non-[a-z0-9-]).
+    let effectiveUsername = user.username;
     if (!user.username) {
       const local = (user.email ?? invitation.email).split("@")[0] ?? "";
       const base = local.toLowerCase().replace(/[^a-z0-9]/g, "");
@@ -467,6 +468,7 @@ export const _acceptInternal = internalMutation({
         if (suffix > 50) break; // give up; informational only
       }
       await ctx.db.patch(user._id, { username: candidate });
+      effectiveUsername = candidate;
     }
 
     // Mirror the invitee's user row to Supabase. Without this, any
@@ -477,7 +479,7 @@ export const _acceptInternal = internalMutation({
       userId: String(user._id),
       email: user.email,
       name: user.name,
-      username: user.username,
+      username: effectiveUsername,
       image: user.image,
       imageStorageId: user.imageId ? String(user.imageId) : undefined,
       phone: user.phone,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2860.

Closes #2860

---

## Claude summary

The bug was real and the fix is committed. Here's what happened:

In `convex/invitations.ts`, the `_acceptInternal` mutation derives a username for new OTP-signup invitees who don't have one yet. It generates a `candidate` string, calls `ctx.db.patch(user._id, { username: candidate })` to persist it, but then passes `user.username` (the stale pre-patch in-memory object) to `writeUserToSupabase`. Since `user` was fetched before the patch, `user.username` is still `null`, so the Supabase `users` row ends up with a null username.

The fix introduces `effectiveUsername = user.username` before the if-block, then sets `effectiveUsername = candidate` inside the block after the patch, and passes `effectiveUsername` to the scheduler instead of `user.username`.