### PR TITLE
Add saved name mappings table

### DIFF
--- a/convex/_ai/invoiceMatching.ts
+++ b/convex/_ai/invoiceMatching.ts
@@ -24,7 +24,7 @@ import type { ParsedInvoiceItem } from "./documentAnalyzer";
 export interface ProductCandidate {
   productId: string;
   productName: string;
-  matchReason: "exact_name" | "similar_name";
+  matchReason: "saved_mapping" | "exact_name" | "similar_name";
 }
 
 export type ItemMatchStatus =
@@ -133,6 +133,9 @@ const SUGGESTION_THRESHOLD = 0.5;
 export function matchInvoiceItems(
   items: ParsedInvoiceItem[],
   products: ProductForMatching[],
+  // Priority #1: previously saved invoice-name → product-id mappings (#3053).
+  // Keys are normalized invoice names; values are product IDs.
+  savedMappings: ReadonlyMap<string, string> = new Map(),
 ): MatchingProposals {
   // Pre-compute normalized names once — avoids repeated work per item.
   const indexed = products.map((p) => {
@@ -143,6 +146,24 @@ export function matchInvoiceItems(
   const results: ItemMatchResult[] = items.map((item) => {
     const normalizedInvoice = normalizeName(item.productName);
     const invoiceTokens = tokenize(normalizedInvoice);
+
+    // Step 0 — saved name mapping (priority #1 per spec)
+    // Only returns a match if the mapped product is still active in the catalog.
+    const savedProductId = savedMappings.get(normalizedInvoice);
+    if (savedProductId !== undefined) {
+      const savedProduct = indexed.find((p) => p.productId === savedProductId);
+      if (savedProduct) {
+        return {
+          invoiceName: item.productName,
+          status: "matched" as const,
+          matched: {
+            productId: savedProduct.productId,
+            productName: savedProduct.productName,
+            matchReason: "saved_mapping" as const,
+          },
+        };
+      }
+    }
 
     // Step 1 — exact match after normalization
     const exactMatches = indexed.filter(

--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -12,6 +12,7 @@ const TABLE_MAP: Record<string, string> = {
   productStockMovements: "product_stock_movements",
   warehouseDeliveries: "warehouse_deliveries",
   warehouseDeliveryItems: "warehouse_delivery_items",
+  deliveryNameMappings: "delivery_name_mappings",
   calls: "calls",
   notes: "notes",
   activities: "activities",

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -454,6 +454,19 @@ export function createCrmTables({
     .index("by_org", ["organizationId"])
     .index("by_product", ["productId"]),
 
+  // Saved invoice-name → product mappings for delivery item matching (#3053).
+  // matchDeliveryItems reads these as priority #1 and writes back auto-confirmed
+  // exact-name matches.  One mapping per (org, invoiceName) — enforced by the
+  // unique index in the Supabase migration.
+  deliveryNameMappings: defineTable({
+    organizationId: v.id("organizations"),
+    invoiceName: v.string(),
+    productId: v.id("products"),
+    createdAt: v.number(),
+  })
+    .index("by_org", ["organizationId"])
+    .index("by_org_and_name", ["organizationId", "invoiceName"]),
+
   dealProducts: defineTable({
     organizationId: v.id("organizations"),
     dealId: v.id("leads"),

--- a/convex/warehouseDeliveries.ts
+++ b/convex/warehouseDeliveries.ts
@@ -16,7 +16,7 @@ import { applyMovementInternal } from "./inventory";
 import type { SupabaseRow } from "./_helpers/supabaseRows";
 import { getDocumentAnalyzer } from "./_ai/documentAnalyzer";
 import type { DocumentPage, ParsedInvoice, ParsedInvoiceItem } from "./_ai/documentAnalyzer";
-import { matchInvoiceItems } from "./_ai/invoiceMatching";
+import { matchInvoiceItems, normalizeName } from "./_ai/invoiceMatching";
 import type { MatchingProposals, ProductForMatching } from "./_ai/invoiceMatching";
 
 type DeliveryRow = SupabaseRow<"warehouseDeliveries">;
@@ -636,7 +636,41 @@ export const matchDeliveryItems = action({
       productName: String(p.name),
     }));
 
-    const proposals = matchInvoiceItems(invoiceItems, products);
+    // Load saved name mappings and build a normalized-name → productId Map
+    // for priority #1 matching (#3053).
+    const mappingRows = await db
+      .query("deliveryNameMappings")
+      .eq("organizationId", String(args.organizationId))
+      .collect();
+    const savedMappings = new Map<string, string>(
+      mappingRows.map((m) => [
+        normalizeName(String(m.invoiceName)),
+        String(m.productId),
+      ]),
+    );
+
+    const proposals = matchInvoiceItems(invoiceItems, products, savedMappings);
+
+    // Write back exact-name matches as saved mappings so future deliveries use
+    // priority #1 for the same invoice names.  Saved-mapping results are skipped
+    // (they are already persisted); other statuses produce no match to save.
+    for (const item of proposals.items) {
+      if (item.status !== "matched" || !item.matched) continue;
+      if (item.matched.matchReason === "saved_mapping") continue;
+      const existing = await db
+        .query("deliveryNameMappings")
+        .eq("organizationId", String(args.organizationId))
+        .eq("invoiceName", item.invoiceName)
+        .first();
+      if (!existing) {
+        await db.insert("deliveryNameMappings", {
+          organizationId: String(args.organizationId),
+          invoiceName: item.invoiceName,
+          productId: item.matched.productId,
+          createdAt: Date.now(),
+        });
+      }
+    }
 
     await db.patch("warehouseDeliveries", args.deliveryId, {
       matchingProposals: proposals,

--- a/supabase/migrations/00061_delivery_name_mappings.sql
+++ b/supabase/migrations/00061_delivery_name_mappings.sql
@@ -1,0 +1,30 @@
+-- Saved invoice-name → product mappings for delivery item matching (#3053).
+--
+-- Persists confirmed invoice item name → product ID mappings per organisation.
+-- matchDeliveryItems reads these as matching priority #1 (ahead of exact-name
+-- and fuzzy-name matching) and writes back auto-confirmed exact-name matches so
+-- future deliveries benefit from the mapping even if the product catalog changes.
+--
+-- invoice_name stores the raw name as it appeared on the invoice; normalisation
+-- happens at query time in the matching engine (see invoiceMatching.ts).
+--
+-- The unique constraint on (organization_id, invoice_name) enforces at most one
+-- product mapping per invoice name per organisation.
+
+CREATE TABLE IF NOT EXISTS delivery_name_mappings (
+  id              TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  invoice_name    TEXT NOT NULL,
+  product_id      TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  created_at      BIGINT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS delivery_name_mappings_org_name_uidx
+  ON delivery_name_mappings (organization_id, invoice_name);
+
+CREATE INDEX IF NOT EXISTS delivery_name_mappings_org_idx
+  ON delivery_name_mappings (organization_id);
+
+ALTER TABLE delivery_name_mappings ENABLE ROW LEVEL SECURITY;
+CREATE POLICY org_isolation ON delivery_name_mappings
+  USING (organization_id = current_org_id());

--- a/tests/convex/deliveryItemMatching.test.ts
+++ b/tests/convex/deliveryItemMatching.test.ts
@@ -313,6 +313,125 @@ describe("matchDeliveryItems action — re-run does not change analysisResult", 
   });
 });
 
+// ---------------------------------------------------------------------------
+// Part B2 — saved name mappings (#3053)
+// ---------------------------------------------------------------------------
+
+describe("matchInvoiceItems — saved mappings are priority #1", () => {
+  test("saved mapping wins over exact name match", () => {
+    const savedMappings = new Map([["rękawiczki nitrylowe", "p-saved"]]);
+    const result = matchInvoiceItems(
+      [makeItem("Rękawiczki nitrylowe")],
+      [
+        { productId: "p-saved", productName: "Rękawiczki nitrylowe" },
+        { productId: "p-catalog", productName: "Rękawiczki nitrylowe" },
+      ],
+      savedMappings,
+    );
+    expect(result.items[0].status).toBe("matched");
+    expect(result.items[0].matched?.matchReason).toBe("saved_mapping");
+    expect(result.items[0].matched?.productId).toBe("p-saved");
+  });
+
+  test("saved mapping is skipped when mapped product is no longer active", () => {
+    const savedMappings = new Map([["stylage xl 1 ml", "p-deleted"]]);
+    // p-deleted is not in the active products list
+    const result = matchInvoiceItems(
+      [makeItem("Stylage XL 1 ml")],
+      [{ productId: "p-current", productName: "Stylage XL 1 ml" }],
+      savedMappings,
+    );
+    // Falls through to exact name match since saved product is gone
+    expect(result.items[0].status).toBe("matched");
+    expect(result.items[0].matched?.matchReason).toBe("exact_name");
+    expect(result.items[0].matched?.productId).toBe("p-current");
+  });
+
+  test("saved mapping normalises the key (case and whitespace)", () => {
+    const savedMappings = new Map([["rękawiczki nitrylowe", "p1"]]);
+    const result = matchInvoiceItems(
+      [makeItem("  RĘKAWICZKI  NITRYLOWE  ")],
+      [{ productId: "p1", productName: "Rękawiczki nitrylowe" }],
+      savedMappings,
+    );
+    expect(result.items[0].status).toBe("matched");
+    expect(result.items[0].matched?.matchReason).toBe("saved_mapping");
+  });
+});
+
+describe("matchDeliveryItems action — saved name mappings persistence", () => {
+  test("exact-name match is written to deliveryNameMappings on first run", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    const productId = await seedProduct(
+      String(organizationId),
+      String(userId),
+      "Rękawiczki nitrylowe",
+    );
+    const deliveryId = await seedDeliveryWithAnalysis(
+      String(organizationId),
+      String(userId),
+      [makeItem("Rękawiczki nitrylowe")],
+    );
+
+    await t
+      .withIdentity(identity)
+      .action(api.warehouseDeliveries.matchDeliveryItems, {
+        organizationId,
+        deliveryId,
+      });
+
+    const db = createSupabaseDb();
+    const mappings = await db
+      .query("deliveryNameMappings")
+      .eq("organizationId", String(organizationId))
+      .collect();
+    expect(mappings).toHaveLength(1);
+    expect(String((mappings[0] as Record<string, unknown>).invoiceName)).toBe(
+      "Rękawiczki nitrylowe",
+    );
+    expect(String((mappings[0] as Record<string, unknown>).productId)).toBe(productId);
+  });
+
+  test("second run returns saved_mapping matchReason", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    await seedProduct(String(organizationId), String(userId), "Rękawiczki nitrylowe");
+    const deliveryId = await seedDeliveryWithAnalysis(
+      String(organizationId),
+      String(userId),
+      [makeItem("Rękawiczki nitrylowe")],
+    );
+
+    // First run writes the mapping
+    await t
+      .withIdentity(identity)
+      .action(api.warehouseDeliveries.matchDeliveryItems, {
+        organizationId,
+        deliveryId,
+      });
+
+    // Second delivery with the same invoice name
+    const deliveryId2 = await seedDeliveryWithAnalysis(
+      String(organizationId),
+      String(userId),
+      [makeItem("Rękawiczki nitrylowe")],
+    );
+
+    const proposals2 = (await t
+      .withIdentity(identity)
+      .action(api.warehouseDeliveries.matchDeliveryItems, {
+        organizationId,
+        deliveryId: deliveryId2,
+      })) as MatchingProposals;
+
+    expect(proposals2.items[0].status).toBe("matched");
+    expect(proposals2.items[0].matched?.matchReason).toBe("saved_mapping");
+  });
+});
+
 describe("matchDeliveryItems action — throws when analysis not completed", () => {
   test("throws if analysisStatus is not completed", async () => {
     const t = createTestCtx();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3053.

Closes #3053

---

## Claude summary

The implementation is complete. Here's a summary of what was done:

**6 files changed across 5 components:**

1. `supabase/migrations/00061_delivery_name_mappings.sql` — new table `delivery_name_mappings` with a unique index on `(organization_id, invoice_name)` and org-scoped RLS (same pattern as `warehouse_deliveries`).

2. `convex/schema/crm.ts` — new `deliveryNameMappings` Convex table definition with `by_org` and `by_org_and_name` indexes.

3. `convex/_helpers/supabaseDb.ts` — added `deliveryNameMappings: "delivery_name_mappings"` to TABLE_MAP.

4. `convex/_ai/invoiceMatching.ts` — added `"saved_mapping"` to `matchReason`, added optional `savedMappings: ReadonlyMap<string, string>` parameter (defaults to empty), inserted "Step 0" before existing exact-name logic. If the mapped product is no longer active in the catalog, it falls through to the next priority.

5. `convex/warehouseDeliveries.ts` — `matchDeliveryItems` now loads saved mappings for the org, normalizes their names into a lookup Map, passes it to `matchInvoiceItems`, then writes back any new `exact_name` matches to the table so future deliveries use priority #1 for those names.

6. `tests/convex/deliveryItemMatching.test.ts` — 5 new tests covering: saved mapping wins over catalog match, inactive product fallthrough, normalization robustness, write-back on first run, and second delivery returns `saved_mapping` reason.