### PR TITLE
Przekieruj „Dodaj dostawę” do pełnego procesu dostaw

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -47,7 +47,6 @@ import { cn } from "@/lib/utils";
 import { ProductForm, type ProductFormData, type ProductSection, PRODUCT_SECTIONS } from "@/components/forms/product-form";
 import { WarehouseInventoryDialog } from "@/components/gabinet/warehouse-inventory-dialog";
 import { WarehouseShoppingListDialog } from "@/components/gabinet/warehouse-shopping-list-dialog";
-import { AddDeliveryPanel } from "@/components/gabinet/add-delivery-panel";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
 import {
   hasAnySimpleFilter,
@@ -587,7 +586,7 @@ function ProductsPage() {
   useSidebarDispatch("openShoppingList", () => setShoppingListOpen(true));
   useSidebarDispatch("openInventory", () => setInventoryOpen(true));
   useSidebarDispatch("addProduct", () => openCreatePanel());
-  useSidebarDispatch("addDelivery", () => setAddDeliveryOpen(true));
+  useSidebarDispatch("addDelivery", () => navigate({ to: "/dashboard/gabinet/deliveries", search: { action: "create" } }));
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
   const [stockAdjustProduct, setStockAdjustProduct] = useState<Product | null>(null);
   const [stockCorrectionProduct, setStockCorrectionProduct] = useState<Product | null>(null);
@@ -595,7 +594,6 @@ function ProductsPage() {
   const [lotBatchesProduct, setLotBatchesProduct] = useState<Product | null>(null);
   const [inventoryOpen, setInventoryOpen] = useState(false);
   const [shoppingListOpen, setShoppingListOpen] = useState(false);
-  const [addDeliveryOpen, setAddDeliveryOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; label: string } | null>(null);
 
   const { data: allProducts = [], isLoading } = useSupabaseProductsList(organizationId);
@@ -1426,12 +1424,6 @@ function ProductsPage() {
           organizationId={organizationId}
         />
       </SidePanel>
-
-      <AddDeliveryPanel
-        organizationId={organizationId}
-        open={addDeliveryOpen}
-        onOpenChange={setAddDeliveryOpen}
-      />
 
       <WarehouseInventoryDialog
         open={inventoryOpen}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3161.

Closes #3161

---

## Claude summary

NOT_A_BUG: The issue is already fully resolved on this branch by commit `9f6da7b` ("fix(routing): register gabinet/deliveries route in routeTree.gen.ts").

Here's the complete picture of what's in place:

**Left panel "Dodaj dostawę" (sidebar quick-actions dropdown):** `src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx:103` — navigates to `/dashboard/gabinet/deliveries?action=create`. ✅

**Bottom bar "Dodaj dostawę" (sidebar dispatch in Products module):** `src/routes/_app/_auth/dashboard/_layout.products.index.tsx:589` — `useSidebarDispatch("addDelivery", ...)` navigates to `/dashboard/gabinet/deliveries?action=create`. ✅

**Route registration:** `src/routeTree.gen.ts:79,502–507` — the deliveries route is imported and registered under `AppAuthDashboardLayoutRoute` with full path `/dashboard/gabinet/deliveries`. ✅

**Deliveries route:** `src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx:59–61,350–358` — validates the `action` search param and auto-opens the new-delivery choice dialog when `action=create`. ✅

The "Not Found" error reported by `@aslocka2026` was caused by the route not being registered in `routeTree.gen.ts`. That was fixed by commit `9f6da7b` which is the current HEAD of this branch. No further changes are needed.