### PR TITLE
Appointment stock deduction uses `locationId

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2151,7 +2151,7 @@ export const updateStatus = action({
             // preserving per-LOT granularity so lot quantities are restored correctly.
             const { data: useMovements } = await db.raw()
               .from("product_stock_movements")
-              .select("product_id, delta, lot_number, expiry_date")
+              .select("product_id, delta, lot_number, expiry_date, location_id")
               .eq("source_type", "appointment")
               .eq("source_id", args.appointmentId)
               .eq("reason", "appointment_use");
@@ -2160,13 +2160,14 @@ export const updateStatus = action({
               delta: number;
               lot_number: string | null;
               expiry_date: string | null;
+              location_id: string | null;
             }>;
             for (const mv of movements) {
               try {
                 await applyMovementInternal({
                   organizationId: String(args.organizationId),
                   productId: mv.product_id,
-                  locationId: null,
+                  locationId: mv.location_id ?? null,
                   delta: -Number(mv.delta), // original delta was negative; negating restores stock
                   reason: "appointment_return",
                   sourceType: "appointment",
@@ -2229,7 +2230,7 @@ export const updateStatus = action({
               const baseMovement = {
                 organizationId: orgId,
                 productId,
-                locationId: null as null,
+                locationId: (appt.locationId ?? null) as string | null,
                 reason: "appointment_use" as const,
                 sourceType: "appointment",
                 sourceId: args.appointmentId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3011.

Closes #3011

---

## Claude summary

The bug is confirmed and fixed. Here's what was wrong and what changed:

**Root cause**: In `convex/gabinet/appointments.ts`, the `updateStatus` action hardcoded `locationId: null` in both the stock deduction path (appointment→completed) and the stock return path (reverting from completed). The `applyMovementInternal` function matches `productStockLevels` rows by `(productId, locationId)` — so any row with a non-null `locationId` was silently missed, leaving per-location balances stale while the null-location row (which may not even exist) was incorrectly targeted.

**Changes** (one file, 4 lines):

1. **Deduction** (`baseMovement`): Changed `locationId: null as null` → `locationId: (appt.locationId ?? null) as string | null`. The appointment row already carries `locationId` from creation time.

2. **Return**: Extended the Supabase `.select()` to include `location_id`, added it to the TypeScript type, and changed `locationId: null` → `locationId: mv.location_id ?? null`. The return now mirrors the exact location of each original use movement, preserving per-location balance symmetry.

## Follow-ups
- Scope `selectFefoLotsForProduct` by location: FEFO lot selection aggregates across all locations even when deductions are now location-scoped — lots received at location A could be "consumed" by an appointment at location B, causing per-location lot balance divergence