### PR TITLE
feat(inventory): show invoicePages badge and viewer in delivery list/panel (#3018)

### DIFF
--- a/convex/warehouseDeliveries.ts
+++ b/convex/warehouseDeliveries.ts
@@ -10,6 +10,7 @@
 import { action } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
+import type { Id } from "./_generated/dataModel";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { applyMovementInternal } from "./inventory";
 import type { SupabaseRow } from "./_helpers/supabaseRows";
@@ -56,6 +57,18 @@ export interface DeliveryWithItems {
   items: DeliveryItemRow[];
 }
 
+export interface InvoicePageUrl {
+  url: string | null;
+  mimeType: string;
+  position: number;
+}
+
+export interface DeliveryWithUrls {
+  delivery: DeliveryRow;
+  items: DeliveryItemRow[];
+  invoicePageUrls: InvoicePageUrl[];
+}
+
 // ---------------------------------------------------------------------------
 // Reads
 // ---------------------------------------------------------------------------
@@ -93,7 +106,7 @@ export const getDelivery = action({
     organizationId: v.id("organizations"),
     deliveryId: v.string(),
   },
-  handler: async (ctx, args): Promise<DeliveryWithItems> => {
+  handler: async (ctx, args): Promise<DeliveryWithUrls> => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
@@ -112,7 +125,21 @@ export const getDelivery = action({
       .query<DeliveryItemRow>("warehouseDeliveryItems")
       .eq("deliveryId", args.deliveryId)
       .collect();
-    return { delivery, items };
+
+    const rawPages = Array.isArray(delivery.invoicePages)
+      ? (delivery.invoicePages as Array<{ storageId: string; mimeType: string; position: number }>)
+          .slice()
+          .sort((a, b) => a.position - b.position)
+      : [];
+    const invoicePageUrls: InvoicePageUrl[] = await Promise.all(
+      rawPages.map(async (p) => ({
+        url: await ctx.storage.getUrl(p.storageId as unknown as Id<"_storage">),
+        mimeType: p.mimeType,
+        position: p.position,
+      })),
+    );
+
+    return { delivery, items, invoicePageUrls };
   },
 });
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
@@ -183,6 +183,7 @@ function DeliveriesPage() {
   const [viewDelivery, setViewDelivery] = useState<{
     delivery: Record<string, unknown>;
     items: Array<Record<string, unknown>>;
+    invoicePageUrls: Array<{ url: string | null; mimeType: string; position: number }>;
   } | null>(null);
   const [viewLoading, setViewLoading] = useState(false);
 
@@ -192,6 +193,7 @@ function DeliveriesPage() {
       const result = await getDeliveryAction({ organizationId, deliveryId: id }) as {
         delivery: Record<string, unknown>;
         items: Array<Record<string, unknown>>;
+        invoicePageUrls: Array<{ url: string | null; mimeType: string; position: number }>;
       };
       setViewDelivery(result);
       setViewPanelOpen(true);
@@ -569,7 +571,19 @@ function DeliveriesPage() {
                         ? fmtMoney(displayValue)
                         : <span className="text-muted-foreground">—</span>}
                     </td>
-                    <td className="px-4 py-3">{statusBadge(status, t)}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        {statusBadge(status, t)}
+                        {Array.isArray(d.invoicePages) && (d.invoicePages as unknown[]).length > 0 && (
+                          <span
+                            title={t("gabinet.deliveries.hasInvoiceDoc", "Zeskanowana faktura")}
+                            className="text-sky-600 dark:text-sky-400"
+                          >
+                            <FileText className="h-3.5 w-3.5" variant="stroke" />
+                          </span>
+                        )}
+                      </div>
+                    </td>
                     <td className="px-4 py-3 text-right">
                       {status === "draft" ? (
                         <div className="flex items-center justify-end gap-2">
@@ -958,6 +972,45 @@ function DeliveriesPage() {
                 <div className="space-y-0.5 text-sm">
                   <p className="text-xs text-muted-foreground">{t("gabinet.deliveries.notes", "Uwagi")}</p>
                   <p className="whitespace-pre-line">{viewNotes}</p>
+                </div>
+              )}
+
+              {viewDelivery.invoicePageUrls.length > 0 && (
+                <div className="space-y-2 text-sm">
+                  <p className="text-xs text-muted-foreground">
+                    {t("gabinet.deliveries.invoicePages", "Zeskanowana faktura")}
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {viewDelivery.invoicePageUrls.map((page, idx) => {
+                      if (!page.url) return null;
+                      const isImage = page.mimeType.startsWith("image/");
+                      return (
+                        <a
+                          key={idx}
+                          href={page.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex flex-col items-center gap-1 rounded-md border p-1.5 hover:bg-muted/50 transition-colors"
+                          title={`${t("gabinet.deliveries.invoicePage", "Strona")} ${page.position + 1}`}
+                        >
+                          {isImage ? (
+                            <img
+                              src={page.url}
+                              alt={`${t("gabinet.deliveries.invoicePage", "Strona")} ${page.position + 1}`}
+                              className="h-16 w-12 object-cover rounded"
+                            />
+                          ) : (
+                            <div className="flex h-16 w-12 items-center justify-center rounded bg-muted">
+                              <FileText className="h-6 w-6 text-muted-foreground" variant="stroke" />
+                            </div>
+                          )}
+                          <span className="text-xs text-muted-foreground">
+                            {t("gabinet.deliveries.invoicePageNum", "s.")} {page.position + 1}
+                          </span>
+                        </a>
+                      );
+                    })}
+                  </div>
                 </div>
               )}
 


### PR DESCRIPTION
## Summary

- **List table**: a `FileText` icon appears next to the status badge for any delivery that was created via "Dodaj dostawę z faktury" (has `invoicePages`). Tooltip reads "Zeskanowana faktura".
- **View panel**: a "Zeskanowana faktura" section renders below the notes. Image pages show as clickable thumbnails; PDF pages show a placeholder card. All cards link to the file in a new tab.
- **Backend**: `getDelivery` now resolves Convex storage URLs for each invoice page (sorted by `position`) and returns them as `invoicePageUrls` in the new `DeliveryWithUrls` interface.

Closes #3018.

## Test plan

- [ ] Open Gabinet → Dostawy
- [ ] Create a delivery via "Dodaj dostawę z faktury", upload one or more pages
- [ ] Verify the `FileText` icon appears in the delivery's row in the list
- [ ] Click "Podgląd" on a posted delivery that has invoice pages — confirm the "Zeskanowana faktura" section appears with thumbnails/cards that open the file
- [ ] Verify deliveries without invoice pages show no icon and no section

🤖 Generated with [Claude Code](https://claude.com/claude-code)