### PR TITLE
Nudges context fetches CRM nudges only when not on a Gabinet route and vice vers

### DIFF
--- a/src/contexts/nudges-context.tsx
+++ b/src/contexts/nudges-context.tsx
@@ -31,6 +31,7 @@ export function NudgesProvider({ children }: { children: React.ReactNode }) {
   const { organizationId } = useOrganization();
   const matchRoute = useMatchRoute();
   const isGabinetRoute = !!matchRoute({ to: "/dashboard/gabinet", fuzzy: true });
+  const isNotificationsRoute = !!matchRoute({ to: "/dashboard/notifications" });
 
   const [nudges, setNudges] = useState<NudgeData[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -41,7 +42,7 @@ export function NudgesProvider({ children }: { children: React.ReactNode }) {
   const { data: crmNudges, isLoading: crmLoading } = useQuery({
     queryKey: ["nudges.getAll", organizationId],
     queryFn: () => getCrmNudges({ organizationId }),
-    enabled: !!organizationId && !isGabinetRoute,
+    enabled: !!organizationId && (!isGabinetRoute || isNotificationsRoute),
   });
 
   // Gabinet nudges (Supabase-primary action)
@@ -50,15 +51,20 @@ export function NudgesProvider({ children }: { children: React.ReactNode }) {
   const { data: gabinetNudges, isLoading: gabinetLoading } = useQuery({
     queryKey: ["gabinet.nudges.getAll", organizationId],
     queryFn: () => getGabinetNudges({ organizationId }),
-    enabled: !!organizationId && isGabinetRoute,
+    enabled: !!organizationId && (isGabinetRoute || isNotificationsRoute),
   });
 
   // Aggregate nudges based on current route
   useEffect(() => {
     setIsLoading(crmLoading || gabinetLoading);
-    const sourceNudges = isGabinetRoute ? gabinetNudges : crmNudges;
-    setNudges(sourceNudges ?? []);
-  }, [crmNudges, gabinetNudges, isGabinetRoute, crmLoading, gabinetLoading]);
+    let sourceNudges: NudgeData[];
+    if (isNotificationsRoute) {
+      sourceNudges = [...(crmNudges ?? []), ...(gabinetNudges ?? [])];
+    } else {
+      sourceNudges = isGabinetRoute ? (gabinetNudges ?? []) : (crmNudges ?? []);
+    }
+    setNudges(sourceNudges);
+  }, [crmNudges, gabinetNudges, isGabinetRoute, isNotificationsRoute, crmLoading, gabinetLoading]);
 
   const totalCount = nudges.length;
   const redCount = nudges.filter(n => n.severity === "red").length;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2897.

Closes #2897

---

## Claude summary

The fix is committed. Here's what changed in `src/contexts/nudges-context.tsx`:

The root cause was that CRM nudges were gated on `!isGabinetRoute` and Gabinet nudges on `isGabinetRoute`, so on `/dashboard/notifications` (not a Gabinet route) only CRM nudges were ever fetched.

The fix adds an `isNotificationsRoute` flag via `matchRoute`. When on the notifications page:
- Both CRM and Gabinet `enabled` conditions become true (lines 45 and 54)
- The aggregation logic combines both arrays instead of picking one (lines 61–63)

On any other route the behaviour is unchanged — CRM routes still show only CRM nudges and Gabinet routes show only Gabinet nudges.