### PR TITLE
Translate hardcoded Polish price range "od"/"do"/"PLN" labels in simple filter p

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -965,7 +965,10 @@
         "lt": "with stock less than"
       },
       "price": {
-        "label": "Show products at purchase price"
+        "label": "Show products at purchase price",
+        "from": "from",
+        "to": "to",
+        "currency": "PLN"
       },
       "active": {
         "label": "Product activity",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -966,7 +966,10 @@
         "lt": "ze stanem mniejszym niż"
       },
       "price": {
-        "label": "Pokaż produkty w cenie zakupu"
+        "label": "Pokaż produkty w cenie zakupu",
+        "from": "od",
+        "to": "do",
+        "currency": "PLN"
       },
       "active": {
         "label": "Aktywność produktu",

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -400,7 +400,7 @@ function ProductSimpleFilterPanel({
             {t("products.simpleFilter.price.label", { defaultValue: "Pokaż produkty w cenie zakupu" })}
           </Label>
           <div className="flex items-center gap-2">
-            <span className="whitespace-nowrap text-sm text-muted-foreground">od</span>
+            <span className="whitespace-nowrap text-sm text-muted-foreground">{t("products.simpleFilter.price.from", { defaultValue: "od" })}</span>
             <Input
               type="number"
               min={0}
@@ -409,7 +409,7 @@ function ProductSimpleFilterPanel({
               className="h-9 flex-1"
               placeholder="min."
             />
-            <span className="whitespace-nowrap text-sm text-muted-foreground">do</span>
+            <span className="whitespace-nowrap text-sm text-muted-foreground">{t("products.simpleFilter.price.to", { defaultValue: "do" })}</span>
             <Input
               type="number"
               min={0}
@@ -418,7 +418,7 @@ function ProductSimpleFilterPanel({
               className="h-9 flex-1"
               placeholder="maks."
             />
-            <span className="text-sm text-muted-foreground">PLN</span>
+            <span className="text-sm text-muted-foreground">{t("products.simpleFilter.price.currency", { defaultValue: "PLN" })}</span>
           </div>
         </div>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3136.

Closes #3136

---

## Claude summary

Done. The three hardcoded Polish spans in the price range row of the simple filter panel are now wrapped with `t()` calls using keys `products.simpleFilter.price.from`, `.to`, and `.currency`. Both translation files have been updated — Polish gets "od"/"do"/"PLN" and English gets "from"/"to"/"PLN".