### PR TITLE
Update stale schema comment for `salePrice`

### DIFF
--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -322,7 +322,7 @@ export function createCrmTables({
     // Net purchase price per unit (#2956, migration 00050). Used to calculate
     // warehouse value. Distinct from unitPrice (the selling price).
     purchasePrice: v.optional(v.number()),
-    // Optional retail sale price per unit (#3201/#3203, migration 00064).
+    // Optional retail sale price per unit (#3201/#3203, migration 00066).
     // Data-layer only for now — form/columns/validation wiring is a follow-up
     // per the #3203 micro-task scoping.
     salePrice: v.optional(v.number()),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3244.

Closes #3244

---

## Claude summary

Fixed. `convex/schema/crm.ts:325` now correctly references `migration 00066` instead of the stale `00064`. The actual migration file `00066_product_sale_price.sql` was confirmed to exist; `00064` belongs to an unrelated gabinet feature.