### PR TITLE
2.6.1 AI/OCR — aktualizacja database.types.ts po migracji item_decisions

### DIFF
--- a/src/lib/supabase/database.columns.ts
+++ b/src/lib/supabase/database.columns.ts
@@ -61,6 +61,12 @@
  *   • 00054_delivery_items_prices.sql
  *   • 00055_stock_levels_avg_cost.sql
  *   • 00056_product_stock_movements_avg_cost_after.sql
+ *   • 00057_lot_tracking.sql
+ *   • 00058_delivery_invoice_pages.sql
+ *   • 00059_delivery_analysis_status.sql
+ *   • 00060_delivery_matching_proposals.sql
+ *   • 00061_delivery_name_mappings.sql
+ *   • 00062_delivery_item_decisions.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  */
@@ -164,7 +170,8 @@ export type TableName =
   | "gabinet_payment_methods"
   | "gabinet_employee_locations"
   | "warehouse_deliveries"
-  | "warehouse_delivery_items";
+  | "warehouse_delivery_items"
+  | "delivery_name_mappings";
 
 /**
  * Column names per table, as a runtime-checkable Set.
@@ -263,10 +270,11 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   automation_run_steps: new Set(["id", "organization_id", "run_id", "rule_id", "action_index", "action_type", "idempotency_key", "status", "recipient", "recipient_name", "linked_entity_type", "linked_entity_id", "rendered_subject", "rendered_body", "metadata_snapshot", "error_message", "email_event_log_id", "appointment_sms_event_id", "processed_at", "created_at", "updated_at"]),
   document_components: new Set(["id", "organization_id", "scope", "created_by", "name", "description", "category", "content_json", "protected", "position_constraint", "version", "is_active", "created_at", "updated_at"]),
   product_stock_levels: new Set(["id", "organization_id", "product_id", "location_id", "quantity", "updated_at", "avg_cost"]),
-  product_stock_movements: new Set(["id", "organization_id", "product_id", "location_id", "delta", "balance_after", "reason", "source_type", "source_id", "note", "performed_by", "created_at", "unit_price", "avg_cost_after"]),
+  product_stock_movements: new Set(["id", "organization_id", "product_id", "location_id", "delta", "balance_after", "reason", "source_type", "source_id", "note", "performed_by", "created_at", "unit_price", "avg_cost_after", "lot_number", "expiry_date"]),
   gabinet_treatment_products: new Set(["id", "organization_id", "treatment_id", "product_id", "product_section", "quantity", "unit", "created_at", "updated_at"]),
   gabinet_payment_methods: new Set(["id", "organization_id", "key", "name", "is_system", "is_active", "order", "available_for_settlement", "available_for_sales", "available_for_refund", "locks_amount_to_treatment_price", "is_package_coverage", "created_by", "created_at", "updated_at"]),
   gabinet_employee_locations: new Set(["id", "organization_id", "employee_id", "location_id", "is_primary", "created_at"]),
-  warehouse_deliveries: new Set(["id", "organization_id", "supplier_name", "invoice_number", "delivery_date", "location_id", "notes", "status", "created_by", "created_at", "updated_at", "total_value", "total_value_gross"]),
-  warehouse_delivery_items: new Set(["id", "organization_id", "delivery_id", "product_id", "quantity", "unit_price", "vat_rate", "movement_id", "created_at", "unit_price_gross", "line_value_net", "line_value_gross", "vat_code"]),
+  warehouse_deliveries: new Set(["id", "organization_id", "supplier_name", "invoice_number", "delivery_date", "location_id", "notes", "status", "created_by", "created_at", "updated_at", "total_value", "total_value_gross", "invoice_pages", "analysis_status", "analysis_result", "analysis_completed_at", "analysis_error", "matching_proposals", "item_decisions"]),
+  warehouse_delivery_items: new Set(["id", "organization_id", "delivery_id", "product_id", "quantity", "unit_price", "vat_rate", "movement_id", "created_at", "unit_price_gross", "line_value_net", "line_value_gross", "vat_code", "lot_number", "expiry_date"]),
+  delivery_name_mappings: new Set(["id", "organization_id", "invoice_name", "product_id", "created_at"]),
 };

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -62,6 +62,11 @@
  *   • 00055_stock_levels_avg_cost.sql
  *   • 00056_product_stock_movements_avg_cost_after.sql
  *   • 00057_lot_tracking.sql
+ *   • 00058_delivery_invoice_pages.sql
+ *   • 00059_delivery_analysis_status.sql
+ *   • 00060_delivery_matching_proposals.sql
+ *   • 00061_delivery_name_mappings.sql
+ *   • 00062_delivery_item_decisions.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -6909,6 +6914,13 @@ export interface Database {
           updated_at: number;
           total_value: number | null;
           total_value_gross: number | null;
+          invoice_pages: unknown | null;
+          analysis_status: string | null;
+          analysis_result: unknown | null;
+          analysis_completed_at: number | null;
+          analysis_error: string | null;
+          matching_proposals: unknown | null;
+          item_decisions: unknown | null;
         };
         Insert: {
           id?: string;
@@ -6924,6 +6936,13 @@ export interface Database {
           updated_at: number;
           total_value?: number | null;
           total_value_gross?: number | null;
+          invoice_pages?: unknown | null;
+          analysis_status?: string | null;
+          analysis_result?: unknown | null;
+          analysis_completed_at?: number | null;
+          analysis_error?: string | null;
+          matching_proposals?: unknown | null;
+          item_decisions?: unknown | null;
         };
         Update: {
           id?: string;
@@ -6939,6 +6958,13 @@ export interface Database {
           updated_at?: number;
           total_value?: number | null;
           total_value_gross?: number | null;
+          invoice_pages?: unknown | null;
+          analysis_status?: string | null;
+          analysis_result?: unknown | null;
+          analysis_completed_at?: number | null;
+          analysis_error?: string | null;
+          matching_proposals?: unknown | null;
+          item_decisions?: unknown | null;
         };
         Relationships: [
           {
@@ -7043,6 +7069,45 @@ export interface Database {
             columns: ["movement_id"];
             isOneToOne: false;
             referencedRelation: "product_stock_movements";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      delivery_name_mappings: {
+        Row: {
+          id: string;
+          organization_id: string;
+          invoice_name: string;
+          product_id: string;
+          created_at: number;
+        };
+        Insert: {
+          id?: string;
+          organization_id: string;
+          invoice_name: string;
+          product_id: string;
+          created_at: number;
+        };
+        Update: {
+          id?: string;
+          organization_id?: string;
+          invoice_name?: string;
+          product_id?: string;
+          created_at?: number;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "delivery_name_mappings_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organizations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "delivery_name_mappings_product_id_fkey";
+            columns: ["product_id"];
+            isOneToOne: false;
+            referencedRelation: "products";
             referencedColumns: ["id"];
           },
         ];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3058.

Closes #3058

---

## Claude summary

Done. The issue was real — `database.types.ts` and `database.columns.ts` were last generated from migrations through `00057_lot_tracking.sql`, missing five newer migrations (00058–00062). Running `node scripts/gen-db-types.mjs` picked up all 62 migrations and regenerated both files. The key change is that `warehouse_deliveries` now has `item_decisions: unknown | null` in its Row/Insert/Update types, which the DB Types Drift check was failing on.