### PR TITLE
`useSupabaseGabinetTreatmentVariants` has the same `limit

### DIFF
--- a/src/hooks/use-supabase-gabinet-treatments.ts
+++ b/src/hooks/use-supabase-gabinet-treatments.ts
@@ -136,7 +136,6 @@ export function useSupabaseGabinetAllTreatmentVariants(
 
 interface UseSupabaseGabinetTreatmentVariantsOptions {
   enabled?: boolean;
-  limit?: number;
 }
 
 export function useSupabaseGabinetTreatmentVariants(
@@ -145,7 +144,7 @@ export function useSupabaseGabinetTreatmentVariants(
   options: UseSupabaseGabinetTreatmentVariantsOptions = {},
 ) {
   const { client, isReady } = useSupabase();
-  const { enabled = true, limit = 100 } = options;
+  const { enabled = true } = options;
 
   return useQuery<MappedGabinetTreatmentVariant[], Error>({
     queryKey: [
@@ -160,8 +159,7 @@ export function useSupabaseGabinetTreatmentVariants(
         .select("*")
         .eq("treatment_id", treatmentId)
         .eq("organization_id", organizationId)
-        .order("sort_order", { ascending: true })
-        .limit(limit);
+        .order("sort_order", { ascending: true });
 
       if (error) throw error;
       return (data ?? []).map(mapGabinetTreatmentVariantFromSupabase);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3219.

Closes #3219

---

## Claude summary

Done. The fix removes the `limit: 100` default (and the `.limit(limit)` Supabase call) from `useSupabaseGabinetTreatmentVariants` in `src/hooks/use-supabase-gabinet-treatments.ts:148-164`. The hook now fetches all variants for a treatment, consistent with how `useSupabaseGabinetAllTreatmentVariants` (the org-wide variant) already worked — it never had a `.limit()` call.