### PR TITLE
Expose `locationRole` in the gabinet employee invite form UI

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1069,7 +1069,10 @@
       "gabinetSectionTitle": "Gabinet employee details",
       "gabinetLocation": "Primary location",
       "gabinetLocationPlaceholder": "Select a location",
-      "gabinetLocationNone": "No specific location"
+      "gabinetLocationNone": "No specific location",
+      "gabinetLocationRole": "Role at this location (optional override)",
+      "gabinetLocationRolePlaceholder": "Same as main role",
+      "gabinetLocationRoleNone": "Same as main role"
     },
     "pipelines": {
       "title": "Pipelines",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1070,7 +1070,10 @@
       "gabinetSectionTitle": "Dane pracownika Gabinetu",
       "gabinetLocation": "Główna lokalizacja",
       "gabinetLocationPlaceholder": "Wybierz lokalizację",
-      "gabinetLocationNone": "Brak konkretnej lokalizacji"
+      "gabinetLocationNone": "Brak konkretnej lokalizacji",
+      "gabinetLocationRole": "Rola w tej lokalizacji (opcjonalne nadpisanie)",
+      "gabinetLocationRolePlaceholder": "Taka sama jak rola główna",
+      "gabinetLocationRoleNone": "Taka sama jak rola główna"
     },
     "pipelines": {
       "title": "Pipeline",

--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -65,6 +65,8 @@ export interface EmployeeFormData {
   grantSystemAccess?: boolean;
   accessEmail?: string;
   accessRole?: "admin" | "member" | "viewer";
+  locationId?: string;
+  locationRole?: EmployeeRole;
 }
 
 interface EmployeeFormProps {
@@ -93,6 +95,13 @@ export function EmployeeForm({
     queryFn: () => listActiveTreatments({ organizationId }),
     enabled: !!organizationId,
   });
+
+  const listLocationsAction = useAction(api.gabinet.locations.listLocations);
+  const { data: locations } = useQuery({
+    queryKey: ["gabinet.locations.listLocations", organizationId],
+    queryFn: () => listLocationsAction({ organizationId }),
+    enabled: !!organizationId,
+  }) as { data: Array<{ _id: string; name: string; isActive: boolean }> | undefined };
 
   const { data: customFieldDefs } = useQuery(
     convexQuery(
@@ -131,6 +140,8 @@ export function EmployeeForm({
   const [grantSystemAccess, setGrantSystemAccess] = useState(false);
   const [accessEmail, setAccessEmail] = useState("");
   const [accessRole, setAccessRole] = useState<"admin" | "member" | "viewer">("member");
+  const [locationId, setLocationId] = useState<string | undefined>(undefined);
+  const [locationRole, setLocationRole] = useState<EmployeeRole | undefined>(undefined);
   const [customFieldValues, setCustomFieldValues] = useState<Record<string, unknown>>({});
 
   const filteredTreatments = useMemo(() => {
@@ -169,6 +180,8 @@ export function EmployeeForm({
       grantSystemAccess: grantSystemAccess || undefined,
       accessEmail: grantSystemAccess ? (accessEmail.trim() || undefined) : undefined,
       accessRole: grantSystemAccess ? accessRole : undefined,
+      locationId: grantSystemAccess ? locationId : undefined,
+      locationRole: grantSystemAccess ? locationRole : undefined,
     });
   };
 
@@ -445,6 +458,51 @@ export function EmployeeForm({
                 </SelectContent>
               </Select>
             </div>
+            {locations && locations.filter((l) => l.isActive).length > 0 && (
+              <div className="space-y-1.5">
+                <Label>{t("settings.team.gabinetLocation")}</Label>
+                <Select
+                  value={locationId ?? "none"}
+                  onValueChange={(v) => {
+                    setLocationId(v === "none" ? undefined : v);
+                    if (v === "none") setLocationRole(undefined);
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder={t("settings.team.gabinetLocationPlaceholder")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">{t("settings.team.gabinetLocationNone")}</SelectItem>
+                    {locations.filter((l) => l.isActive).map((loc) => (
+                      <SelectItem key={loc._id} value={loc._id}>
+                        {loc.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            {locationId && (
+              <div className="space-y-1.5">
+                <Label>{t("settings.team.gabinetLocationRole")}</Label>
+                <Select
+                  value={locationRole ?? "none"}
+                  onValueChange={(v) => setLocationRole(v === "none" ? undefined : v as EmployeeRole)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder={t("settings.team.gabinetLocationRolePlaceholder")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">{t("settings.team.gabinetLocationRoleNone")}</SelectItem>
+                    {ROLES.map((r) => (
+                      <SelectItem key={r} value={r}>
+                        {t(`gabinet.employees.roles.${r}`)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -177,6 +177,7 @@ export function UserInvitationForm({
   const [tagIds, setTagIds] = useState<Id<"tagDefinitions">[]>([]);
   const [categoryId, setCategoryId] = useState<Id<"categoryDefinitions"> | undefined>(undefined);
   const [locationId, setLocationId] = useState<string | undefined>(undefined);
+  const [locationRole, setLocationRole] = useState<GabinetRole | undefined>(undefined);
   const [customFieldValues, setCustomFieldValues] = useState<Record<string, unknown>>({});
   const [showInCalendar, setShowInCalendar] = useState(true);
   const [treatmentSearch, setTreatmentSearch] = useState("");
@@ -238,6 +239,7 @@ export function UserInvitationForm({
         tagIds: tagIds.length > 0 ? tagIds : undefined,
         categoryId: categoryId || undefined,
         locationId: locationId || undefined,
+        locationRole: locationId ? locationRole : undefined,
         customFields: customFields.length > 0 ? customFields : undefined,
         showInCalendar,
       };
@@ -426,25 +428,51 @@ export function UserInvitationForm({
             </div>
 
             {locations && locations.filter((l) => l.isActive).length > 0 && (
-              <div className="space-y-1.5 sm:col-span-2">
-                <Label>{t("settings.team.gabinetLocation")}</Label>
-                <Select
-                  value={locationId ?? "none"}
-                  onValueChange={(v) => setLocationId(v === "none" ? undefined : v)}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder={t("settings.team.gabinetLocationPlaceholder")} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">{t("settings.team.gabinetLocationNone")}</SelectItem>
-                    {locations.filter((l) => l.isActive).map((loc) => (
-                      <SelectItem key={loc._id} value={loc._id}>
-                        {loc.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+              <>
+                <div className="space-y-1.5 sm:col-span-2">
+                  <Label>{t("settings.team.gabinetLocation")}</Label>
+                  <Select
+                    value={locationId ?? "none"}
+                    onValueChange={(v) => {
+                      setLocationId(v === "none" ? undefined : v);
+                      if (v === "none") setLocationRole(undefined);
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder={t("settings.team.gabinetLocationPlaceholder")} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">{t("settings.team.gabinetLocationNone")}</SelectItem>
+                      {locations.filter((l) => l.isActive).map((loc) => (
+                        <SelectItem key={loc._id} value={loc._id}>
+                          {loc.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                {locationId && (
+                  <div className="space-y-1.5 sm:col-span-2">
+                    <Label>{t("settings.team.gabinetLocationRole")}</Label>
+                    <Select
+                      value={locationRole ?? "none"}
+                      onValueChange={(v) => setLocationRole(v === "none" ? undefined : v as GabinetRole)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder={t("settings.team.gabinetLocationRolePlaceholder")} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="none">{t("settings.team.gabinetLocationRoleNone")}</SelectItem>
+                        {GABINET_ROLES.map((r) => (
+                          <SelectItem key={r} value={r}>
+                            {t(`gabinet.employees.roles.${r}`)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+              </>
             )}
           </div>
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -630,6 +630,8 @@ function CreateEmployeeSheet({
                       tagIds: data.tagIds,
                       categoryId: data.categoryId,
                       customFields: data.customFields,
+                      locationId: data.locationId,
+                      locationRole: data.locationRole,
                     },
                   });
                   toast.success(t("team.invitationSent"));


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3316.

Closes #3316

---

## Claude summary

The fix is committed. Here's what was done:

**Root cause confirmed:** The issue was real. `locationRole` was wired through the backend (`_createFromInvitation` reads and stores it in `gabinet_employee_locations.role`) and typed in `GabinetModuleData`, but no UI field existed and it was never included in `moduleData` when sending invitations.

**Changes made across 5 files:**

`src/components/forms/user-invitation-form.tsx` — Added `locationRole` state, a `Select` that appears when a location is chosen (allowing users to override the role for that specific location), and included `locationRole` in the `moduleData` passed to `handleSubmit`. Also clears `locationRole` when the location is deselected.

`src/components/forms/employee-form.tsx` — Added `locationId` and `locationRole` to `EmployeeFormData`, fetches active locations via `listLocations` action, shows a location picker + location-role picker inside the system-access section (visible only when `grantSystemAccess` is true, since these fields only apply to the invite path), and passes both through `onSubmit`.

`src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx:622` — Added `locationId: data.locationId` and `locationRole: data.locationRole` to the `moduleData` object built when triggering an invitation.

`public/locales/en/translation.json` and `public/locales/pl/translation.json` — Added `gabinetLocationRole`, `gabinetLocationRolePlaceholder`, and `gabinetLocationRoleNone` keys.