### PR TITLE
Add `salePrice` to `MappedProduct` interface

### DIFF
--- a/src/lib/supabase/mappers/products.ts
+++ b/src/lib/supabase/mappers/products.ts
@@ -26,6 +26,7 @@ export interface MappedProduct {
   catalogNumber?: string;
   stockNote?: string;
   purchasePrice?: number;
+  salePrice?: number;
   createdBy: string;
   createdAt: number;
   updatedAt: number;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3243.

Closes #3243

---

## Claude summary

Done. Added `salePrice?: number` to the `MappedProduct` interface in `src/lib/supabase/mappers/products.ts:29`. The field was already present in the Supabase `ProductRow` type (`sale_price`, migration `00066`), in the Convex schema, in the mutation validators, and was accessed at `_layout.products.index.tsx:1416` — the interface was simply missing the declaration. TypeScript now sees the property correctly with no new type errors introduced.