### PR TITLE
Pre-existing typecheck error in `convex/documents/generate.ts

### DIFF
--- a/convex/documents/generate.ts
+++ b/convex/documents/generate.ts
@@ -245,7 +245,7 @@ export const getPriorResponseData = action({
         return true;
       // Appointment-linked doc with scopeEntities.patient
       if (doc.scopeEntities) {
-        const scope = doc.scopeEntities as Record<string, unknown>;
+        const scope = doc.scopeEntities as unknown as Record<string, unknown>;
         return String(scope?.patient) === resolvedPatientId;
       }
       return false;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3040.

Closes #3040

---

## Claude summary

Fixed. The change is minimal and precise: `as Record<string, unknown>` → `as unknown as Record<string, unknown>` at `convex/documents/generate.ts:248`.

The root cause: migration `00044_scope_entities_jsonb.sql` changed `scope_entities` from TEXT to JSONB, so Supabase returns it as a JavaScript object at runtime — but the Convex schema still declares `scopeEntities: v.optional(v.string())`, making TypeScript see it as `string | undefined`. TypeScript's TS2352 blocks the direct cast between these incompatible types. The double cast through `unknown` resolves the error while accurately reflecting what the runtime value actually is.

## Follow-ups

- Fix `patientBindings.ts` dead code path for scopeEntities: `resolvePatientId` at line 54 checks `typeof doc.scopeEntities === "string"` before JSON-parsing, but since migration 00044 made `scope_entities` a JSONB column, Supabase returns an object — meaning the `typeof === "string"` guard always fails and `scopeEntities` is never read, silently breaking the patient-binding resolution for appointment-linked documents.
- Update Convex schema `scopeEntities` type from `v.optional(v.string())` to `v.optional(v.any())`: the schema declaration is stale after migration 00044 changed the Postgres column to JSONB; the mismatch propagates a wrong TypeScript type through all SupabaseRow usages of `formDocuments`.