### PR TITLE
Ukryj górny pasek CRM tylko w module Produkty / Magazyn

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -824,6 +824,7 @@ function DashboardLayoutInner({ user, orgs }: DashboardLayoutInnerProps) {
   const showDatePicker = /^\/(dashboard)\/?$/.test(pathname)
     || /^\/dashboard\/(activities|calls|leads|pipelines)/.test(pathname);
   const showAgendaStrip = !pathname.startsWith("/dashboard/gabinet");
+  const showCrmHeader = !pathname.startsWith("/dashboard/products");
 
   const [lastDispatch, setLastDispatch] = useState<{ id: string; seq: number } | null>(null);
   const dispatchSeqRef = useRef(0);
@@ -874,7 +875,7 @@ function DashboardLayoutInner({ user, orgs }: DashboardLayoutInnerProps) {
 
             {/* Column 3: Main content */}
             <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-              <header className="bg-card sticky top-0 z-50 flex min-h-20 items-center justify-between gap-6 border-b px-4 py-2 sm:px-6">
+              {showCrmHeader && <header className="bg-card sticky top-0 z-50 flex min-h-20 items-center justify-between gap-6 border-b px-4 py-2 sm:px-6">
                 <div className="flex items-center gap-4">
                   <HeaderBackButton />
                   <SidebarTrigger className="[&_svg]:!size-4 [&_easier-icon]:!size-4" />
@@ -978,7 +979,7 @@ function DashboardLayoutInner({ user, orgs }: DashboardLayoutInnerProps) {
                     </DropdownMenuContent>
                   </DropdownMenu>
                 </div>
-              </header>
+              </header>}
 
               {showAgendaStrip && firstOrg && user && (
                 <AgendaStrip organizationId={firstOrg._id} userId={user._id} />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3125.

Closes #3125

---

## Claude summary

Done. The fix is 3 lines in one file, following the exact same pattern already used for the Gabinet module (`showAgendaStrip`).

What changed: `src/routes/_app/_auth/dashboard/_layout.tsx` now computes `showCrmHeader = !pathname.startsWith("/dashboard/products")` and wraps the `<header>` with `{showCrmHeader && ...}`. When the user is on any `/dashboard/products` path, the CRM top bar (user name, notification bell, search, agenda strip info) disappears and the warehouse content expands to fill the freed space. All other modules are completely unaffected.