### PR TITLE
Pass customFields through invitation path in EmployeeForm callers

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -629,6 +629,7 @@ function CreateEmployeeSheet({
                       qualifiedTreatmentIds: data.qualifiedTreatmentIds,
                       tagIds: data.tagIds,
                       categoryId: data.categoryId,
+                      customFields: data.customFields,
                     },
                   });
                   toast.success(t("team.invitationSent"));

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -642,6 +642,7 @@ function DashboardLayoutInner({ user, orgs }: DashboardLayoutInnerProps) {
                         qualifiedTreatmentIds: data.qualifiedTreatmentIds,
                         tagIds: data.tagIds,
                         categoryId: data.categoryId,
+                        customFields: data.customFields,
                       },
                     });
                     void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(orgId) });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3292.

Closes #3292

---

## Claude summary

The bug was real and the fix is straightforward. Both `_layout.tsx:635` and `_layout.gabinet.employees.index.tsx:622` were building the `moduleData` object for the invitation path without including `customFields`, even though the `EmployeeFormData` type carries them (`customFields?: Array<{ fieldDefinitionId: string; value: unknown }>`). The backend `_createFromInvitation` already reads `d.customFields` from `moduleData` (line 394 in `convex/gabinet/employees.ts`), so it was wired up correctly on the receiving end — just never sent.

Added `customFields: data.customFields` to the `moduleData` objects in both callers and committed as closes #3292.