### PR TITLE
Magazyn — podgląd produktów przypisanych do zabiegu

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -55,6 +55,7 @@ import {
   Calendar,
   Clock,
   DollarSign,
+  Package,
   Pencil,
   Plus,
   Settings2,
@@ -929,6 +930,71 @@ function TreatmentDetail() {
         ),
       },
       {
+        label: t("gabinet.treatmentDetail.tabs.inventory", "Magazyn"),
+        count: (existingProducts ?? []).length || undefined,
+        content: (() => {
+          const treatmentProducts = (existingProducts ?? []).filter((p) => p.productSection === "treatment");
+          const disposableProducts = (existingProducts ?? []).filter((p) => p.productSection === "disposable");
+          const hasAny = treatmentProducts.length > 0 || disposableProducts.length > 0;
+          return (
+            <div className="space-y-4">
+              <Card>
+                <CardHeader className="pb-3">
+                  <div className="flex items-center gap-2">
+                    <Package className="h-4 w-4 text-muted-foreground" variant="stroke" />
+                    <CardTitle className="text-sm font-medium">
+                      {t("gabinet.treatmentDetail.inventoryUsage", "Zużycie magazynowe")}
+                    </CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  {!hasAny ? (
+                    <p className="py-4 text-center text-sm text-muted-foreground">
+                      {t("gabinet.treatmentDetail.noInventoryProducts", "Brak przypisanych produktów")}
+                    </p>
+                  ) : (
+                    <div className="space-y-6">
+                      {treatmentProducts.length > 0 && (
+                        <div className="space-y-2">
+                          <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                            {t("gabinet.treatmentForm.treatmentProducts", "Preparaty do zabiegu")}
+                          </p>
+                          {treatmentProducts.map((p) => (
+                            <div key={p._id} className="flex items-center justify-between rounded-md border p-3">
+                              <span className="text-sm font-medium">{p.productName}</span>
+                              <span className="text-sm tabular-nums text-muted-foreground">
+                                {p.quantity}
+                                {(p.unit ?? p.stockUnit) ? ` ${p.unit ?? p.stockUnit}` : ""}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                      {disposableProducts.length > 0 && (
+                        <div className="space-y-2">
+                          <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                            {t("gabinet.treatmentForm.disposableProducts", "Materiały jednorazowe")}
+                          </p>
+                          {disposableProducts.map((p) => (
+                            <div key={p._id} className="flex items-center justify-between rounded-md border p-3">
+                              <span className="text-sm font-medium">{p.productName}</span>
+                              <span className="text-sm tabular-nums text-muted-foreground">
+                                {p.quantity}
+                                {(p.unit ?? p.stockUnit) ? ` ${p.unit ?? p.stockUnit}` : ""}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          );
+        })(),
+      },
+      {
         label: t("gabinet.treatmentDetail.tabs.documents"),
         count: treatmentDocuments?.length ?? 0,
         content: (
@@ -1267,7 +1333,7 @@ function TreatmentDetail() {
   }, [
     treatment, detailedStats, recentAppointments, treatmentAppointments,
     treatmentEmployees, variants, activities, unassignedEmployees,
-    editingParam, newOption, empSearchQuery, aptStatusFilter,
+    existingProducts, editingParam, newOption, empSearchQuery, aptStatusFilter,
     aptDateFrom, aptDateTo, navigate, t, treatmentId, organizationId,
   ]);
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2905.

Closes #2905

---

## Claude summary

Done. Here's a summary of what was implemented:

The `gabinet_treatment_products` table and `getTreatmentProducts` backend action already existed, and the treatment detail route was already fetching product data via the `existingProducts` query (used only to pre-populate the edit form). The issue asked to surface that data visually.

**Changes made** — one file only (`_layout.gabinet.treatments.$treatmentId.tsx`):

1. Added `Package` to the icon imports.
2. Inserted a new **"Magazyn"** tab between the Parameters and Documents tabs. The tab:
   - Splits `existingProducts` into "Preparaty do zabiegu" (`productSection === "treatment"`) and "Materiały jednorazowe" (`productSection === "disposable"`) subsections.
   - Each product row shows product name on the left and `quantity + unit` on the right.
   - When neither subsection has products, shows "Brak przypisanych produktów".
   - Shows a badge count on the tab (number of linked products, hidden when 0).
   - Purely read-only — no add/edit/delete actions.
3. Added `existingProducts` to the `useMemo` dependency array for the tabs.

No new network calls, no schema changes, no new components — the existing `existingProducts` query (which returns `productName`, `quantity`, `unit`, `stockUnit`) was all that was needed.