### PR TITLE
Add "Powiadomienia" nav entry to Gabinet manifest

### DIFF
--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -1,5 +1,6 @@
 import {
   BarChart3,
+  Bell,
   Calendar,
   CalendarCheck,
   CheckCircle,
@@ -54,6 +55,7 @@ export const gabinetManifest: ModuleManifest = {
     { labelKey: "nav.gabinet.employees", href: "/dashboard/gabinet/employees", icon: UserCog },
     { labelKey: "nav.gabinet.documents", href: "/dashboard/gabinet/documents", icon: ClipboardList },
     { labelKey: "nav.gabinet.reports", href: "/dashboard/gabinet/reports", icon: PieChart },
+    { labelKey: "nav.notifications", href: "/dashboard/notifications", icon: Bell, crossModule: true },
   ],
   settingsNav: [
     { sectionKey: "settings.gabinetSection", labelKey: "gabinet.locations.title", to: "/dashboard/gabinet/settings/locations", permissionFeature: "gabinet_settings" },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2896.

Closes #2896

---

## Claude summary

Done. The fix adds a "Powiadomienia" entry to the Gabinet module's `primaryNav` in `src/modules/gabinet/manifest.ts`. It follows the same `crossModule: true` pattern already used for the Products link (line 54), which signals to the sidebar renderer that this link points outside the Gabinet workspace root. The `nav.notifications` translation key and the `/dashboard/notifications` route both already exist — only the manifest entry was missing.