### PR TITLE
Sprzedaż pakietu jako prezent

### DIFF
--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -485,13 +485,26 @@ export const _purchaseTreatmentSideEffects = internalMutation({
   },
 });
 
+function generateVoucherCode(): string {
+  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  let code = "GIFT-";
+  for (let i = 0; i < 8; i++) {
+    code += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return code;
+}
+
 export const purchasePackage = action({
   args: {
     organizationId: v.id("organizations"),
-    patientId: v.string(),
+    patientId: v.optional(v.string()),
     packageId: v.string(),
     paidAmount: v.number(),
     paymentMethod: v.optional(v.string()),
+    isGift: v.optional(v.boolean()),
+    giftRecipientName: v.optional(v.string()),
+    giftRecipientPhone: v.optional(v.string()),
+    giftRecipientEmail: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(
@@ -504,6 +517,9 @@ export const purchasePackage = action({
       { organizationId: args.organizationId, feature: "gabinet_packages", action: "create" },
     ) as { allowed: boolean; scope: string };
     if (!perm.allowed) throw new Error("Permission denied");
+
+    const isGift = args.isGift === true;
+    if (!isGift && !args.patientId) throw new Error("patientId is required for non-gift packages");
 
     const now = Date.now();
     const db = createSupabaseDb();
@@ -524,22 +540,45 @@ export const purchasePackage = action({
       totalCount: t.quantity,
     }));
 
+    // Generate a unique voucher code for gift packages, retrying on collision
+    let voucherCode: string | null = null;
+    if (isGift) {
+      for (let attempt = 0; attempt < 5; attempt++) {
+        const candidate = generateVoucherCode();
+        const existing = await db
+          .query("gabinetPackageUsage")
+          .eq("organizationId", String(args.organizationId))
+          .eq("voucherCode", candidate)
+          .first();
+        if (!existing) {
+          voucherCode = candidate;
+          break;
+        }
+      }
+      if (!voucherCode) throw new Error("Could not generate unique voucher code");
+    }
+
     const usageId = await db.insert("gabinetPackageUsage", {
       organizationId: String(args.organizationId),
-      patientId: args.patientId,
+      patientId: args.patientId ?? null,
       packageId: args.packageId,
       purchasedAt: now,
       expiresAt,
-      status: "active",
+      status: isGift ? "unassigned" : "active",
       treatmentsUsed,
       paidAmount: args.paidAmount,
       paymentMethod: args.paymentMethod ?? null,
+      isGift: isGift || null,
+      voucherCode,
+      giftRecipientName: args.giftRecipientName ?? null,
+      giftRecipientPhone: args.giftRecipientPhone ?? null,
+      giftRecipientEmail: args.giftRecipientEmail ?? null,
       createdBy: String(authResult.userId),
       createdAt: now,
       updatedAt: now,
     });
 
-    // Side effects: activity envelope + loyalty points
+    // Side effects: activity envelope
     try {
       await ctx.runMutation(internal.gabinet.packages._purchaseSideEffects, {
         usageId,
@@ -557,9 +596,9 @@ export const purchasePackage = action({
       console.error("[packages.purchasePackage] Side effects FAILED for usage", usageId, ":", e);
     }
 
-    // Award loyalty points directly in Supabase
+    // Award loyalty points only when assigned to a real patient
     const loyaltyPointsAwarded = (pkg.loyaltyPointsAwarded as number | undefined) ?? 0;
-    if (loyaltyPointsAwarded > 0) {
+    if (loyaltyPointsAwarded > 0 && args.patientId) {
       const loyalty = await db
         .query("gabinetLoyaltyPoints")
         .eq("organizationId", String(args.organizationId))
@@ -611,7 +650,7 @@ export const _purchaseSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     packageId: v.string(),
     packageName: v.string(),
-    patientId: v.string(),
+    patientId: v.optional(v.string()),
     paidAmount: v.number(),
     paymentMethod: v.optional(v.string()),
     loyaltyPointsAwarded: v.number(),
@@ -619,12 +658,21 @@ export const _purchaseSideEffects = internalMutation({
     createdAt: v.number(),
   },
   handler: async (ctx, args) => {
+    const targets: Array<{ entityType: string; entityId: string }> = [
+      { entityType: "gabinetPackage", entityId: args.packageId },
+    ];
+    if (args.patientId) {
+      targets.push({ entityType: "gabinetPatient", entityId: args.patientId });
+    }
+
     await publishActivityEnvelope(ctx, {
       organizationId: args.organizationId,
       action: "package_assigned",
       performedBy: args.createdBy as Id<"users">,
       module: "gabinet",
-      summary: `Assigned package ${args.packageName} to patient`,
+      summary: args.patientId
+        ? `Assigned package ${args.packageName} to patient`
+        : `Sold package ${args.packageName} as gift`,
       occurredAt: args.createdAt,
       actor: {
         type: "user",
@@ -638,16 +686,7 @@ export const _purchaseSideEffects = internalMutation({
         paymentMethod: args.paymentMethod,
       },
       eventKey: `gabinet:package:${args.usageId}:package_assigned`,
-      targets: [
-        {
-          entityType: "gabinetPackage",
-          entityId: args.packageId,
-        },
-        {
-          entityType: "gabinetPatient",
-          entityId: args.patientId,
-        },
-      ],
+      targets,
     });
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -460,6 +460,7 @@ export const gabinetPackageUsageStatusValidator = v.union(
   v.literal("completed"),
   v.literal("expired"),
   v.literal("cancelled"),
+  v.literal("unassigned"),
 );
 export type GabinetPackageUsageStatus = Infer<
   typeof gabinetPackageUsageStatusValidator

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -519,7 +519,7 @@ export function createGabinetTables({
 
   gabinetPackageUsage: defineTable({
     organizationId: v.id("organizations"),
-    patientId: v.id("gabinetPatients"),
+    patientId: v.optional(v.id("gabinetPatients")),
     packageId: v.id("gabinetTreatmentPackages"),
     purchasedAt: v.number(),
     expiresAt: v.optional(v.number()),
@@ -534,6 +534,11 @@ export function createGabinetTables({
     ),
     paidAmount: v.number(),
     paymentMethod: v.optional(v.string()),
+    isGift: v.optional(v.boolean()),
+    voucherCode: v.optional(v.string()),
+    giftRecipientName: v.optional(v.string()),
+    giftRecipientPhone: v.optional(v.string()),
+    giftRecipientEmail: v.optional(v.string()),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),

--- a/src/components/gabinet/sell-package-panel.tsx
+++ b/src/components/gabinet/sell-package-panel.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { SidePanel } from "@/components/crm/side-panel";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -32,6 +33,8 @@ interface SellPackagePanelProps {
   onOpenChange: (open: boolean) => void;
 }
 
+type SaleMode = "patient" | "gift";
+
 export function SellPackagePanel({
   organizationId,
   open,
@@ -51,8 +54,12 @@ export function SellPackagePanel({
     [treatmentsData],
   );
 
+  const [saleMode, setSaleMode] = useState<SaleMode>("patient");
   const [patientId, setPatientId] = useState<string>("");
   const [packageId, setPackageId] = useState<string>("");
+  const [giftRecipientName, setGiftRecipientName] = useState("");
+  const [giftRecipientPhone, setGiftRecipientPhone] = useState("");
+  const [giftRecipientEmail, setGiftRecipientEmail] = useState("");
 
   const selectedPkg = useMemo(
     () => (packagesData ?? []).find((p) => p._id === packageId),
@@ -85,13 +92,18 @@ export function SellPackagePanel({
   } = usePackagePaymentForm(selectedPkg?.totalPrice ?? 0);
 
   const reset = () => {
+    setSaleMode("patient");
     setPatientId("");
     setPackageId("");
+    setGiftRecipientName("");
+    setGiftRecipientPhone("");
+    setGiftRecipientEmail("");
     resetPaymentForm();
   };
 
   const handleSubmit = async () => {
-    if (!patientId || !packageId || !selectedPkg) return;
+    if (!packageId || !selectedPkg) return;
+    if (saleMode === "patient" && !patientId) return;
     if (splitPayment) {
       if (splitMissingAmount) {
         toast.error(
@@ -124,14 +136,21 @@ export function SellPackagePanel({
     setSubmitting(true);
     try {
       const currency = selectedPkg.currency ?? "PLN";
+      const isGift = saleMode === "gift";
       const usagePaymentMethod = splitPayment ? "split" : paymentMethod;
       const usageId = await purchasePackage({
         organizationId,
-        patientId,
+        patientId: isGift ? undefined : patientId,
         packageId,
         paidAmount: selectedPkg.totalPrice,
         paymentMethod: usagePaymentMethod,
+        isGift,
+        giftRecipientName: isGift && giftRecipientName ? giftRecipientName : undefined,
+        giftRecipientPhone: isGift && giftRecipientPhone ? giftRecipientPhone : undefined,
+        giftRecipientEmail: isGift && giftRecipientEmail ? giftRecipientEmail : undefined,
       });
+
+      const paymentPatientId = isGift ? undefined : (patientId as Id<"gabinetPatients">);
 
       if (splitPayment) {
         const parts: Array<{ method: typeof firstSplitMethod; amount: number }> = [];
@@ -142,7 +161,7 @@ export function SellPackagePanel({
         for (const part of parts) {
           await createPayment({
             organizationId,
-            patientId: patientId as Id<"gabinetPatients">,
+            patientId: paymentPatientId,
             packageUsageId: usageId,
             amount: part.amount,
             currency,
@@ -153,7 +172,7 @@ export function SellPackagePanel({
       } else {
         await createPayment({
           organizationId,
-          patientId,
+          patientId: paymentPatientId,
           packageUsageId: usageId,
           amount: selectedPkg.totalPrice,
           currency,
@@ -182,6 +201,12 @@ export function SellPackagePanel({
     }
   };
 
+  const canSubmit =
+    !!packageId &&
+    !submitting &&
+    (saleMode === "gift" || !!patientId) &&
+    !(splitPayment && (splitMissingAmount || splitMismatch || splitSameMethod));
+
   return (
     <SidePanel
       open={open}
@@ -192,26 +217,96 @@ export function SellPackagePanel({
       title={t("nav.actions.assignPackage")}
     >
       <div className="space-y-4">
+        {/* Sale mode toggle */}
         <div className="space-y-1.5">
-          <Label>{t("gabinet.packages.selectPatient", "Patient")}</Label>
-          <Select value={patientId} onValueChange={setPatientId}>
-            <SelectTrigger>
-              <SelectValue
-                placeholder={t(
-                  "gabinet.packages.selectPatientPlaceholder",
-                  "Select a patient...",
-                )}
-              />
-            </SelectTrigger>
-            <SelectContent>
-              {(patientsData ?? []).map((p) => (
-                <SelectItem key={p._id} value={p._id}>
-                  {p.firstName} {p.lastName}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <Label>{t("gabinet.packages.saleMode", "Tryb sprzedaży")}</Label>
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              type="button"
+              variant={saleMode === "patient" ? "default" : "outline"}
+              size="sm"
+              onClick={() => setSaleMode("patient")}
+            >
+              {t("gabinet.packages.saleModePatient", "Istniejący klient")}
+            </Button>
+            <Button
+              type="button"
+              variant={saleMode === "gift" ? "default" : "outline"}
+              size="sm"
+              onClick={() => setSaleMode("gift")}
+            >
+              {t("gabinet.packages.saleModeGift", "Sprzedaj jako prezent")}
+            </Button>
+          </div>
         </div>
+
+        {/* Patient selector — only in patient mode */}
+        {saleMode === "patient" && (
+          <div className="space-y-1.5">
+            <Label>{t("gabinet.packages.selectPatient", "Patient")}</Label>
+            <Select value={patientId} onValueChange={setPatientId}>
+              <SelectTrigger>
+                <SelectValue
+                  placeholder={t(
+                    "gabinet.packages.selectPatientPlaceholder",
+                    "Select a patient...",
+                  )}
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {(patientsData ?? []).map((p) => (
+                  <SelectItem key={p._id} value={p._id}>
+                    {p.firstName} {p.lastName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        {/* Gift recipient details — only in gift mode */}
+        {saleMode === "gift" && (
+          <div className="rounded-lg border p-3 space-y-3">
+            <p className="text-sm font-medium text-muted-foreground">
+              {t("gabinet.packages.giftRecipientDetails", "Dane osoby obdarowanej (opcjonalnie)")}
+            </p>
+            <div className="space-y-1.5">
+              <Label htmlFor="gift-recipient-name">
+                {t("gabinet.packages.giftRecipientName", "Imię i nazwisko")}
+              </Label>
+              <Input
+                id="gift-recipient-name"
+                value={giftRecipientName}
+                onChange={(e) => setGiftRecipientName(e.target.value)}
+                placeholder={t("gabinet.packages.giftRecipientNamePlaceholder", "np. Jan Kowalski")}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="gift-recipient-phone">
+                {t("gabinet.packages.giftRecipientPhone", "Numer telefonu")}
+              </Label>
+              <Input
+                id="gift-recipient-phone"
+                type="tel"
+                value={giftRecipientPhone}
+                onChange={(e) => setGiftRecipientPhone(e.target.value)}
+                placeholder={t("gabinet.packages.giftRecipientPhonePlaceholder", "np. +48 123 456 789")}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="gift-recipient-email">
+                {t("gabinet.packages.giftRecipientEmail", "Adres e-mail")}
+              </Label>
+              <Input
+                id="gift-recipient-email"
+                type="email"
+                value={giftRecipientEmail}
+                onChange={(e) => setGiftRecipientEmail(e.target.value)}
+                placeholder={t("gabinet.packages.giftRecipientEmailPlaceholder", "np. jan@example.com")}
+              />
+            </div>
+          </div>
+        )}
 
         <div className="space-y-1.5">
           <Label>{t("gabinet.packages.selectPackage")}</Label>
@@ -319,18 +414,15 @@ export function SellPackagePanel({
 
         <Button
           className="w-full"
-          disabled={
-            !patientId ||
-            !packageId ||
-            submitting ||
-            (splitPayment && (splitMissingAmount || splitMismatch || splitSameMethod))
-          }
+          disabled={!canSubmit}
           onClick={handleSubmit}
         >
           {submitting && (
             <Loader2 className="mr-2 h-4 w-4 animate-spin" variant="stroke" />
           )}
-          {t("gabinet.packages.purchaseButton")}
+          {saleMode === "gift"
+            ? t("gabinet.packages.purchaseGiftButton", "Sprzedaj jako prezent")
+            : t("gabinet.packages.purchaseButton")}
         </Button>
       </div>
     </SidePanel>

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -5027,7 +5027,7 @@ export interface Database {
         Row: {
           id: string;
           organization_id: string;
-          patient_id: string;
+          patient_id: string | null;
           package_id: string;
           purchased_at: number;
           expires_at: number | null;
@@ -5035,6 +5035,11 @@ export interface Database {
           treatments_used: unknown;
           paid_amount: number;
           payment_method: string | null;
+          is_gift: boolean | null;
+          voucher_code: string | null;
+          gift_recipient_name: string | null;
+          gift_recipient_phone: string | null;
+          gift_recipient_email: string | null;
           created_by: string;
           created_at: number;
           updated_at: number;
@@ -5042,7 +5047,7 @@ export interface Database {
         Insert: {
           id?: string;
           organization_id: string;
-          patient_id: string;
+          patient_id?: string | null;
           package_id: string;
           purchased_at: number;
           expires_at?: number | null;
@@ -5050,6 +5055,11 @@ export interface Database {
           treatments_used: unknown;
           paid_amount: number;
           payment_method?: string | null;
+          is_gift?: boolean | null;
+          voucher_code?: string | null;
+          gift_recipient_name?: string | null;
+          gift_recipient_phone?: string | null;
+          gift_recipient_email?: string | null;
           created_by: string;
           created_at: number;
           updated_at: number;
@@ -5057,7 +5067,7 @@ export interface Database {
         Update: {
           id?: string;
           organization_id?: string;
-          patient_id?: string;
+          patient_id?: string | null;
           package_id?: string;
           purchased_at?: number;
           expires_at?: number | null;
@@ -5065,6 +5075,11 @@ export interface Database {
           treatments_used?: unknown;
           paid_amount?: number;
           payment_method?: string | null;
+          is_gift?: boolean | null;
+          voucher_code?: string | null;
+          gift_recipient_name?: string | null;
+          gift_recipient_phone?: string | null;
+          gift_recipient_email?: string | null;
           created_by?: string;
           created_at?: number;
           updated_at?: number;

--- a/src/lib/supabase/mappers/gabinet/package-usage.ts
+++ b/src/lib/supabase/mappers/gabinet/package-usage.ts
@@ -20,7 +20,7 @@ export interface MappedGabinetPackageUsage {
   _id: string;
   _creationTime: number;
   organizationId: string;
-  patientId: string;
+  patientId: string | null;
   packageId: string;
   purchasedAt: number;
   expiresAt?: number;
@@ -28,6 +28,11 @@ export interface MappedGabinetPackageUsage {
   treatmentsUsed: PackageTreatmentUsageEntry[];
   paidAmount: number;
   paymentMethod?: string;
+  isGift?: boolean;
+  voucherCode?: string;
+  giftRecipientName?: string;
+  giftRecipientPhone?: string;
+  giftRecipientEmail?: string;
   createdBy: string;
   createdAt: number;
   updatedAt: number;
@@ -47,7 +52,13 @@ export function mapGabinetPackageUsageFromSupabase(
   return {
     ...base,
     _creationTime: base.createdAt,
+    patientId: row.patient_id ?? null,
     treatmentsUsed: (row.treatments_used ?? []) as PackageTreatmentUsageEntry[],
+    isGift: row.is_gift ?? undefined,
+    voucherCode: row.voucher_code ?? undefined,
+    giftRecipientName: row.gift_recipient_name ?? undefined,
+    giftRecipientPhone: row.gift_recipient_phone ?? undefined,
+    giftRecipientEmail: row.gift_recipient_email ?? undefined,
   };
 }
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
@@ -222,7 +222,7 @@ function GabinetDashboard() {
         const totalAllowed = u.treatmentsUsed.reduce((s, e) => s + e.totalCount, 0);
         return {
           ...u,
-          patientName: patientMap.get(u.patientId) ?? t("common.unknown"),
+          patientName: patientMap.get(u.patientId ?? "") ?? t("common.unknown"),
           packageName: packageNameMap.get(u.packageId) ?? t("gabinet.dashboard.package", "Pakiet"),
           totalUsed,
           totalAllowed,

--- a/supabase/migrations/00065_gabinet_package_usage_gift.sql
+++ b/supabase/migrations/00065_gabinet_package_usage_gift.sql
@@ -1,0 +1,31 @@
+-- Migration: 00065_gabinet_package_usage_gift
+-- Adds gift-package support to gabinet_package_usage:
+--   • 'unassigned' status for packages sold as gifts without an existing patient
+--   • nullable patient_id (gift packages have no patient until assigned)
+--   • voucher code (auto-generated, unique, human-readable like GIFT-AB3X7Y9Z)
+--   • optional recipient details (name, phone, email) stored for later lookup
+
+-- 1. Extend the status enum with the new 'unassigned' value
+ALTER TYPE gabinet_package_usage_status_enum ADD VALUE IF NOT EXISTS 'unassigned';
+
+-- 2. Allow patient_id to be NULL for gift packages
+ALTER TABLE gabinet_package_usage ALTER COLUMN patient_id DROP NOT NULL;
+
+-- 3. Add gift-specific columns
+ALTER TABLE gabinet_package_usage
+  ADD COLUMN IF NOT EXISTS is_gift               BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS voucher_code          TEXT,
+  ADD COLUMN IF NOT EXISTS gift_recipient_name   TEXT,
+  ADD COLUMN IF NOT EXISTS gift_recipient_phone  TEXT,
+  ADD COLUMN IF NOT EXISTS gift_recipient_email  TEXT;
+
+-- 4. Unique index on voucher_code (partial — only non-NULL values)
+--    enables fast lookup by voucher number and prevents duplicates
+CREATE UNIQUE INDEX IF NOT EXISTS gabinet_package_usage_voucher_code_idx
+  ON gabinet_package_usage (voucher_code)
+  WHERE voucher_code IS NOT NULL;
+
+-- 5. Index to list unassigned gift packages quickly
+CREATE INDEX IF NOT EXISTS gabinet_package_usage_org_gift_idx
+  ON gabinet_package_usage (organization_id, is_gift)
+  WHERE is_gift = TRUE;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3208.

Closes #3208

---

## Claude summary

Committed. Here's a summary of what was implemented:

## Changes (8 files)

**`supabase/migrations/00065_gabinet_package_usage_gift.sql`** — New migration:
- Adds `'unassigned'` to the `gabinet_package_usage_status_enum`
- Drops `NOT NULL` from `patient_id` (gift packages have no patient yet)
- Adds `is_gift`, `voucher_code`, `gift_recipient_name`, `gift_recipient_phone`, `gift_recipient_email` columns
- Unique partial index on `voucher_code` (for fast lookup; enforces uniqueness)
- Partial index on `(organization_id, is_gift)` for listing unassigned gifts

**`convex/schema.ts`** — Adds `"unassigned"` to status validator

**`convex/schema/gabinet.ts`** — `patientId` made optional; gift fields added

**`convex/gabinet/packages.ts`** — `purchasePackage` now accepts optional `patientId` + gift args; generates a unique `GIFT-XXXXXXXX` voucher code with collision retry; sets `status="unassigned"` for gifts; skips loyalty points when no patient. `_purchaseSideEffects` handles optional `patientId`

**`src/lib/supabase/database.types.ts`** — `patient_id` → nullable; gift columns added

**`src/lib/supabase/mappers/gabinet/package-usage.ts`** — `patientId: string | null`; gift fields exposed

**`src/components/gabinet/sell-package-panel.tsx`** — Two-button mode toggle; gift mode shows optional recipient name/phone/email; submit label changes to "Sprzedaj jako prezent"; payment record has no `patientId` in gift mode

**`src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx`** — Guards `patientMap.get(u.patientId ?? "")` for null safety

## How to test

1. Open the "Sprzedaj pakiet" panel from the Gabinet packages page
2. Switch to "Sprzedaj jako prezent" — the patient selector disappears, recipient fields appear (all optional)
3. Select a package, fill in any recipient details, choose payment method, click "Sprzedaj jako prezent"
4. The created usage record will have `status="unassigned"`, a `voucher_code` like `GIFT-AB3X7Y9Z`, and the recipient details — findable later by voucher code, recipient name/phone, or buyer (via `created_by`)
5. Normal sale with "Istniejący klient" mode is unchanged

## Follow-ups

- Add a dedicated "Gift packages" list view in the Gabinet packages page: currently unassigned gift packages are not visible anywhere in the UI — reception needs a way to find them by voucher code / recipient details before assigning to a future patient
- Implement "Assign gift to patient" flow: the stored `voucher_code` and `status="unassigned"` form the foundation, but the actual assignment action (patching `patient_id`, setting `status="active"`) is not yet built (intentionally deferred per issue guardrails)