### PR TITLE
2.3 AI/OCR — podłączenie pierwszego providera OpenAI do analizy faktur

### DIFF
--- a/convex/_ai/documentAnalyzer.ts
+++ b/convex/_ai/documentAnalyzer.ts
@@ -1,13 +1,14 @@
-// AI/OCR integration adapter layer (#3026).
+// AI/OCR integration adapter layer (#3026, #3038).
 //
-// Defines the contract any future OCR/AI provider must satisfy and exports a
-// factory (`getDocumentAnalyzer`) that callers use to obtain the active
-// implementation. The warehouse module depends ONLY on the types and factory
-// here — it never imports a concrete provider directly.
+// Defines the contract any OCR/AI provider must satisfy and exports a factory
+// (`getDocumentAnalyzer`) that callers use to obtain the active implementation.
+// The warehouse module depends ONLY on the types and factory here — it never
+// imports a concrete provider directly.
 //
-// Current implementation: NullDocumentAnalyzer (not_implemented placeholder).
-// To wire up a real provider in a later phase: implement DocumentAnalyzer and
-// return it from getDocumentAnalyzer. No changes elsewhere are required.
+// Current implementation: OpenAIDocumentAnalyzer when OPENAI_API_KEY is set,
+// NullDocumentAnalyzer otherwise.
+
+import { OpenAIDocumentAnalyzer } from "./providers/openaiDocumentAnalyzer";
 
 // ---------------------------------------------------------------------------
 // Input — ordered pages that together form one invoice document (#3035).
@@ -122,11 +123,25 @@ class NullDocumentAnalyzer implements DocumentAnalyzer {
 }
 
 // ---------------------------------------------------------------------------
+// Storage fetcher — passed by the calling action so the provider can read
+// file bytes server-side without touching public URLs.
+// ---------------------------------------------------------------------------
+
+export type StorageFetcher = (storageId: string) => Promise<Blob | null>;
+
+// ---------------------------------------------------------------------------
 // Factory — the single entry point for all callers.
 // ---------------------------------------------------------------------------
 
