### PR TITLE
feat(gabinet): add warehouse_deliveries + warehouse_delivery_items tables (closes #2961)

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -10,6 +10,8 @@ const TABLE_MAP: Record<string, string> = {
   products: "products",
   productStockLevels: "product_stock_levels",
   productStockMovements: "product_stock_movements",
+  warehouseDeliveries: "warehouse_deliveries",
+  warehouseDeliveryItems: "warehouse_delivery_items",
   calls: "calls",
   notes: "notes",
   activities: "activities",

--- a/convex/_helpers/supabaseRows.ts
+++ b/convex/_helpers/supabaseRows.ts
@@ -29,6 +29,8 @@ export type AppointmentWorkflowHistoryRow = SupabaseRow<"appointmentWorkflowHist
 export type PaymentRow = SupabaseRow<"payments">;
 export type NoteRow = SupabaseRow<"notes">;
 export type EmailRow = SupabaseRow<"emails">;
+export type WarehouseDeliveryRow = SupabaseRow<"warehouseDeliveries">;
+export type WarehouseDeliveryItemRow = SupabaseRow<"warehouseDeliveryItems">;
 
 // Envelope returned by Supabase-backed list actions that imitate the Convex
 // pagination contract. The cursor encodes the next page offset as a decimal

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -374,6 +374,43 @@ export function createCrmTables({
     .index("by_product", ["productId", "createdAt"])
     .index("by_source", ["sourceType", "sourceId"]),
 
+  // Warehouse delivery document (#2961).  Header table for a goods-receipt
+  // event; groups multiple product receipts from one supplier into a single
+  // document with invoice number and VAT support.  Status 'draft' means items
+  // are still editable; 'posted' means stock movements have been created and
+  // the record is read-only.
+  warehouseDeliveries: defineTable({
+    organizationId: v.id("organizations"),
+    supplierName: v.optional(v.string()),
+    invoiceNumber: v.optional(v.string()),
+    deliveryDate: v.optional(v.string()),
+    locationId: v.optional(v.id("gabinetLocations")),
+    notes: v.optional(v.string()),
+    status: v.union(v.literal("draft"), v.literal("posted")),
+    createdBy: v.id("users"),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_org", ["organizationId", "createdAt"])
+    .index("by_orgAndStatus", ["organizationId", "status"]),
+
+  // One row per product within a warehouse delivery.  `movementId` is filled
+  // in when the parent delivery is posted and links this line back to the
+  // product_stock_movements audit trail.
+  warehouseDeliveryItems: defineTable({
+    organizationId: v.id("organizations"),
+    deliveryId: v.id("warehouseDeliveries"),
+    productId: v.id("products"),
+    quantity: v.number(),
+    unitPrice: v.optional(v.number()),
+    vatRate: v.optional(v.number()),
+    movementId: v.optional(v.string()),
+    createdAt: v.number(),
+  })
+    .index("by_delivery", ["deliveryId"])
+    .index("by_org", ["organizationId"])
+    .index("by_product", ["productId"]),
+
   dealProducts: defineTable({
     organizationId: v.id("organizations"),
     dealId: v.id("leads"),

--- a/convex/warehouseDeliveries.ts
+++ b/convex/warehouseDeliveries.ts
@@ -1,0 +1,209 @@
+// Warehouse deliveries backend (#2961).
+//
+// Manages goods-receipt documents: a delivery header with supplier / invoice
+// metadata plus line items (one per product).  Posting a draft delivery writes
+// one product_stock_movements row per item via applyMovementInternal and
+// stamps the resulting movement_id back onto each item for cross-linking.
+//
+// Status lifecycle: draft → posted (one-way, irreversible from this layer).
+
+import { action } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { v } from "convex/values";
+import { createSupabaseDb } from "./_helpers/supabaseDb";
+import { applyMovementInternal } from "./inventory";
+import type { SupabaseRow } from "./_helpers/supabaseRows";
+
+type DeliveryRow = SupabaseRow<"warehouseDeliveries">;
+type DeliveryItemRow = SupabaseRow<"warehouseDeliveryItems">;
+
+export interface DeliveryWithItems {
+  delivery: DeliveryRow;
+  items: DeliveryItemRow[];
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+export const listDeliveries = action({
+  args: {
+    organizationId: v.id("organizations"),
+    status: v.optional(v.union(v.literal("draft"), v.literal("posted"))),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<DeliveryRow[]> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_inventory", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    const db = createSupabaseDb();
+    const limit = Math.max(1, Math.min(args.limit ?? 50, 200));
+    let query = db
+      .query<DeliveryRow>("warehouseDeliveries")
+      .eq("organizationId", String(args.organizationId));
+    if (args.status) {
+      query = query.eq("status", args.status);
+    }
+    return await query.order("createdAt", false).take(limit).collect();
+  },
+});
+
+export const getDelivery = action({
+  args: {
+    organizationId: v.id("organizations"),
+    deliveryId: v.string(),
+  },
+  handler: async (ctx, args): Promise<DeliveryWithItems> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_inventory", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    const db = createSupabaseDb();
+    const delivery = await db.get<DeliveryRow>("warehouseDeliveries", args.deliveryId);
+    if (!delivery || String(delivery.organizationId) !== String(args.organizationId)) {
+      throw new Error("Delivery not found");
+    }
+    const items = await db
+      .query<DeliveryItemRow>("warehouseDeliveryItems")
+      .eq("deliveryId", args.deliveryId)
+      .collect();
+    return { delivery, items };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+export const createDelivery = action({
+  args: {
+    organizationId: v.id("organizations"),
+    supplierName: v.optional(v.string()),
+    invoiceNumber: v.optional(v.string()),
+    deliveryDate: v.optional(v.string()),
+    locationId: v.optional(v.id("gabinetLocations")),
+    notes: v.optional(v.string()),
+    items: v.array(v.object({
+      productId: v.string(),
+      quantity: v.number(),
+      unitPrice: v.optional(v.number()),
+      vatRate: v.optional(v.number()),
+    })),
+  },
+  handler: async (ctx, args): Promise<{ deliveryId: string }> => {
+    const auth = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_inventory", action: "edit" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    if (args.items.length === 0) {
+      throw new Error("Delivery must have at least one item");
+    }
+
+    const db = createSupabaseDb();
+    const now = Date.now();
+
+    const deliveryId = await db.insert("warehouseDeliveries", {
+      organizationId: String(args.organizationId),
+      supplierName: args.supplierName ?? null,
+      invoiceNumber: args.invoiceNumber ?? null,
+      deliveryDate: args.deliveryDate ?? null,
+      locationId: args.locationId ?? null,
+      notes: args.notes ?? null,
+      status: "draft",
+      createdBy: String(auth.userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    for (const item of args.items) {
+      await db.insert("warehouseDeliveryItems", {
+        organizationId: String(args.organizationId),
+        deliveryId,
+        productId: item.productId,
+        quantity: item.quantity,
+        unitPrice: item.unitPrice ?? null,
+        vatRate: item.vatRate ?? null,
+        movementId: null,
+        createdAt: now,
+      });
+    }
+
+    return { deliveryId };
+  },
+});
+
+export const postDelivery = action({
+  args: {
+    organizationId: v.id("organizations"),
+    deliveryId: v.string(),
+    note: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<{ movementsCreated: number }> => {
+    const auth = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_inventory", action: "edit" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    const db = createSupabaseDb();
+    const delivery = await db.get<DeliveryRow>("warehouseDeliveries", args.deliveryId);
+    if (!delivery || String(delivery.organizationId) !== String(args.organizationId)) {
+      throw new Error("Delivery not found");
+    }
+    if (delivery.status === "posted") {
+      throw new Error("Delivery is already posted");
+    }
+
+    const items = await db
+      .query<DeliveryItemRow>("warehouseDeliveryItems")
+      .eq("deliveryId", args.deliveryId)
+      .collect();
+
+    const locationId = delivery.locationId ? String(delivery.locationId) : null;
+    const noteText = args.note
+      ?? (delivery.invoiceNumber ? `Delivery ${delivery.invoiceNumber}` : null);
+
+    for (const item of items) {
+      const { movementId } = await applyMovementInternal({
+        organizationId: String(args.organizationId),
+        productId: String(item.productId),
+        locationId,
+        delta: Number(item.quantity),
+        reason: "warehouse_receive",
+        sourceType: "warehouse_delivery",
+        sourceId: args.deliveryId,
+        note: noteText,
+        performedBy: String(auth.userId),
+      });
+      await db.patch("warehouseDeliveryItems", String(item._id), { movementId });
+    }
+
+    await db.patch("warehouseDeliveries", args.deliveryId, {
+      status: "posted",
+      updatedAt: Date.now(),
+    });
+
+    return { movementsCreated: items.length };
+  },
+});

--- a/supabase/migrations/00051_warehouse_deliveries.sql
+++ b/supabase/migrations/00051_warehouse_deliveries.sql
@@ -1,0 +1,84 @@
+-- Warehouse deliveries (#2961).
+--
+-- Adds two tables that represent a goods-receipt document:
+--
+--   • warehouse_deliveries — header with supplier, invoice number, VAT, date,
+--     and a status flag that distinguishes a draft being edited from a posted
+--     delivery whose stock movements have already been created.
+--
+--   • warehouse_delivery_items — line items, one row per (delivery, product),
+--     with quantity, unit purchase price, and VAT rate.  When a delivery is
+--     posted the backend writes one product_stock_movements row per item and
+--     stores the resulting movement_id here so the receipt can be cross-linked
+--     back to the audit trail.
+--
+-- The single-movement model (product_stock_movements reason='warehouse_receive')
+-- remains in place for quick ad-hoc receipts; the new tables are the document
+-- layer on top of it for multi-product receipts with supplier tracking.
+
+-- ---------------------------------------------------------------------------
+-- warehouse_deliveries
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS warehouse_deliveries (
+  id              TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  supplier_name   TEXT,
+  invoice_number  TEXT,
+  delivery_date   TEXT,                              -- ISO date YYYY-MM-DD
+  location_id     TEXT REFERENCES gabinet_locations(id) ON DELETE SET NULL,
+  notes           TEXT,
+  -- 'draft'  = items can still be edited, no stock movements yet
+  -- 'posted' = stock movements written, record is read-only
+  status          TEXT NOT NULL DEFAULT 'draft',
+  created_by      TEXT NOT NULL REFERENCES users(id),
+  created_at      BIGINT NOT NULL,
+  updated_at      BIGINT NOT NULL,
+
+  CONSTRAINT warehouse_deliveries_status_check
+    CHECK (status IN ('draft', 'posted'))
+);
+
+CREATE INDEX IF NOT EXISTS warehouse_deliveries_org_created_idx
+  ON warehouse_deliveries (organization_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS warehouse_deliveries_org_status_idx
+  ON warehouse_deliveries (organization_id, status);
+
+-- ---------------------------------------------------------------------------
+-- warehouse_delivery_items
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS warehouse_delivery_items (
+  id              TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  delivery_id     TEXT NOT NULL REFERENCES warehouse_deliveries(id) ON DELETE CASCADE,
+  product_id      TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  quantity        NUMERIC NOT NULL,
+  unit_price      NUMERIC,                           -- purchase price excl. VAT
+  vat_rate        NUMERIC,                           -- percentage, e.g. 23.0
+  -- Filled in when the parent delivery is posted; links to the audit trail.
+  movement_id     TEXT REFERENCES product_stock_movements(id) ON DELETE SET NULL,
+  created_at      BIGINT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS warehouse_delivery_items_delivery_idx
+  ON warehouse_delivery_items (delivery_id);
+
+CREATE INDEX IF NOT EXISTS warehouse_delivery_items_org_idx
+  ON warehouse_delivery_items (organization_id);
+
+CREATE INDEX IF NOT EXISTS warehouse_delivery_items_product_idx
+  ON warehouse_delivery_items (product_id);
+
+-- ---------------------------------------------------------------------------
+-- RLS: org-scoped access, same pattern as existing inventory tables.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE warehouse_deliveries ENABLE ROW LEVEL SECURITY;
+CREATE POLICY org_isolation ON warehouse_deliveries
+  USING (organization_id = current_org_id());
+
+ALTER TABLE warehouse_delivery_items ENABLE ROW LEVEL SECURITY;
+CREATE POLICY org_isolation ON warehouse_delivery_items
+  USING (organization_id = current_org_id());


### PR DESCRIPTION
## Summary

- Adds `warehouse_deliveries` header table (supplier name, invoice number, delivery date, VAT-ready, draft/posted status) and `warehouse_delivery_items` line-item table so multi-product receipts can be tracked as a single document
- The existing `product_stock_movements reason='warehouse_receive'` path remains for quick ad-hoc adjustments; the new tables are the document layer on top of it
- Posting a delivery calls `applyMovementInternal` for each item (writing proper audit trail rows) and stamps the resulting `movement_id` back onto each item for cross-linking

## Changes

| File | What |
|------|------|
| `supabase/migrations/00051_warehouse_deliveries.sql` | Creates both Postgres tables with RLS and indexes |
| `convex/schema/crm.ts` | `warehouseDeliveries` + `warehouseDeliveryItems` Convex schema definitions |
| `convex/_helpers/supabaseDb.ts` | TABLE_MAP entries for both tables |
| `convex/_helpers/supabaseRows.ts` | Type aliases |
| `convex/warehouseDeliveries.ts` | `listDeliveries`, `getDelivery`, `createDelivery`, `postDelivery` actions |

## Test plan

- [ ] Apply migration on Supabase instance; verify tables exist with correct columns and RLS
- [ ] Call `createDelivery` with 2+ items — verify delivery row in `draft` status and items rows
- [ ] Call `postDelivery` — verify status flips to `posted`, one `product_stock_movements` row per item with `source_type='warehouse_delivery'`, `movement_id` stamped on each item
- [ ] Re-posting an already-posted delivery returns an error
- [ ] Org isolation: querying deliveries for org A does not return org B deliveries

🤖 Generated with [Claude Code](https://claude.com/claude-code)