### PR TITLE
Przypisanie pakietu prezentowego do klienta

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -52,6 +52,7 @@ import type { MappedGabinetTreatmentPackage } from "@/lib/supabase/mappers/gabin
 import type { MappedGabinetPackageUsage } from "@/lib/supabase/mappers/gabinet/package-usage";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
+import { PatientForm } from "@/components/forms/patient-form";
 
 // shadcn/studio statistics blocks
 import StatisticsOrderCard from "@/components/shadcn-studio/blocks/statistics-order-card";
@@ -205,6 +206,8 @@ function PackagesIndex() {
 
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
   const assignGiftPkg = useAction(api.gabinet.packages.assignGiftPackage);
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
+  const createPatient = useAction(api.gabinet.patients.create);
 
   const [panelOpen, setPanelOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -216,6 +219,8 @@ function PackagesIndex() {
   const [assigningGiftId, setAssigningGiftId] = useState<string | null>(null);
   const [assignPatientId, setAssignPatientId] = useState("");
   const [assignSubmitting, setAssignSubmitting] = useState(false);
+  const [createPatientPanelOpen, setCreatePatientPanelOpen] = useState(false);
+  const [creatingPatient, setCreatingPatient] = useState(false);
 
   useSidebarDispatch("openFilter", () => setFilterPanelOpen(true));
   useSidebarDispatch("viewExpiring", () => setExpiringOnly(true));
@@ -378,6 +383,41 @@ function PackagesIndex() {
       );
     } finally {
       setAssignSubmitting(false);
+    }
+  };
+
+  const handleCreatePatient = async (formData: {
+    firstName: string;
+    lastName: string;
+    email: string;
+    phone?: string;
+    pesel?: string | null;
+    dateOfBirth?: string | null;
+    gender?: "male" | "female" | "other";
+    address?: { street?: string; city?: string; postalCode?: string } | null;
+    medicalNotes?: string | null;
+    allergies?: string | null;
+    bloodType?: string | null;
+    emergencyContactName?: string | null;
+    emergencyContactPhone?: string | null;
+    referralSource?: string | null;
+  }) => {
+    setCreatingPatient(true);
+    try {
+      const newId = await createPatient({ organizationId, ...formData });
+      setAssignPatientId(String(newId));
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetPatients.list(organizationId) });
+      setCreatePatientPanelOpen(false);
+      toast.success(t("gabinet.patients.created", { defaultValue: "Klient utworzony" }));
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.patients.errors.createFailed",
+          defaultValue: "Nie udało się utworzyć klienta.",
+        }),
+      );
+    } finally {
+      setCreatingPatient(false);
     }
   };
 
@@ -903,7 +943,19 @@ function PackagesIndex() {
             {t("gabinet.packages.assignGiftDescription", "Wybierz pacjenta, do którego zostanie przypisany voucher. Pakiet stanie się aktywny dla wybranego pacjenta.")}
           </p>
           <div className="space-y-1.5">
-            <Label>{t("gabinet.patients.patient", "Pacjent")}</Label>
+            <div className="flex items-center justify-between">
+              <Label>{t("gabinet.patients.patient", "Pacjent")}</Label>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1 text-xs"
+                onClick={() => setCreatePatientPanelOpen(true)}
+              >
+                <Plus className="h-3.5 w-3.5" variant="stroke" />
+                {t("gabinet.patients.createPatient", "Nowy pacjent")}
+              </Button>
+            </div>
             <Select value={assignPatientId} onValueChange={setAssignPatientId}>
               <SelectTrigger>
                 <SelectValue placeholder={t("gabinet.packages.selectPatient", "Wybierz pacjenta...")} />
@@ -924,6 +976,20 @@ function PackagesIndex() {
             </Select>
           </div>
         </div>
+      </SidePanel>
+
+      <SidePanel
+        open={createPatientPanelOpen}
+        onOpenChange={setCreatePatientPanelOpen}
+        title={t("gabinet.patients.createPatient", "Nowy pacjent")}
+        description={t("gabinet.patients.createDescription", "Wypełnij dane nowego pacjenta.")}
+      >
+        <PatientForm
+          onSubmit={handleCreatePatient}
+          onCancel={() => setCreatePatientPanelOpen(false)}
+          isSubmitting={creatingPatient}
+          organizationId={organizationId}
+        />
       </SidePanel>
 
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3209.

Closes #3209

---

## Claude summary

Done. Here's a summary of what was implemented across 3 files:

**`convex/gabinet/packages.ts`** — new `assignGiftPackage` action that verifies auth/permissions, confirms the usage is an unassigned gift voucher, updates `patientId` and `status: "active"`, runs the existing `_purchaseSideEffects` side-chain (activity log), and awards loyalty points if the package definition has them.

**`src/hooks/use-supabase-gabinet-packages.ts`** — new `useSupabaseGabinetPackageUsageUnassigned` hook that queries `gabinet_package_usage` where `status = "unassigned"` and `is_gift = true`.

**`src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx`** — the packages page now has two tabs. The existing package-definition grid is under "Pakiety". The new "Vouchery" tab lists all unassigned gift usages (with badge showing count). Each row shows the voucher code, optional recipient name/phone, purchase date, and a "Przypisz do pacjenta" button that opens a side panel. The panel has a patient dropdown plus a "Nowy pacjent" ghost button that opens a nested panel with a minimal 3-field form (first name, last name, email). After patient creation the new patient is auto-selected, then saving calls `assignGiftPackage` and removes the voucher from the list.

**How to test:**
1. Go to Gabinet → Pakiety → tab "Vouchery"
2. Sell a package as a gift (Gabinet → Pakiety → "Przypisz pakiet" → "Sprzedaj jako prezent")
3. Return to Vouchery tab — the voucher appears with status "Nieprzypisany"
4. Click "Przypisz do pacjenta", select an existing patient, click Save — voucher disappears from the tab and appears on the patient's profile
5. Or: click "Nowy pacjent", fill in name + email, submit — new patient is created and auto-selected, then save to assign