### PR TITLE
Magazyn — ostrzeżenia o kończących się i przeterminowanych partiach LOT

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
@@ -127,7 +127,10 @@ function getExpiryStatus(dateStr: string | null): "expired" | "expiring_soon" | 
   if (!dateStr) return null;
   const today = new Date();
   today.setHours(0, 0, 0, 0);
-  const expiry = new Date(dateStr);
+  const parts = dateStr.split("-").map(Number);
+  if (parts.length !== 3) return null;
+  // Parse as local midnight so the expiry day itself is never flagged as expired
+  const expiry = new Date(parts[0], parts[1] - 1, parts[2]);
   if (expiry < today) return "expired";
   const soon = new Date(today);
   soon.setDate(today.getDate() + 30);
@@ -989,14 +992,27 @@ function DeliveriesPage() {
                             {lotNumber && <span>LOT: <span className="font-medium text-foreground">{lotNumber}</span></span>}
                             {expiryDate && (() => {
                               const expiryStatus = getExpiryStatus(expiryDate);
-                              const expiryClass =
+                              const dateClass =
                                 expiryStatus === "expired"
                                   ? "font-medium text-destructive"
                                   : expiryStatus === "expiring_soon"
                                     ? "font-medium text-amber-600 dark:text-amber-400"
                                     : "font-medium text-foreground";
                               return (
-                                <span>{t("gabinet.deliveries.expiryDate", "Termin ważności")}: <span className={expiryClass}>{expiryDate}</span></span>
+                                <span className="flex flex-wrap items-center gap-1">
+                                  <span>{t("gabinet.deliveries.expiryDate", "Termin ważności")}:</span>
+                                  <span className={dateClass}>{expiryDate}</span>
+                                  {expiryStatus === "expired" && (
+                                    <Badge variant="destructive" className="text-xs px-1.5 py-0 h-4">
+                                      {t("products.stock.lots.expired", "Po terminie")}
+                                    </Badge>
+                                  )}
+                                  {expiryStatus === "expiring_soon" && (
+                                    <Badge className="text-xs px-1.5 py-0 h-4 bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 border-amber-200 dark:border-amber-800">
+                                      {t("products.stock.lots.expiringSoon", "Ważność do 30 dni")}
+                                    </Badge>
+                                  )}
+                                </span>
                               );
                             })()}
                           </div>

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -75,7 +75,10 @@ function getExpiryStatus(dateStr: string | null): "expired" | "expiring_soon" | 
   if (!dateStr) return null;
   const today = new Date();
   today.setHours(0, 0, 0, 0);
-  const expiry = new Date(dateStr);
+  const parts = dateStr.split("-").map(Number);
+  if (parts.length !== 3) return null;
+  // Parse as local midnight so the expiry day itself is never flagged as expired
+  const expiry = new Date(parts[0], parts[1] - 1, parts[2]);
   if (expiry < today) return "expired";
   const soon = new Date(today);
   soon.setDate(today.getDate() + 30);
@@ -971,16 +974,26 @@ function ProductsPage() {
                   <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-muted-foreground">
                     {batch.expiryDate && (() => {
                       const expiryStatus = getExpiryStatus(batch.expiryDate);
-                      const expiryClass =
+                      const dateClass =
                         expiryStatus === "expired"
                           ? "text-destructive font-semibold"
                           : expiryStatus === "expiring_soon"
                             ? "text-amber-600 dark:text-amber-400 font-semibold"
                             : "text-foreground";
                       return (
-                        <span>
-                          {t("gabinet.deliveries.expiryDate", "Termin ważności")}:{" "}
-                          <span className={expiryClass}>{batch.expiryDate}</span>
+                        <span className="flex flex-wrap items-center gap-1">
+                          <span>{t("gabinet.deliveries.expiryDate", "Termin ważności")}:</span>
+                          <span className={dateClass}>{batch.expiryDate}</span>
+                          {expiryStatus === "expired" && (
+                            <Badge variant="destructive" className="text-xs px-1.5 py-0 h-4">
+                              {t("products.stock.lots.expired", "Po terminie")}
+                            </Badge>
+                          )}
+                          {expiryStatus === "expiring_soon" && (
+                            <Badge className="text-xs px-1.5 py-0 h-4 bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 border-amber-200 dark:border-amber-800">
+                              {t("products.stock.lots.expiringSoon", "Ważność do 30 dni")}
+                            </Badge>
+                          )}
                         </span>
                       );
                     })()}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3000.

Closes #3000

---

## Claude summary

Done. Here's a summary of what was implemented:

**Two files changed** — `_layout.products.index.tsx` and `_layout.gabinet.deliveries.tsx`.

**What changed:**

1. In the **Partie (LOT batches) side panel** on the Products page: expired batches now show a red `Badge` with "Po terminie" next to the colored date; batches expiring within 30 days show an amber `Badge` with "Ważność do 30 dni". Batches with no expiry or expiry > 30 days away show no badge. The exact date is always shown.

2. In the **read-only delivery view panel** (posted deliveries): the same badges appear next to each LOT's expiry date.

3. Fixed `getExpiryStatus()` in both files to parse the `YYYY-MM-DD` date string as **local midnight** (`new Date(y, m-1, d)`) instead of UTC midnight (`new Date(str)`). The UTC parsing was a latent bug: in timezones behind UTC, a product with today's expiry date would have been incorrectly flagged as expired. Now the expiry day itself is never marked expired, exactly as required.

No operations are blocked, no schema changes, no FEFO logic touched.

## Follow-ups

- Deduplicate `getExpiryStatus` into a shared utility: the identical function is now defined in two route files; a `src/lib/expiry-utils.ts` helper would eliminate the duplication and make future changes (e.g. a 60-day threshold) a one-line edit.