### PR TITLE
Sprawdź źródło danych eksportu CSV produktów

### DIFF
--- a/convex/csvExport.ts
+++ b/convex/csvExport.ts
@@ -1,6 +1,8 @@
-import { query } from "./_generated/server";
+import { query, action } from "./_generated/server";
+import { internal } from "./_generated/api";
 import { v } from "convex/values";
 import { requireOrgAdmin } from "./_helpers/auth";
+import { createSupabaseDb } from "./_helpers/supabaseDb";
 
 export const exportContacts = query({
   args: { organizationId: v.id("organizations") },
@@ -109,19 +111,22 @@ export const exportPatients = query({
   },
 });
 
-export const exportProducts = query({
+export const exportProducts = action({
   args: { organizationId: v.id("organizations") },
   handler: async (ctx, args) => {
-    await requireOrgAdmin(ctx, args.organizationId);
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
 
-    const products = await ctx.db
+    const db = createSupabaseDb();
+    const products = await db
       .query("products")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+      .eq("organizationId", args.organizationId)
       .collect();
 
     return products.map((p) => ({
       name: p.name,
-      sku: p.sku,
+      sku: p.sku ?? "",
       unitPrice: p.unitPrice.toString(),
       taxRate: p.taxExempt ? "ZW" : p.taxRate != null ? p.taxRate.toString() : "",
       isActive: p.isActive ? "Yes" : "No",

--- a/src/components/csv/csv-export-button.tsx
+++ b/src/components/csv/csv-export-button.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useAction } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { Id } from "@cvx/_generated/dataModel";
@@ -10,13 +11,13 @@ import { Download } from "@/lib/ez-icons";
 import Papa from "papaparse";
 import { formatActionError } from "@/lib/format-action-error";
 
-type EntityType = "contacts" | "companies" | "leads" | "products" | "patients";
+type QueryEntityType = "contacts" | "companies" | "leads" | "patients";
+type EntityType = QueryEntityType | "products";
 
 const exportQueries = {
   contacts: api.csvExport.exportContacts,
   companies: api.csvExport.exportCompanies,
   leads: api.csvExport.exportLeads,
-  products: api.csvExport.exportProducts,
   patients: api.csvExport.exportPatients,
 } as const;
 
@@ -28,19 +29,31 @@ export function useCsvExport(
   const { t } = useTranslation();
   const [isExporting, setIsExporting] = useState(false);
 
+  // useQuery is always called (hook rules). When entityType=products the query
+  // is never used (enabled:false + runProductsExport handles it instead).
+  const queryType: QueryEntityType = entityType !== "products" ? entityType : "contacts";
   const { refetch } = useQuery({
-    ...convexQuery(exportQueries[entityType], { organizationId }),
+    ...convexQuery(exportQueries[queryType], { organizationId }),
     enabled: false,
   });
+
+  // Products data lives in Supabase; exportProducts is a Convex action that
+  // reads from Supabase via createSupabaseDb() rather than ctx.db.
+  const runProductsExport = useAction(api.csvExport.exportProducts);
 
   const handleExport = useCallback(async () => {
     setIsExporting(true);
     try {
-      const result = await refetch();
-      const rows = result.data;
+      let rows: Record<string, unknown>[] | undefined;
+      if (entityType === "products") {
+        rows = (await runProductsExport({ organizationId })) as Record<string, unknown>[];
+      } else {
+        const result = await refetch();
+        rows = result.data as Record<string, unknown>[] | undefined;
+      }
       if (!rows || rows.length === 0) return;
 
-      const csv = Papa.unparse(rows as Record<string, unknown>[]);
+      const csv = Papa.unparse(rows);
       const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
@@ -61,7 +74,7 @@ export function useCsvExport(
     } finally {
       setIsExporting(false);
     }
-  }, [refetch, entityType, fileNamePrefix, t]);
+  }, [refetch, runProductsExport, entityType, organizationId, fileNamePrefix, t]);
 
   return { handleExport, isExporting };
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3274.

Closes #3274

---

## Claude summary

The bug was real and is now fixed. Here's what was happening and what changed:

**Root cause**: `exportProducts` in `convex/csvExport.ts` was a Convex `query` that read from `ctx.db` — the Convex internal database. After the April 2026 migration, all product data lives in Supabase. The Convex internal DB only retained the old E2E seed records (`E2E-Product...`), so the export always returned those 4 stale rows regardless of filters or the user's actual data.

**Fix** (`convex/csvExport.ts` + `src/components/csv/csv-export-button.tsx`):
- Changed `exportProducts` from a Convex `query` to a Convex `action` that uses `createSupabaseDb()` to fetch real product data from Supabase, filtered by `organizationId`.
- Updated `useCsvExport` to call `exportProducts` via `useAction` (actions can't be called via `convexQuery`). The other entity types (contacts, companies, leads, patients) retain their original `useQuery`/`convexQuery` flow.

## Follow-ups
- Fix CSV export for contacts, companies, leads, patients: `exportContacts`, `exportCompanies`, `exportLeads`, and `exportPatients` in `convex/csvExport.ts` all still read from the Convex internal DB (`ctx.db`) — the same problem as #3274 but for those entity types. They should also be converted to actions reading from Supabase.