### PR TITLE
Automatycznie przeliczaj ceny netto i brutto

### DIFF
--- a/src/components/forms/product-form.tsx
+++ b/src/components/forms/product-form.tsx
@@ -167,10 +167,38 @@ export function ProductForm({
 
   const handleTaxRateChange = (newRate: string) => {
     setTaxRate(newRate);
-    const parsedGross = parseFloat(salePrice.replace(",", "."));
-    if (Number.isFinite(parsedGross) && parsedGross >= 0) {
-      const multiplier = getTaxMultiplier(newRate);
-      setSalePriceNet(String(Math.round((parsedGross / multiplier) * 100) / 100));
+    const multiplier = getTaxMultiplier(newRate);
+    // Sale: keep gross, update net
+    const parsedSaleGross = parseFloat(salePrice.replace(",", "."));
+    if (Number.isFinite(parsedSaleGross) && parsedSaleGross >= 0) {
+      setSalePriceNet(String(Math.round((parsedSaleGross / multiplier) * 100) / 100));
+    }
+    // Purchase: keep net (unitPrice), update gross (purchasePrice)
+    const parsedPurchaseNet = parseFloat(unitPrice.replace(",", "."));
+    if (Number.isFinite(parsedPurchaseNet) && parsedPurchaseNet >= 0) {
+      setPurchasePrice(String(Math.round(parsedPurchaseNet * multiplier * 100) / 100));
+    }
+  };
+
+  const handleUnitPriceChange = (v: string) => {
+    if (v !== "" && !/^[0-9]*[.,]?[0-9]*$/.test(v)) return;
+    setUnitPrice(v);
+    const parsed = parseFloat(v.replace(",", "."));
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      const multiplier = getTaxMultiplier(taxRate);
+      setPurchasePrice(String(Math.round(parsed * multiplier * 100) / 100));
+    } else {
+      setPurchasePrice("");
+    }
+  };
+
+  const handlePurchasePriceChange = (v: string) => {
+    if (v !== "" && !/^[0-9]*[.,]?[0-9]*$/.test(v)) return;
+    setPurchasePrice(v);
+    const parsed = parseFloat(v.replace(",", "."));
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      const multiplier = getTaxMultiplier(taxRate);
+      setUnitPrice(String(Math.round((parsed / multiplier) * 100) / 100));
     }
   };
 
@@ -336,10 +364,7 @@ export function ProductForm({
             type="text"
             inputMode="decimal"
             value={unitPrice}
-            onChange={(e) => {
-              const v = e.target.value;
-              if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) setUnitPrice(v);
-            }}
+            onChange={(e) => handleUnitPriceChange(e.target.value)}
             placeholder="0.00"
             required
           />
@@ -367,10 +392,7 @@ export function ProductForm({
             type="text"
             inputMode="decimal"
             value={purchasePrice}
-            onChange={(e) => {
-              const v = e.target.value;
-              if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) setPurchasePrice(v);
-            }}
+            onChange={(e) => handlePurchasePriceChange(e.target.value)}
             placeholder={t("products.stock.purchasePricePlaceholder", { defaultValue: "np. 120,00" })}
           />
           <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3260.

Closes #3260

---

## Claude summary

Done. Here's a summary of what changed and why:

**Changed file:** `src/components/forms/product-form.tsx`

The sale section (Sprzedaż) already had full net↔gross synchronisation from PR #3259. The purchase section (Zakup) had two separate, unlinked fields: `unitPrice` ("Cena zakupu netto") and `purchasePrice` ("Cena zakupu brutto").

Three additions:

1. `handleUnitPriceChange` — when the user edits the net purchase price, the gross is recalculated as `net × (1 + VAT%)` in real time.

2. `handlePurchasePriceChange` — when the user edits the gross purchase price, the net is recalculated as `gross ÷ (1 + VAT%)`. Clearing the gross field does not clear the net (since it's a required field).

3. `handleTaxRateChange` extended — changing the VAT rate now also recalculates the purchase gross from the current net, in addition to the existing sale net recalculation.

No changes to form submission, validation, database writes, or layout.