### PR TITLE
Add "name" empty-string guard in `handleProductFormSubmit`

### DIFF
--- a/src/components/forms/product-form.tsx
+++ b/src/components/forms/product-form.tsx
@@ -122,6 +122,7 @@ export function ProductForm({
   const { t } = useTranslation();
   const isCreate = !initialData;
   const [name, setName] = useState(initialData?.name ?? "");
+  const [nameError, setNameError] = useState("");
   const [description, setDescription] = useState(initialData?.description ?? "");
   const [sku, setSku] = useState(initialData?.sku ?? generateSku());
   const [unitPrice, setUnitPrice] = useState(String(initialData?.unitPrice ?? ""));
@@ -147,6 +148,12 @@ export function ProductForm({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setNameError(t("products.form.nameRequired", { defaultValue: "Nazwa produktu jest wymagana." }));
+      return;
+    }
+    setNameError("");
     const isExempt = taxRate === "zw";
     const numericTaxRate = !isExempt
       ? Number.isFinite(parseFloat(taxRate))
@@ -170,7 +177,7 @@ export function ProductForm({
       return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
     })();
     onSubmit({
-      name,
+      name: trimmedName,
       description: description || null,
       sku,
       unitPrice: parseFloat(normalizedUnitPrice) || 0,
@@ -200,10 +207,13 @@ export function ProductForm({
           </Label>
           <Input
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e) => {
+              setName(e.target.value);
+              if (nameError) setNameError("");
+            }}
             placeholder={t("products.form.namePlaceholder")}
-            required
           />
+          {nameError && <p className="text-sm text-destructive">{nameError}</p>}
         </div>
         <div className="space-y-1.5">
           <Label>{t("products.form.sku")}</Label>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3183.

Closes #3183

---

## Claude summary

Fixed. Here's a summary of what was done:

In `src/components/forms/product-form.tsx`, the `handleSubmit` function now:
1. Trims the `name` value before any further processing.
2. If the trimmed result is empty, sets an inline `nameError` state and returns early — preventing the whitespace-only value from reaching the backend.
3. Passes the pre-trimmed `name` to `onSubmit`, so `handleProductFormSubmit` in the route file no longer silently produces an empty string.
4. Clears the error as soon as the user starts typing again.

The HTML `required` attribute was also removed from the name `<Input>` since the programmatic guard now handles that case, avoiding a clash between browser-native validation UI and the custom error message.