### PR TITLE
Popraw nakładanie się filtrów w magazynie

### DIFF
--- a/e2e/crm/products.spec.ts
+++ b/e2e/crm/products.spec.ts
@@ -138,4 +138,71 @@ test.describe("CRM — Products", () => {
       await page.keyboard.press("Escape");
     }
   });
+
+  // Regression #3109: clicking a top tile must clear any previously active filter
+  test("clicking 'Poniżej min. stanu' tile clears the active section filter", async ({ page }) => {
+    await navigateTo(page, "/dashboard/products");
+    await assertNoErrorBoundary(page);
+
+    // Activate the "Materiały jednorazowe" section tile
+    const disposableTile = page
+      .locator("button")
+      .filter({ hasText: /Materiały jednorazowe/ })
+      .first();
+
+    if (!(await disposableTile.isVisible({ timeout: 5000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+    await disposableTile.click();
+    await page.waitForTimeout(500);
+
+    // Now click "Poniżej min. stanu" — it should clear the section filter
+    const belowMinTile = page
+      .locator("button")
+      .filter({ hasText: /Poniżej min\. stanu/ })
+      .first();
+
+    if (!(await belowMinTile.isVisible({ timeout: 3000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+
+    // Only proceed if the tile is enabled (belowMin > 0 or button is clickable)
+    const isDisabled = await belowMinTile.getAttribute("disabled");
+    if (isDisabled !== null) {
+      test.skip();
+      return;
+    }
+
+    await belowMinTile.click();
+    await page.waitForTimeout(500);
+
+    // URL must contain nudge=low_stock and page must have no errors
+    expect(page.url()).toContain("nudge=low_stock");
+    await assertNoErrorBoundary(page);
+  });
+
+  // Regression #3109: clicking a section tile while nudge filter is active must clear nudge
+  test("clicking section tile clears low_stock nudge filter", async ({ page }) => {
+    await navigateTo(page, "/dashboard/products?nudge=low_stock");
+    await assertNoErrorBoundary(page);
+
+    const disposableTile = page
+      .locator("button")
+      .filter({ hasText: /Materiały jednorazowe/ })
+      .first();
+
+    if (!(await disposableTile.isVisible({ timeout: 5000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+
+    await disposableTile.click();
+    await page.waitForTimeout(500);
+
+    // nudge=low_stock must be gone from the URL
+    expect(page.url()).not.toContain("nudge=low_stock");
+    await assertNoErrorBoundary(page);
+  });
 });

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -737,25 +737,37 @@ function ProductsPage() {
           label={t("products.stats.total", { defaultValue: "Wszystkie pozycje" })}
           value={inventoryStats.total}
           active={activeViewId === "all" && !nudgeFilter}
-          onClick={() => onViewChange("all")}
+          onClick={() => {
+            if (nudgeFilter) navigate({ to: "/dashboard/products", search: { nudge: undefined } });
+            onViewChange("all");
+          }}
         />
         <StatCard
           label={t("products.sections.sale")}
           value={inventoryStats.bySale}
           active={activeViewId === "sale" && !nudgeFilter}
-          onClick={() => onViewChange("sale")}
+          onClick={() => {
+            if (nudgeFilter) navigate({ to: "/dashboard/products", search: { nudge: undefined } });
+            onViewChange("sale");
+          }}
         />
         <StatCard
           label={t("products.sections.treatment")}
           value={inventoryStats.byTreatment}
           active={activeViewId === "treatment" && !nudgeFilter}
-          onClick={() => onViewChange("treatment")}
+          onClick={() => {
+            if (nudgeFilter) navigate({ to: "/dashboard/products", search: { nudge: undefined } });
+            onViewChange("treatment");
+          }}
         />
         <StatCard
           label={t("products.sections.disposable")}
           value={inventoryStats.byDisposable}
           active={activeViewId === "disposable" && !nudgeFilter}
-          onClick={() => onViewChange("disposable")}
+          onClick={() => {
+            if (nudgeFilter) navigate({ to: "/dashboard/products", search: { nudge: undefined } });
+            onViewChange("disposable");
+          }}
         />
         <StatCard
           label={t("products.stats.belowMin", { defaultValue: "Poniżej min. stanu" })}
@@ -763,7 +775,10 @@ function ProductsPage() {
           highlight={inventoryStats.belowMin > 0}
           active={nudgeFilter === "low_stock"}
           onClick={inventoryStats.belowMin > 0
-            ? () => navigate({ to: "/dashboard/products", search: { nudge: "low_stock" } })
+            ? () => {
+                onViewChange("all");
+                navigate({ to: "/dashboard/products", search: { nudge: "low_stock" } });
+              }
             : undefined}
         />
       </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3109.

Closes #3109

---

## Claude summary

The fix is committed. Here's a summary:

**Root cause confirmed.** The warehouse page had two independent filter mechanisms that were applied in an AND fashion inside a single `useMemo`:
- `activeViewId` — React state managed by `useSavedViews`, set by tile clicks or the "Wszystkie produkty" dropdown
- `nudgeFilter` — URL search param (`?nudge=low_stock`), set only by the "Poniżej min. stanu" tile's `navigate` call

Neither mechanism cleared the other, so clicking "Materiały jednorazowe" then "Poniżej min. stanu" produced an empty list because it filtered for `productSection === "disposable"` AND stock status `low|out` simultaneously.

**Fix in `_layout.products.index.tsx`:**
- "Poniżej min. stanu" tile: now also calls `onViewChange("all")` before navigating, resetting the dropdown/section filter.
- All four section tiles (Wszystkie pozycje, Sprzedaż, Zabiegi, Materiały jednorazowe): now call `navigate({ ..., search: { nudge: undefined } })` when a nudge filter is active, clearing it from the URL.

**Two e2e regression tests added** in `e2e/crm/products.spec.ts` covering both directions of the transition.