### PR TITLE
Add optimistic UI lock on "Zaksięguj" (existing postDelivery) when decisions con

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
@@ -42,6 +42,12 @@ import {
 } from "@/components/ui/dialog";
 import { Plus, Trash2, TruckIcon, Loader2, CheckCircle, ChevronUp, ChevronDown, FileText, Sparkles, RefreshCw, AlertCircle, X } from "@/lib/ez-icons";
 import { formatActionError } from "@/lib/format-action-error";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useSupabaseProductsList, useSupabaseProductStockTotals } from "@/hooks/use-supabase-products";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
 import { cn } from "@/lib/utils";
@@ -789,6 +795,14 @@ function DeliveriesPage() {
                 const createdAt = typeof d.createdAt === "number" ? d.createdAt : null;
                 const delivDate = d.deliveryDate ? String(d.deliveryDate) : null;
                 const label = invoice ?? supplier ?? id.slice(0, 8);
+                const rowItemDecisions =
+                  d.itemDecisions != null && typeof d.itemDecisions === "object"
+                    ? (d.itemDecisions as ItemDecisions)
+                    : null;
+                const hasCreateLater =
+                  rowItemDecisions != null &&
+                  Array.isArray(rowItemDecisions.items) &&
+                  rowItemDecisions.items.some((item) => item?.type === "create_later");
                 const displayValue =
                   typeof d.totalValueGross === "number"
                     ? d.totalValueGross
@@ -846,15 +860,41 @@ function DeliveriesPage() {
                               {t("gabinet.deliveries.checkItemsAction", "Sprawdź pozycje")}
                             </Button>
                           )}
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => setPostTarget({ id, label })}
-                            className="gap-1.5"
-                          >
-                            <CheckCircle className="h-3.5 w-3.5" variant="stroke" />
-                            {t("gabinet.deliveries.postAction", "Zaksięguj")}
-                          </Button>
+                          {hasCreateLater ? (
+                            <TooltipProvider>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span className="inline-flex">
+                                    <Button
+                                      size="sm"
+                                      variant="outline"
+                                      disabled
+                                      className="gap-1.5 pointer-events-none"
+                                    >
+                                      <CheckCircle className="h-3.5 w-3.5" variant="stroke" />
+                                      {t("gabinet.deliveries.postAction", "Zaksięguj")}
+                                    </Button>
+                                  </span>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  {t(
+                                    "gabinet.deliveries.postBlockedCreateLater",
+                                    "Najpierw rozwiąż pozycje „Utwórz później" w weryfikacji faktury.",
+                                  )}
+                                </TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
+                          ) : (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => setPostTarget({ id, label })}
+                              className="gap-1.5"
+                            >
+                              <CheckCircle className="h-3.5 w-3.5" variant="stroke" />
+                              {t("gabinet.deliveries.postAction", "Zaksięguj")}
+                            </Button>
+                          )}
                           <Button
                             size="sm"
                             variant="ghost"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3076.

Closes #3076

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Bug confirmed:** The list-row "Zaksięguj" button called `api.warehouseDeliveries.postDelivery` — the simple posting path that just takes whatever rows are in `warehouseDeliveryItems` and creates stock movements. It ignores `itemDecisions` entirely. A delivery created via the invoice OCR flow starts with no items in `warehouseDeliveryItems`; after the user runs analysis and matching, items are only written when `postDeliveryFromDecisions` is called. If any decision has type `"create_later"`, those products don't exist yet — but the list-row button bypassed the decisions flow entirely, so posting would succeed with zero or wrong movements.

**Fix (one file, `_layout.gabinet.deliveries.tsx`):**
1. Imported `Tooltip`/`TooltipProvider`/`TooltipTrigger`/`TooltipContent` from `@/components/ui/tooltip`
2. In the list row render loop, computed `hasCreateLater` by reading `d.itemDecisions.items` and checking for any `type === "create_later"` entry
3. When `hasCreateLater` is true, renders a disabled "Zaksięguj" button wrapped in a `TooltipProvider`/`Tooltip`/`TooltipTrigger(asChild span)` — the span is necessary because browsers don't fire hover events on disabled buttons — with the tooltip text "Najpierw rozwiąż pozycje „Utwórz później" w weryfikacji faktury."