### PR TITLE
Fix pre-existing TS error in `src/components/forms/employee-form.tsx

### DIFF
--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -103,14 +103,13 @@ export function EmployeeForm({
     enabled: !!organizationId,
   }) as { data: Array<{ _id: string; name: string; isActive: boolean }> | undefined };
 
-  const { data: customFieldDefs } = useQuery(
-    convexQuery(
+  const { data: customFieldDefs } = useQuery({
+    ...convexQuery(
       api.customFields.getDefinitions,
-      organizationId
-        ? { organizationId, entityType: "gabinetEmployee" as const }
-        : "skip",
+      { organizationId: organizationId!, entityType: "gabinetEmployee" as const },
     ),
-  ) as {
+    enabled: !!organizationId,
+  }) as {
     data: Array<{
       _id: string;
       name: string;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3321.

Closes #3321

---

## Claude summary

Fixed. The bug was real: `convexQuery` from `@convex-dev/react-query` types its second argument as `FunctionArgs<ConvexQueryReference>`, so passing the string `"skip"` fails the type check. The fix replaces the conditional ternary with the standard React Query pattern: spread `convexQuery(...)` into the query options object and add `enabled: !!organizationId`. When `organizationId` is falsy, the query skips; when it resolves, the query runs with the non-null-asserted id.