### PR TITLE
Fix inconsistent defaultValues for `products.simpleFilter.stock.belowMin` and `s

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -984,7 +984,9 @@
         "priceFrom": "Price: from {{from}} PLN",
         "priceTo": "Price: up to {{to}} PLN",
         "stockGt": "Stock > {{value}}",
-        "stockLt": "Stock < {{value}}"
+        "stockLt": "Stock < {{value}}",
+        "stockBelowMin": "Stock: below minimum",
+        "stockZero": "Stock: equal to 0"
       }
     }
   },

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -985,7 +985,9 @@
         "priceFrom": "Cena: od {{from}} PLN",
         "priceTo": "Cena: do {{to}} PLN",
         "stockGt": "Stan > {{value}}",
-        "stockLt": "Stan < {{value}}"
+        "stockLt": "Stan < {{value}}",
+        "stockBelowMin": "Stan: poniżej minimum",
+        "stockZero": "Stan: równy 0"
       }
     }
   },

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -1243,8 +1243,8 @@ function ProductsPage() {
 
           {simpleFilters.stockFilter && (
             <FilterChip onRemove={() => setSimpleFilters(f => ({ ...f, stockFilter: null, stockValue: "" }))}>
-              {simpleFilters.stockFilter === "below_min" && t("products.simpleFilter.stock.belowMin", { defaultValue: "Stan: poniżej minimum" })}
-              {simpleFilters.stockFilter === "zero" && t("products.simpleFilter.stock.zero", { defaultValue: "Stan: równy 0" })}
+              {simpleFilters.stockFilter === "below_min" && t("products.simpleFilter.chips.stockBelowMin", { defaultValue: "Stan: poniżej minimum" })}
+              {simpleFilters.stockFilter === "zero" && t("products.simpleFilter.chips.stockZero", { defaultValue: "Stan: równy 0" })}
               {simpleFilters.stockFilter === "gt" && t("products.simpleFilter.chips.stockGt", { value: simpleFilters.stockValue })}
               {simpleFilters.stockFilter === "lt" && t("products.simpleFilter.chips.stockLt", { value: simpleFilters.stockValue })}
             </FilterChip>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3137.

Closes #3137

---

## Claude summary

The fix is committed. Here's a summary of what was wrong and what changed:

**Root cause:** Lines 1246–1247 in `_layout.products.index.tsx` used the filter-panel translation keys (`products.simpleFilter.stock.belowMin` / `.zero`) inside the chip renderer, but with different `defaultValue` strings. Since the keys exist in the JSON files, i18next resolved them to the filter-panel text ("poniżej minimalnego stanu", "ze stanem równym 0") instead of the chip-format text ("Stan: poniżej minimum", "Stan: równy 0"). The `defaultValue` was silently ignored.

**Fix:** Added two new dedicated keys to both PL and EN locales under `products.simpleFilter.chips`:
- `stockBelowMin`: "Stan: poniżej minimum" / "Stock: below minimum"
- `stockZero`: "Stan: równy 0" / "Stock: equal to 0"

Updated the chip renderer to use `products.simpleFilter.chips.stockBelowMin` and `.stockZero`, matching the existing pattern used for `stockGt` and `stockLt`.