### PR TITLE
Uprość filtry produktów dla zwykłego użytkownika

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -267,14 +267,14 @@ function ProductSimpleFilterPanel({
           </Label>
           {categories.length > 0 ? (
             <Select
-              value={draft.categoryId ?? ""}
-              onValueChange={(v) => setDraft(d => ({ ...d, categoryId: v || null }))}
+              value={draft.categoryId ?? "all"}
+              onValueChange={(v) => setDraft(d => ({ ...d, categoryId: v === "all" ? null : v }))}
             >
               <SelectTrigger className="h-9">
                 <SelectValue placeholder={t("products.simpleFilter.category.all", { defaultValue: "Wszystkie kategorie" })} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">
+                <SelectItem value="all">
                   {t("products.simpleFilter.category.all", { defaultValue: "Wszystkie kategorie" })}
                 </SelectItem>
                 {categories.map(cat => (
@@ -298,14 +298,14 @@ function ProductSimpleFilterPanel({
           </Label>
           {manufacturers.length > 0 ? (
             <Select
-              value={draft.manufacturer ?? ""}
-              onValueChange={(v) => setDraft(d => ({ ...d, manufacturer: v || null }))}
+              value={draft.manufacturer ?? "all"}
+              onValueChange={(v) => setDraft(d => ({ ...d, manufacturer: v === "all" ? null : v }))}
             >
               <SelectTrigger className="h-9">
                 <SelectValue placeholder={t("products.simpleFilter.manufacturer.all", { defaultValue: "Wszyscy dostawcy" })} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">
+                <SelectItem value="all">
                   {t("products.simpleFilter.manufacturer.all", { defaultValue: "Wszyscy dostawcy" })}
                 </SelectItem>
                 {manufacturers.map(m => (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3119.

Closes #3119

---

## Claude summary

Fixed. The crash was caused by two `<SelectItem value="">` in the simple filter panel — Radix UI Select rejects empty string as an item value. Both selects (category and manufacturer) now use `value="all"` as the "show all" sentinel, matching the pattern used throughout the rest of the codebase (`mail-send-log-tab.tsx`, `calendar.tsx`, etc.). The `onValueChange` handlers were updated to map `"all"` back to `null` in the draft state, so filter logic is unchanged.