### PR TITLE
Magazyn — raport dla księgowej ze stanu na wybrany dzień

### DIFF
--- a/src/components/gabinet/warehouse-accountant-report-dialog.tsx
+++ b/src/components/gabinet/warehouse-accountant-report-dialog.tsx
@@ -1,0 +1,259 @@
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { MappedProduct } from "@/lib/supabase/mappers/products";
+
+interface ReportBodyProps {
+  organizationName: string | undefined;
+  locationName: string | null | undefined;
+  stockDateFormatted: string;
+  generatedAt: string;
+  products: MappedProduct[];
+  historicalStock: Map<string, number>;
+}
+
+function ReportBody({
+  organizationName,
+  locationName,
+  stockDateFormatted,
+  generatedAt,
+  products,
+  historicalStock,
+}: ReportBodyProps) {
+  const { t } = useTranslation();
+  const noPrice = t("inventory.accountantReport.noPrice", {
+    defaultValue: "brak danych",
+  });
+
+  return (
+    <div className="space-y-5 p-6 text-sm text-foreground print:text-black">
+      <div className="text-center">
+        <h1 className="text-xl font-bold">
+          {t("inventory.accountantReport.heading", {
+            defaultValue: "Raport stanów magazynowych",
+          })}
+        </h1>
+        {organizationName && (
+          <p className="mt-1 text-base font-semibold">{organizationName}</p>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs">
+        <div>
+          <span className="font-medium">
+            {t("inventory.accountantReport.location", {
+              defaultValue: "Lokalizacja",
+            })}
+            :
+          </span>{" "}
+          {locationName ??
+            t("inventory.count.locationNone", {
+              defaultValue: "Bez lokalizacji",
+            })}
+        </div>
+        <div>
+          <span className="font-medium">
+            {t("inventory.accountantReport.stockDate", {
+              defaultValue: "Stan na dzień",
+            })}
+            :
+          </span>{" "}
+          {stockDateFormatted}
+        </div>
+        <div>
+          <span className="font-medium">
+            {t("inventory.accountantReport.generatedAt", {
+              defaultValue: "Data wygenerowania",
+            })}
+            :
+          </span>{" "}
+          {generatedAt}
+        </div>
+      </div>
+
+      <table className="w-full border-collapse text-xs">
+        <thead>
+          <tr className="border-b-2 border-border bg-muted/40 print:bg-transparent print:border-black">
+            <th className="px-2 py-2 text-left font-semibold">
+              {t("inventory.accountantReport.colNo", { defaultValue: "Lp." })}
+            </th>
+            <th className="px-2 py-2 text-left font-semibold">
+              {t("common.name")}
+            </th>
+            <th className="px-2 py-2 text-right font-semibold">
+              {t("inventory.count.unit", { defaultValue: "Jedn." })}
+            </th>
+            <th className="px-2 py-2 text-right font-semibold">
+              {t("inventory.history.stockOnDate", { defaultValue: "Stan" })}
+            </th>
+            <th className="px-2 py-2 text-right font-semibold">
+              {t("inventory.accountantReport.purchasePrice", {
+                defaultValue: "Cena zakupu",
+              })}
+            </th>
+            <th className="px-2 py-2 text-right font-semibold">
+              {t("inventory.accountantReport.value", {
+                defaultValue: "Wartość",
+              })}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {products.map((product, idx) => {
+            const qty = historicalStock.get(product._id) ?? 0;
+            const unit = product.stockUnit?.trim() || "—";
+            return (
+              <tr
+                key={product._id}
+                className="border-b border-border print:border-gray-300"
+              >
+                <td className="px-2 py-1.5 tabular-nums text-muted-foreground">
+                  {idx + 1}
+                </td>
+                <td className="px-2 py-1.5 font-medium">{product.name}</td>
+                <td className="px-2 py-1.5 text-right">{unit}</td>
+                <td className="px-2 py-1.5 text-right tabular-nums">{qty}</td>
+                <td className="px-2 py-1.5 text-right text-muted-foreground">
+                  {noPrice}
+                </td>
+                <td className="px-2 py-1.5 text-right text-muted-foreground">
+                  {noPrice}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+
+      <div className="border-t border-border pt-3 text-xs print:border-black">
+        <div>
+          <span className="font-semibold">
+            {t("inventory.accountantReport.itemCount", {
+              defaultValue: "Liczba pozycji",
+            })}
+            :
+          </span>{" "}
+          {products.length}
+        </div>
+        <div className="mt-1">
+          <span className="font-semibold">
+            {t("inventory.accountantReport.totalValue", {
+              defaultValue: "Łączna wartość",
+            })}
+            :
+          </span>{" "}
+          <span className="text-muted-foreground">
+            {t("inventory.accountantReport.notAvailable", {
+              defaultValue: "niedostępna (brak cen zakupu)",
+            })}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatDatePL(dateStr: string): string {
+  const parts = dateStr.split("-");
+  if (parts.length !== 3) return dateStr;
+  const [y, m, d] = parts;
+  return `${d}.${m}.${y}`;
+}
+
+function formatNowPL(): string {
+  return new Date().toLocaleString("pl-PL", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export interface WarehouseAccountantReportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationName: string | undefined;
+  selectedDate: string;
+  products: MappedProduct[];
+  historicalStock: Map<string, number>;
+  locationName?: string | null;
+}
+
+export function WarehouseAccountantReportDialog({
+  open,
+  onOpenChange,
+  organizationName,
+  selectedDate,
+  products,
+  historicalStock,
+  locationName,
+}: WarehouseAccountantReportDialogProps) {
+  const { t } = useTranslation();
+  const stockDateFormatted = formatDatePL(selectedDate);
+  const generatedAt = formatNowPL();
+
+  const bodyProps: ReportBodyProps = {
+    organizationName,
+    locationName,
+    stockDateFormatted,
+    generatedAt,
+    products,
+    historicalStock,
+  };
+
+  const handlePrint = () => {
+    window.print();
+  };
+
+  return (
+    <>
+      {/* Print-only version — hidden on screen, shown by @media print in index.css */}
+      {open && (
+        <div className="print-accountant-report">
+          <ReportBody {...bodyProps} />
+        </div>
+      )}
+
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col">
+          <DialogHeader>
+            <DialogTitle>
+              {t("inventory.accountantReport.title", {
+                defaultValue: "Raport dla księgowej",
+              })}
+            </DialogTitle>
+            <DialogDescription>
+              {t("inventory.accountantReport.description", {
+                defaultValue:
+                  'Podgląd raportu przygotowanego do wydruku na A4. Kliknij "Drukuj", aby wydrukować lub zapisać jako PDF.',
+              })}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="min-h-0 flex-1 overflow-y-auto rounded-md border bg-background">
+            <ReportBody {...bodyProps} />
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              {t("common.close", { defaultValue: "Zamknij" })}
+            </Button>
+            <Button onClick={handlePrint}>
+              {t("inventory.accountantReport.print", {
+                defaultValue: "Drukuj",
+              })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/gabinet/warehouse-inventory-dialog.tsx
+++ b/src/components/gabinet/warehouse-inventory-dialog.tsx
@@ -25,6 +25,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
+import { useSupabaseOrganization } from "@/hooks/use-supabase-organizations";
+import { WarehouseAccountantReportDialog } from "@/components/gabinet/warehouse-accountant-report-dialog";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatActionError } from "@/lib/format-action-error";
 import { cn } from "@/lib/utils";
@@ -92,6 +94,7 @@ export function WarehouseInventoryDialog({
     organizationId,
     { activeOnly: true },
   );
+  const { data: org } = useSupabaseOrganization(organizationId);
 
   // Stable within one open session; recomputes when the dialog opens so re-renders
   // after midnight don't drift todayStr away from the selectedDate initial value.
@@ -102,6 +105,7 @@ export function WarehouseInventoryDialog({
   const [locationId, setLocationId] = useState<string>(NO_LOCATION_VALUE);
   const [selectedDate, setSelectedDate] = useState<string>(todayStr);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
 
   const resolvedLocationId: string | null =
     locationId === NO_LOCATION_VALUE ? null : locationId;
@@ -394,6 +398,7 @@ export function WarehouseInventoryDialog({
 
   // step === "count"
   return (
+    <>
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="flex max-h-[90vh] max-w-2xl flex-col">
         <DialogHeader>
@@ -623,6 +628,17 @@ export function WarehouseInventoryDialog({
           >
             {t("common.cancel")}
           </Button>
+          {isHistoricalMode && historicalStockQuery.isSuccess && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setReportOpen(true)}
+            >
+              {t("inventory.accountantReport.openButton", {
+                defaultValue: "Raport dla księgowej",
+              })}
+            </Button>
+          )}
           {!isHistoricalMode && (
             <Button
               type="button"
@@ -635,5 +651,20 @@ export function WarehouseInventoryDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+
+    <WarehouseAccountantReportDialog
+      open={reportOpen}
+      onOpenChange={setReportOpen}
+      organizationName={org?.name}
+      selectedDate={selectedDate}
+      products={trackedProducts}
+      historicalStock={historicalStockQuery.data ?? new Map()}
+      locationName={
+        resolvedLocationId
+          ? (locations.find((l) => l._id === resolvedLocationId)?.name ?? null)
+          : null
+      }
+    />
+    </>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -423,6 +423,39 @@ img {
   .print-schedule td {
     display: table-cell;
   }
+
+  /* Accountant report — see warehouse-accountant-report-dialog.tsx */
+  .print-accountant-report,
+  .print-accountant-report * {
+    visibility: visible !important;
+    display: block;
+  }
+  .print-accountant-report {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    background: white;
+    color: black;
+  }
+  .print-accountant-report table {
+    display: table;
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .print-accountant-report thead {
+    display: table-header-group;
+  }
+  .print-accountant-report tbody {
+    display: table-row-group;
+  }
+  .print-accountant-report tr {
+    display: table-row;
+  }
+  .print-accountant-report th,
+  .print-accountant-report td {
+    display: table-cell;
+  }
 }
 /*
 ---break---


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2954.

Closes #2954

---

## Claude summary

Committed. Here's a summary of what was implemented:

**3 files changed:**

**`src/components/gabinet/warehouse-accountant-report-dialog.tsx`** (new) — The report dialog component with two parts:
- A `ReportBody` internal component rendering the A4-formatted report (salon name, stock date, generation timestamp, product table with Lp./name/unit/qty/purchase price/value, and totals summary)
- A `WarehouseAccountantReportDialog` exported component that wraps `ReportBody` in two places: a hidden `div.print-accountant-report` (for the actual print) and a scrollable Dialog (for the on-screen preview), with "Zamknij" and "Drukuj" buttons

**`src/components/gabinet/warehouse-inventory-dialog.tsx`** (modified) — Added:
- `useSupabaseOrganization` to fetch the salon name
- `reportOpen` state
- "Raport dla księgowej" button in the footer, visible only when `isHistoricalMode && historicalStockQuery.isSuccess`
- `WarehouseAccountantReportDialog` rendered as a sibling of the main dialog in a Fragment

**`src/index.css`** (modified) — Added `.print-accountant-report` CSS rules inside the existing `@media print` block, following the same `.print-schedule` pattern already used by the calendar print feature.

Since the products schema has no `purchase_price` field, the report correctly shows "brak danych" for purchase price and value — per the issue's explicit requirement. The org/location data comes from existing hooks with no new queries needed.