### PR TITLE
Dodanie ręcznego ustawiania hasła pracownika

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -8,6 +8,8 @@ import { gabinetEmployeeRoleValidator } from "../schema";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import type { GabinetEmployeeRow, SupabasePaginationResult } from "../_helpers/supabaseRows";
 import { Id } from "../_generated/dataModel";
+import { createAccount } from "@convex-dev/auth/server";
+import { checkSeatLimit } from "../_helpers/seatLimits";
 
 // Dual-write refs removed — Supabase is now primary for employee writes
 
@@ -954,5 +956,258 @@ export const _setQualifiedSideEffects = internalMutation({
       description: `Updated treatment qualifications (${args.treatmentCount} treatments)`,
       performedBy: updatedByUserId,
     });
+  },
+});
+
+/**
+ * Internal mutation: finalise team membership for a user created via manual
+ * password flow. Checks seat limit, prevents duplicate membership, derives a
+ * username, creates the teamMemberships row, and schedules Supabase mirrors.
+ * Called from `createWithPassword` action after the auth account is created.
+ */
+export const _finalisePasswordUser = internalMutation({
+  args: {
+    userId: v.string(),
+    email: v.string(),
+    name: v.optional(v.string()),
+    organizationId: v.id("organizations"),
+    teamRole: v.union(v.literal("admin"), v.literal("member"), v.literal("viewer")),
+    invitedBy: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = args.userId as Id<"users">;
+
+    const { canAddMore, currentSeats, seatLimit } = await checkSeatLimit(ctx, {
+      organizationId: args.organizationId,
+    });
+    if (!canAddMore) {
+      throw new Error(
+        `Seat limit reached (${currentSeats}/${seatLimit}). Upgrade your plan to add more team members.`,
+      );
+    }
+
+    const existing = await ctx.db
+      .query("teamMemberships")
+      .withIndex("by_orgAndUser", (q) =>
+        q.eq("organizationId", args.organizationId).eq("userId", userId),
+      )
+      .unique();
+    if (existing) {
+      throw new Error("Ten użytkownik jest już członkiem tej organizacji.");
+    }
+
+    const user = await ctx.db.get(userId);
+    if (!user) throw new Error("User not found after account creation");
+
+    let effectiveUsername = user.username;
+    if (!user.username) {
+      const local = args.email.split("@")[0] ?? "";
+      const base = local.toLowerCase().replace(/[^a-z0-9]/g, "");
+      let candidate = (base || "user").slice(0, 16);
+      let suffix = 0;
+      while (
+        await ctx.db
+          .query("users")
+          .filter((q) => q.eq(q.field("username"), candidate))
+          .first()
+      ) {
+        suffix += 1;
+        candidate = `${(base || "user").slice(0, 14)}${suffix}`;
+        if (suffix > 50) break;
+      }
+      await ctx.db.patch(userId, { username: candidate });
+      effectiveUsername = candidate;
+    }
+
+    const joinedAt = Date.now();
+    const membershipId = await ctx.db.insert("teamMemberships", {
+      userId,
+      organizationId: args.organizationId,
+      role: args.teamRole,
+      invitedBy: args.invitedBy as Id<"users">,
+      joinedAt,
+    });
+
+    await ctx.scheduler.runAfter(0, internal.supabase.users.writeUserToSupabase, {
+      userId: String(userId),
+      email: args.email,
+      name: args.name,
+      username: effectiveUsername,
+      createdAt: Math.floor(user._creationTime),
+      updatedAt: Date.now(),
+    });
+
+    await ctx.scheduler.runAfter(
+      500,
+      internal.supabase.organizations.writeTeamMembershipToSupabase,
+      {
+        membershipId: String(membershipId),
+        userId: String(userId),
+        organizationId: String(args.organizationId),
+        role: args.teamRole,
+        invitedBy: args.invitedBy,
+        joinedAt,
+      },
+    );
+
+    return { userId: String(userId) };
+  },
+});
+
+/**
+ * Admin action: create a gabinet employee account using a manually set
+ * password. Creates the Convex auth account (hashed via Scrypt), team
+ * membership, and gabinet_employees row in one go. No invitation email
+ * is sent. The account is immediately active and the user can log in.
+ *
+ * Password strength is validated on the frontend; the backend only
+ * enforces a minimum length of 8 characters as a safety net.
+ */
+export const createWithPassword = action({
+  args: {
+    organizationId: v.id("organizations"),
+    email: v.string(),
+    password: v.string(),
+    teamRole: v.union(v.literal("admin"), v.literal("member"), v.literal("viewer")),
+    firstName: v.optional(v.string()),
+    lastName: v.optional(v.string()),
+    role: gabinetEmployeeRoleValidator,
+    specialization: v.optional(v.string()),
+    licenseNumber: v.optional(v.string()),
+    color: v.optional(v.string()),
+    showInCalendar: v.optional(v.boolean()),
+    qualifiedTreatmentIds: v.optional(v.array(v.string())),
+    tagIds: v.optional(v.array(v.string())),
+    categoryId: v.optional(v.string()),
+    customFields: v.optional(v.array(v.any())),
+    locationId: v.optional(v.string()),
+    locationRole: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    if (args.password.length < 8) {
+      throw new Error("Hasło musi mieć co najmniej 8 znaków.");
+    }
+
+    const authResult = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    if (authResult.role !== "owner" && authResult.role !== "admin") {
+      throw new Error("Wymagane uprawnienia administratora.");
+    }
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, {
+      organizationId: args.organizationId,
+    });
+
+    const name =
+      [args.firstName, args.lastName].filter(Boolean).join(" ") || undefined;
+
+    const { user } = await createAccount(ctx, {
+      provider: "password",
+      account: { id: args.email, secret: args.password },
+      profile: { email: args.email, name },
+      shouldLinkViaEmail: false,
+      shouldLinkViaPhone: false,
+    });
+
+    const { userId } = await ctx.runMutation(
+      internal.gabinet.employees._finalisePasswordUser,
+      {
+        userId: String(user._id),
+        email: args.email,
+        name: user.name ?? name,
+        organizationId: args.organizationId,
+        teamRole: args.teamRole,
+        invitedBy: String(authResult.userId),
+      },
+    );
+
+    const db = createSupabaseDb();
+    const now = Date.now();
+
+    const employeeId = await db.insert("gabinetEmployees", {
+      organizationId: String(args.organizationId),
+      userId,
+      firstName: args.firstName ?? null,
+      lastName: args.lastName ?? null,
+      role: args.role,
+      specialization: args.specialization ?? null,
+      qualifiedTreatmentIds: args.qualifiedTreatmentIds ?? [],
+      licenseNumber: args.licenseNumber ?? null,
+      hireDate: null,
+      isActive: true,
+      color: args.color ?? null,
+      notes: null,
+      showInCalendar: args.showInCalendar ?? true,
+      tagIds: args.tagIds ?? null,
+      categoryId: args.categoryId ?? null,
+      createdBy: String(authResult.userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    if (args.locationId) {
+      const allowedRoles = [
+        "doctor", "cosmetologist", "nurse", "therapist",
+        "receptionist", "manager", "admin", "other",
+      ];
+      const locationRole =
+        args.locationRole && allowedRoles.includes(args.locationRole)
+          ? args.locationRole
+          : undefined;
+      try {
+        await db.insert("gabinetEmployeeLocations", {
+          organizationId: String(args.organizationId),
+          employeeId: String(employeeId),
+          locationId: args.locationId,
+          isPrimary: true,
+          role: locationRole,
+          createdAt: now,
+        });
+      } catch (e) {
+        console.error("[employees.createWithPassword] location insert failed:", e);
+      }
+    }
+
+    if (args.customFields && args.customFields.length > 0) {
+      for (const f of args.customFields) {
+        if (!f || typeof f !== "object") continue;
+        const defId = (f as Record<string, unknown>).fieldDefinitionId;
+        const val = (f as Record<string, unknown>).value;
+        if (typeof defId !== "string" || defId.length === 0) continue;
+        try {
+          await db.insert("customFieldValues", {
+            organizationId: String(args.organizationId),
+            fieldDefinitionId: defId,
+            entityType: "gabinetEmployee",
+            entityId: String(employeeId),
+            value: val ?? null,
+            createdAt: now,
+            updatedAt: now,
+          });
+        } catch (e) {
+          console.error("[employees.createWithPassword] customField insert failed:", e);
+        }
+      }
+    }
+
+    try {
+      await ctx.runMutation(internal.gabinet.employees._createSideEffects, {
+        employeeId: String(employeeId),
+        organizationId: args.organizationId,
+        createdBy: String(authResult.userId),
+      });
+    } catch (e) {
+      console.error("[employees.createWithPassword] side effects failed:", e);
+    }
+
+    await ctx.runMutation(internal.gabinet.employees._upsertMembership, {
+      organizationId: args.organizationId,
+      userId,
+      gabinetRole: args.role,
+      isActive: true,
+    });
+
+    return String(employeeId);
   },
 });

--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -63,8 +63,10 @@ export interface EmployeeFormData {
   categoryId?: Id<"categoryDefinitions">;
   customFields?: Array<{ fieldDefinitionId: string; value: unknown }>;
   grantSystemAccess?: boolean;
+  accessMode?: "invite" | "password";
   accessEmail?: string;
   accessRole?: "admin" | "member" | "viewer";
+  password?: string;
   locationId?: string;
   locationRole?: EmployeeRole;
 }
@@ -138,6 +140,9 @@ export function EmployeeForm({
   const [treatmentSearch, setTreatmentSearch] = useState("");
   const [accessEmail, setAccessEmail] = useState("");
   const [accessRole, setAccessRole] = useState<"admin" | "member" | "viewer">("member");
+  const [accessMode, setAccessMode] = useState<"invite" | "password">("invite");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [locationId, setLocationId] = useState<string | undefined>(undefined);
   const [locationRole, setLocationRole] = useState<EmployeeRole | undefined>(undefined);
   const [customFieldValues, setCustomFieldValues] = useState<Record<string, unknown>>({});
@@ -148,6 +153,29 @@ export function EmployeeForm({
     if (!q) return treatments;
     return treatments.filter((tr) => tr.name?.toLowerCase().includes(q));
   }, [treatments, treatmentSearch]);
+
+  const passwordError = (() => {
+    if (accessMode !== "password") return null;
+    if (!password) return null;
+    if (password.length < 8) return t("gabinet.employees.passwordTooShort", { defaultValue: "Hasło musi mieć co najmniej 8 znaków." });
+    if (!/[A-Z]/.test(password)) return t("gabinet.employees.passwordNoUppercase", { defaultValue: "Hasło musi zawierać co najmniej 1 wielką literę." });
+    if (!/[0-9]/.test(password)) return t("gabinet.employees.passwordNoDigit", { defaultValue: "Hasło musi zawierać co najmniej 1 cyfrę." });
+    return null;
+  })();
+
+  const confirmPasswordError = (() => {
+    if (accessMode !== "password") return null;
+    if (!confirmPassword) return null;
+    if (password !== confirmPassword) return t("gabinet.employees.passwordMismatch", { defaultValue: "Hasła nie są identyczne." });
+    return null;
+  })();
+
+  const isPasswordValid =
+    accessMode !== "password" ||
+    (password.length >= 8 &&
+      /[A-Z]/.test(password) &&
+      /[0-9]/.test(password) &&
+      password === confirmPassword);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -176,8 +204,10 @@ export function EmployeeForm({
       categoryId: categoryId || undefined,
       customFields: customFields.length > 0 ? customFields : undefined,
       grantSystemAccess: true,
+      accessMode,
       accessEmail: accessEmail.trim() || undefined,
       accessRole: accessRole,
+      password: accessMode === "password" ? password : undefined,
       locationId: locationId,
       locationRole: locationRole,
     });
@@ -413,6 +443,35 @@ export function EmployeeForm({
         </p>
 
         <div className="space-y-3">
+            {/* Access mode toggle */}
+            <div className="space-y-1.5">
+              <Label>{t("gabinet.employees.accessMethod", { defaultValue: "Sposób aktywacji konta" })}</Label>
+              <div className="flex gap-2">
+                <label className="flex flex-1 cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-accent/40 has-[:checked]:border-primary has-[:checked]:bg-accent/60">
+                  <input
+                    type="radio"
+                    name="accessMode"
+                    value="invite"
+                    checked={accessMode === "invite"}
+                    onChange={() => setAccessMode("invite")}
+                    className="accent-primary"
+                  />
+                  {t("gabinet.employees.accessModeInvite", { defaultValue: "Wyślij zaproszenie e-mailem" })}
+                </label>
+                <label className="flex flex-1 cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-accent/40 has-[:checked]:border-primary has-[:checked]:bg-accent/60">
+                  <input
+                    type="radio"
+                    name="accessMode"
+                    value="password"
+                    checked={accessMode === "password"}
+                    onChange={() => setAccessMode("password")}
+                    className="accent-primary"
+                  />
+                  {t("gabinet.employees.accessModePassword", { defaultValue: "Ustaw hasło ręcznie" })}
+                </label>
+              </div>
+            </div>
+
             <div className="space-y-1.5">
               <Label>
                 {t("gabinet.employees.accessEmail", { defaultValue: "Adres e-mail" })} <span className="text-destructive">*</span>
@@ -445,6 +504,48 @@ export function EmployeeForm({
                 </SelectContent>
               </Select>
             </div>
+
+            {/* Password fields — only shown in manual password mode */}
+            {accessMode === "password" && (
+              <div className="space-y-3 pt-1">
+                <div className="space-y-1.5">
+                  <Label>
+                    {t("gabinet.employees.password", { defaultValue: "Hasło" })} <span className="text-destructive">*</span>
+                  </Label>
+                  <Input
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="••••••••"
+                    autoComplete="new-password"
+                  />
+                  {passwordError && (
+                    <p className="text-xs text-destructive">{passwordError}</p>
+                  )}
+                  {!passwordError && (
+                    <p className="text-xs text-muted-foreground">
+                      {t("gabinet.employees.passwordHint", { defaultValue: "Min. 8 znaków, 1 wielka litera, 1 cyfra." })}
+                    </p>
+                  )}
+                </div>
+                <div className="space-y-1.5">
+                  <Label>
+                    {t("gabinet.employees.confirmPassword", { defaultValue: "Powtórz hasło" })} <span className="text-destructive">*</span>
+                  </Label>
+                  <Input
+                    type="password"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    placeholder="••••••••"
+                    autoComplete="new-password"
+                  />
+                  {confirmPasswordError && (
+                    <p className="text-xs text-destructive">{confirmPasswordError}</p>
+                  )}
+                </div>
+              </div>
+            )}
+
             {locations && locations.filter((l) => l.isActive).length > 0 && (
               <div className="space-y-1.5">
                 <Label>{t("settings.team.gabinetLocation")}</Label>
@@ -501,7 +602,8 @@ export function EmployeeForm({
           type="submit"
           disabled={
             isSubmitting ||
-            !accessEmail.trim()
+            !accessEmail.trim() ||
+            !isPasswordValid
           }
         >
           {isSubmitting

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -582,6 +582,7 @@ function CreateEmployeeSheet({
   const queryClient = useQueryClient();
   const createEmployee = useAction(api.gabinet.employees.create);
   const createInvitation = useAction(api.invitations.create);
+  const createWithPassword = useAction(api.gabinet.employees.createWithPassword);
   const [saving, setSaving] = useState(false);
 
   return (
@@ -599,24 +600,36 @@ function CreateEmployeeSheet({
             isSubmitting={saving}
             onCancel={onClose}
             onSubmit={async (data) => {
-              const shouldInvite = !!(data.grantSystemAccess && data.accessEmail);
               setSaving(true);
               try {
-                if (!shouldInvite) {
-                  await createEmployee({
+                if (data.accessMode === "password" && data.accessEmail && data.password) {
+                  await createWithPassword({
                     organizationId,
-                    ...data,
-                    userId: data.userId,
+                    email: data.accessEmail,
+                    password: data.password,
+                    teamRole: data.accessRole ?? "member",
+                    firstName: data.firstName,
+                    lastName: data.lastName,
+                    role: data.role,
+                    specialization: data.specialization,
+                    licenseNumber: data.licenseNumber,
+                    color: data.color,
+                    showInCalendar: data.showInCalendar,
+                    qualifiedTreatmentIds: data.qualifiedTreatmentIds as string[],
+                    tagIds: data.tagIds as string[] | undefined,
+                    categoryId: data.categoryId as string | undefined,
+                    customFields: data.customFields,
+                    locationId: data.locationId,
+                    locationRole: data.locationRole,
                   });
                   toast.success(t("common.created"));
                   void queryClient.invalidateQueries({
                     queryKey: supabaseKeys.gabinetEmployees.list(organizationId),
                   });
-                }
-                if (shouldInvite) {
+                } else if (data.grantSystemAccess && data.accessEmail) {
                   await createInvitation({
                     organizationId,
-                    email: data.accessEmail!,
+                    email: data.accessEmail,
                     role: data.accessRole ?? "member",
                     module: "gabinet",
                     moduleData: {
@@ -637,6 +650,16 @@ function CreateEmployeeSheet({
                   toast.success(t("team.invitationSent"));
                   void queryClient.invalidateQueries({
                     queryKey: supabaseKeys.invitations.list(organizationId),
+                  });
+                } else {
+                  await createEmployee({
+                    organizationId,
+                    ...data,
+                    userId: data.userId,
+                  });
+                  toast.success(t("common.created"));
+                  void queryClient.invalidateQueries({
+                    queryKey: supabaseKeys.gabinetEmployees.list(organizationId),
                   });
                 }
                 onClose();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3325.

Closes #3325

---

## Claude summary

Done. Here's a summary of what was implemented:

## Changes Made

**3 files changed:**

### `convex/gabinet/employees.ts`
- Added imports: `createAccount` from `@convex-dev/auth/server`, `checkSeatLimit` helper
- New `_finalisePasswordUser` internal mutation: checks seat limit, prevents duplicate memberships, derives username, creates `teamMemberships` row, schedules Supabase mirrors for both user and membership
- New `createWithPassword` action: verifies admin role, calls `createAccount` (creates user + Scrypt-hashed password in Convex auth tables), then orchestrates membership, employee record, location, custom fields, side effects, and gabinet role mirror — no invitation email sent, account is immediately active

### `src/components/forms/employee-form.tsx`
- Added `accessMode?: "invite" | "password"` and `password?: string` to `EmployeeFormData`
- Added state: `accessMode`, `password`, `confirmPassword`
- Added real-time password validation (length ≥8, ≥1 uppercase, ≥1 digit, confirmation match) shown as inline error messages
- Added radio toggle "Wyślij zaproszenie e-mailem" / "Ustaw hasło ręcznie" in the System Access section
- Password fields appear only when manual mode is selected; submit button is disabled until passwords are valid

### `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx`
- Added `createWithPassword` action hook
- Updated `onSubmit` to dispatch to the new action when `accessMode === "password"`, existing invitation path otherwise — existing email flow is untouched