### PR TITLE
Add unit tests for `hasAnySimpleFilter` and the stock-filter branching logic in 

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -49,6 +49,13 @@ import { WarehouseInventoryDialog } from "@/components/gabinet/warehouse-invento
 import { WarehouseShoppingListDialog } from "@/components/gabinet/warehouse-shopping-list-dialog";
 import { AddDeliveryPanel } from "@/components/gabinet/add-delivery-panel";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
+import {
+  hasAnySimpleFilter,
+  applyStockFilter,
+  EMPTY_SIMPLE_FILTERS,
+  type SimpleFiltersState,
+  type StockStatus,
+} from "./products-filters";
 
 type ProductsNudgeFilter = "unused" | "low_stock";
 
@@ -77,10 +84,6 @@ function formatCurrency(amount: number): string {
 }
 
 // Returns the stock status for a product given its current total and min stock
-type StockStatus = "ok" | "low" | "out" | "untracked";
-
-
-
 function getStockStatus(
   trackStock: boolean | undefined,
   total: number,
@@ -164,40 +167,6 @@ function StatCard({ label, value, highlight, active, onClick }: {
       )}>{value}</span>
       <span className="text-xs text-muted-foreground">{label}</span>
     </button>
-  );
-}
-
-type SimpleFiltersState = {
-  productSection: string | null;
-  categoryId: string | null;
-  manufacturer: string | null;
-  isActive: "true" | "false" | null;
-  stockFilter: "below_min" | "zero" | "gt" | "lt" | null;
-  stockValue: string;
-  priceFrom: string;
-  priceTo: string;
-};
-
-const EMPTY_SIMPLE_FILTERS: SimpleFiltersState = {
-  productSection: null,
-  categoryId: null,
-  manufacturer: null,
-  isActive: null,
-  stockFilter: null,
-  stockValue: "",
-  priceFrom: "",
-  priceTo: "",
-};
-
-function hasAnySimpleFilter(f: SimpleFiltersState): boolean {
-  return (
-    f.productSection !== null ||
-    f.categoryId !== null ||
-    f.manufacturer !== null ||
-    f.isActive !== null ||
-    f.stockFilter !== null ||
-    f.priceFrom !== "" ||
-    f.priceTo !== ""
   );
 }
 
@@ -665,15 +634,7 @@ function ProductsPage() {
       });
     }
     data = applyFilters(data);
