### PR TITLE
Add `inventory_adjustment` as a dedicated movement reason type

### DIFF
--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -20,6 +20,7 @@ const REASON_VALIDATOR = v.union(
   v.literal("initial"),
   v.literal("warehouse_receive"),
   v.literal("manual_adjust"),
+  v.literal("inventory_adjustment"),
   v.literal("appointment_use"),
   v.literal("appointment_return"),
   v.literal("deal_close"),

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -355,6 +355,7 @@ export function createCrmTables({
       v.literal("initial"),
       v.literal("warehouse_receive"),
       v.literal("manual_adjust"),
+      v.literal("inventory_adjustment"),
       v.literal("appointment_use"),
       v.literal("appointment_return"),
       v.literal("deal_close"),

--- a/src/components/forms/product-stock-adjust-dialog.tsx
+++ b/src/components/forms/product-stock-adjust-dialog.tsx
@@ -58,6 +58,7 @@ type AdjustStockArgs = {
     | "initial"
     | "warehouse_receive"
     | "manual_adjust"
+    | "inventory_adjustment"
     | "appointment_use"
     | "appointment_return"
     | "deal_close"

--- a/src/components/forms/product-stock-history-dialog.tsx
+++ b/src/components/forms/product-stock-history-dialog.tsx
@@ -38,6 +38,7 @@ function reasonLabel(reason: StockMovementReason, t: ReturnType<typeof useTransl
     warehouse_receive: t("products.stock.reason.warehouse_receive", { defaultValue: "Przyjęcie magazynowe" }),
     initial: t("products.stock.reason.initial", { defaultValue: "Stan początkowy" }),
     manual_adjust: t("products.stock.reason.manual_adjust", { defaultValue: "Korekta ręczna" }),
+    inventory_adjustment: t("products.stock.reason.inventory_adjustment", { defaultValue: "Inwentaryzacja" }),
     appointment_use: t("products.stock.reason.appointment_use", { defaultValue: "Zużycie podczas wizyty" }),
     appointment_return: t("products.stock.reason.appointment_return", { defaultValue: "Zwrot po wizycie" }),
     deal_close: t("products.stock.reason.deal_close", { defaultValue: "Zamknięcie transakcji" }),

--- a/src/components/gabinet/warehouse-inventory-dialog.tsx
+++ b/src/components/gabinet/warehouse-inventory-dialog.tsx
@@ -136,7 +136,7 @@ export function WarehouseInventoryDialog({
           productId: row.product._id,
           locationId: null,
           delta: row.delta,
-          reason: "manual_adjust",
+          reason: "inventory_adjustment",
           note,
         });
         if (result.warning === "negative_stock") negativeCount++;

--- a/src/hooks/use-supabase-products.ts
+++ b/src/hooks/use-supabase-products.ts
@@ -6,6 +6,7 @@ export type StockMovementReason =
   | "initial"
   | "warehouse_receive"
   | "manual_adjust"
+  | "inventory_adjustment"
   | "appointment_use"
   | "appointment_return"
   | "deal_close"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2939.

Closes #2939

---

## Claude summary

Done. Here's a summary of what changed across 6 files:

- `convex/schema/crm.ts` — added `v.literal("inventory_adjustment")` to the `productStockMovements.reason` union
- `convex/inventory.ts` — added the same literal to `REASON_VALIDATOR`
- `src/hooks/use-supabase-products.ts` — added `"inventory_adjustment"` to the `StockMovementReason` TS type
- `src/components/forms/product-stock-adjust-dialog.tsx` — added the value to the local `AdjustStockArgs.reason` union
- `src/components/forms/product-stock-history-dialog.tsx` — added the display label `"Inwentaryzacja"` to the reason map
- `src/components/gabinet/warehouse-inventory-dialog.tsx` — changed the hardcoded reason from `"manual_adjust"` to `"inventory_adjustment"` so physical inventory sessions are now correctly tagged

No Supabase migration was needed since the `reason` column is plain `TEXT NOT NULL` with no check constraint.