### PR TITLE
fix(gabinet): stabilize todayStr within inventory dialog session (closes #2951)

### DIFF
--- a/src/components/gabinet/warehouse-inventory-dialog.tsx
+++ b/src/components/gabinet/warehouse-inventory-dialog.tsx
@@ -93,7 +93,9 @@ export function WarehouseInventoryDialog({
     { activeOnly: true },
   );
 
-  const todayStr = toLocalDateStr(new Date());
+  // Stable within one open session; recomputes when the dialog opens so re-renders
+  // after midnight don't drift todayStr away from the selectedDate initial value.
+  const todayStr = useMemo(() => toLocalDateStr(new Date()), [open]);
 
   const [step, setStep] = useState<Step>("count");
   const [counts, setCounts] = useState<Map<string, string>>(new Map());


### PR DESCRIPTION
## Summary

- Wraps `todayStr` in `useMemo(() => toLocalDateStr(new Date()), [open])` in `WarehouseInventoryDialog`
- Previously a plain `const` re-evaluated on every render; if a re-render occurred after midnight while the dialog was still open, `todayStr` would advance to the new day while `selectedDate` state remained on the previous day
- This made `isHistoricalMode = selectedDate < todayStr` unexpectedly `true`, triggering a historical stock snapshot fetch instead of showing live inventory — and blocking the user from submitting a count for today

## Test plan

- [ ] Open the inventory dialog before midnight and verify `selectedDate` defaults to today
- [ ] Verify the date input `max` attribute reflects today (not stale)
- [ ] Verify `isHistoricalMode` is `false` when selected date equals today
- [ ] (Edge case) Simulate midnight crossing: `todayStr` and `selectedDate` remain consistent for the session; the next open of the dialog resets both to the new day

🤖 Generated with [Claude Code](https://claude.com/claude-code)