-    if (simpleFilters.stockFilter === "below_min") {
-      data = data.filter(p => { const s = productStockStatus.get(p._id); return s === "low" || s === "out"; });
-    } else if (simpleFilters.stockFilter === "zero") {
-      data = data.filter(p => p.trackStock && (totalsByProductId.get(p._id)?.total ?? 0) <= 0);
-    } else if (simpleFilters.stockFilter === "gt" && simpleFilters.stockValue) {
-      data = data.filter(p => p.trackStock && (totalsByProductId.get(p._id)?.total ?? 0) > Number(simpleFilters.stockValue));
-    } else if (simpleFilters.stockFilter === "lt" && simpleFilters.stockValue) {
-      data = data.filter(p => p.trackStock && (totalsByProductId.get(p._id)?.total ?? 0) < Number(simpleFilters.stockValue));
-    }
+    data = applyStockFilter(data, simpleFilters.stockFilter, simpleFilters.stockValue, productStockStatus, totalsByProductId);
     data = applyFilterConditions(data, [...simpleFilterConditions, ...activeFilters]);
     if (searchValue.trim()) {
       const q = searchValue.trim().toLowerCase();

--- a/src/routes/_app/_auth/dashboard/products-filters.test.ts
+++ b/src/routes/_app/_auth/dashboard/products-filters.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasAnySimpleFilter,
+  applyStockFilter,
+  EMPTY_SIMPLE_FILTERS,
+  type SimpleFiltersState,
+  type StockStatus,
+} from "./products-filters";
+
+// ─── hasAnySimpleFilter ───────────────────────────────────────────────────────
+
+describe("hasAnySimpleFilter", () => {
+  it("returns false for the empty-filters baseline", () => {
+    expect(hasAnySimpleFilter(EMPTY_SIMPLE_FILTERS)).toBe(false);
+  });
+
+  it("returns true when productSection is set", () => {
+    expect(hasAnySimpleFilter({ ...EMPTY_SIMPLE_FILTERS, productSection: "sale" })).toBe(true);
+  });
+
+  it("returns true when categoryId is set", () => {
+    expect(hasAnySimpleFilter({ ...EMPTY_SIMPLE_FILTERS, categoryId: "cat_1" })).toBe(true);
+  });
+
+  it("returns true when manufacturer is set", () => {
+    expect(hasAnySimpleFilter({ ...EMPTY_SIMPLE_FILTERS, manufacturer: "Acme" })).toBe(true);
+  });
+
+  it("returns true when isActive is set to 'true'", () => {
+    expect(hasAnySimpleFilter({ ...EMPTY_SIMPLE_FILTERS, isActive: "true" })).toBe(true);
+  });
+
+  it("returns true when isActive is set to 'false'", () => {
+    expect(hasAnySimpleFilter({ ...EMPTY_SIMPLE_FILTERS, isActive: "false" })).toBe(true);
+  });
+
+  it("returns true when stockFilter is set", () => {
+    expect(hasAnySimpleFilter({ ...EMPTY_SIMPLE_FILTERS, stockFilter: "zero" })).toBe(true);
+  });
+
+  it("returns true when priceFrom is non-empty", () => {
+    expect(hasAnySimpleFilter({ ...EMPTY_SIMPLE_FILTERS, priceFrom: "10" })).toBe(true);
+  });
+
+  it("returns true when priceTo is non-empty", () => {
+    expect(hasAnySimpleFilter({ ...EMPTY_SIMPLE_FILTERS, priceTo: "200" })).toBe(true);
+  });
+
+  it("does NOT count stockValue alone as an active filter (stockFilter is null)", () => {
+    // stockValue is only meaningful when stockFilter is "gt" or "lt"
+    expect(hasAnySimpleFilter({ ...EMPTY_SIMPLE_FILTERS, stockValue: "5" })).toBe(false);
+  });
+});
+
+// ─── applyStockFilter ─────────────────────────────────────────────────────────
+
+type MinProduct = { _id: string; trackStock?: boolean };
+
+function makeProduct(id: string, trackStock = true): MinProduct {
+  return { _id: id, trackStock };
+}
+
+describe("applyStockFilter", () => {
+  it("returns all products unchanged when stockFilter is null", () => {
+    const products = [makeProduct("p1"), makeProduct("p2")];
+    const result = applyStockFilter(products, null, "", new Map(), new Map());
+    expect(result).toEqual(products);
+  });
+
+  describe("below_min branch", () => {
+    it("keeps products whose stock status is 'low' or 'out'", () => {
+      const products = [makeProduct("p1"), makeProduct("p2"), makeProduct("p3"), makeProduct("p4")];
+      const statusMap = new Map<string, StockStatus>([
+        ["p1", "out"],
+        ["p2", "low"],
+        ["p3", "ok"],
+        ["p4", "untracked"],
+      ]);
+      const result = applyStockFilter(products, "below_min", "", statusMap, new Map());
+      expect(result.map((p) => p._id)).toEqual(["p1", "p2"]);
+    });
+
+    it("returns empty list when all products have ok/untracked status", () => {
+      const products = [makeProduct("p1"), makeProduct("p2")];
+      const statusMap = new Map<string, StockStatus>([
+        ["p1", "ok"],
+        ["p2", "untracked"],
+      ]);
+      const result = applyStockFilter(products, "below_min", "", statusMap, new Map());
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("zero branch", () => {
+    it("keeps tracked products with total <= 0", () => {
+      const products = [makeProduct("p1"), makeProduct("p2"), makeProduct("p3", false)];
+      const totalsMap = new Map([
+        ["p1", { total: 0 }],
+        ["p2", { total: 5 }],
+      ]);
+      const result = applyStockFilter(products, "zero", "", new Map(), totalsMap);
+      expect(result.map((p) => p._id)).toEqual(["p1"]);
+    });
+
+    it("includes tracked products with no entry in the totals map (defaults to 0)", () => {
+      const products = [makeProduct("p1")];
+      const result = applyStockFilter(products, "zero", "", new Map(), new Map());
+      expect(result.map((p) => p._id)).toEqual(["p1"]);
+    });
+
+    it("excludes untracked products even when total is 0", () => {
+      const products = [makeProduct("untracked_p", false)];
+      const totalsMap = new Map([["untracked_p", { total: 0 }]]);
+      const result = applyStockFilter(products, "zero", "", new Map(), totalsMap);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("gt branch", () => {
+    it("keeps tracked products with total strictly greater than the threshold", () => {
+      const products = [makeProduct("p1"), makeProduct("p2"), makeProduct("p3")];
+      const totalsMap = new Map([
+        ["p1", { total: 3 }],
+        ["p2", { total: 10 }],
+        ["p3", { total: 3 }],
+      ]);
+      const result = applyStockFilter(products, "gt", "3", new Map(), totalsMap);
+      expect(result.map((p) => p._id)).toEqual(["p2"]);
+    });
+
+    it("returns all products unchanged when stockValue is empty string", () => {
+      const products = [makeProduct("p1"), makeProduct("p2")];
+      const totalsMap = new Map([["p1", { total: 100 }], ["p2", { total: 1 }]]);
+      const result = applyStockFilter(products, "gt", "", new Map(), totalsMap);
+      expect(result).toEqual(products);
+    });
+
+    it("excludes untracked products", () => {
+      const products = [makeProduct("p1"), makeProduct("p2", false)];
+      const totalsMap = new Map([["p1", { total: 5 }], ["p2", { total: 10 }]]);
+      const result = applyStockFilter(products, "gt", "3", new Map(), totalsMap);
+      expect(result.map((p) => p._id)).toEqual(["p1"]);
+    });
+  });
+
+  describe("lt branch", () => {
+    it("keeps tracked products with total strictly less than the threshold", () => {
+      const products = [makeProduct("p1"), makeProduct("p2"), makeProduct("p3")];
+      const totalsMap = new Map([
+        ["p1", { total: 2 }],
+        ["p2", { total: 5 }],
+        ["p3", { total: 5 }],
+      ]);
+      const result = applyStockFilter(products, "lt", "5", new Map(), totalsMap);
+      expect(result.map((p) => p._id)).toEqual(["p1"]);
+    });
+
+    it("returns all products unchanged when stockValue is empty string", () => {
+      const products = [makeProduct("p1"), makeProduct("p2")];
+      const result = applyStockFilter(products, "lt", "", new Map(), new Map());
+      expect(result).toEqual(products);
+    });
+
+    it("excludes untracked products", () => {
+      const products = [makeProduct("p1"), makeProduct("p2", false)];
+      const totalsMap = new Map([["p1", { total: 1 }], ["p2", { total: 1 }]]);
+      const result = applyStockFilter(products, "lt", "5", new Map(), totalsMap);
+      expect(result.map((p) => p._id)).toEqual(["p1"]);
+    });
+  });
+});

--- a/src/routes/_app/_auth/dashboard/products-filters.ts
+++ b/src/routes/_app/_auth/dashboard/products-filters.ts
@@ -1,0 +1,72 @@
+export type StockStatus = "ok" | "low" | "out" | "untracked";
+
+export type SimpleFiltersState = {
+  productSection: string | null;
+  categoryId: string | null;
+  manufacturer: string | null;
+  isActive: "true" | "false" | null;
+  stockFilter: "below_min" | "zero" | "gt" | "lt" | null;
+  stockValue: string;
+  priceFrom: string;
+  priceTo: string;
+};
+
+export const EMPTY_SIMPLE_FILTERS: SimpleFiltersState = {
+  productSection: null,
+  categoryId: null,
+  manufacturer: null,
+  isActive: null,
+  stockFilter: null,
+  stockValue: "",
+  priceFrom: "",
+  priceTo: "",
+};
+
+export function hasAnySimpleFilter(f: SimpleFiltersState): boolean {
+  return (
+    f.productSection !== null ||
+    f.categoryId !== null ||
+    f.manufacturer !== null ||
+    f.isActive !== null ||
+    f.stockFilter !== null ||
+    f.priceFrom !== "" ||
+    f.priceTo !== ""
+  );
+}
+
+type StockFilterProduct = { _id: string; trackStock?: boolean };
+
+export function applyStockFilter<T extends StockFilterProduct>(
+  data: T[],
+  stockFilter: SimpleFiltersState["stockFilter"],
+  stockValue: string,
+  productStockStatus: Map<string, StockStatus>,
+  totalsByProductId: Map<string, { total: number }>,
+): T[] {
+  if (stockFilter === "below_min") {
+    return data.filter((p) => {
+      const s = productStockStatus.get(p._id);
+      return s === "low" || s === "out";
+    });
+  }
+  if (stockFilter === "zero") {
+    return data.filter(
+      (p) => p.trackStock && (totalsByProductId.get(p._id)?.total ?? 0) <= 0,
+    );
+  }
+  if (stockFilter === "gt" && stockValue) {
+    return data.filter(
+      (p) =>
+        p.trackStock &&
+        (totalsByProductId.get(p._id)?.total ?? 0) > Number(stockValue),
+    );
+  }
+  if (stockFilter === "lt" && stockValue) {
+    return data.filter(
+      (p) =>
+        p.trackStock &&
+        (totalsByProductId.get(p._id)?.total ?? 0) < Number(stockValue),
+    );
+  }
+  return data;
+}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3128.

Closes #3128

---

## Claude summary

Done. Here's a summary of what was done:

**Problem:** `hasAnySimpleFilter` and the stock-filter branching logic were pure functions buried inside the route component file, making them impossible to test without pulling in React, TanStack Router, and Convex dependencies.

**Solution:**

1. **Extracted** `SimpleFiltersState`, `StockStatus`, `EMPTY_SIMPLE_FILTERS`, `hasAnySimpleFilter`, and the four-branch stock-filter logic into `src/routes/_app/_auth/dashboard/products-filters.ts` — a pure TypeScript module with zero external dependencies.

2. **Updated** `_layout.products.index.tsx` to import from the new module. The inline stock-filter `if/else if` chain was replaced with a single `applyStockFilter(...)` call.

3. **Added** `products-filters.test.ts` with 22 tests covering:
   - `hasAnySimpleFilter`: empty baseline returns false, each individual field being set returns true, `stockValue` alone (without `stockFilter`) correctly returns false
   - `applyStockFilter`: null passthrough, `below_min` (status-based), `zero` (including default-to-0 for missing entries, untracked excluded), `gt` and `lt` (both with empty-value no-op case and untracked exclusion)