### PR TITLE
Scope `selectFefoLotsForProduct` by location

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2239,7 +2239,7 @@ export const updateStatus = action({
 
               // FEFO lot tracking (#2992): deduct from earliest-expiry lots first.
               // Falls back to a single untracked movement when no lots exist.
-              const lots = await selectFefoLotsForProduct(productId, orgId);
+              const lots = await selectFefoLotsForProduct(productId, orgId, (appt.locationId ?? null) as string | null);
               if (lots.length === 0) {
                 const result = await applyMovementInternal({ ...baseMovement, delta: -totalNeeded });
                 if (result.warning === "negative_stock") stockWarnings.push(productId);

--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -268,8 +268,8 @@ export async function applyMovementInternal(
 // ---------------------------------------------------------------------------
 // FEFO lot selection — used by appointment settlement to deduct lot stock in
 // First-Expired-First-Out order. Returns batches sorted by expiry_date ASC
-// (null expiry last) with quantity > 0. Aggregates across all locations since
-// appointment deductions don't specify a location.
+// (null expiry last) with quantity > 0. Scoped to the given locationId so that
+// lot balances at location A are not consumed by appointments at location B.
 // ---------------------------------------------------------------------------
 
 export interface FefoLot {
@@ -281,18 +281,27 @@ export interface FefoLot {
 export async function selectFefoLotsForProduct(
   productId: string,
   organizationId: string,
+  locationId: string | null,
 ): Promise<FefoLot[]> {
   const db = createSupabaseDb();
 
-  // Pull every movement that carries a lot_number for this product.
-  // warehouse_receive rows are positive; appointment_use rows (once wired) are
-  // negative. Summing deltas gives net quantity remaining per lot.
-  const { data, error } = await db.raw()
+  // Pull every movement that carries a lot_number for this product at this location.
+  // warehouse_receive rows are positive; appointment_use rows are negative.
+  // Summing deltas gives net quantity remaining per lot at the location.
+  let query = db.raw()
     .from("product_stock_movements")
     .select("lot_number, expiry_date, delta")
     .eq("organization_id", organizationId)
     .eq("product_id", productId)
     .not("lot_number", "is", null);
+
+  if (locationId !== null) {
+    query = query.eq("location_id", locationId);
+  } else {
+    query = query.is("location_id", null);
+  }
+
+  const { data, error } = await query;
 
   if (error) throw new Error(`selectFefoLotsForProduct: ${error.message}`);
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3014.

Closes #3014

---

## Claude summary

The bug was real and the fix is committed. Here's a summary:

**Root cause:** `selectFefoLotsForProduct` queried `product_stock_movements` filtering only by `organization_id` and `product_id`, aggregating lot quantities across all locations. After #3011 scoped deductions to the appointment's `locationId`, this became a mismatch: FEFO selection would pick a lot that exists at location A (aggregated into the total), but the deduction movement would be recorded against location B. This caused location A's lot to appear intact while location B went negative for a lot it never received.

**Fix (2 files):**
- `convex/inventory.ts`: Added `locationId: string | null` parameter to `selectFefoLotsForProduct`. The Supabase query now adds `.eq("location_id", locationId)` for non-null locations or `.is("location_id", null)` for unscoped movements.
- `convex/gabinet/appointments.ts`: Pass `(appt.locationId ?? null) as string | null` as the third argument — the same value already used for `baseMovement.locationId` — so FEFO selection and deduction are always scoped to the same location.