### PR TITLE
Dodaj cenę sprzedaży brutto do edycji produktu

### DIFF
--- a/convex/products.ts
+++ b/convex/products.ts
@@ -39,6 +39,7 @@ export const create = action({
     catalogNumber: v.optional(v.union(v.string(), v.null())),
     stockNote: v.optional(v.union(v.string(), v.null())),
     purchasePrice: v.optional(v.union(v.number(), v.null())),
+    salePrice: v.optional(v.union(v.number(), v.null())),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(
@@ -84,6 +85,8 @@ export const create = action({
     if (args.stockNote != null) insertRow.stockNote = args.stockNote;
     // migration 00050
     if (args.purchasePrice != null) insertRow.purchasePrice = args.purchasePrice;
+    // migration 00066
+    if (args.salePrice != null) insertRow.salePrice = args.salePrice;
 
     const productId = await db.insert("products", insertRow);
 
@@ -160,6 +163,7 @@ export const update = action({
     catalogNumber: v.optional(v.union(v.string(), v.null())),
     stockNote: v.optional(v.union(v.string(), v.null())),
     purchasePrice: v.optional(v.union(v.number(), v.null())),
+    salePrice: v.optional(v.union(v.number(), v.null())),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(
@@ -208,6 +212,7 @@ export const update = action({
     if (updates.catalogNumber !== undefined) patchPayload.catalogNumber = updates.catalogNumber;
     if (updates.stockNote !== undefined) patchPayload.stockNote = updates.stockNote;
     if (updates.purchasePrice !== undefined) patchPayload.purchasePrice = updates.purchasePrice;
+    if (updates.salePrice !== undefined) patchPayload.salePrice = updates.salePrice;
 
     await db.patch("products", productId, patchPayload);
 

--- a/src/components/forms/product-form.tsx
+++ b/src/components/forms/product-form.tsx
@@ -95,6 +95,7 @@ export interface ProductFormData {
   catalogNumber?: string | null;
   stockNote?: string | null;
   purchasePrice?: number | null;
+  salePrice?: number | null;
 }
 
 interface ProductFormProps {
@@ -145,6 +146,9 @@ export function ProductForm({
   const [purchasePrice, setPurchasePrice] = useState(
     initialData?.purchasePrice != null ? String(initialData.purchasePrice) : "",
   );
+  const [salePrice, setSalePrice] = useState(
+    initialData?.salePrice != null ? String(initialData.salePrice) : "",
+  );
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -176,6 +180,11 @@ export function ProductForm({
       const parsed = parseFloat(purchasePrice.replace(",", "."));
       return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
     })();
+    const normalizedSalePrice = (() => {
+      if (!salePrice.trim()) return null;
+      const parsed = parseFloat(salePrice.replace(",", "."));
+      return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+    })();
     onSubmit({
       name: trimmedName,
       description: description || null,
@@ -195,6 +204,7 @@ export function ProductForm({
       catalogNumber: catalogNumber.trim() || null,
       stockNote: stockNote.trim() || null,
       purchasePrice: normalizedPurchasePrice,
+      salePrice: normalizedSalePrice,
     });
   };
 
@@ -299,6 +309,24 @@ export function ProductForm({
           <Switch checked={isActive} onCheckedChange={setIsActive} />
           <Label>{t("products.form.isActive")}</Label>
         </div>
+        {productSection === "sale" && (
+          <div className="space-y-1.5 sm:col-span-2">
+            <Label>{t("products.form.salePrice", { defaultValue: "Cena sprzedaży brutto" })}</Label>
+            <Input
+              type="text"
+              inputMode="decimal"
+              value={salePrice}
+              onChange={(e) => {
+                const v = e.target.value;
+                if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) setSalePrice(v);
+              }}
+              placeholder={t("products.form.salePricePlaceholder", { defaultValue: "np. 150,00" })}
+            />
+            <p className="text-xs text-muted-foreground">
+              {t("products.form.salePriceHelp", { defaultValue: "Cena brutto w złotych, po której sprzedajesz produkt. Opcjonalna." })}
+            </p>
+          </div>
+        )}
         {/* Stock tracking */}
         <div className="space-y-3 rounded-md border bg-muted/30 px-3 py-3 sm:col-span-2">
           <div className="flex items-start gap-2">

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -770,6 +770,7 @@ function ProductsPage() {
           catalogNumber: data.catalogNumber,
           stockNote: data.stockNote,
           purchasePrice: data.purchasePrice,
+          salePrice: data.salePrice,
         });
       } else {
         await createProduct({
@@ -792,6 +793,7 @@ function ProductsPage() {
           catalogNumber: data.catalogNumber,
           stockNote: data.stockNote,
           purchasePrice: data.purchasePrice,
+          salePrice: data.salePrice,
         });
       }
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.products.list(organizationId) });
@@ -1411,6 +1413,7 @@ function ProductsPage() {
             catalogNumber: editingProduct.catalogNumber ?? null,
             stockNote: editingProduct.stockNote ?? null,
             purchasePrice: editingProduct.purchasePrice ?? null,
+            salePrice: editingProduct.salePrice ?? null,
           } : undefined}
           defaultSection={!editingProduct && (PRODUCT_SECTIONS as readonly string[]).includes(activeViewId) ? activeViewId as ProductSection : null}
           onSubmit={handleProductFormSubmit}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3238.

Closes #3238

---

## Claude summary

Done. Here's a summary of the changes:

**3 files changed, 36 lines added:**

`src/components/forms/product-form.tsx`
- Added `salePrice?: number | null` to the `ProductFormData` interface
- Added `salePrice` state initialized from `initialData?.salePrice`
- Added normalization logic (same pattern as `purchasePrice` — comma-safe float parse, non-negative)
- Added the UI input field (`Cena sprzedaży brutto`), rendered conditionally only when `productSection === "sale"`
- Included `salePrice` in the `onSubmit` payload

`convex/products.ts`
- Added `salePrice: v.optional(v.union(v.number(), v.null()))` to both `create` and `update` action args
- `create`: stores the value in `insertRow` when non-null (tagged with `// migration 00066`)
- `update`: writes to `patchPayload` when present in args

`src/routes/_app/_auth/dashboard/_layout.products.index.tsx`
- Passes `salePrice: editingProduct.salePrice ?? null` into `ProductForm` `initialData` (so saved value is shown on reopen)
- Forwards `data.salePrice` in both the `updateProduct` and `createProduct` calls

The field is only visible for the "Produkty do sprzedaży" (`sale`) section — switching to another section hides it, but the value is preserved in state so it round-trips correctly if the user toggles back. Products without `salePrice` continue to work (field starts empty, submits `null`).