### PR TITLE
Fix `reminderOverrides` property missing from `updateStatus` args type in `_layo

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1565,6 +1565,7 @@ export const update = action({
     categoryId: v.optional(v.union(v.string(), v.null())),
     contraindicationAlertsReviewed: v.optional(v.union(v.boolean(), v.null())),
     variantId: v.optional(v.union(v.string(), v.null())),
+    reminderOverrides: v.optional(v.string()), // JSON: per-appointment channel overrides
   },
   handler: async (ctx, args) => {
     try {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2927.

Closes #2927

---

## Claude summary

The fix is committed. Here's a summary:

**Root cause:** The `update` action in `convex/gabinet/appointments.ts` (line 1530) was missing `reminderOverrides: v.optional(v.string())` in its args schema. The appointment detail page (`_layout.gabinet.appointments.$appointmentId.lazy.tsx:1015`) was calling `updateAppointment` (which maps to this `update` action) and passing `reminderOverrides`, causing TypeScript TS2353 ("Object literal may only specify known properties").

**Fix:** Added `reminderOverrides: v.optional(v.string())` to the `update` action's args. No handler changes needed — the handler already uses a spread pattern (`...updates → patch`) that automatically routes the new field to the Supabase patch. The `supabaseDb` helper's `toSnakeCase` conversion maps it to the existing `reminder_overrides` column (added in migration `00043_reminder_channel_settings.sql`).