### PR TITLE
Magazyn — średnia ważona ceny zakupu per salon

### DIFF
--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -194,12 +194,35 @@ export async function applyMovementInternal(
     warning = "negative_stock";
   }
 
+  // Weighted average net purchase price — updated only on warehouse receipts
+  // with a known net price. Guards: no update on manual adjustments,
+  // appointment use, etc. Division by zero prevented by the previousBalance ≤ 0
+  // branch which resets to the new delivery price outright.
+  let newAvgCost: number | null = null;
+  if (
+    params.reason === "warehouse_receive" &&
+    params.unitPrice != null &&
+    resolvedDelta > 0
+  ) {
+    const existingAvgCost =
+      level?.avgCost != null ? Number(level.avgCost) : null;
+    if (!level || previousBalance <= 0 || existingAvgCost == null) {
+      newAvgCost = params.unitPrice;
+    } else {
+      const denom = previousBalance + resolvedDelta;
+      newAvgCost =
+        (previousBalance * existingAvgCost + resolvedDelta * params.unitPrice) /
+        denom;
+    }
+  }
+
   const now = Date.now();
 
   if (trackStock) {
     if (level) {
       await db.patch("productStockLevels", String(level._id), {
         quantity: newBalance,
+        ...(newAvgCost !== null ? { avgCost: newAvgCost } : {}),
         updatedAt: now,
       });
     } else {
@@ -208,6 +231,7 @@ export async function applyMovementInternal(
         productId: params.productId,
         locationId: params.locationId,
         quantity: newBalance,
+        ...(newAvgCost !== null ? { avgCost: newAvgCost } : {}),
         updatedAt: now,
       });
     }

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -334,6 +334,7 @@ export function createCrmTables({
     productId: v.id("products"),
     locationId: v.optional(v.id("gabinetLocations")),
     quantity: v.number(),
+    avgCost: v.optional(v.number()),
     updatedAt: v.number(),
   })
     .index("by_org", ["organizationId"])

