### PR TITLE
Uproszczenie przycisku „Dodaj” w panelu Akcje

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -20,12 +20,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Check, ChevronDown, ChevronLeft, ChevronRight, ClipboardList, Plus, Search, Users, X } from "@/lib/ez-icons";
 import { EmptyState } from "@/components/layout/empty-state";
 import { cn } from "@/lib/utils";
@@ -1456,28 +1450,14 @@ function GabinetCalendarPage() {
                 </Button>
                 <h2 className="ml-2 truncate text-xs font-semibold">{title}</h2>
               </div>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    size="sm"
-                    className="h-7 shrink-0 text-xs md:hidden"
-                    aria-label={t("gabinet.calendar.add", "Dodaj")}
-                  >
-                    <Plus className="h-3.5 w-3.5" variant="stroke" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={openCreateDialog}>
-                    {t(
-                      "gabinet.appointments.createAppointment",
-                      "Nowa wizyta",
-                    )}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={openCreateEventDialog}>
-                    {t("gabinet.events.create", "Nowe zdarzenie")}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              <Button
+                size="sm"
+                className="h-7 shrink-0 text-xs md:hidden"
+                aria-label={t("gabinet.dashboard.addAppointment", "Umów wizytę")}
+                onClick={openCreateDialog}
+              >
+                <Plus className="h-3.5 w-3.5" variant="stroke" />
+              </Button>
             </div>
 
             <div className="flex flex-wrap items-center gap-2">
@@ -1541,39 +1521,18 @@ function GabinetCalendarPage() {
               )}
 
               {/* Create button — hidden on mobile where it lives next to the
-                  date nav (above) to avoid wrapping onto its own row.
-                  Split into a DropdownMenu (issue #1555) so the user can pick
-                  between a regular appointment and a non-patient event
-                  (meeting / training etc.). */}
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    size="sm"
-                    className="hidden h-7 text-xs md:inline-flex"
-                    data-testid="calendar-create-appointment-button"
-                  >
-                    <Plus className="h-3.5 w-3.5 sm:mr-1" variant="stroke" />
-                    <span className="hidden sm:inline">
-                      {t("gabinet.calendar.add", "Dodaj")}
-                    </span>
-                    <ChevronDown
-                      className="ml-1 hidden h-3.5 w-3.5 sm:inline"
-                      variant="stroke"
-                    />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={openCreateDialog}>
-                    {t(
-                      "gabinet.appointments.createAppointment",
-                      "Nowa wizyta",
-                    )}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={openCreateEventDialog}>
-                    {t("gabinet.events.create", "Nowe zdarzenie")}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+                  date nav (above) to avoid wrapping onto its own row. */}
+              <Button
+                size="sm"
+                className="hidden h-7 text-xs md:inline-flex"
+                data-testid="calendar-create-appointment-button"
+                onClick={openCreateDialog}
+              >
+                <Plus className="h-3.5 w-3.5 sm:mr-1" variant="stroke" />
+                <span className="hidden sm:inline">
+                  {t("gabinet.dashboard.addAppointment", "Umów wizytę")}
+                </span>
+              </Button>
             </div>
           </div>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2888.

Closes #2888

---

## Claude summary

Done. Here's a summary of what changed in `_layout.gabinet.calendar.index.lazy.tsx`:

- **Mobile button** (visible below `md` breakpoint): replaced `DropdownMenu` wrapper with a plain `Button` that calls `openCreateDialog` directly. Label updated to "Umów wizytę".
- **Desktop button** (visible at `md+`): same — `DropdownMenu` + `ChevronDown` removed, button now calls `openCreateDialog` directly, text changed from "Dodaj" to "Umów wizytę" (reusing the existing `gabinet.dashboard.addAppointment` translation key which already has the correct PL/EN values).
- **`DropdownMenu` imports** removed (no longer used anywhere in the file).
- The `EventDialog` component and `openCreateEventDialog` handler are untouched — event creation remains accessible from within the appointment form.