### PR TITLE
`useSupabaseGabinetTreatmentsList` defaults to `limit

### DIFF
--- a/src/hooks/use-supabase-gabinet-treatments.ts
+++ b/src/hooks/use-supabase-gabinet-treatments.ts
@@ -22,6 +22,7 @@ interface UseSupabaseGabinetTreatmentsListOptions {
   enabled?: boolean;
   limit?: number;
   sortOrder?: "asc" | "desc";
+  isActive?: boolean;
 }
 
 export function useSupabaseGabinetTreatmentsList(
@@ -29,19 +30,31 @@ export function useSupabaseGabinetTreatmentsList(
   options: UseSupabaseGabinetTreatmentsListOptions = {},
 ) {
   const { client, isReady } = useSupabase();
-  const { enabled = true, limit = 100, sortOrder = "desc" } = options;
+  const { enabled = true, limit, sortOrder = "desc", isActive } = options;
 
   return useQuery<MappedGabinetTreatment[], Error>({
-    queryKey: supabaseKeys.gabinetTreatments.list(organizationId),
+    queryKey: [
+      ...supabaseKeys.gabinetTreatments.list(organizationId),
+      { limit, isActive },
+    ],
     queryFn: async (): Promise<MappedGabinetTreatment[]> => {
       if (!client) throw new Error("Supabase client not ready");
 
-      const { data, error } = await client
+      let query = client
         .from("gabinet_treatments")
         .select("*")
         .eq("organization_id", organizationId)
-        .order("created_at", { ascending: sortOrder === "asc" })
-        .limit(limit);
+        .order("created_at", { ascending: sortOrder === "asc" });
+
+      if (isActive !== undefined) {
+        query = query.eq("is_active", isActive);
+      }
+
+      if (limit !== undefined) {
+        query = query.limit(limit);
+      }
+
+      const { data, error } = await query;
 
       if (error) throw error;
       return (data ?? []).map(mapGabinetTreatmentFromSupabase);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3215.

Closes #3215

---

## Claude summary

The fix is committed. Here's a summary:

**Root cause confirmed:** `useSupabaseGabinetTreatmentsList` in `src/hooks/use-supabase-gabinet-treatments.ts` always applied `.limit(100)` as a default, causing all 9 callers across the gabinet module to silently receive at most 100 treatments. Clinics exceeding that threshold would get broken treatment-name resolution in the package detail card (and everywhere else).

**Changes made (`src/hooks/use-supabase-gabinet-treatments.ts`):**

1. Removed the `limit = 100` default — `limit` is now `undefined` by default, so no `.limit()` clause is sent to Supabase and all rows are returned.
2. Made `limit` opt-in: when explicitly passed, `.limit(limit)` is applied.
3. Added `isActive?: boolean` option: when set, adds `.eq("is_active", isActive)` to the query, enabling server-side filtering (callers that already do client-side `isActive` filtering can switch to this for efficiency).
4. Updated `queryKey` to include `{ limit, isActive }` so distinct option combinations get their own cache entries.

The query key change also means callers that later pass `isActive: true` will correctly get a separate cache bucket from callers fetching all treatments.

## Follow-ups

- Apply `isActive: true` in sell panels that already client-side filter: `sell-treatment-panel.tsx` (line 63-66) and `_layout.gabinet.packages.index.tsx` (line 183-186) both already do `filter((tr) => tr.isActive)` on the result — they should pass `isActive: true` to push the filter server-side and reduce payload
- `useSupabaseGabinetTreatmentVariants` has the same `limit: 100` default at line 135: a clinic with a treatment that has >100 variants (or any future use fetching all org-level variants via the limited hook) would hit the same silent truncation bug