### PR TITLE
Fix unused `SupabaseRow` import in `convex/gabinet/appointments.ts

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -32,7 +32,6 @@ import type {
   FormDocumentRow,
   PaymentRow,
   SupabasePaginationResult,
-  SupabaseRow,
 } from "../_helpers/supabaseRows";
 import { logAudit } from "../auditLog";
 import { createNotificationDirect } from "../notifications";


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2926.

Closes #2926

---

## Claude summary

The fix is committed. Removed the unused `SupabaseRow` type from the import block in `convex/gabinet/appointments.ts:35`. It was listed in the named imports from `../_helpers/supabaseRows` but never referenced anywhere in the file, causing TS6196.