### PR TITLE
Fix TS2551 in convex/supabase/backfill.ts

### DIFF
--- a/convex/supabase/backfill.ts
+++ b/convex/supabase/backfill.ts
@@ -295,8 +295,7 @@ export const backfillSingleTreatment = internalAction({
         sort_order: t.sortOrder ?? null,
         treatment_count: t.treatmentCount ?? null,
         parameters: t.parameters ?? null,
-        required_document_template_ids:
-          t.requiredDocumentTemplateIds?.map(String) ?? null,
+        required_document_template_ids: null,
         required_form_templates: t.requiredFormTemplates ?? null,
         short_description: t.shortDescription ?? null,
         image: t.image ?? null,
@@ -509,8 +508,7 @@ export const backfillTreatments = internalAction({
       sort_order: t.sortOrder ?? null,
       treatment_count: t.treatmentCount ?? null,
       parameters: t.parameters ?? null,
-      required_document_template_ids:
-        t.requiredDocumentTemplateIds?.map(String) ?? null,
+      required_document_template_ids: null,
       required_form_templates: t.requiredFormTemplates ?? null,
       short_description: t.shortDescription ?? null,
       image: t.image ?? null,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3030.

Closes #3030

---

## Claude summary

Fixed. The bug was real: `t.requiredDocumentTemplateIds` was accessed in two places in `convex/supabase/backfill.ts` (lines 298-299 in `backfillSingleTreatment` and 512-513 in `backfillTreatments`), but the field was renamed to `requiredFormTemplates` on the Convex treatment type. The Supabase column `required_document_template_ids TEXT[]` still exists in the DB schema but receives `null` from backfill now — the actual data lives in `required_form_templates JSONB` which was already correctly mapped via `t.requiredFormTemplates`.

## Follow-ups

- Stale `requiredDocumentTemplateIds` in Supabase mapper type: `src/lib/supabase/mappers/gabinet/treatments.ts:32` still declares `requiredDocumentTemplateIds?: string[]` in the mapped output type, which maps a column that always receives `null` from backfill — this type should be removed or set to `null` to reflect reality.