### PR TITLE
feat(ai): generic AnalysisKind pipeline + template generation from scans

### DIFF
--- a/convex/_ai/documentAnalyzer.ts
+++ b/convex/_ai/documentAnalyzer.ts
@@ -1,21 +1,21 @@
 // AI/OCR integration adapter layer (#3026, #3038).
 //
-// Defines the contract any OCR/AI provider must satisfy and exports a factory
-// (`getDocumentAnalyzer`) that callers use to obtain the active implementation.
-// The warehouse module depends ONLY on the types and factory here — it never
+// Defines the transport contract any OCR/AI provider must satisfy and exports
+// factories/helpers that callers use to run document analysis.
+// The warehouse module depends ONLY on the types and factories here — it never
 // imports a concrete provider directly.
 //
 // Current implementation: OpenAIDocumentAnalyzer when OPENAI_API_KEY is set,
-// NullDocumentAnalyzer otherwise.
+// NullDocumentTransport otherwise.
 
 import { OpenAIDocumentAnalyzer } from "./providers/openaiDocumentAnalyzer";
 
 // ---------------------------------------------------------------------------
-// Input — ordered pages that together form one invoice document (#3035).
+// Input — ordered pages that together form one document (#3035).
 // ---------------------------------------------------------------------------
 
-// A single page of an invoice document. Pages are ordered by `position`
-// (1-based). One invoice may be a single PDF or one/several images.
+// A single page of a document. Pages are ordered by `position` (1-based).
+// One document may be a single PDF or one/several images.
 //
 // `storageId` is a Convex storage ID — callers never pass public URLs.
 // Providers fetch file bytes server-side via `ctx.storage.get(storageId)`.
@@ -57,10 +57,17 @@ export interface ParsedInvoice {
 }
 
 // ---------------------------------------------------------------------------
-// Result union — callers check status, never catch provider-specific errors.
+// Storage fetcher — passed by the calling action so the provider can read
+// file bytes server-side without touching public URLs.
+// ---------------------------------------------------------------------------
+
+export type StorageFetcher = (storageId: string) => Promise<Blob | null>;
+
+// ---------------------------------------------------------------------------
+// Transport result — raw JSON string on success, or a typed failure.
 //
 // Statuses:
-//   ok                — analysis succeeded; data holds ParsedInvoice
+//   ok                — transport succeeded; rawJson holds the model's output
 //   not_implemented   — no provider configured (placeholder)
 //   no_pages          — pages array was empty; nothing to analyze
 //   unsupported_format — one or more pages have a mimeType the provider
