### PR TITLE
Fix update action guard for `purchasePrice` to match create

### DIFF
--- a/convex/products.ts
+++ b/convex/products.ts
@@ -211,8 +211,8 @@ export const update = action({
     if (updates.manufacturer !== undefined) patchPayload.manufacturer = updates.manufacturer;
     if (updates.catalogNumber !== undefined) patchPayload.catalogNumber = updates.catalogNumber;
     if (updates.stockNote !== undefined) patchPayload.stockNote = updates.stockNote;
-    if (updates.purchasePrice !== undefined) patchPayload.purchasePrice = updates.purchasePrice;
-    if (updates.salePrice !== undefined) patchPayload.salePrice = updates.salePrice;
+    if (updates.purchasePrice != null) patchPayload.purchasePrice = updates.purchasePrice;
+    if (updates.salePrice != null) patchPayload.salePrice = updates.salePrice;
 
     await db.patch("products", productId, patchPayload);
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3242.

Closes #3242

---

## Claude summary

The fix is committed. Two lines changed in `convex/products.ts`:

- Line 214: `updates.purchasePrice !== undefined` → `updates.purchasePrice != null`
- Line 215: `updates.salePrice !== undefined` → `updates.salePrice != null`

The schema defines both fields as `v.optional(v.number())` — meaning absent-or-number, never null. The `!== undefined` guard was allowing a null value to pass into `patchPayload`, which would then be sent to `db.patch` as an invalid value. The `!= null` guard (used by the create handler) correctly rejects both `null` and `undefined`, so a clear-field attempt just leaves the existing DB value unchanged — which matches the valid states the schema allows.

I also fixed `salePrice` on the immediately adjacent line since it had the identical inconsistency.