### PR TITLE
Menu boczne – dodać subtelną etykietę „Menu” obok ikony

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -282,7 +282,7 @@ const SidebarTrigger = React.forwardRef<
       data-sidebar="trigger"
       variant="ghost"
       size="icon"
-      className={cn("h-7 w-7", className)}
+      className={cn("h-7 w-auto gap-1 px-1.5", className)}
       onClick={(event) => {
         onClick?.(event)
         toggleSidebar()
@@ -291,6 +291,7 @@ const SidebarTrigger = React.forwardRef<
     >
       <PanelLeft />
       <span className="sr-only">{t("common.toggleSidebar")}</span>
+      <span className="hidden text-xs font-normal text-muted-foreground sm:block" aria-hidden>Menu</span>
     </Button>
   )
 })


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2900.

Closes #2900

---

## Claude summary

Done. The change is in `src/components/ui/sidebar.tsx` — 3 lines touched:

1. `w-7` → `w-auto gap-1 px-1.5` so the button expands naturally to fit icon + text without increasing height.
2. Added `<span className="hidden text-xs font-normal text-muted-foreground sm:block" aria-hidden>Menu</span>` — visible on `sm` and up (hidden on mobile per the issue's allowance), using `text-xs` (smaller than header elements), `text-muted-foreground` (neutral/subtle color), no background, and `aria-hidden` since the screen-reader text is already handled by the existing `sr-only` span above it.

The icon and label are part of the same `<Button>` element so they toggle the sidebar together on click.