### PR TITLE
Popraw wybór tagów i kategorii na iPadzie

### DIFF
--- a/src/components/categories-tags/category-picker.tsx
+++ b/src/components/categories-tags/category-picker.tsx
@@ -19,6 +19,8 @@ import { Id } from "@cvx/_generated/dataModel";
 import type { EntityType } from "@cvx/schema";
 import { TAG_COLOR_PALETTE } from "./color-palette";
 
+const isTouchDevice = typeof window !== "undefined" && ("ontouchstart" in window || navigator.maxTouchPoints > 0);
+
 interface CategoryDef {
   _id: Id<"categoryDefinitions">;
   name: string;
@@ -216,7 +218,7 @@ export function CategoryPicker({
               placeholder={t("categories.search", { defaultValue: "Szukaj..." })}
               value={search}
               onChange={setSearch}
-              autoFocus
+              autoFocus={!isTouchDevice}
             />
           </div>
           <div className="max-h-48 min-h-0 overflow-y-auto px-1 pb-1">

--- a/src/components/categories-tags/tags-picker.tsx
+++ b/src/components/categories-tags/tags-picker.tsx
@@ -13,6 +13,8 @@ import {
 import { cx } from "@/lib/utils/cx";
 import { Id } from "@cvx/_generated/dataModel";
 
+const isTouchDevice = typeof window !== "undefined" && ("ontouchstart" in window || navigator.maxTouchPoints > 0);
+
 interface TagDef {
   _id: Id<"tagDefinitions">;
   name: string;
@@ -141,7 +143,7 @@ export function TagsPicker({
               placeholder={t("tags.search", { defaultValue: "Szukaj..." })}
               value={search}
               onChange={setSearch}
-              autoFocus
+              autoFocus={!isTouchDevice}
             />
           </div>
           <div className="max-h-48 min-h-0 overflow-y-auto px-1 pb-1">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3115.

Closes #3115

---

## Claude summary

The fix is committed. Here's what was done:

**Root cause:** Both `TagsPicker` (`tags-picker.tsx:144`) and `CategoryPicker` (`category-picker.tsx:219`) had `autoFocus` on their search inputs. On iPad, React's `autoFocus` triggers the native virtual keyboard as soon as the element mounts — which happens the moment the Radix Popover opens.

**Fix:** Added a module-level `isTouchDevice` constant that checks `ontouchstart in window || navigator.maxTouchPoints > 0`, then changed `autoFocus` → `autoFocus={!isTouchDevice}` on the search input in both components. The "Add new category" input (line 264 in category-picker) retains unconditional `autoFocus` since it only appears after an explicit tap on "Dodaj kategorię" — at that point the keyboard is expected.

**Desktop behavior preserved:** On non-touch devices the constant is `false`, so `autoFocus={true}` — the popover still immediately focuses the search field as before.