### PR TITLE
Guard against double-deduction on repeated "completed" transitions

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2120,8 +2120,9 @@ export const updateStatus = action({
       console.error("[updateStatus] Side effects FAILED for appointment", args.appointmentId, ":", e);
     }
 
-    // Auto-deduct stock on visit completion
-    if (args.status === "completed" && appt.treatmentId) {
+    // Auto-deduct stock on visit completion. Guard against double-deduction:
+    // only deduct when transitioning INTO completed, not on completed→completed.
+    if (args.status === "completed" && appt.status !== "completed" && appt.treatmentId) {
       try {
         const links = await db
           .query("gabinetTreatmentProducts")


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2913.

Closes #2913

---

## Claude summary

The fix is committed. Here's what was done:

**Root cause**: `convex/gabinet/appointments.ts:2124` checked `args.status === "completed"` (the new status) but not `appt.status` (the previous status). Although `MANUAL_TRANSITIONS` already blocks direct `completed → completed` calls, two real scenarios could still cause double-deduction:

1. Race condition: two concurrent Convex actions both read the appointment as `in_progress`, both pass the transition guard, and both deduct stock.
2. Rollback scenario: staff corrects a mistaken completion (`completed → in_progress`, which is allowed by `MANUAL_TRANSITIONS` per issue #1027's "any → any other" policy), then completes it again (`in_progress → completed`), triggering a second deduction.

**Fix**: Added `&& appt.status !== "completed"` so stock is only deducted when genuinely transitioning *into* the completed state from a non-completed state.

## Follow-ups

- Guard against double deduction on rollback via `stockDeducted` flag: the current fix prevents `completed→completed` but not `completed→in_progress→completed` (rollback then re-complete) because `appt.status` is `in_progress` in the second completion; a `stockDeducted: boolean` field on `gabinetAppointments` would make the guard airtight across any transition path.
- Supabase race condition in `updateStatus`: the read-then-write pattern (Supabase read at line 2023, Supabase write at line 2076) has no optimistic locking, so two concurrent `updateStatus` calls can both pass the transition check and both deduct stock — consider adding a version/CAS field or a Supabase advisory lock.