### PR TITLE
Fix CSV export for contacts, companies, leads, patients

### DIFF
--- a/convex/csvExport.ts
+++ b/convex/csvExport.ts
@@ -1,17 +1,30 @@
-import { query, action } from "./_generated/server";
+import { action } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
-import { requireOrgAdmin } from "./_helpers/auth";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 
-export const exportContacts = query({
+async function requireOrgAdminAction(
+  ctx: { runQuery: Function },
+  organizationId: string,
+) {
+  const { role } = await ctx.runQuery(
+    internal._helpers.authAction.verifyOrgAccess,
+    { organizationId },
+  );
+  if (role !== "owner" && role !== "admin") {
+    throw new Error("Admin access required");
+  }
+}
+
+export const exportContacts = action({
   args: { organizationId: v.id("organizations") },
   handler: async (ctx, args) => {
-    await requireOrgAdmin(ctx, args.organizationId);
+    await requireOrgAdminAction(ctx, args.organizationId);
 
-    const contacts = await ctx.db
+    const db = createSupabaseDb();
+    const contacts = await db
       .query("contacts")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+      .eq("organizationId", args.organizationId)
       .collect();
 
     return contacts.map((c) => ({
@@ -21,21 +34,22 @@ export const exportContacts = query({
       phone: c.phone ?? "",
       title: c.title ?? "",
       source: c.source ?? "",
-      tags: (c.tags ?? []).join("; "),
+      tags: ((c.tags as string[] | null) ?? []).join("; "),
       notes: c.notes ?? "",
-      createdAt: new Date(c.createdAt).toISOString(),
+      createdAt: new Date(c.createdAt as number).toISOString(),
     }));
   },
 });
 
-export const exportCompanies = query({
+export const exportCompanies = action({
   args: { organizationId: v.id("organizations") },
   handler: async (ctx, args) => {
-    await requireOrgAdmin(ctx, args.organizationId);
+    await requireOrgAdminAction(ctx, args.organizationId);
 
-    const companies = await ctx.db
+    const db = createSupabaseDb();
+    const companies = await db
       .query("companies")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+      .eq("organizationId", args.organizationId)
       .collect();
 
     return companies.map((c) => ({
@@ -45,26 +59,27 @@ export const exportCompanies = query({
       size: c.size ?? "",
       website: c.website ?? "",
       phone: c.phone ?? "",
-      street: c.address?.street ?? "",
-      city: c.address?.city ?? "",
-      state: c.address?.state ?? "",
-      zip: c.address?.zip ?? "",
-      country: c.address?.country ?? "",
-      tags: (c.tags ?? []).join("; "),
+      street: (c.address as { street?: string } | null)?.street ?? "",
+      city: (c.address as { city?: string } | null)?.city ?? "",
+      state: (c.address as { state?: string } | null)?.state ?? "",
+      zip: (c.address as { zip?: string } | null)?.zip ?? "",
+      country: (c.address as { country?: string } | null)?.country ?? "",
+      tags: ((c.tags as string[] | null) ?? []).join("; "),
       notes: c.notes ?? "",
-      createdAt: new Date(c.createdAt).toISOString(),
+      createdAt: new Date(c.createdAt as number).toISOString(),
     }));
   },
 });
 
-export const exportLeads = query({
+export const exportLeads = action({
   args: { organizationId: v.id("organizations") },
   handler: async (ctx, args) => {
-    await requireOrgAdmin(ctx, args.organizationId);
+    await requireOrgAdminAction(ctx, args.organizationId);
 
-    const leads = await ctx.db
+    const db = createSupabaseDb();
+    const leads = await db
       .query("leads")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+      .eq("organizationId", args.organizationId)
       .collect();
 
     return leads.map((l) => ({
@@ -74,24 +89,25 @@ export const exportLeads = query({
       status: l.status,
       priority: l.priority ?? "",
       expectedCloseDate: l.expectedCloseDate
-        ? new Date(l.expectedCloseDate).toISOString()
+        ? new Date(l.expectedCloseDate as number).toISOString()
         : "",
       source: l.source ?? "",
       notes: l.notes ?? "",
-      tags: (l.tags ?? []).join("; "),
-      createdAt: new Date(l.createdAt).toISOString(),
+      tags: ((l.tags as string[] | null) ?? []).join("; "),
+      createdAt: new Date(l.createdAt as number).toISOString(),
     }));
   },
 });
 
-export const exportPatients = query({
+export const exportPatients = action({
   args: { organizationId: v.id("organizations") },
   handler: async (ctx, args) => {
-    await requireOrgAdmin(ctx, args.organizationId);
+    await requireOrgAdminAction(ctx, args.organizationId);
 
-    const patients = await ctx.db
+    const db = createSupabaseDb();
+    const patients = await db
       .query("gabinetPatients")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+      .eq("organizationId", args.organizationId)
       .collect();
 
     return patients.map((p) => ({
@@ -106,7 +122,7 @@ export const exportPatients = query({
       allergies: p.allergies ?? "",
       status: p.isActive ? "active" : "inactive",
       referralSource: p.referralSource ?? "",
-      createdAt: new Date(p.createdAt).toISOString(),
+      createdAt: new Date(p.createdAt as number).toISOString(),
     }));
   },
 });

--- a/src/components/csv/csv-export-button.tsx
+++ b/src/components/csv/csv-export-button.tsx
@@ -1,7 +1,5 @@
 import { useState, useCallback } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
@@ -11,15 +9,7 @@ import { Download } from "@/lib/ez-icons";
 import Papa from "papaparse";
 import { formatActionError } from "@/lib/format-action-error";
 
-type QueryEntityType = "contacts" | "companies" | "leads" | "patients";
-type EntityType = QueryEntityType | "products";
-
-const exportQueries = {
-  contacts: api.csvExport.exportContacts,
-  companies: api.csvExport.exportCompanies,
-  leads: api.csvExport.exportLeads,
-  patients: api.csvExport.exportPatients,
-} as const;
+type EntityType = "contacts" | "companies" | "leads" | "patients" | "products";
 
 export function useCsvExport(
   organizationId: Id<"organizations">,
@@ -29,27 +19,27 @@ export function useCsvExport(
   const { t } = useTranslation();
   const [isExporting, setIsExporting] = useState(false);
 
-  // useQuery is always called (hook rules). When entityType=products the query
-  // is never used (enabled:false + runProductsExport handles it instead).
-  const queryType: QueryEntityType = entityType !== "products" ? entityType : "contacts";
-  const { refetch } = useQuery({
-    ...convexQuery(exportQueries[queryType], { organizationId }),
-    enabled: false,
-  });
-
-  // Products data lives in Supabase; exportProducts is a Convex action that
-  // reads from Supabase via createSupabaseDb() rather than ctx.db.
+  const runContactsExport = useAction(api.csvExport.exportContacts);
+  const runCompaniesExport = useAction(api.csvExport.exportCompanies);
+  const runLeadsExport = useAction(api.csvExport.exportLeads);
+  const runPatientsExport = useAction(api.csvExport.exportPatients);
   const runProductsExport = useAction(api.csvExport.exportProducts);
 
   const handleExport = useCallback(async () => {
     setIsExporting(true);
     try {
-      let rows: Record<string, unknown>[] | undefined;
-      if (entityType === "products") {
-        rows = (await runProductsExport({ organizationId })) as Record<string, unknown>[];
+      const args = { organizationId };
+      let rows: Record<string, unknown>[];
+      if (entityType === "contacts") {
+        rows = (await runContactsExport(args)) as Record<string, unknown>[];
+      } else if (entityType === "companies") {
+        rows = (await runCompaniesExport(args)) as Record<string, unknown>[];
+      } else if (entityType === "leads") {
+        rows = (await runLeadsExport(args)) as Record<string, unknown>[];
+      } else if (entityType === "patients") {
+        rows = (await runPatientsExport(args)) as Record<string, unknown>[];
       } else {
-        const result = await refetch();
-        rows = result.data as Record<string, unknown>[] | undefined;
+        rows = (await runProductsExport(args)) as Record<string, unknown>[];
       }
       if (!rows || rows.length === 0) return;
 
@@ -74,7 +64,17 @@ export function useCsvExport(
     } finally {
       setIsExporting(false);
     }
-  }, [refetch, runProductsExport, entityType, organizationId, fileNamePrefix, t]);
+  }, [
+    runContactsExport,
+    runCompaniesExport,
+    runLeadsExport,
+    runPatientsExport,
+    runProductsExport,
+    entityType,
+    organizationId,
+    fileNamePrefix,
+    t,
+  ]);
 
   return { handleExport, isExporting };
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3276.

Closes #3276

---

## Claude summary

Done. Here's a summary of what was changed:

**`convex/csvExport.ts`** — Converted `exportContacts`, `exportCompanies`, `exportLeads`, and `exportPatients` from `query` (reading stale Convex DB) to `action` (reading live Supabase data via `createSupabaseDb()`). A local `requireOrgAdminAction` helper runs `internal._helpers.authAction.verifyOrgAccess` and checks the role, preserving the original admin-only gate.

**`src/components/csv/csv-export-button.tsx`** — Replaced the hybrid approach (four `useQuery`+`convexQuery` calls with `enabled: false` / `refetch()` for most types, `useAction` for products) with a clean uniform pattern: one `useAction` hook per entity type, all called unconditionally, with the right one invoked in `handleExport`.