### PR TITLE
Usuń zbędne ikony z górnego menu tabeli magazynu

### DIFF
--- a/src/components/crm/data-list-filter-bar.tsx
+++ b/src/components/crm/data-list-filter-bar.tsx
@@ -129,6 +129,8 @@ export interface DataListFilterBarProps {
   // Tags & Categories management
   onTagsManage?: () => void;
   onCategoriesManage?: () => void;
+  /** When provided, renders the tags/categories button with this text label instead of icon-only. */
+  tagsButtonLabel?: string;
 
   // Extra elements rendered on the left side next to the view selector
   leftExtras?: React.ReactNode;
@@ -184,6 +186,7 @@ export function DataListFilterBar({
   dropdownActions = [],
   onTagsManage: _onTagsManage,
   onCategoriesManage: _onCategoriesManage,
+  tagsButtonLabel,
   leftExtras,
   hideFiltersButton = false,
   hideAddViewButton = false,
@@ -530,9 +533,11 @@ export function DataListFilterBar({
           <Dropdown.Root>
             <Button
               size="sm"
-              color="tertiary"
+              color={tagsButtonLabel ? "secondary" : "tertiary"}
               iconLeading={_onTagsManage && _onCategoriesManage ? Folder : (_onTagsManage ? Tag03 : Folder)}
-            />
+            >
+              {tagsButtonLabel ?? null}
+            </Button>
             <Dropdown.Popover>
               <Dropdown.Menu>
                 {_onTagsManage && (

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -22,7 +22,7 @@ import { SidePanel } from "@/components/crm/side-panel";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Plus, Pencil, Trash2, Power, Upload, Download, X, Package, AlertTriangle, History, Archive, RotateCcw } from "@/lib/ez-icons";
+import { Plus, Pencil, Trash2, Power, X, Package, AlertTriangle, History, Archive, RotateCcw } from "@/lib/ez-icons";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { useCsvExport } from "@/components/csv/csv-export-button";
 import { CsvImportDialog } from "@/components/csv/csv-import-dialog";
@@ -863,10 +863,7 @@ function ProductsPage() {
         searchPlaceholder={t('products.searchPlaceholder')}
         onTagsManage={() => setTagsSlideoutOpen(true)}
         onCategoriesManage={() => setCategoriesSlideoutOpen(true)}
-        dropdownActions={[
-          { label: t("csv.export"), icon: <Download className="h-4 w-4" variant="stroke" />, onClick: handleExport },
-          { label: t("csv.import"), icon: <Upload className="h-4 w-4" variant="stroke" />, onClick: () => setImportOpen(true) },
-        ]}
+        tagsButtonLabel={t("products.categoriesAndTags", { defaultValue: "Kategorie i tagi" })}
         onColumnSettingsOpen={() => setColumnSettingsOpen(true)}
         onFiltersChange={setActiveFilters}
         hideFiltersButton


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3107.

Closes #3107

---

## Claude summary

Done. Here's a summary of the changes:

**Files changed (2):**

`src/components/crm/data-list-filter-bar.tsx` — Added a `tagsButtonLabel?: string` prop. When provided, the folder/tags button renders with that text and `color="secondary"` (styled like the "Pokaż kolumny" button); otherwise it stays icon-only as before. All other pages that use this component are unaffected.

`src/routes/_app/_auth/dashboard/_layout.products.index.tsx` — Removed the `dropdownActions` array (which contained Import/Export) so the three-dots menu no longer appears in the toolbar. Passed `tagsButtonLabel="Kategorie i tagi"` to the DataListFilterBar. Removed the now-unused `Upload` and `Download` icon imports.

The result: the products/warehouse toolbar now shows exactly what was requested — "Wszystkie produkty", search, "Pokaż kolumny", and a labeled "Kategorie i tagi" button. Import/Export remain accessible in the bottom "Akcje" bar. No logic was changed.