### PR TITLE
Fix duplicate identifier errors in `src/lib/supabase/database.types.ts` around l

### DIFF
--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -5044,7 +5044,7 @@ export interface Database {
           treatments_used: unknown;
           paid_amount: number;
           payment_method: string | null;
-          is_gift: boolean | null;
+          is_gift: boolean;
           voucher_code: string | null;
           gift_recipient_name: string | null;
           gift_recipient_phone: string | null;
@@ -5052,11 +5052,6 @@ export interface Database {
           created_by: string;
           created_at: number;
           updated_at: number;
-          is_gift: boolean;
-          voucher_code: string | null;
-          gift_recipient_name: string | null;
-          gift_recipient_phone: string | null;
-          gift_recipient_email: string | null;
         };
         Insert: {
           id?: string;
@@ -5069,7 +5064,7 @@ export interface Database {
           treatments_used: unknown;
           paid_amount: number;
           payment_method?: string | null;
-          is_gift?: boolean | null;
+          is_gift?: boolean;
           voucher_code?: string | null;
           gift_recipient_name?: string | null;
           gift_recipient_phone?: string | null;
@@ -5077,11 +5072,6 @@ export interface Database {
           created_by: string;
           created_at: number;
           updated_at: number;
-          is_gift?: boolean;
-          voucher_code?: string | null;
-          gift_recipient_name?: string | null;
-          gift_recipient_phone?: string | null;
-          gift_recipient_email?: string | null;
         };
         Update: {
           id?: string;
@@ -5094,7 +5084,7 @@ export interface Database {
           treatments_used?: unknown;
           paid_amount?: number;
           payment_method?: string | null;
-          is_gift?: boolean | null;
+          is_gift?: boolean;
           voucher_code?: string | null;
           gift_recipient_name?: string | null;
           gift_recipient_phone?: string | null;
@@ -5102,11 +5092,6 @@ export interface Database {
           created_by?: string;
           created_at?: number;
           updated_at?: number;
-          is_gift?: boolean;
-          voucher_code?: string | null;
-          gift_recipient_name?: string | null;
-          gift_recipient_phone?: string | null;
-          gift_recipient_email?: string | null;
         };
         Relationships: [
           {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3322.

Closes #3322

---

## Claude summary

The bug was real and is now fixed. In `src/lib/supabase/database.types.ts`, the `gabinet_package_usage` table had five fields duplicated in each of its `Row`, `Insert`, and `Update` type objects: `is_gift`, `voucher_code`, `gift_recipient_name`, `gift_recipient_phone`, and `gift_recipient_email`. This caused TypeScript "duplicate identifier" errors.

The duplication came from migration `00065_gabinet_package_usage_gift.sql` adding these columns, and the types file getting two sets of declarations — the first incorrectly typed `is_gift` as `boolean | null`, while the migration defines it as `BOOLEAN NOT NULL DEFAULT FALSE`. The fix removes the duplicate second block in all three objects and corrects `is_gift` to `boolean` in `Row` and `boolean | undefined` (optional) in `Insert`/`Update`.