### PR TITLE
Zmień nazwę „Rodzaj produktu” na „Grupa przeznaczenia produktu”

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -893,7 +893,7 @@
       "sale": "Sales Products",
       "treatment": "Treatment Preparations",
       "disposable": "Disposable Materials",
-      "label": "Product type",
+      "label": "Product destination group",
       "placeholder": "Select product type",
       "none": "None"
     },

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -894,7 +894,7 @@
       "sale": "Produkty do sprzedaży",
       "treatment": "Preparaty zabiegowe",
       "disposable": "Materiały jednorazowe",
-      "label": "Rodzaj produktu",
+      "label": "Grupa przeznaczenia produktu",
       "placeholder": "Wybierz rodzaj produktu",
       "none": "Brak"
     },

--- a/src/components/forms/product-form.tsx
+++ b/src/components/forms/product-form.tsx
@@ -234,7 +234,7 @@ export function ProductForm({
           </div>
         </div>
         <div className="space-y-1.5 sm:col-span-2">
-          <Label>{t("products.sections.label", { defaultValue: "Rodzaj produktu" })}</Label>
+          <Label>{t("products.sections.label", { defaultValue: "Grupa przeznaczenia produktu" })}</Label>
           <Select value={productSection || "none"} onValueChange={(v) => setProductSection(v === "none" ? "" : v as ProductSection)}>
             <SelectTrigger className={!productSection ? "border-purple-300 bg-purple-50/50 dark:border-purple-700 dark:bg-purple-950/20" : ""}>
               <SelectValue placeholder={t("products.sections.placeholder", { defaultValue: "Wybierz rodzaj produktu" })} />

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -473,7 +473,7 @@ function ProductsPage() {
     },
     {
       id: "productSection",
-      label: t("products.sections.label", { defaultValue: "Rodzaj produktu" }),
+      label: t("products.sections.label", { defaultValue: "Grupa przeznaczenia produktu" }),
       render: (item) => {
         if (!item.productSection) return "—";
         return t(`products.sections.${item.productSection}`, { defaultValue: item.productSection });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3098.

Closes #3098

---

## Claude summary

Done. Four files changed, all purely label text — no data model, logic, or migration touched.

Changes made:
- `public/locales/pl/translation.json` — updated the canonical Polish label from "Rodzaj produktu" to "Grupa przeznaczenia produktu"
- `public/locales/en/translation.json` — updated the English equivalent to "Product destination group"
- `src/routes/_app/_auth/dashboard/_layout.products.index.tsx` — updated the `defaultValue` fallback in the table column definition (covers the table header and "Pokaż kolumny" panel, since both use this label)
- `src/components/forms/product-form.tsx` — updated the `defaultValue` fallback in the form label

The column header will naturally wrap to two lines at normal table widths since it's now a longer string — no explicit line-break markup was needed.