### PR TITLE
Seed avgCost from purchasePrice on initial stock movement

### DIFF
--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -202,7 +202,7 @@ export async function applyMovementInternal(
   // branch which resets to the new delivery price outright.
   let newAvgCost: number | null = null;
   if (
-    params.reason === "warehouse_receive" &&
+    (params.reason === "warehouse_receive" || params.reason === "initial") &&
     params.unitPrice != null &&
     resolvedDelta > 0
   ) {

--- a/convex/products.ts
+++ b/convex/products.ts
@@ -102,6 +102,7 @@ export const create = action({
           locationId: null,
           delta: initial,
           reason: "initial",
+          unitPrice: args.purchasePrice ?? undefined,
           performedBy: String(authResult.userId),
         });
       } catch (e) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3280.

Closes #3280

---

## Claude summary

Two-line fix, committed. Here's what changed:

**`convex/products.ts:105`** — forwards `args.purchasePrice` as `unitPrice` when calling `applyMovementInternal` for the initial stock seed. Previously `unitPrice` was never passed for `reason: "initial"` movements.

**`convex/inventory.ts:205`** — extends the avgCost seeding condition to trigger for `reason: "initial"` in addition to `"warehouse_receive"`. Since the initial balance always starts at zero, the branch `!level || previousBalance <= 0` will always fire, so `newAvgCost` is set directly to `purchasePrice` — exactly the right behavior for a product that has no cost history yet.

The two changes work together: without the first, no `unitPrice` arrives; without the second, the `unitPrice` would be recorded on the movement row (via the existing `snapshotPrice` fallback) but would still not seed `avgCost` on the `productStockLevels` row.