### PR TITLE
Przenieś akcje magazynu do najniższego paska

### DIFF
--- a/src/components/layout/app-footer.tsx
+++ b/src/components/layout/app-footer.tsx
@@ -4,13 +4,17 @@ import { Button } from "@/components/ui/button";
 import { LanguageSwitcher } from "@/ui/language-switcher";
 import {
   CalendarCheck,
+  ClipboardList,
   Download,
   Filter,
   Kanban,
   Phone,
   PlusCircle,
   Send,
+  ShoppingCart,
   Tag,
+  TruckIcon,
+  Upload,
   UserPlus,
 } from "@/lib/ez-icons";
 import { useSidebarActions } from "@/components/layout/sidebar-context";
@@ -61,10 +65,12 @@ const routeActions: Record<string, FooterAction[]> = {
     { labelKey: "nav.actions.composeEmail", icon: Send, href: "/dashboard/inbox" },
   ],
   products: [
-    { labelKey: "nav.actions.addProduct", icon: PlusCircle, quickCreate: "document" },
-    { labelKey: "nav.actions.exportCsv", icon: Download, href: "/dashboard/products" },
-    { labelKey: "nav.actions.manageTags", icon: Tag, action: "manageTags" },
-    { labelKey: "nav.actions.manageCategories", icon: Filter, action: "manageCategories" },
+    { labelKey: "nav.actions.addProduct", icon: PlusCircle, action: "addProduct" },
+    { labelKey: "nav.actions.addDelivery", icon: TruckIcon, action: "addDelivery" },
+    { labelKey: "nav.actions.openShoppingList", icon: ShoppingCart, action: "openShoppingList" },
+    { labelKey: "nav.actions.startInventory", icon: ClipboardList, action: "openInventory" },
+    { labelKey: "nav.actions.importCsv", icon: Upload, action: "importCsv" },
+    { labelKey: "nav.actions.exportCsv", icon: Download, action: "exportCsv" },
   ],
 };
 

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -22,7 +22,7 @@ import { SidePanel } from "@/components/crm/side-panel";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Plus, Pencil, Trash2, Power, Upload, Download, X, Package, AlertTriangle, History, Archive, ShoppingCart, TruckIcon, ClipboardList, RotateCcw } from "@/lib/ez-icons";
+import { Plus, Pencil, Trash2, Power, Upload, Download, X, Package, AlertTriangle, History, Archive, RotateCcw } from "@/lib/ez-icons";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { CsvImportDialog } from "@/components/csv/csv-import-dialog";
@@ -221,6 +221,8 @@ function ProductsPage() {
   useSidebarDispatch("manageCategories", () => setCategoriesSlideoutOpen(true));
   useSidebarDispatch("openShoppingList", () => setShoppingListOpen(true));
   useSidebarDispatch("openInventory", () => setInventoryOpen(true));
+  useSidebarDispatch("addProduct", () => openCreatePanel());
+  useSidebarDispatch("addDelivery", () => setAddDeliveryOpen(true));
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
   const [stockAdjustProduct, setStockAdjustProduct] = useState<Product | null>(null);
   const [stockCorrectionProduct, setStockCorrectionProduct] = useState<Product | null>(null);
@@ -882,39 +884,6 @@ function ProductsPage() {
           if (product) openEditPanel(product);
         }}
       />
-
-      {/* Actions section — second access point for common warehouse operations */}
-      <div className="rounded-lg border bg-card p-4">
-        <h3 className="mb-3 text-sm font-semibold text-muted-foreground">
-          {t("products.actionsSection.title", { defaultValue: "Akcje" })}
-        </h3>
-        <div className="flex flex-wrap gap-2">
-          <Button variant="outline" onClick={openCreatePanel}>
-            <Plus className="mr-2 h-4 w-4" variant="stroke" />
-            {t("products.addProduct")}
-          </Button>
-          <Button variant="outline" onClick={() => setAddDeliveryOpen(true)}>
-            <TruckIcon className="mr-2 h-4 w-4" variant="stroke" />
-            {t("nav.actions.addDelivery", { defaultValue: "Dodaj dostawę" })}
-          </Button>
-          <Button variant="outline" onClick={() => setShoppingListOpen(true)}>
-            <ShoppingCart className="mr-2 h-4 w-4" variant="stroke" />
-            {t("nav.actions.openShoppingList", { defaultValue: "Lista zakupowa" })}
-          </Button>
-          <Button variant="outline" onClick={() => setInventoryOpen(true)}>
-            <ClipboardList className="mr-2 h-4 w-4" variant="stroke" />
-            {t("nav.actions.startInventory", { defaultValue: "Rozpocznij inwentaryzację" })}
-          </Button>
-          <Button variant="outline" onClick={() => setImportOpen(true)}>
-            <Upload className="mr-2 h-4 w-4" variant="stroke" />
-            {t("csv.import")}
-          </Button>
-          <Button variant="outline" onClick={handleExport}>
-            <Download className="mr-2 h-4 w-4" variant="stroke" />
-            {t("csv.export")}
-          </Button>
-        </div>
-      </div>
 
       <CsvImportDialog
         organizationId={organizationId}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3100.

Closes #3100

---

## Claude summary

Done. Here's a summary of what changed:

**`src/components/layout/app-footer.tsx`** — replaced the `products` bottom-bar entries (which had a buggy `quickCreate: "document"`, plus Tagi and Kategorie) with the six requested actions, all wired via `action: "..."` dispatch:
- Dodaj produkt (`addProduct`)
- Dodaj dostawę (`addDelivery`)
- Lista zakupowa (`openShoppingList`)
- Rozpocznij inwentaryzację (`openInventory`)
- Importuj (`importCsv`)
- Eksportuj (`exportCsv`)
Added `TruckIcon`, `ShoppingCart`, `ClipboardList`, `Upload` to footer icon imports.

**`src/routes/_app/_auth/dashboard/_layout.products.index.tsx`** — added `useSidebarDispatch` handlers for the two new dispatch IDs (`addProduct` → opens create side panel, `addDelivery` → opens AddDeliveryPanel), removed the standalone "Akcje" section below the table, and cleaned up the now-unused icon imports.

## Follow-ups
- Fix `quickCreate: "document"` bug on products footer was pre-existing: the old `products` footer entry used `quickCreate: "document"` instead of `"product"`, so "Dodaj produkt" was opening the document quick-create dialog instead of a product form — this is now fixed as a side effect of #3100, but worth noting as a regression that existed since the actions were first added.