### PR TITLE
`getByToken` does not expose `module` field

### DIFF
--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -61,6 +61,7 @@ export const getByToken = query({
         status: invitation.status,
         expiresAt: invitation.expiresAt,
         createdAt: invitation.createdAt,
+        module: invitation.module,
       },
       orgName: org?.name ?? null,
       inviterName: inviter?.name ?? null,

--- a/src/routes/_app/invite.$token.tsx
+++ b/src/routes/_app/invite.$token.tsx
@@ -48,7 +48,9 @@ function InviteAcceptPage() {
     try {
       const organizationId = await acceptInvitation({ token });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.teamMemberships.list(organizationId) });
-      void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetEmployees.list(organizationId) });
+      if (inviteData?.invitation.module === "gabinet") {
+        void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetEmployees.list(organizationId) });
+      }
       setResult("accepted");
       setTimeout(() => {
         navigate({ to: "/dashboard" });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3295.

Closes #3295

---

## Claude summary

Done. Two changes were made:

1. `convex/invitations.ts:64` — added `module: invitation.module` to the `getByToken` return shape so callers have visibility into whether the invitation carries module provisioning data.

2. `src/routes/_app/invite.$token.tsx:51-53` — guarded the `gabinetEmployees` cache invalidation behind `inviteData?.invitation.module === "gabinet"`. The previous unconditional invalidation (added in #3294 as a workaround) now only fires for gabinet invitations, avoiding unnecessary refetches for plain org invitations.