### PR TITLE
Uprość filtry produktów dla zwykłego użytkownika

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -267,14 +267,14 @@ function ProductSimpleFilterPanel({
           </Label>
           {categories.length > 0 ? (
             <Select
-              value={draft.categoryId ?? ""}
-              onValueChange={(v) => setDraft(d => ({ ...d, categoryId: v || null }))}
+              value={draft.categoryId ?? "all"}
+              onValueChange={(v) => setDraft(d => ({ ...d, categoryId: v === "all" ? null : v }))}
             >
               <SelectTrigger className="h-9">
                 <SelectValue placeholder={t("products.simpleFilter.category.all", { defaultValue: "Wszystkie kategorie" })} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">
+                <SelectItem value="all">
                   {t("products.simpleFilter.category.all", { defaultValue: "Wszystkie kategorie" })}
                 </SelectItem>
                 {categories.map(cat => (
@@ -298,14 +298,14 @@ function ProductSimpleFilterPanel({
           </Label>
           {manufacturers.length > 0 ? (
             <Select
-              value={draft.manufacturer ?? ""}
-              onValueChange={(v) => setDraft(d => ({ ...d, manufacturer: v || null }))}
+              value={draft.manufacturer ?? "all"}
+              onValueChange={(v) => setDraft(d => ({ ...d, manufacturer: v === "all" ? null : v }))}
             >
               <SelectTrigger className="h-9">
                 <SelectValue placeholder={t("products.simpleFilter.manufacturer.all", { defaultValue: "Wszyscy dostawcy" })} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">
+                <SelectItem value="all">
                   {t("products.simpleFilter.manufacturer.all", { defaultValue: "Wszyscy dostawcy" })}
                 </SelectItem>
                 {manufacturers.map(m => (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3119.

Closes #3119

---

## Claude summary

NOT_A_BUG: The feature requested in issue #3119 is already fully implemented on the current branch (`claude/issue-2422`).

Two commits are already in the git history that address this issue:

- `1aae7d3` — `feat(products): add simple filter panel for non-technical users (closes #3119)` — adds the complete `ProductSimpleFilterPanel` with all 6 requested filter types
- `57ef693` — `fix(products): replace empty-string SelectItem values with "all" sentinel in simple filter panel` — fixes the runtime crash with Radix Select and empty string values

The implementation lives in `src/routes/_app/_auth/dashboard/_layout.products.index.tsx`. Here's what's in place:

- `ProductSimpleFilterPanel` component (lines 209–505) with Polish-language sections for: group (radio), category (Select), manufacturer/supplier (Select), stock status (radio + numeric input), purchase price range (from/to), and active/inactive status (radio)
- Active filter chips shown above the table (lines 1011–1076) with per-chip remove buttons and "Wyczyść wszystko"
- "Filtry zaawansowane" escape hatch at the bottom of the simple panel (line 484) that opens the existing technical filter
- `useSidebarDispatch("openFilter")` at line 583 wired to open the simple panel instead of the technical slideout
- Both Select components use `value="all"` as the no-selection sentinel (lines 291, 322), so the Radix empty-string crash is fixed

No code changes are needed — the feature is complete and working on this branch.