### PR TITLE
feat(gabinet): display variant name in appointment detail and patient history (closes #2868)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10416,8 +10416,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
       "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -12527,7 +12526,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -13505,7 +13503,6 @@
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
       "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
       "license": "MIT",
-      "dev": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -19765,7 +19762,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }

--- a/src/components/gabinet/calendar/appointment-card.tsx
+++ b/src/components/gabinet/calendar/appointment-card.tsx
@@ -21,6 +21,7 @@ interface AppointmentCardProps {
   endTime: string;
   patientName: string;
   treatmentName: string;
+  variantName?: string;
   status: string;
   color?: string;
   tags?: AppointmentTag[];
@@ -41,6 +42,7 @@ export function AppointmentCard({
   endTime,
   patientName,
   treatmentName,
+  variantName,
   status,
   color,
   tags,
@@ -122,7 +124,9 @@ export function AppointmentCard({
       </div>
       <div className="px-2 py-1">
         <div className="truncate font-medium">{patientName}</div>
-        <div className="truncate opacity-75">{treatmentName}</div>
+        <div className="truncate opacity-75">
+          {treatmentName}{variantName ? ` · ${variantName}` : ""}
+        </div>
       </div>
     </button>
   );

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -468,6 +468,8 @@ export function AppointmentPreviewContent({
     treatments?.find((tr) => tr._id === treatmentId) ?? null;
   const treatmentDisplayName =
     selectedTreatment?.name ?? treatment?.name ?? "";
+  const selectedVariantName =
+    variants?.find((v) => v._id === variantId)?.name ?? "";
   const filteredTreatments = (() => {
     const all = treatments ?? [];
     const q = treatmentSearch.trim().toLowerCase();
@@ -1335,8 +1337,11 @@ export function AppointmentPreviewContent({
               >
                 <Stethoscope className="size-3.5 shrink-0 text-primary" />
                 <span className="truncate">
-                  {treatmentDisplayName ||
-                    t("gabinet.appointments.selectTreatment")}
+                  {treatmentDisplayName
+                    ? selectedVariantName
+                      ? `${treatmentDisplayName} · ${selectedVariantName}`
+                      : treatmentDisplayName
+                    : t("gabinet.appointments.selectTreatment")}
                 </span>
                 <ChevronsUpDown className="size-3.5 shrink-0 opacity-60" />
               </button>

--- a/src/components/gabinet/calendar/calendar-day-by-employee-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-by-employee-view.tsx
@@ -14,6 +14,7 @@ interface Appointment {
   endTime: string;
   patientName: string;
   treatmentName: string;
+  variantName?: string;
   status: string;
   color?: string;
   employeeId?: string;

--- a/src/components/gabinet/calendar/calendar-day-view.tsx
+++ b/src/components/gabinet/calendar/calendar-day-view.tsx
@@ -12,6 +12,7 @@ interface Appointment {
   endTime: string;
   patientName: string;
   treatmentName: string;
+  variantName?: string;
   status: string;
   color?: string;
   tags?: Array<{ name: string; color: string }>;

--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -15,6 +15,7 @@ interface Appointment {
   endTime: string;
   patientName: string;
   treatmentName: string;
+  variantName?: string;
   status: string;
   color?: string;
   tags?: Array<{ name: string; color: string }>;

--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -23,6 +23,7 @@ interface Appointment {
   endTime: string;
   patientName: string;
   treatmentName: string;
+  variantName?: string;
   status: string;
   color?: string;
   tags?: AppointmentTag[];
@@ -55,6 +56,7 @@ export function DraggableAppointment({
   endTime,
   patientName,
   treatmentName,
+  variantName,
   status,
   color,
   tags,
@@ -329,6 +331,7 @@ export function DraggableAppointment({
         endTime={displayEndTime}
         patientName={patientName}
         treatmentName={treatmentName}
+        variantName={variantName}
         status={status}
         color={color}
         tags={tags}

--- a/src/hooks/use-supabase-gabinet-treatments.ts
+++ b/src/hooks/use-supabase-gabinet-treatments.ts
@@ -92,6 +92,35 @@ export function useSupabaseGabinetTreatment(
 // Treatment Variants (by treatment ID)
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// All Treatment Variants for Org (for building lookup maps)
+// ---------------------------------------------------------------------------
+
+export function useSupabaseGabinetAllTreatmentVariants(
+  organizationId: string,
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  return useQuery<MappedGabinetTreatmentVariant[], Error>({
+    queryKey: supabaseKeys.gabinetTreatmentVariants.list(organizationId),
+    queryFn: async (): Promise<MappedGabinetTreatmentVariant[]> => {
+      if (!client) throw new Error("Supabase client not ready");
+
+      const { data, error } = await client
+        .from("gabinet_treatment_variants")
+        .select("*")
+        .eq("organization_id", organizationId)
+        .order("sort_order", { ascending: true });
+
+      if (error) throw error;
+      return (data ?? []).map(mapGabinetTreatmentVariantFromSupabase);
+    },
+    enabled: enabled && isReady && !!organizationId,
+  } satisfies UseQueryOptions<MappedGabinetTreatmentVariant[], Error>);
+}
+
 interface UseSupabaseGabinetTreatmentVariantsOptions {
   enabled?: boolean;
   limit?: number;

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -4730,6 +4730,7 @@ export interface Database {
           contraindication_alerts_reviewed: boolean | null;
           price_at_booking: number | null;
           reminder_overrides: string | null;
+          variant_id: string | null;
         };
         Insert: {
           id?: string;
@@ -4777,6 +4778,7 @@ export interface Database {
           contraindication_alerts_reviewed?: boolean | null;
           price_at_booking?: number | null;
           reminder_overrides?: string | null;
+          variant_id?: string | null;
         };
         Update: {
           id?: string;
@@ -4824,6 +4826,7 @@ export interface Database {
           contraindication_alerts_reviewed?: boolean | null;
           price_at_booking?: number | null;
           reminder_overrides?: string | null;
+          variant_id?: string | null;
         };
         Relationships: [
           {

--- a/src/lib/supabase/mappers/gabinet/appointments.ts
+++ b/src/lib/supabase/mappers/gabinet/appointments.ts
@@ -44,6 +44,7 @@ export interface MappedGabinetAppointment {
   bookedByPatientId?: string;
   locationId?: string;
   roomId?: string;
+  variantId?: string;
   tagIds?: string[];
   categoryId?: string;
   requiresCompletion?: boolean;

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -73,7 +73,7 @@ import {
 import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
-import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
+import { useSupabaseGabinetTreatmentsList, useSupabaseGabinetAllTreatmentVariants } from "@/hooks/use-supabase-gabinet-treatments";
 import { useSupabaseGabinetEmployeeSchedulesList } from "@/hooks/use-supabase-gabinet-employee-schedules";
 import { useSupabaseGabinetWorkingHoursList } from "@/hooks/use-supabase-gabinet-working-hours";
 import { useSupabaseGabinetLeavesList } from "@/hooks/use-supabase-gabinet-leaves";
@@ -210,6 +210,7 @@ function GabinetCalendarPage() {
     endTime: string;
     patientName: string;
     treatmentName: string;
+    variantName?: string;
     status: string;
     color?: string;
     tags?: Array<{ name: string; color: string }>;
@@ -334,6 +335,7 @@ function GabinetCalendarPage() {
     organizationId,
     { limit: 200 },
   );
+  const { data: allVariants } = useSupabaseGabinetAllTreatmentVariants(organizationId);
 
   // Fetch employee schedules from Supabase
   const { data: employeeSchedulesRaw } = useSupabaseGabinetEmployeeSchedulesList(
@@ -366,6 +368,16 @@ function GabinetCalendarPage() {
     }
     return map;
   }, [treatments]);
+
+  const variantMap = useMemo(() => {
+    const map = new Map<string, string>();
+    if (allVariants) {
+      for (const v of allVariants) {
+        map.set(v._id, v.name);
+      }
+    }
+    return map;
+  }, [allVariants]);
 
   // Fetch tag definitions to render colored pills on appointment cards
   const { tags: tagDefinitions } = useTagDefinitions(organizationId);
@@ -685,6 +697,7 @@ function GabinetCalendarPage() {
       endTime: string;
       patientName: string;
       treatmentName: string;
+      variantName?: string;
       status: string;
       color?: string;
       employeeId?: string;
@@ -837,6 +850,7 @@ function GabinetCalendarPage() {
           }
         }
 
+        const variantName = a.variantId ? variantMap.get(a.variantId) : undefined;
         items.push({
           _id: a._id,
           date: a.date,
@@ -844,6 +858,7 @@ function GabinetCalendarPage() {
           endTime: a.endTime,
           patientName: patientMap.get(a.patientId) ?? "",
           treatmentName: treatment?.name ?? "",
+          variantName,
           status: a.status,
           // Per-appointment override wins, then the employee's assigned color
           // (issue #1019), then treatment color as a final fallback.
@@ -903,7 +918,7 @@ function GabinetCalendarPage() {
     }
 
     return items;
-  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, tagMap, employeeColorMap, eventTypeColorMap, firstAppointmentIds, packagePositions, recurringPositions, appointmentPaymentTotals, creditByAppointmentId, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
+  }, [rawAppointments, blockedTimeActivities, patientMap, treatmentMap, variantMap, tagMap, employeeColorMap, eventTypeColorMap, firstAppointmentIds, packagePositions, recurringPositions, appointmentPaymentTotals, creditByAppointmentId, treatmentFilter, statusFilter, locationFilter, clientSearch, t]);
 
   // Collapse blocked-time events that target multiple employees into a single
   // tile for views that don't break the day into per-employee columns
@@ -1997,6 +2012,7 @@ function GabinetCalendarPage() {
               endTime={activeAppointment.endTime}
               patientName={activeAppointment.patientName}
               treatmentName={activeAppointment.treatmentName}
+              variantName={activeAppointment.variantName}
               status={activeAppointment.status}
               color={activeAppointment.color}
               tags={activeAppointment.tags}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
@@ -16,7 +16,7 @@ import {
 } from "@/hooks/use-supabase-gabinet-appointments";
 import type { MappedGabinetAppointment } from "@/lib/supabase/mappers/gabinet/appointments";
 import { useSupabaseGabinetLoyaltyBalance, useSupabaseGabinetLoyaltyTransactions } from "@/hooks/use-supabase-gabinet-loyalty";
-import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
+import { useSupabaseGabinetTreatmentsList, useSupabaseGabinetAllTreatmentVariants } from "@/hooks/use-supabase-gabinet-treatments";
 import {
   useSupabaseGabinetPackageUsageByPatient,
   useSupabaseGabinetTreatmentPackagesList,
@@ -259,6 +259,17 @@ function PatientDetail() {
   );
 
   const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId);
+  const { data: allVariantsData } = useSupabaseGabinetAllTreatmentVariants(organizationId);
+
+  const variantNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    if (allVariantsData) {
+      for (const v of allVariantsData) {
+        map.set(v._id, v.name);
+      }
+    }
+    return map;
+  }, [allVariantsData]);
 
   const { data: patientPayments } = useSupabasePaymentsByPatient(
     organizationId,
@@ -924,6 +935,12 @@ function PatientDetail() {
     const treatmentName = treatmentsData?.find(
       (tr) => tr._id === apt.treatmentId,
     )?.name;
+    const variantName = apt.variantId ? variantNameMap.get(apt.variantId) : undefined;
+    const treatmentDisplayName = treatmentName
+      ? variantName
+        ? `${treatmentName} · ${variantName}`
+        : treatmentName
+      : undefined;
     const visitCount = getVisitCountLabel(apt);
     return (
       <div
@@ -942,7 +959,7 @@ function PatientDetail() {
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 min-w-0">
             <p className="text-sm font-medium truncate">
-              {treatmentName ?? t("common.unknown")}
+              {treatmentDisplayName ?? t("common.unknown")}
             </p>
             {visitCount && (
               <Badge
@@ -1217,6 +1234,12 @@ function PatientDetail() {
                   const treatmentName = treatmentsData?.find(
                     (tr) => tr._id === apt.treatmentId,
                   )?.name;
+                  const variantName = apt.variantId ? variantNameMap.get(apt.variantId) : undefined;
+                  const treatmentDisplayName = treatmentName
+                    ? variantName
+                      ? `${treatmentName} · ${variantName}`
+                      : treatmentName
+                    : undefined;
                   const isPast =
                     apt.date < new Date().toISOString().split("T")[0];
                   const visitCount = getVisitCountLabel(apt);
@@ -1240,7 +1263,7 @@ function PatientDetail() {
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 min-w-0">
                           <p className="text-sm font-medium truncate">
-                            {treatmentName ?? t("common.unknown")}
+                            {treatmentDisplayName ?? t("common.unknown")}
                           </p>
                           {visitCount && (
                             <Badge
@@ -1309,6 +1332,12 @@ function PatientDetail() {
                 const treatmentName = treatmentsData?.find(
                   (tr) => tr._id === apt.treatmentId,
                 )?.name;
+                const variantName = apt.variantId ? variantNameMap.get(apt.variantId) : undefined;
+                const treatmentDisplayName = treatmentName
+                  ? variantName
+                    ? `${treatmentName} · ${variantName}`
+                    : treatmentName
+                  : undefined;
                 const planText = plateJsonToText(apt.interviewNotes).trim();
                 return (
                   <Card
@@ -1330,7 +1359,7 @@ function PatientDetail() {
                             variant="stroke"
                           />
                           <p className="text-sm font-medium truncate">
-                            {treatmentName ?? t("common.unknown")}
+                            {treatmentDisplayName ?? t("common.unknown")}
                           </p>
                         </div>
                         <p className="text-xs text-muted-foreground tabular-nums shrink-0">
@@ -2238,9 +2267,13 @@ function PatientDetail() {
                       const treatmentName =
                         treatmentsData?.find((tr) => tr._id === apt.treatmentId)
                           ?.name ?? t("common.unknown");
+                      const variantName = apt.variantId ? variantNameMap.get(apt.variantId) : undefined;
+                      const treatmentDisplayName = variantName
+                        ? `${treatmentName} · ${variantName}`
+                        : treatmentName;
                       return (
                         <SelectItem key={apt._id} value={apt._id}>
-                          {apt.date} · {apt.startTime} · {treatmentName}
+                          {apt.date} · {apt.startTime} · {treatmentDisplayName}
                         </SelectItem>
                       );
                     });


### PR DESCRIPTION
## Summary

- Add `variantName` prop to all calendar view component interfaces (day, week, day-by-employee, draggable appointment)
- Show variant name on calendar appointment cards as `treatment · variant` suffix
- Show variant name in the appointment preview popover (clicks on calendar events)
- Resolve variant names via `variantMap` in the calendar page and pass them down to all views
- Add `useSupabaseGabinetAllTreatmentVariants` hook to fetch all variants efficiently
- Display variant name alongside treatment name in the patient detail page: appointment history rows, beauty plan entries, and the payment appointment select dropdown

## Test plan

- [ ] Open the Gabinet calendar; create/find an appointment that has a treatment variant selected
- [ ] Verify the calendar tile shows `Treatment · Variant` in the subtitle line
- [ ] Click the appointment to open the preview popover; verify the treatment button shows `Treatment · Variant`
- [ ] Open a patient's detail page; go to the Appointments tab and verify variant appears in each row
- [ ] Check the "Beauty Plan" tab — variant name should appear alongside treatment name
- [ ] Add a payment on a patient page; verify the appointment select shows the variant name

🤖 Generated with [Claude Code](https://claude.com/claude-code)