### PR TITLE
Przywróć nagłówek CRM z przyciskiem Menu w module Produkty / Magazyn

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -824,8 +824,6 @@ function DashboardLayoutInner({ user, orgs }: DashboardLayoutInnerProps) {
   const showDatePicker = /^\/(dashboard)\/?$/.test(pathname)
     || /^\/dashboard\/(activities|calls|leads|pipelines)/.test(pathname);
   const showAgendaStrip = !pathname.startsWith("/dashboard/gabinet");
-  const showCrmHeader = !pathname.startsWith("/dashboard/products");
-
   const [lastDispatch, setLastDispatch] = useState<{ id: string; seq: number } | null>(null);
   const dispatchSeqRef = useRef(0);
 
@@ -875,7 +873,7 @@ function DashboardLayoutInner({ user, orgs }: DashboardLayoutInnerProps) {
 
             {/* Column 3: Main content */}
             <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-              {showCrmHeader && <header className="bg-card sticky top-0 z-50 flex min-h-20 items-center justify-between gap-6 border-b px-4 py-2 sm:px-6">
+              <header className="bg-card sticky top-0 z-50 flex min-h-20 items-center justify-between gap-6 border-b px-4 py-2 sm:px-6">
                 <div className="flex items-center gap-4">
                   <HeaderBackButton />
                   <SidebarTrigger className="[&_svg]:!size-4 [&_easier-icon]:!size-4" />
@@ -979,7 +977,7 @@ function DashboardLayoutInner({ user, orgs }: DashboardLayoutInnerProps) {
                     </DropdownMenuContent>
                   </DropdownMenu>
                 </div>
-              </header>}
+              </header>
 
               {showAgendaStrip && firstOrg && user && (
                 <AgendaStrip organizationId={firstOrg._id} userId={user._id} />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3158.

Closes #3158

---

## Claude summary

The fix is committed. Here's the summary:

**Root cause:** In `src/routes/_app/_auth/dashboard/_layout.tsx:827`, a `showCrmHeader` flag was added by issue #3125 (`!pathname.startsWith("/dashboard/products")`). This conditionally removed the entire `<header>` element — including the `SidebarTrigger` (Menu button), search, notifications, and avatar — whenever the user navigated to the Products/Warehouse module.

**Fix:** Removed the `showCrmHeader` variable and its conditional on the `<header>` element. The header now renders unconditionally on all dashboard routes, consistent with all other modules including Gabinet.

**Change scope:** 3 lines in a single file, no routing changes, no product table/filter/form changes.