### PR TITLE
Fix `_e2eTest.ts` package setup to omit variantId propagation

### DIFF
--- a/convex/gabinet/_e2eTest.ts
+++ b/convex/gabinet/_e2eTest.ts
@@ -415,12 +415,21 @@ export const runAll = internalMutation({
 
       if (existingTreatments.length < 2) throw new Error("Need at least 2 treatments for package");
 
+      // Create a variant for the first treatment to exercise variant-aware package paths
+      const testVariantId = await ctx.db.insert("gabinetTreatmentVariants", {
+        organizationId: orgId,
+        treatmentId: existingTreatments[0]._id,
+        name: "E2E Test Variant",
+        price: 120,
+        duration: 45,
+      });
+
       testPackageId = await ctx.db.insert("gabinetTreatmentPackages", {
         organizationId: orgId,
         name: "E2E Test Package",
         description: "Package created by E2E test",
         treatments: [
-          { treatmentId: existingTreatments[0]._id, quantity: 3 },
+          { treatmentId: existingTreatments[0]._id, variantId: testVariantId, quantity: 3 },
           { treatmentId: existingTreatments[1]._id, quantity: 2 },
         ],
         totalPrice: 500,
@@ -473,6 +482,7 @@ export const runAll = internalMutation({
         status: "active",
         treatmentsUsed: pkg.treatments.map((t) => ({
           treatmentId: t.treatmentId,
+          ...(t.variantId ? { variantId: t.variantId } : {}),
           usedCount: 0,
           totalCount: t.quantity,
         })),
@@ -488,6 +498,7 @@ export const runAll = internalMutation({
       if (usage.status !== "active") throw new Error("Status should be active");
       if (usage.treatmentsUsed.length !== 2) throw new Error("Treatments used count mismatch");
       if (usage.treatmentsUsed.some((t) => t.usedCount !== 0)) throw new Error("Used count should be 0");
+      if (!(usage.treatmentsUsed as any[]).some((t) => t.variantId != null)) throw new Error("variantId not propagated to treatmentsUsed");
 
       // Award loyalty points
       if (pkg.loyaltyPointsAwarded && pkg.loyaltyPointsAwarded > 0) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2874.

Closes #2874

---

## Claude summary

The fix is committed. Here's a summary of what was changed in `convex/gabinet/_e2eTest.ts`:

**TEST 14 (Package CREATE):** Added a `gabinetTreatmentVariants` insert before the package creation, and included its id as `variantId` on the first treatment entry. This ensures the test data actually exercises the variant-aware package path rather than always using variant-less treatments.

**TEST 15 (Package PURCHASE):** Fixed the `treatmentsUsed` map to mirror the production `purchasePackage` logic in `packages.ts:520` — it now spreads `variantId` onto each entry when present (`...(t.variantId ? { variantId: t.variantId } : {})`). Added an assertion that at least one `treatmentsUsed` entry has a non-null `variantId`, which will catch any future regression.