### PR TITLE
Magazyn — wybór widocznych kolumn w tabeli

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -409,6 +409,7 @@
   "table": {
     "columns": "Columns",
     "toggleColumns": "Toggle columns",
+    "showColumns": "Show columns",
     "noResults": "No results found",
     "recordCount": "{{count}} records",
     "recordCount_one": "{{count}} record",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -409,6 +409,7 @@
   "table": {
     "columns": "Kolumny",
     "toggleColumns": "Przełącz kolumny",
+    "showColumns": "Pokaż kolumny",
     "noResults": "Brak wyników",
     "recordCount": "{{count}} rekordów",
     "recordCount_one": "{{count}} rekord",

--- a/src/components/crm/data-list-filter-bar.tsx
+++ b/src/components/crm/data-list-filter-bar.tsx
@@ -484,8 +484,9 @@ export function DataListFilterBar({
           </Button>
         )}
         {onColumnSettingsOpen && (
-          <button type="button" className="group relative inline-flex h-max cursor-pointer items-center justify-center rounded-lg border border-border-primary bg-bg-primary px-2 py-1.5 text-fg-quaternary shadow-xs hover:bg-bg-primary_hover hover:text-fg-tertiary" onClick={onColumnSettingsOpen}>
+          <button type="button" className="group relative inline-flex h-max cursor-pointer items-center justify-center gap-1.5 rounded-lg border border-border-primary bg-bg-primary px-3 py-1.5 text-sm text-fg-quaternary shadow-xs hover:bg-bg-primary_hover hover:text-fg-tertiary" onClick={onColumnSettingsOpen}>
             <Columns03 className="size-4 stroke-[2px]" />
+            <span>{t("table.showColumns", { defaultValue: "Show columns" })}</span>
           </button>
         )}
         {!onColumnSettingsOpen && columnDefs && columnDefs.length > 0 && onToggleColumn && (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2958.

Closes #2958

---

## Claude summary

The fix is committed. Here's what was found and what changed:

**Triage finding:** The column visibility feature was already 100% implemented on the warehouse products page: the `useColumnVisibility` hook, localStorage persistence, SidePanel with per-column checkboxes, and real-time table update were all in place. The only gap was discoverability — the trigger button in `DataListFilterBar` showed just an unlabeled `<Columns03>` icon.

**What changed (3 files, 4 lines):**

- `src/components/crm/data-list-filter-bar.tsx` — the `onColumnSettingsOpen` button now renders `<Columns03 icon> Pokaż kolumny` (icon + label) instead of the icon alone, matching the visual style of the adjacent "Filters" button
- `public/locales/pl/translation.json` — added `table.showColumns = "Pokaż kolumny"`
- `public/locales/en/translation.json` — added `table.showColumns = "Show columns"`

This change applies to all pages that pass `onColumnSettingsOpen` to `DataListFilterBar` (contacts, companies, leads, activities, calls, documents, employees, patients, treatments, gabinet documents, and products) — all consistently gain the visible label.