### PR TITLE
Przekieruj „Dodaj dostawę” do pełnego procesu dostaw

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -47,7 +47,6 @@ import { cn } from "@/lib/utils";
 import { ProductForm, type ProductFormData, type ProductSection, PRODUCT_SECTIONS } from "@/components/forms/product-form";
 import { WarehouseInventoryDialog } from "@/components/gabinet/warehouse-inventory-dialog";
 import { WarehouseShoppingListDialog } from "@/components/gabinet/warehouse-shopping-list-dialog";
-import { AddDeliveryPanel } from "@/components/gabinet/add-delivery-panel";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
 import {
   hasAnySimpleFilter,
@@ -587,7 +586,7 @@ function ProductsPage() {
   useSidebarDispatch("openShoppingList", () => setShoppingListOpen(true));
   useSidebarDispatch("openInventory", () => setInventoryOpen(true));
   useSidebarDispatch("addProduct", () => openCreatePanel());
-  useSidebarDispatch("addDelivery", () => setAddDeliveryOpen(true));
+  useSidebarDispatch("addDelivery", () => navigate({ to: "/dashboard/gabinet/deliveries", search: { action: "create" } }));
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
   const [stockAdjustProduct, setStockAdjustProduct] = useState<Product | null>(null);
   const [stockCorrectionProduct, setStockCorrectionProduct] = useState<Product | null>(null);
@@ -595,7 +594,6 @@ function ProductsPage() {
   const [lotBatchesProduct, setLotBatchesProduct] = useState<Product | null>(null);
   const [inventoryOpen, setInventoryOpen] = useState(false);
   const [shoppingListOpen, setShoppingListOpen] = useState(false);
-  const [addDeliveryOpen, setAddDeliveryOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; label: string } | null>(null);
 
   const { data: allProducts = [], isLoading } = useSupabaseProductsList(organizationId);
@@ -1426,12 +1424,6 @@ function ProductsPage() {
           organizationId={organizationId}
         />
       </SidePanel>
-
-      <AddDeliveryPanel
-        organizationId={organizationId}
-        open={addDeliveryOpen}
-        onOpenChange={setAddDeliveryOpen}
-      />
 
       <WarehouseInventoryDialog
         open={inventoryOpen}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3161.

Closes #3161

---

## Claude summary

NOT_A_BUG: All fixes for this issue are already committed on this branch and in main.

Here is the complete picture of what is in place:

**Left panel "Dodaj dostawę"** (`src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx:103`) — navigates to `/dashboard/gabinet/deliveries?action=create`. ✅

**Bottom bar "Dodaj dostawę"** (`src/routes/_app/_auth/dashboard/_layout.products.index.tsx:589`) — `useSidebarDispatch("addDelivery", ...)` navigates to `/dashboard/gabinet/deliveries?action=create`. ✅

**Route registration** (`src/routeTree.gen.ts:504–505, 791, 1858–1861`) — the deliveries route is imported and registered with full path `/dashboard/gabinet/deliveries`. ✅

**Route `action=create` handling** (`src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx:59–61, 351–352`) — validates the search param and auto-opens the new-delivery choice dialog. ✅

**Missing module** (`src/lib/expiry-utils.ts`) — the `@/lib/expiry-utils` module now exists. ✅

**i18n string syntax** — the ASCII closing-quote bug that produced `Unterminated string literal` errors is fixed. ✅

The three commits `9f6da7b`, `837b6dc`, and `6fadbaf` (all visible in `git log`) implement all the changes needed. If the dev environment still shows "Not Found", the issue is that the latest `main` has not been deployed to `quera-dev.helloalex.pl` yet — no further code changes are required.