### PR TITLE
fix(worker): never label claude:done when Claude exits non-zero

### DIFF
--- a/automation/worker/run-claude.sh
+++ b/automation/worker/run-claude.sh
@@ -213,7 +213,7 @@ fi
 COMMENT_FILE=$(mktemp)
 FINAL_LABEL=""
 
-if [ "$COMMITS_AHEAD" -gt 0 ]; then
+if [ "$CLAUDE_EXIT" -eq 0 ] && [ "$COMMITS_AHEAD" -gt 0 ]; then
   echo "pushing branch $BRANCH"
   git push --set-upstream origin "$BRANCH" 2>&1 | tail -3
 


### PR DESCRIPTION
Cherry-picked from the stale `fix/worker-exit-guard-claude-done` branch (still relevant — `automation/worker/run-claude.sh` exists on main and lacked this guard). One-line fix: don't apply the `claude:done` label when the Claude run exited non-zero, so failed runs aren't marked complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)