### PR TITLE
Copy `purchasePrice` from product into stock movement at receipt time

### DIFF
--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -153,6 +153,7 @@ interface ApplyMovementParams {
   sourceType?: string | null;
   sourceId?: string | null;
   note?: string | null;
+  unitPrice?: number | null;
   performedBy: string;
 }
 
@@ -212,6 +213,11 @@ export async function applyMovementInternal(
     }
   }
 
+  const snapshotPrice =
+    params.unitPrice != null
+      ? params.unitPrice
+      : (product.purchasePrice as number | null | undefined) ?? null;
+
   const movementId = await db.insert("productStockMovements", {
     organizationId: params.organizationId,
     productId: params.productId,
@@ -222,6 +228,7 @@ export async function applyMovementInternal(
     sourceType: params.sourceType ?? null,
     sourceId: params.sourceId ?? null,
     note: params.note ?? null,
+    unitPrice: snapshotPrice,
     performedBy: params.performedBy,
     createdAt: now,
   });

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -367,6 +367,7 @@ export function createCrmTables({
     sourceType: v.optional(v.string()),
     sourceId: v.optional(v.string()),
     note: v.optional(v.string()),
+    unitPrice: v.optional(v.number()),
     performedBy: v.id("users"),
     createdAt: v.number(),
   })

--- a/convex/warehouseDeliveries.ts
+++ b/convex/warehouseDeliveries.ts
@@ -194,6 +194,7 @@ export const postDelivery = action({
         sourceType: "warehouse_delivery",
         sourceId: args.deliveryId,
         note: noteText,
+        unitPrice: item.unitPrice != null ? Number(item.unitPrice) : undefined,
         performedBy: String(auth.userId),
       });
       await db.patch("warehouseDeliveryItems", String(item._id), { movementId });

--- a/supabase/migrations/00052_product_stock_movements_unit_price.sql
+++ b/supabase/migrations/00052_product_stock_movements_unit_price.sql
@@ -1,0 +1,12 @@
+-- Snapshot unit_price into stock movements at receipt time (#2963).
+--
+-- Adds an optional unit_price column to product_stock_movements so the
+-- purchase price at the moment of a warehouse receipt (or any other inbound
+-- movement) is preserved even after the product's purchase_price field is
+-- updated.  For warehouse-delivery postings the value comes from the delivery
+-- item's unit_price; if that is absent the product's current purchase_price
+-- is used as the fallback.  All other movement types (manual adjustments,
+-- appointment use, etc.) leave the column NULL unless the caller supplies it.
+
+ALTER TABLE product_stock_movements
+  ADD COLUMN IF NOT EXISTS unit_price NUMERIC;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2963.

Closes #2963

---

## Claude summary

The fix is committed. Here's a summary of what was done and why:

**Problem confirmed:** The `product_stock_movements` table had no price column. When a warehouse delivery was posted, `applyMovementInternal` created the movement row without any price data. Since `products.purchase_price` is mutable, historical cost reconstruction was impossible once the price changed.

**Fix — 4 files changed:**

1. `supabase/migrations/00052_product_stock_movements_unit_price.sql` — adds `unit_price NUMERIC` column to `product_stock_movements`

2. `convex/schema/crm.ts` — adds `unitPrice: v.optional(v.number())` to the `productStockMovements` table definition

3. `convex/inventory.ts` — adds `unitPrice?: number | null` to `ApplyMovementParams`; computes `snapshotPrice` as the explicit value if provided, or `product.purchasePrice` as a fallback, then writes it into the movement row

4. `convex/warehouseDeliveries.ts` — passes `item.unitPrice` to `applyMovementInternal` during `postDelivery`, so the invoice price is captured on the movement; the fallback in `applyMovementInternal` handles the case where no item-level price was entered on the delivery