### PR TITLE
Ukryć widget „Najlepsze produkty” w module Magazyn

### DIFF
--- a/src/components/sidebar-widgets/crm/products-widgets.tsx
+++ b/src/components/sidebar-widgets/crm/products-widgets.tsx
@@ -37,7 +37,10 @@ export function ProductsWidgets({ organizationId }: { organizationId: Id<"organi
         ]}
       />
 
-      {topProducts && topProducts.length > 0 && (
+      {/* TODO: Widget „Najlepsze produkty" został celowo ukryty. Kod pozostawiono do możliwego
+          wykorzystania w przyszłości jako panel statystyk, alertów lub AI Insights.
+          Aby przywrócić: usuń `false &&` z poniższego warunku. */}
+      {false && topProducts && topProducts.length > 0 && (
         <Card className="overflow-hidden gap-0 border-0 bg-blue-500 py-4 shadow-none">
           <CardHeader className="px-4">
             <span className="text-base font-medium text-white">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3086.

Closes #3086

---

## Claude summary

Done. Single file changed (`src/components/sidebar-widgets/crm/products-widgets.tsx`), one insertion: `false &&` prepended to the existing `topProducts && topProducts.length > 0 &&` guard, plus the required TODO comment explaining why it was hidden and how to restore it.

The `KpiRow` above the widget is untouched and will continue to render normally. No empty container is left — the entire `Card` expression short-circuits to `false` at React render time. To re-enable the widget in the future: remove `false &&` from line 43.