### PR TITLE
Deduplicate `PackagePurchaseDrawer` vs `SellPackagePanel`

### DIFF
--- a/src/components/gabinet/package-purchase-drawer.tsx
+++ b/src/components/gabinet/package-purchase-drawer.tsx
@@ -7,7 +7,6 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Sheet,
@@ -27,6 +26,8 @@ import { Loader2 } from "@/lib/ez-icons";
 import { PlateText } from "@/components/plate-text";
 import { formatActionError } from "@/lib/format-action-error";
 import { formatCurrencyPLN } from "@/lib/format-currency";
+import { usePackagePaymentForm } from "@/hooks/use-package-payment-form";
+import { PackageSplitPaymentSection } from "./package-split-payment-section";
 
 interface PackagePurchaseDrawerProps {
   patientId: string;
@@ -47,14 +48,7 @@ export function PackagePurchaseDrawer({
 
   const [selectedPkgId, setSelectedPkgId] = useState<string>("");
   const [paymentType, setPaymentType] = useState<"one_time" | "installment">("one_time");
-  const [paymentMethod, setPaymentMethod] = useState<string>("cash");
-  const [splitPayment, setSplitPayment] = useState(false);
-  const [firstSplitMethod, setFirstSplitMethod] = useState<"cash" | "card" | "transfer" | "other">("cash");
-  const [secondSplitMethod, setSecondSplitMethod] = useState<"cash" | "card" | "transfer" | "other">("card");
-  const [firstSplitAmount, setFirstSplitAmount] = useState<string>("");
-  const [secondSplitAmount, setSecondSplitAmount] = useState<string>("");
   const [installmentCount, setInstallmentCount] = useState<string>("2");
-  const [submitting, setSubmitting] = useState(false);
 
   const listActivePackages = useAction(api.gabinet.packages.listActive);
   const { data: activePackages } = useQuery({
@@ -90,34 +84,48 @@ export function PackagePurchaseDrawer({
     ? Math.round((installmentAmount + installmentRemainder) * 100) / 100
     : 0;
 
-  const parsedFirstSplit = Number.parseFloat(firstSplitAmount.replace(",", ".")) || 0;
-  const parsedSecondSplit = Number.parseFloat(secondSplitAmount.replace(",", ".")) || 0;
-  const splitTotal = Math.round((parsedFirstSplit + parsedSecondSplit) * 100) / 100;
-  const splitExpectedTotal = selectedPkg
+  const effectiveTotalForSplit = selectedPkg
     ? isInstallment
       ? firstInstallmentAmount
-      : Math.round(selectedPkg.totalPrice * 100) / 100
+      : selectedPkg.totalPrice
     : 0;
-  const splitMismatch = splitPayment && selectedPkg && splitTotal !== splitExpectedTotal;
-  const splitMissingMethod = splitPayment && parsedFirstSplit <= 0 && parsedSecondSplit <= 0;
-  const splitSameMethod = splitPayment && firstSplitMethod === secondSplitMethod;
+
+  const {
+    paymentMethod,
+    setPaymentMethod,
+    splitPayment,
+    setSplitPayment,
+    firstSplitMethod,
+    setFirstSplitMethod,
+    secondSplitMethod,
+    setSecondSplitMethod,
+    firstSplitAmount,
+    setFirstSplitAmount,
+    secondSplitAmount,
+    setSecondSplitAmount,
+    submitting,
+    setSubmitting,
+    parsedFirstSplit,
+    parsedSecondSplit,
+    splitTotal,
+    splitExpectedTotal,
+    splitMismatch,
+    splitMissingAmount,
+    splitSameMethod,
+    resetPaymentForm,
+  } = usePackagePaymentForm(effectiveTotalForSplit);
 
   const resetForm = () => {
     setSelectedPkgId("");
     setPaymentType("one_time");
-    setPaymentMethod("cash");
-    setSplitPayment(false);
-    setFirstSplitMethod("cash");
-    setSecondSplitMethod("card");
-    setFirstSplitAmount("");
-    setSecondSplitAmount("");
     setInstallmentCount("2");
+    resetPaymentForm();
   };
 
   const handlePurchase = async () => {
     if (!selectedPkg) return;
     if (splitPayment) {
-      if (splitMissingMethod) {
+      if (splitMissingAmount) {
         toast.error(
           t(
             "gabinet.packages.splitMissingAmount",
@@ -161,7 +169,7 @@ export function PackagePurchaseDrawer({
 
       if (isInstallment) {
         if (splitPayment) {
-          const parts: Array<{ method: "cash" | "card" | "transfer" | "other"; amount: number }> = [];
+          const parts: Array<{ method: typeof firstSplitMethod; amount: number }> = [];
           if (parsedFirstSplit > 0)
             parts.push({ method: firstSplitMethod, amount: parsedFirstSplit });
           if (parsedSecondSplit > 0)
@@ -201,7 +209,7 @@ export function PackagePurchaseDrawer({
           });
         }
       } else if (splitPayment) {
-        const parts: Array<{ method: "cash" | "card" | "transfer" | "other"; amount: number }> = [];
+        const parts: Array<{ method: typeof firstSplitMethod; amount: number }> = [];
         if (parsedFirstSplit > 0)
           parts.push({ method: firstSplitMethod, amount: parsedFirstSplit });
         if (parsedSecondSplit > 0)
@@ -421,97 +429,21 @@ export function PackagePurchaseDrawer({
           )}
 
           {splitPayment && (
-            <div className="rounded-lg border p-3 space-y-3">
-              <div className="grid grid-cols-2 gap-3">
-                <div className="rounded-md border p-2 space-y-2">
-                  <Label className="text-xs font-medium">
-                    {t("gabinet.packages.firstMethod", "First method")}
-                  </Label>
-                  <Select
-                    value={firstSplitMethod}
-                    onValueChange={(v) =>
-                      setFirstSplitMethod(v as typeof firstSplitMethod)
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="cash">{t("gabinet.packages.paymentMethods.cash", "Cash")}</SelectItem>
-                      <SelectItem value="card">{t("gabinet.packages.paymentMethods.card", "Card")}</SelectItem>
-                      <SelectItem value="transfer">{t("gabinet.packages.paymentMethods.transfer", "Transfer")}</SelectItem>
-                      <SelectItem value="other">{t("gabinet.packages.paymentMethods.other", "Other")}</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <Input
-                    id="split-first-amount"
-                    type="text"
-                    inputMode="decimal"
-                    placeholder="0.00"
-                    value={firstSplitAmount}
-                    onChange={(e) => {
-                      const v = e.target.value;
-                      if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
-                        setFirstSplitAmount(v);
-                      }
-                    }}
-                  />
-                </div>
-                <div className="rounded-md border p-2 space-y-2">
-                  <Label className="text-xs font-medium">
-                    {t("gabinet.packages.secondMethod", "Second method")}
-                  </Label>
-                  <Select
-                    value={secondSplitMethod}
-                    onValueChange={(v) =>
-                      setSecondSplitMethod(v as typeof secondSplitMethod)
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="cash">{t("gabinet.packages.paymentMethods.cash", "Cash")}</SelectItem>
-                      <SelectItem value="card">{t("gabinet.packages.paymentMethods.card", "Card")}</SelectItem>
-                      <SelectItem value="transfer">{t("gabinet.packages.paymentMethods.transfer", "Transfer")}</SelectItem>
-                      <SelectItem value="other">{t("gabinet.packages.paymentMethods.other", "Other")}</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <Input
-                    id="split-second-amount"
-                    type="text"
-                    inputMode="decimal"
-                    placeholder="0.00"
-                    value={secondSplitAmount}
-                    onChange={(e) => {
-                      const v = e.target.value;
-                      if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
-                        setSecondSplitAmount(v);
-                      }
-                    }}
-                  />
-                </div>
-              </div>
-              <div
-                className={`flex items-center justify-between text-xs ${
-                  splitMismatch || splitSameMethod ? "text-destructive" : "text-muted-foreground"
-                }`}
-              >
-                <span>
-                  {t("gabinet.packages.splitSum", "Sum")}: {splitTotal.toFixed(2)} /{" "}
-                  {formatCurrencyPLN(splitExpectedTotal, selectedPkg?.currency ?? "PLN")}
-                </span>
-                {splitSameMethod ? (
-                  <span>
-                    {t("gabinet.packages.splitSameMethod", "Methods must differ")}
-                  </span>
-                ) : splitMismatch ? (
-                  <span>
-                    {t("gabinet.packages.splitMismatch", "Must equal total")}
-                  </span>
-                ) : null}
-              </div>
-            </div>
+            <PackageSplitPaymentSection
+              firstSplitMethod={firstSplitMethod}
+              onFirstSplitMethodChange={setFirstSplitMethod}
+              secondSplitMethod={secondSplitMethod}
+              onSecondSplitMethodChange={setSecondSplitMethod}
+              firstSplitAmount={firstSplitAmount}
+              onFirstSplitAmountChange={setFirstSplitAmount}
+              secondSplitAmount={secondSplitAmount}
+              onSecondSplitAmountChange={setSecondSplitAmount}
+              splitTotal={splitTotal}
+              splitExpectedTotal={splitExpectedTotal}
+              splitMismatch={splitMismatch}
+              splitSameMethod={splitSameMethod}
+              currency={selectedPkg?.currency ?? "PLN"}
+            />
           )}
 
         </div>
@@ -522,7 +454,7 @@ export function PackagePurchaseDrawer({
             disabled={
               !selectedPkg ||
               submitting ||
-              (splitPayment && (splitMissingMethod || !!splitMismatch || splitSameMethod))
+              (splitPayment && (splitMissingAmount || !!splitMismatch || splitSameMethod))
             }
             onClick={handlePurchase}
           >

--- a/src/components/gabinet/package-split-payment-section.tsx
+++ b/src/components/gabinet/package-split-payment-section.tsx
@@ -1,0 +1,130 @@
+import { useTranslation } from "react-i18next";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { formatCurrencyPLN } from "@/lib/format-currency";
+import { cn } from "@/lib/utils";
+import type { PackagePaymentMethod } from "@/hooks/use-package-payment-form";
+
+interface PackageSplitPaymentSectionProps {
+  firstSplitMethod: PackagePaymentMethod;
+  onFirstSplitMethodChange: (m: PackagePaymentMethod) => void;
+  secondSplitMethod: PackagePaymentMethod;
+  onSecondSplitMethodChange: (m: PackagePaymentMethod) => void;
+  firstSplitAmount: string;
+  onFirstSplitAmountChange: (v: string) => void;
+  secondSplitAmount: string;
+  onSecondSplitAmountChange: (v: string) => void;
+  splitTotal: number;
+  splitExpectedTotal: number;
+  splitMismatch: boolean;
+  splitSameMethod: boolean;
+  currency?: string;
+}
+
+function SplitMethodSelect({
+  value,
+  onChange,
+}: {
+  value: PackagePaymentMethod;
+  onChange: (m: PackagePaymentMethod) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <Select value={value} onValueChange={(v) => onChange(v as PackagePaymentMethod)}>
+      <SelectTrigger>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="cash">{t("gabinet.packages.paymentMethods.cash")}</SelectItem>
+        <SelectItem value="card">{t("gabinet.packages.paymentMethods.card")}</SelectItem>
+        <SelectItem value="transfer">{t("gabinet.packages.paymentMethods.transfer")}</SelectItem>
+        <SelectItem value="other">{t("gabinet.packages.paymentMethods.other", "Inna")}</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}
+
+function SplitAmountInput({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <Input
+      type="text"
+      inputMode="decimal"
+      placeholder="0.00"
+      value={value}
+      onChange={(e) => {
+        const v = e.target.value;
+        if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+          onChange(v);
+        }
+      }}
+    />
+  );
+}
+
+export function PackageSplitPaymentSection({
+  firstSplitMethod,
+  onFirstSplitMethodChange,
+  secondSplitMethod,
+  onSecondSplitMethodChange,
+  firstSplitAmount,
+  onFirstSplitAmountChange,
+  secondSplitAmount,
+  onSecondSplitAmountChange,
+  splitTotal,
+  splitExpectedTotal,
+  splitMismatch,
+  splitSameMethod,
+  currency = "PLN",
+}: PackageSplitPaymentSectionProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="rounded-lg border p-3 space-y-3">
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-md border p-2 space-y-2">
+          <Label className="text-xs font-medium">
+            {t("gabinet.packages.firstMethod", "Pierwsza metoda")}
+          </Label>
+          <SplitMethodSelect value={firstSplitMethod} onChange={onFirstSplitMethodChange} />
+          <SplitAmountInput value={firstSplitAmount} onChange={onFirstSplitAmountChange} />
+        </div>
+        <div className="rounded-md border p-2 space-y-2">
+          <Label className="text-xs font-medium">
+            {t("gabinet.packages.secondMethod", "Druga metoda")}
+          </Label>
+          <SplitMethodSelect value={secondSplitMethod} onChange={onSecondSplitMethodChange} />
+          <SplitAmountInput value={secondSplitAmount} onChange={onSecondSplitAmountChange} />
+        </div>
+      </div>
+      <div
+        className={cn(
+          "flex items-center justify-between text-xs",
+          splitMismatch || splitSameMethod ? "text-destructive" : "text-muted-foreground",
+        )}
+      >
+        <span>
+          {t("gabinet.packages.splitSum", "Suma")}: {splitTotal.toFixed(2)} /{" "}
+          {formatCurrencyPLN(splitExpectedTotal, currency)}
+        </span>
+        {splitSameMethod ? (
+          <span>{t("gabinet.packages.splitSameMethod", "Metody muszą się różnić")}</span>
+        ) : splitMismatch ? (
+          <span>{t("gabinet.packages.splitMismatch", "Musi się zgadzać z ceną")}</span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/gabinet/sell-package-panel.tsx
+++ b/src/components/gabinet/sell-package-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
@@ -8,7 +8,6 @@ import { toast } from "sonner";
 import { SidePanel } from "@/components/crm/side-panel";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -24,9 +23,8 @@ import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-t
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatActionError } from "@/lib/format-action-error";
 import { formatCurrencyPLN } from "@/lib/format-currency";
-import { cn } from "@/lib/utils";
-
-type PaymentMethod = "cash" | "card" | "transfer" | "other";
+import { usePackagePaymentForm } from "@/hooks/use-package-payment-form";
+import { PackageSplitPaymentSection } from "./package-split-payment-section";
 
 interface SellPackagePanelProps {
   organizationId: Id<"organizations">;
@@ -55,39 +53,42 @@ export function SellPackagePanel({
 
   const [patientId, setPatientId] = useState<string>("");
   const [packageId, setPackageId] = useState<string>("");
-  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("cash");
-  const [splitPayment, setSplitPayment] = useState(false);
-  const [firstSplitMethod, setFirstSplitMethod] = useState<PaymentMethod>("cash");
-  const [secondSplitMethod, setSecondSplitMethod] = useState<PaymentMethod>("card");
-  const [firstSplitAmount, setFirstSplitAmount] = useState<string>("");
-  const [secondSplitAmount, setSecondSplitAmount] = useState<string>("");
-  const [submitting, setSubmitting] = useState(false);
 
   const selectedPkg = useMemo(
     () => (packagesData ?? []).find((p) => p._id === packageId),
     [packagesData, packageId],
   );
 
-  const parsedFirstSplit = Number.parseFloat(firstSplitAmount.replace(",", ".")) || 0;
-  const parsedSecondSplit = Number.parseFloat(secondSplitAmount.replace(",", ".")) || 0;
-  const splitTotal = Math.round((parsedFirstSplit + parsedSecondSplit) * 100) / 100;
-  const splitExpectedTotal = selectedPkg
-    ? Math.round(selectedPkg.totalPrice * 100) / 100
-    : 0;
-  const splitMismatch = splitPayment && !!selectedPkg && splitTotal !== splitExpectedTotal;
-  const splitMissingAmount = splitPayment && parsedFirstSplit <= 0 && parsedSecondSplit <= 0;
-  const splitSameMethod = splitPayment && firstSplitMethod === secondSplitMethod;
+  const {
+    paymentMethod,
+    setPaymentMethod,
+    splitPayment,
+    setSplitPayment,
+    firstSplitMethod,
+    setFirstSplitMethod,
+    secondSplitMethod,
+    setSecondSplitMethod,
+    firstSplitAmount,
+    setFirstSplitAmount,
+    secondSplitAmount,
+    setSecondSplitAmount,
+    submitting,
+    setSubmitting,
+    parsedFirstSplit,
+    parsedSecondSplit,
+    splitTotal,
+    splitExpectedTotal,
+    splitMismatch,
+    splitMissingAmount,
+    splitSameMethod,
+    resetPaymentForm,
+  } = usePackagePaymentForm(selectedPkg?.totalPrice ?? 0);
 
-  const reset = useCallback(() => {
+  const reset = () => {
     setPatientId("");
     setPackageId("");
-    setPaymentMethod("cash");
-    setSplitPayment(false);
-    setFirstSplitMethod("cash");
-    setSecondSplitMethod("card");
-    setFirstSplitAmount("");
-    setSecondSplitAmount("");
-  }, []);
+    resetPaymentForm();
+  };
 
   const handleSubmit = async () => {
     if (!patientId || !packageId || !selectedPkg) return;
@@ -133,7 +134,7 @@ export function SellPackagePanel({
       });
 
       if (splitPayment) {
-        const parts: Array<{ method: PaymentMethod; amount: number }> = [];
+        const parts: Array<{ method: typeof firstSplitMethod; amount: number }> = [];
         if (parsedFirstSplit > 0)
           parts.push({ method: firstSplitMethod, amount: parsedFirstSplit });
         if (parsedSecondSplit > 0)
@@ -266,7 +267,7 @@ export function SellPackagePanel({
           <Label>{t("gabinet.packages.paymentMethod")}</Label>
           <Select
             value={paymentMethod}
-            onValueChange={(v) => setPaymentMethod(v as PaymentMethod)}
+            onValueChange={(v) => setPaymentMethod(v as typeof paymentMethod)}
             disabled={splitPayment}
           >
             <SelectTrigger>
@@ -299,112 +300,21 @@ export function SellPackagePanel({
         </Label>
 
         {splitPayment && (
-          <div className="rounded-lg border p-3 space-y-3">
-            <div className="grid grid-cols-2 gap-3">
-              <div className="rounded-md border p-2 space-y-2">
-                <Label className="text-xs font-medium">
-                  {t("gabinet.packages.firstMethod", "Pierwsza metoda")}
-                </Label>
-                <Select
-                  value={firstSplitMethod}
-                  onValueChange={(v) => setFirstSplitMethod(v as PaymentMethod)}
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="cash">
-                      {t("gabinet.packages.paymentMethods.cash")}
-                    </SelectItem>
-                    <SelectItem value="card">
-                      {t("gabinet.packages.paymentMethods.card")}
-                    </SelectItem>
-                    <SelectItem value="transfer">
-                      {t("gabinet.packages.paymentMethods.transfer")}
-                    </SelectItem>
-                    <SelectItem value="other">
-                      {t("gabinet.packages.paymentMethods.other", "Inna")}
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                <Input
-                  type="text"
-                  inputMode="decimal"
-                  placeholder="0.00"
-                  value={firstSplitAmount}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
-                      setFirstSplitAmount(v);
-                    }
-                  }}
-                />
-              </div>
-              <div className="rounded-md border p-2 space-y-2">
-                <Label className="text-xs font-medium">
-                  {t("gabinet.packages.secondMethod", "Druga metoda")}
-                </Label>
-                <Select
-                  value={secondSplitMethod}
-                  onValueChange={(v) => setSecondSplitMethod(v as PaymentMethod)}
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="cash">
-                      {t("gabinet.packages.paymentMethods.cash")}
-                    </SelectItem>
-                    <SelectItem value="card">
-                      {t("gabinet.packages.paymentMethods.card")}
-                    </SelectItem>
-                    <SelectItem value="transfer">
-                      {t("gabinet.packages.paymentMethods.transfer")}
-                    </SelectItem>
-                    <SelectItem value="other">
-                      {t("gabinet.packages.paymentMethods.other", "Inna")}
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                <Input
-                  type="text"
-                  inputMode="decimal"
-                  placeholder="0.00"
-                  value={secondSplitAmount}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
-                      setSecondSplitAmount(v);
-                    }
-                  }}
-                />
-              </div>
-            </div>
-            <div
-              className={cn(
-                "flex items-center justify-between text-xs",
-                splitMismatch || splitSameMethod
-                  ? "text-destructive"
-                  : "text-muted-foreground",
-              )}
-            >
-              <span>
-                {t("gabinet.packages.splitSum", "Suma")}: {splitTotal.toFixed(2)}
-                {selectedPkg
-                  ? ` / ${formatCurrencyPLN(splitExpectedTotal, selectedPkg.currency ?? "PLN")}`
-                  : ""}
-              </span>
-              {splitSameMethod ? (
-                <span>
-                  {t("gabinet.packages.splitSameMethod", "Metody muszą się różnić")}
-                </span>
-              ) : splitMismatch ? (
-                <span>
-                  {t("gabinet.packages.splitMismatch", "Musi się zgadzać z ceną")}
-                </span>
-              ) : null}
-            </div>
-          </div>
+          <PackageSplitPaymentSection
+            firstSplitMethod={firstSplitMethod}
+            onFirstSplitMethodChange={setFirstSplitMethod}
+            secondSplitMethod={secondSplitMethod}
+            onSecondSplitMethodChange={setSecondSplitMethod}
+            firstSplitAmount={firstSplitAmount}
+            onFirstSplitAmountChange={setFirstSplitAmount}
+            secondSplitAmount={secondSplitAmount}
+            onSecondSplitAmountChange={setSecondSplitAmount}
+            splitTotal={splitTotal}
+            splitExpectedTotal={splitExpectedTotal}
+            splitMismatch={splitMismatch}
+            splitSameMethod={splitSameMethod}
+            currency={selectedPkg?.currency ?? "PLN"}
+          />
         )}
 
         <Button

--- a/src/hooks/use-package-payment-form.ts
+++ b/src/hooks/use-package-payment-form.ts
@@ -1,0 +1,55 @@
+import { useCallback, useState } from "react";
+
+export type PackagePaymentMethod = "cash" | "card" | "transfer" | "other";
+
+export function usePackagePaymentForm(effectiveTotalForSplit: number) {
+  const [paymentMethod, setPaymentMethod] = useState<PackagePaymentMethod>("cash");
+  const [splitPayment, setSplitPayment] = useState(false);
+  const [firstSplitMethod, setFirstSplitMethod] = useState<PackagePaymentMethod>("cash");
+  const [secondSplitMethod, setSecondSplitMethod] = useState<PackagePaymentMethod>("card");
+  const [firstSplitAmount, setFirstSplitAmount] = useState<string>("");
+  const [secondSplitAmount, setSecondSplitAmount] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const parsedFirstSplit = Number.parseFloat(firstSplitAmount.replace(",", ".")) || 0;
+  const parsedSecondSplit = Number.parseFloat(secondSplitAmount.replace(",", ".")) || 0;
+  const splitTotal = Math.round((parsedFirstSplit + parsedSecondSplit) * 100) / 100;
+  const splitExpectedTotal = Math.round(effectiveTotalForSplit * 100) / 100;
+  const splitMismatch = splitPayment && effectiveTotalForSplit > 0 && splitTotal !== splitExpectedTotal;
+  const splitMissingAmount = splitPayment && parsedFirstSplit <= 0 && parsedSecondSplit <= 0;
+  const splitSameMethod = splitPayment && firstSplitMethod === secondSplitMethod;
+
+  const resetPaymentForm = useCallback(() => {
+    setPaymentMethod("cash");
+    setSplitPayment(false);
+    setFirstSplitMethod("cash");
+    setSecondSplitMethod("card");
+    setFirstSplitAmount("");
+    setSecondSplitAmount("");
+  }, []);
+
+  return {
+    paymentMethod,
+    setPaymentMethod,
+    splitPayment,
+    setSplitPayment,
+    firstSplitMethod,
+    setFirstSplitMethod,
+    secondSplitMethod,
+    setSecondSplitMethod,
+    firstSplitAmount,
+    setFirstSplitAmount,
+    secondSplitAmount,
+    setSecondSplitAmount,
+    submitting,
+    setSubmitting,
+    parsedFirstSplit,
+    parsedSecondSplit,
+    splitTotal,
+    splitExpectedTotal,
+    splitMismatch,
+    splitMissingAmount,
+    splitSameMethod,
+    resetPaymentForm,
+  };
+}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3213.

Closes #3213

---

## Claude summary

Done. Here's what was done:

**Triage:** The duplication is real — both components independently implemented identical split-payment state management, validation logic, and UI across ~400 lines.

**Changes made (4 files, -160 net lines):**

`src/hooks/use-package-payment-form.ts` (new) — encapsulates all shared payment form state: `paymentMethod`, `splitPayment`, both split methods and amounts, `submitting`, plus the derived validation values (`splitMismatch`, `splitMissingAmount`, `splitSameMethod`, `splitTotal`, `splitExpectedTotal`). Takes `effectiveTotalForSplit: number` so the caller can pass either the package price or the first installment amount, keeping installment logic in `PackagePurchaseDrawer`.

`src/components/gabinet/package-split-payment-section.tsx` (new) — shared render of the two-column split payment grid (method selectors + amount inputs + mismatch summary row). Replaces ~80 lines duplicated in both components.

`sell-package-panel.tsx` and `package-purchase-drawer.tsx` — both now import and use the hook and shared component. Each keeps only what's unique to it: the drawer retains `paymentType`/`installmentCount` installment state; the panel retains the patient selector and Supabase query invalidation.