### PR TITLE
Fix TS2589 deep-instantiation error in `convex/gabinet/appointments.ts

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -119,6 +119,7 @@ async function emitAutomationEvent(
     payload: Record<string, unknown>;
   },
 ) {
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
   await ctx.runMutation(internal.automation.emitEvent, {
     organizationId: args.organizationId,
     module: args.module,

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -176,6 +176,7 @@ function TreatmentDetail() {
   });
 
   // Mutations
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
   const updateTreatment = useAction(api.gabinet.treatments.update);
   const removeTreatment = useAction(api.gabinet.treatments.remove);
   const saveTreatmentParameters = useAction(api.gabinet.treatments.saveTreatmentParameters);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2925.

Closes #2925

---

## Claude summary

Done. Both TS2589 errors were real — the issue accurately identified pre-existing `// @ts-ignore` gaps.

The fix adds the standard suppression comment `// @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)` (matching the existing pattern used in `convex/stripe.ts`, `convex/nudges.ts`, `convex/app.ts`, `convex/auditLog.ts`, and several frontend components) to:

- `convex/gabinet/appointments.ts:122` — `ctx.runMutation(internal.automation.emitEvent, {...})`
- `src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx:179` — `useAction(api.gabinet.treatments.update)`

Both are well-understood Convex codegen depth issues where TypeScript's instantiation depth limit fires non-deterministically on deeply-nested generated API types. The `// @ts-ignore` pattern is the established mitigation throughout this codebase.