### PR TITLE
Zmień nazwę sekcji „Finanse” na „Zakup”

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -1385,7 +1385,7 @@ function ProductsPage() {
         {[
           { label: t("products.columnSections.identification", { defaultValue: "Identyfikacja produktu" }), ids: ["name", "productSection", "categoryId"] },
           { label: t("products.columnSections.stock", { defaultValue: "Stan magazynowy" }), ids: ["stock", "plannedUsage", "minStock"] },
-          { label: t("products.columnSections.finance", { defaultValue: "Finanse" }), ids: ["unitPrice", "purchasePriceGross", "taxRate", "value"] },
+          { label: t("products.columnSections.finance", { defaultValue: "Zakup" }), ids: ["unitPrice", "purchasePriceGross", "taxRate", "value"] },
           { label: t("products.columnSections.sales", { defaultValue: "Sprzedaż" }), ids: ["salePriceGross", "salePriceNet"] },
           { label: t("products.columnSections.additional", { defaultValue: "Informacje dodatkowe" }), ids: ["manufacturer", "sku", "catalogNumber", "tagIds", "isActive", "createdAt"] },
         ].map((section) => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3251.

Closes #3251

---

## Claude summary

Done. One line changed, one file touched:

**File:** `src/routes/_app/_auth/dashboard/_layout.products.index.tsx:1388`

The `defaultValue` for the `products.columnSections.finance` i18n key was updated from `"Finanse"` to `"Zakup"`. The section's columns (`unitPrice`, `purchasePriceGross`, `taxRate`, `value`), their order, and all other column settings mechanics are untouched.