### PR TITLE
Fix `_createFromInvitation` idempotency to add location assignment on re-invite

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -330,10 +330,39 @@ export const _createFromInvitation = internalAction({
       .eq("userId", args.userId)
       .collect();
     if (existing.length > 0) {
+      const existingEmployeeId = String(existing[0]._id);
       console.log(
         `[gabinet.employees._createFromInvitation] skip — employee already exists for user=${args.userId}`,
       );
-      return { skipped: true, employeeId: String(existing[0]._id) };
+
+      // Still honour any locationId on the re-invite so the new assignment is not silently dropped.
+      const d2 = (args.data ?? {}) as Record<string, unknown>;
+      const locationId2 = typeof d2.locationId === "string" && d2.locationId.length > 0 ? d2.locationId : null;
+      if (locationId2) {
+        try {
+          const existingLocation = await db
+            .query("gabinetEmployeeLocations")
+            .eq("employeeId", existingEmployeeId)
+            .eq("locationId", locationId2)
+            .collect();
+          if (existingLocation.length === 0) {
+            await db.insert("gabinetEmployeeLocations", {
+              organizationId: String(args.organizationId),
+              employeeId: existingEmployeeId,
+              locationId: locationId2,
+              isPrimary: false,
+              createdAt: Date.now(),
+            });
+          }
+        } catch (e) {
+          console.error(
+            `[gabinet.employees._createFromInvitation] location insert on re-invite failed:`,
+            e,
+          );
+        }
+      }
+
+      return { skipped: true, employeeId: existingEmployeeId };
     }
 
     const d = (args.data ?? {}) as Record<string, unknown>;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3302.

Closes #3302

---

## Claude summary

The bug was real and is now fixed. Here's a summary:

**Root cause** (`convex/gabinet/employees.ts:332-336`): the idempotency guard returned `{ skipped: true }` immediately when an employee row already existed, bypassing the `gabinetEmployeeLocations` insert that follows the new-employee creation path. Any `moduleData.locationId` on a re-invite was silently discarded.

**Fix**: before returning in the early-exit branch, the code now:
1. Extracts `locationId` from `args.data`
2. Queries `gabinetEmployeeLocations` for an existing `(employeeId, locationId)` pair using the `by_employeeAndLocation` index
3. Inserts the location row (as non-primary) only if it doesn't already exist
4. Wraps this in a try/catch so a location-insert failure doesn't break the overall idempotency return

The new location is inserted with `isPrimary: false` because the employee may already have an existing primary location, and silently promoting on re-invite would be a separate behaviour change not described in the issue.