### PR TITLE
Rozdzielenie akcji „Umów wizytę” i „Dodaj zdarzenie” w panelu Akcje

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -169,6 +169,7 @@
       "activate": "Activate/Deactivate",
       "add": "Add",
       "bookAppointment": "Book Appointment",
+      "addEvent": "Add Event",
       "addAppointment": "Add Appointment",
       "addPatient": "Add Client",
       "printSchedule": "Print",
@@ -2181,6 +2182,7 @@
     "logCall": "Log Call",
     "share": "Share",
     "bookAppointment": "Book Appointment",
+      "addEvent": "Add Event",
     "addDocument": "Add Document",
     "download": "Download"
   },

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -169,6 +169,7 @@
       "activate": "Aktywuj/Dezaktywuj",
       "add": "Dodaj",
       "bookAppointment": "Umów wizytę",
+      "addEvent": "Dodaj zdarzenie",
       "addAppointment": "Dodaj wizytę",
       "addPatient": "Dodaj klienta",
       "printSchedule": "Drukuj",

--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -97,12 +97,15 @@ export const gabinetManifest: ModuleManifest = {
       matches: [{ to: "/dashboard/gabinet/calendar", fuzzy: true }],
       actions: [
         {
-          labelKey: "nav.actions.add",
+          labelKey: "nav.actions.bookAppointment",
+          icon: CalendarCheck,
+          dispatch: "openCreateAppointment",
+          permissionFeature: "gabinet_appointments",
+        },
+        {
+          labelKey: "nav.actions.addEvent",
           icon: PlusCircle,
-          children: [
-            { labelKey: "gabinet.appointments.createAppointment", dispatch: "openCreateAppointment" },
-            { labelKey: "gabinet.events.create", dispatch: "openCreateEvent" },
-          ],
+          dispatch: "openCreateEvent",
         },
         {
           labelKey: "nav.actions.addPatient",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2892.

Closes #2892

---

## Claude summary

Done. Here's what changed:

**`src/modules/gabinet/manifest.ts`** — calendar `pageContext.actions` now has two flat buttons instead of one dropdown:
- "Umów wizytę" (`CalendarCheck` icon, dispatches `openCreateAppointment`, gated by `gabinet_appointments` permission)
- "Dodaj zdarzenie" (`PlusCircle` icon, dispatches `openCreateEvent`)

Both dispatchers were already wired in the calendar route (`_layout.gabinet.calendar.index.lazy.tsx` lines 1026-1027), so no route changes were needed. The sidebar rendering logic in `app-sidebar.tsx` already handles flat actions (without `children`) — the dropdown branch is simply no longer reached for the calendar context.

**`public/locales/pl/translation.json`** and **`public/locales/en/translation.json`** — added `nav.actions.addEvent` ("Dodaj zdarzenie" / "Add Event") to avoid reusing `gabinet.events.create` which is also used as the event dialog title ("Nowe zdarzenie").