### PR TITLE
Regenerate `database.types.ts` via `scripts/gen-db-types.mjs` after all migratio

### DIFF
--- a/src/lib/supabase/database.columns.ts
+++ b/src/lib/supabase/database.columns.ts
@@ -49,6 +49,18 @@
  *   • 00042_gabinet_employees_nullable_user_id.sql
  *   • 00043_reminder_channel_settings.sql
  *   • 00044_scope_entities_jsonb.sql
+ *   • 00045_backfill_scope_entities_appointment_docs.sql
+ *   • 00046_form_documents_org_entity_type_idx.sql
+ *   • 00047_gabinet_appointments_variant_id.sql
+ *   • 00048_gabinet_appointments_stock_deducted.sql
+ *   • 00049_product_stock_movements_location_idx.sql
+ *   • 00050_product_purchase_price.sql
+ *   • 00051_warehouse_deliveries.sql
+ *   • 00052_product_stock_movements_unit_price.sql
+ *   • 00053_warehouse_deliveries_total_value.sql
+ *   • 00054_delivery_items_prices.sql
+ *   • 00055_stock_levels_avg_cost.sql
+ *   • 00056_product_stock_movements_avg_cost_after.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  */
@@ -150,7 +162,9 @@ export type TableName =
   | "product_stock_movements"
   | "gabinet_treatment_products"
   | "gabinet_payment_methods"
