### PR TITLE
@claude zamień miejscami

### DIFF
--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -105,15 +105,15 @@ export const gabinetManifest: ModuleManifest = {
           permissionFeature: "gabinet_appointments",
         },
         {
-          labelKey: "nav.actions.addEvent",
-          icon: PlusCircle,
-          dispatch: "openCreateEvent",
-        },
-        {
           labelKey: "nav.actions.addPatient",
           icon: UserPlus,
           quickCreate: "patient",
           permissionFeature: "gabinet_patients",
+        },
+        {
+          labelKey: "nav.actions.addEvent",
+          icon: PlusCircle,
+          dispatch: "openCreateEvent",
         },
         { labelKey: "nav.actions.filters", icon: Filter, dispatch: "openFilter" },
       ],


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2902.

Closes #2902

---

## Claude summary

Done. In `src/modules/gabinet/manifest.ts` (calendar pageContext, lines 100-119), I swapped the positions of `addPatient` ("Dodaj klienta") and `addEvent` ("Dodaj zdarzenie"). The Actions panel now renders:

- Row 1: Umów wizytę | Dodaj klienta
- Row 2: Dodaj zdarzenie | Filtry