-// Returns the currently configured DocumentAnalyzer. Swap the return value here
-// when plugging in a real OCR/AI provider — no other file needs to change.
-export function getDocumentAnalyzer(): DocumentAnalyzer {
+// Returns OpenAIDocumentAnalyzer when OPENAI_API_KEY is configured, otherwise
+// NullDocumentAnalyzer. The model can be overridden via OPENAI_INVOICE_MODEL.
+// `fetchFile` is provided by the calling action (ctx.storage.get) so the
+// provider can fetch bytes server-side without exposing public URLs.
+export function getDocumentAnalyzer(fetchFile: StorageFetcher): DocumentAnalyzer {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (apiKey) {
+    const model = process.env.OPENAI_INVOICE_MODEL ?? "gpt-4o";
+    return new OpenAIDocumentAnalyzer(apiKey, model, fetchFile);
+  }
   return new NullDocumentAnalyzer();
 }

--- a/convex/_ai/providers/openaiDocumentAnalyzer.ts
+++ b/convex/_ai/providers/openaiDocumentAnalyzer.ts
@@ -1,0 +1,237 @@
+// OpenAI implementation of DocumentAnalyzer (#3038).
+//
+// Sends invoice pages (PDF, JPEG, PNG) to a GPT-4o-class model and returns a
+// validated ParsedInvoice. Files are fetched server-side via the StorageFetcher
+// callback — no public URLs are exposed to the model.
+//
+// All OpenAI SDK / type imports stay inside this module. Nothing outside
+// convex/_ai/providers/* should import from "openai".
+
+import OpenAI, { APIError } from "openai";
+import type {
+  DocumentAnalyzer,
+  DocumentPage,
+  AnalyzeInvoiceResult,
+  ParsedInvoice,
+  ParsedInvoiceItem,
+  StorageFetcher,
+} from "../documentAnalyzer";
+
+// Duplicate the supported-types check locally to avoid a circular runtime dep.
+const SUPPORTED_MIME_TYPES = new Set(["application/pdf", "image/jpeg", "image/png"]);
+
+const REQUEST_TIMEOUT_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Prompt
+// ---------------------------------------------------------------------------
+
+const USER_PROMPT = `Extract all invoice data from the provided document(s). Return a single JSON object with this exact structure:
+
+{
+  "supplierName": string | null,
+  "supplierNip": string | null,
+  "invoiceNumber": string | null,
+  "invoiceDate": string | null,
+  "deliveryDate": string | null,
+  "currency": string | null,
+  "items": [
+    {
+      "productName": string,
+      "quantity": number,
+      "unit": string | null,
+      "unitPriceNet": number | null,
+      "unitPriceGross": number | null,
+      "vatRate": number | null,
+      "vatCode": string | null,
+      "lineValueNet": number | null,
+      "lineValueGross": number | null,
+      "lotNumber": string | null,
+      "expiryDate": string | null
+    }
+  ],
+  "confidence": number
+}
+
+Rules:
+- All dates must be ISO 8601 format YYYY-MM-DD.
+- Do NOT guess missing values — use null.
+- Extract "lotNumber" and "expiryDate" per item ONLY when explicitly printed on the invoice.
+- "vatRate" is a percentage value (e.g. 23 for 23%, 8 for 8%, 0 for 0%).
+- "confidence" is a 0–1 score reflecting overall extraction certainty.
+- If a field is uncertain, set it to null rather than guessing.`;
+
+// ---------------------------------------------------------------------------
+// Raw response types and validation
+// ---------------------------------------------------------------------------
+
+interface RawItem {
+  productName: unknown;
+  quantity: unknown;
+  unit: unknown;
+  unitPriceNet: unknown;
+  unitPriceGross: unknown;
+  vatRate: unknown;
+  vatCode: unknown;
+  lineValueNet: unknown;
+  lineValueGross: unknown;
+  lotNumber: unknown;
+  expiryDate: unknown;
+}
+
+interface RawInvoice {
+  supplierName: unknown;
+  invoiceNumber: unknown;
+  invoiceDate: unknown;
+  items: RawItem[];
+  confidence: unknown;
+}
+
+function isRawInvoice(v: unknown): v is RawInvoice {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  if (!Array.isArray(o.items)) return false;
+  for (const item of o.items as unknown[]) {
+    if (!item || typeof item !== "object") return false;
+    if (!("productName" in (item as object))) return false;
+  }
+  return true;
+}
+
+function str(v: unknown): string | null {
+  if (v === null || v === undefined || v === "") return null;
+  return String(v);
+}
+
+function num(v: unknown): number | null {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function mapItem(raw: RawItem): ParsedInvoiceItem {
+  return {
+    productName: str(raw.productName) ?? "",
+    quantity: num(raw.quantity) ?? 0,
+    unit: str(raw.unit),
+    unitPrice: num(raw.unitPriceNet),
+    unitPriceGross: num(raw.unitPriceGross),
+    vatRate: num(raw.vatRate),
+    vatCode: str(raw.vatCode),
+    lineValueNet: num(raw.lineValueNet),
+    lineValueGross: num(raw.lineValueGross),
+    lotNumber: str(raw.lotNumber),
+    expiryDate: str(raw.expiryDate),
+  };
+}
+
+function mapInvoice(raw: RawInvoice, rawJson: string): ParsedInvoice {
+  return {
+    supplierName: str(raw.supplierName),
+    invoiceNumber: str(raw.invoiceNumber),
+    invoiceDate: str(raw.invoiceDate),
+    items: raw.items.map(mapItem),
+    confidence: num(raw.confidence),
+    rawText: rawJson,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export class OpenAIDocumentAnalyzer implements DocumentAnalyzer {
+  private readonly client: OpenAI;
+  private readonly model: string;
+  private readonly fetchFile: StorageFetcher;
+
+  constructor(apiKey: string, model: string, fetchFile: StorageFetcher) {
+    this.client = new OpenAI({ apiKey, timeout: REQUEST_TIMEOUT_MS });
+    this.model = model;
+    this.fetchFile = fetchFile;
+  }
+
+  async analyzeInvoice(pages: DocumentPage[]): Promise<AnalyzeInvoiceResult> {
+    if (pages.length === 0) return { status: "no_pages" };
+
+    const unsupported = pages.find((p) => !SUPPORTED_MIME_TYPES.has(p.mimeType));
+    if (unsupported) {
+      return { status: "unsupported_format", mimeType: unsupported.mimeType };
+    }
+
+    const sorted = [...pages].sort((a, b) => a.position - b.position);
+
+    const contentParts: OpenAI.ChatCompletionContentPart[] = [];
+
+    for (const page of sorted) {
+      let blob: Blob | null;
+      try {
+        blob = await this.fetchFile(page.storageId);
+      } catch (err) {
+        return {
+          status: "error",
+          message: `File fetch failed (${page.storageId}): ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+      if (!blob) {
+        return { status: "error", message: `File not found in storage: ${page.storageId}` };
+      }
+
+      const base64 = Buffer.from(await blob.arrayBuffer()).toString("base64");
+
+      if (page.mimeType === "application/pdf") {
+        contentParts.push({
+          type: "file",
+          file: {
+            file_data: `data:application/pdf;base64,${base64}`,
+            filename: `invoice_p${page.position}.pdf`,
+          },
+        });
+      } else {
+        contentParts.push({
+          type: "image_url",
+          image_url: {
+            url: `data:${page.mimeType};base64,${base64}`,
+            detail: "high",
+          },
+        });
+      }
+    }
+
+    contentParts.push({ type: "text", text: USER_PROMPT });
+
+    let rawText: string;
+    try {
+      const completion = await this.client.chat.completions.create({
+        model: this.model,
+        response_format: { type: "json_object" },
+        messages: [{ role: "user", content: contentParts }],
+        max_tokens: 4096,
+      });
+      rawText = completion.choices[0]?.message?.content ?? "";
+    } catch (err) {
+      if (err instanceof APIError) {
+        return { status: "error", message: `OpenAI API error ${err.status}: ${err.message}` };
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      return { status: "error", message: `Request failed: ${msg}` };
+    }
+
+    if (!rawText) {
+      return { status: "error", message: "Empty response from model" };
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawText);
+    } catch {
+      return { status: "error", message: "Model returned non-JSON response" };
+    }
+
+    if (!isRawInvoice(parsed)) {
+      return { status: "error", message: "Model response does not match expected invoice schema" };
+    }
+
+    return { status: "ok", data: mapInvoice(parsed, rawText) };
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
         "lucide-react": "^0.563.0",
         "next-themes": "^0.4.6",
         "npm-run-all": "^4.1.5",
+        "openai": "^6.46.0",
         "oslo": "^1.2.1",
         "papaparse": "^5.5.3",
         "platejs": "^52.3.4",
@@ -15454,6 +15455,36 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.46.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.46.0.tgz",
+      "integrity": "sha512-DFg6jEPT2RO+oAyXtddeUJU8zkGy1OQ1AjGzNIJUMQG03TTqvCpy9tBpQ+2VVVnvrl3E56F8GEin2JYtWpITtA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optics-ts": {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "lucide-react": "^0.563.0",
     "next-themes": "^0.4.6",
     "npm-run-all": "^4.1.5",
+    "openai": "^6.46.0",
     "oslo": "^1.2.1",
     "papaparse": "^5.5.3",
     "platejs": "^52.3.4",

--- a/tests/convex/openaiDocumentAnalyzer.test.ts
+++ b/tests/convex/openaiDocumentAnalyzer.test.ts
@@ -1,0 +1,416 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { OpenAIDocumentAnalyzer } from "../../convex/_ai/providers/openaiDocumentAnalyzer";
+import { getDocumentAnalyzer } from "../../convex/_ai/documentAnalyzer";
+import type { DocumentPage } from "../../convex/_ai/documentAnalyzer";
+
+// ---------------------------------------------------------------------------
+// Hoist mock helpers so they can be referenced inside vi.mock()
+// ---------------------------------------------------------------------------
+
+const { mockCreate, MockAPIError } = vi.hoisted(() => {
+  class MockAPIError extends Error {
+    status: number;
+    constructor(message: string, status = 500) {
+      super(message);
+      this.name = "APIError";
+      this.status = status;
+    }
+  }
+  return { mockCreate: vi.fn(), MockAPIError };
+});
+
+vi.mock("openai", () => {
+  function MockOpenAI() {
+    return { chat: { completions: { create: mockCreate } } };
+  }
+  MockOpenAI.APIError = MockAPIError;
+  return { default: MockOpenAI, APIError: MockAPIError };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const NOOP_FETCHER = async (_id: string): Promise<Blob | null> => null;
+
+function makeBlob(content = "bytes"): Blob {
+  return new Blob([content], { type: "application/octet-stream" });
+}
+
+function fakeFetcher(blob: Blob) {
+  return async (_id: string): Promise<Blob | null> => blob;
+}
+
+function makePages(mimeTypes: string[]): DocumentPage[] {
+  return mimeTypes.map((mimeType, i) => ({
+    storageId: `store-${i}`,
+    mimeType,
+    position: i + 1,
+  }));
+}
+
+const MINIMAL_VALID_RESPONSE = JSON.stringify({
+  supplierName: "ACME Sp. z o.o.",
+  supplierNip: "1234567890",
+  invoiceNumber: "FV/2024/001",
+  invoiceDate: "2024-01-15",
+  deliveryDate: "2024-01-14",
+  currency: "PLN",
+  items: [
+    {
+      productName: "Środek dezynfekujący 5L",
+      quantity: 10,
+      unit: "szt",
+      unitPriceNet: 25.0,
+      unitPriceGross: 30.75,
+      vatRate: 23,
+      vatCode: "A",
+      lineValueNet: 250.0,
+      lineValueGross: 307.5,
+      lotNumber: "LOT-2024-A",
+      expiryDate: "2026-01-01",
+    },
+  ],
+  confidence: 0.95,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Factory — no configuration
+// ---------------------------------------------------------------------------
+
+describe("getDocumentAnalyzer — no configuration", () => {
+  test("returns not_implemented when OPENAI_API_KEY is absent", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "");
+    const analyzer = getDocumentAnalyzer(NOOP_FETCHER);
+    const page: DocumentPage = { storageId: "x", mimeType: "image/jpeg", position: 1 };
+    const result = await analyzer.analyzeInvoice([page]);
+    expect(result.status).toBe("not_implemented");
+    vi.unstubAllEnvs();
+  });
+
+  test("NullDocumentAnalyzer returns no_pages for empty pages", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "");
+    const analyzer = getDocumentAnalyzer(NOOP_FETCHER);
+    const result = await analyzer.analyzeInvoice([]);
+    expect(result.status).toBe("no_pages");
+    vi.unstubAllEnvs();
+  });
+
+  test("NullDocumentAnalyzer returns unsupported_format for unknown MIME", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "");
+    const analyzer = getDocumentAnalyzer(NOOP_FETCHER);
+    const result = await analyzer.analyzeInvoice([
+      { storageId: "x", mimeType: "image/gif", position: 1 },
+    ]);
+    expect(result.status).toBe("unsupported_format");
+    if (result.status === "unsupported_format") {
+      expect(result.mimeType).toBe("image/gif");
+    }
+    vi.unstubAllEnvs();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenAIDocumentAnalyzer — edge cases before calling the model
+// ---------------------------------------------------------------------------
+
+describe("OpenAIDocumentAnalyzer — pre-call validation", () => {
+  test("returns no_pages when pages array is empty", async () => {
+    const analyzer = new OpenAIDocumentAnalyzer("sk-test", "gpt-4o", NOOP_FETCHER);
+    const result = await analyzer.analyzeInvoice([]);
+    expect(result.status).toBe("no_pages");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  test("returns unsupported_format for unknown MIME type", async () => {
+    const analyzer = new OpenAIDocumentAnalyzer("sk-test", "gpt-4o", NOOP_FETCHER);
+    const result = await analyzer.analyzeInvoice([
+      { storageId: "x", mimeType: "image/tiff", position: 1 },
+    ]);
+    expect(result.status).toBe("unsupported_format");
+    if (result.status === "unsupported_format") {
+      expect(result.mimeType).toBe("image/tiff");
+    }
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  test("returns error when file is not found in storage", async () => {
+    const analyzer = new OpenAIDocumentAnalyzer("sk-test", "gpt-4o", NOOP_FETCHER);
+    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.message).toMatch(/not found/i);
+    }
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  test("returns error when file fetch throws", async () => {
+    const throwingFetcher = async (_: string): Promise<Blob | null> => {
+      throw new Error("Storage unavailable");
+    };
+    const analyzer = new OpenAIDocumentAnalyzer("sk-test", "gpt-4o", throwingFetcher);
+    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.message).toContain("Storage unavailable");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenAIDocumentAnalyzer — valid response mapping
+// ---------------------------------------------------------------------------
+
+describe("OpenAIDocumentAnalyzer — correct mapping from model response", () => {
+  test("maps a complete invoice response to ParsedInvoice", async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: MINIMAL_VALID_RESPONSE } }],
+    });
+
+    const analyzer = new OpenAIDocumentAnalyzer(
+      "sk-test",
+      "gpt-4o",
+      fakeFetcher(makeBlob()),
+    );
+    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+
+    expect(result.data.supplierName).toBe("ACME Sp. z o.o.");
+    expect(result.data.invoiceNumber).toBe("FV/2024/001");
+    expect(result.data.invoiceDate).toBe("2024-01-15");
+    expect(result.data.confidence).toBe(0.95);
+    expect(result.data.rawText).toBe(MINIMAL_VALID_RESPONSE);
+
+    const item = result.data.items[0];
+    expect(item.productName).toBe("Środek dezynfekujący 5L");
+    expect(item.quantity).toBe(10);
+    expect(item.unit).toBe("szt");
+    expect(item.unitPrice).toBe(25.0); // unitPriceNet maps to unitPrice
+    expect(item.unitPriceGross).toBe(30.75);
+    expect(item.vatRate).toBe(23);
+    expect(item.vatCode).toBe("A");
+    expect(item.lineValueNet).toBe(250.0);
+    expect(item.lineValueGross).toBe(307.5);
+    expect(item.lotNumber).toBe("LOT-2024-A");
+    expect(item.expiryDate).toBe("2026-01-01");
+  });
+
+  test("maps null fields correctly when data is absent on invoice", async () => {
+    const sparse = JSON.stringify({
+      supplierName: null,
+      invoiceNumber: "FV/001",
+      invoiceDate: "2024-03-01",
+      deliveryDate: null,
+      currency: null,
+      items: [
+        {
+          productName: "Rękawiczki nitrylowe",
+          quantity: 100,
+          unit: null,
+          unitPriceNet: null,
+          unitPriceGross: null,
+          vatRate: null,
+          vatCode: null,
+          lineValueNet: null,
+          lineValueGross: null,
+          lotNumber: null,
+          expiryDate: null,
+        },
+      ],
+      confidence: 0.7,
+    });
+
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: sparse } }],
+    });
+
+    const analyzer = new OpenAIDocumentAnalyzer(
+      "sk-test",
+      "gpt-4o",
+      fakeFetcher(makeBlob()),
+    );
+    const result = await analyzer.analyzeInvoice(makePages(["image/png"]));
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+
+    expect(result.data.supplierName).toBeNull();
+    const item = result.data.items[0];
+    expect(item.lotNumber).toBeNull();
+    expect(item.expiryDate).toBeNull();
+    expect(item.unit).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenAIDocumentAnalyzer — multi-page invoice
+// ---------------------------------------------------------------------------
+
+describe("OpenAIDocumentAnalyzer — multi-page invoice", () => {
+  test("sends all pages to the model and returns merged result", async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: MINIMAL_VALID_RESPONSE } }],
+    });
+
+    const fetcher = fakeFetcher(makeBlob());
+    const analyzer = new OpenAIDocumentAnalyzer("sk-test", "gpt-4o", fetcher);
+
+    const pages: DocumentPage[] = [
+      { storageId: "page-2", mimeType: "image/jpeg", position: 2 },
+      { storageId: "page-1", mimeType: "image/jpeg", position: 1 },
+      { storageId: "page-3", mimeType: "image/png", position: 3 },
+    ];
+
+    const result = await analyzer.analyzeInvoice(pages);
+    expect(result.status).toBe("ok");
+
+    // Model must have been called exactly once with all three pages as content
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const call = mockCreate.mock.calls[0][0];
+    const content = call.messages[0].content as Array<{ type: string }>;
+    // 3 image parts + 1 text prompt
+    expect(content.filter((p) => p.type === "image_url")).toHaveLength(3);
+  });
+
+  test("pages are passed to model sorted by position", async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: MINIMAL_VALID_RESPONSE } }],
+    });
+
+    const fetchOrder: string[] = [];
+    const trackingFetcher = async (id: string): Promise<Blob | null> => {
+      fetchOrder.push(id);
+      return makeBlob();
+    };
+
+    const analyzer = new OpenAIDocumentAnalyzer("sk-test", "gpt-4o", trackingFetcher);
+    await analyzer.analyzeInvoice([
+      { storageId: "c", mimeType: "image/jpeg", position: 3 },
+      { storageId: "a", mimeType: "image/jpeg", position: 1 },
+      { storageId: "b", mimeType: "image/jpeg", position: 2 },
+    ]);
+
+    expect(fetchOrder).toEqual(["a", "b", "c"]);
+  });
+
+  test("mixed PDF and image pages are sent correctly", async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: MINIMAL_VALID_RESPONSE } }],
+    });
+
+    const analyzer = new OpenAIDocumentAnalyzer(
+      "sk-test",
+      "gpt-4o",
+      fakeFetcher(makeBlob()),
+    );
+    const result = await analyzer.analyzeInvoice([
+      { storageId: "pdf", mimeType: "application/pdf", position: 1 },
+      { storageId: "img", mimeType: "image/jpeg", position: 2 },
+    ]);
+
+    expect(result.status).toBe("ok");
+    const content = mockCreate.mock.calls[0][0].messages[0]
+      .content as Array<{ type: string }>;
+    const types = content.filter((p) => p.type !== "text").map((p) => p.type);
+    expect(types).toContain("file");    // PDF → file type
+    expect(types).toContain("image_url"); // JPEG → image_url
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenAIDocumentAnalyzer — model error handling
+// ---------------------------------------------------------------------------
+
+describe("OpenAIDocumentAnalyzer — error handling", () => {
+  test("returns error when model returns invalid JSON", async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: "This is not JSON" } }],
+    });
+
+    const analyzer = new OpenAIDocumentAnalyzer(
+      "sk-test",
+      "gpt-4o",
+      fakeFetcher(makeBlob()),
+    );
+    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.message).toMatch(/non-json/i);
+    }
+  });
+
+  test("returns error when model response does not match expected schema", async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: JSON.stringify({ unexpected: "structure" }) } }],
+    });
+
+    const analyzer = new OpenAIDocumentAnalyzer(
+      "sk-test",
+      "gpt-4o",
+      fakeFetcher(makeBlob()),
+    );
+    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.message).toMatch(/schema/i);
+    }
+  });
+
+  test("returns error when model returns empty content", async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: "" } }],
+    });
+
+    const analyzer = new OpenAIDocumentAnalyzer(
+      "sk-test",
+      "gpt-4o",
+      fakeFetcher(makeBlob()),
+    );
+    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.message).toMatch(/empty/i);
+    }
+  });
+
+  test("returns error on OpenAI API error", async () => {
+    mockCreate.mockRejectedValue(new MockAPIError("Rate limit exceeded", 429));
+
+    const analyzer = new OpenAIDocumentAnalyzer(
+      "sk-test",
+      "gpt-4o",
+      fakeFetcher(makeBlob()),
+    );
+    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.message).toContain("429");
+    }
+  });
+
+  test("returns error on network / timeout failure", async () => {
+    mockCreate.mockRejectedValue(new Error("timeout: request took too long"));
+
+    const analyzer = new OpenAIDocumentAnalyzer(
+      "sk-test",
+      "gpt-4o",
+      fakeFetcher(makeBlob()),
+    );
+    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.message).toContain("timeout");
+    }
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3038.

Closes #3038

---

## Claude summary

All 17 tests pass and typecheck is clean. Here's a summary of what was implemented:

**Files changed:**

`convex/_ai/providers/openaiDocumentAnalyzer.ts` (new) — `OpenAIDocumentAnalyzer` class:
- Fetches file bytes server-side via a `StorageFetcher` callback (no public URLs exposed to OpenAI)
- PDFs → `{ type: "file", file: { file_data: "data:application/pdf;base64,..." } }` (openai v6 native)
- JPEG/PNG → `{ type: "image_url", image_url: { url: "data:image/jpeg;base64,...", detail: "high" } }`
- Sorts pages by `position` before sending
- `response_format: json_object` + validates response with `isRawInvoice()` guard
- Maps raw model output to `ParsedInvoice` / `ParsedInvoiceItem`; stores full raw JSON in `rawText` for debugging
- Handles: fetch errors, API errors, JSON parse errors, schema mismatches, empty responses, timeout

`convex/_ai/documentAnalyzer.ts` (updated):
- Added `import { OpenAIDocumentAnalyzer }` (static import, no circular runtime dep since provider uses `import type`)
- Exported `StorageFetcher` type
- `getDocumentAnalyzer(fetchFile)` now returns `OpenAIDocumentAnalyzer` when `OPENAI_API_KEY` is set; model defaults to `gpt-4o`, overridable via `OPENAI_INVOICE_MODEL`

`tests/convex/openaiDocumentAnalyzer.test.ts` (new) — 17 tests covering all required scenarios.

**Configuration:** Set `OPENAI_API_KEY` in Convex dashboard env vars. Optionally set `OPENAI_INVOICE_MODEL` to override the model (default: `gpt-4o`). When the key is absent, `getDocumentAnalyzer` silently falls back to `NullDocumentAnalyzer` returning `not_implemented`.

## Follow-ups

- Pre-existing typecheck error in `convex/documents/generate.ts:248`: `TS2352` conversion of `string` to `Record<string, unknown>` — unrelated to this PR but should be fixed
- Pre-existing test failures in `appointmentSms.test.ts` and `appointmentStateMachine.test.ts`: `client.from(...).upsert is not a function` in the in-memory stub — needs investigation separately