### PR TITLE
Zaproszenie

### DIFF
--- a/src/routes/_app/invite.$token.tsx
+++ b/src/routes/_app/invite.$token.tsx
@@ -36,28 +36,41 @@ function InviteAcceptPage() {
   const [isAccepting, setIsAccepting] = useState(false);
   const [isDeclining, setIsDeclining] = useState(false);
   const [result, setResult] = useState<"accepted" | "declined" | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const isLoading = authLoading || inviteLoading;
 
   const handleAccept = async () => {
     setIsAccepting(true);
+    setActionError(null);
     try {
       await acceptInvitation({ token });
       setResult("accepted");
       setTimeout(() => {
         navigate({ to: "/dashboard" });
       }, 1500);
-    } catch {
+    } catch (err) {
+      setActionError(
+        err instanceof Error
+          ? err.message
+          : t("invite.acceptError", { defaultValue: "Coś poszło nie tak. Spróbuj ponownie." })
+      );
       setIsAccepting(false);
     }
   };
 
   const handleDecline = async () => {
     setIsDeclining(true);
+    setActionError(null);
     try {
       await declineInvitation({ token });
       setResult("declined");
-    } catch {
+    } catch (err) {
+      setActionError(
+        err instanceof Error
+          ? err.message
+          : t("invite.declineError", { defaultValue: "Coś poszło nie tak. Spróbuj ponownie." })
+      );
       setIsDeclining(false);
     }
   };
@@ -220,6 +233,13 @@ function InviteAcceptPage() {
               </Badge>
             </div>
           </div>
+
+          {actionError && (
+            <div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              <span>{actionError}</span>
+            </div>
+          )}
 
           <div className="flex gap-3">
             <Button

--- a/src/routes/_app/login/_layout.index.tsx
+++ b/src/routes/_app/login/_layout.index.tsx
@@ -66,15 +66,16 @@ function Login() {
 
   useEffect(() => {
     if (isLoading || !isAuthenticated) return;
+    // Redirect back to the invite page before any other check. The invite
+    // page handles its own auth/loading state, and checking !user first would
+    // send new sign-ups to /dashboard, silently dropping the invite token.
+    if (inviteToken) {
+      navigate({ to: "/invite/$token", params: { token: inviteToken }, replace: true });
+      return;
+    }
     if (!user) {
       // No user record yet — let the dashboard's auth gate handle it
       navigate({ to: DashboardRoute.fullPath, replace: true });
-      return;
-    }
-    // If user came from /invite/<token>, send them back so the invitation
-    // gets accepted automatically.
-    if (inviteToken) {
-      navigate({ to: "/invite/$token", params: { token: inviteToken }, replace: true });
       return;
     }
     if (!user.username) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2854.

Closes #2854

---

## Claude summary

The fix for issue #2854 is already fully implemented and committed on this branch as `02e1bd2`. No additional work is needed.

Here's a summary of what was already fixed:

**Bug 1 — `src/routes/_app/invite.$token.tsx`**: `handleAccept` and `handleDecline` were silently swallowing all server errors (email mismatch, seat limit, expired token, etc.). Fixed by adding `actionError` state (line 39) that captures the error message and renders it as a red alert box above the Accept/Decline buttons (lines 229-234).

**Bug 2 — `src/routes/_app/login/_layout.index.tsx`**: After OTP verification, the `useEffect` checked `!user` before `inviteToken`. For brand-new users, `isAuthenticated` becomes true while the `getCurrentUser` query is still pending (`user` is `undefined`), so the `!user` branch fired first and redirected to `/dashboard`, dropping the invite token. Fixed by moving the `inviteToken` check before the `!user` guard (lines 72-75).

**Test path**: Open the invite link in an incognito window. Log in or sign up via OTP — you'll be redirected back to the invite page. Any server error (expired token, email mismatch, seat limit) now appears as a red error message. New users completing OTP are redirected back to the invite page instead of `/dashboard`.