### PR TITLE
Add customFields to EmployeeForm

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -175,6 +175,7 @@ export const create = action({
     showInCalendar: v.optional(v.boolean()),
     tagIds: v.optional(v.array(v.string())),
     categoryId: v.optional(v.union(v.string(), v.null())),
+    customFields: v.optional(v.array(v.any())),
   },
   handler: async (ctx, args) => {
     try {
@@ -251,6 +252,28 @@ export const create = action({
         });
       } catch (e) {
         console.error("[employees.create] Membership mirror FAILED:", e);
+      }
+    }
+
+    if (args.customFields && args.customFields.length > 0) {
+      for (const f of args.customFields) {
+        if (!f || typeof f !== "object") continue;
+        const defId = (f as Record<string, unknown>).fieldDefinitionId;
+        const val = (f as Record<string, unknown>).value;
+        if (typeof defId !== "string" || defId.length === 0) continue;
+        try {
+          await db.insert("customFieldValues", {
+            organizationId: String(args.organizationId),
+            fieldDefinitionId: defId,
+            entityType: "gabinetEmployee",
+            entityId: String(employeeId),
+            value: val ?? null,
+            createdAt: now,
+            updatedAt: now,
+          });
+        } catch (e) {
+          console.error("[employees.create] customField insert failed:", e);
+        }
       }
     }
 

--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
+import { convexQuery } from "@convex-dev/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
@@ -18,6 +19,7 @@ import {
 } from "@/components/ui/select";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { CategoryPicker } from "@/components/categories-tags/category-picker";
+import { CustomFieldFormSection } from "@/components/custom-fields/custom-field-form-section";
 import { Search } from "@/lib/ez-icons";
 
 const ROLES = ["doctor", "cosmetologist", "nurse", "therapist", "receptionist", "manager", "admin", "other"] as const;
@@ -59,6 +61,7 @@ export interface EmployeeFormData {
   qualifiedTreatmentIds: Id<"gabinetTreatments">[];
   tagIds?: Id<"tagDefinitions">[];
   categoryId?: Id<"categoryDefinitions">;
+  customFields?: Array<{ fieldDefinitionId: string; value: unknown }>;
   grantSystemAccess?: boolean;
   accessEmail?: string;
   accessRole?: "admin" | "member" | "viewer";
@@ -91,6 +94,25 @@ export function EmployeeForm({
     enabled: !!organizationId,
   });
 
+  const { data: customFieldDefs } = useQuery(
+    convexQuery(
+      api.customFields.getDefinitions,
+      organizationId
+        ? { organizationId, entityType: "gabinetEmployee" as const }
+        : "skip",
+    ),
+  ) as {
+    data: Array<{
+      _id: string;
+      name: string;
+      fieldKey: string;
+      fieldType: any;
+      options?: string[];
+      isRequired?: boolean;
+      group?: string;
+    }> | undefined;
+  };
+
   const [firstName, setFirstName] = useState(initialData?.firstName ?? "");
   const [lastName, setLastName] = useState(initialData?.lastName ?? "");
   const [role, setRole] = useState<EmployeeRole>(initialData?.role ?? "doctor");
@@ -109,6 +131,7 @@ export function EmployeeForm({
   const [grantSystemAccess, setGrantSystemAccess] = useState(false);
   const [accessEmail, setAccessEmail] = useState("");
   const [accessRole, setAccessRole] = useState<"admin" | "member" | "viewer">("member");
+  const [customFieldValues, setCustomFieldValues] = useState<Record<string, unknown>>({});
 
   const filteredTreatments = useMemo(() => {
     if (!treatments) return [];
@@ -121,6 +144,13 @@ export function EmployeeForm({
     e.preventDefault();
 
     const isClinicalRole = role !== "receptionist" && role !== "manager";
+
+    const customFields = (customFieldDefs ?? [])
+      .map((def) => ({
+        fieldDefinitionId: def._id,
+        value: customFieldValues[def.fieldKey],
+      }))
+      .filter((f) => f.value !== undefined && f.value !== "");
 
     onSubmit({
       firstName: firstName || undefined,
@@ -135,6 +165,7 @@ export function EmployeeForm({
         : [],
       tagIds: tagIds.length > 0 ? tagIds : undefined,
       categoryId: categoryId || undefined,
+      customFields: customFields.length > 0 ? customFields : undefined,
       grantSystemAccess: grantSystemAccess || undefined,
       accessEmail: grantSystemAccess ? (accessEmail.trim() || undefined) : undefined,
       accessRole: grantSystemAccess ? accessRole : undefined,
@@ -348,6 +379,18 @@ export function EmployeeForm({
             onChange={setCategoryId}
             organizationId={organizationId}
             entityType="gabinetEmployee"
+          />
+        </div>
+      )}
+
+      {customFieldDefs && customFieldDefs.length > 0 && (
+        <div className="space-y-2 pt-2 border-t">
+          <CustomFieldFormSection
+            definitions={customFieldDefs as any}
+            values={customFieldValues}
+            onChange={(fieldKey, value) =>
+              setCustomFieldValues((prev) => ({ ...prev, [fieldKey]: value }))
+            }
           />
         </div>
       )}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3286.

Closes #3286

---

## Claude summary

The issue is confirmed and fixed. Here's a summary of what was changed:

**`src/components/forms/employee-form.tsx`** — mirroring what `user-invitation-form.tsx` already had:
- Added `convexQuery` import and `CustomFieldFormSection` import
- Added `customFields?: Array<{ fieldDefinitionId: string; value: unknown }>` to `EmployeeFormData`
- Added a `convexQuery(api.customFields.getDefinitions, { organizationId, entityType: "gabinetEmployee" })` query
- Added `customFieldValues` state
- `handleSubmit` now collects and passes `customFields` (non-empty values only)
- Renders `<CustomFieldFormSection>` below the category picker when definitions exist

**`convex/gabinet/employees.ts`** — backend `create` action:
- Added `customFields: v.optional(v.array(v.any()))` to args
- Added insertion loop that writes each custom field to `customFieldValues` table (same pattern as `_createFromInvitation`)

## Follow-ups
- Pass customFields through invitation path in EmployeeForm callers: Both `_layout.tsx:635` and `_layout.gabinet.employees.index.tsx:629` construct `moduleData` without `customFields`, so custom fields are lost when "Grant system access" is checked and the invitation path is used instead of direct create