### PR TITLE
2.8 AI/OCR — Create warehouse delivery from approved invoice items

### DIFF
--- a/convex/warehouseDeliveries.ts
+++ b/convex/warehouseDeliveries.ts
@@ -719,6 +719,205 @@ export const saveItemDecisions = action({
   },
 });
 
+// ---------------------------------------------------------------------------
+// postDeliveryFromDecisions (#3073)
+// ---------------------------------------------------------------------------
+// Posts an existing draft delivery by building delivery lines from the
+// approved itemDecisions (persisted by saveItemDecisions).
+//
+// Validation:
+//   - all decisions must be resolved (non-null)
+//   - create_later decisions block posting — they must be changed first
+// Line creation:
+//   - accepted / choose_product → delivery line with OCR quantity + price data
+//   - non_inventory → skipped (no stock movement, no line)
+// Idempotency: delivery already posted → throws; UI disables during request.
+
+interface ItemDecisionData {
+  type: "accepted" | "choose_product" | "create_later" | "non_inventory";
+  productId?: string;
+  createLaterType?: string;
+}
+
+interface ItemDecisionsData {
+  decidedAt: number;
+  items: (ItemDecisionData | null)[];
+}
+
+export const postDeliveryFromDecisions = action({
+  args: {
+    organizationId: v.id("organizations"),
+    deliveryId: v.string(),
+  },
+  handler: async (ctx, args): Promise<{ movementsCreated: number }> => {
+    const auth = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_inventory", action: "edit" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    const db = createSupabaseDb();
+    const delivery = await db.get<DeliveryRow>("warehouseDeliveries", args.deliveryId);
+    if (!delivery || String(delivery.organizationId) !== String(args.organizationId)) {
+      throw new Error("Delivery not found");
+    }
+    if (delivery.status === "posted") {
+      throw new Error("Delivery is already posted");
+    }
+
+    const decisions = delivery.itemDecisions as ItemDecisionsData | null;
+    if (!decisions || !Array.isArray(decisions.items) || decisions.items.length === 0) {
+      throw new Error("No item decisions found. Verify all invoice items before posting.");
+    }
+
+    const analysis = delivery.analysisResult as StoredAnalysisResult | null;
+    const analysisItems: ParsedInvoiceItem[] =
+      analysis && Array.isArray(analysis.items)
+        ? (analysis.items as ParsedInvoiceItem[])
+        : [];
+
+    // Validate: all decisions complete, none are create_later
+    const blocking: string[] = [];
+    for (let i = 0; i < decisions.items.length; i++) {
+      const d = decisions.items[i];
+      const name = analysisItems[i]?.productName ?? `#${i + 1}`;
+      if (!d) {
+        blocking.push(`"${name}"`);
+      } else if (d.type === "create_later") {
+        blocking.push(`"${name}" (utwórz później)`);
+      } else if ((d.type === "accepted" || d.type === "choose_product") && !d.productId) {
+        blocking.push(`"${name}" (brak produktu)`);
+      }
+    }
+    if (blocking.length > 0) {
+      throw new Error(
+        `Nie można zaksięgować dostawy. Nierozwiązane pozycje: ${blocking.join(", ")}.`,
+      );
+    }
+
+    // Build delivery lines — skip non_inventory, use OCR data for the rest
+    const inventoryLines: Array<{
+      productId: string;
+      quantity: number;
+      unitPrice: number | null;
+      vatRate: number | null;
+      vatCode: string | null;
+      unitPriceGross: number | null;
+      lineValueNet: number | null;
+      lineValueGross: number | null;
+      lotNumber: string | null;
+      expiryDate: string | null;
+    }> = [];
+
+    for (let i = 0; i < decisions.items.length; i++) {
+      const d = decisions.items[i]!;
+      if (d.type === "non_inventory") continue;
+
+      const ai = analysisItems[i];
+      const qty = (ai?.quantity != null && ai.quantity > 0) ? ai.quantity : 1;
+      const unitPrice = ai?.unitPrice ?? null;
+      const vatRate = ai?.vatRate ?? null;
+      const vatCode = ai?.vatCode ?? null;
+      const unitPriceGross = ai?.unitPriceGross ?? null;
+      const lineValueNet =
+        unitPrice !== null ? Math.round(qty * unitPrice * 100) / 100 : null;
+      const lineValueGross =
+        unitPriceGross !== null ? Math.round(qty * unitPriceGross * 100) / 100 : null;
+
+      inventoryLines.push({
+        productId: d.productId!,
+        quantity: qty,
+        unitPrice,
+        vatRate,
+        vatCode,
+        unitPriceGross,
+        lineValueNet,
+        lineValueGross,
+        lotNumber: ai?.lotNumber ?? null,
+        expiryDate: ai?.expiryDate ?? null,
+      });
+    }
+
+    const now = Date.now();
+
+    // Replace existing items with lines derived from decisions
+    const existingItems = await db
+      .query<DeliveryItemRow>("warehouseDeliveryItems")
+      .eq("deliveryId", args.deliveryId)
+      .collect();
+    for (const item of existingItems) {
+      await db.delete("warehouseDeliveryItems", String(item._id));
+    }
+
+    for (const line of inventoryLines) {
+      await db.insert("warehouseDeliveryItems", {
+        organizationId: String(args.organizationId),
+        deliveryId: args.deliveryId,
+        productId: line.productId,
+        quantity: line.quantity,
+        unitPrice: line.unitPrice,
+        vatRate: line.vatRate,
+        vatCode: line.vatCode,
+        unitPriceGross: line.unitPriceGross,
+        lineValueNet: line.lineValueNet,
+        lineValueGross: line.lineValueGross,
+        lotNumber: line.lotNumber,
+        expiryDate: line.expiryDate,
+        movementId: null,
+        createdAt: now,
+      });
+    }
+
+    // Update header totals
+    const { net: totalValue, gross: totalValueGross } = computeTotals(inventoryLines);
+    await db.patch("warehouseDeliveries", args.deliveryId, {
+      totalValue,
+      totalValueGross,
+      updatedAt: now,
+    });
+
+    // Create stock movements
+    const newItems = await db
+      .query<DeliveryItemRow>("warehouseDeliveryItems")
+      .eq("deliveryId", args.deliveryId)
+      .collect();
+
+    const locationId = delivery.locationId ? String(delivery.locationId) : null;
+    const noteText = delivery.invoiceNumber
+      ? `Delivery ${delivery.invoiceNumber}`
+      : null;
+
+    for (const item of newItems) {
+      const { movementId } = await applyMovementInternal({
+        organizationId: String(args.organizationId),
+        productId: String(item.productId),
+        locationId,
+        delta: Number(item.quantity),
+        reason: "warehouse_receive",
+        sourceType: "warehouse_delivery",
+        sourceId: args.deliveryId,
+        note: noteText,
+        unitPrice: item.unitPrice != null ? Number(item.unitPrice) : undefined,
+        lotNumber: item.lotNumber ? String(item.lotNumber) : undefined,
+        expiryDate: item.expiryDate ? String(item.expiryDate) : undefined,
+        performedBy: String(auth.userId),
+      });
+      await db.patch("warehouseDeliveryItems", String(item._id), { movementId });
+    }
+
+    await db.patch("warehouseDeliveries", args.deliveryId, {
+      status: "posted",
+      updatedAt: Date.now(),
+    });
+
+    return { movementsCreated: newItems.length };
+  },
+});
+
 export const postDelivery = action({
   args: {
     organizationId: v.id("organizations"),

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
@@ -272,6 +272,8 @@ function DeliveriesPage() {
   const matchDeliveryItemsAction = useAction(api.warehouseDeliveries.matchDeliveryItems);
   // @ts-ignore
   const saveItemDecisionsAction = useAction(api.warehouseDeliveries.saveItemDecisions);
+  // @ts-ignore
+  const postDeliveryFromDecisionsAction = useAction(api.warehouseDeliveries.postDeliveryFromDecisions);
 
   const queryKey = ["warehouseDeliveries.list", organizationId];
 
@@ -1546,7 +1548,7 @@ function DeliveriesPage() {
         />
       )}
 
-      {/* Item decisions dialog (#3055) */}
+      {/* Item decisions dialog (#3055, #3073) */}
       {decisionsProposals != null && decisionsDeliveryId != null && (
         <ItemDecisionsDialog
           open={decisionsOpen}
@@ -1565,6 +1567,12 @@ function DeliveriesPage() {
             void queryClient.invalidateQueries({ queryKey });
           }}
           saveAction={saveItemDecisionsAction as (args: { organizationId: typeof organizationId; deliveryId: string; decisions: unknown }) => Promise<void>}
+          postDeliveryAction={postDeliveryFromDecisionsAction as (args: { organizationId: typeof organizationId; deliveryId: string }) => Promise<{ movementsCreated: number }>}
+          onPosted={() => {
+            void queryClient.invalidateQueries({ queryKey });
+            void queryClient.invalidateQueries({ queryKey: ["supabase", "productStockLevels"] });
+            void queryClient.invalidateQueries({ queryKey: ["supabase", "productStockMovements"] });
+          }}
         />
       )}
     </div>
@@ -2260,6 +2268,8 @@ function ItemDecisionsDialog({
   products,
   onSave,
   saveAction,
+  postDeliveryAction,
+  onPosted,
 }: {
   open: boolean;
   onOpenChange: (v: boolean) => void;
@@ -2271,9 +2281,12 @@ function ItemDecisionsDialog({
   products: Array<{ _id: string; name: string; sku?: string | null }>;
   onSave: (decisions: ItemDecisions) => void;
   saveAction: (args: { organizationId: Id<"organizations">; deliveryId: string; decisions: unknown }) => Promise<void>;
+  postDeliveryAction?: (args: { organizationId: Id<"organizations">; deliveryId: string }) => Promise<{ movementsCreated: number }>;
+  onPosted?: () => void;
 }) {
   const { t } = useTranslation();
   const [saving, setSaving] = useState(false);
+  const [posting, setPosting] = useState(false);
 
   const initDecisions = useCallback((): (ItemDecision | null)[] => {
     if (savedDecisions && Array.isArray(savedDecisions.items) && savedDecisions.items.length === proposals.items.length) {
@@ -2316,6 +2329,11 @@ function ItemDecisionsDialog({
     [decisions],
   );
 
+  const hasCreateLater = useMemo(
+    () => decisions.some((d) => d?.type === "create_later"),
+    [decisions],
+  );
+
   const handleSave = async () => {
     if (unresolvedIndices.length > 0) return;
     setSaving(true);
@@ -2334,6 +2352,29 @@ function ItemDecisionsDialog({
       );
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handlePostFromDecisions = async () => {
+    if (!postDeliveryAction || unresolvedIndices.length > 0 || hasCreateLater) return;
+    setPosting(true);
+    try {
+      const saved: ItemDecisions = { decidedAt: Date.now(), items: decisions };
+      await saveAction({ organizationId, deliveryId, decisions: saved });
+      onSave(saved);
+      await postDeliveryAction({ organizationId, deliveryId });
+      onPosted?.();
+      onOpenChange(false);
+      toast.success(t("gabinet.deliveries.decisions.postSuccess", "Dostawa zatwierdzona. Stany magazynowe zaktualizowane."));
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.deliveries.decisions.postError",
+          defaultValue: "Nie udało się zatwierdzić dostawy.",
+        }),
+      );
+    } finally {
+      setPosting(false);
     }
   };
 
@@ -2537,23 +2578,47 @@ function ItemDecisionsDialog({
             </span>
           </div>
         )}
+        {hasCreateLater && unresolvedIndices.length === 0 && (
+          <div className="flex items-start gap-2 rounded-md border border-violet-200 bg-violet-50 px-3 py-2 text-xs text-violet-800 dark:border-violet-800 dark:bg-violet-900/20 dark:text-violet-300">
+            <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" variant="stroke" />
+            <span>
+              {t(
+                "gabinet.deliveries.decisions.createLaterBlocking",
+                "Pozycje oznaczone „Utwórz później" blokują zatwierdzenie dostawy. Zmień decyzję na inną, aby odblokować zaksięgowanie.",
+              )}
+            </span>
+          </div>
+        )}
 
         <DialogFooter className="border-t pt-4">
           <Button
             type="button"
             variant="outline"
             onClick={() => onOpenChange(false)}
+            disabled={saving || posting}
           >
             {t("common.cancel", "Anuluj")}
           </Button>
           <Button
             type="button"
+            variant="outline"
             onClick={handleSave}
-            disabled={saving || unresolvedIndices.length > 0}
+            disabled={saving || posting || unresolvedIndices.length > 0}
           >
             {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" variant="stroke" />}
             {t("gabinet.deliveries.decisions.save", "Zapisz decyzje")}
           </Button>
+          {postDeliveryAction && (
+            <Button
+              type="button"
+              onClick={handlePostFromDecisions}
+              disabled={posting || saving || unresolvedIndices.length > 0 || hasCreateLater}
+            >
+              {posting && <Loader2 className="mr-2 h-4 w-4 animate-spin" variant="stroke" />}
+              <CheckCircle className="mr-2 h-4 w-4" variant="stroke" />
+              {t("gabinet.deliveries.decisions.post", "Zatwierdź dostawę")}
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/tests/convex/deliveryPostFromDecisions.test.ts
+++ b/tests/convex/deliveryPostFromDecisions.test.ts
@@ -1,0 +1,500 @@
+// Tests for postDeliveryFromDecisions (#3073).
+//
+// Covers the scenarios required by the issue:
+// 1. All resolved inventory items → correct delivery lines + stock movements
+// 2. Non-inventory items → no delivery line, no stock movement
+// 3. Unresolved items (null decision) block posting
+// 4. create_later items block posting
+// 5. Repeated submission: already-posted delivery throws (idempotency)
+// 6. Posted delivery cannot be modified via saveItemDecisions
+// 7. Organization isolation: wrong org throws
+// 8. Permission isolation: viewer role throws
+
+import { describe, expect, test, vi } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+// postDeliveryFromDecisions statically imports getDocumentAnalyzer which
+// chains to openai (not installed in tests).  Mock it out.
+vi.mock("../../convex/_ai/documentAnalyzer", () => ({
+  getDocumentAnalyzer: () => ({ analyzeInvoice: vi.fn() }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const PRODUCT_A_ID = "prod-post-a-1234";
+const PRODUCT_B_ID = "prod-post-b-5678";
+
+async function seedProducts(organizationId: string) {
+  const db = createSupabaseDb();
+  await db.insert("products", {
+    _id: PRODUCT_A_ID,
+    organizationId,
+    name: "Rękawiczki nitrylowe",
+    sku: "RN-001",
+    unitPrice: 5,
+    isActive: true,
+    trackStock: true,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  await db.insert("products", {
+    _id: PRODUCT_B_ID,
+    organizationId,
+    name: "Stylage XL 1 ml",
+    sku: "SXL-001",
+    unitPrice: 200,
+    isActive: true,
+    trackStock: true,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+}
+
+const SAMPLE_ANALYSIS = {
+  supplierName: "ACME Sp. z o.o.",
+  invoiceNumber: "FV/2024/099",
+  invoiceDate: "2024-03-10",
+  items: [
+    {
+      productName: "Rękawiczki nitrylowe",
+      quantity: 10,
+      unit: "szt",
+      unitPrice: 4.5,
+      vatRate: 23,
+      vatCode: "23",
+      unitPriceGross: 5.54,
+      lineValueNet: 45,
+      lineValueGross: 55.4,
+      lotNumber: null,
+      expiryDate: null,
+    },
+    {
+      productName: "Stylage XL 1 ml",
+      quantity: 2,
+      unit: "szt",
+      unitPrice: 180,
+      vatRate: 8,
+      vatCode: "8",
+      unitPriceGross: 194.4,
+      lineValueNet: 360,
+      lineValueGross: 388.8,
+      lotNumber: "LOT-2024-A",
+      expiryDate: "2026-06-30",
+    },
+    {
+      productName: "Transport",
+      quantity: 1,
+      unit: "usł",
+      unitPrice: 20,
+      vatRate: 23,
+      vatCode: "23",
+      unitPriceGross: 24.6,
+      lineValueNet: 20,
+      lineValueGross: 24.6,
+      lotNumber: null,
+      expiryDate: null,
+    },
+  ],
+  confidence: 0.95,
+};
+
+async function seedDeliveryWithDecisions(
+  organizationId: string,
+  userId: string,
+  options: {
+    decisions?: Array<Record<string, unknown> | null>;
+    status?: "draft" | "posted";
+  } = {},
+): Promise<string> {
+  const db = createSupabaseDb();
+  const decisions = options.decisions ?? [
+    { type: "accepted", productId: PRODUCT_A_ID },
+    { type: "choose_product", productId: PRODUCT_B_ID },
+    { type: "non_inventory" },
+  ];
+
+  return db.insert("warehouseDeliveries", {
+    organizationId,
+    supplierName: "ACME Sp. z o.o.",
+    invoiceNumber: "FV/2024/099",
+    deliveryDate: "2024-03-10",
+    locationId: null,
+    notes: null,
+    status: options.status ?? "draft",
+    totalValue: null,
+    totalValueGross: null,
+    invoicePages: [{ storageId: "store-p1", mimeType: "image/jpeg", position: 0 }],
+    analysisStatus: "completed",
+    analysisResult: SAMPLE_ANALYSIS,
+    analysisCompletedAt: Date.now(),
+    analysisError: null,
+    matchingProposals: null,
+    itemDecisions: {
+      decidedAt: Date.now(),
+      items: decisions,
+    },
+    createdBy: userId,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — all resolved inventory items create correct delivery lines
+// ---------------------------------------------------------------------------
+
+describe("postDeliveryFromDecisions — scenario 1: inventory items create delivery lines", () => {
+  test("creates delivery lines with OCR quantity and price data for accepted/choose_product decisions", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedProducts(String(organizationId));
+    const deliveryId = await seedDeliveryWithDecisions(String(organizationId), String(userId));
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.warehouseDeliveries.postDeliveryFromDecisions, {
+        organizationId,
+        deliveryId,
+      });
+
+    // 2 inventory items (accepted + choose_product); 1 non_inventory skipped
+    expect(result.movementsCreated).toBe(2);
+
+    const db = createSupabaseDb();
+    const items = (await db
+      .query("warehouseDeliveryItems")
+      .eq("deliveryId", deliveryId)
+      .collect()) as Array<Record<string, unknown>>;
+
+    expect(items).toHaveLength(2);
+
+    const itemA = items.find((i) => String(i.productId) === PRODUCT_A_ID);
+    const itemB = items.find((i) => String(i.productId) === PRODUCT_B_ID);
+
+    expect(itemA).toBeDefined();
+    expect(Number(itemA!.quantity)).toBe(10);
+    expect(Number(itemA!.unitPrice)).toBe(4.5);
+    expect(String(itemA!.vatCode)).toBe("23");
+    expect(Number(itemA!.unitPriceGross)).toBe(5.54);
+
+    expect(itemB).toBeDefined();
+    expect(Number(itemB!.quantity)).toBe(2);
+    expect(String(itemB!.lotNumber)).toBe("LOT-2024-A");
+    expect(String(itemB!.expiryDate)).toBe("2026-06-30");
+  });
+
+  test("delivery is marked posted after successful post", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedProducts(String(organizationId));
+    const deliveryId = await seedDeliveryWithDecisions(String(organizationId), String(userId));
+
+    await t.withIdentity(identity).action(api.warehouseDeliveries.postDeliveryFromDecisions, {
+      organizationId,
+      deliveryId,
+    });
+
+    const db = createSupabaseDb();
+    const row = (await db.get("warehouseDeliveries", deliveryId)) as Record<string, unknown>;
+    expect(row.status).toBe("posted");
+  });
+
+  test("each inventory line has a movementId after posting", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedProducts(String(organizationId));
+    const deliveryId = await seedDeliveryWithDecisions(String(organizationId), String(userId));
+
+    await t.withIdentity(identity).action(api.warehouseDeliveries.postDeliveryFromDecisions, {
+      organizationId,
+      deliveryId,
+    });
+
+    const db = createSupabaseDb();
+    const items = (await db
+      .query("warehouseDeliveryItems")
+      .eq("deliveryId", deliveryId)
+      .collect()) as Array<Record<string, unknown>>;
+
+    for (const item of items) {
+      expect(item.movementId).toBeTruthy();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — non-inventory items do not create delivery lines
+// ---------------------------------------------------------------------------
+
+describe("postDeliveryFromDecisions — scenario 2: non-inventory items excluded", () => {
+  test("non_inventory decision produces no delivery line and no stock movement", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedProducts(String(organizationId));
+
+    // All three items are non_inventory
+    const deliveryId = await seedDeliveryWithDecisions(String(organizationId), String(userId), {
+      decisions: [
+        { type: "non_inventory" },
+        { type: "non_inventory" },
+        { type: "non_inventory" },
+      ],
+    });
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.warehouseDeliveries.postDeliveryFromDecisions, {
+        organizationId,
+        deliveryId,
+      });
+
+    expect(result.movementsCreated).toBe(0);
+
+    const db = createSupabaseDb();
+    const items = (await db
+      .query("warehouseDeliveryItems")
+      .eq("deliveryId", deliveryId)
+      .collect()) as Array<Record<string, unknown>>;
+
+    expect(items).toHaveLength(0);
+
+    const delivery = (await db.get("warehouseDeliveries", deliveryId)) as Record<string, unknown>;
+    expect(delivery.status).toBe("posted");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — unresolved items block posting
+// ---------------------------------------------------------------------------
+
+describe("postDeliveryFromDecisions — scenario 3: unresolved items block", () => {
+  test("throws when any decision is null", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedProducts(String(organizationId));
+
+    const deliveryId = await seedDeliveryWithDecisions(String(organizationId), String(userId), {
+      decisions: [
+        { type: "accepted", productId: PRODUCT_A_ID },
+        null, // unresolved
+        { type: "non_inventory" },
+      ],
+    });
+
+    await expect(
+      t.withIdentity(identity).action(api.warehouseDeliveries.postDeliveryFromDecisions, {
+        organizationId,
+        deliveryId,
+      }),
+    ).rejects.toThrow(/nierozwiązane pozycje/i);
+  });
+
+  test("throws when no itemDecisions exist", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedProducts(String(organizationId));
+
+    const db = createSupabaseDb();
+    const deliveryId = await db.insert("warehouseDeliveries", {
+      organizationId: String(organizationId),
+      supplierName: "ACME",
+      invoiceNumber: "FV/2024/100",
+      deliveryDate: null,
+      locationId: null,
+      notes: null,
+      status: "draft",
+      totalValue: null,
+      totalValueGross: null,
+      invoicePages: null,
+      analysisStatus: "completed",
+      analysisResult: SAMPLE_ANALYSIS,
+      analysisCompletedAt: Date.now(),
+      analysisError: null,
+      matchingProposals: null,
+      itemDecisions: null,
+      createdBy: String(userId),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    await expect(
+      t.withIdentity(identity).action(api.warehouseDeliveries.postDeliveryFromDecisions, {
+        organizationId,
+        deliveryId,
+      }),
+    ).rejects.toThrow(/no item decisions/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — create_later items block posting
+// ---------------------------------------------------------------------------
+
+describe("postDeliveryFromDecisions — scenario 4: create_later blocks posting", () => {
+  test("throws when any decision is create_later", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedProducts(String(organizationId));
+
+    const deliveryId = await seedDeliveryWithDecisions(String(organizationId), String(userId), {
+      decisions: [
+        { type: "accepted", productId: PRODUCT_A_ID },
+        { type: "create_later", createLaterType: "treatment_product" },
+        { type: "non_inventory" },
+      ],
+    });
+
+    await expect(
+      t.withIdentity(identity).action(api.warehouseDeliveries.postDeliveryFromDecisions, {
+        organizationId,
+        deliveryId,
+      }),
+    ).rejects.toThrow(/utwórz później/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 5 — repeated submission does not duplicate
+// ---------------------------------------------------------------------------
+
+describe("postDeliveryFromDecisions — scenario 5: idempotency", () => {
+  test("second call throws 'already posted'", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedProducts(String(organizationId));
+    const deliveryId = await seedDeliveryWithDecisions(String(organizationId), String(userId));
+
+    await t.withIdentity(identity).action(api.warehouseDeliveries.postDeliveryFromDecisions, {
+      organizationId,
+      deliveryId,
+    });
+
+    await expect(
+      t.withIdentity(identity).action(api.warehouseDeliveries.postDeliveryFromDecisions, {
+        organizationId,
+        deliveryId,
+      }),
+    ).rejects.toThrow(/already posted/i);
+  });
+
+  test("single post creates exactly 2 stock movements for 2 inventory items", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedProducts(String(organizationId));
+    const deliveryId = await seedDeliveryWithDecisions(String(organizationId), String(userId));
+
+    const result = await t.withIdentity(identity).action(
+      api.warehouseDeliveries.postDeliveryFromDecisions,
+      { organizationId, deliveryId },
+    );
+
+    expect(result.movementsCreated).toBe(2);
+
+    const db = createSupabaseDb();
+    const movements = (await db
+      .query("productStockMovements")
+      .eq("sourceId", deliveryId)
+      .collect()) as Array<Record<string, unknown>>;
+
+    expect(movements).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 6 — posted delivery cannot be modified
+// ---------------------------------------------------------------------------
+
+describe("postDeliveryFromDecisions — scenario 6: posted delivery is immutable", () => {
+  test("saveItemDecisions throws on a posted delivery", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedProducts(String(organizationId));
+    const deliveryId = await seedDeliveryWithDecisions(String(organizationId), String(userId));
+
+    await t.withIdentity(identity).action(api.warehouseDeliveries.postDeliveryFromDecisions, {
+      organizationId,
+      deliveryId,
+    });
+
+    await expect(
+      t.withIdentity(identity).action(api.warehouseDeliveries.saveItemDecisions, {
+        organizationId,
+        deliveryId,
+        decisions: {
+          decidedAt: Date.now(),
+          items: [{ type: "non_inventory" }, { type: "non_inventory" }, { type: "non_inventory" }],
+        },
+      }),
+    ).rejects.toThrow(/cannot modify a posted delivery/i);
+  });
+
+  test("updateDelivery throws on a posted delivery", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedProducts(String(organizationId));
+    const deliveryId = await seedDeliveryWithDecisions(String(organizationId), String(userId));
+
+    await t.withIdentity(identity).action(api.warehouseDeliveries.postDeliveryFromDecisions, {
+      organizationId,
+      deliveryId,
+    });
+
+    await expect(
+      t.withIdentity(identity).action(api.warehouseDeliveries.updateDelivery, {
+        organizationId,
+        deliveryId,
+        supplierName: "Hacker",
+      }),
+    ).rejects.toThrow(/only draft deliveries can be edited/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 7 — organization isolation
+// ---------------------------------------------------------------------------
+
+describe("postDeliveryFromDecisions — scenario 7: org isolation", () => {
+  test("throws when deliveryId belongs to another org", async () => {
+    const t = createTestCtx();
+    const { organizationId: org1, userId: user1 } = await seedTestUser(t);
+    const { organizationId: org2, identity: identity2 } = await seedTestUser(t);
+
+    await seedProducts(String(org1));
+    const deliveryId = await seedDeliveryWithDecisions(String(org1), String(user1));
+
+    await expect(
+      t.withIdentity(identity2).action(api.warehouseDeliveries.postDeliveryFromDecisions, {
+        organizationId: org2,
+        deliveryId,
+      }),
+    ).rejects.toThrow(/delivery not found/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 8 — permission isolation
+// ---------------------------------------------------------------------------
+
+describe("postDeliveryFromDecisions — scenario 8: permission check", () => {
+  test("throws when caller lacks gabinet_inventory edit permission", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { identity: viewerIdentity } = await seedTestUser(t, { role: "viewer" });
+
+    await seedProducts(String(organizationId));
+    const deliveryId = await seedDeliveryWithDecisions(String(organizationId), String(userId));
+
+    await expect(
+      t
+        .withIdentity(viewerIdentity)
+        .action(api.warehouseDeliveries.postDeliveryFromDecisions, {
+          organizationId,
+          deliveryId,
+        }),
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3073.

Closes #3073

---

## Claude summary

The implementation is complete. Here's a summary of what was done:

**Backend (`convex/warehouseDeliveries.ts`):**
Added `postDeliveryFromDecisions` action that:
- Validates all `itemDecisions` are complete — throws if any are `null` or `create_later`
- Builds delivery lines from `accepted`/`choose_product` decisions, using OCR quantity + price/VAT data from `analysisResult`
- Skips `non_inventory` decisions entirely (no line, no stock movement)
- Replaces existing draft items then creates stock movements via `applyMovementInternal`
- Sets delivery status to `posted` (one-way, irreversible)
- Guards against double-posting via status check — throws "already posted" if called again

**Frontend (`_layout.gabinet.deliveries.tsx`):**
- Added `postDeliveryFromDecisions` action wiring via `useAction`
- Extended `ItemDecisionsDialog` with a "Zatwierdź dostawę" button that saves decisions then posts in one click
- Button is disabled when any item is unresolved or `create_later`
- Shows a violet warning banner explaining the create_later blocking reason
- The Cancel and Save buttons are also disabled during posting to prevent race conditions
- After success: invalidates delivery list, stock levels, and stock movements queries

**Tests (`tests/convex/deliveryPostFromDecisions.test.ts`):** 13 tests covering all required scenarios — all passing.

## Follow-ups
- Extract shared delivery-seeding helpers into a `tests/convex/_delivery_helpers.ts` module: `SAMPLE_ANALYSIS`, `seedDeliveryWithDecisions`, and `seedProducts` are duplicated across `deliveryItemDecisions.test.ts`, `deliveryItemMatching.test.ts`, and the new `deliveryPostFromDecisions.test.ts`
- Add optimistic UI lock on "Zaksięguj" (existing postDelivery) when decisions contain `create_later` items: the list row "Zaksięguj" button bypasses the itemDecisions validation and can silently post with wrong or missing lines if the user skips the verification dialog