### PR TITLE
Pass `locationRole` through invitation `moduleData` and apply on accept

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -334,6 +334,9 @@ export const _createFromInvitation = internalAction({
       // Still honour any locationId on the re-invite so the new assignment is not silently dropped.
       const d2 = (args.data ?? {}) as Record<string, unknown>;
       const locationId2 = typeof d2.locationId === "string" && d2.locationId.length > 0 ? d2.locationId : null;
+      const allowedRoles2 = ["doctor", "cosmetologist", "nurse", "therapist", "receptionist", "manager", "admin", "other"];
+      const locationRole2Raw = typeof d2.locationRole === "string" ? d2.locationRole : null;
+      const locationRole2 = locationRole2Raw && allowedRoles2.includes(locationRole2Raw) ? locationRole2Raw : undefined;
       if (locationId2) {
         try {
           const existingLocation = await db
@@ -347,6 +350,7 @@ export const _createFromInvitation = internalAction({
               employeeId: existingEmployeeId,
               locationId: locationId2,
               isPrimary: false,
+              role: locationRole2,
               createdAt: Date.now(),
             });
           }
@@ -396,6 +400,8 @@ export const _createFromInvitation = internalAction({
 
     // Location assignment — moduleData.locationId seeds the primary location.
     const locationId = asString(d.locationId);
+    const locationRoleRaw = asString(d.locationRole);
+    const locationRole = locationRoleRaw && allowedRoles.includes(locationRoleRaw) ? locationRoleRaw : undefined;
     if (locationId) {
       try {
         await db.insert("gabinetEmployeeLocations", {
@@ -403,6 +409,7 @@ export const _createFromInvitation = internalAction({
           employeeId: String(employeeId),
           locationId,
           isPrimary: true,
+          role: locationRole,
           createdAt: now,
         });
       } catch (e) {

--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -81,6 +81,7 @@ export interface GabinetModuleData {
   tagIds?: string[];
   categoryId?: string;
   locationId?: string;
+  locationRole?: GabinetRole;
   customFields?: Array<{ fieldDefinitionId: string; value: unknown }>;
   showInCalendar?: boolean;
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3313.

Closes #3313

---

## Claude summary

Done. Here's what was changed:

**`convex/gabinet/employees.ts`** — In `_createFromInvitation`, both `gabinetEmployeeLocations` inserts now read `locationRole` from `moduleData.locationRole`, validate it against the allowed-roles list, and write it as the optional `role` field:
- New employee path (lines ~401–414): extracts `d.locationRole` and passes `role: locationRole` to the insert.
- Re-invite path (lines ~334–355): extracts `d2.locationRole` similarly and passes `role: locationRole2` to the insert.

**`src/components/forms/user-invitation-form.tsx`** — Added `locationRole?: GabinetRole` to the `GabinetModuleData` interface, completing the `moduleData` contract so callers can supply the field when building invite payloads.

The `role` field in `gabinetEmployeeLocations` is optional (added in #3311), so omitting it when `locationRole` is absent or invalid preserves the existing fall-through-to-employee-default behavior.

## Follow-ups

- Expose `locationRole` in the gabinet employee invite form UI: `_layout.gabinet.employees.index.tsx:622` builds `moduleData` without `locationRole`; users cannot currently set a per-location role override at invite time even though the backend now supports it.
- Expose `locationRole` in the team settings invite form: `src/components/forms/user-invitation-form.tsx` now has the field in the interface but the form's `moduleData` assembly (line ~228) does not collect or forward it from the user.