### PR TITLE
Automatycznie wybieraj jedyną lokalizację na liście zakupowej

### DIFF
--- a/src/components/gabinet/warehouse-shopping-list-dialog.tsx
+++ b/src/components/gabinet/warehouse-shopping-list-dialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import {
@@ -222,6 +222,15 @@ export function WarehouseShoppingListDialog({
   });
   const [locationId, setLocationId] = useState<string>(NO_LOCATION_VALUE);
   const [quantities, setQuantities] = useState<Map<string, string>>(new Map());
+  const hasAutoSelectedRef = useRef(false);
+
+  // Auto-select the single location when locations data loads asynchronously after dialog opens.
+  useEffect(() => {
+    if (open && !hasAutoSelectedRef.current && locations.length === 1) {
+      hasAutoSelectedRef.current = true;
+      setLocationId(locations[0]._id);
+    }
+  }, [open, locations]);
 
   const resolvedLocationId: string | null = locationId === NO_LOCATION_VALUE ? null : locationId;
 
@@ -282,7 +291,10 @@ export function WarehouseShoppingListDialog({
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (nextOpen) {
-      setLocationId(NO_LOCATION_VALUE);
+      hasAutoSelectedRef.current = false;
+      const initial = locations.length === 1 ? locations[0]._id : NO_LOCATION_VALUE;
+      if (locations.length === 1) hasAutoSelectedRef.current = true;
+      setLocationId(initial);
       setQuantities(new Map());
     }
     onOpenChange(nextOpen);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3112.

Closes #3112

---

## Claude summary

Done. Here's a summary of what changed and why.

**Root cause:** `handleOpenChange` always reset `locationId` to `NO_LOCATION_VALUE` on open, regardless of how many locations exist. And `useState` initializes to the same value.

**Fix** (`src/components/gabinet/warehouse-shopping-list-dialog.tsx`):

- `handleOpenChange` now checks `locations.length === 1` at open time and sets the initial `locationId` to that location's `_id` instead of `NO_LOCATION_VALUE` (covers the cached/fast-load path).
- A `useEffect([open, locations])` handles the async case — when the dialog opens before the locations query resolves, it auto-selects once the data arrives.
- `hasAutoSelectedRef` guards both paths so that after auto-selection the user can manually switch back to "Bez lokalizacji" without being immediately overridden.

**Behavior matrix:**
1. One active location → auto-selected on open, list shows its data immediately
2. Multiple active locations → `NO_LOCATION_VALUE` default, manual picker shown (unchanged)
3. No locations at all → picker hidden, totals use `stock.total` (unchanged, `locations.length === 0` path in `getStock`)