### PR TITLE
Add package-deduction logic to `applySmsReplyTransition` if it ever gains no_sho

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2511,6 +2511,42 @@ export const applySmsReplyTransition = internalMutation({
     }
     await db.patch("gabinetAppointments", args.appointmentId, supabasePatch);
 
+    // Package deduction: mirror the CAS block in updateStatus so that if this
+    // function ever gains no_show/completed intents the deduction fires here
+    // too. Currently unreachable (intent is locked to confirm/cancel → targetStatus
+    // is always "confirmed"|"cancelled"). Cast to string so TS2367 doesn't fire
+    // and the guard becomes live automatically when the intent union is extended.
+    // Closes #3222.
+    const _targetStatusStr: string = targetStatus;
+    if (
+      (_targetStatusStr === "completed" || _targetStatusStr === "no_show") &&
+      appointment.packageUsageId
+    ) {
+      const { data: pkgCasRows } = await db.raw()
+        .from("gabinet_appointments")
+        .update({ package_deducted: true })
+        .eq("id", args.appointmentId)
+        .eq("package_deducted", false)
+        .select("id");
+      const wonPkgRace = Array.isArray(pkgCasRows) && pkgCasRows.length === 1;
+      if (wonPkgRace) {
+        try {
+          await deductPackageEntry(db, {
+            packageUsageId: String(appointment.packageUsageId),
+            treatmentId: String(appointment.treatmentId),
+            variantId: appointment.variantId ? String(appointment.variantId) : undefined,
+          });
+        } catch (e) {
+          console.error(
+            "[applySmsReplyTransition] package entry deduction FAILED for appointment",
+            args.appointmentId,
+            ":",
+            e,
+          );
+        }
+      }
+    }
+
     // --- Side effects (activity log, audit, notifications, automation) ---
     const appointmentProxy = {
       _id: args.appointmentId as Id<"gabinetAppointments">,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3222.

Closes #3222

---

## Claude summary

The fix is committed. Here's a summary of what was done:

The issue is valid. `applySmsReplyTransition` writes the appointment status directly to Supabase and then calls `applyAppointmentStatusChange` for side effects (audit log, notifications, etc.), but the package-deduction CAS block that lives in `updateStatus` was absent. If someone later extends the `intent` union to include `"no_show"` or `"complete"`, the SMS path would silently skip the deduction.

The fix adds the same CAS block from `updateStatus` to `applySmsReplyTransition` (convex/gabinet/appointments.ts, after line 2512). The condition `_targetStatusStr === "completed" || _targetStatusStr === "no_show"` is currently unreachable (intent is locked to `"confirm"|"cancel"` so targetStatus can only be `"confirmed"|"cancelled"`), but the guard becomes live automatically when the intent union is widened. A local `string` cast avoids the TS2367 "no overlap" error without suppressing legitimate type checking elsewhere.