### PR TITLE
Magazyn — pokaż aktualny stan produktu na formularzu dostawy

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
@@ -33,7 +33,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Plus, Trash2, TruckIcon, Loader2, CheckCircle } from "@/lib/ez-icons";
 import { formatActionError } from "@/lib/format-action-error";
-import { useSupabaseProductsList } from "@/hooks/use-supabase-products";
+import { useSupabaseProductsList, useSupabaseProductStockTotals } from "@/hooks/use-supabase-products";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
 import { cn } from "@/lib/utils";
 
@@ -160,6 +160,7 @@ function DeliveriesPage() {
 
   const { data: productsData = [] } = useSupabaseProductsList(String(organizationId));
   const { data: locations = [] } = useSupabaseGabinetLocationsList(String(organizationId), { activeOnly: true });
+  const { totalsByProductId } = useSupabaseProductStockTotals(String(organizationId));
 
   const stockableProducts = useMemo(
     () => productsData.filter((p) => p.isActive && p.trackStock),
@@ -799,6 +800,19 @@ function DeliveriesPage() {
                         <Trash2 className="h-3.5 w-3.5" variant="stroke" />
                       </button>
                     </div>
+
+                    {/* Stock-before-delivery hint */}
+                    {line.productId && (() => {
+                      const stockEntry = totalsByProductId.get(line.productId);
+                      if (!stockEntry) return null;
+                      const product = stockableProducts.find((p) => p._id === line.productId);
+                      const unit = product?.stockUnit ?? "szt.";
+                      return (
+                        <p className="text-xs text-muted-foreground px-0.5">
+                          {t("gabinet.deliveries.stockBefore", "Stan przed dostawą")}: {stockEntry.total.toLocaleString("pl-PL")} {unit}
+                        </p>
+                      );
+                    })()}
 
                     {/* Row 2: LOT number + expiry date (optional) */}
                     <div className="grid grid-cols-2 gap-1">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2994.

Closes #2994

---

## Claude summary

Done. Here's what was changed:

**File:** `src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx`

Three minimal additions:

1. Added `useSupabaseProductStockTotals` to the existing import from `@/hooks/use-supabase-products` (line 36).
2. Called the hook at component level: `const { totalsByProductId } = useSupabaseProductStockTotals(String(organizationId));` — this reuses the same `product_stock_levels` React Query fetch that already runs on the products page, so it's served from cache when warm.
3. Added a conditional `<p>` element between the product-selection row and the LOT/expiry row in each line item. It only renders when a product is selected and has a stock entry. It reads the product's `stockUnit` (falls back to `"szt."`) and formats the total with `toLocaleString("pl-PL")` matching the rest of the file's number formatting.

The text shown: **Stan przed dostawą: 12 szt.** — exactly as requested. No database changes, no delivery logic changes, mobile-responsive (it's just a `<p>` tag with `text-xs`).