### PR TITLE
Magazyn — cena zakupu produktu i wartość magazynu

### DIFF
--- a/convex/products.ts
+++ b/convex/products.ts
@@ -38,6 +38,7 @@ export const create = action({
     manufacturer: v.optional(v.union(v.string(), v.null())),
     catalogNumber: v.optional(v.union(v.string(), v.null())),
     stockNote: v.optional(v.union(v.string(), v.null())),
+    purchasePrice: v.optional(v.union(v.number(), v.null())),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(
@@ -81,6 +82,8 @@ export const create = action({
     if (args.manufacturer != null) insertRow.manufacturer = args.manufacturer;
     if (args.catalogNumber != null) insertRow.catalogNumber = args.catalogNumber;
     if (args.stockNote != null) insertRow.stockNote = args.stockNote;
+    // migration 00050
+    if (args.purchasePrice != null) insertRow.purchasePrice = args.purchasePrice;
 
     const productId = await db.insert("products", insertRow);
 
@@ -156,6 +159,7 @@ export const update = action({
     manufacturer: v.optional(v.union(v.string(), v.null())),
     catalogNumber: v.optional(v.union(v.string(), v.null())),
     stockNote: v.optional(v.union(v.string(), v.null())),
+    purchasePrice: v.optional(v.union(v.number(), v.null())),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(
@@ -203,6 +207,7 @@ export const update = action({
     if (updates.manufacturer !== undefined) patchPayload.manufacturer = updates.manufacturer;
     if (updates.catalogNumber !== undefined) patchPayload.catalogNumber = updates.catalogNumber;
     if (updates.stockNote !== undefined) patchPayload.stockNote = updates.stockNote;
+    if (updates.purchasePrice !== undefined) patchPayload.purchasePrice = updates.purchasePrice;
 
     await db.patch("products", productId, patchPayload);
 

--- a/src/components/forms/product-form.tsx
+++ b/src/components/forms/product-form.tsx
@@ -94,6 +94,7 @@ export interface ProductFormData {
   manufacturer?: string | null;
   catalogNumber?: string | null;
   stockNote?: string | null;
+  purchasePrice?: number | null;
 }
 
 interface ProductFormProps {
@@ -140,6 +141,9 @@ export function ProductForm({
   const [manufacturer, setManufacturer] = useState(initialData?.manufacturer ?? "");
   const [catalogNumber, setCatalogNumber] = useState(initialData?.catalogNumber ?? "");
   const [stockNote, setStockNote] = useState(initialData?.stockNote ?? "");
+  const [purchasePrice, setPurchasePrice] = useState(
+    initialData?.purchasePrice != null ? String(initialData.purchasePrice) : "",
+  );
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -160,6 +164,11 @@ export function ProductForm({
       const parsed = parseFloat(minStock.replace(",", "."));
       return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
     })();
+    const normalizedPurchasePrice = (() => {
+      if (!purchasePrice.trim()) return null;
+      const parsed = parseFloat(purchasePrice.replace(",", "."));
+      return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+    })();
     onSubmit({
       name,
       description: description || null,
@@ -178,6 +187,7 @@ export function ProductForm({
       manufacturer: manufacturer.trim() || null,
       catalogNumber: catalogNumber.trim() || null,
       stockNote: stockNote.trim() || null,
+      purchasePrice: normalizedPurchasePrice,
     });
   };
 
@@ -337,6 +347,24 @@ export function ProductForm({
                     placeholder="0"
                   />
                 </div>
+              </div>
+              <div className="space-y-1.5">
+                <Label>
+                  {t("products.stock.purchasePriceLabel", { defaultValue: "Cena zakupu brutto" })}
+                </Label>
+                <Input
+                  type="text"
+                  inputMode="decimal"
+                  value={purchasePrice}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) setPurchasePrice(v);
+                  }}
+                  placeholder={t("products.stock.purchasePricePlaceholder", { defaultValue: "np. 120,00" })}
+                />
+                <p className="text-xs text-muted-foreground">
+                  {t("products.stock.purchasePriceHelp", { defaultValue: "Używana do wyliczenia wartości magazynu. Opcjonalna." })}
+                </p>
               </div>
               {isCreate && (
                 <div className="space-y-1.5">

--- a/src/components/gabinet/warehouse-accountant-report-dialog.tsx
+++ b/src/components/gabinet/warehouse-accountant-report-dialog.tsx
@@ -10,6 +10,13 @@ import {
 } from "@/components/ui/dialog";
 import type { MappedProduct } from "@/lib/supabase/mappers/products";
 
+function formatPricePLN(value: number): string {
+  return value.toLocaleString("pl-PL", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }) + " zł";
+}
+
 interface ReportBodyProps {
   organizationName: string | undefined;
   locationName: string | null | undefined;
@@ -109,6 +116,8 @@ function ReportBody({
           {products.map((product, idx) => {
             const qty = historicalStock.get(product._id) ?? 0;
             const unit = product.stockUnit?.trim() || "—";
+            const hasPrice = product.purchasePrice != null;
+            const value = hasPrice ? qty * product.purchasePrice! : null;
             return (
               <tr
                 key={product._id}
@@ -120,11 +129,15 @@ function ReportBody({
                 <td className="px-2 py-1.5 font-medium">{product.name}</td>
                 <td className="px-2 py-1.5 text-right">{unit}</td>
                 <td className="px-2 py-1.5 text-right tabular-nums">{qty}</td>
-                <td className="px-2 py-1.5 text-right text-muted-foreground">
-                  {noPrice}
+                <td className="px-2 py-1.5 text-right tabular-nums">
+                  {hasPrice
+                    ? formatPricePLN(product.purchasePrice!)
+                    : <span className="text-muted-foreground">{noPrice}</span>}
                 </td>
-                <td className="px-2 py-1.5 text-right text-muted-foreground">
-                  {noPrice}
+                <td className="px-2 py-1.5 text-right tabular-nums">
+                  {value != null
+                    ? formatPricePLN(value)
+                    : <span className="text-muted-foreground">{noPrice}</span>}
                 </td>
               </tr>
             );
@@ -149,11 +162,17 @@ function ReportBody({
             })}
             :
           </span>{" "}
-          <span className="text-muted-foreground">
-            {t("inventory.accountantReport.notAvailable", {
-              defaultValue: "niedostępna (brak cen zakupu)",
-            })}
-          </span>
+          {(() => {
+            const total = products.reduce((sum, p) => {
+              if (p.purchasePrice == null) return sum;
+              const qty = historicalStock.get(p._id) ?? 0;
+              return sum + qty * p.purchasePrice;
+            }, 0);
+            const hasAnyPrice = products.some((p) => p.purchasePrice != null);
+            return hasAnyPrice
+              ? <span className="font-semibold">{formatPricePLN(total)}</span>
+              : <span className="text-muted-foreground">{t("inventory.accountantReport.notAvailable", { defaultValue: "niedostępna (brak cen zakupu)" })}</span>;
+          })()}
         </div>
       </div>
     </div>

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -49,6 +49,7 @@
  *   • 00042_gabinet_employees_nullable_user_id.sql
  *   • 00043_reminder_channel_settings.sql
  *   • 00044_scope_entities_jsonb.sql
+ *   • 00050_product_purchase_price.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -1859,6 +1860,7 @@ export interface Database {
           manufacturer: string | null;
           catalog_number: string | null;
           stock_note: string | null;
+          purchase_price: number | null;
         };
         Insert: {
           id?: string;
@@ -1882,6 +1884,7 @@ export interface Database {
           manufacturer?: string | null;
           catalog_number?: string | null;
           stock_note?: string | null;
+          purchase_price?: number | null;
         };
         Update: {
           id?: string;
@@ -1905,6 +1908,7 @@ export interface Database {
           manufacturer?: string | null;
           catalog_number?: string | null;
           stock_note?: string | null;
+          purchase_price?: number | null;
         };
         Relationships: [
           {

--- a/src/lib/supabase/mappers/products.ts
+++ b/src/lib/supabase/mappers/products.ts
@@ -25,6 +25,7 @@ export interface MappedProduct {
   manufacturer?: string;
   catalogNumber?: string;
   stockNote?: string;
+  purchasePrice?: number;
   createdBy: string;
   createdAt: number;
   updatedAt: number;

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -380,6 +380,7 @@ function ProductsPage() {
           manufacturer: data.manufacturer,
           catalogNumber: data.catalogNumber,
           stockNote: data.stockNote,
+          purchasePrice: data.purchasePrice,
         });
       } else {
         await createProduct({
@@ -401,6 +402,7 @@ function ProductsPage() {
           manufacturer: data.manufacturer,
           catalogNumber: data.catalogNumber,
           stockNote: data.stockNote,
+          purchasePrice: data.purchasePrice,
         });
       }
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.products.list(organizationId) });
@@ -488,6 +490,24 @@ function ProductsPage() {
       getSortValue: (item) => {
         if (!item.trackStock) return -Infinity;
         return totalsByProductId.get(item._id)?.total ?? 0;
+      },
+      sortable: true,
+    },
+    {
+      id: "value",
+      label: t("products.stock.valueColumn", { defaultValue: "Wartość" }),
+      headerClassName: "whitespace-normal leading-tight",
+      render: (item) => {
+        if (!item.trackStock) return <span className="text-muted-foreground">—</span>;
+        if (item.purchasePrice == null) {
+          return <span className="text-muted-foreground">{t("inventory.accountantReport.noPrice", { defaultValue: "brak danych" })}</span>;
+        }
+        const qty = totalsByProductId.get(item._id)?.total ?? 0;
+        return <span>{formatCurrency(qty * item.purchasePrice)}</span>;
+      },
+      getSortValue: (item) => {
+        if (!item.trackStock || item.purchasePrice == null) return -Infinity;
+        return (totalsByProductId.get(item._id)?.total ?? 0) * item.purchasePrice;
       },
       sortable: true,
     },
@@ -842,6 +862,7 @@ function ProductsPage() {
             manufacturer: editingProduct.manufacturer ?? null,
             catalogNumber: editingProduct.catalogNumber ?? null,
             stockNote: editingProduct.stockNote ?? null,
+            purchasePrice: editingProduct.purchasePrice ?? null,
           } : undefined}
           defaultSection={!editingProduct && activeSection !== "all" ? activeSection : null}
           onSubmit={handleProductFormSubmit}

--- a/supabase/migrations/00050_product_purchase_price.sql
+++ b/supabase/migrations/00050_product_purchase_price.sql
@@ -1,0 +1,8 @@
+-- Add purchase_price field to products (#2956).
+--
+-- Extends the products table with an optional gross purchase price per unit.
+-- Used to calculate warehouse value (stock × purchase_price) in the accountant
+-- stock report. Nullable so existing products are unaffected.
+
+ALTER TABLE products
+  ADD COLUMN IF NOT EXISTS purchase_price NUMERIC;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2956.

Closes #2956

---

## Claude summary

All done. Here's a summary of the 7 files changed (+ 1 new migration):

**`supabase/migrations/00050_product_purchase_price.sql`** — adds nullable `purchase_price NUMERIC` column to `products` table.

**`src/lib/supabase/database.types.ts`** — adds `purchase_price: number | null` to the products Row/Insert/Update shapes.

**`src/lib/supabase/mappers/products.ts`** — adds `purchasePrice?: number` to `MappedProduct`.

**`src/components/forms/product-form.tsx`** — adds "Cena zakupu brutto" input field inside the stock-tracking section (optional, decimal, shows only when `trackStock` is enabled). Included in `ProductFormData` and `onSubmit`.

**`convex/products.ts`** — `create` and `update` actions now accept `purchasePrice?: number | null` and write it to Supabase.

**`src/routes/_app/_auth/dashboard/_layout.products.index.tsx`** — passes `purchasePrice` in create/update calls; adds a "Wartość" column computed as `stock × purchasePrice`, showing "brak danych" when no price is set. Pre-populates the field when opening the edit panel.

**`src/components/gabinet/warehouse-accountant-report-dialog.tsx`** — the accountant report now shows actual purchase price and calculated value per row (formatted as PLN with 2 decimal places), and computes a total warehouse value at the bottom summing only rows that have a price. Rows without a price show "brak danych" as before.