### PR TITLE
Magazyn — ostrzeżenia o produktach z krótkim terminem ważności

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
@@ -123,6 +123,18 @@ function statusBadge(status: string, t: ReturnType<typeof useTranslation>["t"]) 
   );
 }
 
+function getExpiryStatus(dateStr: string | null): "expired" | "expiring_soon" | "ok" | null {
+  if (!dateStr) return null;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const expiry = new Date(dateStr);
+  if (expiry < today) return "expired";
+  const soon = new Date(today);
+  soon.setDate(today.getDate() + 30);
+  if (expiry <= soon) return "expiring_soon";
+  return "ok";
+}
+
 function formatDate(ms: number | null | undefined) {
   if (!ms) return "—";
   return new Date(ms).toLocaleDateString("pl-PL");
@@ -975,7 +987,18 @@ function DeliveriesPage() {
                         {(lotNumber || expiryDate) && (
                           <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
                             {lotNumber && <span>LOT: <span className="font-medium text-foreground">{lotNumber}</span></span>}
-                            {expiryDate && <span>{t("gabinet.deliveries.expiryDate", "Termin ważności")}: <span className="font-medium text-foreground">{expiryDate}</span></span>}
+                            {expiryDate && (() => {
+                              const expiryStatus = getExpiryStatus(expiryDate);
+                              const expiryClass =
+                                expiryStatus === "expired"
+                                  ? "font-medium text-destructive"
+                                  : expiryStatus === "expiring_soon"
+                                    ? "font-medium text-amber-600 dark:text-amber-400"
+                                    : "font-medium text-foreground";
+                              return (
+                                <span>{t("gabinet.deliveries.expiryDate", "Termin ważności")}: <span className={expiryClass}>{expiryDate}</span></span>
+                              );
+                            })()}
                           </div>
                         )}
                       </div>

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -71,6 +71,18 @@ function formatCurrency(amount: number): string {
 // Returns the stock status for a product given its current total and min stock
 type StockStatus = "ok" | "low" | "out" | "untracked";
 
+function getExpiryStatus(dateStr: string | null): "expired" | "expiring_soon" | "ok" | null {
+  if (!dateStr) return null;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const expiry = new Date(dateStr);
+  if (expiry < today) return "expired";
+  const soon = new Date(today);
+  soon.setDate(today.getDate() + 30);
+  if (expiry <= soon) return "expiring_soon";
+  return "ok";
+}
+
 function getStockStatus(
   trackStock: boolean | undefined,
   total: number,
@@ -957,12 +969,21 @@ function ProductsPage() {
                     </div>
                   </div>
                   <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-muted-foreground">
-                    {batch.expiryDate && (
-                      <span>
-                        {t("gabinet.deliveries.expiryDate", "Termin ważności")}:{" "}
-                        <span className="text-foreground">{batch.expiryDate}</span>
-                      </span>
-                    )}
+                    {batch.expiryDate && (() => {
+                      const expiryStatus = getExpiryStatus(batch.expiryDate);
+                      const expiryClass =
+                        expiryStatus === "expired"
+                          ? "text-destructive font-semibold"
+                          : expiryStatus === "expiring_soon"
+                            ? "text-amber-600 dark:text-amber-400 font-semibold"
+                            : "text-foreground";
+                      return (
+                        <span>
+                          {t("gabinet.deliveries.expiryDate", "Termin ważności")}:{" "}
+                          <span className={expiryClass}>{batch.expiryDate}</span>
+                        </span>
+                      );
+                    })()}
                     {locationName && (
                       <span>
                         {t("gabinet.deliveries.location", "Lokalizacja")}:{" "}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #2997.

Closes #2997

---

## Claude summary

Done. Here's what was changed:

**2 files modified, display-only, no schema/logic changes:**

`_layout.products.index.tsx` — product LOT batch list panel:
- Added `getExpiryStatus()` helper function (classifies a date as `"expired"`, `"expiring_soon"` within 30 days, or `"ok"`)
- Expiry date on each LOT batch card now renders in red (`text-destructive`) if expired, amber (`text-amber-600 dark:text-amber-400`) if within 30 days, normal otherwise

`_layout.gabinet.deliveries.tsx` — delivery read-only view:
- Same `getExpiryStatus()` helper added
- Expiry date on each delivery line item follows the same red/amber/normal color logic

No operations are blocked; existing `expiryDate` field is used as-is; no migrations, no new hooks, no UI restructuring.