### PR TITLE
Translate hardcoded Polish price chip strings in products index

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -976,7 +976,10 @@
       "chips": {
         "section": "Group:",
         "category": "Category:",
-        "manufacturer": "Supplier:"
+        "manufacturer": "Supplier:",
+        "priceRange": "Price: {{from}}–{{to}} PLN",
+        "priceFrom": "Price: from {{from}} PLN",
+        "priceTo": "Price: up to {{to}} PLN"
       }
     }
   },

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -977,7 +977,10 @@
       "chips": {
         "section": "Grupa:",
         "category": "Kategoria:",
-        "manufacturer": "Dostawca:"
+        "manufacturer": "Dostawca:",
+        "priceRange": "Cena: {{from}}–{{to}} PLN",
+        "priceFrom": "Cena: od {{from}} PLN",
+        "priceTo": "Cena: do {{to}} PLN"
       }
     }
   },

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -1253,10 +1253,10 @@ function ProductsPage() {
           {(simpleFilters.priceFrom || simpleFilters.priceTo) && (
             <FilterChip onRemove={() => setSimpleFilters(f => ({ ...f, priceFrom: "", priceTo: "" }))}>
               {simpleFilters.priceFrom && simpleFilters.priceTo
-                ? `Cena: ${simpleFilters.priceFrom}–${simpleFilters.priceTo} PLN`
+                ? t("products.simpleFilter.chips.priceRange", { from: simpleFilters.priceFrom, to: simpleFilters.priceTo, defaultValue: `Cena: ${simpleFilters.priceFrom}–${simpleFilters.priceTo} PLN` })
                 : simpleFilters.priceFrom
-                  ? `Cena: od ${simpleFilters.priceFrom} PLN`
-                  : `Cena: do ${simpleFilters.priceTo} PLN`}
+                  ? t("products.simpleFilter.chips.priceFrom", { from: simpleFilters.priceFrom, defaultValue: `Cena: od ${simpleFilters.priceFrom} PLN` })
+                  : t("products.simpleFilter.chips.priceTo", { to: simpleFilters.priceTo, defaultValue: `Cena: do ${simpleFilters.priceTo} PLN` })}
             </FilterChip>
           )}
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3134.

Closes #3134

---

## Claude summary

The fix is committed. Here's a summary of what was done:

Three files changed:

`src/routes/_app/_auth/dashboard/_layout.products.index.tsx` — replaced the three bare Polish template literals (`Cena: ${from}–${to} PLN`, `Cena: od ${from} PLN`, `Cena: do ${to} PLN`) at lines 1256–1259 with `t()` calls using i18next interpolation (`{{from}}`, `{{to}}`).

`public/locales/en/translation.json` and `public/locales/pl/translation.json` — added three new keys under `products.simpleFilter.chips`: `priceRange`, `priceFrom`, and `priceTo`, with the appropriate English and Polish strings respectively.

## Follow-ups

- Translate hardcoded Polish stock chip strings in products index: lines 1248–1249 use bare template literals `` `Stan > ${simpleFilters.stockValue}` `` and `` `Stan < ${simpleFilters.stockValue}` `` without `t()`, the same class of bug as #3134