### PR TITLE
2.6.2 CI — naprawa błędów Unit Tests niezwiązanych z AI/OCR

### DIFF
--- a/src/components/layout/app-sidebar.test.tsx
+++ b/src/components/layout/app-sidebar.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@convex-dev/react-query", () => ({
 
 vi.mock("@cvx/_generated/api", () => ({
   api: {
+    app: { getCurrentUser: {} },
     productSubscriptions: { getActiveProducts: {} },
     gabinet: { scheduling: { listLeaves: {} } },
   },
@@ -109,8 +110,10 @@ vi.mock("@/components/sidebar-widgets/day-timeline", () => ({
 vi.mock("@/modules/registry", () => {
   const crmModule = {
     id: "crm",
+    productKey: "crm",
     workspaceRoot: "/dashboard/leads",
     settingsRoots: [],
+    settingsNav: [],
     primaryNav: [],
     pageContexts: [
       {
@@ -121,7 +124,7 @@ vi.mock("@/modules/registry", () => {
       },
     ],
     fallbackPageContextKey: "leads",
-    workspace: { id: "crm", label: "CRM" },
+    workspace: { id: "crm", nameKey: "nav.workspace.crm", descKey: "", href: "/dashboard/leads" },
   };
 
   return {

--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -255,7 +255,12 @@ function cleanConvexMessage(raw: string): string {
   let msg = raw;
 
   // Drop the leading "[CONVEX ...] [Request ID: ...] Server Error" banner.
-  msg = msg.replace(/^\s*\[CONVEX[^\]]*\][^\n]*\n?/i, "");
+  // Require a trailing \n so that single-line errors (e.g. "Connection lost
+  // while action was in flight") whose payload sits on the same line as the
+  // [CONVEX ...] token are NOT consumed here — the fallback strip below then
+  // removes only the bracket, leaving the payload intact.
+  msg = msg.replace(/^\s*\[CONVEX[^\]]*\]\s*(?:\[Request ID:[^\]]*\])?\s*(?:Server Error)?\s*\n/i, "");
+  msg = msg.replace(/^\s*\[CONVEX[^\]]*\]\s*/i, "");
   msg = msg.replace(/^\s*\[Request ID:[^\]]*\][^\n]*\n?/i, "");
   msg = msg.replace(/^\s*Server Error\s*\n?/i, "");
 

--- a/vitest.frontend.config.ts
+++ b/vitest.frontend.config.ts
@@ -13,6 +13,13 @@ export default defineConfig({
       "@cvx": path.resolve(__dirname, "convex"),
     },
   },
+  // Provide safe placeholder values so that modules which eagerly read
+  // import.meta.env.VITE_SUPABASE_* at load time (e.g. src/lib/supabase/client.ts)
+  // do not throw during tests that don't actually use Supabase.
+  define: {
+    "import.meta.env.VITE_SUPABASE_URL": JSON.stringify("http://localhost:54321"),
+    "import.meta.env.VITE_SUPABASE_ANON_KEY": JSON.stringify("test-anon-key-placeholder"),
+  },
   test: {
     root: __dirname,
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3060.

Closes #3060

---

## Claude summary

All three fixes are committed. Here's a precise summary of what was repaired and why:

---

**Fix 1 — `vitest.frontend.config.ts` (VITE_SUPABASE_URL)**

`src/lib/supabase/client.ts` throws an error at module load time when `VITE_SUPABASE_URL` is not set. The test `document-extensions.test.ts` tests only TipTap extension metadata but its import chain pulls in `form-field-node.tsx → use-supabase-custom-fields → supabase-provider → client.ts`. Added safe placeholder values via Vite's `define` so the guard passes without any real credentials.

**Fix 2 — `src/lib/format-action-error.ts` (connection error message)**

`cleanConvexMessage()` had a regex `/^\s*\[CONVEX[^\]]*\][^\n]*\n?/i` that stripped everything on the same line as the `[CONVEX ...]` bracket. For Convex connection errors (format: `[CONVEX A(...)] Connection lost while action was in flight. Called by client` — all one line), the regex consumed the entire error payload, leaving an empty string that matched no error map entry. Fix: the first pass now requires a trailing `\n` to strip a full banner line; a second pass strips only the `[CONVEX ...]` token when no newline follows, preserving the inline payload.

**Fix 3 — `src/components/layout/app-sidebar.test.tsx` (AppSidebar)**

The `@cvx/_generated/api` mock was missing `api.app` entirely → `TypeError: Cannot read properties of undefined (reading 'getCurrentUser')` on line 104. The module registry mock was also missing `settingsNav: []` → `.flatMap()` returned `undefined` items that crashed on `item.adminOnly` access. Added both, plus `productKey` and a proper `workspace` shape with a distinct `nameKey` so the icon-only assertion (which checks that the wide panel's page-context title disappears) doesn't collide with the narrow sidebar's workspace name.

## Follow-ups

- Add `openai` package or mock to convex test suite: `deliveryItemMatching.test.ts` fails with "Cannot find package 'openai'" — 4 tests fail pre-existing, likely introduced with the AI/OCR feature; the package needs to be installed or stubbed for the test environment.