### PR TITLE
Zmień jedną etykietę ceny w ProductForm

### DIFF
--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -905,7 +905,7 @@
       "namePlaceholder": "Wpisz nazwę produktu",
       "sku": "SKU",
       "skuPlaceholder": "np. PROD-001",
-      "unitPrice": "Cena jednostkowa",
+      "unitPrice": "Cena zakupu netto",
       "taxRate": "Stawka VAT (%)",
       "isActive": "Aktywny",
       "description": "Opis",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3254.

Closes #3254

---

## Claude summary

Done. Changed line 908 of `public/locales/pl/translation.json`:

```
"unitPrice": "Cena jednostkowa"  →  "unitPrice": "Cena zakupu netto"
```

The form at `src/components/forms/product-form.tsx:279` uses `t("products.form.unitPrice")` — no code change needed, only the translation value. Field name, validation, and all other behavior remain untouched.