### PR TITLE
Dodaj wybór sposobu utworzenia dostawy

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
@@ -349,7 +349,7 @@ function DeliveriesPage() {
   // refresh doesn't reopen it.
   useEffect(() => {
     if (actionParam === "create") {
-      setPanelOpen(true);
+      setChoiceDialogOpen(true);
       void routeNavigate({
         to: "/dashboard/gabinet/deliveries",
         search: { action: undefined },
@@ -376,6 +376,9 @@ function DeliveriesPage() {
   // Cancel delivery confirmation
   const [cancelTarget, setCancelTarget] = useState<{ id: string; label: string } | null>(null);
   const [cancelling, setCancelling] = useState(false);
+
+  // Choice dialog (shown when navigating from Products "Dodaj dostawę")
+  const [choiceDialogOpen, setChoiceDialogOpen] = useState(false);
 
   // Invoice import dialog
   const [invoiceDialogOpen, setInvoiceDialogOpen] = useState(false);
@@ -1642,6 +1645,20 @@ function DeliveriesPage() {
           }}
         />
       )}
+
+      {/* Delivery creation method choice dialog (#3163) */}
+      <DeliveryChoiceDialog
+        open={choiceDialogOpen}
+        onOpenChange={setChoiceDialogOpen}
+        onInvoice={() => {
+          setChoiceDialogOpen(false);
+          setInvoiceDialogOpen(true);
+        }}
+        onManual={() => {
+          setChoiceDialogOpen(false);
+          setPanelOpen(true);
+        }}
+      />
     </div>
   );
 }
@@ -2745,6 +2762,81 @@ function ItemDecisionsDialog({
             </Button>
           )}
         </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Delivery creation method choice dialog (#3163)
+// ---------------------------------------------------------------------------
+
+function DeliveryChoiceDialog({
+  open,
+  onOpenChange,
+  onInvoice,
+  onManual,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onInvoice: () => void;
+  onManual: () => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {t("gabinet.deliveries.choiceTitle", "Dodaj dostawę")}
+          </DialogTitle>
+          <DialogDescription>
+            {t("gabinet.deliveries.choiceDesc", "Wybierz sposób dodania dostawy.")}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3 py-2">
+          <button
+            type="button"
+            onClick={onInvoice}
+            className="flex items-start gap-4 rounded-lg border-2 border-primary/20 bg-primary/5 p-4 text-left transition-colors hover:border-primary/40 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <span className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-primary/10">
+              <FileText className="h-5 w-5 text-primary" variant="stroke" />
+            </span>
+            <span className="space-y-1">
+              <span className="block text-sm font-semibold">
+                {t("gabinet.deliveries.choiceInvoiceTitle", "Załaduj fakturę")}
+              </span>
+              <span className="block text-xs text-muted-foreground">
+                {t(
+                  "gabinet.deliveries.choiceInvoiceDesc",
+                  "Dodaj fakturę w PDF lub jako zdjęcie, a system odczyta jej dane i produkty.",
+                )}
+              </span>
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={onManual}
+            className="flex items-start gap-4 rounded-lg border p-4 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <span className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted">
+              <Plus className="h-5 w-5 text-muted-foreground" variant="stroke" />
+            </span>
+            <span className="space-y-1">
+              <span className="block text-sm font-semibold">
+                {t("gabinet.deliveries.choiceManualTitle", "Dodaj ręcznie")}
+              </span>
+              <span className="block text-xs text-muted-foreground">
+                {t(
+                  "gabinet.deliveries.choiceManualDesc",
+                  "Dodaj produkty do dostawy bez faktury.",
+                )}
+              </span>
+            </span>
+          </button>
+        </div>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3163.

Closes #3163

---

## Claude summary

Done. Here's a summary of what was changed and why.

**What changed** — one file, `_layout.gabinet.deliveries.tsx`, with 3 targeted edits:

1. **State**: Added `choiceDialogOpen` state variable alongside the existing `invoiceDialogOpen`.

2. **useEffect for `?action=create`**: Changed from directly opening `panelOpen` (manual form) to opening `choiceDialogOpen` (the new selection screen). This is the hook that fires when the user clicks "Dodaj dostawę" from the Products/Warehouse module.

3. **New `DeliveryChoiceDialog` component**: A centered Dialog with two clickable option cards:
   - **"Załaduj fakturę"** — visually primary (blue tinted border/bg, `FileText` icon), description matches the issue spec, routes to the existing `InvoiceImportDialog`
   - **"Dodaj ręcznie"** — visually secondary (muted bg, `Plus` icon), description matches the issue spec, routes to the existing manual-creation `SidePanel`

Closing the dialog (X or backdrop) returns the user to the deliveries list without starting any delivery. No data models, OCR logic, stock movements, or other warehouse actions were touched.