### PR TITLE
Fix pre-existing unused variable errors in gabinet/leaveTypes.ts and gabinet/sch

### DIFF
--- a/convex/gabinet/leaveTypes.ts
+++ b/convex/gabinet/leaveTypes.ts
@@ -151,7 +151,7 @@ export const update = action({
   },
   handler: async (ctx, args) => {
     try {
-    const authResult = await ctx.runQuery(
+    await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -201,7 +201,7 @@ export const remove = action({
     leaveTypeId: v.string(),
   },
   handler: async (ctx, args) => {
-    const authResult = await ctx.runQuery(
+    await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -289,7 +289,7 @@ export const initializeBalance = action({
     totalDays: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const authResult = await ctx.runQuery(
+    await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -348,7 +348,7 @@ export const adjustBalance = action({
     usedDays: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const authResult = await ctx.runQuery(
+    await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -381,7 +381,7 @@ export const initializeAllBalances = action({
     year: v.number(),
   },
   handler: async (ctx, args) => {
-    const authResult = await ctx.runQuery(
+    await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );

--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -405,7 +405,7 @@ export const removeSchedulePeriod = action({
     effectiveFrom: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const authResult = await ctx.runQuery(
+    await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -717,7 +717,7 @@ export const removeEmployeeSchedule = action({
     scheduleId: v.string(),
   },
   handler: async (ctx, args) => {
-    const authResult = await ctx.runQuery(
+    await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3028.

Closes #3028

---

## Claude summary

Fixed. The issue was real: seven functions across the two files declared `const authResult = await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, ...)` but never referenced `authResult` in the function body. Functions that actually need the result (e.g. `create` uses `authResult.userId` for `createdBy`) were left untouched. Dropping the binding to a bare `await` silences the TS6133 errors with no behavior change.