--- a/src/components/gabinet/warehouse-accountant-report-dialog.tsx
+++ b/src/components/gabinet/warehouse-accountant-report-dialog.tsx
@@ -24,6 +24,7 @@ interface ReportBodyProps {
   generatedAt: string;
   products: MappedProduct[];
   historicalStock: Map<string, number>;
+  avgCostByProductId: Map<string, number | null>;
 }
 
 function ReportBody({
@@ -33,6 +34,7 @@ function ReportBody({
   generatedAt,
   products,
   historicalStock,
+  avgCostByProductId,
 }: ReportBodyProps) {
   const { t } = useTranslation();
   const noPrice = t("inventory.accountantReport.noPrice", {
@@ -101,13 +103,13 @@ function ReportBody({
               {t("inventory.history.stockOnDate", { defaultValue: "Stan" })}
             </th>
             <th className="px-2 py-2 text-right font-semibold">
-              {t("inventory.accountantReport.purchasePrice", {
-                defaultValue: "Cena zakupu",
+              {t("inventory.accountantReport.avgCostNet", {
+                defaultValue: "Śr. cena zakupu netto",
               })}
             </th>
             <th className="px-2 py-2 text-right font-semibold">
-              {t("inventory.accountantReport.value", {
-                defaultValue: "Wartość",
+              {t("inventory.accountantReport.valueNet", {
+                defaultValue: "Wartość netto",
               })}
             </th>
           </tr>
@@ -116,8 +118,8 @@ function ReportBody({
           {products.map((product, idx) => {
             const qty = historicalStock.get(product._id) ?? 0;
             const unit = product.stockUnit?.trim() || "—";
-            const hasPrice = product.purchasePrice != null;
-            const value = hasPrice ? qty * product.purchasePrice! : null;
+            const avgCost = avgCostByProductId.get(product._id) ?? null;
+            const value = avgCost != null ? qty * avgCost : null;
             return (
               <tr
                 key={product._id}
@@ -130,8 +132,8 @@ function ReportBody({
                 <td className="px-2 py-1.5 text-right">{unit}</td>
                 <td className="px-2 py-1.5 text-right tabular-nums">{qty}</td>
                 <td className="px-2 py-1.5 text-right tabular-nums">
-                  {hasPrice
-                    ? formatPricePLN(product.purchasePrice!)
+                  {avgCost != null
+                    ? formatPricePLN(avgCost)
                     : <span className="text-muted-foreground">{noPrice}</span>}
                 </td>
                 <td className="px-2 py-1.5 text-right tabular-nums">
@@ -157,18 +159,21 @@ function ReportBody({
         </div>
         <div className="mt-1">
           <span className="font-semibold">
-            {t("inventory.accountantReport.totalValue", {
-              defaultValue: "Łączna wartość",
+            {t("inventory.accountantReport.totalValueNet", {
+              defaultValue: "Łączna wartość magazynu netto",
             })}
             :
           </span>{" "}
           {(() => {
-            const total = products.reduce((sum, p) => {
-              if (p.purchasePrice == null) return sum;
+            let total = 0;
+            let hasAnyPrice = false;
+            for (const p of products) {
+              const avgCost = avgCostByProductId.get(p._id) ?? null;
+              if (avgCost == null) continue;
+              hasAnyPrice = true;
               const qty = historicalStock.get(p._id) ?? 0;
-              return sum + qty * p.purchasePrice;
-            }, 0);
-            const hasAnyPrice = products.some((p) => p.purchasePrice != null);
+              total += qty * avgCost;
+            }
             return hasAnyPrice
               ? <span className="font-semibold">{formatPricePLN(total)}</span>
               : <span className="text-muted-foreground">{t("inventory.accountantReport.notAvailable", { defaultValue: "niedostępna (brak cen zakupu)" })}</span>;
@@ -203,6 +208,7 @@ export interface WarehouseAccountantReportDialogProps {
   selectedDate: string;
   products: MappedProduct[];
   historicalStock: Map<string, number>;
+  avgCostByProductId: Map<string, number | null>;
   locationName?: string | null;
 }
 
@@ -213,6 +219,7 @@ export function WarehouseAccountantReportDialog({
   selectedDate,
   products,
   historicalStock,
+  avgCostByProductId,
   locationName,
 }: WarehouseAccountantReportDialogProps) {
   const { t } = useTranslation();
@@ -226,6 +233,7 @@ export function WarehouseAccountantReportDialog({
     generatedAt,
     products,
     historicalStock,
+    avgCostByProductId,
   };
 
   const handlePrint = () => {

--- a/src/components/gabinet/warehouse-inventory-dialog.tsx
+++ b/src/components/gabinet/warehouse-inventory-dialog.tsx
@@ -154,6 +154,16 @@ export function WarehouseInventoryDialog({
     [products],
   );
 
+  const avgCostByProductId = useMemo(() => {
+    const map = new Map<string, number | null>();
+    for (const p of trackedProducts) {
+      const stock = totalsByProductId.get(p._id);
+      const loc = stock?.byLocation.find((l) => l.locationId === resolvedLocationId);
+      map.set(p._id, loc?.avgCost ?? null);
+    }
+    return map;
+  }, [trackedProducts, totalsByProductId, resolvedLocationId]);
+
   const diffs: DiffRow[] = useMemo(() => {
     const result: DiffRow[] = [];
     for (const p of trackedProducts) {
@@ -400,7 +410,7 @@ export function WarehouseInventoryDialog({
   return (
     <>
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="flex max-h-[90vh] max-w-2xl flex-col">
+      <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col">
         <DialogHeader>
           <DialogTitle>
             {t("inventory.count.title", {
@@ -498,6 +508,12 @@ export function WarehouseInventoryDialog({
                     <th className="px-3 py-2 text-right font-medium">
                       {t("inventory.history.stockOnDate", { defaultValue: "Stan" })}
                     </th>
+                    <th className="px-3 py-2 text-right font-medium">
+                      {t("inventory.count.avgCostNet", { defaultValue: "Śr. cena netto" })}
+                    </th>
+                    <th className="px-3 py-2 text-right font-medium">
+                      {t("inventory.count.valueNet", { defaultValue: "Wartość netto" })}
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
@@ -505,6 +521,8 @@ export function WarehouseInventoryDialog({
                     const qty = historicalStockQuery.data?.get(product._id) ?? 0;
                     const unit = product.stockUnit?.trim() ?? "";
                     const u = unit ? ` ${unit}` : "";
+                    const avgCost = avgCostByProductId.get(product._id) ?? null;
+                    const valueNet = avgCost != null ? qty * avgCost : null;
                     return (
                       <tr key={product._id} className="border-b last:border-0">
                         <td className="px-3 py-2 font-medium">{product.name}</td>
@@ -513,6 +531,16 @@ export function WarehouseInventoryDialog({
                         </td>
                         <td className="px-3 py-2 text-right tabular-nums">
                           {qty}{u}
+                        </td>
+                        <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                          {avgCost != null
+                            ? avgCost.toLocaleString("pl-PL", { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + " zł"
+                            : "—"}
+                        </td>
+                        <td className="px-3 py-2 text-right tabular-nums">
+                          {valueNet != null
+                            ? valueNet.toLocaleString("pl-PL", { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + " zł"
+                            : "—"}
                         </td>
                       </tr>
                     );
@@ -545,6 +573,12 @@ export function WarehouseInventoryDialog({
                     })}
                   </th>
                   <th className="px-3 py-2 text-right font-medium">
+                    {t("inventory.count.avgCostNet", { defaultValue: "Śr. cena netto" })}
+                  </th>
+                  <th className="px-3 py-2 text-right font-medium">
+                    {t("inventory.count.valueNet", { defaultValue: "Wartość netto" })}
+                  </th>
+                  <th className="px-3 py-2 text-right font-medium">
                     {t("inventory.count.actual", {
                       defaultValue: "Rzeczywisty",
                     })}
@@ -564,6 +598,8 @@ export function WarehouseInventoryDialog({
                   const delta = actual !== null ? actual - systemStock : null;
                   const unit = product.stockUnit?.trim() ?? "";
                   const u = unit ? ` ${unit}` : "";
+                  const avgCost = avgCostByProductId.get(product._id) ?? null;
+                  const valueNet = avgCost != null ? systemStock * avgCost : null;
                   return (
                     <tr key={product._id} className="border-b last:border-0">
                       <td className="px-3 py-2 font-medium">{product.name}</td>
@@ -573,6 +609,16 @@ export function WarehouseInventoryDialog({
                       <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
                         {systemStock}
                         {u}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                        {avgCost != null
+                          ? avgCost.toLocaleString("pl-PL", { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + " zł"
+                          : "—"}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                        {valueNet != null
+                          ? valueNet.toLocaleString("pl-PL", { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + " zł"
+                          : "—"}
                       </td>
                       <td className="px-3 py-2">
                         <Input
@@ -659,6 +705,7 @@ export function WarehouseInventoryDialog({
       selectedDate={selectedDate}
       products={trackedProducts}
       historicalStock={historicalStockQuery.data ?? new Map()}
+      avgCostByProductId={avgCostByProductId}
       locationName={
         resolvedLocationId
           ? (locations.find((l) => l._id === resolvedLocationId)?.name ?? null)

--- a/src/hooks/use-supabase-products.ts
+++ b/src/hooks/use-supabase-products.ts
@@ -137,7 +137,7 @@ export function useSupabaseUsedProductIds(
 
 export interface ProductStockTotal {
   total: number;
-  byLocation: Array<{ locationId: string | null; quantity: number }>;
+  byLocation: Array<{ locationId: string | null; quantity: number; avgCost: number | null }>;
 }
 
 export function useSupabaseProductStockTotals(
@@ -148,7 +148,7 @@ export function useSupabaseProductStockTotals(
   const { enabled = true } = options;
 
   const query = useQuery<
-    Array<{ product_id: string; location_id: string | null; quantity: number }>,
+    Array<{ product_id: string; location_id: string | null; quantity: number; avg_cost: number | null }>,
     Error
   >({
     queryKey: supabaseKeys.productStockLevels.list(organizationId),
@@ -156,13 +156,14 @@ export function useSupabaseProductStockTotals(
       if (!client) throw new Error("Supabase client not ready");
       const { data, error } = await client
         .from("product_stock_levels")
-        .select("product_id, location_id, quantity")
+        .select("product_id, location_id, quantity, avg_cost")
         .eq("organization_id", organizationId);
       if (error) throw error;
       return (data ?? []) as Array<{
         product_id: string;
         location_id: string | null;
         quantity: number;
+        avg_cost: number | null;
       }>;
     },
     enabled: enabled && isReady && !!organizationId,
@@ -177,6 +178,7 @@ export function useSupabaseProductStockTotals(
       existing.byLocation.push({
         locationId: row.location_id,
         quantity: qty,
+        avgCost: row.avg_cost != null ? Number(row.avg_cost) : null,
       });
       map.set(row.product_id, existing);
     }

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -6565,6 +6565,7 @@ export interface Database {
           product_id: string;
           location_id: string | null;
           quantity: number;
+          avg_cost: number | null;
           updated_at: number;
         };
         Insert: {
@@ -6573,6 +6574,7 @@ export interface Database {
           product_id: string;
           location_id?: string | null;
           quantity?: number;
+          avg_cost?: number | null;
           updated_at: number;
         };
         Update: {
@@ -6581,6 +6583,7 @@ export interface Database {
           product_id?: string;
           location_id?: string | null;
           quantity?: number;
+          avg_cost?: number | null;
           updated_at?: number;
         };
         Relationships: [

--- a/supabase/migrations/00055_stock_levels_avg_cost.sql
+++ b/supabase/migrations/00055_stock_levels_avg_cost.sql
@@ -1,0 +1,17 @@
+-- Weighted-average net purchase price per (product, location) (#2977).
+--
+-- avg_cost is NULL until the first warehouse delivery with a net unit price is
+-- posted for a given (product, location) pair. It is recomputed by the backend
+-- each time a delivery is posted using the formula:
+--
+--   new_avg = (prev_qty × prev_avg + incoming_qty × unit_price_net)
+--             ÷ (prev_qty + incoming_qty)
+--
+-- When prev_qty ≤ 0 or prev_avg IS NULL the new delivery price replaces the
+-- average outright (avoids dividing by zero and resets a negative-stock base).
+--
+-- Intentionally NOT updated on manual adjustments or inventory reconciliations
+-- per issue #2977 scope guardrails.
+
+ALTER TABLE product_stock_levels
+  ADD COLUMN IF NOT EXISTS avg_cost NUMERIC;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2977.

Closes #2977

---

## Claude summary

The implementation is complete. Here's what was done:

**7 files changed across backend, schema, and UI:**

**Database (migration 00055):** Adds `avg_cost NUMERIC` to `product_stock_levels`, scoped per `(organization_id, product_id, location_id)`. Starts NULL until a delivery with a net price is posted.

**Backend (`convex/inventory.ts`):** In `applyMovementInternal`, when `reason === "warehouse_receive"` and a net `unitPrice` is supplied and the delta is positive, computes the weighted average:
- `(prev_qty × prev_avg + incoming_qty × unit_price) ÷ (prev_qty + incoming_qty)`
- Resets to the delivery price when previous balance ≤ 0 or avg was never set (avoids division by zero)
- No update for manual adjustments, inventory reconciliations, appointment use etc.

**Convex schema:** Added `avgCost: v.optional(v.number())` to `productStockLevels`.

**Database types (`database.types.ts`):** Added `avg_cost: number | null` to the `product_stock_levels` Row/Insert/Update types.

**Hook (`use-supabase-products.ts`):** `useSupabaseProductStockTotals` now fetches `avg_cost` and exposes it as `avgCost` in each `byLocation` entry of `ProductStockTotal`.

**Inventory dialog:** Builds `avgCostByProductId` map per selected location, adds "Śr. cena netto" and "Wartość netto" columns to both the live count table and historical read-only table. Dialog widened from `max-w-2xl` to `max-w-4xl` to fit the extra columns. Passes `avgCostByProductId` to the accountant report.

**Accountant report:** Uses `avgCostByProductId` (location-scoped weighted average) instead of `product.purchasePrice`. Column headers updated to "Śr. cena zakupu netto" / "Wartość netto" / "Łączna wartość magazynu netto". Shows "brak danych" for products without a computed average — no fallback to `purchasePrice`.

## Follow-ups

- Add unit tests for weighted average calculation in `applyMovementInternal`: the core `warehouse_receive` avg_cost formula has no test coverage; edge cases (zero previous balance, null previous avg, negative delta) should be tested in `tests/convex/`
- Historical avg_cost view: the accountant report uses current avg_cost for historical date snapshots; a future iteration could snapshot avg_cost into `product_stock_movements` to enable truly historical valuation reports