### PR TITLE
Magazyn — ostrzeżenie o planowanym niedoborze podczas zapisywania wizyty

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -92,6 +92,7 @@ import type * as gabinet_appointments from "../gabinet/appointments.js";
 import type * as gabinet_documentDataSources from "../gabinet/documentDataSources.js";
 import type * as gabinet_employees from "../gabinet/employees.js";
 import type * as gabinet_equipment from "../gabinet/equipment.js";
+import type * as gabinet_inventory from "../gabinet/inventory.js";
 import type * as gabinet_leaveTypes from "../gabinet/leaveTypes.js";
 import type * as gabinet_locations from "../gabinet/locations.js";
 import type * as gabinet_loyalty from "../gabinet/loyalty.js";
@@ -276,6 +277,7 @@ declare const fullApi: ApiFromModules<{
   "gabinet/documentDataSources": typeof gabinet_documentDataSources;
   "gabinet/employees": typeof gabinet_employees;
   "gabinet/equipment": typeof gabinet_equipment;
+  "gabinet/inventory": typeof gabinet_inventory;
   "gabinet/leaveTypes": typeof gabinet_leaveTypes;
   "gabinet/locations": typeof gabinet_locations;
   "gabinet/loyalty": typeof gabinet_loyalty;

--- a/convex/gabinet/inventory.ts
+++ b/convex/gabinet/inventory.ts
@@ -29,6 +29,14 @@ export interface PlannedUsageItem {
   deficit: number | null;
 }
 
+export interface ShortagePreviewItem {
+  productName: string;
+  unit: string;
+  currentStock: number;
+  plannedAfterSave: number;
+  deficit: number;
+}
+
 export const getPlannedUsage = action({
   args: {
     organizationId: v.id("organizations"),
@@ -182,5 +190,134 @@ export const getPlannedUsage = action({
         (b.deficit ?? 0) - (a.deficit ?? 0) ||
         a.productName.localeCompare(b.productName, "pl"),
     );
+  },
+});
+
+// Check whether adding a single appointment for the given treatment would push
+// any product into deficit given the current 7-day planned usage. Returns only
+// products that would be in shortage after saving — empty means no issues.
+// Called live from the appointment create/edit form for the inline warning
+// (issue #2933). No inventory permission required since this is part of the
+// appointment booking flow.
+export const checkAppointmentShortage = action({
+  args: {
+    organizationId: v.id("organizations"),
+    treatmentId: v.string(),
+    locationId: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<ShortagePreviewItem[]> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+
+    const db = createSupabaseDb();
+    const now = new Date();
+    const todayStr = now.toISOString().slice(0, 10);
+    const currentTimeStr = now.toISOString().slice(11, 16);
+    const sevenDaysLater = new Date(now);
+    sevenDaysLater.setDate(sevenDaysLater.getDate() + 7);
+    const sevenDaysStr = sevenDaysLater.toISOString().slice(0, 10);
+
+    // 1. Get this treatment's product recipe
+    const thisLinks = await db
+      .query<TreatmentProductRow>("gabinetTreatmentProducts")
+      .eq("organizationId", String(args.organizationId))
+      .eq("treatmentId", args.treatmentId)
+      .collect();
+
+    if (thisLinks.length === 0) return [];
+
+    const productIds = thisLinks.map((l) => String(l.productId));
+    const locationId = args.locationId ?? null;
+
+    // 2. Compute existing planned usage for the recipe products over the next 7 days
+    const allAppts = await db
+      .query<AppointmentRow>("gabinetAppointments")
+      .eq("organizationId", String(args.organizationId))
+      .gte("date", todayStr)
+      .lte("date", sevenDaysStr)
+      .neq("status", "completed")
+      .neq("status", "cancelled")
+      .neq("status", "no_show")
+      .collect();
+
+    const appointments = allAppts.filter((a) => {
+      if (!a.treatmentId) return false;
+      if (String(a.date) === todayStr && String(a.startTime) < currentTimeStr) return false;
+      return true;
+    });
+
+    // `${productId}::${locationId}` → total already-planned quantity
+    const usageMap = new Map<string, number>();
+    if (appointments.length > 0) {
+      const existingTreatmentIds = [
+        ...new Set(appointments.map((a) => String(a.treatmentId))),
+      ];
+      const existingLinks = await db
+        .query<TreatmentProductRow>("gabinetTreatmentProducts")
+        .eq("organizationId", String(args.organizationId))
+        .in("treatmentId", existingTreatmentIds)
+        .collect();
+
+      // Only track products that appear in this treatment's recipe
+      const relevantLinks = existingLinks.filter((l) =>
+        productIds.includes(String(l.productId)),
+      );
+
+      for (const appt of appointments) {
+        const tid = String(appt.treatmentId);
+        const apptLoc = appt.locationId ? String(appt.locationId) : null;
+        const apptLinks = relevantLinks.filter((l) => String(l.treatmentId) === tid);
+        for (const link of apptLinks) {
+          const key = `${String(link.productId)}::${apptLoc ?? ""}`;
+          usageMap.set(key, (usageMap.get(key) ?? 0) + Number(link.quantity));
+        }
+      }
+    }
+
+    // 3. Current stock levels
+    const [productRows, stockLevelRows] = await Promise.all([
+      db.getMany<ProductRow>("products", productIds),
+      db.query<StockLevelRow>("productStockLevels").in("productId", productIds).collect(),
+    ]);
+
+    const productMap = new Map(
+      productRows.map((p) => [
+        String(p._id),
+        {
+          name: String(p.name),
+          stockUnit: (p.stockUnit as string | null | undefined) ?? null,
+        },
+      ]),
+    );
+
+    const stockLookup = new Map<string, number>();
+    for (const level of stockLevelRows) {
+      const key = `${String(level.productId)}::${level.locationId ? String(level.locationId) : ""}`;
+      stockLookup.set(key, Number(level.quantity));
+    }
+
+    // 4. Check each recipe product: will saving this appointment cause a deficit?
+    const result: ShortagePreviewItem[] = [];
+    for (const link of thisLinks) {
+      const pid = String(link.productId);
+      const key = `${pid}::${locationId ?? ""}`;
+      const currentStock = stockLookup.get(key) ?? 0;
+      const existingPlanned = usageMap.get(key) ?? 0;
+      const thisQty = Number(link.quantity);
+      const plannedAfterSave = existingPlanned + thisQty;
+      const projectedStock = currentStock - plannedAfterSave;
+      if (projectedStock < 0) {
+        const product = productMap.get(pid);
+        result.push({
+          productName: product?.name ?? pid,
+          unit: (link.unit as string | null | undefined) ?? product?.stockUnit ?? "",
+          currentStock,
+          plannedAfterSave,
+          deficit: -projectedStock,
+        });
+      }
+    }
+    return result;
   },
 });

--- a/src/components/gabinet/appointment-shared/use-appointment-warnings.ts
+++ b/src/components/gabinet/appointment-shared/use-appointment-warnings.ts
@@ -5,6 +5,14 @@ import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useSupabaseGabinetLeavesList } from "@/hooks/use-supabase-gabinet-leaves";
 
+export interface ShortagePreviewItem {
+  productName: string;
+  unit: string;
+  currentStock: number;
+  plannedAfterSave: number;
+  deficit: number;
+}
+
 /**
  * Returns the approved leave (if any) that overlaps the chosen date for the
  * selected employee. The available-slots backend already excludes leave time,
@@ -80,4 +88,40 @@ export function useMissingEquipment(params: {
     missingEquipmentIds,
     blocking: missingEquipmentIds.length > 0,
   };
+}
+
+/**
+ * Checks whether saving an appointment for the given treatment would push any
+ * product into planned-usage deficit over the next 7 days (issue #2933).
+ * Returns shortage items and a boolean flag — informational only, does not
+ * block submission.
+ */
+export function useAppointmentShortage(params: {
+  organizationId: Id<"organizations"> | string | null | undefined;
+  treatmentId: string;
+  locationId?: string;
+}) {
+  const { organizationId, treatmentId, locationId } = params;
+  const checkShortageAction = useAction(
+    api.gabinet.inventory.checkAppointmentShortage,
+  );
+  const { data } = useQuery({
+    queryKey: [
+      "gabinet.inventory.checkAppointmentShortage",
+      String(organizationId ?? ""),
+      treatmentId,
+      locationId ?? "",
+    ],
+    queryFn: () =>
+      checkShortageAction({
+        organizationId: organizationId as Id<"organizations">,
+        treatmentId,
+        locationId: locationId || undefined,
+      }),
+    enabled: !!organizationId && !!treatmentId,
+    retry: false,
+    staleTime: 30_000,
+  });
+  const items = (data ?? []) as ShortagePreviewItem[];
+  return { shortageItems: items, hasShortage: items.length > 0 };
 }

--- a/src/components/gabinet/appointment-shared/warnings.tsx
+++ b/src/components/gabinet/appointment-shared/warnings.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
+import type { ShortagePreviewItem } from "./use-appointment-warnings";
 
 export interface LeaveOnDate {
   startTime?: string;
@@ -73,6 +74,70 @@ export function EquipmentWarning({
         className={cn("shrink-0", size === "sm" ? "size-4" : "size-3.5")}
       />
       {t("gabinet.appointments.equipmentWarning")}
+    </div>
+  );
+}
+
+interface StockShortageWarningProps {
+  items: ShortagePreviewItem[];
+  className?: string;
+  size?: "sm" | "compact";
+}
+
+export function StockShortageWarning({
+  items,
+  className,
+  size = "sm",
+}: StockShortageWarningProps) {
+  const { t } = useTranslation();
+  if (items.length === 0) return null;
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "rounded-md border border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200",
+        size === "sm" ? "px-3 py-2.5 text-sm" : "px-2.5 py-2 text-xs",
+        className,
+      )}
+    >
+      <div
+        className={cn(
+          "flex items-center gap-2 font-medium",
+          items.length > 0 && "mb-2",
+        )}
+      >
+        <AlertTriangle
+          className={cn("shrink-0", size === "sm" ? "size-4" : "size-3.5")}
+        />
+        <span>
+          {t(
+            "gabinet.appointments.warnings.stockShortageTitle",
+            "Planowany niedobór produktów",
+          )}
+        </span>
+      </div>
+      <ul className={cn("space-y-2", size === "sm" ? "ml-6" : "ml-5")}>
+        {items.map((item) => (
+          <li key={item.productName}>
+            <p className="font-medium">{item.productName}</p>
+            <p>
+              {t("gabinet.appointments.warnings.stockCurrent", "Stan")}:{" "}
+              {item.currentStock} {item.unit}
+            </p>
+            <p>
+              {t(
+                "gabinet.appointments.warnings.stockPlannedAfterSave",
+                "Planowane zużycie po zapisaniu tej wizyty",
+              )}
+              : {item.plannedAfterSave} {item.unit}
+            </p>
+            <p className="font-medium">
+              {t("gabinet.appointments.warnings.stockDeficit", "Brakuje")}:{" "}
+              {item.deficit} {item.unit}
+            </p>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -85,10 +85,12 @@ import {
   ConflictWarning,
   EquipmentWarning,
   LeaveWarning,
+  StockShortageWarning,
 } from "@/components/gabinet/appointment-shared/warnings";
 import {
   useEmployeeLeaveOnDate,
   useMissingEquipment,
+  useAppointmentShortage,
 } from "@/components/gabinet/appointment-shared/use-appointment-warnings";
 import { SlotPicker } from "@/components/gabinet/appointment-shared/slot-picker";
 import { TreatmentPicker } from "@/components/gabinet/appointment-shared/treatment-picker";
@@ -601,6 +603,12 @@ export function AppointmentDialog({
     organizationId,
     locationId,
     treatment: selectedTreatment,
+  });
+
+  const { shortageItems, hasShortage } = useAppointmentShortage({
+    organizationId,
+    treatmentId,
+    locationId: locationId || undefined,
   });
 
   // -------------------------------------------------------------------------
@@ -1874,6 +1882,13 @@ export function AppointmentDialog({
                           </span>
                         </div>
                       </div>
+
+                      {hasShortage && (
+                        <StockShortageWarning
+                          items={shortageItems}
+                          size="compact"
+                        />
+                      )}
 
                       <Button
                         className="w-full"

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -102,6 +102,8 @@ import {
   AppointmentIndicatorBadge,
   type AppointmentIndicator,
 } from "./appointment-indicators";
+import { StockShortageWarning } from "@/components/gabinet/appointment-shared/warnings";
+import { useAppointmentShortage } from "@/components/gabinet/appointment-shared/use-appointment-warnings";
 
 // All statuses can transition to any other status. Lets staff correct mistakes
 // after a visit was already marked completed/cancelled/no_show (issue #1027).
@@ -417,6 +419,14 @@ export function AppointmentPreviewContent({
       organizationId,
       indicatorRecurringGroupIds,
     );
+
+  const { shortageItems, hasShortage } = useAppointmentShortage({
+    organizationId,
+    treatmentId,
+    locationId: detail?.appointment.locationId
+      ? String(detail.appointment.locationId)
+      : undefined,
+  });
 
   // Only seed local form state from `detail` once per appointment. Refetches
   // triggered by status changes must not clobber the user's other unsaved edits
@@ -1826,6 +1836,10 @@ export function AppointmentPreviewContent({
       </div>
 
       <Separator />
+
+      {hasShortage && (
+        <StockShortageWarning items={shortageItems} size="compact" />
+      )}
 
       {/* Actions — unified Button size="sm" (h-9) so every clickable in the
           popover matches the same scale (issue #1738 follow-up: previously


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2933.

Closes #2933

---

## Claude summary

The feature is already implemented and committed. Looking at the git log from the start of this conversation, commit `342bf20` already closes #2933 with the message "feat(gabinet): add planned shortage warning in appointment forms".

The implementation is complete:

**Backend** (`convex/gabinet/inventory.ts`): `checkAppointmentShortage` action computes 7-day planned usage for the selected treatment's products, compares against current stock levels per location, and returns only products with actual deficit.

**Hook** (`src/components/gabinet/appointment-shared/use-appointment-warnings.ts`): `useAppointmentShortage` wraps the action and returns `{ shortageItems, hasShortage }`.

**Warning component** (`src/components/gabinet/appointment-shared/warnings.tsx`): `StockShortageWarning` renders an amber inline alert listing each product with current stock, planned consumption after save, and deficit.

**Integration** (`src/components/gabinet/calendar/appointment-dialog.tsx:608-612, 1886-1891`): The hook is called reactively when `treatmentId` or `locationId` changes; `<StockShortageWarning>` renders directly above the "Save appointment" button when `hasShortage` is true. The warning is purely informational — the save button remains enabled regardless.

The branch is clean and the commit is already in place. No further action needed.