### PR TITLE
Udostępnij pakiety zabiegowe w procesie sprzedaży

### DIFF
--- a/src/components/gabinet/sell-package-panel.tsx
+++ b/src/components/gabinet/sell-package-panel.tsx
@@ -20,6 +20,7 @@ import {
 import { Loader2 } from "@/lib/ez-icons";
 import { useSupabaseGabinetTreatmentPackagesList } from "@/hooks/use-supabase-gabinet-packages";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
+import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatActionError } from "@/lib/format-action-error";
 import { formatCurrencyPLN } from "@/lib/format-currency";
@@ -45,6 +46,12 @@ export function SellPackagePanel({
 
   const { data: packagesData } = useSupabaseGabinetTreatmentPackagesList(organizationId);
   const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId);
+  const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId);
+
+  const treatmentMap = useMemo(
+    () => new Map((treatmentsData ?? []).map((tr) => [tr._id, tr.name])),
+    [treatmentsData],
+  );
 
   const [patientId, setPatientId] = useState<string>("");
   const [packageId, setPackageId] = useState<string>("");
@@ -224,6 +231,36 @@ export function SellPackagePanel({
             </SelectContent>
           </Select>
         </div>
+
+        {selectedPkg && (
+          <div className="rounded-lg border p-3 space-y-2 text-sm">
+            <p className="font-medium">{selectedPkg.name}</p>
+            <div className="space-y-1">
+              {selectedPkg.treatments.map((tr) => (
+                <div
+                  key={tr.treatmentId}
+                  className="flex items-center justify-between text-xs"
+                >
+                  <span>{treatmentMap.get(tr.treatmentId) ?? t("common.unknown")}</span>
+                  <span className="text-muted-foreground">&times;{tr.quantity}</span>
+                </div>
+              ))}
+            </div>
+            <div className="flex items-center justify-between border-t pt-1">
+              <span>{t("gabinet.packages.totalPrice")}</span>
+              <span className="font-bold">
+                {formatCurrencyPLN(selectedPkg.totalPrice, selectedPkg.currency ?? "PLN")}
+              </span>
+            </div>
+            {selectedPkg.validityDays && (
+              <p className="text-xs text-muted-foreground">
+                {t("gabinet.packages.validFor", "Ważny przez")}{" "}
+                {selectedPkg.validityDays}{" "}
+                {t("gabinet.packages.days", "dni")}
+              </p>
+            )}
+          </div>
+        )}
 
         <div className="space-y-1.5">
           <Label>{t("gabinet.packages.paymentMethod")}</Label>

--- a/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
+++ b/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
@@ -22,6 +22,7 @@ import { useSidebarActions } from "@/components/layout/sidebar-context";
 import { usePermission } from "@/hooks/use-permission";
 import { useOrganization } from "@/components/org-context";
 import { SellTreatmentPanel } from "@/components/gabinet/sell-treatment-panel";
+import { SellPackagePanel } from "@/components/gabinet/sell-package-panel";
 
 export function GabinetQuickActionsDropdown() {
   const { t } = useTranslation();
@@ -30,6 +31,7 @@ export function GabinetQuickActionsDropdown() {
   const { allowed: canManageLeaves } = usePermission("gabinet_settings", "edit");
   const { organizationId } = useOrganization();
   const [sellTreatmentOpen, setSellTreatmentOpen] = useState(false);
+  const [sellPackageOpen, setSellPackageOpen] = useState(false);
 
   // "Umów wizytę" routes through the calendar so every appointment entry
   // point opens the same AppointmentDialog (issue #1506).
@@ -84,6 +86,13 @@ export function GabinetQuickActionsDropdown() {
         </DropdownMenuItem>
         <DropdownMenuItem
           className="px-3 py-2.5 text-sm"
+          onSelect={() => setSellPackageOpen(true)}
+        >
+          <Package className="text-foreground size-5 shrink-0" />
+          {t("sidebar.gabinet.sellPackage", "Sprzedaj pakiet")}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="px-3 py-2.5 text-sm"
           onSelect={() => openQuickCreate("package")}
         >
           <Package className="text-foreground size-5" />
@@ -118,6 +127,11 @@ export function GabinetQuickActionsDropdown() {
       organizationId={organizationId}
       open={sellTreatmentOpen}
       onOpenChange={setSellTreatmentOpen}
+    />
+    <SellPackagePanel
+      organizationId={organizationId}
+      open={sellPackageOpen}
+      onOpenChange={setSellPackageOpen}
     />
     </>
   );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3205.

Closes #3205

---

## Claude summary

Done. Here's a summary of what was done and how to test it:

**Changed files:**

`src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx` — Added "Sprzedaj pakiet" menu item (with `Package` icon) right below "Sprzedaj produkt". It opens `SellPackagePanel` with the org context, the same way the treatment panel is wired.

`src/components/gabinet/sell-package-panel.tsx` — Added treatment-name lookup via `useSupabaseGabinetTreatmentsList` and a detail card that appears when a package is selected. The card shows: package name, each included treatment (name × quantity), total price, and validity period if set.

**How to test:**

1. Open the Gabinet module sidebar → click the quick-actions "+" button → you should now see **"Sprzedaj pakiet"** between "Sprzedaj produkt" and "Dodaj pakiet".
2. Click it → the Sell Package panel opens. Select a patient, then select a package (including inline packages created from the Treatments module).
3. After selecting a package, a detail card should appear showing: name, treatment(s) with session count, price, and validity days if configured.
4. Complete the sale → a `gabinetPackageUsage` record is created (status: active, purchasedAt, treatmentsUsed with totalCount, expiresAt from validityDays).
5. The patient card already has `PackagePurchaseDrawer` — verify it still works unchanged.

**No backend changes were needed** — `purchasePackage` already creates the complete `gabinetPackageUsage` record with all required fields (purchase date, total/remaining counts via `treatmentsUsed`, expiry date, base treatment link via `packageId → autoGeneratedForTreatmentId`).

## Follow-ups

- Deduplicate `PackagePurchaseDrawer` vs `SellPackagePanel`: both implement near-identical payment logic (split, installments, method selection); the pattern is repeated in ~400 lines across two components and should be extracted into a shared hook or form.
- `SellPackagePanel` uses `useSupabaseGabinetTreatmentPackagesList` (fetches all packages, filters `isActive` client-side) while `PackagePurchaseDrawer` uses `api.gabinet.packages.listActive` (Convex action with RBAC scope check); the two panels apply different permission models for the same operation.
- `useSupabaseGabinetTreatmentsList` defaults to `limit: 100` — clinics with >100 treatments will silently get incomplete treatment-name resolution in the package detail card; the hook should support pagination or an `isActive` filter.