### PR TITLE
Add `api.d.ts` sync step to the PR/merge workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Typecheck convex/
         run: npx tsc -p convex/tsconfig.json
+
+      - name: Check convex/_generated/api.d.ts is in sync
+        run: npm run check:convex-codegen


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3068.

Closes #3068

---

## Claude summary

Done. Added a `check:convex-codegen` step to `.github/workflows/typecheck.yml` (runs after `tsc`). It calls the existing `npm run check:convex-codegen` script (`scripts/check-convex-codegen.mjs`), which exits non-zero if `convex/_generated/api.d.ts` is out of sync with the module files in `convex/`. The script passes cleanly on the current codebase (184 modules in sync). This runs on every PR and push to `main`.