### PR TITLE
2.5 AI/OCR — dopasowanie pozycji z faktury do produktów w magazynie

### DIFF
--- a/convex/_ai/invoiceMatching.ts
+++ b/convex/_ai/invoiceMatching.ts
@@ -1,0 +1,215 @@
+// Invoice item → product matching engine (#3050).
+//
+// Pure functions: no I/O, no side-effects. The calling action is responsible
+// for loading products and persisting the result.
+//
+// Matching priority (per issue #3050 spec):
+//   1. Saved name mappings       — reserved for a future phase (not yet stored)
+//   2. Exact name match          → status "matched"
+//   3. Similar name (Jaccard ≥ 0.5) → status "suggestions"
+//   4. Non-inventory keyword     → status "non_inventory_candidate"
+//   5. No match                  → status "unmatched"
+//
+// Normalization is intentionally conservative: only whitespace collapsing,
+// lowercasing, and simple punctuation removal. Capacity, size, and variant
+// tokens ("XL", "1 ml", "2 ml") are preserved so "Stylage XL" does NOT
+// auto-match "Stylage M".
+
+import type { ParsedInvoiceItem } from "./documentAnalyzer";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ProductCandidate {
+  productId: string;
+  productName: string;
+  matchReason: "exact_name" | "similar_name";
+}
+
+export type ItemMatchStatus =
+  | "matched"
+  | "suggestions"
+  | "unmatched"
+  | "non_inventory_candidate";
+
+export interface ItemMatchResult {
+  invoiceName: string;
+  status: ItemMatchStatus;
+  matched?: ProductCandidate;
+  suggestions?: ProductCandidate[];
+  handlingHint?: string;
+}
+
+export interface MatchingProposals {
+  matchedAt: number;
+  items: ItemMatchResult[];
+}
+
+export interface ProductForMatching {
+  productId: string;
+  productName: string;
+}
+
+// ---------------------------------------------------------------------------
+// Name normalization
+// ---------------------------------------------------------------------------
+
+// Safe normalization — whitespace and simple punctuation only.
+// Does NOT strip units, sizes, or variant identifiers.
+export function normalizeName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[.,;:!?'"]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function tokenize(normalized: string): string[] {
+  return normalized.split(" ").filter(Boolean);
+}
+
+// Jaccard similarity on token sets.
+function jaccardSimilarity(a: string[], b: string[]): number {
+  if (a.length === 0 && b.length === 0) return 1;
+  const setA = new Set(a);
+  const setB = new Set(b);
+  let intersection = 0;
+  for (const t of setA) {
+    if (setB.has(t)) intersection++;
+  }
+  const union = new Set([...a, ...b]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+// ---------------------------------------------------------------------------
+// Non-inventory detection
+// ---------------------------------------------------------------------------
+
+// Items whose names start with these keywords are likely service / logistics
+// line items rather than stockable products. The caller still surfaces them
+// to the user; the flag is advisory only.
+const NON_INVENTORY_PREFIXES = [
+  "transport",
+  "dostawa",
+  "przesyłka",
+  "przesylka",
+  "kurier",
+  "shipping",
+  "delivery",
+  "rabat",
+  "discount",
+  "upust",
+  "bonifikata",
+  "usługa",
+  "usluga",
+  "serwis",
+  "obsługa",
+  "obsluga",
+  "service",
+  "opłata",
+  "oplata",
+  "prowizja",
+  "fee",
+  "charge",
+];
+
+export function isNonInventoryCandidate(name: string): boolean {
+  const lower = name.trim().toLowerCase();
+  return NON_INVENTORY_PREFIXES.some(
+    (kw) =>
+      lower === kw ||
+      lower.startsWith(kw + " ") ||
+      lower.startsWith(kw + "-"),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Core matching
+// ---------------------------------------------------------------------------
+
+const SUGGESTION_THRESHOLD = 0.5;
+
+export function matchInvoiceItems(
+  items: ParsedInvoiceItem[],
+  products: ProductForMatching[],
+): MatchingProposals {
+  // Pre-compute normalized names once — avoids repeated work per item.
+  const indexed = products.map((p) => {
+    const normalized = normalizeName(p.productName);
+    return { ...p, normalized, tokens: tokenize(normalized) };
+  });
+
+  const results: ItemMatchResult[] = items.map((item) => {
+    const normalizedInvoice = normalizeName(item.productName);
+    const invoiceTokens = tokenize(normalizedInvoice);
+
+    // Step 1 — exact match after normalization
+    const exactMatches = indexed.filter(
+      (p) => p.normalized === normalizedInvoice,
+    );
+
+    if (exactMatches.length === 1) {
+      return {
+        invoiceName: item.productName,
+        status: "matched" as const,
+        matched: {
+          productId: exactMatches[0].productId,
+          productName: exactMatches[0].productName,
+          matchReason: "exact_name" as const,
+        },
+      };
+    }
+
+    if (exactMatches.length > 1) {
+      // Ambiguous — surface all exact matches as suggestions
+      return {
+        invoiceName: item.productName,
+        status: "suggestions" as const,
+        suggestions: exactMatches.map((p) => ({
+          productId: p.productId,
+          productName: p.productName,
+          matchReason: "exact_name" as const,
+        })),
+      };
+    }
+
+    // Step 2 — similar name (Jaccard ≥ SUGGESTION_THRESHOLD)
+    const similar = indexed
+      .map((p) => ({
+        ...p,
+        score: jaccardSimilarity(invoiceTokens, p.tokens),
+      }))
+      .filter((p) => p.score >= SUGGESTION_THRESHOLD)
+      .sort((a, b) => b.score - a.score);
+
+    if (similar.length > 0) {
+      return {
+        invoiceName: item.productName,
+        status: "suggestions" as const,
+        suggestions: similar.map((p) => ({
+          productId: p.productId,
+          productName: p.productName,
+          matchReason: "similar_name" as const,
+        })),
+      };
+    }
+
+    // Step 3 — non-inventory candidate (no product match found)
+    if (isNonInventoryCandidate(item.productName)) {
+      return {
+        invoiceName: item.productName,
+        status: "non_inventory_candidate" as const,
+        handlingHint: "pozycja niemagazynowa",
+      };
+    }
+
+    // Step 4 — no match
+    return {
+      invoiceName: item.productName,
+      status: "unmatched" as const,
+    };
+  });
+
+  return { matchedAt: Date.now(), items: results };
+}

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -421,6 +421,9 @@ export function createCrmTables({
     analysisResult: v.optional(v.any()),
     analysisCompletedAt: v.optional(v.number()),
     analysisError: v.optional(v.string()),
+    // Item-to-product matching proposals (#3050). Stored as MatchingProposals
+    // JSONB. Overwritten on each re-run; never touches analysisResult.
+    matchingProposals: v.optional(v.any()),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),

--- a/convex/warehouseDeliveries.ts
+++ b/convex/warehouseDeliveries.ts
@@ -15,9 +15,12 @@ import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { applyMovementInternal } from "./inventory";
 import type { SupabaseRow } from "./_helpers/supabaseRows";
 import { getDocumentAnalyzer } from "./_ai/documentAnalyzer";
-import type { DocumentPage, ParsedInvoice } from "./_ai/documentAnalyzer";
+import type { DocumentPage, ParsedInvoice, ParsedInvoiceItem } from "./_ai/documentAnalyzer";
+import { matchInvoiceItems } from "./_ai/invoiceMatching";
+import type { MatchingProposals, ProductForMatching } from "./_ai/invoiceMatching";
 
 type DeliveryRow = SupabaseRow<"warehouseDeliveries">;
+type ProductRow = SupabaseRow<"products">;
 type DeliveryItemRow = SupabaseRow<"warehouseDeliveryItems">;
 
 // Throws if the same (productId, lotNumber) pair appears more than once within
@@ -571,6 +574,76 @@ export const analyzeDeliveryInvoice = action({
     await db.patch("warehouseDeliveries", args.deliveryId, failurePatch);
 
     return { status: "failed", error: errorMessage };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Invoice item → product matching (#3050)
+// ---------------------------------------------------------------------------
+
+// Matches each item from a completed invoice analysis against active products
+// in the organisation and saves the proposals on the delivery for use in the
+// verification screen.  Re-running replaces only matchingProposals — it never
+// touches analysisResult or posted deliveries.
+export const matchDeliveryItems = action({
+  args: {
+    organizationId: v.id("organizations"),
+    deliveryId: v.string(),
+  },
+  handler: async (ctx, args): Promise<MatchingProposals> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const perm = (await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_inventory", action: "edit" },
+    )) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    const db = createSupabaseDb();
+    const delivery = await db.get<DeliveryRow>(
+      "warehouseDeliveries",
+      args.deliveryId,
+    );
+    if (
+      !delivery ||
+      String(delivery.organizationId) !== String(args.organizationId)
+    ) {
+      throw new Error("Delivery not found");
+    }
+    if (delivery.status !== "draft") {
+      throw new Error("Only draft deliveries can be matched");
+    }
+    if (delivery.analysisStatus !== "completed" || !delivery.analysisResult) {
+      throw new Error(
+        "Invoice analysis must be completed before matching items",
+      );
+    }
+
+    const analysis = delivery.analysisResult as StoredAnalysisResult;
+    const invoiceItems = Array.isArray(analysis.items)
+      ? (analysis.items as ParsedInvoiceItem[])
+      : [];
+
+    const productRows = await db
+      .query<ProductRow>("products")
+      .eq("organizationId", String(args.organizationId))
+      .eq("isActive", true)
+      .collect();
+
+    const products: ProductForMatching[] = productRows.map((p) => ({
+      productId: String(p._id),
+      productName: String(p.name),
+    }));
+
+    const proposals = matchInvoiceItems(invoiceItems, products);
+
+    await db.patch("warehouseDeliveries", args.deliveryId, {
+      matchingProposals: proposals,
+      updatedAt: Date.now(),
+    });
+
+    return proposals;
   },
 });
 

--- a/supabase/migrations/00060_delivery_matching_proposals.sql
+++ b/supabase/migrations/00060_delivery_matching_proposals.sql
@@ -1,0 +1,11 @@
+-- Matching proposals for warehouse delivery invoice items (#3050).
+--
+-- Stores the result of matchDeliveryItems as JSONB alongside the delivery.
+-- Shape: MatchingProposals { matchedAt: number, items: ItemMatchResult[] }
+--
+-- This column is auxiliary data for the future verification screen.
+-- It is overwritten on each re-run of matching; it never replaces
+-- analysis_result or affects posted deliveries or stock movements.
+
+ALTER TABLE warehouse_deliveries
+  ADD COLUMN IF NOT EXISTS matching_proposals JSONB;

--- a/tests/convex/deliveryItemMatching.test.ts
+++ b/tests/convex/deliveryItemMatching.test.ts
@@ -1,0 +1,351 @@
+// Tests for invoice item → product matching (#3050).
+//
+// Part A — pure unit tests of matchInvoiceItems / normalizeName /
+//           isNonInventoryCandidate (no I/O, no auth).
+// Part B — action-level test for matchDeliveryItems: verifies proposals are
+//           persisted and that re-running replaces only matchingProposals (not
+//           analysisResult).
+
+import { describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+import {
+  matchInvoiceItems,
+  normalizeName,
+  isNonInventoryCandidate,
+} from "../../convex/_ai/invoiceMatching";
+import type { ParsedInvoiceItem } from "../../convex/_ai/documentAnalyzer";
+import type { MatchingProposals } from "../../convex/_ai/invoiceMatching";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeItem(productName: string): ParsedInvoiceItem {
+  return {
+    productName,
+    quantity: 1,
+    unit: "szt",
+    unitPrice: null,
+    vatRate: null,
+    vatCode: null,
+    unitPriceGross: null,
+    lineValueNet: null,
+    lineValueGross: null,
+    lotNumber: null,
+    expiryDate: null,
+  };
+}
+
+const SAMPLE_ANALYSIS_RESULT = {
+  supplierName: "ACME Sp. z o.o.",
+  invoiceNumber: "FV/2024/001",
+  invoiceDate: "2024-01-15",
+  items: [
+    makeItem("Rękawiczki nitrylowe"),
+  ],
+  confidence: 0.92,
+};
+
+async function seedDeliveryWithAnalysis(
+  organizationId: string,
+  userId: string,
+  items: ParsedInvoiceItem[] = [makeItem("Rękawiczki nitrylowe")],
+): Promise<string> {
+  const db = createSupabaseDb();
+  return db.insert("warehouseDeliveries", {
+    organizationId,
+    supplierName: "ACME Sp. z o.o.",
+    invoiceNumber: "FV/2024/001",
+    deliveryDate: null,
+    locationId: null,
+    notes: null,
+    status: "draft",
+    totalValue: null,
+    totalValueGross: null,
+    invoicePages: [{ storageId: "store-p1", mimeType: "image/jpeg", position: 1 }],
+    analysisStatus: "completed",
+    analysisResult: { ...SAMPLE_ANALYSIS_RESULT, items },
+    analysisCompletedAt: Date.now(),
+    analysisError: null,
+    createdBy: userId,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+}
+
+async function seedProduct(
+  organizationId: string,
+  userId: string,
+  name: string,
+): Promise<string> {
+  const db = createSupabaseDb();
+  return db.insert("products", {
+    organizationId,
+    name,
+    sku: `SKU-${Math.random().toString(36).slice(2)}`,
+    unitPrice: 10,
+    isActive: true,
+    createdBy: userId,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Part A — pure function tests
+// ---------------------------------------------------------------------------
+
+describe("normalizeName", () => {
+  test("lowercases and trims", () => {
+    expect(normalizeName("  Stylage XL  ")).toBe("stylage xl");
+  });
+
+  test("collapses whitespace", () => {
+    expect(normalizeName("Stylage  XL   1  ml")).toBe("stylage xl 1 ml");
+  });
+
+  test("removes simple punctuation and collapses resulting spaces", () => {
+    expect(normalizeName("Stylage, XL.")).toBe("stylage xl");
+  });
+
+  test("preserves hyphens (variant separators)", () => {
+    expect(normalizeName("Juvederm Ultra-2")).toBe("juvederm ultra-2");
+  });
+});
+
+describe("isNonInventoryCandidate", () => {
+  test.each([
+    ["Transport", true],
+    ["Dostawa kurierska", true],
+    ["Rabat 10%", true],
+    ["Usługa pakowania", true],
+    ["Opłata manipulacyjna", true],
+    ["Rękawiczki nitrylowe", false],
+    ["Stylage XL 1 ml", false],
+  ])("%s → %s", (name, expected) => {
+    expect(isNonInventoryCandidate(name)).toBe(expected);
+  });
+});
+
+describe("matchInvoiceItems — exact match", () => {
+  test("returns status=matched when one product has an identical normalized name", () => {
+    const result = matchInvoiceItems(
+      [makeItem("Rękawiczki nitrylowe")],
+      [{ productId: "p1", productName: "Rękawiczki nitrylowe" }],
+    );
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].status).toBe("matched");
+    expect(result.items[0].matched?.productId).toBe("p1");
+    expect(result.items[0].matched?.matchReason).toBe("exact_name");
+    expect(result.items[0].invoiceName).toBe("Rękawiczki nitrylowe");
+  });
+
+  test("exact match is case- and whitespace-insensitive", () => {
+    const result = matchInvoiceItems(
+      [makeItem("rękawiczki  nitrylowe")],
+      [{ productId: "p1", productName: "Rękawiczki nitrylowe" }],
+    );
+    expect(result.items[0].status).toBe("matched");
+  });
+});
+
+describe("matchInvoiceItems — variant/capacity difference → suggestions not matched", () => {
+  test("Stylage XL 1 ml vs Stylage M 1 ml produces suggestions", () => {
+    const result = matchInvoiceItems(
+      [makeItem("Stylage XL 1 ml")],
+      [
+        { productId: "p1", productName: "Stylage M 1 ml" },
+        { productId: "p2", productName: "Stylage L 1 ml" },
+      ],
+    );
+    expect(result.items[0].status).toBe("suggestions");
+    expect(result.items[0].matched).toBeUndefined();
+    // Both similar products should appear as candidates
+    expect(result.items[0].suggestions).toBeDefined();
+    expect(result.items[0].suggestions!.length).toBeGreaterThan(0);
+  });
+
+  test("Stylage XL 1 ml does not auto-match Stylage M 1 ml as 'matched'", () => {
+    const result = matchInvoiceItems(
+      [makeItem("Stylage XL 1 ml")],
+      [{ productId: "p1", productName: "Stylage M 1 ml" }],
+    );
+    expect(result.items[0].status).not.toBe("matched");
+  });
+});
+
+describe("matchInvoiceItems — multiple similar products → suggestions", () => {
+  test("returns status=suggestions with all candidates when multiple products share high similarity", () => {
+    const result = matchInvoiceItems(
+      [makeItem("Juvederm Ultra 2 ml")],
+      [
+        { productId: "p1", productName: "Juvederm Ultra 1 ml" },
+        { productId: "p2", productName: "Juvederm Ultra 2 ml" },
+        { productId: "p3", productName: "Juvederm Ultra 4 ml" },
+      ],
+    );
+    // "Juvederm Ultra 2 ml" exactly matches p2
+    expect(result.items[0].status).toBe("matched");
+    expect(result.items[0].matched?.productId).toBe("p2");
+  });
+
+  test("returns suggestions when invoice name partially matches multiple products", () => {
+    const result = matchInvoiceItems(
+      [makeItem("Juvederm Ultra")],
+      [
+        { productId: "p1", productName: "Juvederm Ultra 1 ml" },
+        { productId: "p2", productName: "Juvederm Ultra 2 ml" },
+      ],
+    );
+    expect(result.items[0].status).toBe("suggestions");
+    expect(result.items[0].suggestions!.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("matchInvoiceItems — no match", () => {
+  test("returns status=unmatched when no product is similar", () => {
+    const result = matchInvoiceItems(
+      [makeItem("Całkowicie nieznany preparat XYZ")],
+      [{ productId: "p1", productName: "Rękawiczki nitrylowe" }],
+    );
+    expect(result.items[0].status).toBe("unmatched");
+    expect(result.items[0].matched).toBeUndefined();
+    expect(result.items[0].suggestions).toBeUndefined();
+  });
+
+  test("returns unmatched when product list is empty", () => {
+    const result = matchInvoiceItems([makeItem("Stylage XL 1 ml")], []);
+    expect(result.items[0].status).toBe("unmatched");
+  });
+});
+
+describe("matchInvoiceItems — non-inventory candidate", () => {
+  test("returns status=non_inventory_candidate for transport line with no product match", () => {
+    const result = matchInvoiceItems([makeItem("Transport")], []);
+    expect(result.items[0].status).toBe("non_inventory_candidate");
+    expect(result.items[0].handlingHint).toBeDefined();
+  });
+
+  test("dostawa is detected as non_inventory_candidate", () => {
+    const result = matchInvoiceItems([makeItem("Dostawa ekspresowa")], []);
+    expect(result.items[0].status).toBe("non_inventory_candidate");
+  });
+
+  test("rabat is detected as non_inventory_candidate", () => {
+    const result = matchInvoiceItems([makeItem("Rabat 5%")], []);
+    expect(result.items[0].status).toBe("non_inventory_candidate");
+  });
+
+  test("product named 'Transport' that exists in catalog still matches", () => {
+    // If the org has a product literally called "Transport", exact match wins
+    const result = matchInvoiceItems(
+      [makeItem("Transport")],
+      [{ productId: "p1", productName: "Transport" }],
+    );
+    expect(result.items[0].status).toBe("matched");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Part B — action-level tests
+// ---------------------------------------------------------------------------
+
+describe("matchDeliveryItems action — re-run does not change analysisResult", () => {
+  test("proposals are persisted; re-run overwrites only matchingProposals", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    const productId = await seedProduct(
+      String(organizationId),
+      String(userId),
+      "Rękawiczki nitrylowe",
+    );
+
+    const deliveryId = await seedDeliveryWithAnalysis(
+      String(organizationId),
+      String(userId),
+      [makeItem("Rękawiczki nitrylowe")],
+    );
+
+    // First run
+    const proposals = (await t
+      .withIdentity(identity)
+      .action(api.warehouseDeliveries.matchDeliveryItems, {
+        organizationId,
+        deliveryId,
+      })) as MatchingProposals;
+
+    expect(proposals.items).toHaveLength(1);
+    expect(proposals.items[0].status).toBe("matched");
+    expect(proposals.items[0].matched?.productId).toBe(productId);
+
+    const db = createSupabaseDb();
+    const row1 = (await db.get("warehouseDeliveries", deliveryId)) as Record<
+      string,
+      unknown
+    > | null;
+    // analysisResult must be untouched
+    expect(
+      (row1?.analysisResult as Record<string, unknown>)?.invoiceNumber,
+    ).toBe("FV/2024/001");
+    expect(row1?.matchingProposals).toBeDefined();
+
+    // Second run (re-matching)
+    await t
+      .withIdentity(identity)
+      .action(api.warehouseDeliveries.matchDeliveryItems, {
+        organizationId,
+        deliveryId,
+      });
+
+    const row2 = (await db.get("warehouseDeliveries", deliveryId)) as Record<
+      string,
+      unknown
+    > | null;
+    // analysisResult still intact after second run
+    expect(
+      (row2?.analysisResult as Record<string, unknown>)?.invoiceNumber,
+    ).toBe("FV/2024/001");
+    // matchingProposals updated (matchedAt may differ but items shape is same)
+    expect(row2?.matchingProposals).toBeDefined();
+  });
+});
+
+describe("matchDeliveryItems action — throws when analysis not completed", () => {
+  test("throws if analysisStatus is not completed", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    const db = createSupabaseDb();
+    const deliveryId = await db.insert("warehouseDeliveries", {
+      organizationId: String(organizationId),
+      supplierName: null,
+      invoiceNumber: null,
+      deliveryDate: null,
+      locationId: null,
+      notes: null,
+      status: "draft",
+      totalValue: null,
+      totalValueGross: null,
+      invoicePages: [{ storageId: "s1", mimeType: "image/jpeg", position: 1 }],
+      analysisStatus: "processing",
+      analysisResult: null,
+      analysisCompletedAt: null,
+      analysisError: null,
+      createdBy: String(userId),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    await expect(
+      t
+        .withIdentity(identity)
+        .action(api.warehouseDeliveries.matchDeliveryItems, {
+          organizationId,
+          deliveryId,
+        }),
+    ).rejects.toThrow(/analysis must be completed/i);
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3050.

Closes #3050

---

## Claude summary

All done. Here's a summary of what was implemented:

## Implementation

**5 files changed, 654 insertions:**

`convex/_ai/invoiceMatching.ts` (new) — pure matching engine with no I/O. Exports `matchInvoiceItems`, `normalizeName`, `isNonInventoryCandidate`, and the public types (`MatchingProposals`, `ItemMatchResult`, `ProductCandidate`, etc.).

`convex/warehouseDeliveries.ts` — new `matchDeliveryItems` action. Loads the delivery, checks it's draft with a completed analysis, fetches active products for the org, runs the matching engine, patches only `matchingProposals` on the row, and returns the proposals.

`convex/schema/crm.ts` — `matchingProposals: v.optional(v.any())` added to `warehouseDeliveries`.

`supabase/migrations/00060_delivery_matching_proposals.sql` — adds `matching_proposals JSONB` column to `warehouse_deliveries`.

`tests/convex/deliveryItemMatching.test.ts` (new) — 25 tests covering all required cases: exact match, variant-difference → suggestions (not matched), multiple similar products, no match, non-inventory candidate detection (transport/dostawa/rabat/usługa/opłata), re-run preserves `analysisResult`, and guard when analysis isn't completed.

**Key design decisions:**
- Matching is conservative: normalization only collapses whitespace and removes commas/periods — never strips units or variant letters, so "Stylage XL" cannot auto-match "Stylage M".
- Jaccard similarity threshold of 0.5 on token sets determines "suggestions". Any non-exact match is always a suggestion, never auto-confirmed as "matched".
- Non-inventory detection only fires when no product match exists — if the org has a product literally called "Transport", it still gets `matched`.
- `analysisResult` is never touched; `matchingProposals` is the only field written.

## Follow-ups
- Add verification screen UI for matchingProposals: the future step (issue scope explicitly deferred) — a UI to let users confirm/reject each match proposal and select handling hints for unmatched items
- Add saved name mappings table: req #2 calls for "wcześniej zapamiętane mapowanie" as the first priority in matching; the mapping persistence layer was excluded from this issue per req #10 but needs a future migration and a write path in `matchDeliveryItems`