### PR TITLE
Deduplicate `getExpiryStatus` into a shared utility

### DIFF
--- a/src/lib/expiry-utils.ts
+++ b/src/lib/expiry-utils.ts
@@ -1,0 +1,14 @@
+export function getExpiryStatus(dateStr: string | null): "expired" | "expiring_soon" | "ok" | null {
+  if (!dateStr) return null;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const parts = dateStr.split("-").map(Number);
+  if (parts.length !== 3) return null;
+  // Parse as local midnight so the expiry day itself is never flagged as expired
+  const expiry = new Date(parts[0], parts[1] - 1, parts[2]);
+  if (expiry < today) return "expired";
+  const soon = new Date(today);
+  soon.setDate(today.getDate() + 30);
+  if (expiry <= soon) return "expiring_soon";
+  return "ok";
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useCallback } from "react";
 import { createFileRoute } from "@tanstack/react-router";
+import { getExpiryStatus } from "@/lib/expiry-utils";
 import { useAction } from "convex/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@cvx/_generated/api";
@@ -123,20 +124,7 @@ function statusBadge(status: string, t: ReturnType<typeof useTranslation>["t"]) 
   );
 }
 
-function getExpiryStatus(dateStr: string | null): "expired" | "expiring_soon" | "ok" | null {
-  if (!dateStr) return null;
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const parts = dateStr.split("-").map(Number);
-  if (parts.length !== 3) return null;
-  // Parse as local midnight so the expiry day itself is never flagged as expired
-  const expiry = new Date(parts[0], parts[1] - 1, parts[2]);
-  if (expiry < today) return "expired";
-  const soon = new Date(today);
-  soon.setDate(today.getDate() + 30);
-  if (expiry <= soon) return "expiring_soon";
-  return "ok";
-}
+
 
 function formatDate(ms: number | null | undefined) {
   if (!ms) return "—";

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from "react";
 import { createFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
+import { getExpiryStatus } from "@/lib/expiry-utils";
 import { useAction } from "convex/react";
 import { useQueryClient, useQuery } from "@tanstack/react-query";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
@@ -71,20 +72,7 @@ function formatCurrency(amount: number): string {
 // Returns the stock status for a product given its current total and min stock
 type StockStatus = "ok" | "low" | "out" | "untracked";
 
-function getExpiryStatus(dateStr: string | null): "expired" | "expiring_soon" | "ok" | null {
-  if (!dateStr) return null;
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const parts = dateStr.split("-").map(Number);
-  if (parts.length !== 3) return null;
-  // Parse as local midnight so the expiry day itself is never flagged as expired
-  const expiry = new Date(parts[0], parts[1] - 1, parts[2]);
-  if (expiry < today) return "expired";
-  const soon = new Date(today);
-  soon.setDate(today.getDate() + 30);
-  if (expiry <= soon) return "expiring_soon";
-  return "ok";
-}
+
 
 function getStockStatus(
   trackStock: boolean | undefined,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3002.

Closes #3002

---

## Claude summary

Done. The fix was straightforward:

- Created `src/lib/expiry-utils.ts` exporting the single canonical `getExpiryStatus` function.
- Removed the local duplicate from `_layout.gabinet.deliveries.tsx` (line 126) and from `_layout.products.index.tsx` (line 74).
- Both files now import from `@/lib/expiry-utils`.

The two implementations were byte-for-byte identical, so no behavior changes. The 30-day threshold now lives in one place — a future change to e.g. 60 days is a single-line edit in `expiry-utils.ts`.