### PR TITLE
Consider adding `total_value` denormalized column on `warehouse_deliveries`

### DIFF
--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -388,6 +388,9 @@ export function createCrmTables({
     locationId: v.optional(v.id("gabinetLocations")),
     notes: v.optional(v.string()),
     status: v.union(v.literal("draft"), v.literal("posted")),
+    // Denormalized SUM(quantity × unit_price) across all items (#2968).
+    // NULL when no items carried a unit_price.
+    totalValue: v.optional(v.number()),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),

--- a/convex/warehouseDeliveries.ts
+++ b/convex/warehouseDeliveries.ts
@@ -17,6 +17,20 @@ import type { SupabaseRow } from "./_helpers/supabaseRows";
 type DeliveryRow = SupabaseRow<"warehouseDeliveries">;
 type DeliveryItemRow = SupabaseRow<"warehouseDeliveryItems">;
 
+function computeTotalValue(
+  items: Array<{ quantity: number; unitPrice?: number | null }>,
+): number | null {
+  let total = 0;
+  let hasPrice = false;
+  for (const item of items) {
+    if (item.unitPrice != null) {
+      total += item.quantity * item.unitPrice;
+      hasPrice = true;
+    }
+  }
+  return hasPrice ? total : null;
+}
+
 export interface DeliveryWithItems {
   delivery: DeliveryRow;
   items: DeliveryItemRow[];
@@ -119,6 +133,8 @@ export const createDelivery = action({
     const db = createSupabaseDb();
     const now = Date.now();
 
+    const totalValue = computeTotalValue(args.items);
+
     const deliveryId = await db.insert("warehouseDeliveries", {
       organizationId: String(args.organizationId),
       supplierName: args.supplierName ?? null,
@@ -127,6 +143,7 @@ export const createDelivery = action({
       locationId: args.locationId ?? null,
       notes: args.notes ?? null,
       status: "draft",
+      totalValue,
       createdBy: String(auth.userId),
       createdAt: now,
       updatedAt: now,
@@ -184,19 +201,21 @@ export const updateDelivery = action({
       throw new Error("Only draft deliveries can be edited");
     }
 
-    await db.patch("warehouseDeliveries", args.deliveryId, {
+    const headerPatch: Record<string, unknown> = {
       supplierName: args.supplierName ?? null,
       invoiceNumber: args.invoiceNumber ?? null,
       deliveryDate: args.deliveryDate ?? null,
       locationId: args.locationId ?? null,
       notes: args.notes ?? null,
       updatedAt: Date.now(),
-    });
+    };
 
     if (args.items !== undefined) {
       if (args.items.length === 0) {
         throw new Error("Delivery must have at least one item");
       }
+      headerPatch.totalValue = computeTotalValue(args.items);
+
       const existing = await db
         .query<DeliveryItemRow>("warehouseDeliveryItems")
         .eq("deliveryId", args.deliveryId)
@@ -218,6 +237,8 @@ export const updateDelivery = action({
         });
       }
     }
+
+    await db.patch("warehouseDeliveries", args.deliveryId, headerPatch);
   },
 });
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
@@ -345,6 +345,9 @@ function DeliveriesPage() {
                 <th className="px-4 py-3 text-left font-medium text-muted-foreground">
                   {t("gabinet.deliveries.col.invoice", "Nr faktury")}
                 </th>
+                <th className="px-4 py-3 text-right font-medium text-muted-foreground">
+                  {t("gabinet.deliveries.col.totalValue", "Wartość")}
+                </th>
                 <th className="px-4 py-3 text-left font-medium text-muted-foreground">
                   {t("gabinet.deliveries.col.status", "Status")}
                 </th>
@@ -372,6 +375,11 @@ function DeliveriesPage() {
                     </td>
                     <td className="px-4 py-3">
                       {invoice ?? <span className="text-muted-foreground">—</span>}
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums">
+                      {typeof d.totalValue === "number"
+                        ? d.totalValue.toLocaleString("pl-PL", { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+                        : <span className="text-muted-foreground">—</span>}
                     </td>
                     <td className="px-4 py-3">{statusBadge(status, t)}</td>
                     <td className="px-4 py-3 text-right">

--- a/supabase/migrations/00053_warehouse_deliveries_total_value.sql
+++ b/supabase/migrations/00053_warehouse_deliveries_total_value.sql
@@ -1,0 +1,8 @@
+-- Denormalized total_value on warehouse_deliveries (#2968).
+--
+-- Stores the pre-computed SUM(quantity × unit_price) so the deliveries list
+-- view can display the total without joining warehouse_delivery_items at
+-- query time.  NULL means no line items carried a unit_price.
+-- Existing rows stay NULL (no backfill; unit prices are optional anyway).
+
+ALTER TABLE warehouse_deliveries ADD COLUMN IF NOT EXISTS total_value NUMERIC;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2968.

Closes #2968

---

## Claude summary

Done. Here's a summary of what was changed across 4 files:

**`supabase/migrations/00053_warehouse_deliveries_total_value.sql`** — new migration that adds `total_value NUMERIC` to `warehouse_deliveries`. Existing rows get NULL (no backfill needed since unit prices are optional).

**`convex/schema/crm.ts`** — added `totalValue: v.optional(v.number())` to the `warehouseDeliveries` table definition.

**`convex/warehouseDeliveries.ts`** — added a `computeTotalValue()` helper that returns `SUM(quantity × unit_price)` for items with a price (NULL if none have a price). Called on `createDelivery` (stored at insert time) and on `updateDelivery` whenever the item set is replaced.

**`_layout.gabinet.deliveries.tsx`** — added a "Wartość" column to the deliveries table showing the pre-computed total, formatted with Polish locale (e.g. `1 234,56`), with `—` for NULL totals.