### PR TITLE
Pre-existing syntax errors in `gabinet.deliveries.tsx`

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
@@ -909,7 +909,7 @@ function DeliveriesPage() {
                                 <TooltipContent>
                                   {t(
                                     "gabinet.deliveries.postBlockedCreateLater",
-                                    "Najpierw rozwiąż pozycje „Utwórz później" w weryfikacji faktury.",
+                                    "Najpierw rozwiąż pozycje „Utwórz później” w weryfikacji faktury.",
                                   )}
                                 </TooltipContent>
                               </Tooltip>
@@ -2726,7 +2726,7 @@ function ItemDecisionsDialog({
             <span>
               {t(
                 "gabinet.deliveries.decisions.createLaterBlocking",
-                "Pozycje oznaczone „Utwórz później" blokują zatwierdzenie dostawy. Zmień decyzję na inną, aby odblokować zaksięgowanie.",
+                "Pozycje oznaczone „Utwórz później” blokują zatwierdzenie dostawy. Zmień decyzję na inną, aby odblokować zaksięgowanie.",
               )}
             </span>
           </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3177.

Closes #3177

---

## Claude summary

Fixed. The root cause was that both strings used an ASCII `"` (U+0022) as the closing mark of inner Polish quotation pairs `„..."`, which the TypeScript parser interpreted as the delimiter ending the outer string literal — leaving the remaining text as unparseable code and triggering "Unterminated string literal" errors at lines 912 and 2729.

Both characters have been replaced with the proper Polish right double quotation mark `"` (U+201D), matching the opening `„` (U+201E). The tsc parse errors on those two lines are now gone.