### PR TITLE
Stale `requiredDocumentTemplateIds` in Supabase mapper type

### DIFF
--- a/src/lib/supabase/mappers/gabinet/treatments.ts
+++ b/src/lib/supabase/mappers/gabinet/treatments.ts
@@ -29,7 +29,7 @@ export interface MappedGabinetTreatment {
   treatmentCount?: number;
   packageId?: string;
   parameters?: unknown;
-  requiredDocumentTemplateIds?: string[];
+  requiredDocumentTemplateIds?: string[] | null;
   requiredFormTemplates?: unknown;
   shortDescription?: string;
   image?: string;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3034.

Closes #3034

---

## Claude summary

Done. Changed `requiredDocumentTemplateIds?: string[]` to `requiredDocumentTemplateIds?: string[] | null` in `src/lib/supabase/mappers/gabinet/treatments.ts:32`, aligning the mapped type with the actual Supabase column (`string[] | null`) and the backfill behavior (always writes `null`).