### PR TITLE
feat(gabinet): surface negative-stock warnings to UI on appointment completion

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2122,6 +2122,7 @@ export const updateStatus = action({
 
     // Auto-deduct stock on visit completion. Guard against double-deduction:
     // only deduct when transitioning INTO completed, not on completed→completed.
+    const stockWarnings: string[] = [];
     if (args.status === "completed" && appt.status !== "completed" && appt.treatmentId) {
       try {
         const links = await db
@@ -2132,7 +2133,7 @@ export const updateStatus = action({
         for (const link of links) {
           if (!link.quantity || Number(link.quantity) <= 0) continue;
           try {
-            await applyMovementInternal({
+            const result = await applyMovementInternal({
               organizationId: String(args.organizationId),
               productId: String(link.productId),
               locationId: null,
@@ -2142,6 +2143,9 @@ export const updateStatus = action({
               sourceId: args.appointmentId,
               performedBy: authResult.userId,
             });
+            if (result.warning === "negative_stock") {
+              stockWarnings.push(String(link.productId));
+            }
           } catch (e) {
             console.warn(
               "[updateStatus] stock deduction failed for product",
@@ -2161,7 +2165,7 @@ export const updateStatus = action({
       }
     }
 
-    return args.appointmentId;
+    return { appointmentId: args.appointmentId, warnings: stockWarnings };
     } catch (err) {
       await logError(ctx, err, {
         scope: "gabinet.appointments",

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -544,7 +544,7 @@ export function AppointmentPreviewContent({
     setStatus(newStatus);
     setSavingStatus(true);
     try {
-      await updateStatus({
+      const result = await updateStatus({
         organizationId,
         appointmentId: appointment._id,
         status: newStatus,
@@ -559,6 +559,9 @@ export function AppointmentPreviewContent({
       ]);
       await refetch();
       toast.success(t("gabinet.appointments.statusUpdated"));
+      if (result?.warnings && result.warnings.length > 0) {
+        toast.warning(t("gabinet.stock.negativeWarning"));
+      }
     } catch (error) {
       setStatus(previous);
       console.error("[appointment-preview] status update failed", error);
@@ -1179,12 +1182,14 @@ export function AppointmentPreviewContent({
           notes: settleNotes.trim() || undefined,
         });
       }
+      let settleStockWarnings: string[] = [];
       if (settleMarkCompleted && canMarkCompleted) {
-        await updateStatus({
+        const result = await updateStatus({
           organizationId,
           appointmentId: appointment._id,
           status: "completed",
         });
+        settleStockWarnings = result?.warnings ?? [];
       }
       await Promise.all([
         queryClient.invalidateQueries({
@@ -1222,6 +1227,9 @@ export function AppointmentPreviewContent({
           defaultValue: "Wizyta rozliczona",
         }),
       );
+      if (settleStockWarnings.length > 0) {
+        toast.warning(t("gabinet.stock.negativeWarning"));
+      }
       onClose();
     } catch (error) {
       console.error("[appointment-preview] settle failed", error);

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -743,12 +743,15 @@ function AppointmentDetail() {
   const performStatusChange = async (newStatus: string) => {
     setIsUpdating(true);
     try {
-      await updateStatus({
+      const result = await updateStatus({
         organizationId,
         appointmentId: appointment._id,
         status: newStatus as "scheduled" | "confirmed" | "in_progress" | "completed" | "cancelled" | "no_show" | "pending_confirmation",
       });
       toast.success(t("gabinet.appointments.statusUpdated"));
+      if (result?.warnings && result.warnings.length > 0) {
+        toast.warning(t("gabinet.stock.negativeWarning"));
+      }
       await invalidateAppointmentCaches();
       refetch();
 


### PR DESCRIPTION
## Summary

- `updateStatus` in `convex/gabinet/appointments.ts` now captures the return value of each `applyMovementInternal` call and collects any `"negative_stock"` warnings instead of discarding them
- The action now returns `{ appointmentId, warnings: string[] }` (product IDs of products that went negative) instead of just the appointment ID string
- Both UI call sites that invoke `updateStatus` now check the returned warnings and show a `toast.warning(t("gabinet.stock.negativeWarning"))` so staff can see when stock dropped below zero during visit completion

## Test plan

- [ ] Mark an appointment as completed when treatment has products with zero/low stock — warning toast appears after the success toast
- [ ] Mark an appointment as completed when stock is sufficient — no warning toast
- [ ] Complete via the settle dialog ("mark as completed" checkbox) — warning toast appears if stock went negative
- [ ] Appointment detail page status change also shows the warning

Closes #2914

🤖 Generated with [Claude Code](https://claude.com/claude-code)