### PR TITLE
Add `(organization_id, location_id, created_at DESC)` composite index on `produc

### DIFF
--- a/supabase/migrations/00049_product_stock_movements_location_idx.sql
+++ b/supabase/migrations/00049_product_stock_movements_location_idx.sql
@@ -1,0 +1,13 @@
+-- Add composite index on product_stock_movements for the historical snapshot
+-- query in the inventory dialog (#2950).
+--
+-- The historical view queries:
+--   WHERE organization_id = ? AND location_id = ? AND created_at <= ?
+--   ORDER BY created_at DESC
+--
+-- The existing (organization_id, created_at DESC) index leaves location_id
+-- as a post-scan filter, making the query O(n) in org movement history.
+-- This covering index makes it O(log n).
+
+CREATE INDEX IF NOT EXISTS product_stock_movements_org_location_created_idx
+  ON product_stock_movements (organization_id, location_id, created_at DESC);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2950.

Closes #2950

---

## Claude summary

Done. Created and committed `supabase/migrations/00049_product_stock_movements_location_idx.sql`.

The issue was real: the historical snapshot query in `src/components/gabinet/warehouse-inventory-dialog.tsx:115-123` filters `product_stock_movements` by `organization_id`, `location_id`, and `created_at <= endMs`. The existing index `product_stock_movements_org_created_idx` covers only `(organization_id, created_at DESC)` — Postgres has to scan all movements for the org and apply `location_id` as a row-level filter. The new index `product_stock_movements_org_location_created_idx` on `(organization_id, location_id, created_at DESC)` makes the planner hit an index seek on both columns before walking `created_at` in order, reducing the query from O(n) to O(log n) per inventory snapshot load.