### PR TITLE
Fix `usePackageTreatment` decrement to match by variantId

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -241,6 +241,7 @@ async function applyAppointmentStatusChange(
         appointmentId: args.appointment._id,
         patientId: args.appointment.patientId,
         treatmentId: args.appointment.treatmentId,
+        variantId: args.appointment.variantId as Id<"gabinetTreatmentVariants"> | undefined,
         packageUsageId: args.appointment.packageUsageId as
           | Id<"gabinetPackageUsage">
           | undefined,
@@ -2624,6 +2625,7 @@ async function handleAppointmentCompletion(
     appointmentId: Id<"gabinetAppointments">;
     patientId: Id<"gabinetPatients">;
     treatmentId: Id<"gabinetTreatments">;
+    variantId?: Id<"gabinetTreatmentVariants">;
     packageUsageId?: Id<"gabinetPackageUsage">;
     priceAtBooking?: number;
     userId: Id<"users">;
@@ -2652,14 +2654,13 @@ async function handleAppointmentCompletion(
       packageUsageIdStr,
     );
     if (usage && usage.status === "active") {
-      const entry = usage.treatmentsUsed.find(
-        (t: any) => t.treatmentId === treatmentIdStr,
-      );
+      const variantIdStr = args.variantId ? String(args.variantId) : undefined;
+      const matchesTreatment = (t: any) =>
+        t.treatmentId === treatmentIdStr && (variantIdStr == null || t.variantId === variantIdStr);
+      const entry = usage.treatmentsUsed.find(matchesTreatment);
       if (entry && entry.usedCount < entry.totalCount) {
         const updatedTreatments = usage.treatmentsUsed.map((t: any) =>
-          t.treatmentId === treatmentIdStr
-            ? { ...t, usedCount: t.usedCount + 1 }
-            : t,
+          matchesTreatment(t) ? { ...t, usedCount: t.usedCount + 1 } : t,
         );
         const allUsed = updatedTreatments.every(
           (t: any) => t.usedCount >= t.totalCount,

--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -655,6 +655,7 @@ export const usePackageTreatment = action({
     organizationId: v.id("organizations"),
     usageId: v.string(),
     treatmentId: v.string(),
+    variantId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await ctx.runQuery(
@@ -675,13 +676,15 @@ export const usePackageTreatment = action({
     if ((usage.status as string) !== "active") throw new Error("Package is not active");
     if (usage.expiresAt && (usage.expiresAt as number) < Date.now()) throw new Error("Package has expired");
 
-    const treatmentsUsed = usage.treatmentsUsed as Array<{ treatmentId: string; usedCount: number; totalCount: number }>;
-    const treatmentEntry = treatmentsUsed.find((t) => t.treatmentId === args.treatmentId);
+    const treatmentsUsed = usage.treatmentsUsed as Array<{ treatmentId: string; variantId?: string; usedCount: number; totalCount: number }>;
+    const treatmentEntry = treatmentsUsed.find(
+      (t) => t.treatmentId === args.treatmentId && (args.variantId == null || t.variantId === args.variantId),
+    );
     if (!treatmentEntry) throw new Error("Treatment not in package");
     if (treatmentEntry.usedCount >= treatmentEntry.totalCount) throw new Error("Treatment usage exhausted");
 
     const updatedTreatments = treatmentsUsed.map((t) =>
-      t.treatmentId === args.treatmentId
+      t.treatmentId === args.treatmentId && (args.variantId == null || t.variantId === args.variantId)
         ? { ...t, usedCount: t.usedCount + 1 }
         : t
     );
@@ -705,6 +708,7 @@ export const usePackageTreatmentsBatch = action({
     items: v.array(
       v.object({
         treatmentId: v.string(),
+        variantId: v.optional(v.string()),
         quantity: v.number(),
       }),
     ),
@@ -731,12 +735,15 @@ export const usePackageTreatmentsBatch = action({
     if ((usage.status as string) !== "active") throw new Error("Package is not active");
     if (usage.expiresAt && (usage.expiresAt as number) < Date.now()) throw new Error("Package has expired");
 
-    const treatmentsUsed = usage.treatmentsUsed as Array<{ treatmentId: string; usedCount: number; totalCount: number }>;
+    const treatmentsUsed = usage.treatmentsUsed as Array<{ treatmentId: string; variantId?: string; usedCount: number; totalCount: number }>;
+
+    const matchesItem = (t: { treatmentId: string; variantId?: string }, item: { treatmentId: string; variantId?: string }) =>
+      t.treatmentId === item.treatmentId && (item.variantId == null || t.variantId === item.variantId);
 
     // Validate all items before applying any
     for (const item of args.items) {
       if (item.quantity < 1) throw new Error("Quantity must be at least 1");
-      const entry = treatmentsUsed.find((t) => t.treatmentId === item.treatmentId);
+      const entry = treatmentsUsed.find((t) => matchesItem(t, item));
       if (!entry) throw new Error(`Treatment ${item.treatmentId} not in package`);
       if (entry.usedCount + item.quantity > entry.totalCount) {
         throw new Error(
@@ -747,7 +754,7 @@ export const usePackageTreatmentsBatch = action({
 
     // Apply all increments
     const updatedTreatments = treatmentsUsed.map((t) => {
-      const item = args.items.find((i) => i.treatmentId === t.treatmentId);
+      const item = args.items.find((i) => matchesItem(t, i));
       if (!item) return t;
       return { ...t, usedCount: t.usedCount + item.quantity };
     });

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -496,6 +496,7 @@ export function createGabinetTables({
     treatments: v.array(
       v.object({
         treatmentId: v.id("gabinetTreatments"),
+        variantId: v.optional(v.id("gabinetTreatmentVariants")),
         quantity: v.number(),
       }),
     ),
@@ -524,6 +525,7 @@ export function createGabinetTables({
     treatmentsUsed: v.array(
       v.object({
         treatmentId: v.id("gabinetTreatments"),
+        variantId: v.optional(v.id("gabinetTreatmentVariants")),
         usedCount: v.number(),
         totalCount: v.number(),
       }),

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -1066,6 +1066,7 @@ export function AppointmentPreviewContent({
           items: [
             {
               treatmentId: String(appointment.treatmentId),
+              ...(appointment.variantId ? { variantId: String(appointment.variantId) } : {}),
               quantity: settlePackageQuantity,
             },
           ],

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -249,7 +249,7 @@ function AppointmentDetail() {
   const [usageDialogOpen, setUsageDialogOpen] = useState(false);
   const [usageDialogPkgId, setUsageDialogPkgId] = useState<string | null>(null);
   const [usageDialogItems, setUsageDialogItems] = useState<
-    Array<{ treatmentId: string; treatmentName: string; remaining: number; qty: number }>
+    Array<{ treatmentId: string; variantId?: string; treatmentName: string; remaining: number; qty: number }>
   >([]);
   const [isUsageSubmitting, setIsUsageSubmitting] = useState(false);
 
@@ -1869,6 +1869,7 @@ function AppointmentDetail() {
                                       .filter((e) => (e.usedCount ?? 0) < (e.totalCount ?? 0))
                                       .map((e) => ({
                                         treatmentId: e.treatmentId,
+                                        variantId: (e as any).variantId ?? undefined,
                                         treatmentName: e.treatmentName ?? t("gabinet.packages.treatment"),
                                         remaining: (e.totalCount ?? 0) - (e.usedCount ?? 0),
                                         qty: 0,
@@ -2483,6 +2484,7 @@ function AppointmentDetail() {
                   .filter((it) => it.qty > 0)
                   .map((it) => ({
                     treatmentId: it.treatmentId,
+                    ...(it.variantId ? { variantId: it.variantId } : {}),
                     quantity: it.qty,
                   }));
                 if (items.length === 0) return;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2873.

Closes #2873

---

## Claude summary

The bug was real and is now fixed. Here's a summary of what changed:

**Root cause**: `usePackageTreatment` and `usePackageTreatmentsBatch` matched `treatmentsUsed` entries by `treatmentId` only. If a package held the same treatment under two different variants, the `map` would increment both entries' `usedCount` simultaneously, and the `find` could validate the wrong slot.

**Changes across 5 files:**

- `convex/schema/gabinet.ts` — added `variantId: v.optional(v.id("gabinetTreatmentVariants"))` to both `gabinetTreatmentPackages.treatments` and `gabinetPackageUsage.treatmentsUsed` item shapes.

- `convex/gabinet/packages.ts` — `usePackageTreatment` now accepts an optional `variantId` arg; the `find` and `map` predicates match on both `treatmentId` and `variantId` (when provided). `usePackageTreatmentsBatch` items likewise accept `variantId`, with a shared `matchesItem` helper used for both the validation loop and the apply loop.

- `convex/gabinet/appointments.ts` — `handleAppointmentCompletion` now accepts `variantId` and uses it in the package deduction predicate; the call site passes `appointment.variantId`.

- `src/components/gabinet/calendar/appointment-preview-content.tsx` — settle-payment batch call now spreads `appointment.variantId` into the item.

- `src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx` — `usageDialogItems` state type includes `variantId`; it's populated from `treatmentsUsed` entries and forwarded in the batch call.