### PR TITLE
Translate simple filter label keys into the i18n translation files

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -936,6 +936,48 @@
         "negativeWarning": "Stock went negative. Review the movement history and correct shortages.",
         "error": "Could not update stock."
       }
+    },
+    "simpleFilter": {
+      "title": "Filter products",
+      "description": "Select filters to narrow down the product list.",
+      "activeFilters": "Active filters:",
+      "advanced": "Advanced filters",
+      "section": {
+        "label": "Show products from group",
+        "all": "All groups"
+      },
+      "category": {
+        "label": "Show products from category",
+        "all": "All categories",
+        "empty": "No categories defined."
+      },
+      "manufacturer": {
+        "label": "Show products by supplier",
+        "all": "All suppliers",
+        "empty": "No suppliers in products."
+      },
+      "stock": {
+        "label": "Show products",
+        "all": "all stock levels",
+        "belowMin": "below minimum stock",
+        "zero": "with stock equal to 0",
+        "gt": "with stock greater than",
+        "lt": "with stock less than"
+      },
+      "price": {
+        "label": "Show products at purchase price"
+      },
+      "active": {
+        "label": "Product activity",
+        "all": "all",
+        "active": "Active",
+        "inactive": "Inactive"
+      },
+      "chips": {
+        "section": "Group:",
+        "category": "Category:",
+        "manufacturer": "Supplier:"
+      }
     }
   },
   "calls": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -937,6 +937,48 @@
         "negativeWarning": "Stan magazynowy spadł poniżej zera. Sprawdź historię ruchów i skoryguj braki.",
         "error": "Nie udało się zaktualizować stanu magazynowego."
       }
+    },
+    "simpleFilter": {
+      "title": "Filtruj produkty",
+      "description": "Wybierz filtry, aby zawęzić listę produktów.",
+      "activeFilters": "Aktywne filtry:",
+      "advanced": "Filtry zaawansowane",
+      "section": {
+        "label": "Pokaż produkty z grupy",
+        "all": "Wszystkie grupy"
+      },
+      "category": {
+        "label": "Pokaż produkty z kategorii",
+        "all": "Wszystkie kategorie",
+        "empty": "Brak zdefiniowanych kategorii."
+      },
+      "manufacturer": {
+        "label": "Pokaż produkty od dostawcy",
+        "all": "Wszyscy dostawcy",
+        "empty": "Brak dostawców w produktach."
+      },
+      "stock": {
+        "label": "Pokaż produkty",
+        "all": "wszystkie stany",
+        "belowMin": "poniżej minimalnego stanu",
+        "zero": "ze stanem równym 0",
+        "gt": "ze stanem większym niż",
+        "lt": "ze stanem mniejszym niż"
+      },
+      "price": {
+        "label": "Pokaż produkty w cenie zakupu"
+      },
+      "active": {
+        "label": "Aktywność produktu",
+        "all": "wszystkie",
+        "active": "Aktywne",
+        "inactive": "Nieaktywne"
+      },
+      "chips": {
+        "section": "Grupa:",
+        "category": "Kategoria:",
+        "manufacturer": "Dostawca:"
+      }
     }
   },
   "calls": {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3127.

Closes #3127

---

## Claude summary

Done. Both `public/locales/pl/translation.json` and `public/locales/en/translation.json` now contain the full `products.simpleFilter` key tree (26 keys across `title`, `description`, `activeFilters`, `advanced`, `section`, `category`, `manufacturer`, `stock`, `price`, `active`, and `chips`). The `defaultValue` fallbacks in the component will no longer be needed in practice since i18next will now resolve them from the files.

## Follow-ups

- Translate hardcoded Polish price chip strings in products index: lines 1294–1298 build price chip labels as `Cena: ${from}–${to} PLN` / `Cena: od ${from} PLN` / `Cena: do ${to} PLN` using template literals without `t()`, so they won't translate to English
- Translate hardcoded Polish stock chip labels for gt/lt: lines 1287–1288 render `Stan > ${value}` / `Stan < ${value}` without `t()`, bypassing i18n entirely
- Translate hardcoded Polish price range "od"/"do"/"PLN" labels in simple filter panel: lines 434, 443, 452 use bare Polish text inside `<span>` elements without i18n
- Fix inconsistent defaultValues for `products.simpleFilter.stock.belowMin` and `stock.zero`: the filter panel defaultValue ("poniżej minimalnego stanu") differs from the chip defaultValue ("Stan: poniżej minimum") for the same key, suggesting the chip context may need its own key (`chips.stock*`)