-  | "gabinet_employee_locations";
+  | "gabinet_employee_locations"
+  | "warehouse_deliveries"
+  | "warehouse_delivery_items";
 
 /**
  * Column names per table, as a runtime-checkable Set.
@@ -190,7 +204,7 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   object_relationships: new Set(["id", "organization_id", "source_type", "source_id", "target_type", "target_id", "relationship_type", "created_by", "created_at"]),
   activities: new Set(["id", "organization_id", "entity_type", "entity_id", "action", "description", "metadata", "performed_by", "created_at"]),
   notes: new Set(["id", "organization_id", "entity_type", "entity_id", "content", "created_by", "is_pinned", "parent_note_id", "created_at", "updated_at"]),
-  products: new Set(["id", "organization_id", "name", "sku", "unit_price", "tax_rate", "is_active", "description", "tag_ids", "category_id", "created_by", "created_at", "updated_at", "tax_exempt", "track_stock", "stock_unit", "product_section", "min_stock", "manufacturer", "catalog_number", "stock_note"]),
+  products: new Set(["id", "organization_id", "name", "sku", "unit_price", "tax_rate", "is_active", "description", "tag_ids", "category_id", "created_by", "created_at", "updated_at", "tax_exempt", "track_stock", "stock_unit", "product_section", "min_stock", "manufacturer", "catalog_number", "stock_note", "purchase_price"]),
   deal_products: new Set(["id", "organization_id", "deal_id", "product_id", "quantity", "unit_price", "discount", "created_at"]),
   calls: new Set(["id", "organization_id", "outcome", "call_date", "note", "duration", "tag_ids", "category_id", "created_by", "created_at", "updated_at"]),
   lost_reasons: new Set(["id", "organization_id", "label", "order", "is_active", "created_by", "created_at", "updated_at"]),
@@ -227,7 +241,7 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   gabinet_leaves: new Set(["id", "organization_id", "user_id", "type", "leave_type_id", "start_date", "end_date", "start_time", "end_time", "status", "reason", "approved_by", "approved_at", "created_by", "created_at", "updated_at"]),
   gabinet_overtime: new Set(["id", "organization_id", "user_id", "date", "hours", "reason", "status", "approved_by", "approved_at", "created_by", "created_at", "updated_at"]),
   gabinet_patients: new Set(["id", "organization_id", "contact_id", "first_name", "last_name", "pesel", "date_of_birth", "gender", "email", "phone", "address", "medical_notes", "allergies", "blood_type", "emergency_contact_name", "emergency_contact_phone", "referral_source", "referred_by_patient_id", "is_active", "tags", "tag_ids", "category_id", "custom_fields", "created_by", "created_at", "updated_at", "preferred_location_id", "sms_consent"]),
-  gabinet_appointments: new Set(["id", "organization_id", "patient_id", "treatment_id", "employee_id", "date", "start_time", "end_time", "status", "notes", "internal_notes", "body_chart_data", "treatment_parameter_values", "interview_notes", "clinical_remarks", "photos", "color", "is_recurring", "recurring_rule", "recurring_group_id", "recurring_index", "prepayment_required", "prepayment_amount", "prepayment_status", "prepayment_paid_at", "package_usage_id", "scheduled_activity_id", "reminder_sent_at", "send_reminder", "cancelled_at", "cancelled_by", "cancellation_reason", "booked_from_portal", "booked_by_patient_id", "location_id", "room_id", "tag_ids", "category_id", "requires_completion", "created_by", "created_at", "updated_at", "contraindication_alerts_reviewed", "price_at_booking", "reminder_overrides"]),
+  gabinet_appointments: new Set(["id", "organization_id", "patient_id", "treatment_id", "employee_id", "date", "start_time", "end_time", "status", "notes", "internal_notes", "body_chart_data", "treatment_parameter_values", "interview_notes", "clinical_remarks", "photos", "color", "is_recurring", "recurring_rule", "recurring_group_id", "recurring_index", "prepayment_required", "prepayment_amount", "prepayment_status", "prepayment_paid_at", "package_usage_id", "scheduled_activity_id", "reminder_sent_at", "send_reminder", "cancelled_at", "cancelled_by", "cancellation_reason", "booked_from_portal", "booked_by_patient_id", "location_id", "room_id", "tag_ids", "category_id", "requires_completion", "created_by", "created_at", "updated_at", "contraindication_alerts_reviewed", "price_at_booking", "reminder_overrides", "variant_id", "stock_deducted"]),
   gabinet_treatment_packages: new Set(["id", "organization_id", "name", "description", "treatments", "total_price", "currency", "discount_percent", "validity_days", "is_active", "loyalty_points_awarded", "auto_generated_for_treatment_id", "created_by", "created_at", "updated_at"]),
   gabinet_package_usage: new Set(["id", "organization_id", "patient_id", "package_id", "purchased_at", "expires_at", "status", "treatments_used", "paid_amount", "payment_method", "created_by", "created_at", "updated_at"]),
   gabinet_loyalty_points: new Set(["id", "organization_id", "patient_id", "balance", "lifetime_earned", "lifetime_spent", "tier", "created_at", "updated_at"]),
@@ -248,9 +262,11 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   automation_runs: new Set(["id", "organization_id", "rule_id", "module", "event_type", "entity_type", "entity_id", "event_idempotency_key", "correlation_key", "payload_snapshot", "actor_user_id", "status", "error_message", "occurred_at", "processed_at", "created_at", "updated_at"]),
   automation_run_steps: new Set(["id", "organization_id", "run_id", "rule_id", "action_index", "action_type", "idempotency_key", "status", "recipient", "recipient_name", "linked_entity_type", "linked_entity_id", "rendered_subject", "rendered_body", "metadata_snapshot", "error_message", "email_event_log_id", "appointment_sms_event_id", "processed_at", "created_at", "updated_at"]),
   document_components: new Set(["id", "organization_id", "scope", "created_by", "name", "description", "category", "content_json", "protected", "position_constraint", "version", "is_active", "created_at", "updated_at"]),
-  product_stock_levels: new Set(["id", "organization_id", "product_id", "location_id", "quantity", "avg_cost", "updated_at"]),
-  product_stock_movements: new Set(["id", "organization_id", "product_id", "location_id", "delta", "balance_after", "reason", "source_type", "source_id", "note", "unit_price", "avg_cost_after", "performed_by", "created_at"]),
+  product_stock_levels: new Set(["id", "organization_id", "product_id", "location_id", "quantity", "updated_at", "avg_cost"]),
+  product_stock_movements: new Set(["id", "organization_id", "product_id", "location_id", "delta", "balance_after", "reason", "source_type", "source_id", "note", "performed_by", "created_at", "unit_price", "avg_cost_after"]),
   gabinet_treatment_products: new Set(["id", "organization_id", "treatment_id", "product_id", "product_section", "quantity", "unit", "created_at", "updated_at"]),
   gabinet_payment_methods: new Set(["id", "organization_id", "key", "name", "is_system", "is_active", "order", "available_for_settlement", "available_for_sales", "available_for_refund", "locks_amount_to_treatment_price", "is_package_coverage", "created_by", "created_at", "updated_at"]),
   gabinet_employee_locations: new Set(["id", "organization_id", "employee_id", "location_id", "is_primary", "created_at"]),
+  warehouse_deliveries: new Set(["id", "organization_id", "supplier_name", "invoice_number", "delivery_date", "location_id", "notes", "status", "created_by", "created_at", "updated_at", "total_value", "total_value_gross"]),
+  warehouse_delivery_items: new Set(["id", "organization_id", "delivery_id", "product_id", "quantity", "unit_price", "vat_rate", "movement_id", "created_at", "unit_price_gross", "line_value_net", "line_value_gross", "vat_code"]),
 };

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -49,7 +49,18 @@
  *   • 00042_gabinet_employees_nullable_user_id.sql
  *   • 00043_reminder_channel_settings.sql
  *   • 00044_scope_entities_jsonb.sql
+ *   • 00045_backfill_scope_entities_appointment_docs.sql
+ *   • 00046_form_documents_org_entity_type_idx.sql
+ *   • 00047_gabinet_appointments_variant_id.sql
+ *   • 00048_gabinet_appointments_stock_deducted.sql
+ *   • 00049_product_stock_movements_location_idx.sql
  *   • 00050_product_purchase_price.sql
+ *   • 00051_warehouse_deliveries.sql
+ *   • 00052_product_stock_movements_unit_price.sql
+ *   • 00053_warehouse_deliveries_total_value.sql
+ *   • 00054_delivery_items_prices.sql
+ *   • 00055_stock_levels_avg_cost.sql
+ *   • 00056_product_stock_movements_avg_cost_after.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -4735,6 +4746,7 @@ export interface Database {
           price_at_booking: number | null;
           reminder_overrides: string | null;
           variant_id: string | null;
+          stock_deducted: boolean;
         };
         Insert: {
           id?: string;
@@ -4783,6 +4795,7 @@ export interface Database {
           price_at_booking?: number | null;
           reminder_overrides?: string | null;
           variant_id?: string | null;
+          stock_deducted?: boolean;
         };
         Update: {
           id?: string;
@@ -4831,6 +4844,7 @@ export interface Database {
           price_at_booking?: number | null;
           reminder_overrides?: string | null;
           variant_id?: string | null;
+          stock_deducted?: boolean;
         };
         Relationships: [
           {
@@ -4915,6 +4929,13 @@ export interface Database {
             columns: ["package_usage_id"];
             isOneToOne: false;
             referencedRelation: "gabinet_package_usage";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gabinet_appointments_variant_id_fkey";
+            columns: ["variant_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_treatment_variants";
             referencedColumns: ["id"];
           },
         ];
@@ -6565,8 +6586,8 @@ export interface Database {
           product_id: string;
           location_id: string | null;
           quantity: number;
-          avg_cost: number | null;
           updated_at: number;
+          avg_cost: number | null;
         };
         Insert: {
           id?: string;
@@ -6574,8 +6595,8 @@ export interface Database {
           product_id: string;
           location_id?: string | null;
           quantity?: number;
-          avg_cost?: number | null;
           updated_at: number;
+          avg_cost?: number | null;
         };
         Update: {
           id?: string;
@@ -6583,8 +6604,8 @@ export interface Database {
           product_id?: string;
           location_id?: string | null;
           quantity?: number;
-          avg_cost?: number | null;
           updated_at?: number;
+          avg_cost?: number | null;
         };
         Relationships: [
           {
@@ -6622,10 +6643,10 @@ export interface Database {
           source_type: string | null;
           source_id: string | null;
           note: string | null;
-          unit_price: number | null;
-          avg_cost_after: number | null;
           performed_by: string;
           created_at: number;
+          unit_price: number | null;
+          avg_cost_after: number | null;
         };
         Insert: {
           id?: string;
@@ -6638,10 +6659,10 @@ export interface Database {
           source_type?: string | null;
           source_id?: string | null;
           note?: string | null;
-          unit_price?: number | null;
-          avg_cost_after?: number | null;
           performed_by: string;
           created_at: number;
+          unit_price?: number | null;
+          avg_cost_after?: number | null;
         };
         Update: {
           id?: string;
@@ -6654,10 +6675,10 @@ export interface Database {
           source_type?: string | null;
           source_id?: string | null;
           note?: string | null;
-          unit_price?: number | null;
-          avg_cost_after?: number | null;
           performed_by?: string;
           created_at?: number;
+          unit_price?: number | null;
+          avg_cost_after?: number | null;
         };
         Relationships: [
           {
@@ -6862,6 +6883,153 @@ export interface Database {
             columns: ["location_id"];
             isOneToOne: false;
             referencedRelation: "gabinet_locations";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      warehouse_deliveries: {
+        Row: {
+          id: string;
+          organization_id: string;
+          supplier_name: string | null;
+          invoice_number: string | null;
+          delivery_date: string | null;
+          location_id: string | null;
+          notes: string | null;
+          status: string;
+          created_by: string;
+          created_at: number;
+          updated_at: number;
+          total_value: number | null;
+          total_value_gross: number | null;
+        };
+        Insert: {
+          id?: string;
+          organization_id: string;
+          supplier_name?: string | null;
+          invoice_number?: string | null;
+          delivery_date?: string | null;
+          location_id?: string | null;
+          notes?: string | null;
+          status?: string;
+          created_by: string;
+          created_at: number;
+          updated_at: number;
+          total_value?: number | null;
+          total_value_gross?: number | null;
+        };
+        Update: {
+          id?: string;
+          organization_id?: string;
+          supplier_name?: string | null;
+          invoice_number?: string | null;
+          delivery_date?: string | null;
+          location_id?: string | null;
+          notes?: string | null;
+          status?: string;
+          created_by?: string;
+          created_at?: number;
+          updated_at?: number;
+          total_value?: number | null;
+          total_value_gross?: number | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "warehouse_deliveries_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organizations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "warehouse_deliveries_location_id_fkey";
+            columns: ["location_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_locations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "warehouse_deliveries_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      warehouse_delivery_items: {
+        Row: {
+          id: string;
+          organization_id: string;
+          delivery_id: string;
+          product_id: string;
+          quantity: number;
+          unit_price: number | null;
+          vat_rate: number | null;
+          movement_id: string | null;
+          created_at: number;
+          unit_price_gross: number | null;
+          line_value_net: number | null;
+          line_value_gross: number | null;
+          vat_code: string | null;
+        };
+        Insert: {
+          id?: string;
+          organization_id: string;
+          delivery_id: string;
+          product_id: string;
+          quantity: number;
+          unit_price?: number | null;
+          vat_rate?: number | null;
+          movement_id?: string | null;
+          created_at: number;
+          unit_price_gross?: number | null;
+          line_value_net?: number | null;
+          line_value_gross?: number | null;
+          vat_code?: string | null;
+        };
+        Update: {
+          id?: string;
+          organization_id?: string;
+          delivery_id?: string;
+          product_id?: string;
+          quantity?: number;
+          unit_price?: number | null;
+          vat_rate?: number | null;
+          movement_id?: string | null;
+          created_at?: number;
+          unit_price_gross?: number | null;
+          line_value_net?: number | null;
+          line_value_gross?: number | null;
+          vat_code?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "warehouse_delivery_items_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organizations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "warehouse_delivery_items_delivery_id_fkey";
+            columns: ["delivery_id"];
+            isOneToOne: false;
+            referencedRelation: "warehouse_deliveries";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "warehouse_delivery_items_product_id_fkey";
+            columns: ["product_id"];
+            isOneToOne: false;
+            referencedRelation: "products";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "warehouse_delivery_items_movement_id_fkey";
+            columns: ["movement_id"];
+            isOneToOne: false;
+            referencedRelation: "product_stock_movements";
             referencedColumns: ["id"];
           },
         ];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2985.

Closes #2985

---

## Claude summary

Done. The generator was run and both `database.types.ts` and `database.columns.ts` are now up to date with all 56 migrations.

The specific `warehouse_lot_batches` table mentioned in the issue title doesn't exist in any migration — that was likely a placeholder name used when the issue was auto-filed. The real gap was migrations 00045–00056, which are now reflected in the generated types. The additions include:

- Two new tables: `warehouse_deliveries` and `warehouse_delivery_items`
- New columns: `gabinet_appointments.stock_deducted`, `gabinet_appointments.variant_id`, `product_stock_levels.avg_cost`, `product_stock_movements.avg_cost_after`, plus unit/gross price columns on delivery items