### PR TITLE
Cache invalidation missing in `invite.$token.tsx` after acceptance

### DIFF
--- a/src/routes/_app/invite.$token.tsx
+++ b/src/routes/_app/invite.$token.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { useAction } from "convex/react";
 import { convexQuery, useConvexAuth } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
@@ -30,6 +31,7 @@ function InviteAcceptPage() {
     enabled: isAuthenticated,
   });
 
+  const queryClient = useQueryClient();
   const acceptInvitation = useAction(api.invitations.accept);
   const declineInvitation = useAction(api.invitations.decline);
 
@@ -44,7 +46,9 @@ function InviteAcceptPage() {
     setIsAccepting(true);
     setActionError(null);
     try {
-      await acceptInvitation({ token });
+      const organizationId = await acceptInvitation({ token });
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.teamMemberships.list(organizationId) });
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetEmployees.list(organizationId) });
       setResult("accepted");
       setTimeout(() => {
         navigate({ to: "/dashboard" });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3294.

Closes #3294

---

## Claude summary

The fix is committed. Here's a summary of what was done:

**Root cause:** `handleAccept` in `src/routes/_app/invite.$token.tsx` called `await acceptInvitation({ token })` but discarded the returned `organizationId` and never invalidated any React Query caches. An invitee who already had the org's data cached (e.g. from a previous session) would see stale `teamMemberships` or `gabinetEmployees` data on redirect to `/dashboard`.

**Fix (3 lines):**
1. Added `useQueryClient` import and instantiated `queryClient`.
2. Captured the `organizationId` string returned by the `accept` action.
3. Called `queryClient.invalidateQueries` for `supabaseKeys.teamMemberships.list(organizationId)` and `supabaseKeys.gabinetEmployees.list(organizationId)` immediately after acceptance. Since `getByToken` strips the `module` field from the invitation, the frontend can't distinguish gabinet from non-gabinet invites — but the extra gabinet invalidation is harmless for non-gabinet orgs.