### PR TITLE
Zaproszenie

### DIFF
--- a/src/routes/_app/invite.$token.tsx
+++ b/src/routes/_app/invite.$token.tsx
@@ -36,28 +36,41 @@ function InviteAcceptPage() {
   const [isAccepting, setIsAccepting] = useState(false);
   const [isDeclining, setIsDeclining] = useState(false);
   const [result, setResult] = useState<"accepted" | "declined" | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const isLoading = authLoading || inviteLoading;
 
   const handleAccept = async () => {
     setIsAccepting(true);
+    setActionError(null);
     try {
       await acceptInvitation({ token });
       setResult("accepted");
       setTimeout(() => {
         navigate({ to: "/dashboard" });
       }, 1500);
-    } catch {
+    } catch (err) {
+      setActionError(
+        err instanceof Error
+          ? err.message
+          : t("invite.acceptError", { defaultValue: "Coś poszło nie tak. Spróbuj ponownie." })
+      );
       setIsAccepting(false);
     }
   };
 
   const handleDecline = async () => {
     setIsDeclining(true);
+    setActionError(null);
     try {
       await declineInvitation({ token });
       setResult("declined");
-    } catch {
+    } catch (err) {
+      setActionError(
+        err instanceof Error
+          ? err.message
+          : t("invite.declineError", { defaultValue: "Coś poszło nie tak. Spróbuj ponownie." })
+      );
       setIsDeclining(false);
     }
   };
@@ -220,6 +233,13 @@ function InviteAcceptPage() {
               </Badge>
             </div>
           </div>
+
+          {actionError && (
+            <div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              <span>{actionError}</span>
+            </div>
+          )}
 
           <div className="flex gap-3">
             <Button

--- a/src/routes/_app/login/_layout.index.tsx
+++ b/src/routes/_app/login/_layout.index.tsx
@@ -66,15 +66,16 @@ function Login() {
 
   useEffect(() => {
     if (isLoading || !isAuthenticated) return;
+    // Redirect back to the invite page before any other check. The invite
+    // page handles its own auth/loading state, and checking !user first would
+    // send new sign-ups to /dashboard, silently dropping the invite token.
+    if (inviteToken) {
+      navigate({ to: "/invite/$token", params: { token: inviteToken }, replace: true });
+      return;
+    }
     if (!user) {
       // No user record yet — let the dashboard's auth gate handle it
       navigate({ to: DashboardRoute.fullPath, replace: true });
-      return;
-    }
-    // If user came from /invite/<token>, send them back so the invitation
-    // gets accepted automatically.
-    if (inviteToken) {
-      navigate({ to: "/invite/$token", params: { token: inviteToken }, replace: true });
       return;
     }
     if (!user.username) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2854.

Closes #2854

---

## Claude summary

Both fixes from commit `02e1bd2` are already in place and verified:

**`src/routes/_app/invite.$token.tsx`** — `actionError` state added at line 39, `handleAccept`/`handleDecline` catch blocks now set it (lines 52-54, 64-66), and it renders as a red alert box at lines 229-234.

**`src/routes/_app/login/_layout.index.tsx`** — the `useEffect` now checks `inviteToken` before `!user` at lines 72-75, with an explanatory comment, so new users completing OTP are redirected back to the invite page instead of `/dashboard`.

This issue is already resolved on this branch. The two bugs were:

1. Silent failure on accept/decline — errors were swallowed, now shown to the user.
2. New-user invite redirect — OTP completion redirected to `/dashboard` before the `getCurrentUser` query resolved, dropping the invite token. Fixed by checking `inviteToken` first.

No further changes needed.

## Follow-ups
- Fix race condition in `_acceptInternal`: `writeTeamMembershipToSupabase` and `writeUserToSupabase` are both scheduled with `runAfter(0)`, but the membership row has a FK on the users table — membership write should use `runAfter(500)` to ensure the user row lands in Supabase first, avoiding `23503` FK violations
- Fix null username in `writeUserToSupabase` call in `_acceptInternal`: `user.username` is read before `ctx.db.patch` sets it, so the Supabase users row always gets `username: null`; capture the generated `candidate` and pass it explicitly to the scheduled job