### PR TITLE
Dodaj sekcję „Sprzedaż” do ustawień kolumn produktów

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -971,6 +971,39 @@ function ProductsPage() {
       },
       sortable: true,
     },
+    // SEKCJA – Sprzedaż
+    {
+      id: "salePriceGross",
+      label: t("products.salePriceGross", { defaultValue: "Cena sprzedaży brutto" }),
+      headerClassName: "whitespace-normal leading-tight",
+      sortable: true,
+      render: (item) => {
+        if (item.productSection !== "sale") return <span className="text-muted-foreground">—</span>;
+        if (item.salePrice == null) return <span className="text-muted-foreground">—</span>;
+        return formatCurrency(item.salePrice);
+      },
+      getSortValue: (item) => {
+        if (item.productSection !== "sale" || item.salePrice == null) return -Infinity;
+        return item.salePrice;
+      },
+    },
+    {
+      id: "salePriceNet",
+      label: t("products.salePriceNet", { defaultValue: "Cena sprzedaży netto" }),
+      headerClassName: "whitespace-normal leading-tight",
+      sortable: true,
+      render: (item) => {
+        if (item.productSection !== "sale") return <span className="text-muted-foreground">—</span>;
+        if (item.salePrice == null) return <span className="text-muted-foreground">—</span>;
+        if (item.taxExempt || item.taxRate == null) return formatCurrency(item.salePrice);
+        return formatCurrency(item.salePrice / (1 + item.taxRate / 100));
+      },
+      getSortValue: (item) => {
+        if (item.productSection !== "sale" || item.salePrice == null) return -Infinity;
+        if (item.taxExempt || item.taxRate == null) return item.salePrice;
+        return item.salePrice / (1 + item.taxRate / 100);
+      },
+    },
     // SEKCJA 4 – Informacje dodatkowe
     {
       id: "manufacturer",
@@ -1026,6 +1059,8 @@ function ProductsPage() {
     d.add("tagIds");
     d.add("createdAt");
     d.add("purchasePriceGross");
+    d.add("salePriceGross");
+    d.add("salePriceNet");
     return d;
   }, [autoDefaultHidden]);
   const { hiddenColumnIds, toggleColumn, setHiddenColumns } = useColumnVisibility(defaultHidden, "products");
@@ -1351,6 +1386,7 @@ function ProductsPage() {
           { label: t("products.columnSections.identification", { defaultValue: "Identyfikacja produktu" }), ids: ["name", "productSection", "categoryId"] },
           { label: t("products.columnSections.stock", { defaultValue: "Stan magazynowy" }), ids: ["stock", "plannedUsage", "minStock"] },
           { label: t("products.columnSections.finance", { defaultValue: "Finanse" }), ids: ["unitPrice", "purchasePriceGross", "taxRate", "value"] },
+          { label: t("products.columnSections.sales", { defaultValue: "Sprzedaż" }), ids: ["salePriceGross", "salePriceNet"] },
           { label: t("products.columnSections.additional", { defaultValue: "Informacje dodatkowe" }), ids: ["manufacturer", "sku", "catalogNumber", "tagIds", "isActive", "createdAt"] },
         ].map((section) => {
           const sectionCols = section.ids


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3250.

Closes #3250

---

## Claude summary

Done. Here's a summary of what was changed in a single file:

**`src/routes/_app/_auth/dashboard/_layout.products.index.tsx`**

1. Two new columns added to the `columns` array (after the "Finanse" section):
   - `salePriceGross` — renders `salePrice` formatted as PLN; shows "—" for non-sale products or when `salePrice` is null
   - `salePriceNet` — computes `salePrice / (1 + taxRate/100)`; for tax-exempt products shows `salePrice` unchanged; shows "—" for non-sale products or missing `salePrice`; both columns are sortable

2. Both column IDs added to `defaultHidden` so they start hidden until the user enables them.

3. A new `{ label: "Sprzedaż", ids: ["salePriceGross", "salePriceNet"] }` section inserted between "Finanse" and "Informacje dodatkowe" in the column settings panel. The section heading renders uppercase in the same style as all other sections.