@@ -68,24 +75,41 @@ export interface ParsedInvoice {
 //   error             — provider returned an unexpected failure
 // ---------------------------------------------------------------------------
 
-export type AnalyzeInvoiceResult =
-  | { status: "ok"; data: ParsedInvoice }
+export type TransportResult =
+  | { status: "ok"; rawJson: string }
   | { status: "not_implemented" }
   | { status: "no_pages" }
   | { status: "unsupported_format"; mimeType: string }
   | { status: "error"; message: string };
 
 // ---------------------------------------------------------------------------
-// Adapter contract
+// Transport contract — any provider must implement this interface.
 // ---------------------------------------------------------------------------
 
-// Any future OCR/AI provider must implement this interface.
-// analyzeInvoice receives all pages of one invoice and returns one result.
-// Pages MUST be sorted by position before being passed in; the provider may
-// rely on that order when it reassembles the document.
-export interface DocumentAnalyzer {
-  analyzeInvoice(pages: DocumentPage[]): Promise<AnalyzeInvoiceResult>;
+export interface DocumentTransport {
+  run(pages: DocumentPage[], prompt: string, maxTokens?: number): Promise<TransportResult>;
 }
+
+// ---------------------------------------------------------------------------
+// Analysis kind — encapsulates prompt, validation, and result mapping for
+// a specific document type (e.g. invoice, form_template).
+// ---------------------------------------------------------------------------
+
+export interface AnalysisKind<TResult> {
+  id: string;
+  buildPrompt(context?: Record<string, unknown>): string;
+  validate(raw: unknown): boolean;
+  map(raw: unknown, opts: { rawJson: string; context?: Record<string, unknown> }): TResult;
+  maxTokens?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Analyze result — callers check status, never catch provider-specific errors.
+// ---------------------------------------------------------------------------
+
+export type AnalyzeResult<T> =
+  | { status: "ok"; data: T }
+  | Exclude<TransportResult, { status: "ok" }>;
 
 // ---------------------------------------------------------------------------
 // Supported MIME types (shared validation used by callers and providers)
@@ -102,46 +126,55 @@ export function isSupportedMimeType(mimeType: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Placeholder implementation
+// Placeholder transport implementation
 // ---------------------------------------------------------------------------
 
-// Returns not_implemented for every call. Replaced in a later phase by a real
-// provider without any changes to callers.
-class NullDocumentAnalyzer implements DocumentAnalyzer {
-  async analyzeInvoice(pages: DocumentPage[]): Promise<AnalyzeInvoiceResult> {
-    if (pages.length === 0) {
-      return { status: "no_pages" };
-    }
-
+class NullDocumentTransport implements DocumentTransport {
+  async run(pages: DocumentPage[]): Promise<TransportResult> {
+    if (pages.length === 0) return { status: "no_pages" };
     const unsupported = pages.find((p) => !isSupportedMimeType(p.mimeType));
-    if (unsupported) {
-      return { status: "unsupported_format", mimeType: unsupported.mimeType };
-    }
-
+    if (unsupported) return { status: "unsupported_format", mimeType: unsupported.mimeType };
     return { status: "not_implemented" };
   }
 }
-
-// ---------------------------------------------------------------------------
-// Storage fetcher — passed by the calling action so the provider can read
-// file bytes server-side without touching public URLs.
-// ---------------------------------------------------------------------------
-
-export type StorageFetcher = (storageId: string) => Promise<Blob | null>;
 
 // ---------------------------------------------------------------------------
 // Factory — the single entry point for all callers.
 // ---------------------------------------------------------------------------
 
 // Returns OpenAIDocumentAnalyzer when OPENAI_API_KEY is configured, otherwise
-// NullDocumentAnalyzer. The model can be overridden via OPENAI_INVOICE_MODEL.
+// NullDocumentTransport. The model can be overridden via OPENAI_INVOICE_MODEL.
 // `fetchFile` is provided by the calling action (ctx.storage.get) so the
 // provider can fetch bytes server-side without exposing public URLs.
-export function getDocumentAnalyzer(fetchFile: StorageFetcher): DocumentAnalyzer {
+export function getDocumentTransport(fetchFile: StorageFetcher): DocumentTransport {
   const apiKey = process.env.OPENAI_API_KEY;
   if (apiKey) {
     const model = process.env.OPENAI_INVOICE_MODEL ?? "gpt-4o";
     return new OpenAIDocumentAnalyzer(apiKey, model, fetchFile);
   }
-  return new NullDocumentAnalyzer();
+  return new NullDocumentTransport();
+}
+
+// ---------------------------------------------------------------------------
+// analyzeDocument — generic analysis runner.
+// ---------------------------------------------------------------------------
+
+export async function analyzeDocument<T>(
+  transport: DocumentTransport,
+  kind: AnalysisKind<T>,
+  pages: DocumentPage[],
+  context?: Record<string, unknown>,
+): Promise<AnalyzeResult<T>> {
+  const res = await transport.run(pages, kind.buildPrompt(context), kind.maxTokens);
+  if (res.status !== "ok") return res;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(res.rawJson);
+  } catch {
+    return { status: "error", message: "Model returned non-JSON response" };
+  }
+  if (!kind.validate(raw)) {
+    return { status: "error", message: `Model response does not match expected ${kind.id} schema` };
+  }
+  return { status: "ok", data: kind.map(raw, { rawJson: res.rawJson, context }) };
 }

--- a/convex/_ai/kinds/formTemplate.ts
+++ b/convex/_ai/kinds/formTemplate.ts
@@ -1,0 +1,133 @@
+import type { AnalysisKind } from "../documentAnalyzer";
+
+export type ParsedSegment =
+  | { type: "text"; text: string }
+  | { type: "field"; label: string;
+      fieldType: "text"|"textarea"|"select"|"button_select"|"date"|"checkbox";
+      options?: string[]; required?: boolean; patientFieldHint?: string | null };
+
+export type ParsedBlock =
+  | { type: "heading"; level: 1|2|3; text: string }
+  | { type: "paragraph"; segments: ParsedSegment[] }
+  | { type: "bulletList" | "orderedList"; items: ParsedSegment[][] };
+
+export interface ParsedFormTemplate {
+  title: string | null;
+  blocks: ParsedBlock[];
+  confidence: number | null;
+}
+
+const FIELD_TYPES = new Set(["text", "textarea", "select", "button_select", "date", "checkbox"]);
+const BLOCK_TYPES = new Set(["heading", "paragraph", "bulletList", "orderedList"]);
+
+function buildPrompt(context?: Record<string, unknown>): string {
+  const patientFields = Array.isArray((context as { patientFields?: unknown })?.patientFields)
+    ? ((context as { patientFields: Array<{ key: string; label: string }> }).patientFields)
+    : [];
+  const targets = patientFields.map((f) => `- "builtin:${f.key}" — ${f.label}`).join("\n");
+  return `You are reconstructing a scanned paper form (typically Polish: consent forms, medical intake, GDPR) into a structured template. Return ONE JSON object:
+
+{
+  "title": string | null,
+  "blocks": [
+    { "type": "heading", "level": 1|2|3, "text": string }
+    | { "type": "paragraph", "segments": Segment[] }
+    | { "type": "bulletList" | "orderedList", "items": Segment[][] }
+  ],
+  "confidence": number
+}
+
+Segment = { "type": "text", "text": string }
+        | { "type": "field", "label": string,
+            "fieldType": "text"|"textarea"|"select"|"button_select"|"date"|"checkbox",
+            "options"?: string[], "required"?: boolean, "patientFieldHint"?: string | null }
+
+Rules:
+- Reproduce ALL static text of the document verbatim (Polish stays Polish).
+- Blank lines, dotted lines, underscores, empty boxes to be filled in → a "field" segment (NOT text).
+- A group of mutually exclusive checkboxes/options → one "select" field with "options".
+- A single yes/no checkbox → "checkbox". Larger empty areas for free writing → "textarea". Date slots (e.g. next to signature) → "date".
+- "label" = the caption printed next to the blank (e.g. "Imię i nazwisko").
+- patientFieldHint: ONLY when the blank clearly corresponds to one of these client-record targets, use EXACTLY one of the values below; otherwise null. Never invent other values.
+${targets || "- (no targets available — always use null)"}
+- Do NOT guess content that is not on the document. "confidence" is a 0-1 overall score.`;
+}
+
+function isSegment(v: unknown): boolean {
+  if (!v || typeof v !== "object") return false;
+  const s = v as Record<string, unknown>;
+  if (s.type === "text") return typeof s.text === "string";
+  if (s.type === "field") return typeof s.label === "string" && s.label.length > 0;
+  return false;
+}
+
+function validate(raw: unknown): boolean {
+  if (!raw || typeof raw !== "object") return false;
+  const o = raw as Record<string, unknown>;
+  if (!Array.isArray(o.blocks)) return false;
+  for (const b of o.blocks as unknown[]) {
+    if (!b || typeof b !== "object") return false;
+    const blk = b as Record<string, unknown>;
+    if (!BLOCK_TYPES.has(String(blk.type))) return false;
+    if (blk.type === "heading" && typeof blk.text !== "string") return false;
+    if (blk.type === "paragraph") {
+      if (!Array.isArray(blk.segments) || !(blk.segments as unknown[]).every(isSegment)) return false;
+    }
+    if (blk.type === "bulletList" || blk.type === "orderedList") {
+      if (!Array.isArray(blk.items)) return false;
+      for (const item of blk.items as unknown[]) {
+        if (!Array.isArray(item) || !(item as unknown[]).every(isSegment)) return false;
+      }
+    }
+  }
+  return true;
+}
+
+function mapSegment(s: Record<string, unknown>, allowed: Set<string>): ParsedSegment {
+  if (s.type === "text") return { type: "text", text: String(s.text ?? "") };
+  const rawHint = typeof s.patientFieldHint === "string" ? s.patientFieldHint : null;
+  return {
+    type: "field",
+    label: String(s.label ?? ""),
+    fieldType: FIELD_TYPES.has(String(s.fieldType)) ? (String(s.fieldType) as never) : "text",
+    options: Array.isArray(s.options) ? (s.options as unknown[]).map(String) : undefined,
+    required: s.required === true ? true : undefined,
+    patientFieldHint: rawHint && allowed.has(rawHint) ? rawHint : null,
+  };
+}
+
+function map(raw: unknown, opts: { rawJson: string; context?: Record<string, unknown> }): ParsedFormTemplate {
+  const o = raw as Record<string, unknown>;
+  const patientFields = Array.isArray((opts.context as { patientFields?: unknown })?.patientFields)
+    ? ((opts.context as { patientFields: Array<{ key: string }> }).patientFields)
+    : [];
+  const allowed = new Set(patientFields.map((f) => `builtin:${f.key}`));
+  const blocks: ParsedBlock[] = [];
+  for (const b of (o.blocks as Array<Record<string, unknown>>)) {
+    if (b.type === "heading") {
+      const lvl = Number(b.level);
+      blocks.push({ type: "heading", level: (lvl === 2 || lvl === 3 ? lvl : 1) as 1|2|3, text: String(b.text ?? "") });
+    } else if (b.type === "paragraph") {
+      blocks.push({ type: "paragraph", segments: (b.segments as Array<Record<string, unknown>>).map((s) => mapSegment(s, allowed)) });
+    } else {
+      blocks.push({
+        type: b.type as "bulletList" | "orderedList",
+        items: (b.items as Array<Array<Record<string, unknown>>>).map((item) => item.map((s) => mapSegment(s, allowed))),
+      });
+    }
+  }
+  const conf = Number(o.confidence);
+  return {
+    title: typeof o.title === "string" && o.title ? o.title : null,
+    blocks,
+    confidence: Number.isFinite(conf) ? conf : null,
+  };
+}
+
+export const formTemplateKind: AnalysisKind<ParsedFormTemplate> = {
+  id: "form_template",
+  maxTokens: 8192,
+  buildPrompt,
+  validate,
+  map,
+};

--- a/convex/_ai/kinds/invoice.ts
+++ b/convex/_ai/kinds/invoice.ts
@@ -1,0 +1,129 @@
+// Kind "invoice" — prompt + walidacja + mapowanie wyniesione 1:1 z providera
+// OpenAI (refaktor). Zachowanie identyczne jak przed refaktorem.
+import type { AnalysisKind, ParsedInvoice, ParsedInvoiceItem } from "../documentAnalyzer";
+
+// ---------------------------------------------------------------------------
+// Prompt (przeniesiony bez zmian z openaiDocumentAnalyzer.ts)
+// ---------------------------------------------------------------------------
+
+const INVOICE_PROMPT = `Extract all invoice data from the provided document(s). Return a single JSON object with this exact structure:
+
+{
+  "supplierName": string | null,
+  "supplierNip": string | null,
+  "invoiceNumber": string | null,
+  "invoiceDate": string | null,
+  "deliveryDate": string | null,
+  "currency": string | null,
+  "items": [
+    {
+      "productName": string,
+      "quantity": number,
+      "unit": string | null,
+      "unitPriceNet": number | null,
+      "unitPriceGross": number | null,
+      "vatRate": number | null,
+      "vatCode": string | null,
+      "lineValueNet": number | null,
+      "lineValueGross": number | null,
+      "lotNumber": string | null,
+      "expiryDate": string | null
+    }
+  ],
+  "confidence": number
+}
+
+Rules:
+- All dates must be ISO 8601 format YYYY-MM-DD.
+- Do NOT guess missing values — use null.
+- Extract "lotNumber" and "expiryDate" per item ONLY when explicitly printed on the invoice.
+- "vatRate" is a percentage value (e.g. 23 for 23%, 8 for 8%, 0 for 0%).
+- "confidence" is a 0–1 score reflecting overall extraction certainty.
+- If a field is uncertain, set it to null rather than guessing.`;
+
+// ---------------------------------------------------------------------------
+// Raw response types and validation (przeniesione bez zmian)
+// ---------------------------------------------------------------------------
+
+interface RawItem {
+  productName: unknown;
+  quantity: unknown;
+  unit: unknown;
+  unitPriceNet: unknown;
+  unitPriceGross: unknown;
+  vatRate: unknown;
+  vatCode: unknown;
+  lineValueNet: unknown;
+  lineValueGross: unknown;
+  lotNumber: unknown;
+  expiryDate: unknown;
+}
+
+interface RawInvoice {
+  supplierName: unknown;
+  invoiceNumber: unknown;
+  invoiceDate: unknown;
+  items: RawItem[];
+  confidence: unknown;
+}
+
+function isRawInvoice(v: unknown): v is RawInvoice {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  if (!Array.isArray(o.items)) return false;
+  for (const item of o.items as unknown[]) {
+    if (!item || typeof item !== "object") return false;
+    if (!("productName" in (item as object))) return false;
+  }
+  return true;
+}
+
+function str(v: unknown): string | null {
+  if (v === null || v === undefined || v === "") return null;
+  return String(v);
+}
+
+function num(v: unknown): number | null {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function mapItem(raw: RawItem): ParsedInvoiceItem {
+  return {
+    productName: str(raw.productName) ?? "",
+    quantity: num(raw.quantity) ?? 0,
+    unit: str(raw.unit),
+    unitPrice: num(raw.unitPriceNet),
+    unitPriceGross: num(raw.unitPriceGross),
+    vatRate: num(raw.vatRate),
+    vatCode: str(raw.vatCode),
+    lineValueNet: num(raw.lineValueNet),
+    lineValueGross: num(raw.lineValueGross),
+    lotNumber: str(raw.lotNumber),
+    expiryDate: str(raw.expiryDate),
+  };
+}
+
+function mapInvoice(raw: RawInvoice, rawJson: string): ParsedInvoice {
+  return {
+    supplierName: str(raw.supplierName),
+    invoiceNumber: str(raw.invoiceNumber),
+    invoiceDate: str(raw.invoiceDate),
+    items: raw.items.map(mapItem),
+    confidence: num(raw.confidence),
+    rawText: rawJson,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Kind definition
+// ---------------------------------------------------------------------------
+
+export const invoiceKind: AnalysisKind<ParsedInvoice> = {
+  id: "invoice",
+  maxTokens: 4096,
+  buildPrompt: () => INVOICE_PROMPT,
+  validate: (raw) => isRawInvoice(raw),
+  map: (raw, opts) => mapInvoice(raw as RawInvoice, opts.rawJson),
+};

--- a/convex/_ai/providers/openaiDocumentAnalyzer.ts
+++ b/convex/_ai/providers/openaiDocumentAnalyzer.ts
@@ -1,19 +1,17 @@
-// OpenAI implementation of DocumentAnalyzer (#3038).
+// OpenAI implementation of DocumentTransport (#3038).
 //
-// Sends invoice pages (PDF, JPEG, PNG) to a GPT-4o-class model and returns a
-// validated ParsedInvoice. Files are fetched server-side via the StorageFetcher
-// callback — no public URLs are exposed to the model.
+// Sends document pages (PDF, JPEG, PNG) to a GPT-4o-class model and returns
+// the raw JSON string from the model. Files are fetched server-side via the
+// StorageFetcher callback — no public URLs are exposed to the model.
 //
 // All OpenAI SDK / type imports stay inside this module. Nothing outside
 // convex/_ai/providers/* should import from "openai".
 
 import OpenAI, { APIError } from "openai";
 import type {
-  DocumentAnalyzer,
+  DocumentTransport,
   DocumentPage,
-  AnalyzeInvoiceResult,
-  ParsedInvoice,
-  ParsedInvoiceItem,
+  TransportResult,
   StorageFetcher,
 } from "../documentAnalyzer";
 
@@ -23,124 +21,10 @@ const SUPPORTED_MIME_TYPES = new Set(["application/pdf", "image/jpeg", "image/pn
 const REQUEST_TIMEOUT_MS = 60_000;
 
 // ---------------------------------------------------------------------------
-// Prompt
-// ---------------------------------------------------------------------------
-
-const USER_PROMPT = `Extract all invoice data from the provided document(s). Return a single JSON object with this exact structure:
-
-{
-  "supplierName": string | null,
-  "supplierNip": string | null,
-  "invoiceNumber": string | null,
-  "invoiceDate": string | null,
-  "deliveryDate": string | null,
-  "currency": string | null,
-  "items": [
-    {
-      "productName": string,
-      "quantity": number,
-      "unit": string | null,
-      "unitPriceNet": number | null,
-      "unitPriceGross": number | null,
-      "vatRate": number | null,
-      "vatCode": string | null,
-      "lineValueNet": number | null,
-      "lineValueGross": number | null,
-      "lotNumber": string | null,
-      "expiryDate": string | null
-    }
-  ],
-  "confidence": number
-}
-
-Rules:
-- All dates must be ISO 8601 format YYYY-MM-DD.
-- Do NOT guess missing values — use null.
-- Extract "lotNumber" and "expiryDate" per item ONLY when explicitly printed on the invoice.
-- "vatRate" is a percentage value (e.g. 23 for 23%, 8 for 8%, 0 for 0%).
-- "confidence" is a 0–1 score reflecting overall extraction certainty.
-- If a field is uncertain, set it to null rather than guessing.`;
-
-// ---------------------------------------------------------------------------
-// Raw response types and validation
-// ---------------------------------------------------------------------------
-
-interface RawItem {
-  productName: unknown;
-  quantity: unknown;
-  unit: unknown;
-  unitPriceNet: unknown;
-  unitPriceGross: unknown;
-  vatRate: unknown;
-  vatCode: unknown;
-  lineValueNet: unknown;
-  lineValueGross: unknown;
-  lotNumber: unknown;
-  expiryDate: unknown;
-}
-
-interface RawInvoice {
-  supplierName: unknown;
-  invoiceNumber: unknown;
-  invoiceDate: unknown;
-  items: RawItem[];
-  confidence: unknown;
-}
-
-function isRawInvoice(v: unknown): v is RawInvoice {
-  if (!v || typeof v !== "object") return false;
-  const o = v as Record<string, unknown>;
-  if (!Array.isArray(o.items)) return false;
-  for (const item of o.items as unknown[]) {
-    if (!item || typeof item !== "object") return false;
-    if (!("productName" in (item as object))) return false;
-  }
-  return true;
-}
-
-function str(v: unknown): string | null {
-  if (v === null || v === undefined || v === "") return null;
-  return String(v);
-}
-
-function num(v: unknown): number | null {
-  if (v === null || v === undefined) return null;
-  const n = Number(v);
-  return Number.isFinite(n) ? n : null;
-}
-
-function mapItem(raw: RawItem): ParsedInvoiceItem {
-  return {
-    productName: str(raw.productName) ?? "",
-    quantity: num(raw.quantity) ?? 0,
-    unit: str(raw.unit),
-    unitPrice: num(raw.unitPriceNet),
-    unitPriceGross: num(raw.unitPriceGross),
-    vatRate: num(raw.vatRate),
-    vatCode: str(raw.vatCode),
-    lineValueNet: num(raw.lineValueNet),
-    lineValueGross: num(raw.lineValueGross),
-    lotNumber: str(raw.lotNumber),
-    expiryDate: str(raw.expiryDate),
-  };
-}
-
-function mapInvoice(raw: RawInvoice, rawJson: string): ParsedInvoice {
-  return {
-    supplierName: str(raw.supplierName),
-    invoiceNumber: str(raw.invoiceNumber),
-    invoiceDate: str(raw.invoiceDate),
-    items: raw.items.map(mapItem),
-    confidence: num(raw.confidence),
-    rawText: rawJson,
-  };
-}
-
-// ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------
 
-export class OpenAIDocumentAnalyzer implements DocumentAnalyzer {
+export class OpenAIDocumentAnalyzer implements DocumentTransport {
   private readonly client: OpenAI;
   private readonly model: string;
   private readonly fetchFile: StorageFetcher;
@@ -151,7 +35,7 @@ export class OpenAIDocumentAnalyzer implements DocumentAnalyzer {
     this.fetchFile = fetchFile;
   }
 
-  async analyzeInvoice(pages: DocumentPage[]): Promise<AnalyzeInvoiceResult> {
+  async run(pages: DocumentPage[], prompt: string, maxTokens = 4096): Promise<TransportResult> {
     if (pages.length === 0) return { status: "no_pages" };
 
     const unsupported = pages.find((p) => !SUPPORTED_MIME_TYPES.has(p.mimeType));
@@ -198,7 +82,7 @@ export class OpenAIDocumentAnalyzer implements DocumentAnalyzer {
       }
     }
 
-    contentParts.push({ type: "text", text: USER_PROMPT });
+    contentParts.push({ type: "text", text: prompt });
 
     let rawText: string;
     try {
@@ -206,7 +90,7 @@ export class OpenAIDocumentAnalyzer implements DocumentAnalyzer {
         model: this.model,
         response_format: { type: "json_object" },
         messages: [{ role: "user", content: contentParts }],
-        max_tokens: 4096,
+        max_tokens: maxTokens,
       });
       rawText = completion.choices[0]?.message?.content ?? "";
     } catch (err) {
@@ -221,17 +105,6 @@ export class OpenAIDocumentAnalyzer implements DocumentAnalyzer {
       return { status: "error", message: "Empty response from model" };
     }
 
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(rawText);
-    } catch {
-      return { status: "error", message: "Model returned non-JSON response" };
-    }
-
-    if (!isRawInvoice(parsed)) {
-      return { status: "error", message: "Model response does not match expected invoice schema" };
-    }
-
-    return { status: "ok", data: mapInvoice(parsed, rawText) };
+    return { status: "ok", rawJson: rawText };
   }
 }

--- a/convex/_ai/registry.ts
+++ b/convex/_ai/registry.ts
@@ -1,0 +1,12 @@
+import type { AnalysisKind } from "./documentAnalyzer";
+import { invoiceKind } from "./kinds/invoice";
+import { formTemplateKind } from "./kinds/formTemplate";
+
+const KINDS: Record<string, AnalysisKind<unknown>> = {
+  [invoiceKind.id]: invoiceKind as AnalysisKind<unknown>,
+  [formTemplateKind.id]: formTemplateKind as AnalysisKind<unknown>,
+};
+
+export function getAnalysisKind(id: string): AnalysisKind<unknown> | null {
+  return KINDS[id] ?? null;
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,7 +10,10 @@
 
 import type * as _ai_documentAnalyzer from "../_ai/documentAnalyzer.js";
 import type * as _ai_invoiceMatching from "../_ai/invoiceMatching.js";
+import type * as _ai_kinds_formTemplate from "../_ai/kinds/formTemplate.js";
+import type * as _ai_kinds_invoice from "../_ai/kinds/invoice.js";
 import type * as _ai_providers_openaiDocumentAnalyzer from "../_ai/providers/openaiDocumentAnalyzer.js";
+import type * as _ai_registry from "../_ai/registry.js";
 import type * as _helpers_activities from "../_helpers/activities.js";
 import type * as _helpers_activityEnvelope from "../_helpers/activityEnvelope.js";
 import type * as _helpers_auth from "../_helpers/auth.js";
@@ -49,6 +52,7 @@ import type * as customFields from "../customFields.js";
 import type * as dashboard from "../dashboard.js";
 import type * as dev_emails from "../dev/emails.js";
 import type * as dev_helpers from "../dev/helpers.js";
+import type * as documentAnalysisJobs from "../documentAnalysisJobs.js";
 import type * as documentDataSources from "../documentDataSources.js";
 import type * as documentInstances from "../documentInstances.js";
 import type * as documentTemplateFields from "../documentTemplateFields.js";
@@ -202,7 +206,10 @@ import type {
 declare const fullApi: ApiFromModules<{
   "_ai/documentAnalyzer": typeof _ai_documentAnalyzer;
   "_ai/invoiceMatching": typeof _ai_invoiceMatching;
+  "_ai/kinds/formTemplate": typeof _ai_kinds_formTemplate;
+  "_ai/kinds/invoice": typeof _ai_kinds_invoice;
   "_ai/providers/openaiDocumentAnalyzer": typeof _ai_providers_openaiDocumentAnalyzer;
+  "_ai/registry": typeof _ai_registry;
   "_helpers/activities": typeof _helpers_activities;
   "_helpers/activityEnvelope": typeof _helpers_activityEnvelope;
   "_helpers/auth": typeof _helpers_auth;
@@ -241,6 +248,7 @@ declare const fullApi: ApiFromModules<{
   dashboard: typeof dashboard;
   "dev/emails": typeof dev_emails;
   "dev/helpers": typeof dev_helpers;
+  documentAnalysisJobs: typeof documentAnalysisJobs;
   documentDataSources: typeof documentDataSources;
   documentInstances: typeof documentInstances;
   documentTemplateFields: typeof documentTemplateFields;

--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -44,6 +44,7 @@ const TABLE_MAP: Record<string, string> = {
   documentTemplateFields: "document_template_fields",
   documentInstances: "document_instances",
   documentComponents: "document_components",
+  documentAnalysisJobs: "document_analysis_jobs",
   formTemplates: "form_templates",
   formDocuments: "form_documents",
   signatureRequests: "signature_requests",

--- a/convex/_helpers/supabaseRows.ts
+++ b/convex/_helpers/supabaseRows.ts
@@ -6,6 +6,7 @@ import type { Doc, TableNames } from "../_generated/dataModel";
 // `undefined`; consumers that read those fields should coalesce with `??`.
 export type SupabaseRow<T extends TableNames> = Omit<Doc<T>, "_creationTime">;
 
+export type DocumentAnalysisJobRow = SupabaseRow<"documentAnalysisJobs">;
 export type FormDocumentRow = SupabaseRow<"formDocuments">;
 export type FormTemplateRow = SupabaseRow<"formTemplates">;
 export type GabinetTreatmentRow = SupabaseRow<"gabinetTreatments">;

--- a/convex/documentAnalysisJobs.ts
+++ b/convex/documentAnalysisJobs.ts
@@ -42,6 +42,8 @@ export const createJob = action({
       throw new Error(`Unknown analysis kind: ${args.kind}`);
     }
 
+    if (args.pages.length === 0) throw new Error("No pages to analyze");
+
     const db = createSupabaseDb();
     const now = Date.now();
     const jobId = await db.insert("documentAnalysisJobs", {

--- a/convex/documentAnalysisJobs.ts
+++ b/convex/documentAnalysisJobs.ts
@@ -1,0 +1,182 @@
+// Generic document-analysis job actions (#3026).
+//
+// Provides createJob / runJob / getJob for any analysis kind registered in
+// convex/_ai/registry.ts. Auth pattern mirrors convex/documents/templates.ts:create —
+// uses internal._helpers.authAction.verifyOrgAccess, which returns { userId, role, … }.
+
+import { action } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { v } from "convex/values";
+import type { Id } from "./_generated/dataModel";
+import { createSupabaseDb } from "./_helpers/supabaseDb";
+import { getAnalysisKind } from "./_ai/registry";
+import { analyzeDocument, getDocumentTransport } from "./_ai/documentAnalyzer";
+import type { DocumentPage } from "./_ai/documentAnalyzer";
+
+const pagesValidator = v.array(
+  v.object({
+    storageId: v.string(),
+    mimeType: v.string(),
+    position: v.number(),
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// createJob
+// ---------------------------------------------------------------------------
+
+export const createJob = action({
+  args: {
+    organizationId: v.id("organizations"),
+    kind: v.string(),
+    pages: pagesValidator,
+    context: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<string> => {
+    const authResult = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+
+    if (!getAnalysisKind(args.kind)) {
+      throw new Error(`Unknown analysis kind: ${args.kind}`);
+    }
+
+    const db = createSupabaseDb();
+    const now = Date.now();
+    const jobId = await db.insert("documentAnalysisJobs", {
+      organizationId: String(args.organizationId),
+      kind: args.kind,
+      pages: args.pages,
+      context: args.context ?? null,
+      status: "pending",
+      resultJson: null,
+      errorMessage: null,
+      createdBy: String(authResult.userId),
+      createdAt: now,
+      updatedAt: now,
+      completedAt: null,
+    });
+
+    return String(jobId);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// runJob
+// ---------------------------------------------------------------------------
+
+export const runJob = action({
+  args: {
+    organizationId: v.id("organizations"),
+    jobId: v.string(),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ status: "ok"; resultJson: string } | { status: "error"; errorMessage: string }> => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+
+    const db = createSupabaseDb();
+    const job = await db.get("documentAnalysisJobs", args.jobId);
+    if (!job || String(job.organizationId) !== String(args.organizationId)) {
+      throw new Error("Analysis job not found");
+    }
+
+    const kind = getAnalysisKind(String(job.kind));
+    if (!kind) throw new Error(`Unknown analysis kind: ${job.kind}`);
+
+    await db.patch("documentAnalysisJobs", args.jobId, {
+      status: "running",
+      updatedAt: Date.now(),
+    });
+
+    const pages = (job.pages as DocumentPage[])
+      .slice()
+      .sort((a, b) => a.position - b.position);
+
+    let context: Record<string, unknown> | undefined;
+    if (typeof job.context === "string" && job.context) {
+      try {
+        context = JSON.parse(job.context) as Record<string, unknown>;
+      } catch {
+        context = undefined;
+      }
+    }
+
+    const transport = getDocumentTransport(
+      (id: string) => ctx.storage.get(id as unknown as Id<"_storage">),
+    );
+    const res = await analyzeDocument(transport, kind, pages, context);
+    const now = Date.now();
+
+    if (res.status === "ok") {
+      const resultJson = JSON.stringify(res.data);
+      await db.patch("documentAnalysisJobs", args.jobId, {
+        status: "ok",
+        resultJson,
+        errorMessage: null,
+        completedAt: now,
+        updatedAt: now,
+      });
+      return { status: "ok", resultJson };
+    }
+
+    let errorMessage: string;
+    switch (res.status) {
+      case "not_implemented":
+        errorMessage = "AI analysis provider is not configured";
+        break;
+      case "no_pages":
+        errorMessage = "No pages to analyze";
+        break;
+      case "unsupported_format":
+        errorMessage = `Unsupported file format: ${res.mimeType}`;
+        break;
+      default:
+        errorMessage = (res as { message: string }).message;
+    }
+
+    await db.patch("documentAnalysisJobs", args.jobId, {
+      status: "error",
+      errorMessage,
+      completedAt: now,
+      updatedAt: now,
+    });
+    return { status: "error", errorMessage };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// getJob
+// ---------------------------------------------------------------------------
+
+export const getJob = action({
+  args: {
+    organizationId: v.id("organizations"),
+    jobId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+
+    const db = createSupabaseDb();
+    const job = await db.get("documentAnalysisJobs", args.jobId);
+    if (!job || String(job.organizationId) !== String(args.organizationId)) {
+      return null;
+    }
+
+    return {
+      _id: String(job._id ?? args.jobId),
+      kind: String(job.kind),
+      status: String(job.status),
+      resultJson: (job.resultJson as string | null) ?? null,
+      errorMessage: (job.errorMessage as string | null) ?? null,
+      createdAt: Number(job.createdAt),
+      completedAt: (job.completedAt as number | null) ?? null,
+    };
+  },
+});

--- a/convex/schema/documents.ts
+++ b/convex/schema/documents.ts
@@ -166,4 +166,27 @@ export const documentTables = {
     .index("by_orgAndStatus", ["organizationId", "status"])
     .index("by_template", ["templateId"])
     .index("by_signingToken", ["signingToken"]),
+
+  // Generic AI document-analysis jobs (spec 2026-07-16). One row per analysis
+  // request for kinds that have no natural host row (e.g. a template that does
+  // not exist yet). Deliveries keep their own inline analysis fields.
+  documentAnalysisJobs: defineTable({
+    organizationId: v.id("organizations"),
+    kind: v.string(), // registry id: "form_template" | ...
+    pages: v.array(v.object({
+      storageId: v.string(),
+      mimeType: v.string(),
+      position: v.number(),
+    })),
+    context: v.optional(v.union(v.string(), v.null())), // JSON string, kind-specific
+    status: v.union(v.literal("pending"), v.literal("running"), v.literal("ok"), v.literal("error")),
+    resultJson: v.optional(v.union(v.string(), v.null())),
+    errorMessage: v.optional(v.union(v.string(), v.null())),
+    createdBy: v.id("users"),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    completedAt: v.optional(v.union(v.number(), v.null())),
+  })
+    .index("by_org", ["organizationId"])
+    .index("by_orgAndKind", ["organizationId", "kind"]),
 };

--- a/convex/warehouseDeliveries.ts
+++ b/convex/warehouseDeliveries.ts
@@ -14,8 +14,9 @@ import type { Id } from "./_generated/dataModel";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { applyMovementInternal } from "./inventory";
 import type { SupabaseRow } from "./_helpers/supabaseRows";
-import { getDocumentAnalyzer } from "./_ai/documentAnalyzer";
+import { getDocumentTransport, analyzeDocument } from "./_ai/documentAnalyzer";
 import type { DocumentPage, ParsedInvoice, ParsedInvoiceItem } from "./_ai/documentAnalyzer";
+import { invoiceKind } from "./_ai/kinds/invoice";
 import { matchInvoiceItems, normalizeName } from "./_ai/invoiceMatching";
 import type { MatchingProposals, ProductForMatching } from "./_ai/invoiceMatching";
 
@@ -521,11 +522,11 @@ export const analyzeDeliveryInvoice = action({
       .slice()
       .sort((a, b) => a.position - b.position);
 
-    const analyzer = getDocumentAnalyzer(
-      (id) => ctx.storage.get(id as unknown as Id<"_storage">),
+    const transport = getDocumentTransport(
+      (id: string) => ctx.storage.get(id as unknown as Id<"_storage">),
     );
 
-    const analysisResult = await analyzer.analyzeInvoice(pages);
+    const analysisResult = await analyzeDocument(transport, invoiceKind, pages);
     const now = Date.now();
 
     // 6. Persist result

--- a/docs/superpowers/plans/2026-07-16-ocr-template-generation.md
+++ b/docs/superpowers/plans/2026-07-16-ocr-template-generation.md
@@ -1,0 +1,1355 @@
+# OCR Template Generation (AnalysisKind pipeline) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Zrefaktorować pipeline OCR do generycznego rejestru `AnalysisKind` (provider = czysty transport) i zbudować pierwszy nowy tryb: generowanie szablonów dokumentów ze skanów, otwieranych do weryfikacji w istniejącym edytorze TipTap.
+
+**Architecture:** Provider OpenAI staje się transportem `(pages, prompt, maxTokens) → surowy JSON`; rodzaje analizy są pluginami `{ id, buildPrompt, validate, map }` w `convex/_ai/kinds/`. Wynik trybów bez własnego wiersza trwa w nowej generycznej tabeli `document_analysis_jobs`. Faktury zostają pierwszym kind bez zmiany zachowania (`analyzeDeliveryInvoice` zachowuje kontrakt). Spec: `docs/superpowers/specs/2026-07-16-ocr-template-generation-design.md`.
+
+**Tech Stack:** Convex actions + Supabase (hybryda projektu), OpenAI SDK (mockowany w testach przez `vi.mock("openai")`), TipTap `formField` nodes, TanStack Router, vitest (`npm run test:unit` = `cd convex && vitest run`; testy w `tests/convex/`).
+
+## Global Constraints
+
+- Gałąź robocza: `feat/ocr-template-generation` (istnieje; spec już zacommitowany).
+- Zero zmian zachowania przepływu faktur — istniejący `tests/convex/openaiDocumentAnalyzer.test.ts` po adaptacji API musi przechodzić z tymi samymi asercjami wyników.
+- Zero NOWYCH błędów `tsc` vs main: `npx tsc -p convex/tsconfig.json --pretty false` i `npx tsc -p tsconfig.app.json --pretty false` — porównuj listę błędów z main (main ma znane pre-existing błędy; nie naprawiaj ich, nie dodawaj nowych).
+- Każdy string UI ma klucze i18n PL + EN (`public/locales/pl/translation.json`, `public/locales/en/translation.json`).
+- Migracja SQL: NIE nakładać ręcznie na bazę — commit + PR; CI auto-apply na merge. Przed commitem sprawdź najwyższy numer w `supabase/migrations/` na aktualnym main i w razie kolizji przenumeruj (main jest szybki; dziś ostatnia = `00062`). Po dodaniu SQL uruchom `node scripts/gen-db-types.mjs` i zacommituj wygenerowane typy.
+- Uwierzytelnianie akcji: wzorzec `ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, { organizationId })` — dokładnie jak `convex/documents/templates.ts:create` (szablony nie mają dodatkowego `checkPermission`; jobs też nie).
+- Komendy testów: `npm run test:unit -- ../tests/convex/<plik>.test.ts` (cwd skryptu to `convex/`, stąd `../`). Pełny suite: `npm run test:unit`.
+
+---
+
+### Task 1: Rdzeń — transport + `AnalysisKind` + kind `invoice` (refaktor bez zmiany zachowania)
+
+**Files:**
+- Modify: `convex/_ai/documentAnalyzer.ts` (kontrakt + `analyzeDocument`)
+- Modify: `convex/_ai/providers/openaiDocumentAnalyzer.ts` (czysty transport)
+- Create: `convex/_ai/kinds/invoice.ts`
+- Modify: `convex/warehouseDeliveries.ts:520-530` (call site) + import na górze pliku
+- Modify: `tests/convex/openaiDocumentAnalyzer.test.ts` (adaptacja do nowego API)
+- Test: `tests/convex/analysisKindInvoice.test.ts` (nowy)
+
+**Interfaces:**
+- Produces (używane przez WSZYSTKIE późniejsze taski):
+  ```ts
+  // convex/_ai/documentAnalyzer.ts
+  export interface DocumentPage { storageId: string; mimeType: string; position: number }
+  export type StorageFetcher = (storageId: string) => Promise<Blob | null>;
+  export type TransportResult =
+    | { status: "ok"; rawJson: string }
+    | { status: "not_implemented" }
+    | { status: "no_pages" }
+    | { status: "unsupported_format"; mimeType: string }
+    | { status: "error"; message: string };
+  export interface DocumentTransport {
+    run(pages: DocumentPage[], prompt: string, maxTokens?: number): Promise<TransportResult>;
+  }
+  export interface AnalysisKind<TResult> {
+    id: string;
+    buildPrompt(context?: Record<string, unknown>): string;
+    validate(raw: unknown): boolean;
+    map(raw: unknown, opts: { rawJson: string; context?: Record<string, unknown> }): TResult;
+    maxTokens?: number;
+  }
+  export type AnalyzeResult<T> =
+    | { status: "ok"; data: T }
+    | Exclude<TransportResult, { status: "ok" }>;
+  export function getDocumentTransport(fetchFile: StorageFetcher): DocumentTransport;
+  export async function analyzeDocument<T>(
+    transport: DocumentTransport, kind: AnalysisKind<T>,
+    pages: DocumentPage[], context?: Record<string, unknown>,
+  ): Promise<AnalyzeResult<T>>;
+  // ParsedInvoice, ParsedInvoiceItem, isSupportedMimeType — eksporty ZOSTAJĄ bez zmian
+  ```
+  ```ts
+  // convex/_ai/kinds/invoice.ts
+  export const invoiceKind: AnalysisKind<ParsedInvoice>; // id: "invoice", maxTokens: 4096
+  ```
+
+- [ ] **Step 1: Napisz failing test dla kind invoice**
+
+`tests/convex/analysisKindInvoice.test.ts` (fixture skopiowana 1:1 z `MINIMAL_VALID_RESPONSE` w istniejącym `tests/convex/openaiDocumentAnalyzer.test.ts` — zachowujemy identyczne dane, żeby udowodnić brak zmiany zachowania):
+
+```ts
+import { describe, expect, test } from "vitest";
+import { invoiceKind } from "../../convex/_ai/kinds/invoice";
+
+const VALID = {
+  supplierName: "ACME Sp. z o.o.",
+  supplierNip: "1234567890",
+  invoiceNumber: "FV/2024/001",
+  invoiceDate: "2024-06-01",
+  deliveryDate: null,
+  currency: "PLN",
+  items: [
+    {
+      productName: "Krem regenerujący",
+      quantity: 2,
+      unit: "szt",
+      unitPriceNet: 100,
+      unitPriceGross: 123,
+      vatRate: 23,
+      vatCode: "A",
+      lineValueNet: 200,
+      lineValueGross: 246,
+      lotNumber: "L-77",
+      expiryDate: "2027-01-31",
+    },
+  ],
+  confidence: 0.92,
+};
+
+describe("invoiceKind", () => {
+  test("id and prompt", () => {
+    expect(invoiceKind.id).toBe("invoice");
+    expect(invoiceKind.buildPrompt()).toContain("supplierName");
+    expect(invoiceKind.maxTokens).toBe(4096);
+  });
+
+  test("validate accepts a valid invoice and rejects garbage", () => {
+    expect(invoiceKind.validate(VALID)).toBe(true);
+    expect(invoiceKind.validate(null)).toBe(false);
+    expect(invoiceKind.validate({ items: "nope" })).toBe(false);
+    expect(invoiceKind.validate({ items: [{}] })).toBe(false); // item bez productName
+  });
+
+  test("map coerces types and carries rawJson as rawText", () => {
+    const rawJson = JSON.stringify(VALID);
+    const out = invoiceKind.map(VALID, { rawJson });
+    expect(out.supplierName).toBe("ACME Sp. z o.o.");
+    expect(out.items[0].unitPrice).toBe(100); // unitPriceNet → unitPrice
+    expect(out.items[0].lotNumber).toBe("L-77");
+    expect(out.confidence).toBe(0.92);
+    expect(out.rawText).toBe(rawJson);
+  });
+
+  test("map nulls empty strings and non-finite numbers", () => {
+    const messy = { ...VALID, supplierName: "", items: [{ ...VALID.items[0], quantity: "abc", unit: "" }] };
+    const out = invoiceKind.map(messy, { rawJson: "{}" });
+    expect(out.supplierName).toBeNull();
+    expect(out.items[0].quantity).toBe(0);
+    expect(out.items[0].unit).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Uruchom — ma FAILować (brak modułu)**
+
+Run: `npm run test:unit -- ../tests/convex/analysisKindInvoice.test.ts`
+Expected: FAIL — `Cannot find module '../../convex/_ai/kinds/invoice'`.
+
+- [ ] **Step 3: Utwórz `convex/_ai/kinds/invoice.ts`**
+
+PRZENIEŚ (nie kopiuj — usuń ze źródła w Step 4) z `convex/_ai/providers/openaiDocumentAnalyzer.ts`: `USER_PROMPT` (przemianuj na `INVOICE_PROMPT`), `RawItem`, `RawInvoice`, `isRawInvoice`, `str`, `num`, `mapItem`, `mapInvoice` — treść funkcji BEZ ZMIAN. Dodaj definicję kind:
+
+```ts
+// convex/_ai/kinds/invoice.ts
+// Kind "invoice" — prompt + walidacja + mapowanie wyniesione 1:1 z providera
+// OpenAI (refaktor #<PR>). Zachowanie identyczne jak przed refaktorem.
+import type { AnalysisKind, ParsedInvoice } from "../documentAnalyzer";
+
+const INVOICE_PROMPT = `<< dokładna, niezmieniona treść USER_PROMPT z openaiDocumentAnalyzer.ts:29-62 >>`;
+
+// ... tu wklejone bez zmian: RawItem, RawInvoice, isRawInvoice, str, num, mapItem, mapInvoice ...
+
+export const invoiceKind: AnalysisKind<ParsedInvoice> = {
+  id: "invoice",
+  maxTokens: 4096,
+  buildPrompt: () => INVOICE_PROMPT,
+  validate: (raw) => isRawInvoice(raw),
+  map: (raw, opts) => mapInvoice(raw as RawInvoice, opts.rawJson),
+};
+```
+
+(`<< ... >>` oznacza wierne przeniesienie istniejącego bloku — to jedyne miejsce w planie, gdzie treść już istnieje w repo i przenosi się bez modyfikacji.)
+
+- [ ] **Step 4: Refaktor `documentAnalyzer.ts` i providera**
+
+`convex/_ai/documentAnalyzer.ts`: zostaw `DocumentPage`, `ParsedInvoiceItem`, `ParsedInvoice`, `StorageFetcher`, `isSupportedMimeType`, `SUPPORTED_MIME_TYPES` bez zmian. USUŃ `interface DocumentAnalyzer { analyzeInvoice }`, `AnalyzeInvoiceResult` i klasę `NullDocumentAnalyzer` w obecnej formie. DODAJ typy z bloku Interfaces powyżej oraz:
+
+```ts
+class NullDocumentTransport implements DocumentTransport {
+  async run(pages: DocumentPage[]): Promise<TransportResult> {
+    if (pages.length === 0) return { status: "no_pages" };
+    const unsupported = pages.find((p) => !isSupportedMimeType(p.mimeType));
+    if (unsupported) return { status: "unsupported_format", mimeType: unsupported.mimeType };
+    return { status: "not_implemented" };
+  }
+}
+
+export function getDocumentTransport(fetchFile: StorageFetcher): DocumentTransport {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (apiKey) {
+    const model = process.env.OPENAI_INVOICE_MODEL ?? "gpt-4o";
+    return new OpenAIDocumentAnalyzer(apiKey, model, fetchFile);
+  }
+  return new NullDocumentTransport();
+}
+
+export async function analyzeDocument<T>(
+  transport: DocumentTransport,
+  kind: AnalysisKind<T>,
+  pages: DocumentPage[],
+  context?: Record<string, unknown>,
+): Promise<AnalyzeResult<T>> {
+  const res = await transport.run(pages, kind.buildPrompt(context), kind.maxTokens);
+  if (res.status !== "ok") return res;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(res.rawJson);
+  } catch {
+    return { status: "error", message: "Model returned non-JSON response" };
+  }
+  if (!kind.validate(raw)) {
+    return { status: "error", message: `Model response does not match expected ${kind.id} schema` };
+  }
+  return { status: "ok", data: kind.map(raw, { rawJson: res.rawJson, context }) };
+}
+```
+
+`convex/_ai/providers/openaiDocumentAnalyzer.ts`: klasa implementuje teraz `DocumentTransport`. Metoda `analyzeInvoice(pages)` staje się `run(pages, prompt, maxTokens = 4096)`. Zmiany wewnątrz ciała metody (reszta transportu — pętla stron, base64, PDF/image parts, obsługa APIError — BEZ ZMIAN):
+- `contentParts.push({ type: "text", text: USER_PROMPT })` → `contentParts.push({ type: "text", text: prompt })`
+- `max_tokens: 4096` → `max_tokens: maxTokens`
+- końcówka: zamiast `JSON.parse` + `isRawInvoice` + `mapInvoice` — po otrzymaniu niepustego `rawText` po prostu `return { status: "ok", rawJson: rawText };` (parsowanie/walidacja przeniesione do `analyzeDocument`). Pusty `rawText` → `{ status: "error", message: "Empty response from model" }` (bez zmian).
+- Usuń z pliku przeniesione do kinds: prompt, typy Raw*, isRawInvoice, str/num/mapItem/mapInvoice. Zaktualizuj importy typów (`TransportResult`, `DocumentTransport` zamiast `AnalyzeInvoiceResult`, `DocumentAnalyzer`).
+
+- [ ] **Step 5: Zaktualizuj call site w `convex/warehouseDeliveries.ts`**
+
+Import (góra pliku): zamień `getDocumentAnalyzer` na `getDocumentTransport, analyzeDocument` (z `./_ai/documentAnalyzer`) i dodaj `import { invoiceKind } from "./_ai/kinds/invoice";`. W `analyzeDeliveryInvoice` (~linie 523-528):
+
+```ts
+const transport = getDocumentTransport(
+  (id) => ctx.storage.get(id as unknown as Id<"_storage">),
+);
+const analysisResult = await analyzeDocument(transport, invoiceKind, pages);
+```
+
+Cała reszta funkcji (switch po statusach, strip `rawText`, persist) — BEZ ZMIAN; statusy i komunikaty są identyczne.
+
+- [ ] **Step 6: Zaadaptuj `tests/convex/openaiDocumentAnalyzer.test.ts`**
+
+Mechaniczna adaptacja, asercje wyników BEZ ZMIAN:
+1. Importy: `import { analyzeDocument, getDocumentTransport } from "../../convex/_ai/documentAnalyzer";` + `import { invoiceKind } from "../../convex/_ai/kinds/invoice";` (usuń import `getDocumentAnalyzer`).
+2. Dodaj helper pod sekcją Helpers: `const analyzeInvoice = (t: { run: DocumentTransport["run"] }, pages: DocumentPage[]) => analyzeDocument(t as DocumentTransport, invoiceKind, pages);` (dostosuj typ importu `DocumentTransport`).
+3. Zamień każde `analyzer.analyzeInvoice(pages)` → `analyzeInvoice(analyzer, pages)` oraz każde `getDocumentAnalyzer(` → `getDocumentTransport(`.
+4. Jeżeli któryś test woła prywatne symbole providera (isRawInvoice itp.) — przełącz import na `../../convex/_ai/kinds/invoice` lub przenieś asercję do `analysisKindInvoice.test.ts`.
+
+- [ ] **Step 7: Uruchom oba pliki testów + pełny suite**
+
+Run: `npm run test:unit -- ../tests/convex/analysisKindInvoice.test.ts ../tests/convex/openaiDocumentAnalyzer.test.ts`
+Expected: PASS (wszystkie).
+Run: `npm run test:unit` — Expected: PASS (bez regresji).
+Run: `npx tsc -p convex/tsconfig.json --pretty false` — Expected: bez nowych błędów vs main.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add convex/_ai tests/convex/analysisKindInvoice.test.ts tests/convex/openaiDocumentAnalyzer.test.ts convex/warehouseDeliveries.ts
+git commit -m "refactor(ai): extract DocumentTransport + AnalysisKind; invoice becomes first kind (no behavior change)"
+```
+
+---
+
+### Task 2: Kind `form_template` + rejestr
+
+**Files:**
+- Create: `convex/_ai/kinds/formTemplate.ts`
+- Create: `convex/_ai/registry.ts`
+- Test: `tests/convex/analysisKindFormTemplate.test.ts`
+
+**Interfaces:**
+- Consumes: `AnalysisKind` z Task 1.
+- Produces:
+  ```ts
+  // convex/_ai/kinds/formTemplate.ts
+  export type ParsedSegment =
+    | { type: "text"; text: string }
+    | { type: "field"; label: string;
+        fieldType: "text"|"textarea"|"select"|"button_select"|"date"|"checkbox";
+        options?: string[]; required?: boolean; patientFieldHint?: string | null };
+  export type ParsedBlock =
+    | { type: "heading"; level: 1|2|3; text: string }
+    | { type: "paragraph"; segments: ParsedSegment[] }
+    | { type: "bulletList" | "orderedList"; items: ParsedSegment[][] };
+  export interface ParsedFormTemplate {
+    title: string | null;
+    blocks: ParsedBlock[];
+    confidence: number | null;
+  }
+  export const formTemplateKind: AnalysisKind<ParsedFormTemplate>; // id: "form_template", maxTokens: 8192
+  // context: { patientFields?: Array<{ key: string; label: string }> }
+  //   → prompt listuje "builtin:<key> — <label>"; map odrzuca hinty spoza "builtin:<key>" zbioru
+  ```
+  ```ts
+  // convex/_ai/registry.ts
+  export function getAnalysisKind(id: string): AnalysisKind<unknown> | null; // "invoice" | "form_template"
+  ```
+
+- [ ] **Step 1: Failing test**
+
+`tests/convex/analysisKindFormTemplate.test.ts`:
+
+```ts
+import { describe, expect, test } from "vitest";
+import { formTemplateKind, type ParsedFormTemplate } from "../../convex/_ai/kinds/formTemplate";
+import { getAnalysisKind } from "../../convex/_ai/registry";
+
+const CTX = { patientFields: [{ key: "pesel", label: "PESEL" }, { key: "phone", label: "Telefon" }] };
+
+const VALID = {
+  title: "Zgoda na zabieg",
+  blocks: [
+    { type: "heading", level: 1, text: "Zgoda na zabieg" },
+    { type: "paragraph", segments: [
+      { type: "text", text: "Ja, " },
+      { type: "field", label: "Imię i nazwisko", fieldType: "text", required: true, patientFieldHint: null },
+      { type: "text", text: ", PESEL: " },
+      { type: "field", label: "PESEL", fieldType: "text", patientFieldHint: "builtin:pesel" },
+    ]},
+    { type: "bulletList", items: [
+      [{ type: "text", text: "Zapoznałem się z przeciwwskazaniami" }],
+    ]},
+  ],
+  confidence: 0.8,
+};
+
+describe("formTemplateKind", () => {
+  test("registry resolves both kinds", () => {
+    expect(getAnalysisKind("invoice")?.id).toBe("invoice");
+    expect(getAnalysisKind("form_template")?.id).toBe("form_template");
+    expect(getAnalysisKind("nope")).toBeNull();
+  });
+
+  test("prompt includes allowed patient targets from context", () => {
+    const p = formTemplateKind.buildPrompt(CTX);
+    expect(p).toContain("builtin:pesel");
+    expect(p).toContain("PESEL");
+    expect(formTemplateKind.maxTokens).toBe(8192);
+  });
+
+  test("validate: accepts valid, rejects malformed", () => {
+    expect(formTemplateKind.validate(VALID)).toBe(true);
+    expect(formTemplateKind.validate(null)).toBe(false);
+    expect(formTemplateKind.validate({ blocks: "x" })).toBe(false);
+    expect(formTemplateKind.validate({ blocks: [{ type: "widget" }] })).toBe(false);
+    expect(formTemplateKind.validate({ blocks: [{ type: "paragraph", segments: [{ type: "field" }] }] })).toBe(false); // field bez label
+  });
+
+  test("map: keeps allowed hint, drops hint outside allowlist, coerces fieldType", () => {
+    const messy = { ...VALID, blocks: [
+      { type: "paragraph", segments: [
+        { type: "field", label: "PESEL", fieldType: "text", patientFieldHint: "builtin:pesel" },
+        { type: "field", label: "Hasło", fieldType: "text", patientFieldHint: "builtin:password" }, // spoza listy
+        { type: "field", label: "Coś", fieldType: "fancy" }, // nieznany typ → "text"
+      ]},
+    ]};
+    const out = formTemplateKind.map(messy, { rawJson: "{}", context: CTX }) as ParsedFormTemplate;
+    const seg = out.blocks[0] as Extract<typeof out.blocks[0], { type: "paragraph" }>;
+    const fields = seg.segments.filter((s) => s.type === "field") as Array<Extract<ParsedSegment, {type:"field"}>>;
+    expect(fields[0].patientFieldHint).toBe("builtin:pesel");
+    expect(fields[1].patientFieldHint).toBeNull();
+    expect(fields[2].fieldType).toBe("text");
+  });
+
+  test("map without context drops all hints", () => {
+    const out = formTemplateKind.map(VALID, { rawJson: "{}" }) as ParsedFormTemplate;
+    const para = out.blocks[1] as Extract<typeof out.blocks[1], { type: "paragraph" }>;
+    const pesel = para.segments.find((s) => s.type === "field" && s.label === "PESEL");
+    expect((pesel as Extract<ParsedSegment, {type:"field"}>).patientFieldHint).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run — FAIL** (`Cannot find module .../kinds/formTemplate`)
+
+Run: `npm run test:unit -- ../tests/convex/analysisKindFormTemplate.test.ts`
+
+- [ ] **Step 3: Implementacja `convex/_ai/kinds/formTemplate.ts`**
+
+```ts
+import type { AnalysisKind } from "../documentAnalyzer";
+
+export type ParsedSegment = /* jak w Interfaces */;
+export type ParsedBlock = /* jak w Interfaces */;
+export interface ParsedFormTemplate { title: string | null; blocks: ParsedBlock[]; confidence: number | null }
+
+const FIELD_TYPES = new Set(["text", "textarea", "select", "button_select", "date", "checkbox"]);
+const BLOCK_TYPES = new Set(["heading", "paragraph", "bulletList", "orderedList"]);
+
+function buildPrompt(context?: Record<string, unknown>): string {
+  const patientFields = Array.isArray((context as { patientFields?: unknown })?.patientFields)
+    ? ((context as { patientFields: Array<{ key: string; label: string }> }).patientFields)
+    : [];
+  const targets = patientFields.map((f) => `- "builtin:${f.key}" — ${f.label}`).join("\n");
+  return `You are reconstructing a scanned paper form (typically Polish: consent forms, medical intake, GDPR) into a structured template. Return ONE JSON object:
+
+{
+  "title": string | null,
+  "blocks": [
+    { "type": "heading", "level": 1|2|3, "text": string }
+    | { "type": "paragraph", "segments": Segment[] }
+    | { "type": "bulletList" | "orderedList", "items": Segment[][] }
+  ],
+  "confidence": number
+}
+
+Segment = { "type": "text", "text": string }
+        | { "type": "field", "label": string,
+            "fieldType": "text"|"textarea"|"select"|"button_select"|"date"|"checkbox",
+            "options"?: string[], "required"?: boolean, "patientFieldHint"?: string | null }
+
+Rules:
+- Reproduce ALL static text of the document verbatim (Polish stays Polish).
+- Blank lines, dotted lines, underscores, empty boxes to be filled in → a "field" segment (NOT text).
+- A group of mutually exclusive checkboxes/options → one "select" field with "options".
+- A single yes/no checkbox → "checkbox". Larger empty areas for free writing → "textarea". Date slots (e.g. next to signature) → "date".
+- "label" = the caption printed next to the blank (e.g. "Imię i nazwisko").
+- patientFieldHint: ONLY when the blank clearly corresponds to one of these client-record targets, use EXACTLY one of the values below; otherwise null. Never invent other values.
+${targets || "- (no targets available — always use null)"}
+- Do NOT guess content that is not on the document. "confidence" is a 0-1 overall score.`;
+}
+
+function isSegment(v: unknown): boolean {
+  if (!v || typeof v !== "object") return false;
+  const s = v as Record<string, unknown>;
+  if (s.type === "text") return typeof s.text === "string";
+  if (s.type === "field") return typeof s.label === "string" && s.label.length > 0;
+  return false;
+}
+
+function validate(raw: unknown): boolean {
+  if (!raw || typeof raw !== "object") return false;
+  const o = raw as Record<string, unknown>;
+  if (!Array.isArray(o.blocks)) return false;
+  for (const b of o.blocks as unknown[]) {
+    if (!b || typeof b !== "object") return false;
+    const blk = b as Record<string, unknown>;
+    if (!BLOCK_TYPES.has(String(blk.type))) return false;
+    if (blk.type === "heading" && typeof blk.text !== "string") return false;
+    if (blk.type === "paragraph") {
+      if (!Array.isArray(blk.segments) || !(blk.segments as unknown[]).every(isSegment)) return false;
+    }
+    if (blk.type === "bulletList" || blk.type === "orderedList") {
+      if (!Array.isArray(blk.items)) return false;
+      for (const item of blk.items as unknown[]) {
+        if (!Array.isArray(item) || !(item as unknown[]).every(isSegment)) return false;
+      }
+    }
+  }
+  return true;
+}
+
+function mapSegment(s: Record<string, unknown>, allowed: Set<string>): ParsedSegment {
+  if (s.type === "text") return { type: "text", text: String(s.text ?? "") };
+  const rawHint = typeof s.patientFieldHint === "string" ? s.patientFieldHint : null;
+  return {
+    type: "field",
+    label: String(s.label ?? ""),
+    fieldType: FIELD_TYPES.has(String(s.fieldType)) ? (String(s.fieldType) as never) : "text",
+    options: Array.isArray(s.options) ? (s.options as unknown[]).map(String) : undefined,
+    required: s.required === true ? true : undefined,
+    patientFieldHint: rawHint && allowed.has(rawHint) ? rawHint : null,
+  };
+}
+
+function map(raw: unknown, opts: { rawJson: string; context?: Record<string, unknown> }): ParsedFormTemplate {
+  const o = raw as Record<string, unknown>;
+  const patientFields = Array.isArray((opts.context as { patientFields?: unknown })?.patientFields)
+    ? ((opts.context as { patientFields: Array<{ key: string }> }).patientFields)
+    : [];
+  const allowed = new Set(patientFields.map((f) => `builtin:${f.key}`));
+  const blocks: ParsedBlock[] = [];
+  for (const b of (o.blocks as Array<Record<string, unknown>>)) {
+    if (b.type === "heading") {
+      const lvl = Number(b.level);
+      blocks.push({ type: "heading", level: (lvl === 2 || lvl === 3 ? lvl : 1) as 1|2|3, text: String(b.text ?? "") });
+    } else if (b.type === "paragraph") {
+      blocks.push({ type: "paragraph", segments: (b.segments as Array<Record<string, unknown>>).map((s) => mapSegment(s, allowed)) });
+    } else {
+      blocks.push({
+        type: b.type as "bulletList" | "orderedList",
+        items: (b.items as Array<Array<Record<string, unknown>>>).map((item) => item.map((s) => mapSegment(s, allowed))),
+      });
+    }
+  }
+  const conf = Number(o.confidence);
+  return {
+    title: typeof o.title === "string" && o.title ? o.title : null,
+    blocks,
+    confidence: Number.isFinite(conf) ? conf : null,
+  };
+}
+
+export const formTemplateKind: AnalysisKind<ParsedFormTemplate> = {
+  id: "form_template",
+  maxTokens: 8192,
+  buildPrompt,
+  validate,
+  map,
+};
+```
+
+- [ ] **Step 4: Implementacja `convex/_ai/registry.ts`**
+
+```ts
+import type { AnalysisKind } from "./documentAnalyzer";
+import { invoiceKind } from "./kinds/invoice";
+import { formTemplateKind } from "./kinds/formTemplate";
+
+const KINDS: Record<string, AnalysisKind<unknown>> = {
+  [invoiceKind.id]: invoiceKind as AnalysisKind<unknown>,
+  [formTemplateKind.id]: formTemplateKind as AnalysisKind<unknown>,
+};
+
+export function getAnalysisKind(id: string): AnalysisKind<unknown> | null {
+  return KINDS[id] ?? null;
+}
+```
+
+- [ ] **Step 5: Run — PASS + typecheck**
+
+Run: `npm run test:unit -- ../tests/convex/analysisKindFormTemplate.test.ts` — Expected: PASS.
+Run: `npx tsc -p convex/tsconfig.json --pretty false` — bez nowych błędów.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add convex/_ai/kinds/formTemplate.ts convex/_ai/registry.ts tests/convex/analysisKindFormTemplate.test.ts
+git commit -m "feat(ai): form_template analysis kind + kind registry"
+```
+
+---
+
+### Task 3: Warstwa danych — tabela `document_analysis_jobs`
+
+**Files:**
+- Modify: `convex/schema/documents.ts` (po `formDocuments`, ~linia 163)
+- Modify: `convex/_helpers/supabaseDb.ts` (TABLE_MAP, obok `formTemplates`/`formDocuments`, linie 47-48)
+- Modify: `convex/_helpers/supabaseRows.ts` (obok `FormTemplateRow`, linia 10)
+- Create: `supabase/migrations/00063_document_analysis_jobs.sql` (SPRAWDŹ najwyższy numer na main; przenumeruj w razie kolizji)
+- Modify (generowane): `src/lib/supabase/database.types.ts`, `src/lib/supabase/database.columns.ts`
+
+**Interfaces:**
+- Produces: tabela Convex `documentAnalysisJobs` (indeksy `by_org`, `by_orgAndKind`), typ `DocumentAnalysisJobRow`, mapowanie `documentAnalysisJobs → document_analysis_jobs`.
+
+- [ ] **Step 1: Convex schema — dodaj tabelę**
+
+W `convex/schema/documents.ts`, po zamknięciu `formDocuments` (linia ~163), wewnątrz tego samego obiektu tabel:
+
+```ts
+  // Generic AI document-analysis jobs (spec 2026-07-16). One row per analysis
+  // request for kinds that have no natural host row (e.g. a template that does
+  // not exist yet). Deliveries keep their own inline analysis fields.
+  documentAnalysisJobs: defineTable({
+    organizationId: v.id("organizations"),
+    kind: v.string(), // registry id: "form_template" | ...
+    pages: v.array(v.object({
+      storageId: v.string(),
+      mimeType: v.string(),
+      position: v.number(),
+    })),
+    context: v.optional(v.union(v.string(), v.null())), // JSON string, kind-specific
+    status: v.union(v.literal("pending"), v.literal("running"), v.literal("ok"), v.literal("error")),
+    resultJson: v.optional(v.union(v.string(), v.null())),
+    errorMessage: v.optional(v.union(v.string(), v.null())),
+    createdBy: v.id("users"),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    completedAt: v.optional(v.union(v.number(), v.null())),
+  })
+    .index("by_org", ["organizationId"])
+    .index("by_orgAndKind", ["organizationId", "kind"]),
+```
+
+- [ ] **Step 2: Row type + TABLE_MAP**
+
+`convex/_helpers/supabaseRows.ts` (po linii 10): `export type DocumentAnalysisJobRow = SupabaseRow<"documentAnalysisJobs">;`
+`convex/_helpers/supabaseDb.ts` TABLE_MAP (po `formDocuments`): `documentAnalysisJobs: "document_analysis_jobs",`
+
+- [ ] **Step 3: Migracja SQL**
+
+`supabase/migrations/00063_document_analysis_jobs.sql` (wzorzec RLS jak `00028_gabinet_payment_methods.sql`):
+
+```sql
+-- Generic AI document-analysis jobs (spec 2026-07-16). Stores request pages,
+-- status and result for analysis kinds without a natural host row.
+-- Timestamps are BIGINT ms-epoch, PK is TEXT (project convention).
+
+CREATE TABLE IF NOT EXISTS document_analysis_jobs (
+  id              TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  kind            TEXT NOT NULL,
+  pages           JSONB NOT NULL,
+  context         TEXT,
+  status          TEXT NOT NULL CHECK (status IN ('pending','running','ok','error')),
+  result_json     TEXT,
+  error_message   TEXT,
+  created_by      TEXT NOT NULL REFERENCES users(id),
+  created_at      BIGINT NOT NULL,
+  updated_at      BIGINT NOT NULL,
+  completed_at    BIGINT
+);
+
+CREATE INDEX IF NOT EXISTS document_analysis_jobs_org_idx
+  ON document_analysis_jobs (organization_id);
+CREATE INDEX IF NOT EXISTS document_analysis_jobs_org_kind_idx
+  ON document_analysis_jobs (organization_id, kind);
+
+ALTER TABLE document_analysis_jobs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY document_analysis_jobs_select ON document_analysis_jobs
+  FOR SELECT USING (current_org_id() = organization_id);
+CREATE POLICY document_analysis_jobs_insert ON document_analysis_jobs
+  FOR INSERT WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY document_analysis_jobs_update ON document_analysis_jobs
+  FOR UPDATE USING (current_org_id() = organization_id)
+  WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY document_analysis_jobs_delete ON document_analysis_jobs
+  FOR DELETE USING (current_org_id() = organization_id);
+```
+
+- [ ] **Step 4: Regeneracja typów + weryfikacja**
+
+Run: `node scripts/gen-db-types.mjs` — Expected: `Migrations: 63` (lub wyższa po przenumerowaniu), tabela w obu plikach.
+Run: `npx tsc -p convex/tsconfig.json --pretty false && npx tsc -p tsconfig.app.json --pretty false` — bez nowych błędów.
+Run: `npm run test:unit` — Expected: PASS (stub in-memory czyta TABLE_MAP — nowa tabela dostępna w testach automatycznie).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add convex/schema/documents.ts convex/_helpers/supabaseRows.ts convex/_helpers/supabaseDb.ts supabase/migrations/00063_document_analysis_jobs.sql src/lib/supabase/database.types.ts src/lib/supabase/database.columns.ts
+git commit -m "feat(ai): document_analysis_jobs data layer (schema, TABLE_MAP, migration)"
+```
+
+---
+
+### Task 4: Akcje `createJob` / `runJob` / `getJob`
+
+**Files:**
+- Create: `convex/documentAnalysisJobs.ts`
+- Test: `tests/convex/documentAnalysisJobs.test.ts`
+
+**Interfaces:**
+- Consumes: `getAnalysisKind` (Task 2), `getDocumentTransport`/`analyzeDocument` (Task 1), tabela (Task 3), wzorzec auth z `convex/documents/templates.ts:create`.
+- Produces (dla frontendu, Task 6-7):
+  ```ts
+  api.documentAnalysisJobs.createJob({ organizationId, kind, pages, context? }) → string (jobId)
+  api.documentAnalysisJobs.runJob({ organizationId, jobId }) →
+    { status: "ok"; resultJson: string } | { status: "error"; errorMessage: string }
+  api.documentAnalysisJobs.getJob({ organizationId, jobId }) →
+    { _id, kind, status, resultJson, errorMessage, createdAt, completedAt } | null
+  ```
+
+- [ ] **Step 1: Failing testy integracyjne**
+
+`tests/convex/documentAnalysisJobs.test.ts` (harness jak `tests/convex/productsCreate.test.ts`; w testach NIE ma `OPENAI_API_KEY`, więc `runJob` deterministycznie kończy się błędem konfiguracji — to jest testowana ścieżka):
+
+```ts
+import { describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+const PAGES = [{ storageId: "st-1", mimeType: "application/pdf", position: 1 }];
+
+describe("documentAnalysisJobs", () => {
+  test("createJob persists a pending job scoped to the org", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const jobId = await t.withIdentity(identity).action(api.documentAnalysisJobs.createJob, {
+      organizationId, kind: "form_template", pages: PAGES,
+      context: JSON.stringify({ patientFields: [{ key: "pesel", label: "PESEL" }] }),
+    });
+    const row = (await createSupabaseDb().get("documentAnalysisJobs", String(jobId))) as Record<string, unknown>;
+    expect(row?.status).toBe("pending");
+    expect(row?.kind).toBe("form_template");
+    expect(row?.organizationId).toBe(String(organizationId));
+    expect(row?.createdBy).toBe(String(userId));
+  });
+
+  test("createJob rejects unknown kind", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await expect(
+      t.withIdentity(identity).action(api.documentAnalysisJobs.createJob, {
+        organizationId, kind: "nope", pages: PAGES,
+      }),
+    ).rejects.toThrow(/unknown analysis kind/i);
+  });
+
+  test("runJob without provider records error status on the job (retryable)", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    const jobId = await t.withIdentity(identity).action(api.documentAnalysisJobs.createJob, {
+      organizationId, kind: "form_template", pages: PAGES,
+    });
+    const res = await t.withIdentity(identity).action(api.documentAnalysisJobs.runJob, {
+      organizationId, jobId: String(jobId),
+    });
+    expect(res.status).toBe("error");
+    const row = (await createSupabaseDb().get("documentAnalysisJobs", String(jobId))) as Record<string, unknown>;
+    expect(row?.status).toBe("error");
+    expect(String(row?.errorMessage)).toMatch(/not configured/i);
+    expect(typeof row?.completedAt).toBe("number");
+    // retry = to samo wywołanie, bez wyjątku
+    const res2 = await t.withIdentity(identity).action(api.documentAnalysisJobs.runJob, {
+      organizationId, jobId: String(jobId),
+    });
+    expect(res2.status).toBe("error");
+  });
+
+  test("getJob returns the row and hides other orgs' jobs", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    const jobId = await t.withIdentity(identity).action(api.documentAnalysisJobs.createJob, {
+      organizationId, kind: "form_template", pages: PAGES,
+    });
+    const job = await t.withIdentity(identity).action(api.documentAnalysisJobs.getJob, {
+      organizationId, jobId: String(jobId),
+    });
+    expect(job?.kind).toBe("form_template");
+
+    const other = await seedTestUser(t); // druga organizacja
+    await expect(
+      t.withIdentity(other.identity).action(api.documentAnalysisJobs.getJob, {
+        organizationId: other.organizationId, jobId: String(jobId),
+      }),
+    ).resolves.toBeNull();
+  });
+});
+```
+
+(Jeśli `seedTestUser` w tym repo nie tworzy za każdym razem nowej organizacji — sprawdź `convex/_test_helpers.ts` i użyj istniejącego helpera do drugiej organizacji; asercja izolacji musi zostać.)
+
+- [ ] **Step 2: Run — FAIL** (`documentAnalysisJobs` nie istnieje w api)
+
+Run: `npm run test:unit -- ../tests/convex/documentAnalysisJobs.test.ts`
+
+- [ ] **Step 3: Implementacja `convex/documentAnalysisJobs.ts`**
+
+```ts
+import { action } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { v } from "convex/values";
+import { Id } from "./_generated/dataModel";
+import { createSupabaseDb } from "./_helpers/supabaseDb";
+import { getAnalysisKind } from "./_ai/registry";
+import { analyzeDocument, getDocumentTransport, type DocumentPage } from "./_ai/documentAnalyzer";
+
+const pagesValidator = v.array(v.object({
+  storageId: v.string(),
+  mimeType: v.string(),
+  position: v.number(),
+}));
+
+// Auth: identyczny wzorzec jak convex/documents/templates.ts:create —
+// verifyOrgAccess zwraca użytkownika; jobs nie mają dodatkowego checkPermission
+// (tworzenie szablonu ze skanu = tworzenie szablonu).
+async function requireUser(ctx: { runQuery: Function }, organizationId: string) {
+  const auth = (await (ctx as any).runQuery(internal._helpers.authAction.verifyOrgAccess, {
+    organizationId,
+  })) as { user: { _id: string } };
+  return auth.user;
+}
+// UWAGA implementacyjna: dopasuj kształt zwrotki do faktycznego użycia w
+// templates.ts:create (createdBy) — skopiuj stamtąd 1:1, łącznie z typami,
+// zamiast polegać na powyższym szkicu.
+
+export const createJob = action({
+  args: {
+    organizationId: v.id("organizations"),
+    kind: v.string(),
+    pages: pagesValidator,
+    context: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<string> => {
+    const user = await requireUser(ctx, String(args.organizationId));
+    if (!getAnalysisKind(args.kind)) throw new Error(`Unknown analysis kind: ${args.kind}`);
+    if (args.pages.length === 0) throw new Error("No pages to analyze");
+    const db = createSupabaseDb();
+    const now = Date.now();
+    const jobId = await db.insert("documentAnalysisJobs", {
+      organizationId: String(args.organizationId),
+      kind: args.kind,
+      pages: args.pages,
+      context: args.context ?? null,
+      status: "pending",
+      resultJson: null,
+      errorMessage: null,
+      createdBy: String(user._id),
+      createdAt: now,
+      updatedAt: now,
+      completedAt: null,
+    });
+    return String(jobId);
+  },
+});
+
+export const runJob = action({
+  args: { organizationId: v.id("organizations"), jobId: v.string() },
+  handler: async (ctx, args): Promise<
+    { status: "ok"; resultJson: string } | { status: "error"; errorMessage: string }
+  > => {
+    await requireUser(ctx, String(args.organizationId));
+    const db = createSupabaseDb();
+    const job = await db.get("documentAnalysisJobs", args.jobId);
+    if (!job || String(job.organizationId) !== String(args.organizationId)) {
+      throw new Error("Analysis job not found");
+    }
+    const kind = getAnalysisKind(String(job.kind));
+    if (!kind) throw new Error(`Unknown analysis kind: ${job.kind}`);
+
+    await db.patch("documentAnalysisJobs", args.jobId, { status: "running", updatedAt: Date.now() });
+
+    const pages = (job.pages as DocumentPage[]).slice().sort((a, b) => a.position - b.position);
+    let context: Record<string, unknown> | undefined;
+    if (typeof job.context === "string" && job.context) {
+      try { context = JSON.parse(job.context) as Record<string, unknown>; } catch { context = undefined; }
+    }
+
+    const transport = getDocumentTransport((id) => ctx.storage.get(id as unknown as Id<"_storage">));
+    const res = await analyzeDocument(transport, kind, pages, context);
+    const now = Date.now();
+
+    if (res.status === "ok") {
+      const resultJson = JSON.stringify(res.data);
+      await db.patch("documentAnalysisJobs", args.jobId, {
+        status: "ok", resultJson, errorMessage: null, completedAt: now, updatedAt: now,
+      });
+      return { status: "ok", resultJson };
+    }
+
+    let errorMessage: string;
+    switch (res.status) {
+      case "not_implemented": errorMessage = "AI analysis provider is not configured"; break;
+      case "no_pages": errorMessage = "No pages to analyze"; break;
+      case "unsupported_format": errorMessage = `Unsupported file format: ${res.mimeType}`; break;
+      default: errorMessage = res.message;
+    }
+    await db.patch("documentAnalysisJobs", args.jobId, {
+      status: "error", errorMessage, completedAt: now, updatedAt: now,
+    });
+    return { status: "error", errorMessage };
+  },
+});
+
+export const getJob = action({
+  args: { organizationId: v.id("organizations"), jobId: v.string() },
+  handler: async (ctx, args) => {
+    await requireUser(ctx, String(args.organizationId));
+    const db = createSupabaseDb();
+    const job = await db.get("documentAnalysisJobs", args.jobId);
+    if (!job || String(job.organizationId) !== String(args.organizationId)) return null;
+    return {
+      _id: String(job._id),
+      kind: String(job.kind),
+      status: String(job.status),
+      resultJson: (job.resultJson as string | null) ?? null,
+      errorMessage: (job.errorMessage as string | null) ?? null,
+      createdAt: Number(job.createdAt),
+      completedAt: (job.completedAt as number | null) ?? null,
+    };
+  },
+});
+```
+
+- [ ] **Step 4: Run — PASS + typecheck + pełny suite**
+
+Run: `npm run test:unit -- ../tests/convex/documentAnalysisJobs.test.ts` — PASS.
+Run: `npx tsc -p convex/tsconfig.json --pretty false` — bez nowych błędów.
+Run: `npm run test:unit` — PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add convex/documentAnalysisJobs.ts tests/convex/documentAnalysisJobs.test.ts
+git commit -m "feat(ai): generic document analysis job actions (create/run/get)"
+```
+
+---
+
+### Task 5: Mapper `parsedTemplateToTipTap`
+
+**Files:**
+- Create: `src/lib/documents/analysis-to-template.ts`
+- Test: `tests/convex/analysisToTemplate.test.ts`
+
+**Interfaces:**
+- Consumes: `ParsedFormTemplate`/`ParsedBlock`/`ParsedSegment` (kształt z Task 2 — zduplikowany lokalnie jako typ wejścia, żeby frontend nie importował z `convex/_ai`; patrz komentarz w kodzie), `slugifyFieldKey` z `./patient-mappable-fields` (istnieje).
+- Produces: `parsedTemplateToTipTap(parsed: ParsedFormTemplateInput): string` — string `content_json` TipTap gotowy do `setContentJson` w edytorze.
+
+- [ ] **Step 1: Failing test**
+
+`tests/convex/analysisToTemplate.test.ts`:
+
+```ts
+import { describe, expect, test } from "vitest";
+import { parsedTemplateToTipTap } from "../../src/lib/documents/analysis-to-template";
+
+const PARSED = {
+  title: "Zgoda",
+  confidence: 0.9,
+  blocks: [
+    { type: "heading" as const, level: 1 as const, text: "Zgoda na zabieg" },
+    { type: "paragraph" as const, segments: [
+      { type: "text" as const, text: "PESEL: " },
+      { type: "field" as const, label: "PESEL", fieldType: "text" as const, required: true, patientFieldHint: "builtin:pesel" },
+      { type: "field" as const, label: "PESEL", fieldType: "text" as const }, // duplikat labela → inny fieldId
+    ]},
+    { type: "bulletList" as const, items: [
+      [{ type: "text" as const, text: "Punkt pierwszy" }],
+    ]},
+    { type: "paragraph" as const, segments: [
+      { type: "field" as const, label: "Zgody marketingowe", fieldType: "select" as const, options: ["Tak", "Nie"] },
+    ]},
+  ],
+};
+
+describe("parsedTemplateToTipTap", () => {
+  const doc = JSON.parse(parsedTemplateToTipTap(PARSED));
+
+  test("builds a TipTap doc with heading, paragraphs and list", () => {
+    expect(doc.type).toBe("doc");
+    expect(doc.content[0]).toMatchObject({ type: "heading", attrs: { level: 1 } });
+    expect(doc.content[0].content[0].text).toBe("Zgoda na zabieg");
+    expect(doc.content[2].type).toBe("bulletList");
+    expect(doc.content[2].content[0].type).toBe("listItem");
+  });
+
+  test("field segments become formField nodes with client filledBy and mapping", () => {
+    const para = doc.content[1];
+    const fields = para.content.filter((n: { type: string }) => n.type === "formField");
+    expect(fields).toHaveLength(2);
+    expect(fields[0].attrs).toMatchObject({
+      label: "PESEL", fieldType: "text", required: true,
+      filledBy: "client", patientField: "builtin:pesel",
+    });
+    expect(fields[0].attrs.fieldId).toBeTruthy();
+    expect(fields[1].attrs.fieldId).not.toBe(fields[0].attrs.fieldId); // kolizja labela rozwiązana
+    expect(fields[1].attrs.patientField).toBe("");
+  });
+
+  test("select options serialize comma-separated (editor convention)", () => {
+    const sel = doc.content[3].content.find((n: { type: string }) => n.type === "formField");
+    expect(sel.attrs.options).toBe("Tak, Nie");
+    expect(sel.attrs.fieldType).toBe("select");
+  });
+
+  test("empty blocks produce an empty doc, not a crash", () => {
+    const empty = JSON.parse(parsedTemplateToTipTap({ title: null, confidence: null, blocks: [] }));
+    expect(empty).toEqual({ type: "doc", content: [] });
+  });
+});
+```
+
+- [ ] **Step 2: Run — FAIL** (`Cannot find module .../analysis-to-template`)
+
+Run: `npm run test:unit -- ../tests/convex/analysisToTemplate.test.ts`
+
+- [ ] **Step 3: Implementacja `src/lib/documents/analysis-to-template.ts`**
+
+```ts
+/**
+ * Maps a ParsedFormTemplate (AI analysis result, kind "form_template") to a
+ * TipTap content_json string using the existing formField inline nodes.
+ *
+ * Input types are declared locally (structurally identical to
+ * convex/_ai/kinds/formTemplate.ts) so the frontend bundle does not import
+ * backend modules; the shape is validated server-side by the kind anyway.
+ */
+import { slugifyFieldKey } from "./patient-mappable-fields";
+
+export interface ParsedTemplateFieldSegment {
+  type: "field";
+  label: string;
+  fieldType: "text" | "textarea" | "select" | "button_select" | "date" | "checkbox";
+  options?: string[];
+  required?: boolean;
+  patientFieldHint?: string | null;
+}
+export type ParsedTemplateSegment = { type: "text"; text: string } | ParsedTemplateFieldSegment;
+export type ParsedTemplateBlock =
+  | { type: "heading"; level: 1 | 2 | 3; text: string }
+  | { type: "paragraph"; segments: ParsedTemplateSegment[] }
+  | { type: "bulletList" | "orderedList"; items: ParsedTemplateSegment[][] };
+export interface ParsedFormTemplateInput {
+  title: string | null;
+  blocks: ParsedTemplateBlock[];
+  confidence: number | null;
+}
+
+type TipTapNode = { type: string; attrs?: Record<string, unknown>; content?: TipTapNode[]; text?: string };
+
+function segmentsToInline(segments: ParsedTemplateSegment[], usedIds: Set<string>): TipTapNode[] {
+  const out: TipTapNode[] = [];
+  for (const seg of segments) {
+    if (seg.type === "text") {
+      if (seg.text) out.push({ type: "text", text: seg.text });
+      continue;
+    }
+    let fieldId = slugifyFieldKey(seg.label) || "pole";
+    let n = 2;
+    while (usedIds.has(fieldId)) fieldId = `${slugifyFieldKey(seg.label) || "pole"}_${n++}`;
+    usedIds.add(fieldId);
+    out.push({
+      type: "formField",
+      attrs: {
+        fieldId,
+        fieldType: seg.fieldType,
+        label: seg.label,
+        options: (seg.options ?? []).join(", "),
+        required: seg.required === true,
+        placeholder: "",
+        filledBy: "client",
+        patientField: seg.patientFieldHint ?? "",
+      },
+    });
+  }
+  return out;
+}
+
+export function parsedTemplateToTipTap(parsed: ParsedFormTemplateInput): string {
+  const usedIds = new Set<string>();
+  const content: TipTapNode[] = [];
+  for (const block of parsed.blocks) {
+    if (block.type === "heading") {
+      content.push({
+        type: "heading",
+        attrs: { level: block.level },
+        content: block.text ? [{ type: "text", text: block.text }] : [],
+      });
+    } else if (block.type === "paragraph") {
+      content.push({ type: "paragraph", content: segmentsToInline(block.segments, usedIds) });
+    } else {
+      content.push({
+        type: block.type,
+        content: block.items.map((item) => ({
+          type: "listItem",
+          content: [{ type: "paragraph", content: segmentsToInline(item, usedIds) }],
+        })),
+      });
+    }
+  }
+  return JSON.stringify({ type: "doc", content });
+}
+```
+
+- [ ] **Step 4: Run — PASS**
+
+Run: `npm run test:unit -- ../tests/convex/analysisToTemplate.test.ts` — PASS.
+Run: `npx tsc -p tsconfig.app.json --pretty false` — bez nowych błędów.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/documents/analysis-to-template.ts tests/convex/analysisToTemplate.test.ts
+git commit -m "feat(documents): ParsedFormTemplate -> TipTap content mapper"
+```
+
+---
+
+### Task 6: UI — dialog „Nowy ze skanu" na liście szablonów
+
+**Files:**
+- Create: `src/components/documents/template-scan-dialog.tsx`
+- Modify: `src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx` (przycisk obok istniejących akcji nagłówka, okolice linii 855)
+- Modify: `public/locales/pl/translation.json`, `public/locales/en/translation.json` (blok `settings.formTemplates.*`)
+
+**Interfaces:**
+- Consumes: `api.app.generateUploadUrl` (istniejący wzorzec uploadu z `deliveries.tsx:1720-1761`), `api.documentAnalysisJobs.createJob/runJob` (Task 4), `PATIENT_BUILTIN_FIELDS` (istnieje).
+- Produces: `<TemplateScanDialog open onOpenChange />` — po sukcesie nawiguje na `/dashboard/settings/form-templates/new?analysisJobId=<id>`.
+
+- [ ] **Step 1: Komponent dialogu**
+
+`src/components/documents/template-scan-dialog.tsx` — pełny komponent:
+
+```tsx
+import { useCallback, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { useAction, useMutation } from "convex/react";
+import { api } from "@cvx/_generated/api";
+import { useOrganization } from "@/components/org-context";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { PATIENT_BUILTIN_FIELDS } from "@/lib/documents/patient-mappable-fields";
+
+const ACCEPTED = ["application/pdf", "image/jpeg", "image/png"];
+
+interface PendingFile { file: File; storageId: string | null; uploading: boolean; error: boolean }
+
+export function TemplateScanDialog({
+  open, onOpenChange,
+}: { open: boolean; onOpenChange: (o: boolean) => void }) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { organizationId } = useOrganization();
+  const generateUploadUrl = useMutation(api.app.generateUploadUrl);
+  const createJob = useAction(api.documentAnalysisJobs.createJob);
+  const runJob = useAction(api.documentAnalysisJobs.runJob);
+
+  const [files, setFiles] = useState<PendingFile[]>([]);
+  const [analyzing, setAnalyzing] = useState(false);
+
+  const addFiles = useCallback(async (list: FileList | null) => {
+    if (!list) return;
+    const accepted = Array.from(list).filter((f) => ACCEPTED.includes(f.type));
+    if (accepted.length !== (list?.length ?? 0)) {
+      toast.error(t("settings.formTemplates.scanUnsupportedType", "Obsługiwane formaty: PDF, JPG, PNG"));
+    }
+    for (const file of accepted) {
+      setFiles((prev) => [...prev, { file, storageId: null, uploading: true, error: false }]);
+      try {
+        const uploadUrl = await generateUploadUrl();
+        const res = await fetch(uploadUrl, {
+          method: "POST",
+          headers: { "Content-Type": file.type },
+          body: file,
+        });
+        const { storageId } = (await res.json()) as { storageId: string };
+        setFiles((prev) => prev.map((p) => (p.file === file ? { ...p, storageId, uploading: false } : p)));
+      } catch {
+        setFiles((prev) => prev.map((p) => (p.file === file ? { ...p, uploading: false, error: true } : p)));
+      }
+    }
+  }, [generateUploadUrl, t]);
+
+  const ready = files.filter((f) => f.storageId && !f.error);
+
+  const handleAnalyze = async () => {
+    if (ready.length === 0) return;
+    setAnalyzing(true);
+    try {
+      const pages = ready.map((f, i) => ({ storageId: f.storageId!, mimeType: f.file.type, position: i + 1 }));
+      const jobId = await createJob({
+        organizationId,
+        kind: "form_template",
+        pages,
+        context: JSON.stringify({ patientFields: PATIENT_BUILTIN_FIELDS.map((f) => ({ key: f.key, label: f.label })) }),
+      });
+      const res = await runJob({ organizationId, jobId });
+      if (res.status === "error") {
+        toast.error(t("settings.formTemplates.scanFailed", "Analiza nie powiodła się: {{error}}", { error: res.errorMessage }));
+        return; // dialog zostaje otwarty — ponowienie = ponowny klik "Analizuj" (tworzy nowy job; runJob jest idempotentny, test w Task 4)
+      }
+      onOpenChange(false);
+      void navigate({
+        to: "/dashboard/settings/form-templates/new",
+        search: { analysisJobId: jobId },
+      });
+    } finally {
+      setAnalyzing(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!analyzing) onOpenChange(o); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("settings.formTemplates.scanTitle", "Nowy szablon ze skanu")}</DialogTitle>
+          <DialogDescription>
+            {t("settings.formTemplates.scanDescription", "Wgraj skan lub PDF istniejącego formularza. AI odtworzy treść i wykryje pola do wypełnienia — wynik zweryfikujesz w edytorze.")}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          <Input type="file" multiple accept={ACCEPTED.join(",")} onChange={(e) => void addFiles(e.target.files)} />
+          {files.map((f, i) => (
+            <div key={i} className="flex items-center justify-between text-sm">
+              <span className="truncate">{f.file.name}</span>
+              <span className="text-muted-foreground">
+                {f.uploading
+                  ? t("settings.formTemplates.scanUploading", "Wgrywanie…")
+                  : f.error
+                    ? t("settings.formTemplates.scanUploadError", "Błąd")
+                    : "✓"}
+              </span>
+            </div>
+          ))}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={analyzing}>
+            {t("common.cancel", "Anuluj")}
+          </Button>
+          <Button onClick={() => void handleAnalyze()} disabled={analyzing || ready.length === 0}>
+            {analyzing
+              ? t("settings.formTemplates.scanAnalyzing", "Analizuję…")
+              : t("settings.formTemplates.scanAnalyze", "Analizuj ({{count}})", { count: ready.length })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 2: Przycisk na stronie listy**
+
+W `_layout.settings.form-templates.index.tsx`: import `TemplateScanDialog` + ikona (np. `ScanText` lub inna dostępna w `@/lib/ez-icons` — sprawdź eksporty i wybierz istniejącą, np. `FileText`), stan `const [scanOpen, setScanOpen] = useState(false)`, obok istniejącego przycisku „Nowy szablon"/edytora (okolice linii 855):
+
+```tsx
+<Button size="sm" variant="outline" onClick={() => setScanOpen(true)}>
+  {t("settings.formTemplates.scanNew", "Nowy ze skanu")}
+</Button>
+<TemplateScanDialog open={scanOpen} onOpenChange={setScanOpen} />
+```
+
+- [ ] **Step 3: i18n — dodaj klucze w OBU plikach locale**
+
+Do bloku `settings.formTemplates` (PL / EN):
+
+| klucz | PL | EN |
+|---|---|---|
+| `scanNew` | Nowy ze skanu | New from scan |
+| `scanTitle` | Nowy szablon ze skanu | New template from scan |
+| `scanDescription` | Wgraj skan lub PDF istniejącego formularza. AI odtworzy treść i wykryje pola do wypełnienia — wynik zweryfikujesz w edytorze. | Upload a scan or PDF of an existing form. AI reconstructs the content and detects fillable fields — you verify the result in the editor. |
+| `scanUploading` | Wgrywanie… | Uploading… |
+| `scanUploadError` | Błąd | Error |
+| `scanUnsupportedType` | Obsługiwane formaty: PDF, JPG, PNG | Supported formats: PDF, JPG, PNG |
+| `scanAnalyze` | Analizuj ({{count}}) | Analyze ({{count}}) |
+| `scanAnalyzing` | Analizuję… | Analyzing… |
+| `scanFailed` | Analiza nie powiodła się: {{error}} | Analysis failed: {{error}} |
+| `scanBanner` | Szablon wygenerowany ze skanu — zweryfikuj wykryte pola przed zapisem. Pewność analizy: {{confidence}}% | Template generated from a scan — verify detected fields before saving. Analysis confidence: {{confidence}}% |
+| `scanLoadFailed` | Nie udało się wczytać wyniku analizy | Failed to load the analysis result |
+
+- [ ] **Step 4: Weryfikacja**
+
+Run: `npx tsc -p tsconfig.app.json --pretty false` — bez nowych błędów.
+Run: `node -e "JSON.parse(require('fs').readFileSync('public/locales/pl/translation.json')); JSON.parse(require('fs').readFileSync('public/locales/en/translation.json')); console.log('locales OK')"`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/documents/template-scan-dialog.tsx src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx public/locales/pl/translation.json public/locales/en/translation.json
+git commit -m "feat(documents): 'New from scan' dialog on template list (upload -> analysis job)"
+```
+
+---
+
+### Task 7: `new.tsx` — start edytora z wyniku analizy
+
+**Files:**
+- Modify: `src/routes/_app/_auth/dashboard/_layout.settings.form-templates.new.tsx`
+
+**Interfaces:**
+- Consumes: `api.documentAnalysisJobs.getJob` (Task 4), `parsedTemplateToTipTap` (Task 5), i18n `scanBanner`/`scanLoadFailed` (Task 6).
+
+- [ ] **Step 1: validateSearch + ładowanie joba**
+
+W definicji Route (linia ~26-30) dodaj `validateSearch` (wzorzec jak `_layout.products.index.tsx:78`):
+
+```ts
+export const Route = createFileRoute(
+  "/_app/_auth/dashboard/_layout/settings/form-templates/new",
+)({
+  validateSearch: (search: Record<string, unknown>): { analysisJobId?: string } => ({
+    analysisJobId: typeof search.analysisJobId === "string" ? search.analysisJobId : undefined,
+  }),
+  component: NewFormTemplatePage,
+});
+```
+
+W komponencie (obok istniejących stanów, ~linia 110): 
+
+```ts
+const { analysisJobId } = Route.useSearch();
+const getJob = useAction(api.documentAnalysisJobs.getJob);
+const [scanConfidence, setScanConfidence] = useState<number | null>(null);
+const [scanLoaded, setScanLoaded] = useState(false);
+
+useEffect(() => {
+  if (!analysisJobId || scanLoaded) return;
+  setScanLoaded(true);
+  void (async () => {
+    try {
+      const job = await getJob({ organizationId, jobId: analysisJobId });
+      if (!job || job.status !== "ok" || !job.resultJson) {
+        toast.error(t("settings.formTemplates.scanLoadFailed", "Nie udało się wczytać wyniku analizy"));
+        return;
+      }
+      const parsed = JSON.parse(job.resultJson) as ParsedFormTemplateInput;
+      setContentJson(parsedTemplateToTipTap(parsed));
+      if (parsed.title) setName(parsed.title);
+      setScanConfidence(parsed.confidence);
+    } catch {
+      toast.error(t("settings.formTemplates.scanLoadFailed", "Nie udało się wczytać wyniku analizy"));
+    }
+  })();
+}, [analysisJobId, scanLoaded, getJob, organizationId, t]);
+```
+
+Importy do dodania: `useEffect` (rozszerzyć istniejący import z react), `parsedTemplateToTipTap, type ParsedFormTemplateInput` z `@/lib/documents/analysis-to-template`.
+
+- [ ] **Step 2: Baner nad edytorem**
+
+Bezpośrednio nad `<DocumentTemplateEditor ...>` (linia ~392):
+
+```tsx
+{analysisJobId && scanConfidence !== null && (
+  <div className="mb-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800">
+    {t("settings.formTemplates.scanBanner",
+      "Szablon wygenerowany ze skanu — zweryfikuj wykryte pola przed zapisem. Pewność analizy: {{confidence}}%",
+      { confidence: Math.round(scanConfidence * 100) })}
+  </div>
+)}
+```
+
+- [ ] **Step 3: Weryfikacja**
+
+Run: `npx tsc -p tsconfig.app.json --pretty false` — bez nowych błędów.
+Ręcznie (dev server, wymaga `OPENAI_API_KEY` w env Convex dev): przejdź pełny flow — Ustawienia → Szablony → „Nowy ze skanu" → wgraj PDF przykładowej zgody → Analizuj → edytor z treścią i polami → ustaw brakujące mapowania → Zapisz → szablon widoczny na liście; wejście na `/new?analysisJobId=...` po odświeżeniu odtwarza treść. Bez klucza API: oczekiwany czytelny toast „Analiza nie powiodła się: AI analysis provider is not configured".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/routes/_app/_auth/dashboard/_layout.settings.form-templates.new.tsx
+git commit -m "feat(documents): open template editor prefilled from scan analysis job"
+```
+
+---
+
+### Task 8: Weryfikacja końcowa + PR
+
+**Files:** brak nowych.
+
+- [ ] **Step 1: Pełna weryfikacja**
+
+Run (wszystkie muszą przejść):
+```bash
+npm run test:unit
+npx tsc -p convex/tsconfig.json --pretty false   # porównaj z main — zero NOWYCH błędów
+npx tsc -p tsconfig.app.json --pretty false      # jw.
+```
+
+- [ ] **Step 2: Sprawdź numer migracji vs aktualny main**
+
+```bash
+git fetch origin && git ls-tree -r --name-only origin/main supabase/migrations/ | sort | tail -3
+```
+Jeśli main ma już `00063_*` — przenumeruj plik + `node scripts/gen-db-types.mjs` + commit poprawki.
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin feat/ocr-template-generation
+gh pr create --base main --head feat/ocr-template-generation \
+  --title "feat(ai): generic AnalysisKind pipeline + template generation from scans" \
+  --body "Implements docs/superpowers/specs/2026-07-16-ocr-template-generation-design.md.
+
+- Provider OCR refactored to pure transport; analysis kinds are plugins (invoice = first kind, no behavior change — existing analyzer tests adapted, same assertions).
+- New kind form_template: scan/PDF -> structured template with detected fillable fields + patient-record mapping hints (allowlist-restricted).
+- Generic document_analysis_jobs table (migration via CI auto-apply) + create/run/get actions.
+- 'New from scan' dialog on template list; editor opens prefilled for verification; save path unchanged (variableBindings derived automatically).
+
+Adding a future analysis kind = one file in convex/_ai/kinds/ + registry entry (spec success criterion #3)."
+```
+
+- [ ] **Step 4: Checklist manualny (wpisz wyniki do PR)**
+
+1. Przepływ faktur w dostawach działa bez zmian (analiza faktury na quera-dev).
+2. Skan zgody → szablon → zapis → szablon działa w wypełnianiu/podpisie.
+3. Po podpisie dokument z polem zmapowanym `builtin:*` uzupełnia pustą kartotekę (feature z 2026-07-09 działa na szablonie ze skanu).

--- a/docs/superpowers/specs/2026-07-16-ocr-template-generation-design.md
+++ b/docs/superpowers/specs/2026-07-16-ocr-template-generation-design.md
@@ -1,0 +1,214 @@
+# Spec: Generyczny pipeline analizy dokumentów (AnalysisKind) + generowanie szablonów ze skanów
+
+Data: 2026-07-16
+Status: zatwierdzony (brainstorming z użytkownikiem)
+
+## Cel
+
+Rozszerzyć istniejący pipeline OCR/AI (`convex/_ai/documentAnalyzer.ts`, dziś używany
+wyłącznie do faktur dostaw) tak, aby:
+
+1. był **horyzontalnie reużywalny** — dodanie kolejnego rodzaju analizy dokumentu nie
+   wymaga zmian w providerze, fabryce ani infrastrukturze („raz zrobione, używane
+   wielokrotnie"),
+2. pierwszym nowym zastosowaniem było **generowanie szablonów dokumentów ze skanów**:
+   użytkownik wgrywa skan/PDF istniejącego formularza (zgoda, wywiad, RODO…), AI
+   odtwarza strukturę dokumentu i wykrywa edytowalne pola, wynik otwiera się w
+   istniejącym edytorze szablonów TipTap do weryfikacji i zapisu.
+
+## Decyzje produktowe (zatwierdzone)
+
+1. **Zakres reuse:** abstrakcja projektowana pod cztery zastosowania — faktury (już
+   jest), szablony ze skanów (budujemy teraz), a w przyszłości: skan wypełnionego
+   dokumentu → dane (odpowiedzi do formDocument/kartoteki), skan dowodu → kartoteka,
+   wyniki badań → karta klienta. Implementujemy TYLKO faktury+szablony (YAGNI na
+   pozostałych; mają być tanie do dodania).
+2. **Weryfikacja wyniku:** bez dedykowanego ekranu decyzji — wygenerowany szablon
+   otwiera się bezpośrednio w istniejącym edytorze TipTap (węzły `formField` są już
+   wizualnie wyróżnione, edytowalne, z dropdownem mapowania do kartoteki). Edytor JEST
+   ekranem weryfikacji.
+3. **Persystencja wyniku:** generyczna tabela `document_analysis_jobs` współdzielona
+   przez wszystkie tryby (przeżywa odświeżenie strony, gotowa pod przyszły async).
+4. **Auto-mapowanie:** AI sugeruje mapowanie wykrytych pól do PÓL WBUDOWANYCH
+   kartoteki (`patientFieldHint`), z zamkniętej listy; NIE proponuje pól
+   niestandardowych (`custom:*`).
+
+## Architektura rdzenia (podejście B — rejestr AnalysisKind)
+
+Odwrócenie zależności: provider staje się czystym transportem, rodzaje analizy są
+pluginami.
+
+```
+convex/_ai/
+  documentAnalyzer.ts          # kontrakt: DocumentPage, transport, fabryka (refaktor)
+  providers/
+    openaiDocumentAnalyzer.ts  # CZYSTY transport: (pages, prompt, maxTokens) → surowy JSON
+  kinds/
+    invoice.ts                 # kind "invoice" — prompt+walidacja+map WYNIESIONE z providera
+    formTemplate.ts            # kind "form_template" — NOWY
+  registry.ts                  # mapa id → definicja kind
+convex/documentAnalysisJobs.ts # generyczne akcje: createJob / runJob / getJob (+ RBAC)
+```
+
+Kontrakt rodzaju analizy:
+
+```ts
+interface AnalysisKind<TResult> {
+  id: string;                                          // "invoice" | "form_template" | ...
+  buildPrompt(context?: Record<string, unknown>): string;
+  validate(raw: unknown): boolean;                     // czysta funkcja
+  map(raw: unknown): TResult;                          // czysta funkcja
+  maxTokens?: number;
+}
+```
+
+`context` to kanał na dane specyficzne dla trybu (dla szablonów: lista pól wbudowanych
+kartoteki; dla przyszłego „wypełnionego dokumentu": `variableBindings` szablonu).
+Provider nic o nim nie wie — wchodzi wyłącznie do `buildPrompt`.
+
+Transport providera: `runAnalysis(pages, prompt, maxTokens) → { status, rawJson }`.
+Zachowuje całą obecną mechanikę: fetch bajtów z Convex storage server-side (bez
+publicznych URL-i), base64, PDF jako `file` / obrazy jako `image_url detail:high`,
+`response_format: json_object`, mapowanie błędów API, statusy `no_pages` /
+`unsupported_format` / `not_implemented` / `error`. NullProvider bez zmian.
+
+### Wspólna tabela zadań
+
+```
+document_analysis_jobs:
+  id, organization_id, kind, pages (JSON [{storageId,mimeType,position}]),
+  context (JSON, opcjonalny), status (pending|running|ok|error),
+  result_json (TEXT), error_message (TEXT),
+  created_by, created_at, updated_at, completed_at
+indeksy: by_org, by_org_and_kind; RLS: standardowe org-isolation (4 polityki per-command)
+```
+
+Jedna migracja SQL + wpis w `TABLE_MAP` + row type + regeneracja typów. CI auto-apply
+(naprawione w #2855) nakłada ją przy merge.
+
+Akcje (`convex/documentAnalysisJobs.ts`):
+- `createJob(kind, pages, context?)` → id (status `pending`)
+- `runJob(jobId)` — synchronicznie: registry→kind, buildPrompt(context), transport,
+  validate+map, zapis `result_json`/`error_message` + status. Idempotentny (retry =
+  ponowne wywołanie, nadpisuje wynik).
+- `getJob(jobId)` → pełny job.
+
+### Dwie kluczowe zasady
+
+1. **Faktury stają się pierwszym kind.** `analyzeDeliveryInvoice` zachowuje identyczny
+   publiczny kontrakt (zero zmian dla magazynu/UI dostaw), wewnętrznie woła rdzeń z
+   kind `invoice`. Refaktor udowodniony na produkcyjnym konsumencie od pierwszego dnia.
+2. **Jobs są opcją, nie przymusem.** Dostawy NIE przechodzą na tabelę zadań (mają
+   własne pola `analysisStatus` na wierszu dostawy). Tabela zadań jest dla trybów bez
+   naturalnego wiersza na wynik (np. szablon przed zapisaniem). Kind można wołać oboma
+   kanałami.
+
+## Tryb `form_template`
+
+### Schemat wyniku (ParsedFormTemplate)
+
+```ts
+{
+  title: string | null,
+  blocks: Array<
+    | { type: "heading", level: 1|2|3, text: string }
+    | { type: "paragraph", segments: Segment[] }
+    | { type: "bulletList" | "orderedList", items: Segment[][] }
+  >,
+  confidence: number | null
+}
+
+Segment =
+  | { type: "text", text: string }
+  | { type: "field",
+      label: string,
+      fieldType: "text"|"textarea"|"select"|"button_select"|"date"|"checkbox",
+      options?: string[],
+      required?: boolean,
+      patientFieldHint?: string | null }   // np. "builtin:pesel"
+```
+
+Reguły prompta: puste linie / kropkowane miejsca / kratki → `field`; checkboxy z
+opcjami → `select`/`checkbox`; daty przy podpisach → `date`; większe ramki na opis →
+`textarea`. Dokumenty głównie po polsku — prompt to uwzględnia.
+
+**Auto-mapowanie zawężone:** prompt dostaje w `context` zamkniętą listę celów z
+`PATIENT_BUILTIN_FIELDS` (ta sama stała, którą renderuje dropdown w edytorze —
+`src/lib/documents/patient-mappable-fields.ts`); AI wolno zwrócić wyłącznie wartość z
+listy albo `null`. `map()` dodatkowo odrzuca hinty spoza listy (podwójna walidacja).
+Bez sugerowania `custom:*` (ryzyko zaśmiecenia rejestru definicji) — pola
+niestandardowe użytkownik tworzy ręcznie w edytorze (funkcja już istnieje).
+
+### Mapper → TipTap
+
+Czysta funkcja frontendowa `parsedTemplateToTipTap(parsed): string` w
+`src/lib/documents/analysis-to-template.ts`. Buduje `content_json`: bloki → węzły
+heading/paragraph/bulletList/orderedList; segmenty `field` → istniejące węzły
+`formField` (`fieldId` = slug z label + licznik przy kolizji, `filledBy: "client"`,
+`patientField` z hinta). Zero nowych typów węzłów — edytor renderuje wynik bez zmian.
+
+### Przepływ UI
+
+1. Ustawienia → Szablony: przycisk **„Nowy ze skanu"** obok „Nowy szablon".
+2. Dialog uploadu multi-plik (PDF/JPG/PNG; reuse wzorca uploadu stron faktury do
+   Convex storage) → `createJob(kind: "form_template", pages, context)` → `runJob` →
+   spinner.
+3. Sukces → nawigacja na `/settings/form-templates/new?analysisJobId=<id>`. Strona
+   `new` przy obecności parametru robi `getJob`, mapper buduje treść, edytor startuje
+   wypełniony + baner „Szablon wygenerowany ze skanu — zweryfikuj wykryte pola przed
+   zapisem" (z `confidence`). Refresh nie gubi pracy — job w tabeli.
+4. Zapis = istniejący `createTemplate` bez zmian; `buildPatientVariableBindings`
+   automatycznie zbiera `patientField` z wygenerowanych węzłów → szablon ze skanu od
+   razu zapisuje dane podpisanych dokumentów do kartoteki (feature mapowania z
+   2026-07-09).
+
+### Ograniczenie (zapisane wprost)
+
+TipTap jest flow-based: skan odtwarzamy jako strukturalny dokument (nagłówki, akapity,
+listy, pola inline), NIE jako pixel-perfect kopię graficzną. Dla zgód / wywiadów /
+RODO to właściwa semantyka. Format `pdfme` (współrzędne) jest w projekcie martwy
+(legacy w schema) i nie wraca.
+
+## Błędy, bezpieczeństwo, testy
+
+**Błędy:** statusy transportu → `status: "error"` + `error_message` na jobie; UI toast
+z konkretem + „Ponów" (idempotentny `runJob`). JSON niezgodny z walidacją kind →
+`error` (bez ratowania połowicznych wyników). NullProvider → czytelny komunikat
+„Analiza AI niedostępna — brak konfiguracji". Timeout 60s; `maxTokens` dla
+`form_template` = 8192. `confidence` w banerze edytora. Bez crona sprzątającego joby w
+MVP (świadoma decyzja; kandydat do tech-debt).
+
+**RBAC:** `createJob`/`runJob`/`getJob` — `verifyOrgAccess` + ten sam `checkPermission`,
+którego używa `templates.create` (tworzenie szablonu ze skanu = tworzenie szablonu).
+Nowa tabela: standardowe RLS org-isolation. `created_by` na jobie. Pliki w Convex
+storage, czytane server-side.
+
+**Testy:**
+- Jednostkowe (czyste funkcje, bez OpenAI): regresja kind `invoice` (walidacja/map na
+  fixture'ach identyczna z obecną logiką — dowód nieinwazyjności refaktoru); kind
+  `form_template` (poprawny JSON / zepsuty JSON / hint spoza allowlisty odrzucony);
+  mapper `parsedTemplateToTipTap` (bloki→węzły, kolizje `fieldId`, propagacja
+  `patientField`).
+- Integracyjne (convex-test + stub Supabase in-memory): create→run→get happy path,
+  ścieżka błędu z NullProviderem, odmowa RBAC, odczyt joba po „odświeżeniu".
+- Polityka zero nowych błędów typecheck vs main.
+- E2E: ręczna checklista smoke (upload → edytor wypełniony → zapis → szablon działa w
+  przepływie wypełniania/podpisu).
+
+## Poza zakresem MVP (świadomie)
+
+- Asynchroniczna kolejka analizy (tabela gotowa, `runJob` synchroniczny).
+- Sugerowanie pól `custom:*` przez AI.
+- Pozostałe trzy tryby (wypełniony dokument → dane; dowód → kartoteka; wyniki badań →
+  karta klienta) — każdy to w tej architekturze nowy plik w `kinds/` + własny
+  konsument.
+- Sprzątanie starych jobów (cron).
+
+## Kryteria sukcesu
+
+1. Istniejący przepływ faktur działa bez żadnej zmiany zachowania (regresja testowa).
+2. Skan przykładowej zgody/wywiadu (PDF lub zdjęcie) → szablon w edytorze ze
+   strukturą, wykrytymi polami i sensownymi hintami mapowania → zapis → szablon
+   normalnie działa w przepływie wypełniania i podpisu.
+3. Dodanie hipotetycznego trzeciego kind nie wymaga zmian poza nowym plikiem w
+   `kinds/` i rejestracją (weryfikowalne przeglądem kodu).

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1670,7 +1670,18 @@
       "seedAlreadyLoaded": "All example templates are already loaded",
       "seedSuccess": "Loaded {{count}} templates",
       "migrateFolders": "Assign folders to templates",
-      "migrateSuccess": "Assigned folders to {{count}} templates"
+      "migrateSuccess": "Assigned folders to {{count}} templates",
+      "scanNew": "New from scan",
+      "scanTitle": "New template from scan",
+      "scanDescription": "Upload a scan or PDF of an existing form. AI reconstructs the content and detects fillable fields — you verify the result in the editor.",
+      "scanUploading": "Uploading…",
+      "scanUploadError": "Error",
+      "scanUnsupportedType": "Supported formats: PDF, JPG, PNG",
+      "scanAnalyze": "Analyze ({{count}})",
+      "scanAnalyzing": "Analyzing…",
+      "scanFailed": "Analysis failed: {{error}}",
+      "scanBanner": "Template generated from a scan — verify detected fields before saving. Analysis confidence: {{confidence}}%",
+      "scanLoadFailed": "Failed to load the analysis result"
     },
     "documentComponents": {
       "errors": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1673,7 +1673,18 @@
       "seedAlreadyLoaded": "Wszystkie przykładowe szablony są już załadowane",
       "seedSuccess": "Załadowano {{count}} szablonów",
       "migrateFolders": "Przypisz foldery do szablonów",
-      "migrateSuccess": "Przypisano foldery do {{count}} szablonów"
+      "migrateSuccess": "Przypisano foldery do {{count}} szablonów",
+      "scanNew": "Nowy ze skanu",
+      "scanTitle": "Nowy szablon ze skanu",
+      "scanDescription": "Wgraj skan lub PDF istniejącego formularza. AI odtworzy treść i wykryje pola do wypełnienia — wynik zweryfikujesz w edytorze.",
+      "scanUploading": "Wgrywanie…",
+      "scanUploadError": "Błąd",
+      "scanUnsupportedType": "Obsługiwane formaty: PDF, JPG, PNG",
+      "scanAnalyze": "Analizuj ({{count}})",
+      "scanAnalyzing": "Analizuję…",
+      "scanFailed": "Analiza nie powiodła się: {{error}}",
+      "scanBanner": "Szablon wygenerowany ze skanu — zweryfikuj wykryte pola przed zapisem. Pewność analizy: {{confidence}}%",
+      "scanLoadFailed": "Nie udało się wczytać wyniku analizy"
     },
     "documentComponents": {
       "errors": {

--- a/src/components/documents/template-scan-dialog.tsx
+++ b/src/components/documents/template-scan-dialog.tsx
@@ -81,7 +81,7 @@ export function TemplateScanDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={(o) => { if (!analyzing) onOpenChange(o); }}>
+    <Dialog open={open} onOpenChange={(o) => { if (!analyzing) { if (!o) setFiles([]); onOpenChange(o); } }}>
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>{t("settings.formTemplates.scanTitle", "Nowy szablon ze skanu")}</DialogTitle>
@@ -105,7 +105,7 @@ export function TemplateScanDialog({
           ))}
         </div>
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={analyzing}>
+          <Button variant="outline" onClick={() => { setFiles([]); onOpenChange(false); }} disabled={analyzing}>
             {t("common.cancel", "Anuluj")}
           </Button>
           <Button onClick={() => void handleAnalyze()} disabled={analyzing || ready.length === 0}>

--- a/src/components/documents/template-scan-dialog.tsx
+++ b/src/components/documents/template-scan-dialog.tsx
@@ -1,0 +1,120 @@
+import { useCallback, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { useAction, useMutation } from "convex/react";
+import { api } from "@cvx/_generated/api";
+import { useOrganization } from "@/components/org-context";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { PATIENT_BUILTIN_FIELDS } from "@/lib/documents/patient-mappable-fields";
+
+const ACCEPTED = ["application/pdf", "image/jpeg", "image/png"];
+
+interface PendingFile { file: File; storageId: string | null; uploading: boolean; error: boolean }
+
+export function TemplateScanDialog({
+  open, onOpenChange,
+}: { open: boolean; onOpenChange: (o: boolean) => void }) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { organizationId } = useOrganization();
+  const generateUploadUrl = useMutation(api.app.generateUploadUrl);
+  const createJob = useAction(api.documentAnalysisJobs.createJob);
+  const runJob = useAction(api.documentAnalysisJobs.runJob);
+
+  const [files, setFiles] = useState<PendingFile[]>([]);
+  const [analyzing, setAnalyzing] = useState(false);
+
+  const addFiles = useCallback(async (list: FileList | null) => {
+    if (!list) return;
+    const accepted = Array.from(list).filter((f) => ACCEPTED.includes(f.type));
+    if (accepted.length !== (list?.length ?? 0)) {
+      toast.error(t("settings.formTemplates.scanUnsupportedType", "Obsługiwane formaty: PDF, JPG, PNG"));
+    }
+    for (const file of accepted) {
+      setFiles((prev) => [...prev, { file, storageId: null, uploading: true, error: false }]);
+      try {
+        const uploadUrl = await generateUploadUrl();
+        const res = await fetch(uploadUrl, {
+          method: "POST",
+          headers: { "Content-Type": file.type },
+          body: file,
+        });
+        const { storageId } = (await res.json()) as { storageId: string };
+        setFiles((prev) => prev.map((p) => (p.file === file ? { ...p, storageId, uploading: false } : p)));
+      } catch {
+        setFiles((prev) => prev.map((p) => (p.file === file ? { ...p, uploading: false, error: true } : p)));
+      }
+    }
+  }, [generateUploadUrl, t]);
+
+  const ready = files.filter((f) => f.storageId && !f.error);
+
+  const handleAnalyze = async () => {
+    if (ready.length === 0) return;
+    setAnalyzing(true);
+    try {
+      const pages = ready.map((f, i) => ({ storageId: f.storageId!, mimeType: f.file.type, position: i + 1 }));
+      const jobId = await createJob({
+        organizationId,
+        kind: "form_template",
+        pages,
+        context: JSON.stringify({ patientFields: PATIENT_BUILTIN_FIELDS.map((f) => ({ key: f.key, label: f.label })) }),
+      });
+      const res = await runJob({ organizationId, jobId });
+      if (res.status === "error") {
+        toast.error(t("settings.formTemplates.scanFailed", "Analiza nie powiodła się: {{error}}", { error: res.errorMessage }));
+        return; // dialog zostaje otwarty — ponowienie = ponowny klik "Analizuj" (tworzy nowy job; runJob jest idempotentny, test w Task 4)
+      }
+      onOpenChange(false);
+      void navigate({
+        to: "/dashboard/settings/form-templates/new",
+        search: { analysisJobId: jobId },
+      });
+    } finally {
+      setAnalyzing(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!analyzing) onOpenChange(o); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("settings.formTemplates.scanTitle", "Nowy szablon ze skanu")}</DialogTitle>
+          <DialogDescription>
+            {t("settings.formTemplates.scanDescription", "Wgraj skan lub PDF istniejącego formularza. AI odtworzy treść i wykryje pola do wypełnienia — wynik zweryfikujesz w edytorze.")}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          <Input type="file" multiple accept={ACCEPTED.join(",")} onChange={(e) => void addFiles(e.target.files)} />
+          {files.map((f, i) => (
+            <div key={i} className="flex items-center justify-between text-sm">
+              <span className="truncate">{f.file.name}</span>
+              <span className="text-muted-foreground">
+                {f.uploading
+                  ? t("settings.formTemplates.scanUploading", "Wgrywanie…")
+                  : f.error
+                    ? t("settings.formTemplates.scanUploadError", "Błąd")
+                    : "✓"}
+              </span>
+            </div>
+          ))}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={analyzing}>
+            {t("common.cancel", "Anuluj")}
+          </Button>
+          <Button onClick={() => void handleAnalyze()} disabled={analyzing || ready.length === 0}>
+            {analyzing
+              ? t("settings.formTemplates.scanAnalyzing", "Analizuję…")
+              : t("settings.formTemplates.scanAnalyze", "Analizuj ({{count}})", { count: ready.length })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/documents/analysis-to-template.ts
+++ b/src/lib/documents/analysis-to-template.ts
@@ -1,0 +1,83 @@
+/**
+ * Maps a ParsedFormTemplate (AI analysis result, kind "form_template") to a
+ * TipTap content_json string using the existing formField inline nodes.
+ *
+ * Input types are declared locally (structurally identical to
+ * convex/_ai/kinds/formTemplate.ts) so the frontend bundle does not import
+ * backend modules; the shape is validated server-side by the kind anyway.
+ */
+import { slugifyFieldKey } from "./patient-mappable-fields";
+
+export interface ParsedTemplateFieldSegment {
+  type: "field";
+  label: string;
+  fieldType: "text" | "textarea" | "select" | "button_select" | "date" | "checkbox";
+  options?: string[];
+  required?: boolean;
+  patientFieldHint?: string | null;
+}
+export type ParsedTemplateSegment = { type: "text"; text: string } | ParsedTemplateFieldSegment;
+export type ParsedTemplateBlock =
+  | { type: "heading"; level: 1 | 2 | 3; text: string }
+  | { type: "paragraph"; segments: ParsedTemplateSegment[] }
+  | { type: "bulletList" | "orderedList"; items: ParsedTemplateSegment[][] };
+export interface ParsedFormTemplateInput {
+  title: string | null;
+  blocks: ParsedTemplateBlock[];
+  confidence: number | null;
+}
+
+type TipTapNode = { type: string; attrs?: Record<string, unknown>; content?: TipTapNode[]; text?: string };
+
+function segmentsToInline(segments: ParsedTemplateSegment[], usedIds: Set<string>): TipTapNode[] {
+  const out: TipTapNode[] = [];
+  for (const seg of segments) {
+    if (seg.type === "text") {
+      if (seg.text) out.push({ type: "text", text: seg.text });
+      continue;
+    }
+    let fieldId = slugifyFieldKey(seg.label) || "pole";
+    let n = 2;
+    while (usedIds.has(fieldId)) fieldId = `${slugifyFieldKey(seg.label) || "pole"}_${n++}`;
+    usedIds.add(fieldId);
+    out.push({
+      type: "formField",
+      attrs: {
+        fieldId,
+        fieldType: seg.fieldType,
+        label: seg.label,
+        options: (seg.options ?? []).join(", "),
+        required: seg.required === true,
+        placeholder: "",
+        filledBy: "client",
+        patientField: seg.patientFieldHint ?? "",
+      },
+    });
+  }
+  return out;
+}
+
+export function parsedTemplateToTipTap(parsed: ParsedFormTemplateInput): string {
+  const usedIds = new Set<string>();
+  const content: TipTapNode[] = [];
+  for (const block of parsed.blocks) {
+    if (block.type === "heading") {
+      content.push({
+        type: "heading",
+        attrs: { level: block.level },
+        content: block.text ? [{ type: "text", text: block.text }] : [],
+      });
+    } else if (block.type === "paragraph") {
+      content.push({ type: "paragraph", content: segmentsToInline(block.segments, usedIds) });
+    } else {
+      content.push({
+        type: block.type,
+        content: block.items.map((item) => ({
+          type: "listItem",
+          content: [{ type: "paragraph", content: segmentsToInline(item, usedIds) }],
+        })),
+      });
+    }
+  }
+  return JSON.stringify({ type: "doc", content });
+}

--- a/src/lib/supabase/database.columns.ts
+++ b/src/lib/supabase/database.columns.ts
@@ -67,6 +67,7 @@
  *   • 00060_delivery_matching_proposals.sql
  *   • 00061_delivery_name_mappings.sql
  *   • 00062_delivery_item_decisions.sql
+ *   • 00063_document_analysis_jobs.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  */
@@ -171,7 +172,8 @@ export type TableName =
   | "gabinet_employee_locations"
   | "warehouse_deliveries"
   | "warehouse_delivery_items"
-  | "delivery_name_mappings";
+  | "delivery_name_mappings"
+  | "document_analysis_jobs";
 
 /**
  * Column names per table, as a runtime-checkable Set.
@@ -277,4 +279,5 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   warehouse_deliveries: new Set(["id", "organization_id", "supplier_name", "invoice_number", "delivery_date", "location_id", "notes", "status", "created_by", "created_at", "updated_at", "total_value", "total_value_gross", "invoice_pages", "analysis_status", "analysis_result", "analysis_completed_at", "analysis_error", "matching_proposals", "item_decisions"]),
   warehouse_delivery_items: new Set(["id", "organization_id", "delivery_id", "product_id", "quantity", "unit_price", "vat_rate", "movement_id", "created_at", "unit_price_gross", "line_value_net", "line_value_gross", "vat_code", "lot_number", "expiry_date"]),
   delivery_name_mappings: new Set(["id", "organization_id", "invoice_name", "product_id", "created_at"]),
+  document_analysis_jobs: new Set(["id", "organization_id", "kind", "pages", "context", "status", "result_json", "error_message", "created_by", "created_at", "updated_at", "completed_at"]),
 };

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -67,6 +67,7 @@
  *   • 00060_delivery_matching_proposals.sql
  *   • 00061_delivery_name_mappings.sql
  *   • 00062_delivery_item_decisions.sql
+ *   • 00063_document_analysis_jobs.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -7108,6 +7109,66 @@ export interface Database {
             columns: ["product_id"];
             isOneToOne: false;
             referencedRelation: "products";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      document_analysis_jobs: {
+        Row: {
+          id: string;
+          organization_id: string;
+          kind: string;
+          pages: unknown;
+          context: string | null;
+          status: string;
+          result_json: string | null;
+          error_message: string | null;
+          created_by: string;
+          created_at: number;
+          updated_at: number;
+          completed_at: number | null;
+        };
+        Insert: {
+          id?: string;
+          organization_id: string;
+          kind: string;
+          pages: unknown;
+          context?: string | null;
+          status: string;
+          result_json?: string | null;
+          error_message?: string | null;
+          created_by: string;
+          created_at: number;
+          updated_at: number;
+          completed_at?: number | null;
+        };
+        Update: {
+          id?: string;
+          organization_id?: string;
+          kind?: string;
+          pages?: unknown;
+          context?: string | null;
+          status?: string;
+          result_json?: string | null;
+          error_message?: string | null;
+          created_by?: string;
+          created_at?: number;
+          updated_at?: number;
+          completed_at?: number | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "document_analysis_jobs_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organizations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "document_analysis_jobs_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "users";
             referencedColumns: ["id"];
           },
         ];

--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -66,6 +66,7 @@ import {
 } from "@/lib/ez-icons";
 import { toast } from "sonner";
 import type { Id } from "@cvx/_generated/dataModel";
+import { TemplateScanDialog } from "@/components/documents/template-scan-dialog";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/settings/form-templates/",
@@ -543,6 +544,7 @@ export function FormTemplatesListPage() {
   const navigate = useNavigate();
 
   const [search, setSearch] = useState("");
+  const [scanOpen, setScanOpen] = useState(false);
   const [deletingTemplate, setDeletingTemplate] =
     useState<FormTemplateRecord | null>(null);
   const [seedConfirmOpen, setSeedConfirmOpen] = useState(false);
@@ -852,6 +854,9 @@ export function FormTemplatesListPage() {
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
+            <Button size="sm" variant="outline" onClick={() => setScanOpen(true)}>
+              {t("settings.formTemplates.scanNew", "Nowy ze skanu")}
+            </Button>
             <Button size="sm" variant="outline" asChild>
               <Link to="/dashboard/document-editor/new">
                 <Plus className="mr-2 h-4 w-4" variant="stroke" />
@@ -1050,6 +1055,9 @@ export function FormTemplatesListPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Scan dialog */}
+      <TemplateScanDialog open={scanOpen} onOpenChange={setScanOpen} />
     </div>
   );
 }

--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.new.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 import { useAction } from "convex/react";
@@ -23,6 +23,10 @@ import { ArrowLeft, ChevronDown, ChevronUp } from "@/lib/ez-icons";
 import { toast } from "sonner";
 import { DocumentTemplateEditor } from "@/components/documents/document-template-editor";
 import { buildPatientVariableBindings } from "@/lib/documents/variable-bindings";
+import {
+  parsedTemplateToTipTap,
+  type ParsedFormTemplateInput,
+} from "@/lib/documents/analysis-to-template";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/settings/form-templates/new",
@@ -115,6 +119,41 @@ function NewFormTemplatePage() {
   const [contentJson, setContentJson] = useState("{}");
 
   const createTemplate = useAction(api.documents.templates.create);
+  const getJob = useAction(api.documentAnalysisJobs.getJob);
+
+  const { analysisJobId } = Route.useSearch();
+  const [scanConfidence, setScanConfidence] = useState<number | null>(null);
+  const [scanLoaded, setScanLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!analysisJobId || scanLoaded) return;
+    setScanLoaded(true);
+    void (async () => {
+      try {
+        const job = await getJob({ organizationId, jobId: analysisJobId });
+        if (!job || job.status !== "ok" || !job.resultJson) {
+          toast.error(
+            t(
+              "settings.formTemplates.scanLoadFailed",
+              "Nie udało się wczytać wyniku analizy",
+            ),
+          );
+          return;
+        }
+        const parsed = JSON.parse(job.resultJson) as ParsedFormTemplateInput;
+        setContentJson(parsedTemplateToTipTap(parsed));
+        if (parsed.title) setName(parsed.title);
+        setScanConfidence(parsed.confidence);
+      } catch {
+        toast.error(
+          t(
+            "settings.formTemplates.scanLoadFailed",
+            "Nie udało się wczytać wyniku analizy",
+          ),
+        );
+      }
+    })();
+  }, [analysisJobId, scanLoaded, getJob, organizationId, t]);
 
   const toggleModule = (mod: Module) => {
     setModules((prev) =>
@@ -391,6 +430,17 @@ function NewFormTemplatePage() {
           </CardContent>
         )}
       </Card>
+
+      {/* Scan banner */}
+      {analysisJobId && scanConfidence !== null && (
+        <div className="mb-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800">
+          {t(
+            "settings.formTemplates.scanBanner",
+            "Szablon wygenerowany ze skanu — zweryfikuj wykryte pola przed zapisem. Pewność analizy: {{confidence}}%",
+            { confidence: Math.round(scanConfidence * 100) },
+          )}
+        </div>
+      )}
 
       {/* Document editor — takes remaining viewport height */}
       <div className="min-h-0 flex-1">

--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.new.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from "react";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { z } from "zod";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
@@ -26,6 +27,9 @@ import { buildPatientVariableBindings } from "@/lib/documents/variable-bindings"
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/settings/form-templates/new",
 )({
+  validateSearch: z.object({
+    analysisJobId: z.string().optional(),
+  }),
   component: NewFormTemplatePage,
 });
 

--- a/supabase/migrations/00063_document_analysis_jobs.sql
+++ b/supabase/migrations/00063_document_analysis_jobs.sql
@@ -1,0 +1,35 @@
+-- Generic AI document-analysis jobs (spec 2026-07-16). Stores request pages,
+-- status and result for analysis kinds without a natural host row.
+-- Timestamps are BIGINT ms-epoch, PK is TEXT (project convention).
+
+CREATE TABLE IF NOT EXISTS document_analysis_jobs (
+  id              TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  kind            TEXT NOT NULL,
+  pages           JSONB NOT NULL,
+  context         TEXT,
+  status          TEXT NOT NULL CHECK (status IN ('pending','running','ok','error')),
+  result_json     TEXT,
+  error_message   TEXT,
+  created_by      TEXT NOT NULL REFERENCES users(id),
+  created_at      BIGINT NOT NULL,
+  updated_at      BIGINT NOT NULL,
+  completed_at    BIGINT
+);
+
+CREATE INDEX IF NOT EXISTS document_analysis_jobs_org_idx
+  ON document_analysis_jobs (organization_id);
+CREATE INDEX IF NOT EXISTS document_analysis_jobs_org_kind_idx
+  ON document_analysis_jobs (organization_id, kind);
+
+ALTER TABLE document_analysis_jobs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY document_analysis_jobs_select ON document_analysis_jobs
+  FOR SELECT USING (current_org_id() = organization_id);
+CREATE POLICY document_analysis_jobs_insert ON document_analysis_jobs
+  FOR INSERT WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY document_analysis_jobs_update ON document_analysis_jobs
+  FOR UPDATE USING (current_org_id() = organization_id)
+  WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY document_analysis_jobs_delete ON document_analysis_jobs
+  FOR DELETE USING (current_org_id() = organization_id);

--- a/tests/convex/analysisKindFormTemplate.test.ts
+++ b/tests/convex/analysisKindFormTemplate.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+import { formTemplateKind, type ParsedFormTemplate, type ParsedSegment } from "../../convex/_ai/kinds/formTemplate";
+import { getAnalysisKind } from "../../convex/_ai/registry";
+
+const CTX = { patientFields: [{ key: "pesel", label: "PESEL" }, { key: "phone", label: "Telefon" }] };
+
+const VALID = {
+  title: "Zgoda na zabieg",
+  blocks: [
+    { type: "heading", level: 1, text: "Zgoda na zabieg" },
+    { type: "paragraph", segments: [
+      { type: "text", text: "Ja, " },
+      { type: "field", label: "Imię i nazwisko", fieldType: "text", required: true, patientFieldHint: null },
+      { type: "text", text: ", PESEL: " },
+      { type: "field", label: "PESEL", fieldType: "text", patientFieldHint: "builtin:pesel" },
+    ]},
+    { type: "bulletList", items: [
+      [{ type: "text", text: "Zapoznałem się z przeciwwskazaniami" }],
+    ]},
+  ],
+  confidence: 0.8,
+};
+
+describe("formTemplateKind", () => {
+  test("registry resolves both kinds", () => {
+    expect(getAnalysisKind("invoice")?.id).toBe("invoice");
+    expect(getAnalysisKind("form_template")?.id).toBe("form_template");
+    expect(getAnalysisKind("nope")).toBeNull();
+  });
+
+  test("prompt includes allowed patient targets from context", () => {
+    const p = formTemplateKind.buildPrompt(CTX);
+    expect(p).toContain("builtin:pesel");
+    expect(p).toContain("PESEL");
+    expect(formTemplateKind.maxTokens).toBe(8192);
+  });
+
+  test("validate: accepts valid, rejects malformed", () => {
+    expect(formTemplateKind.validate(VALID)).toBe(true);
+    expect(formTemplateKind.validate(null)).toBe(false);
+    expect(formTemplateKind.validate({ blocks: "x" })).toBe(false);
+    expect(formTemplateKind.validate({ blocks: [{ type: "widget" }] })).toBe(false);
+    expect(formTemplateKind.validate({ blocks: [{ type: "paragraph", segments: [{ type: "field" }] }] })).toBe(false); // field bez label
+  });
+
+  test("map: keeps allowed hint, drops hint outside allowlist, coerces fieldType", () => {
+    const messy = { ...VALID, blocks: [
+      { type: "paragraph", segments: [
+        { type: "field", label: "PESEL", fieldType: "text", patientFieldHint: "builtin:pesel" },
+        { type: "field", label: "Hasło", fieldType: "text", patientFieldHint: "builtin:password" }, // spoza listy
+        { type: "field", label: "Coś", fieldType: "fancy" }, // nieznany typ → "text"
+      ]},
+    ]};
+    const out = formTemplateKind.map(messy, { rawJson: "{}", context: CTX }) as ParsedFormTemplate;
+    const seg = out.blocks[0] as Extract<typeof out.blocks[0], { type: "paragraph" }>;
+    const fields = seg.segments.filter((s) => s.type === "field") as Array<Extract<ParsedSegment, {type:"field"}>>;
+    expect(fields[0].patientFieldHint).toBe("builtin:pesel");
+    expect(fields[1].patientFieldHint).toBeNull();
+    expect(fields[2].fieldType).toBe("text");
+  });
+
+  test("map without context drops all hints", () => {
+    const out = formTemplateKind.map(VALID, { rawJson: "{}" }) as ParsedFormTemplate;
+    const para = out.blocks[1] as Extract<typeof out.blocks[1], { type: "paragraph" }>;
+    const pesel = para.segments.find((s) => s.type === "field" && s.label === "PESEL");
+    expect((pesel as Extract<ParsedSegment, {type:"field"}>).patientFieldHint).toBeNull();
+  });
+});

--- a/tests/convex/analysisKindInvoice.test.ts
+++ b/tests/convex/analysisKindInvoice.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+import { invoiceKind } from "../../convex/_ai/kinds/invoice";
+
+const VALID = {
+  supplierName: "ACME Sp. z o.o.",
+  supplierNip: "1234567890",
+  invoiceNumber: "FV/2024/001",
+  invoiceDate: "2024-06-01",
+  deliveryDate: null,
+  currency: "PLN",
+  items: [
+    {
+      productName: "Krem regenerujący",
+      quantity: 2,
+      unit: "szt",
+      unitPriceNet: 100,
+      unitPriceGross: 123,
+      vatRate: 23,
+      vatCode: "A",
+      lineValueNet: 200,
+      lineValueGross: 246,
+      lotNumber: "L-77",
+      expiryDate: "2027-01-31",
+    },
+  ],
+  confidence: 0.92,
+};
+
+describe("invoiceKind", () => {
+  test("id and prompt", () => {
+    expect(invoiceKind.id).toBe("invoice");
+    expect(invoiceKind.buildPrompt()).toContain("supplierName");
+    expect(invoiceKind.maxTokens).toBe(4096);
+  });
+
+  test("validate accepts a valid invoice and rejects garbage", () => {
+    expect(invoiceKind.validate(VALID)).toBe(true);
+    expect(invoiceKind.validate(null)).toBe(false);
+    expect(invoiceKind.validate({ items: "nope" })).toBe(false);
+    expect(invoiceKind.validate({ items: [{}] })).toBe(false); // item bez productName
+  });
+
+  test("map coerces types and carries rawJson as rawText", () => {
+    const rawJson = JSON.stringify(VALID);
+    const out = invoiceKind.map(VALID, { rawJson });
+    expect(out.supplierName).toBe("ACME Sp. z o.o.");
+    expect(out.items[0].unitPrice).toBe(100); // unitPriceNet → unitPrice
+    expect(out.items[0].lotNumber).toBe("L-77");
+    expect(out.confidence).toBe(0.92);
+    expect(out.rawText).toBe(rawJson);
+  });
+
+  test("map nulls empty strings and non-finite numbers", () => {
+    const messy = { ...VALID, supplierName: "", items: [{ ...VALID.items[0], quantity: "abc", unit: "" }] };
+    const out = invoiceKind.map(messy, { rawJson: "{}" });
+    expect(out.supplierName).toBeNull();
+    expect(out.items[0].quantity).toBe(0);
+    expect(out.items[0].unit).toBeNull();
+  });
+});

--- a/tests/convex/analysisToTemplate.test.ts
+++ b/tests/convex/analysisToTemplate.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import { parsedTemplateToTipTap } from "../../src/lib/documents/analysis-to-template";
+
+const PARSED = {
+  title: "Zgoda",
+  confidence: 0.9,
+  blocks: [
+    { type: "heading" as const, level: 1 as const, text: "Zgoda na zabieg" },
+    { type: "paragraph" as const, segments: [
+      { type: "text" as const, text: "PESEL: " },
+      { type: "field" as const, label: "PESEL", fieldType: "text" as const, required: true, patientFieldHint: "builtin:pesel" },
+      { type: "field" as const, label: "PESEL", fieldType: "text" as const }, // duplikat labela → inny fieldId
+    ]},
+    { type: "bulletList" as const, items: [
+      [{ type: "text" as const, text: "Punkt pierwszy" }],
+    ]},
+    { type: "paragraph" as const, segments: [
+      { type: "field" as const, label: "Zgody marketingowe", fieldType: "select" as const, options: ["Tak", "Nie"] },
+    ]},
+  ],
+};
+
+describe("parsedTemplateToTipTap", () => {
+  const doc = JSON.parse(parsedTemplateToTipTap(PARSED));
+
+  test("builds a TipTap doc with heading, paragraphs and list", () => {
+    expect(doc.type).toBe("doc");
+    expect(doc.content[0]).toMatchObject({ type: "heading", attrs: { level: 1 } });
+    expect(doc.content[0].content[0].text).toBe("Zgoda na zabieg");
+    expect(doc.content[2].type).toBe("bulletList");
+    expect(doc.content[2].content[0].type).toBe("listItem");
+  });
+
+  test("field segments become formField nodes with client filledBy and mapping", () => {
+    const para = doc.content[1];
+    const fields = para.content.filter((n: { type: string }) => n.type === "formField");
+    expect(fields).toHaveLength(2);
+    expect(fields[0].attrs).toMatchObject({
+      label: "PESEL", fieldType: "text", required: true,
+      filledBy: "client", patientField: "builtin:pesel",
+    });
+    expect(fields[0].attrs.fieldId).toBeTruthy();
+    expect(fields[1].attrs.fieldId).not.toBe(fields[0].attrs.fieldId); // kolizja labela rozwiązana
+    expect(fields[1].attrs.patientField).toBe("");
+  });
+
+  test("select options serialize comma-separated (editor convention)", () => {
+    const sel = doc.content[3].content.find((n: { type: string }) => n.type === "formField");
+    expect(sel.attrs.options).toBe("Tak, Nie");
+    expect(sel.attrs.fieldType).toBe("select");
+  });
+
+  test("empty blocks produce an empty doc, not a crash", () => {
+    const empty = JSON.parse(parsedTemplateToTipTap({ title: null, confidence: null, blocks: [] }));
+    expect(empty).toEqual({ type: "doc", content: [] });
+  });
+});

--- a/tests/convex/deliveryInvoiceAnalysis.test.ts
+++ b/tests/convex/deliveryInvoiceAnalysis.test.ts
@@ -9,7 +9,7 @@ import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
 import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
 
 // ---------------------------------------------------------------------------
-// Mock getDocumentAnalyzer so tests control what the analyzer returns without
+// Mock documentAnalyzer so tests control what the analyzer returns without
 // touching real OpenAI or Convex file storage.
 // ---------------------------------------------------------------------------
 
@@ -18,7 +18,8 @@ const { mockAnalyzeInvoice } = vi.hoisted(() => ({
 }));
 
 vi.mock("../../convex/_ai/documentAnalyzer", () => ({
-  getDocumentAnalyzer: () => ({ analyzeInvoice: mockAnalyzeInvoice }),
+  getDocumentTransport: () => ({}),
+  analyzeDocument: mockAnalyzeInvoice,
 }));
 
 // ---------------------------------------------------------------------------
@@ -133,7 +134,8 @@ describe("analyzeDeliveryInvoice — multi-page success (#3045)", () => {
 
     // Analyzer was called once with pages sorted by position
     expect(mockAnalyzeInvoice).toHaveBeenCalledTimes(1);
-    const passedPages = mockAnalyzeInvoice.mock.calls[0][0] as Array<{
+    // analyzeDocument(transport, kind, pages) — pages is arg index 2
+    const passedPages = mockAnalyzeInvoice.mock.calls[0][2] as Array<{
       position: number;
     }>;
     expect(passedPages.map((p) => p.position)).toEqual([1, 2]);

--- a/tests/convex/documentAnalysisJobs.test.ts
+++ b/tests/convex/documentAnalysisJobs.test.ts
@@ -30,6 +30,16 @@ describe("documentAnalysisJobs", () => {
     ).rejects.toThrow(/unknown analysis kind/i);
   });
 
+  test("createJob rejects empty pages", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await expect(
+      t.withIdentity(identity).action(api.documentAnalysisJobs.createJob, {
+        organizationId, kind: "form_template", pages: [],
+      }),
+    ).rejects.toThrow(/no pages/i);
+  });
+
   test("runJob without provider records error status on the job (retryable)", async () => {
     const t = createTestCtx();
     const { organizationId, identity } = await seedTestUser(t);

--- a/tests/convex/documentAnalysisJobs.test.ts
+++ b/tests/convex/documentAnalysisJobs.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+const PAGES = [{ storageId: "st-1", mimeType: "application/pdf", position: 1 }];
+
+describe("documentAnalysisJobs", () => {
+  test("createJob persists a pending job scoped to the org", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const jobId = await t.withIdentity(identity).action(api.documentAnalysisJobs.createJob, {
+      organizationId, kind: "form_template", pages: PAGES,
+      context: JSON.stringify({ patientFields: [{ key: "pesel", label: "PESEL" }] }),
+    });
+    const row = (await createSupabaseDb().get("documentAnalysisJobs", String(jobId))) as Record<string, unknown>;
+    expect(row?.status).toBe("pending");
+    expect(row?.kind).toBe("form_template");
+    expect(row?.organizationId).toBe(String(organizationId));
+    expect(row?.createdBy).toBe(String(userId));
+  });
+
+  test("createJob rejects unknown kind", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await expect(
+      t.withIdentity(identity).action(api.documentAnalysisJobs.createJob, {
+        organizationId, kind: "nope", pages: PAGES,
+      }),
+    ).rejects.toThrow(/unknown analysis kind/i);
+  });
+
+  test("runJob without provider records error status on the job (retryable)", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    const jobId = await t.withIdentity(identity).action(api.documentAnalysisJobs.createJob, {
+      organizationId, kind: "form_template", pages: PAGES,
+    });
+    const res = await t.withIdentity(identity).action(api.documentAnalysisJobs.runJob, {
+      organizationId, jobId: String(jobId),
+    });
+    expect(res.status).toBe("error");
+    const row = (await createSupabaseDb().get("documentAnalysisJobs", String(jobId))) as Record<string, unknown>;
+    expect(row?.status).toBe("error");
+    expect(String(row?.errorMessage)).toMatch(/not configured/i);
+    expect(typeof row?.completedAt).toBe("number");
+    // retry = to samo wywołanie, bez wyjątku
+    const res2 = await t.withIdentity(identity).action(api.documentAnalysisJobs.runJob, {
+      organizationId, jobId: String(jobId),
+    });
+    expect(res2.status).toBe("error");
+  });
+
+  test("getJob returns the row and hides other orgs' jobs", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    const jobId = await t.withIdentity(identity).action(api.documentAnalysisJobs.createJob, {
+      organizationId, kind: "form_template", pages: PAGES,
+    });
+    const job = await t.withIdentity(identity).action(api.documentAnalysisJobs.getJob, {
+      organizationId, jobId: String(jobId),
+    });
+    expect(job?.kind).toBe("form_template");
+
+    const other = await seedTestUser(t); // druga organizacja
+    await expect(
+      t.withIdentity(other.identity).action(api.documentAnalysisJobs.getJob, {
+        organizationId: other.organizationId, jobId: String(jobId),
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/tests/convex/openaiDocumentAnalyzer.test.ts
+++ b/tests/convex/openaiDocumentAnalyzer.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test, vi, beforeEach } from "vitest";
 import { OpenAIDocumentAnalyzer } from "../../convex/_ai/providers/openaiDocumentAnalyzer";
-import { getDocumentAnalyzer } from "../../convex/_ai/documentAnalyzer";
-import type { DocumentPage } from "../../convex/_ai/documentAnalyzer";
+import { getDocumentTransport, analyzeDocument } from "../../convex/_ai/documentAnalyzer";
+import type { DocumentPage, DocumentTransport } from "../../convex/_ai/documentAnalyzer";
+import { invoiceKind } from "../../convex/_ai/kinds/invoice";
 
 // ---------------------------------------------------------------------------
 // Hoist mock helpers so they can be referenced inside vi.mock()
@@ -74,6 +75,10 @@ const MINIMAL_VALID_RESPONSE = JSON.stringify({
   confidence: 0.95,
 });
 
+// Helper: runs invoice analysis through the full analyzeDocument pipeline
+const analyzeInvoice = (t: { run: DocumentTransport["run"] }, pages: DocumentPage[]) =>
+  analyzeDocument(t as DocumentTransport, invoiceKind, pages);
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -82,28 +87,28 @@ beforeEach(() => {
 // Factory — no configuration
 // ---------------------------------------------------------------------------
 
-describe("getDocumentAnalyzer — no configuration", () => {
+describe("getDocumentTransport — no configuration", () => {
   test("returns not_implemented when OPENAI_API_KEY is absent", async () => {
     vi.stubEnv("OPENAI_API_KEY", "");
-    const analyzer = getDocumentAnalyzer(NOOP_FETCHER);
+    const transport = getDocumentTransport(NOOP_FETCHER);
     const page: DocumentPage = { storageId: "x", mimeType: "image/jpeg", position: 1 };
-    const result = await analyzer.analyzeInvoice([page]);
+    const result = await analyzeInvoice(transport, [page]);
     expect(result.status).toBe("not_implemented");
     vi.unstubAllEnvs();
   });
 
-  test("NullDocumentAnalyzer returns no_pages for empty pages", async () => {
+  test("NullDocumentTransport returns no_pages for empty pages", async () => {
     vi.stubEnv("OPENAI_API_KEY", "");
-    const analyzer = getDocumentAnalyzer(NOOP_FETCHER);
-    const result = await analyzer.analyzeInvoice([]);
+    const transport = getDocumentTransport(NOOP_FETCHER);
+    const result = await analyzeInvoice(transport, []);
     expect(result.status).toBe("no_pages");
     vi.unstubAllEnvs();
   });
 
-  test("NullDocumentAnalyzer returns unsupported_format for unknown MIME", async () => {
+  test("NullDocumentTransport returns unsupported_format for unknown MIME", async () => {
     vi.stubEnv("OPENAI_API_KEY", "");
-    const analyzer = getDocumentAnalyzer(NOOP_FETCHER);
-    const result = await analyzer.analyzeInvoice([
+    const transport = getDocumentTransport(NOOP_FETCHER);
+    const result = await analyzeInvoice(transport, [
       { storageId: "x", mimeType: "image/gif", position: 1 },
     ]);
     expect(result.status).toBe("unsupported_format");
@@ -121,14 +126,14 @@ describe("getDocumentAnalyzer — no configuration", () => {
 describe("OpenAIDocumentAnalyzer — pre-call validation", () => {
   test("returns no_pages when pages array is empty", async () => {
     const analyzer = new OpenAIDocumentAnalyzer("sk-test", "gpt-4o", NOOP_FETCHER);
-    const result = await analyzer.analyzeInvoice([]);
+    const result = await analyzeInvoice(analyzer, []);
     expect(result.status).toBe("no_pages");
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
   test("returns unsupported_format for unknown MIME type", async () => {
     const analyzer = new OpenAIDocumentAnalyzer("sk-test", "gpt-4o", NOOP_FETCHER);
-    const result = await analyzer.analyzeInvoice([
+    const result = await analyzeInvoice(analyzer, [
       { storageId: "x", mimeType: "image/tiff", position: 1 },
     ]);
     expect(result.status).toBe("unsupported_format");
@@ -140,7 +145,7 @@ describe("OpenAIDocumentAnalyzer — pre-call validation", () => {
 
   test("returns error when file is not found in storage", async () => {
     const analyzer = new OpenAIDocumentAnalyzer("sk-test", "gpt-4o", NOOP_FETCHER);
-    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+    const result = await analyzeInvoice(analyzer, makePages(["image/jpeg"]));
     expect(result.status).toBe("error");
     if (result.status === "error") {
       expect(result.message).toMatch(/not found/i);
@@ -153,7 +158,7 @@ describe("OpenAIDocumentAnalyzer — pre-call validation", () => {
       throw new Error("Storage unavailable");
     };
     const analyzer = new OpenAIDocumentAnalyzer("sk-test", "gpt-4o", throwingFetcher);
-    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+    const result = await analyzeInvoice(analyzer, makePages(["image/jpeg"]));
     expect(result.status).toBe("error");
     if (result.status === "error") {
       expect(result.message).toContain("Storage unavailable");
@@ -176,7 +181,7 @@ describe("OpenAIDocumentAnalyzer — correct mapping from model response", () =>
       "gpt-4o",
       fakeFetcher(makeBlob()),
     );
-    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+    const result = await analyzeInvoice(analyzer, makePages(["image/jpeg"]));
 
     expect(result.status).toBe("ok");
     if (result.status !== "ok") return;
@@ -235,7 +240,7 @@ describe("OpenAIDocumentAnalyzer — correct mapping from model response", () =>
       "gpt-4o",
       fakeFetcher(makeBlob()),
     );
-    const result = await analyzer.analyzeInvoice(makePages(["image/png"]));
+    const result = await analyzeInvoice(analyzer, makePages(["image/png"]));
 
     expect(result.status).toBe("ok");
     if (result.status !== "ok") return;
@@ -267,7 +272,7 @@ describe("OpenAIDocumentAnalyzer — multi-page invoice", () => {
       { storageId: "page-3", mimeType: "image/png", position: 3 },
     ];
 
-    const result = await analyzer.analyzeInvoice(pages);
+    const result = await analyzeInvoice(analyzer, pages);
     expect(result.status).toBe("ok");
 
     // Model must have been called exactly once with all three pages as content
@@ -290,7 +295,7 @@ describe("OpenAIDocumentAnalyzer — multi-page invoice", () => {
     };
 
     const analyzer = new OpenAIDocumentAnalyzer("sk-test", "gpt-4o", trackingFetcher);
-    await analyzer.analyzeInvoice([
+    await analyzeInvoice(analyzer, [
       { storageId: "c", mimeType: "image/jpeg", position: 3 },
       { storageId: "a", mimeType: "image/jpeg", position: 1 },
       { storageId: "b", mimeType: "image/jpeg", position: 2 },
@@ -309,7 +314,7 @@ describe("OpenAIDocumentAnalyzer — multi-page invoice", () => {
       "gpt-4o",
       fakeFetcher(makeBlob()),
     );
-    const result = await analyzer.analyzeInvoice([
+    const result = await analyzeInvoice(analyzer, [
       { storageId: "pdf", mimeType: "application/pdf", position: 1 },
       { storageId: "img", mimeType: "image/jpeg", position: 2 },
     ]);
@@ -338,7 +343,7 @@ describe("OpenAIDocumentAnalyzer — error handling", () => {
       "gpt-4o",
       fakeFetcher(makeBlob()),
     );
-    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+    const result = await analyzeInvoice(analyzer, makePages(["image/jpeg"]));
 
     expect(result.status).toBe("error");
     if (result.status === "error") {
@@ -356,7 +361,7 @@ describe("OpenAIDocumentAnalyzer — error handling", () => {
       "gpt-4o",
       fakeFetcher(makeBlob()),
     );
-    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+    const result = await analyzeInvoice(analyzer, makePages(["image/jpeg"]));
 
     expect(result.status).toBe("error");
     if (result.status === "error") {
@@ -374,7 +379,7 @@ describe("OpenAIDocumentAnalyzer — error handling", () => {
       "gpt-4o",
       fakeFetcher(makeBlob()),
     );
-    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+    const result = await analyzeInvoice(analyzer, makePages(["image/jpeg"]));
 
     expect(result.status).toBe("error");
     if (result.status === "error") {
@@ -390,7 +395,7 @@ describe("OpenAIDocumentAnalyzer — error handling", () => {
       "gpt-4o",
       fakeFetcher(makeBlob()),
     );
-    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+    const result = await analyzeInvoice(analyzer, makePages(["image/jpeg"]));
 
     expect(result.status).toBe("error");
     if (result.status === "error") {
@@ -406,7 +411,7 @@ describe("OpenAIDocumentAnalyzer — error handling", () => {
       "gpt-4o",
       fakeFetcher(makeBlob()),
     );
-    const result = await analyzer.analyzeInvoice(makePages(["image/jpeg"]));
+    const result = await analyzeInvoice(analyzer, makePages(["image/jpeg"]));
 
     expect(result.status).toBe("error");
     if (result.status === "error") {


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-07-16-ocr-template-generation-design.md` (plan: `docs/superpowers/plans/2026-07-16-ocr-template-generation.md`).

## What

- **Provider OCR refactored to pure transport**; analysis kinds are plugins (`convex/_ai/kinds/`). Invoice = first kind, **no behavior change** — existing analyzer tests adapted with identical assertions; deliveries flow untouched.
- **New kind `form_template`**: scan/PDF → structured template with detected fillable fields (TipTap `formField` nodes) + patient-record mapping hints (allowlist-restricted, `builtin:*` only).
- **Generic `document_analysis_jobs` table** (migration `00063`, RLS org-isolation, applies via CI on merge) + `createJob`/`runJob`/`getJob` actions (org-isolated, tested incl. cross-org and empty-pages guard).
- **UI**: "Nowy ze skanu" dialog on the templates list (multi-file PDF/JPG/PNG upload) → editor opens prefilled for verification (banner + confidence); save path unchanged — `variableBindings` derive automatically, so scan-generated templates write back to the patient record after signing (2026-07-09 feature).
- i18n PL+EN complete.

**Horizontal criterion:** adding a future analysis kind = one file in `convex/_ai/kinds/` + a registry entry — verified in final review (no kind-specific coupling in transport/jobs/actions).

## Verification

- Unit: 309 convex + 119 frontend tests green (incl. new: invoice-kind regression, form_template kind, mapper, jobs actions).
- `tsc` convex: 0 errors; app: 0 new vs main (29 pre-existing in untouched files).
- Per-task reviews (7 tasks, 2 fix loops) + final whole-branch review (opus): **Ready to merge — Yes**; 0 Critical, 0 Important.

## Manual E2E checklist (requires dev env with `OPENAI_API_KEY` — complete before final merge)

- [ ] Invoice analysis on deliveries still works (regression)
- [ ] Scan a consent form → "Nowy ze skanu" → editor shows structure + detected fields + mapping hints → save
- [ ] Saved template works in fill/sign flow
- [ ] After signing, a `builtin:*`-mapped field populates an empty patient record field

## Non-blocking follow-ups (from final review)

- Banner: theme tokens instead of raw blue-* (dark mode); gate on scan-provenance instead of `confidence !== null`
- Tech-debt: cron cleanup for old analysis jobs; `runJob` short-circuit for already-ok jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)