### PR TITLE
1.1 Magazyn — usuwanie plików faktury po anulowaniu roboczej dostawy

### DIFF
--- a/convex/warehouseDeliveries.ts
+++ b/convex/warehouseDeliveries.ts
@@ -325,7 +325,7 @@ export const cancelDelivery = action({
     organizationId: v.id("organizations"),
     deliveryId: v.string(),
   },
-  handler: async (ctx, args): Promise<void> => {
+  handler: async (ctx, args): Promise<{ warnings: string[] }> => {
     await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
@@ -352,14 +352,31 @@ export const cancelDelivery = action({
       await db.delete("warehouseDeliveryItems", String(item._id));
     }
 
+    // Best-effort: delete each invoice page from storage. Failures are collected
+    // and returned as warnings rather than aborting the cancellation — a stuck
+    // delivery is worse than an orphaned file that can be cleaned up manually.
     const invoicePages = Array.isArray(delivery.invoicePages)
       ? (delivery.invoicePages as Array<{ storageId: string }>)
       : [];
+    const failedStorageIds: string[] = [];
     for (const page of invoicePages) {
-      await ctx.storage.delete(page.storageId as unknown as Id<"_storage">);
+      try {
+        await ctx.storage.delete(page.storageId as unknown as Id<"_storage">);
+      } catch {
+        failedStorageIds.push(page.storageId);
+      }
     }
 
     await db.delete("warehouseDeliveries", args.deliveryId);
+
+    const warnings: string[] = failedStorageIds.length > 0
+      ? [
+          `Nie udało się usunąć ${failedStorageIds.length} z ${invoicePages.length} pliku/plików faktury ze storage.` +
+          ` ID: ${failedStorageIds.join(", ")}`,
+        ]
+      : [];
+
+    return { warnings };
   },
 });
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
@@ -462,8 +462,13 @@ function DeliveriesPage() {
     if (!cancelTarget) return;
     setCancelling(true);
     try {
-      await cancelDeliveryAction({ organizationId, deliveryId: cancelTarget.id });
+      const result = await cancelDeliveryAction({ organizationId, deliveryId: cancelTarget.id });
       toast.success(t("gabinet.deliveries.cancelSuccess", "Dostawa usunięta."));
+      if (result?.warnings?.length) {
+        for (const w of result.warnings) {
+          toast.warning(w);
+        }
+      }
       void queryClient.invalidateQueries({ queryKey });
     } catch (e) {
       toast.error(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3022.

Closes #3022

---

## Claude summary

The fix is committed. Here's a summary of what was done and why:

**Root cause:** `cancelDelivery` used `await ctx.storage.delete(...)` without any error handling inside a sequential loop. If even one file was unreachable (e.g. Convex storage already deleted it, or an upload partially failed), the entire action threw, leaving the delivery stuck in draft state permanently — the user could never cancel it.

**Changes (2 files, 25 lines):**

`convex/warehouseDeliveries.ts` — `cancelDelivery` handler:
- Changed return type from `Promise<void>` to `Promise<{ warnings: string[] }>`
- Wrapped each `ctx.storage.delete` call in try/catch, collecting failing storage IDs
- The delivery record is always deleted regardless of storage failures
- If any files failed, their IDs are returned in the `warnings` array with a Polish-language description

`src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx` — `handleCancelConfirm`:
- Captures the action result and checks `result?.warnings`
- Shows a `toast.warning` for each warning while still showing the success toast and invalidating the query

This satisfies all issue requirements: draft-only guard is unchanged, posted deliveries are untouched, stock movements are unaffected, both single PDF and multi-page (array) cases are handled, and partial failures are reported clearly instead of being hidden.