### PR TITLE
Uporządkowanie akcji w lewym panelu kalendarza

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -167,6 +167,7 @@
       "syncGmail": "Sync Gmail",
       "viewUnread": "Unread",
       "activate": "Activate/Deactivate",
+      "add": "Add",
       "bookAppointment": "Book Appointment",
       "addAppointment": "Add Appointment",
       "addPatient": "Add Client",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -167,6 +167,7 @@
       "syncGmail": "Synchronizuj Gmail",
       "viewUnread": "Nieprzeczytane",
       "activate": "Aktywuj/Dezaktywuj",
+      "add": "Dodaj",
       "bookAppointment": "Umów wizytę",
       "addAppointment": "Dodaj wizytę",
       "addPatient": "Dodaj klienta",

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -35,6 +35,12 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { DayTimeline } from "@/components/sidebar-widgets/day-timeline";
 import { getModuleById, getVisibleModules, moduleRegistry } from "@/modules/registry";
 
@@ -284,25 +290,57 @@ export function AppSidebar() {
                             if (!action.permissionFeature) return true;
                             return canCreate(action.permissionFeature);
                           })
-                          .map((action) => (
-                            <button
-                              key={action.labelKey}
-                              type="button"
-                              className="hover:bg-primary/5 flex flex-col items-center gap-1.5 rounded-md border px-2 py-3 text-xs transition-colors"
-                              onClick={() => {
-                                if (action.quickCreate) {
-                                  openQuickCreate(action.quickCreate);
-                                } else if (action.dispatch) {
-                                  dispatch(action.dispatch);
-                                } else if (action.href) {
-                                  navigateTo(action.href, action.search);
-                                }
-                              }}
-                            >
-                              <action.icon className="size-4" variant="stroke" />
-                              <span className="text-center leading-tight">{t(action.labelKey)}</span>
-                            </button>
-                          ))}
+                          .map((action) =>
+                            action.children ? (
+                              <DropdownMenu key={action.labelKey}>
+                                <DropdownMenuTrigger asChild>
+                                  <button
+                                    type="button"
+                                    className="hover:bg-primary/5 flex flex-col items-center gap-1.5 rounded-md border px-2 py-3 text-xs transition-colors"
+                                  >
+                                    <action.icon className="size-4" variant="stroke" />
+                                    <span className="text-center leading-tight">{t(action.labelKey)}</span>
+                                  </button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="start">
+                                  {action.children.map((child) => (
+                                    <DropdownMenuItem
+                                      key={child.labelKey}
+                                      onClick={() => {
+                                        if (child.quickCreate) {
+                                          openQuickCreate(child.quickCreate);
+                                        } else if (child.dispatch) {
+                                          dispatch(child.dispatch);
+                                        } else if (child.href) {
+                                          navigateTo(child.href, child.search);
+                                        }
+                                      }}
+                                    >
+                                      {t(child.labelKey)}
+                                    </DropdownMenuItem>
+                                  ))}
+                                </DropdownMenuContent>
+                              </DropdownMenu>
+                            ) : (
+                              <button
+                                key={action.labelKey}
+                                type="button"
+                                className="hover:bg-primary/5 flex flex-col items-center gap-1.5 rounded-md border px-2 py-3 text-xs transition-colors"
+                                onClick={() => {
+                                  if (action.quickCreate) {
+                                    openQuickCreate(action.quickCreate);
+                                  } else if (action.dispatch) {
+                                    dispatch(action.dispatch);
+                                  } else if (action.href) {
+                                    navigateTo(action.href, action.search);
+                                  }
+                                }}
+                              >
+                                <action.icon className="size-4" variant="stroke" />
+                                <span className="text-center leading-tight">{t(action.labelKey)}</span>
+                              </button>
+                            )
+                          )}
                       </div>
                     </div>
                   )}

--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -97,10 +97,18 @@ export const gabinetManifest: ModuleManifest = {
       matches: [{ to: "/dashboard/gabinet/calendar", fuzzy: true }],
       actions: [
         {
-          labelKey: "nav.actions.bookAppointment",
-          icon: CalendarCheck,
-          dispatch: "openCreateAppointment",
-          permissionFeature: "gabinet_appointments",
+          labelKey: "nav.actions.add",
+          icon: PlusCircle,
+          children: [
+            { labelKey: "gabinet.appointments.createAppointment", dispatch: "openCreateAppointment" },
+            { labelKey: "gabinet.events.create", dispatch: "openCreateEvent" },
+          ],
+        },
+        {
+          labelKey: "nav.actions.addPatient",
+          icon: UserPlus,
+          quickCreate: "patient",
+          permissionFeature: "gabinet_patients",
         },
         { labelKey: "nav.actions.filters", icon: Filter, dispatch: "openFilter" },
       ],

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -26,6 +26,14 @@ export interface ModuleNavItem {
   crossModule?: boolean;
 }
 
+export interface ModuleContextSubAction {
+  labelKey: string;
+  dispatch?: string;
+  quickCreate?: string;
+  href?: string;
+  search?: Record<string, string>;
+}
+
 export interface ModuleContextAction {
   labelKey: string;
   icon: ElementType;
@@ -34,6 +42,8 @@ export interface ModuleContextAction {
   search?: Record<string, string>;
   dispatch?: string;
   permissionFeature?: Feature;
+  /** When present the button renders as a dropdown; each child is a menu item. */
+  children?: ModuleContextSubAction[];
 }
 
 export interface ModulePageContext {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -1030,6 +1030,7 @@ function GabinetCalendarPage() {
   // used by the toolbar's "Nowa wizyta" button so all entry points behave
   // identically on the calendar page (issue #1502).
   useSidebarDispatch("openCreateAppointment", openCreateDialog);
+  useSidebarDispatch("openCreateEvent", openCreateEventDialog);
 
   // ?action=sell-package opens the sell package side panel after navigation
   // from the gabinet quick-actions dropdown (issue #1236).


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2883.

Closes #2883

---

## Claude summary

Done. Here's a summary of what was implemented:

**6 files changed:**

- `src/modules/types.ts` — added `ModuleContextSubAction` type and `children?: ModuleContextSubAction[]` to `ModuleContextAction`. When `children` is present, the action renders as a dropdown instead of a plain button.

- `src/components/layout/app-sidebar.tsx` — imported `DropdownMenu` components and updated the action grid rendering to produce a `DropdownMenu` when `action.children` exists, preserving the existing plain-button path for all other actions.

- `src/modules/gabinet/manifest.ts` — updated the `calendar` page context: replaced the single "Umów wizytę" entry with three actions: **Dodaj** (dropdown with "Nowa wizyta" → `openCreateAppointment` and "Nowe zdarzenie" → `openCreateEvent`), **Dodaj klienta** (`quickCreate: "patient"`), and **Filtry** (`openFilter`).

- `src/routes/.../calendar.index.lazy.tsx` — added `useSidebarDispatch("openCreateEvent", openCreateEventDialog)` alongside the existing appointment and filter dispatches so the new manifest entry is correctly wired up.

- `public/locales/pl/translation.json` and `en/translation.json` — added `nav.actions.add: "Dodaj"/"Add"`.

No existing handlers, forms, or modals were duplicated. The toolbar "Dodaj" button, bottom "Dodaj klienta", and "Szybkie akcje" entries are untouched.