### PR TITLE
Sync Gabinet role enum between EmployeeForm and UserInvitationForm

### DIFF
--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -28,9 +28,11 @@ type OrgRole = "owner" | "admin" | "member" | "viewer";
 type InviteModule = "none" | "gabinet";
 type GabinetRole =
   | "doctor"
+  | "cosmetologist"
   | "nurse"
   | "therapist"
   | "receptionist"
+  | "manager"
   | "admin"
   | "other";
 
@@ -42,9 +44,11 @@ const ROLES: { value: OrgRole; labelKey: string }[] = [
 
 const GABINET_ROLES: GabinetRole[] = [
   "doctor",
+  "cosmetologist",
   "nurse",
   "therapist",
   "receptionist",
+  "manager",
   "admin",
   "other",
 ];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3285.

Closes #3285

---

## Claude summary

The bug was real and is now fixed. In `src/components/forms/user-invitation-form.tsx`, the `GabinetRole` type (line 29) and `GABINET_ROLES` array (line 45) were missing "cosmetologist" and "manager" compared to the 8-role enum in both `employee-form.tsx` and `convex/schema.ts` (`gabinetEmployeeRoleValidator`). Both missing values have been added. Translation keys for them already existed in both EN and PL locale files (`gabinet.employees.roles.cosmetologist` / `gabinet.employees.roles.manager`), so no i18n changes were needed.