### PR TITLE
Zablokowanie tworzenia pracownika bez konta użytkownika

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -179,6 +179,10 @@ export const create = action({
   },
   handler: async (ctx, args) => {
     try {
+    if (!args.userId) {
+      throw new Error("Tworzenie pracownika bez konta użytkownika jest niedozwolone. Wyślij zaproszenie e-mail.");
+    }
+
     // --- Auth + permissions (via internal queries) ---
     const authResult = await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,

--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -137,7 +137,6 @@ export function EmployeeForm({
   const [tagIds, setTagIds] = useState<Id<"tagDefinitions">[]>(initialData?.tagIds ?? []);
   const [categoryId, setCategoryId] = useState<Id<"categoryDefinitions"> | undefined>(initialData?.categoryId);
   const [treatmentSearch, setTreatmentSearch] = useState("");
-  const [grantSystemAccess, setGrantSystemAccess] = useState(false);
   const [accessEmail, setAccessEmail] = useState("");
   const [accessRole, setAccessRole] = useState<"admin" | "member" | "viewer">("member");
   const [locationId, setLocationId] = useState<string | undefined>(undefined);
@@ -177,11 +176,11 @@ export function EmployeeForm({
       tagIds: tagIds.length > 0 ? tagIds : undefined,
       categoryId: categoryId || undefined,
       customFields: customFields.length > 0 ? customFields : undefined,
-      grantSystemAccess: grantSystemAccess || undefined,
-      accessEmail: grantSystemAccess ? (accessEmail.trim() || undefined) : undefined,
-      accessRole: grantSystemAccess ? accessRole : undefined,
-      locationId: grantSystemAccess ? locationId : undefined,
-      locationRole: grantSystemAccess ? locationRole : undefined,
+      grantSystemAccess: true,
+      accessEmail: accessEmail.trim() || undefined,
+      accessRole: accessRole,
+      locationId: locationId,
+      locationRole: locationRole,
     });
   };
 
@@ -413,19 +412,8 @@ export function EmployeeForm({
         <p className="text-sm font-medium">
           {t("gabinet.employees.systemAccess", { defaultValue: "Dostęp do systemu" })}
         </p>
-        <label className="flex items-start gap-3 cursor-pointer">
-          <Checkbox
-            className="mt-0.5 h-5 w-5"
-            checked={grantSystemAccess}
-            onCheckedChange={(checked) => setGrantSystemAccess(checked === true)}
-          />
-          <span className="text-sm leading-none pt-0.5">
-            {t("gabinet.employees.grantSystemAccess", { defaultValue: "Nadaj dostęp do systemu" })}
-          </span>
-        </label>
 
-        {grantSystemAccess && (
-          <div className="mt-3 space-y-3 border-t pt-3">
+        <div className="space-y-3">
             <div className="space-y-1.5">
               <Label>
                 {t("gabinet.employees.accessEmail", { defaultValue: "Adres e-mail" })} <span className="text-destructive">*</span>
@@ -503,8 +491,7 @@ export function EmployeeForm({
                 </Select>
               </div>
             )}
-          </div>
-        )}
+        </div>
       </div>
 
       <div className="flex justify-end gap-2 pt-2">
@@ -515,7 +502,7 @@ export function EmployeeForm({
           type="submit"
           disabled={
             isSubmitting ||
-            (grantSystemAccess && !accessEmail.trim())
+            !accessEmail.trim()
           }
         >
           {isSubmitting


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3319.

Closes #3319

---

## Claude summary

Done. Here is what changed and why:

**Files changed:**

`src/components/forms/employee-form.tsx` — Removed the `grantSystemAccess` toggle checkbox. The "Dostęp do systemu" section now always shows the email and role fields (previously only shown when the checkbox was ticked). The submit button is now disabled whenever `accessEmail` is empty, so `handleSubmit` always passes `grantSystemAccess: true` and always routes through the invitation path in `CreateEmployeeSheet`.

`convex/gabinet/employees.ts` — Added a guard at the top of the `create` action handler that throws `"Tworzenie pracownika bez konta użytkownika jest niedozwolone"` if `args.userId` is falsy. This means even a direct API call (bypassing the UI) cannot produce a `gabinet_employees` row with `user_id = null`.

**Test performed:** Reviewed both files after edits. TypeScript typecheck shows no new errors introduced (pre-existing errors in `database.types.ts`, `package-purchase-drawer.tsx`, and others were there before). Existing `gabinet_employees` rows with `user_id = null` are not touched — the guard only fires on the write path.

## Follow-ups

- Fix pre-existing TS error in `src/components/forms/employee-form.tsx:109`: `convexQuery` receiving `"skip"` string fails type-check because the function signature changed — needs a conditional render or typed skip value
- Fix duplicate identifier errors in `src/lib/supabase/database.types.ts` around lines 5047–5109: gift voucher fields (`is_gift`, `voucher_code`, etc.) are declared multiple times with conflicting types, likely from a migration that duplicated column definitions