### PR TITLE
Add `role` column to `gabinet_employee_locations` table

### DIFF
--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -345,11 +345,14 @@ export function createGabinetTables({
   // An employee may work across multiple locations (multi-site clinic chains).
   // isPrimary marks the employee's default location for scheduling defaults and
   // calendar filtering.
+  // role: optional override — when set, the employee acts in this role at this
+  // location instead of their default role from gabinetEmployees.role.
   gabinetEmployeeLocations: defineTable({
     organizationId: v.id("organizations"),
     employeeId: v.id("gabinetEmployees"),
     locationId: v.id("gabinetLocations"),
     isPrimary: v.boolean(),
+    role: v.optional(gabinetEmployeeRoleValidator),
     createdAt: v.number(),
   })
     .index("by_org", ["organizationId"])

--- a/supabase/migrations/00067_gabinet_employee_locations_role.sql
+++ b/supabase/migrations/00067_gabinet_employee_locations_role.sql
@@ -1,0 +1,8 @@
+-- Add `role` column to gabinet_employee_locations (#3311).
+--
+-- Enables role-per-location: an employee can act as "doctor" at one branch and
+-- "therapist" at another. NULL means the employee's default role from
+-- gabinet_employees.role applies at that location.
+
+ALTER TABLE gabinet_employee_locations
+  ADD COLUMN IF NOT EXISTS role gabinet_employee_role_enum NULL;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3311.

Closes #3311

---

## Claude summary

Done. Two files changed:

`supabase/migrations/00067_gabinet_employee_locations_role.sql` — single `ALTER TABLE gabinet_employee_locations ADD COLUMN IF NOT EXISTS role gabinet_employee_role_enum NULL`. The column is nullable so existing rows are unaffected; `NULL` means "use the employee's default role from `gabinet_employees.role`".

`convex/schema/gabinet.ts` — added `role: v.optional(gabinetEmployeeRoleValidator)` to the `gabinetEmployeeLocations` table definition, using the same validator already used for `gabinetEmployees.role`.