### PR TITLE
Replace `AddDeliveryPanel` quick-action with navigation to `/dashboard/gabinet/d

### DIFF
--- a/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
+++ b/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
@@ -22,7 +22,6 @@ import { useSidebarActions } from "@/components/layout/sidebar-context";
 import { usePermission } from "@/hooks/use-permission";
 import { useOrganization } from "@/components/org-context";
 import { SellTreatmentPanel } from "@/components/gabinet/sell-treatment-panel";
-import { AddDeliveryPanel } from "@/components/gabinet/add-delivery-panel";
 
 export function GabinetQuickActionsDropdown() {
   const { t } = useTranslation();
@@ -31,7 +30,6 @@ export function GabinetQuickActionsDropdown() {
   const { allowed: canManageLeaves } = usePermission("gabinet_settings", "edit");
   const { organizationId } = useOrganization();
   const [sellTreatmentOpen, setSellTreatmentOpen] = useState(false);
-  const [addDeliveryOpen, setAddDeliveryOpen] = useState(false);
 
   // "Umów wizytę" routes through the calendar so every appointment entry
   // point opens the same AppointmentDialog (issue #1506).
@@ -102,7 +100,7 @@ export function GabinetQuickActionsDropdown() {
         )}
         <DropdownMenuItem
           className="px-3 py-2.5 text-sm"
-          onSelect={() => setAddDeliveryOpen(true)}
+          onSelect={() => navigate({ to: "/dashboard/gabinet/deliveries", search: { action: "create" } })}
         >
           <TruckIcon className="text-foreground size-5 shrink-0" />
           {t("sidebar.gabinet.addDelivery", "Dodaj dostawę")}
@@ -120,11 +118,6 @@ export function GabinetQuickActionsDropdown() {
       organizationId={organizationId}
       open={sellTreatmentOpen}
       onOpenChange={setSellTreatmentOpen}
-    />
-    <AddDeliveryPanel
-      organizationId={organizationId}
-      open={addDeliveryOpen}
-      onOpenChange={setAddDeliveryOpen}
     />
     </>
   );

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from "react";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { getExpiryStatus } from "@/lib/expiry-utils";
 import { useAction, useMutation } from "convex/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -56,6 +56,9 @@ export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/deliveries",
 )({
   component: DeliveriesPage,
+  validateSearch: (search: Record<string, unknown>): { action?: "create" } => ({
+    action: search.action === "create" ? "create" : undefined,
+  }),
 });
 
 const NO_LOCATION = "__none__";
@@ -266,6 +269,8 @@ function DeliveriesPage() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
   const queryClient = useQueryClient();
+  const routeNavigate = useNavigate();
+  const { action: actionParam } = useSearch({ from: "/_app/_auth/dashboard/_layout/gabinet/deliveries" });
 
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen
   const listDeliveriesAction = useAction(api.warehouseDeliveries.listDeliveries);
@@ -338,6 +343,21 @@ function DeliveriesPage() {
 
   // Create/edit panel state
   const [panelOpen, setPanelOpen] = useState(false);
+
+  // ?action=create navigates here from the sidebar quick-action and auto-opens
+  // the new-delivery panel (issue #3153). Clear the param after consuming so a
+  // refresh doesn't reopen it.
+  useEffect(() => {
+    if (actionParam === "create") {
+      setPanelOpen(true);
+      void routeNavigate({
+        to: "/dashboard/gabinet/deliveries",
+        search: { action: undefined },
+        replace: true,
+      });
+    }
+  }, [actionParam, routeNavigate]);
+
   const [editDeliveryId, setEditDeliveryId] = useState<string | null>(null);
   const [editLoading, setEditLoading] = useState(false);
   const [supplierName, setSupplierName] = useState("");


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3153.

Closes #3153

---

## Claude summary

Done. Here's what was changed:

**Root cause confirmed:** The sidebar "Dodaj dostawę" quick-action opened `AddDeliveryPanel`, which called `adjustStock` directly with `reason: "warehouse_receive"` but no `deliveryId`, creating stock movements with no associated delivery record — an audit trail gap.

**Fix (2 files):**

1. `src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx` — Added `validateSearch` to the route accepting `action: "create"`, plus `useSearch`/`useEffect` in `DeliveriesPage` that auto-opens `panelOpen` when the param is present and then clears it (same pattern as `?action=create-appointment` on the calendar route, issue #1506).

2. `src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx` — Replaced `setAddDeliveryOpen(true)` with `navigate({ to: "/dashboard/gabinet/deliveries", search: { action: "create" } })`, removed the `AddDeliveryPanel` import/state/JSX.

The `AddDeliveryPanel` component itself is untouched — it's still used in the Products/Warehouse page (`_layout.products.index.tsx`) where it provides a legitimate single-product quick-adjust without the audit trail concern.