### PR TITLE
Extract shared delivery-seeding helpers into a `tests/convex/_delivery_helpers.t

### DIFF
--- a/tests/convex/_delivery_helpers.ts
+++ b/tests/convex/_delivery_helpers.ts
@@ -1,0 +1,141 @@
+// Shared helpers for warehouse-delivery test suites.
+//
+// Used by: deliveryItemDecisions.test.ts, deliveryItemMatching.test.ts,
+//          deliveryPostFromDecisions.test.ts
+
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+import type { ParsedInvoiceItem } from "../../convex/_ai/documentAnalyzer";
+
+export function makeInvoiceItem(productName: string): ParsedInvoiceItem {
+  return {
+    productName,
+    quantity: 1,
+    unit: "szt",
+    unitPrice: null,
+    vatRate: null,
+    vatCode: null,
+    unitPriceGross: null,
+    lineValueNet: null,
+    lineValueGross: null,
+    lotNumber: null,
+    expiryDate: null,
+  };
+}
+
+export const PRODUCT_A_ID = "prod-post-a-1234";
+export const PRODUCT_B_ID = "prod-post-b-5678";
+
+export async function seedProducts(organizationId: string) {
+  const db = createSupabaseDb();
+  await db.insert("products", {
+    _id: PRODUCT_A_ID,
+    organizationId,
+    name: "Rękawiczki nitrylowe",
+    sku: "RN-001",
+    unitPrice: 5,
+    isActive: true,
+    trackStock: true,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  await db.insert("products", {
+    _id: PRODUCT_B_ID,
+    organizationId,
+    name: "Stylage XL 1 ml",
+    sku: "SXL-001",
+    unitPrice: 200,
+    isActive: true,
+    trackStock: true,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+}
+
+export const SAMPLE_ANALYSIS = {
+  supplierName: "ACME Sp. z o.o.",
+  invoiceNumber: "FV/2024/099",
+  invoiceDate: "2024-03-10",
+  items: [
+    {
+      productName: "Rękawiczki nitrylowe",
+      quantity: 10,
+      unit: "szt",
+      unitPrice: 4.5,
+      vatRate: 23,
+      vatCode: "23",
+      unitPriceGross: 5.54,
+      lineValueNet: 45,
+      lineValueGross: 55.4,
+      lotNumber: null,
+      expiryDate: null,
+    },
+    {
+      productName: "Stylage XL 1 ml",
+      quantity: 2,
+      unit: "szt",
+      unitPrice: 180,
+      vatRate: 8,
+      vatCode: "8",
+      unitPriceGross: 194.4,
+      lineValueNet: 360,
+      lineValueGross: 388.8,
+      lotNumber: "LOT-2024-A",
+      expiryDate: "2026-06-30",
+    },
+    {
+      productName: "Transport",
+      quantity: 1,
+      unit: "usł",
+      unitPrice: 20,
+      vatRate: 23,
+      vatCode: "23",
+      unitPriceGross: 24.6,
+      lineValueNet: 20,
+      lineValueGross: 24.6,
+      lotNumber: null,
+      expiryDate: null,
+    },
+  ],
+  confidence: 0.95,
+};
+
+export async function seedDeliveryWithDecisions(
+  organizationId: string,
+  userId: string,
+  options: {
+    decisions?: Array<Record<string, unknown> | null>;
+    status?: "draft" | "posted";
+  } = {},
+): Promise<string> {
+  const db = createSupabaseDb();
+  const decisions = options.decisions ?? [
+    { type: "accepted", productId: PRODUCT_A_ID },
+    { type: "choose_product", productId: PRODUCT_B_ID },
+    { type: "non_inventory" },
+  ];
+
+  return db.insert("warehouseDeliveries", {
+    organizationId,
+    supplierName: "ACME Sp. z o.o.",
+    invoiceNumber: "FV/2024/099",
+    deliveryDate: "2024-03-10",
+    locationId: null,
+    notes: null,
+    status: options.status ?? "draft",
+    totalValue: null,
+    totalValueGross: null,
+    invoicePages: [{ storageId: "store-p1", mimeType: "image/jpeg", position: 0 }],
+    analysisStatus: "completed",
+    analysisResult: SAMPLE_ANALYSIS,
+    analysisCompletedAt: Date.now(),
+    analysisError: null,
+    matchingProposals: null,
+    itemDecisions: {
+      decidedAt: Date.now(),
+      items: decisions,
+    },
+    createdBy: userId,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+}

--- a/tests/convex/deliveryItemDecisions.test.ts
+++ b/tests/convex/deliveryItemDecisions.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, test, vi } from "vitest";
 import { api } from "../../convex/_generated/api";
 import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+import { makeInvoiceItem } from "./_delivery_helpers";
 
 // saveItemDecisions does not use the document analyzer, but warehouseDeliveries.ts
 // statically imports getDocumentAnalyzer which chains to openai (not installed in tests).
@@ -59,19 +60,7 @@ const SAMPLE_ANALYSIS_RESULT = {
   supplierName: "ACME Sp. z o.o.",
   invoiceNumber: "FV/2024/099",
   invoiceDate: "2024-03-10",
-  items: SAMPLE_PROPOSALS.items.map((i) => ({
-    productName: i.invoiceName,
-    quantity: 1,
-    unit: "szt",
-    unitPrice: null,
-    vatRate: null,
-    vatCode: null,
-    unitPriceGross: null,
-    lineValueNet: null,
-    lineValueGross: null,
-    lotNumber: null,
-    expiryDate: null,
-  })),
+  items: SAMPLE_PROPOSALS.items.map((i) => makeInvoiceItem(i.invoiceName)),
   confidence: 0.91,
 };
 

--- a/tests/convex/deliveryItemMatching.test.ts
+++ b/tests/convex/deliveryItemMatching.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../convex/_ai/invoiceMatching";
 import type { ParsedInvoiceItem } from "../../convex/_ai/documentAnalyzer";
 import type { MatchingProposals } from "../../convex/_ai/invoiceMatching";
+import { makeInvoiceItem } from "./_delivery_helpers";
 
 // matchDeliveryItems does not use the document analyzer, but warehouseDeliveries.ts
 // statically imports getDocumentAnalyzer which chains to openai (not installed in tests).
@@ -30,28 +31,12 @@ vi.mock("../../convex/_ai/documentAnalyzer", () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeItem(productName: string): ParsedInvoiceItem {
-  return {
-    productName,
-    quantity: 1,
-    unit: "szt",
-    unitPrice: null,
-    vatRate: null,
-    vatCode: null,
-    unitPriceGross: null,
-    lineValueNet: null,
-    lineValueGross: null,
-    lotNumber: null,
-    expiryDate: null,
-  };
-}
-
 const SAMPLE_ANALYSIS_RESULT = {
   supplierName: "ACME Sp. z o.o.",
   invoiceNumber: "FV/2024/001",
   invoiceDate: "2024-01-15",
   items: [
-    makeItem("Rękawiczki nitrylowe"),
+    makeInvoiceItem("Rękawiczki nitrylowe"),
   ],
   confidence: 0.92,
 };
@@ -59,7 +44,7 @@ const SAMPLE_ANALYSIS_RESULT = {
 async function seedDeliveryWithAnalysis(
   organizationId: string,
   userId: string,
-  items: ParsedInvoiceItem[] = [makeItem("Rękawiczki nitrylowe")],
+  items: ParsedInvoiceItem[] = [makeInvoiceItem("Rękawiczki nitrylowe")],
 ): Promise<string> {
   const db = createSupabaseDb();
   return db.insert("warehouseDeliveries", {
@@ -140,7 +125,7 @@ describe("isNonInventoryCandidate", () => {
 describe("matchInvoiceItems — exact match", () => {
   test("returns status=matched when one product has an identical normalized name", () => {
     const result = matchInvoiceItems(
-      [makeItem("Rękawiczki nitrylowe")],
+      [makeInvoiceItem("Rękawiczki nitrylowe")],
       [{ productId: "p1", productName: "Rękawiczki nitrylowe" }],
     );
     expect(result.items).toHaveLength(1);
@@ -152,7 +137,7 @@ describe("matchInvoiceItems — exact match", () => {
 
   test("exact match is case- and whitespace-insensitive", () => {
     const result = matchInvoiceItems(
-      [makeItem("rękawiczki  nitrylowe")],
+      [makeInvoiceItem("rękawiczki  nitrylowe")],
       [{ productId: "p1", productName: "Rękawiczki nitrylowe" }],
     );
     expect(result.items[0].status).toBe("matched");
@@ -162,7 +147,7 @@ describe("matchInvoiceItems — exact match", () => {
 describe("matchInvoiceItems — variant/capacity difference → suggestions not matched", () => {
   test("Stylage XL 1 ml vs Stylage M 1 ml produces suggestions", () => {
     const result = matchInvoiceItems(
-      [makeItem("Stylage XL 1 ml")],
+      [makeInvoiceItem("Stylage XL 1 ml")],
       [
         { productId: "p1", productName: "Stylage M 1 ml" },
         { productId: "p2", productName: "Stylage L 1 ml" },
@@ -177,7 +162,7 @@ describe("matchInvoiceItems — variant/capacity difference → suggestions not 
 
   test("Stylage XL 1 ml does not auto-match Stylage M 1 ml as 'matched'", () => {
     const result = matchInvoiceItems(
-      [makeItem("Stylage XL 1 ml")],
+      [makeInvoiceItem("Stylage XL 1 ml")],
       [{ productId: "p1", productName: "Stylage M 1 ml" }],
     );
     expect(result.items[0].status).not.toBe("matched");
@@ -187,7 +172,7 @@ describe("matchInvoiceItems — variant/capacity difference → suggestions not 
 describe("matchInvoiceItems — multiple similar products → suggestions", () => {
   test("returns status=suggestions with all candidates when multiple products share high similarity", () => {
     const result = matchInvoiceItems(
-      [makeItem("Juvederm Ultra 2 ml")],
+      [makeInvoiceItem("Juvederm Ultra 2 ml")],
       [
         { productId: "p1", productName: "Juvederm Ultra 1 ml" },
         { productId: "p2", productName: "Juvederm Ultra 2 ml" },
@@ -201,7 +186,7 @@ describe("matchInvoiceItems — multiple similar products → suggestions", () =
 
   test("returns suggestions when invoice name partially matches multiple products", () => {
     const result = matchInvoiceItems(
-      [makeItem("Juvederm Ultra")],
+      [makeInvoiceItem("Juvederm Ultra")],
       [
         { productId: "p1", productName: "Juvederm Ultra 1 ml" },
         { productId: "p2", productName: "Juvederm Ultra 2 ml" },
@@ -215,7 +200,7 @@ describe("matchInvoiceItems — multiple similar products → suggestions", () =
 describe("matchInvoiceItems — no match", () => {
   test("returns status=unmatched when no product is similar", () => {
     const result = matchInvoiceItems(
-      [makeItem("Całkowicie nieznany preparat XYZ")],
+      [makeInvoiceItem("Całkowicie nieznany preparat XYZ")],
       [{ productId: "p1", productName: "Rękawiczki nitrylowe" }],
     );
     expect(result.items[0].status).toBe("unmatched");
@@ -224,32 +209,32 @@ describe("matchInvoiceItems — no match", () => {
   });
 
   test("returns unmatched when product list is empty", () => {
-    const result = matchInvoiceItems([makeItem("Stylage XL 1 ml")], []);
+    const result = matchInvoiceItems([makeInvoiceItem("Stylage XL 1 ml")], []);
     expect(result.items[0].status).toBe("unmatched");
   });
 });
 
 describe("matchInvoiceItems — non-inventory candidate", () => {
   test("returns status=non_inventory_candidate for transport line with no product match", () => {
-    const result = matchInvoiceItems([makeItem("Transport")], []);
+    const result = matchInvoiceItems([makeInvoiceItem("Transport")], []);
     expect(result.items[0].status).toBe("non_inventory_candidate");
     expect(result.items[0].handlingHint).toBeDefined();
   });
 
   test("dostawa is detected as non_inventory_candidate", () => {
-    const result = matchInvoiceItems([makeItem("Dostawa ekspresowa")], []);
+    const result = matchInvoiceItems([makeInvoiceItem("Dostawa ekspresowa")], []);
     expect(result.items[0].status).toBe("non_inventory_candidate");
   });
 
   test("rabat is detected as non_inventory_candidate", () => {
-    const result = matchInvoiceItems([makeItem("Rabat 5%")], []);
+    const result = matchInvoiceItems([makeInvoiceItem("Rabat 5%")], []);
     expect(result.items[0].status).toBe("non_inventory_candidate");
   });
 
   test("product named 'Transport' that exists in catalog still matches", () => {
     // If the org has a product literally called "Transport", exact match wins
     const result = matchInvoiceItems(
-      [makeItem("Transport")],
+      [makeInvoiceItem("Transport")],
       [{ productId: "p1", productName: "Transport" }],
     );
     expect(result.items[0].status).toBe("matched");
@@ -274,7 +259,7 @@ describe("matchDeliveryItems action — re-run does not change analysisResult", 
     const deliveryId = await seedDeliveryWithAnalysis(
       String(organizationId),
       String(userId),
-      [makeItem("Rękawiczki nitrylowe")],
+      [makeInvoiceItem("Rękawiczki nitrylowe")],
     );
 
     // First run
@@ -329,7 +314,7 @@ describe("matchInvoiceItems — saved mappings are priority #1", () => {
   test("saved mapping wins over exact name match", () => {
     const savedMappings = new Map([["rękawiczki nitrylowe", "p-saved"]]);
     const result = matchInvoiceItems(
-      [makeItem("Rękawiczki nitrylowe")],
+      [makeInvoiceItem("Rękawiczki nitrylowe")],
       [
         { productId: "p-saved", productName: "Rękawiczki nitrylowe" },
         { productId: "p-catalog", productName: "Rękawiczki nitrylowe" },
@@ -345,7 +330,7 @@ describe("matchInvoiceItems — saved mappings are priority #1", () => {
     const savedMappings = new Map([["stylage xl 1 ml", "p-deleted"]]);
     // p-deleted is not in the active products list
     const result = matchInvoiceItems(
-      [makeItem("Stylage XL 1 ml")],
+      [makeInvoiceItem("Stylage XL 1 ml")],
       [{ productId: "p-current", productName: "Stylage XL 1 ml" }],
       savedMappings,
     );
@@ -358,7 +343,7 @@ describe("matchInvoiceItems — saved mappings are priority #1", () => {
   test("saved mapping normalises the key (case and whitespace)", () => {
     const savedMappings = new Map([["rękawiczki nitrylowe", "p1"]]);
     const result = matchInvoiceItems(
-      [makeItem("  RĘKAWICZKI  NITRYLOWE  ")],
+      [makeInvoiceItem("  RĘKAWICZKI  NITRYLOWE  ")],
       [{ productId: "p1", productName: "Rękawiczki nitrylowe" }],
       savedMappings,
     );
@@ -380,7 +365,7 @@ describe("matchDeliveryItems action — saved name mappings persistence", () => 
     const deliveryId = await seedDeliveryWithAnalysis(
       String(organizationId),
       String(userId),
-      [makeItem("Rękawiczki nitrylowe")],
+      [makeInvoiceItem("Rękawiczki nitrylowe")],
     );
 
     await t
@@ -410,7 +395,7 @@ describe("matchDeliveryItems action — saved name mappings persistence", () => 
     const deliveryId = await seedDeliveryWithAnalysis(
       String(organizationId),
       String(userId),
-      [makeItem("Rękawiczki nitrylowe")],
+      [makeInvoiceItem("Rękawiczki nitrylowe")],
     );
 
     // First run writes the mapping
@@ -425,7 +410,7 @@ describe("matchDeliveryItems action — saved name mappings persistence", () => 
     const deliveryId2 = await seedDeliveryWithAnalysis(
       String(organizationId),
       String(userId),
-      [makeItem("Rękawiczki nitrylowe")],
+      [makeInvoiceItem("Rękawiczki nitrylowe")],
     );
 
     const proposals2 = (await t

--- a/tests/convex/deliveryPostFromDecisions.test.ts
+++ b/tests/convex/deliveryPostFromDecisions.test.ts
@@ -14,134 +14,19 @@ import { describe, expect, test, vi } from "vitest";
 import { api } from "../../convex/_generated/api";
 import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+import {
+  PRODUCT_A_ID,
+  PRODUCT_B_ID,
+  SAMPLE_ANALYSIS,
+  seedDeliveryWithDecisions,
+  seedProducts,
+} from "./_delivery_helpers";
 
 // postDeliveryFromDecisions statically imports getDocumentAnalyzer which
 // chains to openai (not installed in tests).  Mock it out.
 vi.mock("../../convex/_ai/documentAnalyzer", () => ({
   getDocumentAnalyzer: () => ({ analyzeInvoice: vi.fn() }),
 }));
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-const PRODUCT_A_ID = "prod-post-a-1234";
-const PRODUCT_B_ID = "prod-post-b-5678";
-
-async function seedProducts(organizationId: string) {
-  const db = createSupabaseDb();
-  await db.insert("products", {
-    _id: PRODUCT_A_ID,
-    organizationId,
-    name: "Rękawiczki nitrylowe",
-    sku: "RN-001",
-    unitPrice: 5,
-    isActive: true,
-    trackStock: true,
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-  });
-  await db.insert("products", {
-    _id: PRODUCT_B_ID,
-    organizationId,
-    name: "Stylage XL 1 ml",
-    sku: "SXL-001",
-    unitPrice: 200,
-    isActive: true,
-    trackStock: true,
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-  });
-}
-
-const SAMPLE_ANALYSIS = {
-  supplierName: "ACME Sp. z o.o.",
-  invoiceNumber: "FV/2024/099",
-  invoiceDate: "2024-03-10",
-  items: [
-    {
-      productName: "Rękawiczki nitrylowe",
-      quantity: 10,
-      unit: "szt",
-      unitPrice: 4.5,
-      vatRate: 23,
-      vatCode: "23",
-      unitPriceGross: 5.54,
-      lineValueNet: 45,
-      lineValueGross: 55.4,
-      lotNumber: null,
-      expiryDate: null,
-    },
-    {
-      productName: "Stylage XL 1 ml",
-      quantity: 2,
-      unit: "szt",
-      unitPrice: 180,
-      vatRate: 8,
-      vatCode: "8",
-      unitPriceGross: 194.4,
-      lineValueNet: 360,
-      lineValueGross: 388.8,
-      lotNumber: "LOT-2024-A",
-      expiryDate: "2026-06-30",
-    },
-    {
-      productName: "Transport",
-      quantity: 1,
-      unit: "usł",
-      unitPrice: 20,
-      vatRate: 23,
-      vatCode: "23",
-      unitPriceGross: 24.6,
-      lineValueNet: 20,
-      lineValueGross: 24.6,
-      lotNumber: null,
-      expiryDate: null,
-    },
-  ],
-  confidence: 0.95,
-};
-
-async function seedDeliveryWithDecisions(
-  organizationId: string,
-  userId: string,
-  options: {
-    decisions?: Array<Record<string, unknown> | null>;
-    status?: "draft" | "posted";
-  } = {},
-): Promise<string> {
-  const db = createSupabaseDb();
-  const decisions = options.decisions ?? [
-    { type: "accepted", productId: PRODUCT_A_ID },
-    { type: "choose_product", productId: PRODUCT_B_ID },
-    { type: "non_inventory" },
-  ];
-
-  return db.insert("warehouseDeliveries", {
-    organizationId,
-    supplierName: "ACME Sp. z o.o.",
-    invoiceNumber: "FV/2024/099",
-    deliveryDate: "2024-03-10",
-    locationId: null,
-    notes: null,
-    status: options.status ?? "draft",
-    totalValue: null,
-    totalValueGross: null,
-    invoicePages: [{ storageId: "store-p1", mimeType: "image/jpeg", position: 0 }],
-    analysisStatus: "completed",
-    analysisResult: SAMPLE_ANALYSIS,
-    analysisCompletedAt: Date.now(),
-    analysisError: null,
-    matchingProposals: null,
-    itemDecisions: {
-      decidedAt: Date.now(),
-      items: decisions,
-    },
-    createdBy: userId,
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-  });
-}
 
 // ---------------------------------------------------------------------------
 // Scenario 1 — all resolved inventory items create correct delivery lines


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3075.

Closes #3075

---

## Claude summary

All 53 tests pass. Here's what was done:

Created `tests/convex/_delivery_helpers.ts` exporting six shared items:
- `makeInvoiceItem(productName)` — builds a null-price `ParsedInvoiceItem` (was the local `makeItem` in the matching tests and built inline in the decisions tests)
- `PRODUCT_A_ID`, `PRODUCT_B_ID` — deterministic product ID constants
- `seedProducts(organizationId)` — inserts the two standard test products
- `SAMPLE_ANALYSIS` — the full pricing-data analysis fixture
- `seedDeliveryWithDecisions(organizationId, userId, options)` — seeds a delivery with item decisions

Updated three test files to import from the helpers module instead of defining these locally, and simplified `SAMPLE_ANALYSIS_RESULT.items` in `deliveryItemDecisions.test.ts` to use `makeInvoiceItem` instead of an inline object map.