### PR TITLE
Ujednolić przyciski nad tabelą produktów

### DIFF
--- a/src/components/crm/data-list-filter-bar.tsx
+++ b/src/components/crm/data-list-filter-bar.tsx
@@ -492,11 +492,39 @@ export function DataListFilterBar({
             </span>
           </Button>
         )}
+        {(_onTagsManage || _onCategoriesManage) && (
+          <Dropdown.Root>
+            <Button
+              size="sm"
+              color={tagsButtonLabel ? "secondary" : "tertiary"}
+              iconLeading={_onTagsManage && _onCategoriesManage ? Folder : (_onTagsManage ? Tag03 : Folder)}
+            >
+              {tagsButtonLabel ?? null}
+            </Button>
+            <Dropdown.Popover>
+              <Dropdown.Menu>
+                {_onTagsManage && (
+                  <Dropdown.Item
+                    label={t("common.tags", { defaultValue: "Tagi" })}
+                    icon={Tag03}
+                    onAction={_onTagsManage}
+                  />
+                )}
+                {_onCategoriesManage && (
+                  <Dropdown.Item
+                    label={t("common.category", { defaultValue: "Kategorie" })}
+                    icon={Folder}
+                    onAction={_onCategoriesManage}
+                  />
+                )}
+              </Dropdown.Menu>
+            </Dropdown.Popover>
+          </Dropdown.Root>
+        )}
         {onColumnSettingsOpen && (
-          <button type="button" className="group relative inline-flex h-max cursor-pointer items-center justify-center gap-1.5 rounded-lg border border-border-primary bg-bg-primary px-3 py-1.5 text-sm text-fg-quaternary shadow-xs hover:bg-bg-primary_hover hover:text-fg-tertiary" onClick={onColumnSettingsOpen}>
-            <Columns03 className="size-4 stroke-[2px]" />
-            <span>{t("table.showColumns", { defaultValue: "Show columns" })}</span>
-          </button>
+          <Button size="sm" color="secondary" iconLeading={Columns03} onClick={onColumnSettingsOpen}>
+            {t("table.showColumns", { defaultValue: "Show columns" })}
+          </Button>
         )}
         {!onColumnSettingsOpen && columnDefs && columnDefs.length > 0 && onToggleColumn && (
           <Popover>
@@ -528,35 +556,6 @@ export function DataListFilterBar({
               })}
             </PopoverContent>
           </Popover>
-        )}
-        {(_onTagsManage || _onCategoriesManage) && (
-          <Dropdown.Root>
-            <Button
-              size="sm"
-              color={tagsButtonLabel ? "secondary" : "tertiary"}
-              iconLeading={_onTagsManage && _onCategoriesManage ? Folder : (_onTagsManage ? Tag03 : Folder)}
-            >
-              {tagsButtonLabel ?? null}
-            </Button>
-            <Dropdown.Popover>
-              <Dropdown.Menu>
-                {_onTagsManage && (
-                  <Dropdown.Item
-                    label={t("common.tags", { defaultValue: "Tagi" })}
-                    icon={Tag03}
-                    onAction={_onTagsManage}
-                  />
-                )}
-                {_onCategoriesManage && (
-                  <Dropdown.Item
-                    label={t("common.category", { defaultValue: "Kategorie" })}
-                    icon={Folder}
-                    onAction={_onCategoriesManage}
-                  />
-                )}
-              </Dropdown.Menu>
-            </Dropdown.Popover>
-          </Dropdown.Root>
         )}
         {renderMoreActions()}
       </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3248.

Closes #3248

---

## Claude summary

Done. One file changed: `src/components/crm/data-list-filter-bar.tsx`.

**What was fixed:**

- **Order**: The "Kategorie i tagi" dropdown block was moved before the "Pokaż kolumny" button block. The desktop toolbar now reads: search → Kategorie i tagi → Pokaż kolumny.
- **Style**: The "Pokaż kolumny" button (when `onColumnSettingsOpen` is provided) was a raw `<button>` with hand-rolled border/bg/padding classes that didn't match the UTUI design system. It's now `<Button size="sm" color="secondary" iconLeading={Columns03}>` — identical variant to the "Kategorie i tagi" button when a text label is present. Both buttons now share the same background, border, height, text style, and icon treatment.

The "Pokaż kolumny" popover path (when `columnDefs`/`onToggleColumn` is used instead of `onColumnSettingsOpen`) was left untouched since products page uses `onColumnSettingsOpen`. Mobile layout was also left untouched since it never showed either of these buttons.