### PR TITLE
Fix `patientBindings.ts` dead code path for scopeEntities

### DIFF
--- a/convex/documents/_helpers/patientBindings.ts
+++ b/convex/documents/_helpers/patientBindings.ts
@@ -50,10 +50,16 @@ async function resolvePatientId(
   orgIdStr: string,
   doc: Record<string, unknown>,
 ): Promise<string | null> {
-  // Prefer the explicit scope link
-  if (typeof doc.scopeEntities === "string" && doc.scopeEntities) {
+  // Prefer the explicit scope link.
+  // scope_entities is JSONB since migration 00044 — Supabase returns an object,
+  // not a string. Handle both to stay compatible with any legacy string paths.
+  if (doc.scopeEntities) {
     try {
-      const scope = JSON.parse(doc.scopeEntities) as Record<string, unknown>;
+      const scope = (
+        typeof doc.scopeEntities === "string"
+          ? JSON.parse(doc.scopeEntities)
+          : doc.scopeEntities
+      ) as Record<string, unknown>;
       if (scope.patient) return String(scope.patient);
     } catch {
       // ignore malformed scope


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3043.

Closes #3043

---

## Claude summary

Bug confirmed and fixed. In `convex/documents/_helpers/patientBindings.ts:54`, the `resolvePatientId` function guarded with `typeof doc.scopeEntities === "string"` before calling `JSON.parse()`. Migration 00044 (`supabase/migrations/00044_scope_entities_jsonb.sql`) changed the `scope_entities` column from `TEXT` to `JSONB`, so the Supabase JS client now deserializes the value into a JavaScript object before it reaches the function. The string check always returned false, meaning `scopeEntities` was never read — silently breaking patient-binding resolution for any document linked to an appointment via `scope_entities`.

The fix removes the string gate as the primary condition and instead branches inside the `try` block: if the value is still a string, it JSON-parses it; otherwise it uses it directly as an object. This handles both the current JSONB path and any legacy edge cases.