### PR TITLE
Fix TS2339 in convex/inventory.ts

### DIFF
--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -242,7 +242,7 @@ export async function applyMovementInternal(
   const snapshotPrice =
     params.unitPrice != null
       ? params.unitPrice
-      : (product.purchasePrice as number | null | undefined) ?? null;
+      : product.purchasePrice ?? null;
 
   const movementId = await db.insert("productStockMovements", {
     organizationId: params.organizationId,

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -319,6 +319,9 @@ export function createCrmTables({
     manufacturer: v.optional(v.string()),
     catalogNumber: v.optional(v.string()),
     stockNote: v.optional(v.string()),
+    // Net purchase price per unit (#2956, migration 00050). Used to calculate
+    // warehouse value. Distinct from unitPrice (the selling price).
+    purchasePrice: v.optional(v.number()),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3029.

Closes #3029

---

## Claude summary

The fix is committed. Here's what happened:

**Root cause:** `purchasePrice` was added to the Supabase `products` table via migration `00050_product_purchase_price.sql` and was already being written by `convex/products.ts` mutations, but it was never declared in `convex/schema/crm.ts`. Since `SupabaseRow<"products">` is derived from the Convex schema, TypeScript had no knowledge of the field, producing TS2339.

**Fix:** Added `purchasePrice: v.optional(v.number())` to the `products` `defineTable` in `convex/schema/crm.ts` (2 lines), and removed the now-unnecessary `as number | null | undefined` cast in `convex/inventory.ts:245` (1 line changed).