### PR TITLE
Add `openai` package or mock to convex test suite

### DIFF
--- a/tests/convex/deliveryItemMatching.test.ts
+++ b/tests/convex/deliveryItemMatching.test.ts
@@ -6,7 +6,7 @@
 //           persisted and that re-running replaces only matchingProposals (not
 //           analysisResult).
 
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { api } from "../../convex/_generated/api";
 import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
@@ -17,6 +17,14 @@ import {
 } from "../../convex/_ai/invoiceMatching";
 import type { ParsedInvoiceItem } from "../../convex/_ai/documentAnalyzer";
 import type { MatchingProposals } from "../../convex/_ai/invoiceMatching";
+
+// matchDeliveryItems does not use the document analyzer, but warehouseDeliveries.ts
+// statically imports getDocumentAnalyzer which chains to openai (not installed in tests).
+// Mock it to avoid the missing-package error, matching the pattern in
+// deliveryInvoiceAnalysis.test.ts and deliveryItemDecisions.test.ts.
+vi.mock("../../convex/_ai/documentAnalyzer", () => ({
+  getDocumentAnalyzer: () => ({ analyzeInvoice: vi.fn() }),
+}));
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3062.

Closes #3062

---

## Claude summary

The fix is committed. Here's what was happening and what changed:

`warehouseDeliveries.ts` has a top-level `import { getDocumentAnalyzer } from "./_ai/documentAnalyzer"`. When any test loads that module (including the Part B tests in `deliveryItemMatching.test.ts`), it triggers the entire static import chain: `documentAnalyzer.ts` → `openaiDocumentAnalyzer.ts` → `import OpenAI from "openai"`. Since `openai` is not installed in the Convex test environment, all 4 Part B action-level tests fail.

The other two test files touching `warehouseDeliveries.ts` (`deliveryInvoiceAnalysis.test.ts` and `deliveryItemDecisions.test.ts`) already have the exact same `vi.mock("../../convex/_ai/documentAnalyzer", ...)` guard for this reason. `deliveryItemMatching.test.ts` was simply missing it. The fix adds the mock and imports `vi` from vitest.