### PR TITLE
`cancelDelivery` does not delete orphaned Convex storage files

### DIFF
--- a/convex/warehouseDeliveries.ts
+++ b/convex/warehouseDeliveries.ts
@@ -351,6 +351,14 @@ export const cancelDelivery = action({
     for (const item of items) {
       await db.delete("warehouseDeliveryItems", String(item._id));
     }
+
+    const invoicePages = Array.isArray(delivery.invoicePages)
+      ? (delivery.invoicePages as Array<{ storageId: string }>)
+      : [];
+    for (const page of invoicePages) {
+      await ctx.storage.delete(page.storageId as unknown as Id<"_storage">);
+    }
+
     await db.delete("warehouseDeliveries", args.deliveryId);
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3019.

Closes #3019

---

## Claude summary

The bug was real and the fix is straightforward. `cancelDelivery` in `convex/warehouseDeliveries.ts:323` deleted the Supabase rows for the delivery and its line items, but never cleaned up the Convex file storage entries referenced in `invoicePages`. The fix adds 8 lines before the final `db.delete` call: it reads `delivery.invoicePages` (the same cast pattern already used at line 129), then calls `ctx.storage.delete` for each `storageId`. The guard `Array.isArray(...)` ensures deliveries without invoice pages are handled safely.