### PR TITLE
Fix locationId silently dropped in `_createFromInvitation`

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -346,6 +346,25 @@ export const _createFromInvitation = internalAction({
       updatedAt: now,
     });
 
+    // Location assignment — moduleData.locationId seeds the primary location.
+    const locationId = asString(d.locationId);
+    if (locationId) {
+      try {
+        await db.insert("gabinetEmployeeLocations", {
+          organizationId: String(args.organizationId),
+          employeeId: String(employeeId),
+          locationId,
+          isPrimary: true,
+          createdAt: now,
+        });
+      } catch (e) {
+        console.error(
+          `[gabinet.employees._createFromInvitation] location insert failed:`,
+          e,
+        );
+      }
+    }
+
     // Custom fields (free-form per-org definitions) — moduleData.customFields
     // is expected to be an array of { fieldDefinitionId, value }. Matches the
     // shape `customFields.setValues` produces and what the renderer emits.


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3284.

Closes #3284

---

## Claude summary

The bug was real and the fix is committed. Here's what happened:

`_createFromInvitation` in `convex/gabinet/employees.ts:293` receives the invitation's `moduleData` payload as `args.data`. The frontend's `GabinetModuleData` type includes `locationId` (set in `src/components/forms/user-invitation-form.tsx:235`) and the invitation form does pass it — but the handler extracted all other fields from `d` (role, firstName, lastName, color, etc.) and wrote them to Supabase, while silently ignoring `d.locationId` entirely. No row was ever inserted into `gabinetEmployeeLocations`.

The fix inserts a `gabinetEmployeeLocations` row with `isPrimary: true` right after the employee row is created, wrapped in the same try/catch pattern used by the custom fields block below. Since this is the only location assigned at invite time, marking it as primary is the correct default.