### PR TITLE
licenseNumber lost in invitation flow

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -356,7 +356,7 @@ export const _createFromInvitation = internalAction({
       role: safeRole,
       specialization: asString(d.specialization),
       qualifiedTreatmentIds: asStringArray(d.qualifiedTreatmentIds) ?? [],
-      licenseNumber: null,
+      licenseNumber: asString(d.licenseNumber),
       hireDate: null,
       isActive: true,
       color: asString(d.color),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3287.

Closes #3287

---

## Claude summary

The fix is committed. The issue was exactly as reported: `convex/gabinet/employees.ts:359` had `licenseNumber: null` hardcoded in `_createFromInvitation`. Changed it to `asString(d.licenseNumber)`, which uses the same helper already used for all other string fields in that function — it reads the value from the invitation payload and coerces it to `string | null`.