### PR TITLE
Napraw nazwę pozycji menu „Dostawy”

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -130,6 +130,7 @@
       "packages": "Packages",
       "documents": "Communication",
       "employees": "Employees",
+      "deliveries": "Deliveries",
       "reports": "Reports",
       "scheduling": "Working Hours",
       "leaves": "Leaves",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -130,6 +130,7 @@
       "packages": "Pakiety",
       "documents": "Komunikacja",
       "employees": "Pracownicy",
+      "deliveries": "Dostawy",
       "reports": "Raporty",
       "scheduling": "Godziny pracy",
       "leaves": "Urlopy",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3270.

Closes #3270

---

## Claude summary

The bug was real and the fix is simple. The `nav.gabinet.deliveries` key was added to `src/modules/gabinet/manifest.ts:58` to define the "Dostawy" sidebar entry, but the corresponding translation strings were never added to either locale file. Added `"deliveries": "Dostawy"` to `public/locales/pl/translation.json` and `"deliveries": "Deliveries"` to `public/locales/en/translation.json` in the `nav.gabinet` section (line 132 of each file), matching the position of the entry in the manifest.