### PR TITLE
Napraw nawigację przycisku „Dodaj dostawę”

### DIFF
--- a/src/modules/crm/manifest.ts
+++ b/src/modules/crm/manifest.ts
@@ -221,7 +221,7 @@ export const crmManifest: ModuleManifest = {
         },
         { labelKey: "nav.actions.openShoppingList", icon: ShoppingCart, dispatch: "openShoppingList" },
         { labelKey: "nav.actions.startInventory", icon: ClipboardList, dispatch: "openInventory" },
-        { labelKey: "nav.actions.addDelivery", icon: TruckIcon, href: "/dashboard/gabinet/deliveries" },
+        { labelKey: "nav.actions.addDelivery", icon: TruckIcon, dispatch: "addDelivery" },
         { labelKey: "nav.actions.importCsv", icon: Upload, dispatch: "importCsv" },
         { labelKey: "nav.actions.exportCsv", icon: Download, dispatch: "exportCsv" },
         { labelKey: "nav.actions.categoryFilter", icon: Tag, dispatch: "openFilter" },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3118.

Closes #3118

---

## Claude summary

Fix committed. Here's what happened and what was changed:

**Root cause:** In `src/modules/crm/manifest.ts:224`, the "Dodaj dostawę" action in the Products sidebar Actions panel was declared with `href: "/dashboard/gabinet/deliveries"`. This caused a hard navigation to the Gabinet deliveries route which isn't accessible from the Products module context and rendered as "Not Found".

**Fix:** Changed to `dispatch: "addDelivery"` — one line, in `src/modules/crm/manifest.ts:224`. This fires the `useSidebarDispatch("addDelivery", ...)` handler already wired up in the products page (`_layout.products.index.tsx:225`), which opens `AddDeliveryPanel` as a side panel. The user stays in the Products module.

**Both buttons covered:**
- Left panel "Akcje" button: was broken (`href`), now fixed (`dispatch`)
- Bottom footer button (`app-footer.tsx:67`): already used `action: "addDelivery"` — was already correct

**Regression test:** `src/modules/manifest-dispatches.test.ts` already validates that every `dispatch:` entry in any manifest has a corresponding `useSidebarDispatch` handler on the target route. My fix plugs the delivery action into this coverage automatically — no new test code needed.