### PR TITLE
Poprawa tłumaczenia „Nowe zdarzenie” w panelu Akcje

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3183,6 +3183,9 @@
         "changeEmployeeFailed": "Could not change the appointment's employee."
       }
     },
+    "events": {
+      "create": "New Event"
+    },
     "appointmentDetail": {
       "title": "Appointment Details",
       "time": "Time",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3205,6 +3205,9 @@
         "changeEmployeeFailed": "Nie udało się zmienić pracownika dla wizyty."
       }
     },
+    "events": {
+      "create": "Nowe zdarzenie"
+    },
     "appointmentDetail": {
       "title": "Szczegóły wizyty",
       "time": "Godzina",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2886.

Closes #2886

---

## Claude summary

The fix is committed. Here's a summary of what happened:

The `gabinet.events.create` translation key was referenced in `src/modules/gabinet/manifest.ts:104` as the `labelKey` for the "New Event" action in the calendar's left panel dropdown. The sidebar renders it via `t(child.labelKey)` without any fallback (`app-sidebar.tsx:319`), so when the key was absent from both locale files, i18next fell back to displaying the raw key string `gabinet.events.create`.

The other places in the codebase that use this same key (`event-dialog.tsx`, `calendar.index.lazy.tsx`) all pass an inline `defaultValue` fallback, which is why they worked correctly — only the manifest path was broken.

The fix adds the missing key to both `public/locales/pl/translation.json` ("Nowe zdarzenie") and `public/locales/en/translation.json` ("New Event"), placed in a new `gabinet.events` sub-section right after the `gabinet.appointments` section.