### PR TITLE
Pokaż dokładny błąd walidacji przy zapisie produktu

### DIFF
--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -30,6 +30,18 @@ const COLUMN_LABEL_MAP: Record<string, string> = {
   reminder_overrides: "Konfiguracja przypomnień",
   send_reminder: "Przypomnienia",
   reminder_hours_before: "Czas przypomnienia",
+  // Products (#3180)
+  sku: "SKU",
+  unit_price: "Cena netto",
+  is_active: "Aktywność",
+  track_stock: "Śledzenie stanu magazynowego",
+  stock_unit: "Jednostka",
+  product_section: "Typ produktu",
+  min_stock: "Minimalny stan",
+  manufacturer: "Producent",
+  catalog_number: "Nr katalogowy",
+  stock_note: "Notatka magazynowa",
+  purchase_price: "Cena zakupu",
 };
 
 function humanFieldLabel(rawField: string): string {
@@ -117,6 +129,30 @@ export function extractFieldValidationDetail(
       rawField: "string",
       fieldLabel: "Tekst",
       reason: "wartość jest za długa",
+    };
+  }
+
+  // Postgres: duplicate key value violates unique constraint "X" — extract field
+  // name from the index name (e.g. "products_org_sku_idx" → "sku").
+  const uniqueCon = msg.match(/duplicate key value violates unique constraint "([^"]+)"/i);
+  if (uniqueCon) {
+    const constraintName = uniqueCon[1];
+    const withoutSuffix = constraintName.replace(/_key$/i, "").replace(/_idx$/i, "");
+    const knownCols = Object.keys(COLUMN_LABEL_MAP).sort((a, b) => b.length - a.length);
+    const matchedCol = knownCols.find(
+      (col) => withoutSuffix.endsWith(`_${col}`) || withoutSuffix === col,
+    );
+    if (matchedCol) {
+      return {
+        rawField: matchedCol,
+        fieldLabel: humanFieldLabel(matchedCol),
+        reason: "taka wartość już istnieje",
+      };
+    }
+    return {
+      rawField: constraintName,
+      fieldLabel: "Pole",
+      reason: "taka wartość już istnieje",
     };
   }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3180.

Closes #3180

---

## Claude summary

The fix is committed. Here's a summary of what was wrong and what was changed:

**Root cause:** `src/lib/format-action-error.ts` had two gaps that caused the generic "Nieprawidłowe dane. Sprawdź formularz i spróbuj ponownie." toast to appear instead of a specific field error:

1. `COLUMN_LABEL_MAP` had no entries for product columns (`sku`, `unit_price`, `is_active`, etc.), so even when a constraint error was partially parsed, the field label was the raw Postgres column name.

2. `extractFieldValidationDetail` had no handler for `duplicate key value violates unique constraint` errors. When a duplicate SKU caused a save to fail, the error matched the generic `invalidArguments` pattern but returned `null` from `extractFieldValidationDetail`, falling back to the generic toast.

**Fix** (one file, `src/lib/format-action-error.ts`):
- Added 11 product-specific column labels to `COLUMN_LABEL_MAP`
- Added a unique constraint violation parser that extracts the column name from the index name (e.g. `"products_org_sku_idx"` → `"sku"`) using the same longest-match strategy already used for FK constraints

Now users will see messages like "Nieprawidłowe dane: SKU — taka wartość już istnieje." or "Nieprawidłowe dane: Cena netto — to pole jest wymagane." instead of the generic fallback. All 21 existing tests continue to pass.

## Follow-ups
- Add unique constraint violation test cases to `format-action-error.test.ts`: the new `uniqueCon` parser in `extractFieldValidationDetail` has no test coverage — similar to how FK and null-violation cases are tested in the existing suite.
- Add "name" empty-string guard in `handleProductFormSubmit`: `data.name.trim()` can produce `""` when the user enters only spaces (bypassing the HTML `required` check), which stores an empty product name in the DB without error.