### PR TITLE
Add variantId filtering to package usage selector

### DIFF
--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -514,9 +514,10 @@ export const purchasePackage = action({
       ? now + pkgValidityDays * 24 * 60 * 60 * 1000
       : null;
 
-    const pkgTreatments = pkg.treatments as Array<{ treatmentId: string; quantity: number }>;
+    const pkgTreatments = pkg.treatments as Array<{ treatmentId: string; variantId?: string; quantity: number }>;
     const treatmentsUsed = pkgTreatments.map((t) => ({
       treatmentId: t.treatmentId,
+      ...(t.variantId ? { variantId: t.variantId } : {}),
       usedCount: 0,
       totalCount: t.quantity,
     }));

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -1324,6 +1324,7 @@ export function AppointmentDialog({
                   <PackageUsageSelector
                     patientId={patientId}
                     treatmentId={treatmentId}
+                    variantId={variantId || undefined}
                     organizationId={organizationId}
                     selectedUsageId={packageUsageId}
                     onSelect={setPackageUsageId}

--- a/src/components/gabinet/package-usage-selector.tsx
+++ b/src/components/gabinet/package-usage-selector.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 interface PackageUsageSelectorProps {
   patientId: string;
   treatmentId: string;
+  variantId?: string;
   organizationId: Id<"organizations">;
   onSelect: (packageUsageId: string | null) => void;
   selectedUsageId?: string | null;
@@ -17,6 +18,7 @@ interface PackageUsageSelectorProps {
 export function PackageUsageSelector({
   patientId,
   treatmentId,
+  variantId,
   organizationId,
   onSelect,
   selectedUsageId,
@@ -47,11 +49,18 @@ export function PackageUsageSelector({
 
   if (!patientId || !treatmentId || !usages) return null;
 
-  // Find active usages that have remaining uses for this treatment
+  const matchesVariant = (tuVariantId?: string) => {
+    if (!tuVariantId) return true;
+    return tuVariantId === variantId;
+  };
+
+  // Find active usages that have remaining uses for this treatment and variant
   const eligibleUsages = usages.filter((u) => {
     if (u.status !== "active") return false;
     if (u.expiresAt && u.expiresAt < Date.now()) return false;
-    const entry = u.treatmentsUsed.find((tu) => tu.treatmentId === treatmentId);
+    const entry = u.treatmentsUsed.find(
+      (tu) => tu.treatmentId === treatmentId && matchesVariant(tu.variantId),
+    );
     return entry && entry.usedCount < entry.totalCount;
   });
 
@@ -60,7 +69,9 @@ export function PackageUsageSelector({
   return (
     <div className="space-y-2">
       {eligibleUsages.map((usage) => {
-        const entry = usage.treatmentsUsed.find((tu) => tu.treatmentId === treatmentId)!;
+        const entry = usage.treatmentsUsed.find(
+          (tu) => tu.treatmentId === treatmentId && matchesVariant(tu.variantId),
+        )!;
         const pkgName = packageMap.get(usage.packageId) ?? t("common.unknown");
         const remaining = entry.totalCount - entry.usedCount;
         const isChecked = selectedUsageId === usage._id;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2869.

Closes #2869

---

## Claude summary

The fix is committed. Here's what was changed across 3 files:

**`src/components/gabinet/package-usage-selector.tsx`**
- Added `variantId?: string` prop
- Added `matchesVariant()` helper: entries without a `variantId` are eligible for all variants (backwards compatibility with existing usage records); entries with a `variantId` only match when it equals the selected variant
- Applied the variant filter in both the eligibility check and the render-loop entry lookup

**`src/components/gabinet/calendar/appointment-dialog.tsx`**
- Passes `variantId={variantId || undefined}` from the already-present dialog state to `PackageUsageSelector`

**`convex/gabinet/packages.ts`**
- In the package purchase action, widened the `pkgTreatments` cast to include `variantId?: string` and spreads it into each `treatmentsUsed` entry, so newly purchased packages record which variant each treatment slot covers

## Follow-ups

- Fix `usePackageTreatment` decrement to match by variantId: `packages.ts:677-678` finds the treatment entry by `treatmentId` only — if a package has the same treatment for two different variants, it could decrement the wrong slot; should also match on `variantId` when present
- Fix `_e2eTest.ts` package setup to omit variantId propagation: `_e2eTest.ts:474-478` mirrors the old purchase mapping and doesn't copy `variantId`, so integration tests won't exercise variant-aware packages