### PR TITLE
`teamMemberships.list` unnecessarily invalidated at invitation send time

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -636,9 +636,6 @@ function CreateEmployeeSheet({
                   void queryClient.invalidateQueries({
                     queryKey: supabaseKeys.invitations.list(organizationId),
                   });
-                  void queryClient.invalidateQueries({
-                    queryKey: supabaseKeys.teamMemberships.list(organizationId),
-                  });
                 }
                 onClose();
               } catch (e) {

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -646,7 +646,6 @@ function DashboardLayoutInner({ user, orgs }: DashboardLayoutInnerProps) {
                       },
                     });
                     void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(orgId) });
-                    void queryClient.invalidateQueries({ queryKey: supabaseKeys.teamMemberships.list(orgId) });
                   }
                   opts.onSuccess();
                 } catch (e) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3296.

Closes #3296

---

## Claude summary

The fix is committed. Removed the spurious `queryClient.invalidateQueries({ queryKey: supabaseKeys.teamMemberships.list(...) })` calls from both:

- `_layout.gabinet.employees.index.tsx:639–641` (the standalone gabinet employees page)
- `_layout.tsx:649` (the shared layout's "employee" create sheet)

Both were in the `shouldInvite` branch which calls `createInvitation` — a pending invitation row is created, but no `teamMembership` record exists yet. That only happens on acceptance. The `invitations.list` invalidation (which refreshes the pending invitations table) is correct and was preserved.