### PR TITLE
Translate hardcoded Polish stock chip labels for gt/lt

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -979,7 +979,9 @@
         "manufacturer": "Supplier:",
         "priceRange": "Price: {{from}}–{{to}} PLN",
         "priceFrom": "Price: from {{from}} PLN",
-        "priceTo": "Price: up to {{to}} PLN"
+        "priceTo": "Price: up to {{to}} PLN",
+        "stockGt": "Stock > {{value}}",
+        "stockLt": "Stock < {{value}}"
       }
     }
   },

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -980,7 +980,9 @@
         "manufacturer": "Dostawca:",
         "priceRange": "Cena: {{from}}–{{to}} PLN",
         "priceFrom": "Cena: od {{from}} PLN",
-        "priceTo": "Cena: do {{to}} PLN"
+        "priceTo": "Cena: do {{to}} PLN",
+        "stockGt": "Stan > {{value}}",
+        "stockLt": "Stan < {{value}}"
       }
     }
   },

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -1245,8 +1245,8 @@ function ProductsPage() {
             <FilterChip onRemove={() => setSimpleFilters(f => ({ ...f, stockFilter: null, stockValue: "" }))}>
               {simpleFilters.stockFilter === "below_min" && t("products.simpleFilter.stock.belowMin", { defaultValue: "Stan: poniżej minimum" })}
               {simpleFilters.stockFilter === "zero" && t("products.simpleFilter.stock.zero", { defaultValue: "Stan: równy 0" })}
-              {simpleFilters.stockFilter === "gt" && `Stan > ${simpleFilters.stockValue}`}
-              {simpleFilters.stockFilter === "lt" && `Stan < ${simpleFilters.stockValue}`}
+              {simpleFilters.stockFilter === "gt" && t("products.simpleFilter.chips.stockGt", { value: simpleFilters.stockValue })}
+              {simpleFilters.stockFilter === "lt" && t("products.simpleFilter.chips.stockLt", { value: simpleFilters.stockValue })}
             </FilterChip>
           )}
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3135.

Closes #3135

---

## Claude summary

Done. Here's what was changed:

**Root cause:** Lines 1248-1249 of `_layout.products.index.tsx` rendered filter chip labels as plain JS template literals (`Stan > ${simpleFilters.stockValue}`) instead of using `t()`, bypassing i18n entirely. The neighboring `belowMin` and `zero` stock chips already used `t()` correctly.

**Fix (3 files):**

1. `public/locales/pl/translation.json` — added `stockGt: "Stan > {{value}}"` and `stockLt: "Stan < {{value}}"` under `products.simpleFilter.chips`
2. `public/locales/en/translation.json` — added `stockGt: "Stock > {{value}}"` and `stockLt: "Stock < {{value}}"` under `products.simpleFilter.chips`
3. `src/routes/_app/_auth/dashboard/_layout.products.index.tsx:1248-1249` — replaced template literals with `t("products.simpleFilter.chips.stockGt", { value: ... })` / `t("products.simpleFilter.chips.stockLt", { value: ... })`