### PR TITLE
Guard `_upsertMembership` call in `employees.remove` against null userId

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -708,7 +708,7 @@ export const update = action({
 
     // Mirror role change (or isActive change) into Convex `gabinetMemberships`
     // so permission checks reflect the new role on the next call.
-    if (args.role !== undefined || args.isActive !== undefined) {
+    if ((args.role !== undefined || args.isActive !== undefined) && emp.userId) {
       const effectiveRole = args.role ?? (emp.role as string);
       const effectiveActive = args.isActive ?? Boolean(emp.isActive);
       await ctx.runMutation(internal.gabinet.employees._upsertMembership, {
@@ -815,12 +815,14 @@ export const remove = action({
     }
 
     // Mark membership inactive so the gabinet-role overlay no longer applies.
-    await ctx.runMutation(internal.gabinet.employees._upsertMembership, {
-      organizationId: args.organizationId,
-      userId: String(emp.userId),
-      gabinetRole: emp.role as string,
-      isActive: false,
-    });
+    if (emp.userId) {
+      await ctx.runMutation(internal.gabinet.employees._upsertMembership, {
+        organizationId: args.organizationId,
+        userId: String(emp.userId),
+        gabinetRole: emp.role as string,
+        isActive: false,
+      });
+    }
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3307.

Closes #3307

---

## Claude summary

The bug was real and the fix is committed. Here's the summary:

**Root cause:** `gabinetEmployees.userId` is `v.optional(v.id("users"))` — employees can exist without a linked user account. Two call sites passed `String(emp.userId)` to `_upsertMembership` without checking for null first. `String(null)` produces the literal string `"null"`, which would be written as a `userId` into `gabinetMemberships`, silently corrupting the table.

**Fixed locations in `convex/gabinet/employees.ts`:**
- `employees.remove` (line 818): wrapped the `_upsertMembership` call in `if (emp.userId)`
- `employees.update` (line 711): added `&& emp.userId` to the existing condition

Both fixes match the pattern already used in `employees.create` (line 245) and `_backfillMemberships` (line 492), which were already correctly guarded.