### PR TITLE
Add unique constraint violation test cases to `format-action-error.test.ts`

### DIFF
--- a/session_state.json
+++ b/session_state.json
@@ -1,9 +1,9 @@
 {
-  "session_id": "S0104",
-  "started_at": "2026-06-30T00:00:00Z",
-  "last_updated": "2026-06-30T00:10:00Z",
+  "session_id": "S0105",
+  "started_at": "2026-07-15T10:08:00Z",
+  "last_updated": "2026-07-15T10:08:40Z",
   "status": "completed",
-  "focus": "Issue #2475: CRM v1.0 audit of Klienci (patients) module",
+  "focus": "Issue #3182: Add unique constraint violation test cases to format-action-error.test.ts",
   "tasks_snapshot": {
     "total": 1,
     "not_started": 0,
@@ -12,7 +12,7 @@
     "failing": 0,
     "blocked": 0
   },
-  "active_task_ids": ["2475-AUDIT"],
+  "active_task_ids": [],
   "blockers": [],
-  "notes": "S0104: Audited gabinet patients module end-to-end. All 9 checklist areas functional. Found and fixed one blocking bug: allergies field was a plain const (no useState, no <Input> rendered) so users could not view or edit allergies on any patient form. Fixed by converting to useState and adding Input element. All other features (create, edit, search, history, appointments, packages, payments, documents, delete) are fully implemented."
+  "notes": "S0105: Added 3 test cases for the uniqueCon parser in extractFieldValidationDetail: (1) _key suffix with identified column (products_sku_key → sku → SKU), (2) _idx suffix with identified column (products_org_sku_idx → sku → SKU), (3) fallback when column not identified (raw constraint name + 'Pole' label). All 17 tests pass."
 }

--- a/src/lib/format-action-error.test.ts
+++ b/src/lib/format-action-error.test.ts
@@ -92,6 +92,39 @@ describe("extractFieldValidationDetail", () => {
     expect(detail).toBeNull();
   });
 
+  it("extracts column from unique constraint with _key suffix", () => {
+    const detail = extractFieldValidationDetail(
+      'duplicate key value violates unique constraint "products_sku_key"',
+    );
+    expect(detail).toEqual({
+      rawField: "sku",
+      fieldLabel: "SKU",
+      reason: "taka wartość już istnieje",
+    });
+  });
+
+  it("extracts column from unique constraint with _idx suffix", () => {
+    const detail = extractFieldValidationDetail(
+      'duplicate key value violates unique constraint "products_org_sku_idx"',
+    );
+    expect(detail).toEqual({
+      rawField: "sku",
+      fieldLabel: "SKU",
+      reason: "taka wartość już istnieje",
+    });
+  });
+
+  it("falls back to raw constraint name and 'Pole' label when unique constraint column cannot be identified", () => {
+    const detail = extractFieldValidationDetail(
+      'duplicate key value violates unique constraint "some_unknown_uniqueness_constraint_key"',
+    );
+    expect(detail).toEqual({
+      rawField: "some_unknown_uniqueness_constraint_key",
+      fieldLabel: "Pole",
+      reason: "taka wartość już istnieje",
+    });
+  });
+
   it("extracts field from Convex 'Validator error: Missing required field' (issue #1941)", () => {
     const detail = extractFieldValidationDetail(
       "Validator error: Missing required field `name` in object",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3182.

Closes #3182

---

## Claude summary

Added three test cases for the `uniqueCon` parser in `extractFieldValidationDetail` (`src/lib/format-action-error.test.ts`):

1. **`_key` suffix, column identified** — `products_sku_key` → `rawField: "sku"`, `fieldLabel: "SKU"`, `reason: "taka wartość już istnieje"`
2. **`_idx` suffix, column identified** — `products_org_sku_idx` → same resolution via the longest-match column lookup
3. **Fallback when column unidentifiable** — `rawField` is the full raw constraint name, `fieldLabel` is `"Pole"`, `reason` unchanged

All 17 tests pass (14 pre-existing + 3 new).