### PR TITLE
feat(products): add optional salePrice to product data layer (closes #3201)

### DIFF
--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -322,6 +322,10 @@ export function createCrmTables({
     // Net purchase price per unit (#2956, migration 00050). Used to calculate
     // warehouse value. Distinct from unitPrice (the selling price).
     purchasePrice: v.optional(v.number()),
+    // Optional retail sale price per unit (#3201/#3203, migration 00064).
+    // Data-layer only for now — form/columns/validation wiring is a follow-up
+    // per the #3203 micro-task scoping.
+    salePrice: v.optional(v.number()),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),

--- a/src/lib/supabase/database.columns.ts
+++ b/src/lib/supabase/database.columns.ts
@@ -68,6 +68,7 @@
  *   • 00061_delivery_name_mappings.sql
  *   • 00062_delivery_item_decisions.sql
  *   • 00063_document_analysis_jobs.sql
+ *   • 00064_product_sale_price.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  */
@@ -213,7 +214,7 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   object_relationships: new Set(["id", "organization_id", "source_type", "source_id", "target_type", "target_id", "relationship_type", "created_by", "created_at"]),
   activities: new Set(["id", "organization_id", "entity_type", "entity_id", "action", "description", "metadata", "performed_by", "created_at"]),
   notes: new Set(["id", "organization_id", "entity_type", "entity_id", "content", "created_by", "is_pinned", "parent_note_id", "created_at", "updated_at"]),
-  products: new Set(["id", "organization_id", "name", "sku", "unit_price", "tax_rate", "is_active", "description", "tag_ids", "category_id", "created_by", "created_at", "updated_at", "tax_exempt", "track_stock", "stock_unit", "product_section", "min_stock", "manufacturer", "catalog_number", "stock_note", "purchase_price"]),
+  products: new Set(["id", "organization_id", "name", "sku", "unit_price", "tax_rate", "is_active", "description", "tag_ids", "category_id", "created_by", "created_at", "updated_at", "tax_exempt", "track_stock", "stock_unit", "product_section", "min_stock", "manufacturer", "catalog_number", "stock_note", "purchase_price", "sale_price"]),
   deal_products: new Set(["id", "organization_id", "deal_id", "product_id", "quantity", "unit_price", "discount", "created_at"]),
   calls: new Set(["id", "organization_id", "outcome", "call_date", "note", "duration", "tag_ids", "category_id", "created_by", "created_at", "updated_at"]),
   lost_reasons: new Set(["id", "organization_id", "label", "order", "is_active", "created_by", "created_at", "updated_at"]),

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -68,6 +68,7 @@
  *   • 00061_delivery_name_mappings.sql
  *   • 00062_delivery_item_decisions.sql
  *   • 00063_document_analysis_jobs.sql
+ *   • 00064_product_sale_price.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -1879,6 +1880,7 @@ export interface Database {
           catalog_number: string | null;
           stock_note: string | null;
           purchase_price: number | null;
+          sale_price: number | null;
         };
         Insert: {
           id?: string;
@@ -1903,6 +1905,7 @@ export interface Database {
           catalog_number?: string | null;
           stock_note?: string | null;
           purchase_price?: number | null;
+          sale_price?: number | null;
         };
         Update: {
           id?: string;
@@ -1927,6 +1930,7 @@ export interface Database {
           catalog_number?: string | null;
           stock_note?: string | null;
           purchase_price?: number | null;
+          sale_price?: number | null;
         };
         Relationships: [
           {

--- a/supabase/migrations/00064_product_sale_price.sql
+++ b/supabase/migrations/00064_product_sale_price.sql
@@ -1,0 +1,9 @@
+-- Add sale_price field to products (#3201, #3203).
+--
+-- Optional retail sale price per unit for sellable warehouse products.
+-- Nullable so existing products are unaffected. Data-layer only — the form,
+-- table columns and validation wiring are follow-ups per the #3203 micro-task
+-- scoping. Mirrors the purchase_price pattern from migration 00050.
+
+ALTER TABLE products
+  ADD COLUMN IF NOT EXISTS sale_price NUMERIC;


### PR DESCRIPTION
Clean, minimal PR for the #3203 micro-task ("dodaj wyłącznie opcjonalne pole salePrice do właściwego schematu produktu").

**State correction:** the automation worker reported this as done (claiming #3201 had already landed migration/types/mutations and only the Convex schema line was missing, pushed to its stale 35-commit branch via closed PR #3165). Verified against main: **`salePrice` existed in NO layer** — migration 00050 is `purchase_price`, not sale_price; `git grep salePrice` on main = zero hits; the claimed commit doesn't exist on any branch. This PR implements the change for real, from current main.

Changes (data layer only, per scoping — no form, no columns, no validation):
- `convex/schema/crm.ts` — `salePrice: v.optional(v.number())` on products
- `supabase/migrations/00064_product_sale_price.sql` — `sale_price NUMERIC` nullable (pattern of 00050)
- regenerated `database.types.ts` / `database.columns.ts`

CI auto-applies the migration on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)