### PR TITLE
Uprość filtry produktów dla zwykłego użytkownika

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, type ReactNode } from "react";
 import { createFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { getExpiryStatus } from "@/lib/expiry-utils";
 import { useAction } from "convex/react";
@@ -22,6 +22,10 @@ import { SidePanel } from "@/components/crm/side-panel";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Plus, Pencil, Trash2, Power, X, Package, AlertTriangle, History, Archive, RotateCcw } from "@/lib/ez-icons";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { useCsvExport } from "@/components/csv/csv-export-button";
@@ -163,6 +167,354 @@ function StatCard({ label, value, highlight, active, onClick }: {
   );
 }
 
+type SimpleFiltersState = {
+  productSection: string | null;
+  categoryId: string | null;
+  manufacturer: string | null;
+  isActive: "true" | "false" | null;
+  stockFilter: "below_min" | "zero" | "gt" | "lt" | null;
+  stockValue: string;
+  priceFrom: string;
+  priceTo: string;
+};
+
+const EMPTY_SIMPLE_FILTERS: SimpleFiltersState = {
+  productSection: null,
+  categoryId: null,
+  manufacturer: null,
+  isActive: null,
+  stockFilter: null,
+  stockValue: "",
+  priceFrom: "",
+  priceTo: "",
+};
+
+function hasAnySimpleFilter(f: SimpleFiltersState): boolean {
+  return (
+    f.productSection !== null ||
+    f.categoryId !== null ||
+    f.manufacturer !== null ||
+    f.isActive !== null ||
+    f.stockFilter !== null ||
+    f.priceFrom !== "" ||
+    f.priceTo !== ""
+  );
+}
+
+function FilterChip({ children, onRemove }: { children: ReactNode; onRemove: () => void }) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-2 py-0.5 text-xs font-medium">
+      {children}
+      <button
+        type="button"
+        onClick={onRemove}
+        className="ml-0.5 rounded hover:bg-muted"
+        aria-label="Usuń filtr"
+      >
+        <X className="h-3 w-3" variant="stroke" />
+      </button>
+    </span>
+  );
+}
+
+function ProductSimpleFilterPanel({
+  open,
+  onOpenChange,
+  filters,
+  onApply,
+  categories,
+  manufacturers,
+  onOpenAdvanced,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  filters: SimpleFiltersState;
+  onApply: (f: SimpleFiltersState) => void;
+  categories: Array<{ _id: string; name: string }>;
+  manufacturers: string[];
+  onOpenAdvanced: () => void;
+}) {
+  const { t } = useTranslation();
+  const [draft, setDraft] = useState<SimpleFiltersState>(EMPTY_SIMPLE_FILTERS);
+
+  useEffect(() => {
+    if (open) setDraft(filters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const hasAny = hasAnySimpleFilter(draft);
+
+  const handleApply = () => {
+    onApply(draft);
+    onOpenChange(false);
+  };
+
+  const handleClear = () => {
+    setDraft(EMPTY_SIMPLE_FILTERS);
+    onApply(EMPTY_SIMPLE_FILTERS);
+    onOpenChange(false);
+  };
+
+  return (
+    <SidePanel
+      open={open}
+      onOpenChange={onOpenChange}
+      title={t("products.simpleFilter.title", { defaultValue: "Filtruj produkty" })}
+      description={t("products.simpleFilter.description", { defaultValue: "Wybierz filtry, aby zawęzić listę produktów." })}
+    >
+      <div className="space-y-5">
+        {/* productSection */}
+        <div className="space-y-2">
+          <Label className="text-sm font-semibold">
+            {t("products.simpleFilter.section.label", { defaultValue: "Pokaż produkty z grupy" })}
+          </Label>
+          <RadioGroup
+            value={draft.productSection ?? ""}
+            onValueChange={(v) => setDraft(d => ({ ...d, productSection: v || null }))}
+            className="space-y-2"
+          >
+            {([
+              ["", t("products.simpleFilter.section.all", { defaultValue: "Wszystkie grupy" })],
+              ["sale", t("products.sections.sale")],
+              ["treatment", t("products.sections.treatment")],
+              ["disposable", t("products.sections.disposable")],
+            ] as [string, string][]).map(([value, label]) => (
+              <div key={value || "all"} className="flex items-center gap-2">
+                <RadioGroupItem value={value} id={`sf-section-${value || "all"}`} />
+                <label htmlFor={`sf-section-${value || "all"}`} className="cursor-pointer text-sm leading-none">
+                  {label}
+                </label>
+              </div>
+            ))}
+          </RadioGroup>
+        </div>
+
+        <div className="h-px bg-border" />
+
+        {/* categoryId */}
+        <div className="space-y-2">
+          <Label className="text-sm font-semibold">
+            {t("products.simpleFilter.category.label", { defaultValue: "Pokaż produkty z kategorii" })}
+          </Label>
+          {categories.length > 0 ? (
+            <Select
+              value={draft.categoryId ?? ""}
+              onValueChange={(v) => setDraft(d => ({ ...d, categoryId: v || null }))}
+            >
+              <SelectTrigger className="h-9">
+                <SelectValue placeholder={t("products.simpleFilter.category.all", { defaultValue: "Wszystkie kategorie" })} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="">
+                  {t("products.simpleFilter.category.all", { defaultValue: "Wszystkie kategorie" })}
+                </SelectItem>
+                {categories.map(cat => (
+                  <SelectItem key={cat._id} value={cat._id}>{cat.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {t("products.simpleFilter.category.empty", { defaultValue: "Brak zdefiniowanych kategorii." })}
+            </p>
+          )}
+        </div>
+
+        <div className="h-px bg-border" />
+
+        {/* manufacturer */}
+        <div className="space-y-2">
+          <Label className="text-sm font-semibold">
+            {t("products.simpleFilter.manufacturer.label", { defaultValue: "Pokaż produkty od dostawcy" })}
+          </Label>
+          {manufacturers.length > 0 ? (
+            <Select
+              value={draft.manufacturer ?? ""}
+              onValueChange={(v) => setDraft(d => ({ ...d, manufacturer: v || null }))}
+            >
+              <SelectTrigger className="h-9">
+                <SelectValue placeholder={t("products.simpleFilter.manufacturer.all", { defaultValue: "Wszyscy dostawcy" })} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="">
+                  {t("products.simpleFilter.manufacturer.all", { defaultValue: "Wszyscy dostawcy" })}
+                </SelectItem>
+                {manufacturers.map(m => (
+                  <SelectItem key={m} value={m}>{m}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {t("products.simpleFilter.manufacturer.empty", { defaultValue: "Brak dostawców w produktach." })}
+            </p>
+          )}
+        </div>
+
+        <div className="h-px bg-border" />
+
+        {/* stockFilter */}
+        <div className="space-y-2">
+          <Label className="text-sm font-semibold">
+            {t("products.simpleFilter.stock.label", { defaultValue: "Pokaż produkty" })}
+          </Label>
+          <RadioGroup
+            value={draft.stockFilter ?? ""}
+            onValueChange={(v) => {
+              const val = v as SimpleFiltersState["stockFilter"] | "";
+              setDraft(d => ({
+                ...d,
+                stockFilter: val || null,
+                stockValue: val !== "gt" && val !== "lt" ? "" : d.stockValue,
+              }));
+            }}
+            className="space-y-2"
+          >
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="" id="sf-stock-all" />
+              <label htmlFor="sf-stock-all" className="cursor-pointer text-sm leading-none">
+                {t("products.simpleFilter.stock.all", { defaultValue: "wszystkie stany" })}
+              </label>
+            </div>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="below_min" id="sf-stock-below-min" />
+              <label htmlFor="sf-stock-below-min" className="cursor-pointer text-sm leading-none">
+                {t("products.simpleFilter.stock.belowMin", { defaultValue: "poniżej minimalnego stanu" })}
+              </label>
+            </div>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="zero" id="sf-stock-zero" />
+              <label htmlFor="sf-stock-zero" className="cursor-pointer text-sm leading-none">
+                {t("products.simpleFilter.stock.zero", { defaultValue: "ze stanem równym 0" })}
+              </label>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <RadioGroupItem value="gt" id="sf-stock-gt" />
+              <label htmlFor="sf-stock-gt" className="cursor-pointer text-sm leading-none">
+                {t("products.simpleFilter.stock.gt", { defaultValue: "ze stanem większym niż" })}
+              </label>
+              {draft.stockFilter === "gt" && (
+                <Input
+                  type="number"
+                  min={0}
+                  value={draft.stockValue}
+                  onChange={e => setDraft(d => ({ ...d, stockValue: e.target.value }))}
+                  className="h-7 w-20 text-sm"
+                  placeholder="0"
+                />
+              )}
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <RadioGroupItem value="lt" id="sf-stock-lt" />
+              <label htmlFor="sf-stock-lt" className="cursor-pointer text-sm leading-none">
+                {t("products.simpleFilter.stock.lt", { defaultValue: "ze stanem mniejszym niż" })}
+              </label>
+              {draft.stockFilter === "lt" && (
+                <Input
+                  type="number"
+                  min={0}
+                  value={draft.stockValue}
+                  onChange={e => setDraft(d => ({ ...d, stockValue: e.target.value }))}
+                  className="h-7 w-20 text-sm"
+                  placeholder="0"
+                />
+              )}
+            </div>
+          </RadioGroup>
+        </div>
+
+        <div className="h-px bg-border" />
+
+        {/* price */}
+        <div className="space-y-2">
+          <Label className="text-sm font-semibold">
+            {t("products.simpleFilter.price.label", { defaultValue: "Pokaż produkty w cenie zakupu" })}
+          </Label>
+          <div className="flex items-center gap-2">
+            <span className="whitespace-nowrap text-sm text-muted-foreground">od</span>
+            <Input
+              type="number"
+              min={0}
+              value={draft.priceFrom}
+              onChange={e => setDraft(d => ({ ...d, priceFrom: e.target.value }))}
+              className="h-9 flex-1"
+              placeholder="min."
+            />
+            <span className="whitespace-nowrap text-sm text-muted-foreground">do</span>
+            <Input
+              type="number"
+              min={0}
+              value={draft.priceTo}
+              onChange={e => setDraft(d => ({ ...d, priceTo: e.target.value }))}
+              className="h-9 flex-1"
+              placeholder="maks."
+            />
+            <span className="text-sm text-muted-foreground">PLN</span>
+          </div>
+        </div>
+
+        <div className="h-px bg-border" />
+
+        {/* isActive */}
+        <div className="space-y-2">
+          <Label className="text-sm font-semibold">
+            {t("products.simpleFilter.active.label", { defaultValue: "Aktywność produktu" })}
+          </Label>
+          <RadioGroup
+            value={draft.isActive ?? ""}
+            onValueChange={(v) => setDraft(d => ({ ...d, isActive: v as SimpleFiltersState["isActive"] || null }))}
+            className="space-y-2"
+          >
+            {([
+              ["", t("products.simpleFilter.active.all", { defaultValue: "wszystkie" })],
+              ["true", t("products.simpleFilter.active.active", { defaultValue: "aktywne" })],
+              ["false", t("products.simpleFilter.active.inactive", { defaultValue: "nieaktywne" })],
+            ] as [string, string][]).map(([value, label]) => (
+              <div key={value || "all"} className="flex items-center gap-2">
+                <RadioGroupItem value={value} id={`sf-active-${value || "all"}`} />
+                <label htmlFor={`sf-active-${value || "all"}`} className="cursor-pointer text-sm leading-none">
+                  {label}
+                </label>
+              </div>
+            ))}
+          </RadioGroup>
+        </div>
+
+        <div className="h-px bg-border" />
+
+        {/* advanced filter link */}
+        <div className="flex justify-center">
+          <button
+            type="button"
+            className="text-sm text-muted-foreground underline underline-offset-2 transition-colors hover:text-foreground"
+            onClick={() => {
+              onOpenChange(false);
+              onOpenAdvanced();
+            }}
+          >
+            {t("products.simpleFilter.advanced", { defaultValue: "Filtry zaawansowane" })}
+          </button>
+        </div>
+
+        {/* footer buttons */}
+        <div className="flex items-center justify-between gap-3 border-t pt-4">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleClear}
+            disabled={!hasAny}
+          >
+            {t("filters.clearAll", { defaultValue: "Wyczyść wszystko" })}
+          </Button>
+          <Button size="sm" onClick={handleApply}>
+            {t("filters.apply", { defaultValue: "Zastosuj filtry" })}
+          </Button>
+        </div>
+      </div>
+    </SidePanel>
+  );
+}
+
 function ProductsPage() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
@@ -187,6 +539,8 @@ function ProductsPage() {
   const [filterSlideoutOpen, setFilterSlideoutOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
   const [activeFilters, setActiveFilters] = useState<FilterCondition[]>([]);
+  const [simpleFiltersOpen, setSimpleFiltersOpen] = useState(false);
+  const [simpleFilters, setSimpleFilters] = useState<SimpleFiltersState>(EMPTY_SIMPLE_FILTERS);
   const { handleExport } = useCsvExport(organizationId, "products");
   const { tags } = useTagDefinitions(organizationId);
   const { categories } = useCategoryDefinitions(organizationId, "product");
@@ -208,6 +562,18 @@ function ProductsPage() {
     { id: "categoryId", label: t('common.category', { defaultValue: "Kategoria" }), type: "select" as const, options: categories.map(cat => ({ label: cat.name, value: cat._id })) },
     { id: "manufacturer", label: t("products.manufacturer", { defaultValue: "Producent" }), type: "text" },
   ], [t, tags, categories]);
+
+  const simpleFilterConditions = useMemo((): FilterCondition[] => {
+    const conditions: FilterCondition[] = [];
+    if (simpleFilters.productSection) conditions.push({ field: "productSection", operator: "equals", value: simpleFilters.productSection });
+    if (simpleFilters.categoryId) conditions.push({ field: "categoryId", operator: "equals", value: simpleFilters.categoryId });
+    if (simpleFilters.manufacturer) conditions.push({ field: "manufacturer", operator: "equals", value: simpleFilters.manufacturer });
+    if (simpleFilters.isActive) conditions.push({ field: "isActive", operator: "equals", value: simpleFilters.isActive });
+    if (simpleFilters.priceFrom) conditions.push({ field: "unitPrice", operator: "greaterThan", value: simpleFilters.priceFrom });
+    if (simpleFilters.priceTo) conditions.push({ field: "unitPrice", operator: "lessThan", value: simpleFilters.priceTo });
+    return conditions;
+  }, [simpleFilters]);
+
   const [tagsSlideoutOpen, setTagsSlideoutOpen] = useState(false);
   const [categoriesSlideoutOpen, setCategoriesSlideoutOpen] = useState(false);
   const [columnSettingsOpen, setColumnSettingsOpen] = useState(false);
@@ -216,7 +582,7 @@ function ProductsPage() {
   useSidebarDispatch("importCsv", () => setImportOpen(true));
   useSidebarDispatch("exportCsv", () => handleExport());
   useSidebarDispatch("savedViews", () => setSavedViewsDialogOpen(true));
-  useSidebarDispatch("openFilter", () => setFilterSlideoutOpen(true));
+  useSidebarDispatch("openFilter", () => setSimpleFiltersOpen(true));
   useSidebarDispatch("manageTags", () => setTagsSlideoutOpen(true));
   useSidebarDispatch("manageCategories", () => setCategoriesSlideoutOpen(true));
   useSidebarDispatch("openShoppingList", () => setShoppingListOpen(true));
@@ -243,6 +609,11 @@ function ProductsPage() {
     organizationId,
     lotBatchesProduct?._id ?? null,
     { enabled: !!lotBatchesProduct },
+  );
+
+  const manufacturers = useMemo(
+    () => [...new Set(allProducts.map(p => p.manufacturer).filter((m): m is string => Boolean(m)))].sort(),
+    [allProducts],
   );
 
   // Compute per-product stock status for filtering and display
@@ -294,7 +665,16 @@ function ProductsPage() {
       });
     }
     data = applyFilters(data);
-    data = applyFilterConditions(data, activeFilters);
+    if (simpleFilters.stockFilter === "below_min") {
+      data = data.filter(p => { const s = productStockStatus.get(p._id); return s === "low" || s === "out"; });
+    } else if (simpleFilters.stockFilter === "zero") {
+      data = data.filter(p => p.trackStock && (totalsByProductId.get(p._id)?.total ?? 0) <= 0);
+    } else if (simpleFilters.stockFilter === "gt" && simpleFilters.stockValue) {
+      data = data.filter(p => p.trackStock && (totalsByProductId.get(p._id)?.total ?? 0) > Number(simpleFilters.stockValue));
+    } else if (simpleFilters.stockFilter === "lt" && simpleFilters.stockValue) {
+      data = data.filter(p => p.trackStock && (totalsByProductId.get(p._id)?.total ?? 0) < Number(simpleFilters.stockValue));
+    }
+    data = applyFilterConditions(data, [...simpleFilterConditions, ...activeFilters]);
     if (searchValue.trim()) {
       const q = searchValue.trim().toLowerCase();
       data = data.filter((p) =>
@@ -306,7 +686,7 @@ function ProductsPage() {
       );
     }
     return data;
-  }, [activeViewId, allProducts, applyFilters, activeFilters, searchValue, nudgeFilter, usedProductIds, productStockStatus, totalsByProductId]);
+  }, [activeViewId, allProducts, applyFilters, activeFilters, simpleFilters, simpleFilterConditions, searchValue, nudgeFilter, usedProductIds, productStockStatus, totalsByProductId]);
 
   const createProduct = useAction(api.products.create);
   const updateProduct = useAction(api.products.update);
@@ -862,6 +1242,73 @@ function ProductsPage() {
         </div>
       )}
 
+      {hasAnySimpleFilter(simpleFilters) && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2 text-sm">
+          <span className="shrink-0 text-xs font-medium text-muted-foreground">
+            {t("products.simpleFilter.activeFilters", { defaultValue: "Aktywne filtry:" })}
+          </span>
+
+          {simpleFilters.productSection && (
+            <FilterChip onRemove={() => setSimpleFilters(f => ({ ...f, productSection: null }))}>
+              {t("products.simpleFilter.chips.section", { defaultValue: "Grupa:" })}
+              {" "}
+              {({ sale: t("products.sections.sale"), treatment: t("products.sections.treatment"), disposable: t("products.sections.disposable") })[simpleFilters.productSection] ?? simpleFilters.productSection}
+            </FilterChip>
+          )}
+
+          {simpleFilters.categoryId && (
+            <FilterChip onRemove={() => setSimpleFilters(f => ({ ...f, categoryId: null }))}>
+              {t("products.simpleFilter.chips.category", { defaultValue: "Kategoria:" })}
+              {" "}
+              {categories.find(c => c._id === simpleFilters.categoryId)?.name ?? ""}
+            </FilterChip>
+          )}
+
+          {simpleFilters.manufacturer && (
+            <FilterChip onRemove={() => setSimpleFilters(f => ({ ...f, manufacturer: null }))}>
+              {t("products.simpleFilter.chips.manufacturer", { defaultValue: "Dostawca:" })}
+              {" "}
+              {simpleFilters.manufacturer}
+            </FilterChip>
+          )}
+
+          {simpleFilters.isActive && (
+            <FilterChip onRemove={() => setSimpleFilters(f => ({ ...f, isActive: null }))}>
+              {simpleFilters.isActive === "true"
+                ? t("products.simpleFilter.active.active", { defaultValue: "Aktywne" })
+                : t("products.simpleFilter.active.inactive", { defaultValue: "Nieaktywne" })}
+            </FilterChip>
+          )}
+
+          {simpleFilters.stockFilter && (
+            <FilterChip onRemove={() => setSimpleFilters(f => ({ ...f, stockFilter: null, stockValue: "" }))}>
+              {simpleFilters.stockFilter === "below_min" && t("products.simpleFilter.stock.belowMin", { defaultValue: "Stan: poniżej minimum" })}
+              {simpleFilters.stockFilter === "zero" && t("products.simpleFilter.stock.zero", { defaultValue: "Stan: równy 0" })}
+              {simpleFilters.stockFilter === "gt" && `Stan > ${simpleFilters.stockValue}`}
+              {simpleFilters.stockFilter === "lt" && `Stan < ${simpleFilters.stockValue}`}
+            </FilterChip>
+          )}
+
+          {(simpleFilters.priceFrom || simpleFilters.priceTo) && (
+            <FilterChip onRemove={() => setSimpleFilters(f => ({ ...f, priceFrom: "", priceTo: "" }))}>
+              {simpleFilters.priceFrom && simpleFilters.priceTo
+                ? `Cena: ${simpleFilters.priceFrom}–${simpleFilters.priceTo} PLN`
+                : simpleFilters.priceFrom
+                  ? `Cena: od ${simpleFilters.priceFrom} PLN`
+                  : `Cena: do ${simpleFilters.priceTo} PLN`}
+            </FilterChip>
+          )}
+
+          <button
+            type="button"
+            className="ml-auto shrink-0 text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+            onClick={() => setSimpleFilters(EMPTY_SIMPLE_FILTERS)}
+          >
+            {t("filters.clearAll", { defaultValue: "Wyczyść wszystko" })}
+          </button>
+        </div>
+      )}
+
       <DataListFilterBar
         views={views}
         activeViewId={activeViewId}
@@ -1129,6 +1576,16 @@ function ProductsPage() {
         organizationId={organizationId}
         entityType="product"
         categories={categories}
+      />
+
+      <ProductSimpleFilterPanel
+        open={simpleFiltersOpen}
+        onOpenChange={setSimpleFiltersOpen}
+        filters={simpleFilters}
+        onApply={setSimpleFilters}
+        categories={categories}
+        manufacturers={manufacturers}
+        onOpenAdvanced={() => setFilterSlideoutOpen(true)}
       />
 
       <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3119.

Closes #3119

---

## Claude summary

The implementation is committed. Here's a summary of what was done:

The issue asked to replace the technical filter UI (showing raw `products.name`, `zawiera`, `wartość` rows) with a user-friendly filter panel as the default.

**What changed** (all in `src/routes/_app/_auth/dashboard/_layout.products.index.tsx`):

1. **`ProductSimpleFilterPanel` component** — A new `SidePanel` with 6 plain-Polish filter sections:
   - "Pokaż produkty z grupy" — radio group (sale/treatment/disposable)
   - "Pokaż produkty z kategorii" — select from existing categories
   - "Pokaż produkty od dostawcy" — select from distinct manufacturer values in products
   - "Pokaż produkty" (stock status) — radio group with optional numeric input for `>` / `<`
   - "Pokaż produkty w cenie zakupu" — from/to number inputs in PLN
   - "Aktywność produktu" — radio group (all/active/inactive)
   - "Filtry zaawansowane" link at the bottom to open the existing technical filter
   - "Wyczyść wszystko" + "Zastosuj filtry" buttons

2. **Filter pipeline** — Simple filters map to existing `FilterCondition[]` for non-stock fields. Stock status uses a separate inline `.filter()` step (as stock is computed from `totalsByProductId`, not a direct product field).

3. **Active filter chips** — Shown as removable badges above the data table whenever any simple filter is active, with per-chip remove buttons and a "Wyczyść wszystko" link.

4. **Sidebar dispatch** — `useSidebarDispatch("openFilter")` now opens the simple panel instead of the technical slideout.

## Follow-ups
- Translate simple filter label keys into the i18n translation files: currently using `defaultValue` fallbacks (e.g. `products.simpleFilter.title`) which won't appear in the PL/EN translation files and will fall back to hardcoded Polish strings
- Add unit tests for `hasAnySimpleFilter` and the stock-filter branching logic in the products useMemo: these are new, testable pure functions with no coverage