### PR TITLE
Ustawienie domyślnego widoku „Dzień” i skali „60 min” w kalendarzu

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -146,7 +146,7 @@ function GabinetCalendarPage() {
 
   const [calendarTab, setCalendarTab] = useState<"calendar" | "waitlist">("calendar");
   const [viewMode, setViewMode] = useState<ViewMode>(
-    nudgeFilter === "unconfirmed-today" ? "day" : "week",
+    nudgeFilter === "unconfirmed-today" ? "day" : "day",
   );
   const [slotMinutes, setSlotMinutesState] = useState<SlotMinutes>(readStoredSlotMinutes);
   const setSlotMinutes = useCallback((next: SlotMinutes) => {
@@ -1481,43 +1481,24 @@ function GabinetCalendarPage() {
 
               {/* Slot size switcher (only meaningful for day/week) */}
               {viewMode !== "month" && (
-                <>
-                  <div
-                    className="hidden rounded-md border sm:flex"
+                <Select
+                  value={String(slotMinutes)}
+                  onValueChange={(v) => setSlotMinutes(Number(v) as SlotMinutes)}
+                >
+                  <SelectTrigger
+                    className="h-7 w-[88px] text-xs"
                     aria-label={t("gabinet.calendar.slotSize", "Rozdzielczość")}
                   >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
                     {SLOT_OPTIONS.map((opt) => (
-                      <Button
-                        key={opt}
-                        variant={slotMinutes === opt ? "default" : "ghost"}
-                        size="sm"
-                        className="h-7 rounded-none first:rounded-l-md last:rounded-r-md text-xs px-2"
-                        onClick={() => setSlotMinutes(opt)}
-                        title={t("gabinet.calendar.slotSize", "Rozdzielczość")}
-                      >
+                      <SelectItem key={opt} value={String(opt)} className="text-xs">
                         {opt} min
-                      </Button>
+                      </SelectItem>
                     ))}
-                  </div>
-                  <Select
-                    value={String(slotMinutes)}
-                    onValueChange={(v) => setSlotMinutes(Number(v) as SlotMinutes)}
-                  >
-                    <SelectTrigger
-                      className="h-7 w-[88px] text-xs sm:hidden"
-                      aria-label={t("gabinet.calendar.slotSize", "Rozdzielczość")}
-                    >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {SLOT_OPTIONS.map((opt) => (
-                        <SelectItem key={opt} value={String(opt)} className="text-xs">
-                          {opt} min
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </>
+                  </SelectContent>
+                </Select>
               )}
 
               {/* Create button — hidden on mobile where it lives next to the


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2889.

Closes #2889

---

## Claude summary

Done. Two minimal changes in `src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx`:

1. **Default view changed to "Day"** — line 149: the fallback in the `viewMode` useState init changed from `"week"` to `"day"`. The nudge-filter path already used `"day"`, so now both paths are `"day"`.

2. **Slot size buttons replaced with a dropdown** — the desktop-only button group (`hidden sm:flex`) and the mobile-only `Select` (`sm:hidden` trigger) were replaced with a single `Select` that renders on all screen sizes. The `slotMinutes` state, localStorage persistence, and `SLOT_OPTIONS` array are all untouched — only the UI control changed.

The 60 min default was already in place via `readStoredSlotMinutes()` returning 60 when localStorage is empty, so no change was needed there.