### PR TITLE
Panel Gabinetu → Pulpit oraz uporządkowanie kolejności menu

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -123,7 +123,7 @@
     "calls": "Calls",
     "gabinet": {
       "_": "Cabinet",
-      "dashboard": "Cabinet Dashboard",
+      "dashboard": "Dashboard",
       "calendar": "Calendar",
       "patients": "Clients",
       "treatments": "Treatments",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -123,7 +123,7 @@
     "calls": "Połączenia",
     "gabinet": {
       "_": "Gabinet",
-      "dashboard": "Panel Gabinetu",
+      "dashboard": "Pulpit",
       "calendar": "Kalendarz",
       "patients": "Klienci",
       "treatments": "Zabiegi",

--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -50,9 +50,9 @@ export const gabinetManifest: ModuleManifest = {
     { labelKey: "nav.gabinet.patients", href: "/dashboard/gabinet/patients", icon: Heart },
     { labelKey: "nav.gabinet.treatments", href: "/dashboard/gabinet/treatments", icon: Stethoscope },
     { labelKey: "nav.gabinet.packages", href: "/dashboard/gabinet/packages", icon: Gift },
+    { labelKey: "nav.products", href: "/dashboard/products", icon: Package, crossModule: true },
     { labelKey: "nav.gabinet.employees", href: "/dashboard/gabinet/employees", icon: UserCog },
     { labelKey: "nav.gabinet.documents", href: "/dashboard/gabinet/documents", icon: ClipboardList },
-    { labelKey: "nav.products", href: "/dashboard/products", icon: Package, crossModule: true },
     { labelKey: "nav.gabinet.reports", href: "/dashboard/gabinet/reports", icon: PieChart },
   ],
   settingsNav: [


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2882.

Closes #2882

---

## Claude summary

Done. Three files changed:

- `public/locales/pl/translation.json` — `"Panel Gabinetu"` → `"Pulpit"`
- `public/locales/en/translation.json` — `"Cabinet Dashboard"` → `"Dashboard"` (English equivalent)
- `src/modules/gabinet/manifest.ts` — `primaryNav` reordered: Produkty / Magazyn moved from position 8 to position 6, before Pracownicy and Komunikacja

The new sidebar order is exactly: Pulpit, Kalendarz, Klienci, Zabiegi, Pakiety, Produkty / Magazyn, Pracownicy, Komunikacja, Raporty. No routing, icons, logic, or other UI elements were changed.