### PR TITLE
Apply `isActive

### DIFF
--- a/src/components/gabinet/sell-treatment-panel.tsx
+++ b/src/components/gabinet/sell-treatment-panel.tsx
@@ -45,7 +45,7 @@ export function SellTreatmentPanel({
   const createPayment = useAction(api.payments.create);
 
   const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId);
-  const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId);
+  const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId, { isActive: true });
 
   const [patientId, setPatientId] = useState<string>("");
   const [treatmentId, setTreatmentId] = useState<string>("");
@@ -61,7 +61,7 @@ export function SellTreatmentPanel({
   const [submitting, setSubmitting] = useState(false);
 
   const activeTreatments = useMemo(
-    () => (treatmentsData ?? []).filter((tr) => tr.isActive),
+    () => treatmentsData ?? [],
     [treatmentsData],
   );
   const selectedTreatment = useMemo(

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -176,12 +176,11 @@ function PackagesIndex() {
 
   // Supabase-backed queries (replacing convexQuery)
   const { data: packagesData } = useSupabaseGabinetTreatmentPackagesList(organizationId);
-  const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId);
+  const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId, { isActive: true });
   const { data: activeUsagesData } = useSupabaseGabinetPackageUsageActive(organizationId);
 
-  // Filter treatments to active-only (original Convex query was listActive)
   const treatments = useMemo(
-    () => (treatmentsData ?? []).filter((tr) => tr.isActive),
+    () => treatmentsData ?? [],
     [treatmentsData],
   );
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3218.

Closes #3218

---

## Claude summary

Done. Two files changed:

- `src/components/gabinet/sell-treatment-panel.tsx` — passes `{ isActive: true }` to the hook and drops the `filter((tr) => tr.isActive)` from the `useMemo`.
- `src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx` — same pattern; also removed the now-stale comment about the original Convex query.

The `useSupabaseGabinetTreatmentsList` hook already had the `isActive` option wired up (line 49–51 in the hook adds `.eq("is_active", isActive)` when the option is defined), so this was purely a missing call-site argument.