### PR TITLE
Uprość filtry produktów dla zwykłego użytkownika

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -267,14 +267,14 @@ function ProductSimpleFilterPanel({
           </Label>
           {categories.length > 0 ? (
             <Select
-              value={draft.categoryId ?? ""}
-              onValueChange={(v) => setDraft(d => ({ ...d, categoryId: v || null }))}
+              value={draft.categoryId ?? "all"}
+              onValueChange={(v) => setDraft(d => ({ ...d, categoryId: v === "all" ? null : v }))}
             >
               <SelectTrigger className="h-9">
                 <SelectValue placeholder={t("products.simpleFilter.category.all", { defaultValue: "Wszystkie kategorie" })} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">
+                <SelectItem value="all">
                   {t("products.simpleFilter.category.all", { defaultValue: "Wszystkie kategorie" })}
                 </SelectItem>
                 {categories.map(cat => (
@@ -298,14 +298,14 @@ function ProductSimpleFilterPanel({
           </Label>
           {manufacturers.length > 0 ? (
             <Select
-              value={draft.manufacturer ?? ""}
-              onValueChange={(v) => setDraft(d => ({ ...d, manufacturer: v || null }))}
+              value={draft.manufacturer ?? "all"}
+              onValueChange={(v) => setDraft(d => ({ ...d, manufacturer: v === "all" ? null : v }))}
             >
               <SelectTrigger className="h-9">
                 <SelectValue placeholder={t("products.simpleFilter.manufacturer.all", { defaultValue: "Wszyscy dostawcy" })} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">
+                <SelectItem value="all">
                   {t("products.simpleFilter.manufacturer.all", { defaultValue: "Wszyscy dostawcy" })}
                 </SelectItem>
                 {manufacturers.map(m => (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3119.

Closes #3119

---

## Claude summary

PR #3140 is merged to `main` as commit `050c089`. Here's what happened:

The conflict in PR #3140 existed because the original `claude/issue-3119` branch had stale code (inline type definitions) while `origin/main` had already refactored those into a separate `products-filters.ts` file with i18n and tests. I resolved it by:

1. Rebasing `claude/issue-3119` onto `origin/main` — Git recognized the original commit as already applied and skipped it cleanly
2. Applying the actual `SelectItem value=""` fix on top: both the category and manufacturer selects now use `value="all"` as the no-selection sentinel (mapped back to `null` in `onValueChange`), which is the correct pattern for Radix UI Select
3. Force-pushed the branch and merged PR #3140

The filter panel crash is now fixed in `main`. Users can open the filter panel without the "Something went wrong" error.