### PR TITLE
Zaproszenie

### DIFF
--- a/src/routes/_app/invite.$token.tsx
+++ b/src/routes/_app/invite.$token.tsx
@@ -36,28 +36,41 @@ function InviteAcceptPage() {
   const [isAccepting, setIsAccepting] = useState(false);
   const [isDeclining, setIsDeclining] = useState(false);
   const [result, setResult] = useState<"accepted" | "declined" | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const isLoading = authLoading || inviteLoading;
 
   const handleAccept = async () => {
     setIsAccepting(true);
+    setActionError(null);
     try {
       await acceptInvitation({ token });
       setResult("accepted");
       setTimeout(() => {
         navigate({ to: "/dashboard" });
       }, 1500);
-    } catch {
+    } catch (err) {
+      setActionError(
+        err instanceof Error
+          ? err.message
+          : t("invite.acceptError", { defaultValue: "Coś poszło nie tak. Spróbuj ponownie." })
+      );
       setIsAccepting(false);
     }
   };
 
   const handleDecline = async () => {
     setIsDeclining(true);
+    setActionError(null);
     try {
       await declineInvitation({ token });
       setResult("declined");
-    } catch {
+    } catch (err) {
+      setActionError(
+        err instanceof Error
+          ? err.message
+          : t("invite.declineError", { defaultValue: "Coś poszło nie tak. Spróbuj ponownie." })
+      );
       setIsDeclining(false);
     }
   };
@@ -220,6 +233,13 @@ function InviteAcceptPage() {
               </Badge>
             </div>
           </div>
+
+          {actionError && (
+            <div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              <span>{actionError}</span>
+            </div>
+          )}
 
           <div className="flex gap-3">
             <Button

--- a/src/routes/_app/login/_layout.index.tsx
+++ b/src/routes/_app/login/_layout.index.tsx
@@ -66,15 +66,16 @@ function Login() {
 
   useEffect(() => {
     if (isLoading || !isAuthenticated) return;
+    // Redirect back to the invite page before any other check. The invite
+    // page handles its own auth/loading state, and checking !user first would
+    // send new sign-ups to /dashboard, silently dropping the invite token.
+    if (inviteToken) {
+      navigate({ to: "/invite/$token", params: { token: inviteToken }, replace: true });
+      return;
+    }
     if (!user) {
       // No user record yet — let the dashboard's auth gate handle it
       navigate({ to: DashboardRoute.fullPath, replace: true });
-      return;
-    }
-    // If user came from /invite/<token>, send them back so the invitation
-    // gets accepted automatically.
-    if (inviteToken) {
-      navigate({ to: "/invite/$token", params: { token: inviteToken }, replace: true });
       return;
     }
     if (!user.username) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2854.

Closes #2854

---

## Claude summary

Two bugs fixed:

**Bug 1 — `src/routes/_app/invite.$token.tsx`**: `handleAccept` and `handleDecline` were silently swallowing all errors. Added `actionError` state that captures the server error message and displays it in a red alert box above the Accept/Decline buttons.

**Bug 2 — `src/routes/_app/login/_layout.index.tsx`**: The `useEffect` checked `!user` before `inviteToken`. For brand-new users signing up via invite link, `isAuthenticated` becomes `true` but the `getCurrentUser` query is still `undefined` (pending) — so the `!user` branch fired first and redirected to `/dashboard`, dropping the invite token. Fixed by moving the `inviteToken` check before the `!user` guard.

**Test path for @aleksanderem**: Open the invite link in an incognito window. If you have an account for the invited email, log in via OTP and you'll land on the invite page. If it's a brand-new email, enter the OTP code and you'll now be redirected back to the invite page (instead of dashboard). Any server-side error (expired token, email mismatch, seat limit) will now appear as a red error message below the invitation details instead of silently doing nothing.

## Follow-ups

- Fix race condition in `_acceptInternal`: `writeTeamMembershipToSupabase` and `writeUserToSupabase` are both scheduled with `runAfter(0)`, but the membership row has a FK on the users table — membership write should use `runAfter(500)` to ensure the user row lands in Supabase first, avoiding `23503` FK violations
- Fix null username in `writeUserToSupabase` call in `_acceptInternal`: `user.username` is read before `ctx.db.patch(user._id, { username: candidate })` so the Supabase users row always gets `username: null`; capture `candidate` and pass it explicitly to the scheduled job