### PR TITLE
Add "at argument" line preservation in `cleanConvexMessage`

### DIFF
--- a/src/lib/format-action-error.test.ts
+++ b/src/lib/format-action-error.test.ts
@@ -264,4 +264,23 @@ describe("formatTreatmentError", () => {
     });
     expect(msg).toContain("Cena");
   });
+
+  it("surfaces field when Convex emits 'at argument' on a follow-up line (issue #3187)", () => {
+    // ArgumentValidationError traces include lines like
+    // `at argument 'price': Expected number, got null` which
+    // cleanConvexMessage previously dropped (caught by the bare `^at\s+\S`
+    // filter before the `at argument` guard was added).
+    const err = new Error(
+      "[CONVEX A(gabinet/treatments:create)] [Request ID: xx] Server Error\n" +
+        "Uncaught ArgumentValidationError: Value does not match validator\n" +
+        "    at argument 'price': Expected `number`, got `null`\n" +
+        "    at handler (../convex/gabinet/treatments.ts:42:13)\n" +
+        "  Called by client",
+    );
+    const msg = formatTreatmentError(err, t, {
+      key: "gabinet.treatments.errors.createFailed",
+      defaultValue: "Nie udało się utworzyć zabiegu.",
+    });
+    expect(msg).toContain("Cena");
+  });
 });

--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -316,8 +316,10 @@ function cleanConvexMessage(raw: string): string {
         if (!trimmed) return false;
         if (/^Called by client\s*$/i.test(trimmed)) return false;
         // Drop stack frames ("at fn (file:N:N)" or bare "at fn") but keep
-        // validator detail lines like "at path 'foo.bar'".
+        // validator detail lines like "at path 'foo.bar'" and
+        // "at argument 'fieldName': ..." (ArgumentValidationError).
         if (/^at\s+path\b/i.test(trimmed)) return true;
+        if (/^at\s+argument\b/i.test(trimmed)) return true;
         if (/^at\s+\S/i.test(trimmed)) return false;
         return true;
       })


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3187.

Closes #3187

---

## Claude summary

The fix is committed. Here's a summary:

**Root cause:** In `cleanConvexMessage` (`src/lib/format-action-error.ts:314-325`), the filter loop that strips stack frames had an explicit carve-out for `at path '...'` lines (added in #1966), but no equivalent for `at argument '...'` lines. The catch-all `^at\s+\S` filter dropped `at argument 'fieldName': ...` before `extractFieldValidationDetail` could see them, so the `convexArg` pattern at line 199 never fired on multi-line `ArgumentValidationError` messages.

**Fix:** Added `if (/^at\s+argument\b/i.test(trimmed)) return true;` immediately after the `at path` guard in `format-action-error.ts:321`, and a matching regression test in `format-action-error.test.ts`. All 25 tests pass.