### PR TITLE
@claude 2.10 OCR — Complete end-to-end automation and final UX polish

### DIFF
--- a/convex/warehouseDeliveries.ts
+++ b/convex/warehouseDeliveries.ts
@@ -749,7 +749,12 @@ export const postDeliveryFromDecisions = action({
     organizationId: v.id("organizations"),
     deliveryId: v.string(),
   },
-  handler: async (ctx, args): Promise<{ movementsCreated: number }> => {
+  handler: async (ctx, args): Promise<{
+    movementsCreated: number;
+    nonInventorySkipped: number;
+    autoMatchedCount: number;
+    newMappingsLearned: number;
+  }> => {
     const auth = await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
@@ -843,6 +848,13 @@ export const postDeliveryFromDecisions = action({
     }
 
     const now = Date.now();
+    let nonInventorySkipped = 0;
+    let autoMatchedCount = 0;
+    for (const d of decisions.items) {
+      if (!d) continue;
+      if (d.type === "non_inventory") nonInventorySkipped++;
+      else if (d.type === "accepted") autoMatchedCount++;
+    }
 
     // Replace existing items with lines derived from decisions
     const existingItems = await db
@@ -917,6 +929,7 @@ export const postDeliveryFromDecisions = action({
     // Save name mappings from approved decisions (#3077).
     // Only runs after a successful post; skips non_inventory, create_later, and
     // null decisions. Upserts so a manual override replaces the previous mapping.
+    let newMappingsLearned = 0;
     const mappingNow = Date.now();
     for (let i = 0; i < decisions.items.length; i++) {
       const d = decisions.items[i]!;
@@ -938,6 +951,7 @@ export const postDeliveryFromDecisions = action({
           productId: d.productId,
           createdAt: mappingNow,
         });
+        newMappingsLearned++;
       } else if (String(existing.productId) !== String(d.productId)) {
         // User chose a different product — update the existing mapping.
         await db.patch("deliveryNameMappings", String(existing._id), {
@@ -947,7 +961,7 @@ export const postDeliveryFromDecisions = action({
       // Same productId as existing mapping → no-op; avoids redundant writes.
     }
 
-    return { movementsCreated: newItems.length };
+    return { movementsCreated: newItems.length, nonInventorySkipped, autoMatchedCount, newMappingsLearned };
   },
 });
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
@@ -175,6 +175,13 @@ interface ItemDecisions {
   items: (ItemDecision | null)[];
 }
 
+interface PostDeliveryResult {
+  movementsCreated: number;
+  nonInventorySkipped: number;
+  autoMatchedCount: number;
+  newMappingsLearned: number;
+}
+
 function isDecisionComplete(d: ItemDecision | null): boolean {
   if (!d) return false;
   if (d.type === "non_inventory") return true;
@@ -1607,7 +1614,7 @@ function DeliveriesPage() {
             void queryClient.invalidateQueries({ queryKey });
           }}
           saveAction={saveItemDecisionsAction as (args: { organizationId: typeof organizationId; deliveryId: string; decisions: unknown }) => Promise<void>}
-          postDeliveryAction={postDeliveryFromDecisionsAction as (args: { organizationId: typeof organizationId; deliveryId: string }) => Promise<{ movementsCreated: number }>}
+          postDeliveryAction={postDeliveryFromDecisionsAction as (args: { organizationId: typeof organizationId; deliveryId: string }) => Promise<PostDeliveryResult>}
           onPosted={() => {
             void queryClient.invalidateQueries({ queryKey });
             void queryClient.invalidateQueries({ queryKey: ["supabase", "productStockLevels"] });
@@ -2321,12 +2328,17 @@ function ItemDecisionsDialog({
   products: Array<{ _id: string; name: string; sku?: string | null }>;
   onSave: (decisions: ItemDecisions) => void;
   saveAction: (args: { organizationId: Id<"organizations">; deliveryId: string; decisions: unknown }) => Promise<void>;
-  postDeliveryAction?: (args: { organizationId: Id<"organizations">; deliveryId: string }) => Promise<{ movementsCreated: number }>;
+  postDeliveryAction?: (args: { organizationId: Id<"organizations">; deliveryId: string }) => Promise<PostDeliveryResult>;
   onPosted?: () => void;
 }) {
   const { t } = useTranslation();
   const [saving, setSaving] = useState(false);
   const [posting, setPosting] = useState(false);
+  const [postSummary, setPostSummary] = useState<PostDeliveryResult | null>(null);
+
+  useEffect(() => {
+    if (!open) setPostSummary(null);
+  }, [open]);
 
   const initDecisions = useCallback((): (ItemDecision | null)[] => {
     if (savedDecisions && Array.isArray(savedDecisions.items) && savedDecisions.items.length === proposals.items.length) {
@@ -2402,10 +2414,9 @@ function ItemDecisionsDialog({
       const saved: ItemDecisions = { decidedAt: Date.now(), items: decisions };
       await saveAction({ organizationId, deliveryId, decisions: saved });
       onSave(saved);
-      await postDeliveryAction({ organizationId, deliveryId });
+      const result = await postDeliveryAction({ organizationId, deliveryId });
       onPosted?.();
-      onOpenChange(false);
-      toast.success(t("gabinet.deliveries.decisions.postSuccess", "Dostawa zatwierdzona. Stany magazynowe zaktualizowane."));
+      setPostSummary(result);
     } catch (e) {
       toast.error(
         formatActionError(e, t, {
@@ -2417,6 +2428,60 @@ function ItemDecisionsDialog({
       setPosting(false);
     }
   };
+
+  if (postSummary) {
+    const manuallyMatched = postSummary.movementsCreated - postSummary.autoMatchedCount;
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <CheckCircle className="h-5 w-5 text-emerald-600" variant="stroke" />
+              {t("gabinet.deliveries.decisions.postDoneTitle", "Dostawa zaksięgowana")}
+            </DialogTitle>
+            <DialogDescription>
+              {t("gabinet.deliveries.decisions.postDoneDesc", "Stany magazynowe zostały zaktualizowane.")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 py-1 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">{t("gabinet.deliveries.decisions.summaryImported", "Produktów dodanych do magazynu")}</span>
+              <span className="font-semibold tabular-nums">{postSummary.movementsCreated}</span>
+            </div>
+            {postSummary.autoMatchedCount > 0 && (
+              <div className="flex justify-between pl-4 text-xs text-muted-foreground">
+                <span>{t("gabinet.deliveries.decisions.summaryAutoMatched", "w tym dopasowanych automatycznie (AI)")}</span>
+                <span className="tabular-nums">{postSummary.autoMatchedCount}</span>
+              </div>
+            )}
+            {manuallyMatched > 0 && (
+              <div className="flex justify-between pl-4 text-xs text-muted-foreground">
+                <span>{t("gabinet.deliveries.decisions.summaryManualMatched", "w tym dopasowanych ręcznie")}</span>
+                <span className="tabular-nums">{manuallyMatched}</span>
+              </div>
+            )}
+            {postSummary.nonInventorySkipped > 0 && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">{t("gabinet.deliveries.decisions.summaryNonInventory", "Pozycji niemagazynowych pominięto")}</span>
+                <span className="font-semibold tabular-nums">{postSummary.nonInventorySkipped}</span>
+              </div>
+            )}
+            {postSummary.newMappingsLearned > 0 && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">{t("gabinet.deliveries.decisions.summaryNewMappings", "Nowych mapowań zapamiętano")}</span>
+                <span className="font-semibold tabular-nums">{postSummary.newMappingsLearned}</span>
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button type="button" onClick={() => onOpenChange(false)}>
+              {t("common.close", "Zamknij")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/tests/convex/deliveryPostFromDecisions.test.ts
+++ b/tests/convex/deliveryPostFromDecisions.test.ts
@@ -50,6 +50,9 @@ describe("postDeliveryFromDecisions — scenario 1: inventory items create deliv
 
     // 2 inventory items (accepted + choose_product); 1 non_inventory skipped
     expect(result.movementsCreated).toBe(2);
+    expect(result.nonInventorySkipped).toBe(1);
+    expect(result.autoMatchedCount).toBe(1); // only "accepted" counts as auto-matched
+    expect(result.newMappingsLearned).toBe(2); // first post learns both inventory names
 
     const db = createSupabaseDb();
     const items = (await db
@@ -140,6 +143,9 @@ describe("postDeliveryFromDecisions — scenario 2: non-inventory items excluded
       });
 
     expect(result.movementsCreated).toBe(0);
+    expect(result.nonInventorySkipped).toBe(3);
+    expect(result.autoMatchedCount).toBe(0);
+    expect(result.newMappingsLearned).toBe(0);
 
     const db = createSupabaseDb();
     const items = (await db
@@ -679,5 +685,69 @@ describe("postDeliveryFromDecisions — scenario 9: name mapping learning", () =
     expect(proposals.items[0].status).toBe("matched");
     expect(proposals.items[0].matched?.matchReason).toBe("saved_mapping");
     expect(proposals.items[0].matched?.productId).toBe(PRODUCT_A_ID);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 10 — completion summary stats (#3081)
+// ---------------------------------------------------------------------------
+
+describe("postDeliveryFromDecisions — scenario 10: completion summary stats", () => {
+  test("returns correct autoMatchedCount for accepted vs choose_product decisions", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedProducts(String(organizationId));
+
+    // accepted=1, choose_product=1, non_inventory=1
+    const deliveryId = await seedDeliveryWithDecisions(String(organizationId), String(userId));
+
+    const result = await t.withIdentity(identity).action(
+      api.warehouseDeliveries.postDeliveryFromDecisions,
+      { organizationId, deliveryId },
+    );
+
+    expect(result.autoMatchedCount).toBe(1);
+  });
+
+  test("returns newMappingsLearned=0 on second post of same invoice names (no duplicates)", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedProducts(String(organizationId));
+
+    const deliveryId1 = await seedDeliveryWithDecisions(String(organizationId), String(userId));
+    const r1 = await t.withIdentity(identity).action(
+      api.warehouseDeliveries.postDeliveryFromDecisions,
+      { organizationId, deliveryId: deliveryId1 },
+    );
+    expect(r1.newMappingsLearned).toBe(2); // first post learns 2 inventory names
+
+    const deliveryId2 = await seedDeliveryWithDecisions(String(organizationId), String(userId));
+    const r2 = await t.withIdentity(identity).action(
+      api.warehouseDeliveries.postDeliveryFromDecisions,
+      { organizationId, deliveryId: deliveryId2 },
+    );
+    expect(r2.newMappingsLearned).toBe(0); // same names already mapped → no new learnings
+  });
+
+  test("nonInventorySkipped matches the number of non_inventory decisions", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await seedProducts(String(organizationId));
+
+    const deliveryId = await seedDeliveryWithDecisions(String(organizationId), String(userId), {
+      decisions: [
+        { type: "accepted", productId: PRODUCT_A_ID },
+        { type: "non_inventory" },
+        { type: "non_inventory" },
+      ],
+    });
+
+    const result = await t.withIdentity(identity).action(
+      api.warehouseDeliveries.postDeliveryFromDecisions,
+      { organizationId, deliveryId },
+    );
+
+    expect(result.movementsCreated).toBe(1);
+    expect(result.nonInventorySkipped).toBe(2);
   });
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3081.

Closes #3081

---

## Claude summary

Here's a summary of what was done for issue #3081:

**Backend (`convex/warehouseDeliveries.ts`):**  
`postDeliveryFromDecisions` now returns four stats instead of just `movementsCreated`:
- `movementsCreated` — inventory lines posted (was already there)
- `nonInventorySkipped` — transport/service/fee items that were intentionally excluded
- `autoMatchedCount` — items the AI auto-matched (type `"accepted"`) vs. manually chosen
- `newMappingsLearned` — new invoice-name→product mappings saved for future imports (updates to existing mappings don't count)

**Frontend (`_layout.gabinet.deliveries.tsx`):**  
After "Zatwierdź dostawę" succeeds, `ItemDecisionsDialog` transitions to a compact summary view inside the same dialog (instead of just showing a toast and closing). The list refreshes in the background while the user reads the summary. The user clicks "Zamknij" to dismiss. The summary shows all four stats, with auto-matched and manually-matched as sub-rows under the total count, and only shows non-zero rows to keep it clean.

**Tests (`deliveryPostFromDecisions.test.ts`):**  
Scenario 1 (default decisions) and Scenario 2 (all non-inventory) now assert the new stat fields. Scenario 10 adds three focused tests: `autoMatchedCount` accuracy, `newMappingsLearned=0` on repeated imports of the same invoice names (idempotency), and `nonInventorySkipped` count with mixed decisions.

## Follow-ups

- Sync `api.d.ts` after backend return-type change: the `postDeliveryFromDecisions` signature changed; per `docs/plans` the manually-maintained `api.d.ts` file may need updating (see the manual procedure doc added in #3071)
- Add "Zaksięguj" quick-post summary for non-OCR deliveries: `handlePostConfirm` (the legacy `postDelivery` path at line 684) still shows only a plain toast with no stats; it could benefit from similar polish but uses a different Convex action