### PR TITLE
Rozbuduj listę zakupową o koszt i proste uzasadnienie zapotrzebowania

### DIFF
--- a/src/components/gabinet/warehouse-shopping-list-dialog.test.tsx
+++ b/src/components/gabinet/warehouse-shopping-list-dialog.test.tsx
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeItemCost,
+  getEffectiveQty,
+  groupShoppingItems,
+} from "./warehouse-shopping-list-helpers";
+
+// ---------------------------------------------------------------------------
+// computeItemCost
+// ---------------------------------------------------------------------------
+
+describe("computeItemCost", () => {
+  it("returns qty × price when price is set", () => {
+    expect(computeItemCost(6, 200)).toBe(1200);
+  });
+
+  it("returns null when price is null (missing price)", () => {
+    expect(computeItemCost(6, null)).toBeNull();
+  });
+
+  it("returns 0 when qty is 0 and price is set", () => {
+    expect(computeItemCost(0, 200)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEffectiveQty
+// ---------------------------------------------------------------------------
+
+describe("getEffectiveQty", () => {
+  it("returns the default qty when no override exists", () => {
+    expect(getEffectiveQty(6, "prod-1", new Map())).toBe(6);
+  });
+
+  it("returns the parsed override when the user typed a number", () => {
+    const quantities = new Map([["prod-1", "10"]]);
+    expect(getEffectiveQty(6, "prod-1", quantities)).toBe(10);
+  });
+
+  it("falls back to default qty when override is empty string", () => {
+    const quantities = new Map([["prod-1", ""]]);
+    expect(getEffectiveQty(6, "prod-1", quantities)).toBe(6);
+  });
+
+  it("falls back to default qty when override is not a valid number", () => {
+    const quantities = new Map([["prod-1", "abc"]]);
+    expect(getEffectiveQty(6, "prod-1", quantities)).toBe(6);
+  });
+
+  it("cost recalculates when quantity changes", () => {
+    const quantities = new Map([["prod-1", "3"]]);
+    const qty = getEffectiveQty(6, "prod-1", quantities);
+    expect(computeItemCost(qty, 200)).toBe(600);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupShoppingItems — multi-supplier, no supplier, no price
+// ---------------------------------------------------------------------------
+
+type MinItem = { supplier: string | null };
+
+function makeItem(supplier: string | null): MinItem {
+  return { supplier };
+}
+
+describe("groupShoppingItems", () => {
+  it("groups items by supplier", () => {
+    const items = [
+      makeItem("Dostawca A"),
+      makeItem("Dostawca B"),
+      makeItem("Dostawca A"),
+    ];
+    const groups = groupShoppingItems(items);
+    expect(groups).toHaveLength(2);
+    const a = groups.find((g) => g.supplier === "Dostawca A");
+    expect(a?.items).toHaveLength(2);
+    const b = groups.find((g) => g.supplier === "Dostawca B");
+    expect(b?.items).toHaveLength(1);
+  });
+
+  it("puts null-supplier items in the last group", () => {
+    const items = [
+      makeItem("Dostawca A"),
+      makeItem(null),
+      makeItem("Dostawca B"),
+    ];
+    const groups = groupShoppingItems(items);
+    expect(groups[groups.length - 1].supplier).toBeNull();
+  });
+
+  it("handles items with no supplier (all null)", () => {
+    const items = [makeItem(null), makeItem(null)];
+    const groups = groupShoppingItems(items);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].supplier).toBeNull();
+    expect(groups[0].items).toHaveLength(2);
+  });
+
+  it("sorts named suppliers alphabetically (pl locale)", () => {
+    const items = [makeItem("Zeta"), makeItem("Alpha"), makeItem("Beta")];
+    const groups = groupShoppingItems(items);
+    const names = groups.map((g) => g.supplier);
+    expect(names).toEqual(["Alpha", "Beta", "Zeta"]);
+  });
+
+  it("handles empty input", () => {
+    expect(groupShoppingItems([])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cost totals with missing prices
+// ---------------------------------------------------------------------------
+
+describe("cost total with missing prices", () => {
+  it("excludes items without price from total", () => {
+    const quantities = new Map<string, string>();
+    const items = [
+      { id: "a", defaultQty: 5, unitPriceGross: 100 as number | null },
+      { id: "b", defaultQty: 3, unitPriceGross: null },
+    ];
+    let total = 0;
+    let hasMissing = false;
+    for (const item of items) {
+      const qty = getEffectiveQty(item.defaultQty, item.id, quantities);
+      const cost = computeItemCost(qty, item.unitPriceGross);
+      if (cost === null) {
+        hasMissing = true;
+      } else {
+        total += cost;
+      }
+    }
+    expect(total).toBe(500);
+    expect(hasMissing).toBe(true);
+  });
+});

--- a/src/components/gabinet/warehouse-shopping-list-dialog.tsx
+++ b/src/components/gabinet/warehouse-shopping-list-dialog.tsx
@@ -20,11 +20,27 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
+import { useSupabaseProductsLastDeliveryInfo } from "@/hooks/use-supabase-products";
 import { CopyIcon } from "@/lib/ez-icons";
+import { formatCurrencyPLN } from "@/lib/format-currency";
 import type { MappedProduct } from "@/lib/supabase/mappers/products";
 import type { ProductStockTotal } from "@/hooks/use-supabase-products";
+import {
+  getEffectiveQty,
+  computeItemCost,
+  groupShoppingItems,
+  type GroupedItems as GroupedShoppingItems,
+} from "./warehouse-shopping-list-helpers";
+
+export { getEffectiveQty, computeItemCost, groupShoppingItems };
+export type { GroupedShoppingItems };
 
 const NO_LOCATION_VALUE = "__none__";
+const NO_SUPPLIER_LABEL = "Brak przypisanego dostawcy";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 interface WarehouseShoppingListDialogProps {
   open: boolean;
@@ -32,6 +48,7 @@ interface WarehouseShoppingListDialogProps {
   organizationId: string;
   products: MappedProduct[];
   totalsByProductId: Map<string, ProductStockTotal>;
+  plannedUsageByProductId: Map<string, { plannedUsage: number }>;
 }
 
 interface ShoppingItem {
@@ -39,6 +56,9 @@ interface ShoppingItem {
   currentStock: number;
   minStock: number;
   defaultQty: number;
+  plannedUsage: number | null;
+  supplier: string | null;
+  unitPriceGross: number | null;
 }
 
 function formatNowPL(): string {
@@ -49,74 +69,143 @@ function formatNowPL(): string {
   });
 }
 
+function fmtQty(qty: number, unit: string | null | undefined): string {
+  const u = unit?.trim();
+  return u ? `${qty} ${u}` : String(qty);
+}
+
+function fmtPrice(unitPriceGross: number | null): string {
+  if (unitPriceGross === null) return "Brak ceny";
+  return formatCurrencyPLN(unitPriceGross, "zł");
+}
+
+function fmtCost(qty: number, unitPriceGross: number | null): string {
+  const cost = computeItemCost(qty, unitPriceGross);
+  if (cost === null) return "—";
+  return formatCurrencyPLN(cost, "zł");
+}
+
+// ---------------------------------------------------------------------------
+// Print view
+// ---------------------------------------------------------------------------
+
 interface PrintBodyProps {
-  items: ShoppingItem[];
+  groups: GroupedShoppingItems<ShoppingItem>[];
   quantities: Map<string, string>;
   locationLabel: string;
   generatedAt: string;
+  grandTotal: number;
+  hasItemsWithoutPrice: boolean;
 }
 
-function PrintBody({ items, quantities, locationLabel, generatedAt }: PrintBodyProps) {
-  const { t } = useTranslation();
+function PrintBody({
+  groups,
+  quantities,
+  locationLabel,
+  generatedAt,
+  grandTotal,
+  hasItemsWithoutPrice,
+}: PrintBodyProps) {
+  let globalIdx = 0;
   return (
     <div className="space-y-4 p-6 text-sm text-foreground print:text-black">
       <div className="text-center">
-        <h1 className="text-xl font-bold">
-          {t("shoppingList.print.title", { defaultValue: "Lista zakupowa" })}
-        </h1>
+        <h1 className="text-xl font-bold">Lista zakupowa</h1>
         <p className="mt-1 text-sm text-muted-foreground print:text-gray-600">
           {locationLabel} · {generatedAt}
         </p>
       </div>
-      <table className="w-full border-collapse text-xs">
-        <thead>
-          <tr className="border-b-2 border-border bg-muted/40 print:bg-transparent print:border-black">
-            <th className="px-2 py-2 text-left font-semibold">
-              {t("inventory.accountantReport.colNo", { defaultValue: "Lp." })}
-            </th>
-            <th className="px-2 py-2 text-left font-semibold">
-              {t("common.name")}
-            </th>
-            <th className="px-2 py-2 text-right font-semibold">
-              {t("inventory.count.unit", { defaultValue: "Jedn." })}
-            </th>
-            <th className="px-2 py-2 text-right font-semibold">
-              {t("shoppingList.col.currentStock", { defaultValue: "Stan" })}
-            </th>
-            <th className="px-2 py-2 text-right font-semibold">
-              {t("shoppingList.col.minStock", { defaultValue: "Min. stan" })}
-            </th>
-            <th className="px-2 py-2 text-right font-semibold">
-              {t("shoppingList.col.toOrder", { defaultValue: "Do zamówienia" })}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((item, idx) => {
-            const unit = item.product.stockUnit?.trim() || "—";
-            const override = quantities.get(item.product._id);
-            const qty = override !== undefined
-              ? (parseInt(override, 10) || item.defaultQty)
-              : item.defaultQty;
-            return (
-              <tr key={item.product._id} className="border-b border-border print:border-gray-300">
-                <td className="px-2 py-1.5 tabular-nums text-muted-foreground">{idx + 1}</td>
-                <td className="px-2 py-1.5 font-medium">{item.product.name}</td>
-                <td className="px-2 py-1.5 text-right">{unit}</td>
-                <td className="px-2 py-1.5 text-right tabular-nums">{item.currentStock}</td>
-                <td className="px-2 py-1.5 text-right tabular-nums">{item.minStock}</td>
-                <td className="px-2 py-1.5 text-right tabular-nums font-semibold">{qty}</td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+
+      {groups.map((group) => {
+        const supplierLabel = group.supplier ?? NO_SUPPLIER_LABEL;
+        let groupTotal = 0;
+        let groupHasMissingPrice = false;
+
+        const rows = group.items.map((item) => {
+          const qty = getEffectiveQty(item.defaultQty, item.product._id, quantities);
+          const cost = computeItemCost(qty, item.unitPriceGross);
+          if (cost === null) {
+            groupHasMissingPrice = true;
+          } else {
+            groupTotal += cost;
+          }
+          globalIdx += 1;
+          return { item, qty, cost, idx: globalIdx };
+        });
+
+        return (
+          <div key={supplierLabel} className="space-y-1">
+            <h2 className="font-semibold text-sm border-b pb-1">{supplierLabel}</h2>
+            <table className="w-full border-collapse text-xs">
+              <thead>
+                <tr className="border-b-2 border-border bg-muted/40 print:bg-transparent print:border-black">
+                  <th className="px-2 py-2 text-left font-semibold">Lp.</th>
+                  <th className="px-2 py-2 text-left font-semibold">Produkt</th>
+                  <th className="px-2 py-2 text-right font-semibold">Stan</th>
+                  <th className="px-2 py-2 text-right font-semibold">Min.</th>
+                  <th className="px-2 py-2 text-right font-semibold">Plan.</th>
+                  <th className="px-2 py-2 text-right font-semibold">Do zam.</th>
+                  <th className="px-2 py-2 text-right font-semibold">Cena brutto</th>
+                  <th className="px-2 py-2 text-right font-semibold">Szac. wartość</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map(({ item, qty, cost, idx }) => (
+                  <tr key={item.product._id} className="border-b border-border print:border-gray-300">
+                    <td className="px-2 py-1.5 tabular-nums text-muted-foreground">{idx}</td>
+                    <td className="px-2 py-1.5 font-medium">{item.product.name}</td>
+                    <td className="px-2 py-1.5 text-right tabular-nums">
+                      {fmtQty(item.currentStock, item.product.stockUnit)}
+                    </td>
+                    <td className="px-2 py-1.5 text-right tabular-nums">
+                      {fmtQty(item.minStock, item.product.stockUnit)}
+                    </td>
+                    <td className="px-2 py-1.5 text-right tabular-nums">
+                      {item.plannedUsage !== null
+                        ? fmtQty(item.plannedUsage, item.product.stockUnit)
+                        : "—"}
+                    </td>
+                    <td className="px-2 py-1.5 text-right tabular-nums font-semibold">
+                      {fmtQty(qty, item.product.stockUnit)}
+                    </td>
+                    <td className="px-2 py-1.5 text-right tabular-nums">
+                      {fmtPrice(item.unitPriceGross)}
+                    </td>
+                    <td className="px-2 py-1.5 text-right tabular-nums font-semibold">
+                      {cost === null ? "—" : formatCurrencyPLN(cost, "zł")}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div className="text-right text-xs font-medium pt-1">
+              {groupHasMissingPrice && groupTotal === 0
+                ? "Razem u dostawcy: —"
+                : `Razem u dostawcy: ${formatCurrencyPLN(groupTotal, "zł")}${groupHasMissingPrice ? "*" : ""}`}
+            </div>
+          </div>
+        );
+      })}
+
+      <div className="border-t-2 border-border pt-2 text-sm font-bold text-right">
+        Łączny szacowany koszt zamówień brutto: {formatCurrencyPLN(grandTotal, "zł")}
+        {hasItemsWithoutPrice ? "*" : ""}
+      </div>
+      {hasItemsWithoutPrice && (
+        <p className="text-xs text-muted-foreground print:text-gray-500">
+          * Łączny koszt nie obejmuje pozycji bez ceny.
+        </p>
+      )}
       <div className="border-t border-border pt-2 text-xs print:border-black">
-        {t("inventory.accountantReport.itemCount", { defaultValue: "Liczba pozycji" })}: {items.length}
+        Liczba pozycji: {groups.reduce((s, g) => s + g.items.length, 0)}
       </div>
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Dialog
+// ---------------------------------------------------------------------------
 
 export function WarehouseShoppingListDialog({
   open,
@@ -124,9 +213,13 @@ export function WarehouseShoppingListDialog({
   organizationId,
   products,
   totalsByProductId,
+  plannedUsageByProductId,
 }: WarehouseShoppingListDialogProps) {
   const { t } = useTranslation();
   const { data: locations = [] } = useSupabaseGabinetLocationsList(organizationId, { activeOnly: true });
+  const { lastDeliveryByProductId } = useSupabaseProductsLastDeliveryInfo(organizationId, {
+    enabled: open,
+  });
   const [locationId, setLocationId] = useState<string>(NO_LOCATION_VALUE);
   const [quantities, setQuantities] = useState<Map<string, string>>(new Map());
 
@@ -147,14 +240,45 @@ export function WarehouseShoppingListDialog({
       .map((p) => {
         const currentStock = getStock(p._id);
         const minStock = p.minStock!;
+        const usageData = plannedUsageByProductId.get(p._id);
+        const deliveryInfo = lastDeliveryByProductId.get(p._id);
+        const unitPriceGross =
+          deliveryInfo?.unitPriceGross != null
+            ? deliveryInfo.unitPriceGross
+            : p.purchasePrice != null && p.purchasePrice > 0
+              ? p.purchasePrice
+              : null;
         return {
           product: p,
           currentStock,
           minStock,
           defaultQty: Math.max(minStock - currentStock, 1),
+          plannedUsage: usageData?.plannedUsage ?? null,
+          supplier: deliveryInfo?.supplierName ?? null,
+          unitPriceGross,
         };
       });
-  }, [products, totalsByProductId, locationId, locations, resolvedLocationId]);
+  }, [products, totalsByProductId, locationId, locations, resolvedLocationId, plannedUsageByProductId, lastDeliveryByProductId]);
+
+  const supplierGroups = useMemo(
+    () => groupShoppingItems(shoppingItems),
+    [shoppingItems],
+  );
+
+  const { grandTotal, hasItemsWithoutPrice } = useMemo(() => {
+    let total = 0;
+    let hasWithout = false;
+    for (const item of shoppingItems) {
+      const qty = getEffectiveQty(item.defaultQty, item.product._id, quantities);
+      const cost = computeItemCost(qty, item.unitPriceGross);
+      if (cost === null) {
+        hasWithout = true;
+      } else {
+        total += cost;
+      }
+    }
+    return { grandTotal: total, hasItemsWithoutPrice: hasWithout };
+  }, [shoppingItems, quantities]);
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (nextOpen) {
@@ -170,7 +294,8 @@ export function WarehouseShoppingListDialog({
   };
 
   const locationLabel = useMemo(() => {
-    if (locations.length === 0) return t("inventory.count.locationNone", { defaultValue: "Bez lokalizacji" });
+    if (locations.length === 0)
+      return t("inventory.count.locationNone", { defaultValue: "Bez lokalizacji" });
     const loc = locations.find((l) => l._id === resolvedLocationId);
     return loc?.name ?? t("inventory.count.locationNone", { defaultValue: "Bez lokalizacji" });
   }, [locations, resolvedLocationId, t]);
@@ -183,20 +308,56 @@ export function WarehouseShoppingListDialog({
       `${locationLabel} · ${generatedAt}`,
       "",
     ];
-    shoppingItems.forEach((item, idx) => {
-      const unit = item.product.stockUnit?.trim();
-      const unitStr = unit ? ` ${unit}` : "";
-      const override = quantities.get(item.product._id);
-      const qty = override !== undefined ? (parseInt(override, 10) || item.defaultQty) : item.defaultQty;
-      lines.push(
-        `${idx + 1}. ${item.product.name} — ${qty}${unitStr} (${t("shoppingList.col.currentStock", { defaultValue: "stan" })}: ${item.currentStock}${unitStr}, min: ${item.minStock}${unitStr})`,
-      );
-    });
-    navigator.clipboard.writeText(lines.join("\n")).then(() => {
-      toast.success(t("shoppingList.copySuccess", { defaultValue: "Lista skopiowana do schowka." }));
-    }).catch(() => {
-      toast.error(t("shoppingList.copyError", { defaultValue: "Nie udało się skopiować listy." }));
-    });
+    let globalIdx = 0;
+    for (const group of supplierGroups) {
+      const supplierLabel = group.supplier ?? NO_SUPPLIER_LABEL;
+      lines.push(`=== ${supplierLabel} ===`);
+      let groupTotal = 0;
+      let groupHasMissing = false;
+      for (const item of group.items) {
+        globalIdx += 1;
+        const qty = getEffectiveQty(item.defaultQty, item.product._id, quantities);
+        const unit = item.product.stockUnit?.trim();
+        const unitStr = unit ? ` ${unit}` : "";
+        const cost = computeItemCost(qty, item.unitPriceGross);
+        if (cost === null) {
+          groupHasMissing = true;
+        } else {
+          groupTotal += cost;
+        }
+        const costStr = cost === null ? "Brak ceny" : formatCurrencyPLN(cost, "zł");
+        lines.push(
+          `${globalIdx}. ${item.product.name} — ${qty}${unitStr}` +
+            ` (stan: ${item.currentStock}${unitStr}, min: ${item.minStock}${unitStr}` +
+            (item.plannedUsage !== null ? `, plan.: ${item.plannedUsage}${unitStr}` : "") +
+            `) · ${fmtPrice(item.unitPriceGross)} · ${costStr}`,
+        );
+      }
+      const groupTotalStr =
+        groupHasMissing && groupTotal === 0
+          ? "—"
+          : formatCurrencyPLN(groupTotal, "zł") + (groupHasMissing ? "*" : "");
+      lines.push(`Razem u dostawcy: ${groupTotalStr}`, "");
+    }
+    lines.push(
+      `Łączny szacowany koszt zamówień brutto: ${formatCurrencyPLN(grandTotal, "zł")}${hasItemsWithoutPrice ? "*" : ""}`,
+    );
+    if (hasItemsWithoutPrice) {
+      lines.push("* Łączny koszt nie obejmuje pozycji bez ceny.");
+    }
+
+    navigator.clipboard
+      .writeText(lines.join("\n"))
+      .then(() => {
+        toast.success(
+          t("shoppingList.copySuccess", { defaultValue: "Lista skopiowana do schowka." }),
+        );
+      })
+      .catch(() => {
+        toast.error(
+          t("shoppingList.copyError", { defaultValue: "Nie udało się skopiować listy." }),
+        );
+      });
   };
 
   const handlePrint = () => {
@@ -205,30 +366,29 @@ export function WarehouseShoppingListDialog({
 
   const printBody = (
     <PrintBody
-      items={shoppingItems}
+      groups={supplierGroups}
       quantities={quantities}
       locationLabel={locationLabel}
       generatedAt={generatedAt}
+      grandTotal={grandTotal}
+      hasItemsWithoutPrice={hasItemsWithoutPrice}
     />
   );
 
   return (
     <>
-      {open && (
-        <div className="print-shopping-list">
-          {printBody}
-        </div>
-      )}
+      {open && <div className="print-shopping-list">{printBody}</div>}
 
       <Dialog open={open} onOpenChange={handleOpenChange}>
-        <DialogContent className="flex max-h-[90vh] max-w-3xl flex-col">
+        <DialogContent className="flex max-h-[90vh] max-w-5xl flex-col">
           <DialogHeader>
             <DialogTitle>
               {t("shoppingList.title", { defaultValue: "Lista zakupowa" })}
             </DialogTitle>
             <DialogDescription>
               {t("shoppingList.description", {
-                defaultValue: "Produkty, których stan jest równy lub niższy od minimalnego. Możesz edytować sugerowane ilości przed wydrukiem.",
+                defaultValue:
+                  "Produkty, których stan jest równy lub niższy od minimalnego. Możesz edytować sugerowane ilości przed wydrukiem.",
               })}
             </DialogDescription>
           </DialogHeader>
@@ -259,71 +419,158 @@ export function WarehouseShoppingListDialog({
           {shoppingItems.length === 0 ? (
             <div className="flex flex-1 items-center justify-center py-12">
               <p className="text-sm text-muted-foreground">
-                {t("shoppingList.empty", { defaultValue: "Brak produktów wymagających zamówienia." })}
+                {t("shoppingList.empty", {
+                  defaultValue: "Brak produktów wymagających zamówienia.",
+                })}
               </p>
             </div>
           ) : (
             <div className="min-h-0 flex-1 overflow-y-auto">
-              <table className="w-full text-sm">
-                <thead className="sticky top-0 z-10 bg-background">
-                  <tr className="border-b">
-                    <th className="px-3 py-2 text-left font-medium">
-                      {t("common.name")}
-                    </th>
-                    <th className="px-3 py-2 text-right font-medium">
-                      {t("inventory.count.unit", { defaultValue: "Jedn." })}
-                    </th>
-                    <th className="px-3 py-2 text-right font-medium">
-                      {t("shoppingList.col.currentStock", { defaultValue: "Stan" })}
-                    </th>
-                    <th className="px-3 py-2 text-right font-medium">
-                      {t("shoppingList.col.minStock", { defaultValue: "Min. stan" })}
-                    </th>
-                    <th className="px-3 py-2 text-right font-medium">
-                      {t("shoppingList.col.toOrder", { defaultValue: "Do zamówienia" })}
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {shoppingItems.map((item) => {
-                    const unit = item.product.stockUnit?.trim() || "";
-                    const override = quantities.get(item.product._id);
-                    const displayVal = override ?? String(item.defaultQty);
-                    return (
-                      <tr key={item.product._id} className="border-b last:border-0">
-                        <td className="px-3 py-2 font-medium">{item.product.name}</td>
-                        <td className="px-3 py-2 text-right text-muted-foreground">
-                          {unit || "—"}
-                        </td>
-                        <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
-                          {item.currentStock}
-                        </td>
-                        <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
-                          {item.minStock}
-                        </td>
-                        <td className="px-3 py-2">
-                          <Input
-                            type="text"
-                            inputMode="numeric"
-                            className="ml-auto h-8 w-20 text-right tabular-nums"
-                            value={displayVal}
-                            onChange={(e) => {
-                              const v = e.target.value;
-                              if (v === "" || /^[0-9]*$/.test(v)) {
-                                setQuantities((prev) => {
-                                  const next = new Map(prev);
-                                  next.set(item.product._id, v);
-                                  return next;
-                                });
-                              }
-                            }}
-                          />
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+              <div className="overflow-x-auto">
+                {supplierGroups.map((group) => {
+                  const supplierLabel = group.supplier ?? NO_SUPPLIER_LABEL;
+                  let groupTotal = 0;
+                  let groupHasMissingPrice = false;
+
+                  const itemRows = group.items.map((item) => {
+                    const qty = getEffectiveQty(item.defaultQty, item.product._id, quantities);
+                    const cost = computeItemCost(qty, item.unitPriceGross);
+                    if (cost === null) {
+                      groupHasMissingPrice = true;
+                    } else {
+                      groupTotal += cost;
+                    }
+                    return { item, qty, cost };
+                  });
+
+                  return (
+                    <div key={supplierLabel} className="mb-4">
+                      <div className="px-3 py-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide border-b bg-muted/30">
+                        {supplierLabel}
+                      </div>
+                      <table className="w-full text-sm">
+                        <thead className="sticky top-0 z-10 bg-background">
+                          <tr className="border-b">
+                            <th className="px-3 py-2 text-left font-medium min-w-[140px]">
+                              {t("common.name")}
+                            </th>
+                            <th className="px-3 py-2 text-right font-medium whitespace-nowrap">
+                              {t("shoppingList.col.currentStock", { defaultValue: "Stan" })}
+                            </th>
+                            <th className="px-3 py-2 text-right font-medium whitespace-nowrap">
+                              {t("shoppingList.col.minStock", { defaultValue: "Min. stan" })}
+                            </th>
+                            <th className="px-3 py-2 text-right font-medium whitespace-nowrap">
+                              {t("products.plannedUsage.column", {
+                                defaultValue: "Plan. zużycie",
+                              })}
+                            </th>
+                            <th className="px-3 py-2 text-right font-medium whitespace-nowrap">
+                              {t("shoppingList.col.toOrder", { defaultValue: "Do zamówienia" })}
+                            </th>
+                            <th className="px-3 py-2 text-right font-medium whitespace-nowrap">
+                              {t("shoppingList.col.unitPriceGross", {
+                                defaultValue: "Cena brutto",
+                              })}
+                            </th>
+                            <th className="px-3 py-2 text-right font-medium whitespace-nowrap">
+                              {t("shoppingList.col.estimatedCost", {
+                                defaultValue: "Szac. wartość",
+                              })}
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {itemRows.map(({ item, qty, cost }) => {
+                            const unit = item.product.stockUnit?.trim() || "";
+                            const override = quantities.get(item.product._id);
+                            const displayVal = override ?? String(item.defaultQty);
+                            return (
+                              <tr key={item.product._id} className="border-b last:border-0">
+                                <td className="px-3 py-2 font-medium">{item.product.name}</td>
+                                <td className="px-3 py-2 text-right tabular-nums text-muted-foreground whitespace-nowrap">
+                                  {fmtQty(item.currentStock, unit)}
+                                </td>
+                                <td className="px-3 py-2 text-right tabular-nums text-muted-foreground whitespace-nowrap">
+                                  {fmtQty(item.minStock, unit)}
+                                </td>
+                                <td className="px-3 py-2 text-right tabular-nums text-muted-foreground whitespace-nowrap">
+                                  {item.plannedUsage !== null
+                                    ? fmtQty(item.plannedUsage, unit)
+                                    : "—"}
+                                </td>
+                                <td className="px-3 py-2">
+                                  <div className="flex items-center justify-end gap-1">
+                                    <Input
+                                      type="text"
+                                      inputMode="numeric"
+                                      className="h-8 w-20 text-right tabular-nums"
+                                      value={displayVal}
+                                      onChange={(e) => {
+                                        const v = e.target.value;
+                                        if (v === "" || /^[0-9]*$/.test(v)) {
+                                          setQuantities((prev) => {
+                                            const next = new Map(prev);
+                                            next.set(item.product._id, v);
+                                            return next;
+                                          });
+                                        }
+                                      }}
+                                    />
+                                    {unit && (
+                                      <span className="text-xs text-muted-foreground w-6">
+                                        {unit}
+                                      </span>
+                                    )}
+                                  </div>
+                                </td>
+                                <td className="px-3 py-2 text-right tabular-nums text-muted-foreground whitespace-nowrap">
+                                  {fmtPrice(item.unitPriceGross)}
+                                </td>
+                                <td className="px-3 py-2 text-right tabular-nums font-semibold whitespace-nowrap">
+                                  {cost === null ? "—" : formatCurrencyPLN(cost, "zł")}
+                                </td>
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+                      <div className="flex justify-end px-3 py-1.5 text-xs font-medium text-muted-foreground border-t bg-muted/20">
+                        {t("shoppingList.supplierTotal", {
+                          defaultValue: "Razem u dostawcy:",
+                        })}{" "}
+                        <span className="ml-1 font-semibold text-foreground">
+                          {groupHasMissingPrice && groupTotal === 0
+                            ? "—"
+                            : formatCurrencyPLN(groupTotal, "zł") +
+                              (groupHasMissingPrice ? "*" : "")}
+                        </span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              <div className="border-t px-3 py-3 space-y-1">
+                <div className="flex justify-between items-center text-sm font-semibold">
+                  <span>
+                    {t("shoppingList.grandTotal", {
+                      defaultValue: "Łączny szacowany koszt zamówień brutto:",
+                    })}
+                  </span>
+                  <span>
+                    {formatCurrencyPLN(grandTotal, "zł")}
+                    {hasItemsWithoutPrice ? "*" : ""}
+                  </span>
+                </div>
+                {hasItemsWithoutPrice && (
+                  <p className="text-xs text-muted-foreground">
+                    {t("shoppingList.missingPriceNote", {
+                      defaultValue: "* Łączny koszt nie obejmuje pozycji bez ceny.",
+                    })}
+                  </p>
+                )}
+              </div>
             </div>
           )}
 

--- a/src/components/gabinet/warehouse-shopping-list-helpers.ts
+++ b/src/components/gabinet/warehouse-shopping-list-helpers.ts
@@ -1,0 +1,51 @@
+// Pure utility functions for the warehouse shopping list.
+// Extracted into a separate file so they can be unit-tested without JSX.
+
+export function getEffectiveQty(
+  defaultQty: number,
+  productId: string,
+  quantities: Map<string, string>,
+): number {
+  const override = quantities.get(productId);
+  return override !== undefined ? (parseInt(override, 10) || defaultQty) : defaultQty;
+}
+
+export function computeItemCost(qty: number, unitPriceGross: number | null): number | null {
+  if (unitPriceGross === null) return null;
+  return qty * unitPriceGross;
+}
+
+export interface GroupedItems<T> {
+  supplier: string | null;
+  items: T[];
+}
+
+export function groupShoppingItems<T extends { supplier: string | null }>(
+  items: T[],
+): GroupedItems<T>[] {
+  const map = new Map<string | null, T[]>();
+  for (const item of items) {
+    const key = item.supplier;
+    const group = map.get(key) ?? [];
+    group.push(item);
+    map.set(key, group);
+  }
+  const named: [string, T[]][] = [];
+  let noSupplier: T[] | undefined;
+  for (const [key, groupItems] of map) {
+    if (key === null) {
+      noSupplier = groupItems;
+    } else {
+      named.push([key, groupItems]);
+    }
+  }
+  named.sort((a, b) => a[0].localeCompare(b[0], "pl"));
+  const result: GroupedItems<T>[] = named.map(([s, groupItems]) => ({
+    supplier: s,
+    items: groupItems,
+  }));
+  if (noSupplier !== undefined) {
+    result.push({ supplier: null, items: noSupplier });
+  }
+  return result;
+}

--- a/src/hooks/use-supabase-products.ts
+++ b/src/hooks/use-supabase-products.ts
@@ -311,3 +311,68 @@ export function useSupabaseProductLotBatches(
     enabled: enabled && isReady && !!organizationId && !!productId,
   });
 }
+
+// ---------------------------------------------------------------------------
+// Product Last Delivery Info (#3111)
+//
+// Fetches the most recent warehouse_delivery_items row per product for the org,
+// joining warehouse_deliveries to get the supplier_name. Used in the shopping
+// list dialog to show "Dostawca" (group header) and "Ostatnia cena zakupu brutto".
+// Items are ordered newest-first so the first occurrence per product_id is the
+// most recent delivery.
+// ---------------------------------------------------------------------------
+
+export interface ProductLastDeliveryInfo {
+  supplierName: string | null;
+  unitPriceGross: number | null;
+}
+
+export function useSupabaseProductsLastDeliveryInfo(
+  organizationId: string,
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  const query = useQuery<
+    Array<{ product_id: string; unit_price_gross: number | null; supplier_name: string | null }>,
+    Error
+  >({
+    queryKey: ["supabase", "warehouseDeliveryItems", "lastPerProduct", organizationId],
+    queryFn: async () => {
+      if (!client) throw new Error("Supabase client not ready");
+      const { data, error } = await client
+        .from("warehouse_delivery_items")
+        .select("product_id, unit_price_gross, created_at, warehouse_deliveries(supplier_name)")
+        .eq("organization_id", organizationId)
+        .order("created_at", { ascending: false });
+      if (error) throw error;
+      type Row = {
+        product_id: string;
+        unit_price_gross: number | null;
+        warehouse_deliveries: { supplier_name: string | null } | null;
+      };
+      return ((data ?? []) as Row[]).map((row) => ({
+        product_id: row.product_id,
+        unit_price_gross: row.unit_price_gross != null ? Number(row.unit_price_gross) : null,
+        supplier_name: row.warehouse_deliveries?.supplier_name ?? null,
+      }));
+    },
+    enabled: enabled && isReady && !!organizationId,
+  });
+
+  const lastDeliveryByProductId = useMemo(() => {
+    const map = new Map<string, ProductLastDeliveryInfo>();
+    for (const row of query.data ?? []) {
+      if (!map.has(row.product_id)) {
+        map.set(row.product_id, {
+          supplierName: row.supplier_name,
+          unitPriceGross: row.unit_price_gross,
+        });
+      }
+    }
+    return map;
+  }, [query.data]);
+
+  return { ...query, lastDeliveryByProductId };
+}

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -1009,6 +1009,7 @@ function ProductsPage() {
         organizationId={organizationId}
         products={allProducts}
         totalsByProductId={totalsByProductId}
+        plannedUsageByProductId={plannedUsageByProductId}
       />
 
       <ProductStockAdjustDialog


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3111.

Closes #3111

---

## Claude summary

Committed. Here's a summary of what was done:

**Changes made across 5 files:**

1. `src/hooks/use-supabase-products.ts` — added `useSupabaseProductsLastDeliveryInfo` hook that queries `warehouse_delivery_items` joined with `warehouse_deliveries` to get the most recent supplier name and gross unit price per product.

2. `src/components/gabinet/warehouse-shopping-list-helpers.ts` (new) — pure utility functions (`getEffectiveQty`, `computeItemCost`, `groupShoppingItems`) in a plain `.ts` file so they can be unit-tested without JSX.

3. `src/components/gabinet/warehouse-shopping-list-dialog.tsx` — rewrote the dialog to add:
   - New columns: planned usage, last purchase price gross ("Cena brutto"), estimated item value ("Szac. wartość")
   - Items grouped by supplier (named suppliers alphabetically, then "Brak przypisanego dostawcy" last)
   - Per-supplier subtotal row ("Razem u dostawcy: X zł")
   - Grand total footer ("Łączny szacowany koszt zamówień brutto: X zł")
   - "Brak ceny" label for items without price; footnote explains they're excluded from totals
   - Live recalculation when "Do zamówienia" input is edited
   - Dialog widened to `max-w-5xl` with `overflow-x-auto` for iPad compatibility
   - Print and copy views updated to match

4. `src/routes/_app/_auth/dashboard/_layout.products.index.tsx` — passes existing `plannedUsageByProductId` map to the dialog as a new prop.

5. `src/components/gabinet/warehouse-shopping-list-dialog.test.tsx` (new) — 14 unit tests covering: multi-supplier grouping, no-supplier fallback ordering, no-price cost exclusion, quantity-override cost recalculation.