### PR TITLE
Zmień kolejność kolumn sprzedaży w ustawieniach

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -1386,7 +1386,7 @@ function ProductsPage() {
           { label: t("products.columnSections.identification", { defaultValue: "Identyfikacja produktu" }), ids: ["name", "productSection", "categoryId"] },
           { label: t("products.columnSections.stock", { defaultValue: "Stan magazynowy" }), ids: ["stock", "plannedUsage", "minStock"] },
           { label: t("products.columnSections.finance", { defaultValue: "Zakup" }), ids: ["unitPrice", "purchasePriceGross", "taxRate", "value"] },
-          { label: t("products.columnSections.sales", { defaultValue: "Sprzedaż" }), ids: ["salePriceGross", "salePriceNet"] },
+          { label: t("products.columnSections.sales", { defaultValue: "Sprzedaż" }), ids: ["salePriceNet", "salePriceGross"] },
           { label: t("products.columnSections.additional", { defaultValue: "Informacje dodatkowe" }), ids: ["manufacturer", "sku", "catalogNumber", "tagIds", "isActive", "createdAt"] },
         ].map((section) => {
           const sectionCols = section.ids


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3264.

Closes #3264

---

## Claude summary

Done. One character-for-character swap on line 1389 of `src/routes/_app/_auth/dashboard/_layout.products.index.tsx`. The "Sprzedaż" section in the column settings panel now lists `salePriceNet` ("Cena sprzedaży netto") first and `salePriceGross` ("Cena sprzedaży brutto") second. All toggle/visibility behavior is unchanged.