### PR TITLE
Rozwiń pola pakietu w formularzu tworzenia zabiegu

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -61,6 +61,12 @@ export interface TreatmentFormData {
   color?: string | null;
   treatmentCount?: number;
   packageId?: string | null;
+  inlinePackageData?: {
+    count: number;
+    totalPrice: number;
+    validityDays?: number | null;
+    name: string;
+  } | null;
   requiredFormTemplates?: RequiredFormTemplateValue[];
   products?: TreatmentProductLine[];
   materials?: TreatmentProductLine[];
@@ -137,6 +143,13 @@ export function TreatmentForm({
   const [selectedPackageId, setSelectedPackageId] = useState<string>(
     initialPackageId ?? "",
   );
+
+  const [pkgCount, setPkgCount] = useState("");
+  const [pkgTotalPrice, setPkgTotalPrice] = useState("");
+  const [pkgValidityAmount, setPkgValidityAmount] = useState("");
+  const [pkgValidityUnit, setPkgValidityUnit] = useState<"days" | "months">("months");
+  const [pkgName, setPkgName] = useState("");
+  const [pkgNameEdited, setPkgNameEdited] = useState(false);
 
   const [productLines, setProductLines] = useState<TreatmentProductLine[]>(
     initialData?.products ?? [],
@@ -283,7 +296,20 @@ export function TreatmentForm({
       aftercareInstructions: initialData?.aftercareInstructions ?? null,
       requiresApproval: requiresApproval || undefined,
       color: initialData?.color ?? null,
-      packageId: isPackage && selectedPackageId ? selectedPackageId : null,
+      packageId: isPackage && initialPackageId && selectedPackageId ? selectedPackageId : null,
+      inlinePackageData:
+        isPackage && !initialPackageId && pkgCount && pkgTotalPrice
+          ? {
+              count: parseInt(pkgCount, 10),
+              totalPrice: parseFloat(pkgTotalPrice.replace(",", ".")),
+              validityDays: pkgValidityAmount
+                ? pkgValidityUnit === "months"
+                  ? parseInt(pkgValidityAmount, 10) * 30
+                  : parseInt(pkgValidityAmount, 10)
+                : null,
+              name: pkgName.trim() || `${name} – ${pkgCount} zabiegów`,
+            }
+          : null,
       requiredFormTemplates,
       products: validProducts,
       materials: validMaterials,
@@ -311,7 +337,13 @@ export function TreatmentForm({
           </Label>
           <Input
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e) => {
+              const n = e.target.value;
+              setName(n);
+              if (isPackage && !initialPackageId && !pkgNameEdited) {
+                setPkgName(pkgCount ? `${n} – ${pkgCount} zabiegów` : "");
+              }
+            }}
             required
             aria-invalid={!!fieldErr("name")}
             className={fieldErr("name") ? errorClass : undefined}
@@ -356,6 +388,11 @@ export function TreatmentForm({
             className={fieldErr("price") ? errorClass : undefined}
           />
           {renderFieldError("price")}
+          {isPackage && !initialPackageId && (
+            <p className="text-xs text-muted-foreground">
+              {t("gabinet.treatments.pricePerSessionHint", "Cena jednej sesji zabiegu.")}
+            </p>
+          )}
         </div>
         <div className="space-y-1.5">
           <Label>{t("gabinet.treatments.currency")}</Label>
@@ -398,6 +435,15 @@ export function TreatmentForm({
                 setIsPackage(next);
                 if (!next) {
                   setSelectedPackageId("");
+                  setPkgCount("");
+                  setPkgTotalPrice("");
+                  setPkgValidityAmount("");
+                  setPkgValidityUnit("months");
+                  setPkgName("");
+                  setPkgNameEdited(false);
+                } else if (!initialPackageId) {
+                  // Auto-generate name from current treatment name if already entered
+                  if (name) setPkgName(name + " – __ zabiegów");
                 }
               }}
             />
@@ -406,7 +452,7 @@ export function TreatmentForm({
             </Label>
           </div>
         </div>
-        {isPackage && (
+        {isPackage && !!initialPackageId && (
           <div className="space-y-1.5">
             <Label>{t("gabinet.treatments.linkedPackage", "Powiązany pakiet")}</Label>
             <Select
@@ -448,6 +494,114 @@ export function TreatmentForm({
                 "Wybierz pakiet z zakładki \"Pakiety\" — liczba zabiegów zostanie pobrana z pakietu.",
               )}
             </p>
+          </div>
+        )}
+        {isPackage && !initialPackageId && (
+          <div className="space-y-3 sm:col-span-2 rounded-md border p-3 bg-muted/30">
+            <p className="text-xs font-medium text-muted-foreground">
+              {t("gabinet.treatments.inlinePackageSection", "Dane pakietu")}
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label>
+                  {t("gabinet.treatments.packageName", "Nazwa pakietu")}{" "}
+                  <span className="text-destructive">*</span>
+                </Label>
+                <Input
+                  value={pkgName}
+                  onChange={(e) => {
+                    setPkgName(e.target.value);
+                    setPkgNameEdited(true);
+                  }}
+                  placeholder={t(
+                    "gabinet.treatments.packageNamePlaceholder",
+                    "np. Peeling chemiczny – 5 zabiegów",
+                  )}
+                  required={isPackage && !initialPackageId}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>
+                  {t("gabinet.treatments.packageCount", "Liczba zabiegów w pakiecie")}{" "}
+                  <span className="text-destructive">*</span>
+                </Label>
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  min="2"
+                  step="1"
+                  value={pkgCount}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    setPkgCount(val);
+                    if (!pkgNameEdited && name) {
+                      setPkgName(`${name} – ${val} zabiegów`);
+                    }
+                  }}
+                  onWheel={(e) => (e.currentTarget as HTMLInputElement).blur()}
+                  placeholder="5"
+                  required={isPackage && !initialPackageId}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>
+                  {t("gabinet.treatments.packageTotalPrice", "Cena całego pakietu")}{" "}
+                  <span className="text-destructive">*</span>
+                </Label>
+                <Input
+                  type="text"
+                  inputMode="decimal"
+                  value={pkgTotalPrice}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                      setPkgTotalPrice(v);
+                    }
+                  }}
+                  placeholder="0.00"
+                  required={isPackage && !initialPackageId}
+                />
+              </div>
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label>
+                  {t("gabinet.treatments.packageValidity", "Okres ważności")}
+                </Label>
+                <div className="flex gap-2">
+                  <Input
+                    type="number"
+                    inputMode="numeric"
+                    min="1"
+                    value={pkgValidityAmount}
+                    onChange={(e) => setPkgValidityAmount(e.target.value)}
+                    onWheel={(e) => (e.currentTarget as HTMLInputElement).blur()}
+                    placeholder={t("gabinet.treatments.packageValidityPlaceholder", "np. 6")}
+                    className="flex-1"
+                  />
+                  <Select
+                    value={pkgValidityUnit}
+                    onValueChange={(v) => setPkgValidityUnit(v as "days" | "months")}
+                  >
+                    <SelectTrigger className="w-32">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="months">
+                        {t("gabinet.treatments.packageValidityMonths", "miesięcy")}
+                      </SelectItem>
+                      <SelectItem value="days">
+                        {t("gabinet.treatments.packageValidityDays", "dni")}
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {t(
+                    "gabinet.treatments.packageValidityHint",
+                    "Opcjonalnie. Liczba miesięcy lub dni od zakupu, po których pakiet wygasa.",
+                  )}
+                </p>
+              </div>
+            </div>
           </div>
         )}
         <div className="space-y-1.5">

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -107,6 +107,7 @@ function TreatmentsIndex() {
   const removeTreatment = useAction(api.gabinet.treatments.remove);
   const getTreatmentProductsAction = useAction(api.gabinet.treatments.getTreatmentProducts);
   const setTreatmentProductsAction = useAction(api.gabinet.treatments.setTreatmentProducts);
+  const createPackage = useAction(api.gabinet.packages.create);
 
   const { allowed: canEdit } = usePermission("gabinet_treatments", "edit");
   const { allowed: canDelete } = usePermission("gabinet_treatments", "delete");
@@ -493,7 +494,7 @@ function TreatmentsIndex() {
       setIsSubmitting(true);
       setFieldErrors({});
       try {
-        const { products, materials, ...treatmentData } = formData;
+        const { products, materials, inlinePackageData, ...treatmentData } = formData;
         const allProductLinks = [
           ...(products ?? []).map((p) => ({
             productId: p.productId,
@@ -512,6 +513,7 @@ function TreatmentsIndex() {
         // step can reference it even if the main catch fires (it won't fire
         // after this point because we close the panel before the product step).
         let savedTreatmentId: string | null = null;
+        let isNewTreatment = false;
 
         if (editingTreatment) {
           await updateTreatment({
@@ -530,6 +532,7 @@ function TreatmentsIndex() {
             categoryId,
           });
           savedTreatmentId = newTreatmentId;
+          isNewTreatment = true;
         }
 
         // Main write succeeded — close the panel now so a product-link failure
@@ -539,6 +542,37 @@ function TreatmentsIndex() {
         setEditingTreatment(null);
         setTagIds([]);
         setCategoryId(undefined);
+
+        // Auto-create package from inline form data (create case only).
+        if (isNewTreatment && inlinePackageData && savedTreatmentId) {
+          try {
+            const newPackageId = await createPackage({
+              organizationId,
+              name: inlinePackageData.name,
+              treatments: [{ treatmentId: savedTreatmentId, quantity: inlinePackageData.count }],
+              totalPrice: inlinePackageData.totalPrice,
+              validityDays: inlinePackageData.validityDays ?? null,
+            });
+            await updateTreatment({
+              organizationId,
+              treatmentId: savedTreatmentId,
+              packageId: newPackageId,
+            });
+          } catch (pkgErr) {
+            void reportError(pkgErr, {
+              scope: "gabinet.treatments",
+              fnName: "createInlinePackage",
+              argsJson: JSON.stringify({ treatmentId: savedTreatmentId }),
+              organizationId,
+            });
+            toast.warning(
+              t("gabinet.treatments.errors.packageCreateFailed", {
+                defaultValue:
+                  "Zabieg zapisany. Nie udało się utworzyć pakietu — przejdź do zakładki \"Pakiety\" i utwórz ręcznie.",
+              }),
+            );
+          }
+        }
 
         // Save product/material links separately. Failure here does NOT mean
         // the treatment was lost — only that the ingredient recipe needs to be
@@ -607,7 +641,7 @@ function TreatmentsIndex() {
         setIsSubmitting(false);
       }
     },
-    [editingTreatment, createTreatment, updateTreatment, setTreatmentProductsAction, organizationId, tagIds, categoryId, t],
+    [editingTreatment, createTreatment, updateTreatment, setTreatmentProductsAction, createPackage, organizationId, tagIds, categoryId, t],
   );
 
   const handleBulkAction = useCallback(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3202.

Closes #3202

---

## Claude summary

Done. Here's a summary of what changed and how to test manually:

---

**Changed files:**

`src/components/gabinet/treatment-form.tsx` — When "Ten zabieg to pakiet" is checked on a **new** treatment (no prior `packageId`), a "Dane pakietu" section expands with:
- **Nazwa pakietu** (required) — auto-filled as `[nazwa zabiegu] – [liczba] zabiegów` as the user types; editable
- **Liczba zabiegów w pakiecie** (required, integer ≥ 2) — typing updates the auto-name
- **Cena całego pakietu** (required)
- **Okres ważności** (optional number + months/days select)

The existing "Cena" field shows a hint "Cena jednej sesji zabiegu." when the package section is open. The old package-selector dropdown is preserved only for edit mode when a package is already linked.

`src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx` — After creating a treatment with inline package data: calls `packages.create` (with `treatmentId` + count, totalPrice, validityDays), then calls `treatments.update` to link the new `packageId`. Failure shows a toast warning while keeping the treatment.

**Manual test steps:**
1. Open Gabinet → Zabiegi → "Utwórz zabieg"
2. Enter treatment name (e.g. "Peeling chemiczny"), duration, price
3. Check "Ten zabieg to pakiet" → verify no package selector appears; "Dane pakietu" section appears instead
4. Enter count "5" → verify package name auto-fills as "Peeling chemiczny – 5 zabiegów"
5. Edit name → verify it stops auto-updating
6. Enter package total price, optionally validity
7. Save → verify treatment is created, then package "Peeling chemiczny – 5 zabiegów" appears in Pakiety tab with the treatment linked
8. Edit the saved treatment → verify checkbox state matches and package selector (old UI) shows for edit