### PR TITLE
Uproszczenie dostępu do ustawień konta pracownika

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3057,7 +3057,10 @@
         "baseSalary": "Base Salary",
         "commissionPercent": "Commission %",
         "bankAccount": "Bank Account",
-        "noCompensationYet": "No compensation data added yet."
+        "noCompensationYet": "No compensation data added yet.",
+        "accountAccess": "Account & Access",
+        "accountActive": "Active",
+        "accountInactive": "Inactive"
       },
       "schedule": {
         "hasOverrides": "This employee has a custom schedule defined.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3077,7 +3077,10 @@
         "baseSalary": "Wynagrodzenie podstawowe",
         "commissionPercent": "Prowizja %",
         "bankAccount": "Numer konta bankowego",
-        "noCompensationYet": "Brak danych o wynagrodzeniu."
+        "noCompensationYet": "Brak danych o wynagrodzeniu.",
+        "accountAccess": "Konto i dostęp",
+        "accountActive": "Aktywne",
+        "accountInactive": "Nieaktywne"
       },
       "schedule": {
         "hasOverrides": "Ten pracownik ma zdefiniowany indywidualny grafik.",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -559,21 +559,6 @@ function EmployeeDetail() {
           <Pencil className="mr-2 h-4 w-4" variant="stroke" />
           {t("gabinet.employees.editEmployee")}
         </DropdownMenuItem>
-        {(role === "admin" || role === "owner") && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onClick={() => {
-                setNewPassword("");
-                setConfirmPassword("");
-                setChangePasswordError(null);
-                setChangePasswordOpen(true);
-              }}
-            >
-              {t("gabinet.employees.changePassword")}
-            </DropdownMenuItem>
-          </>
-        )}
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onClick={handleDeactivate}
@@ -751,6 +736,13 @@ function EmployeeDetail() {
           treatments={treatments}
           treatmentMap={treatmentMap}
           organizationId={organizationId}
+          role={role}
+          onChangePassword={() => {
+            setNewPassword("");
+            setConfirmPassword("");
+            setChangePasswordError(null);
+            setChangePasswordOpen(true);
+          }}
           onUpdate={async (a) => { await updateEmployee(a); invalidateEmployeeCache(); }}
           onSetTreatments={async (a) => { await setQualifiedTreatments(a); invalidateEmployeeCache(); }}
           t={t}
@@ -1816,6 +1808,8 @@ function DetailedDataTab({
   treatments,
   treatmentMap,
   organizationId,
+  role,
+  onChangePassword,
   onUpdate,
   onSetTreatments,
   t,
@@ -1826,6 +1820,8 @@ function DetailedDataTab({
   treatments: Array<{ _id: string; name: string }> | undefined;
   treatmentMap: Map<string, string>;
   organizationId: Id<"organizations">;
+  role?: string | null;
+  onChangePassword?: () => void;
   onUpdate: (args: FunctionArgs<typeof api.gabinet.employees.update>) => Promise<void>;
   onSetTreatments: (args: FunctionArgs<typeof api.gabinet.employees.setQualifiedTreatments>) => Promise<void>;
   t: TFunction;
@@ -2194,6 +2190,26 @@ function DetailedDataTab({
                     .join(", "),
                   <MapPin className="h-3.5 w-3.5" />,
                 )}
+              {(role === "admin" || role === "owner") && (
+                <div className="col-span-2 border-t pt-3 mt-1 flex items-center justify-between gap-4">
+                  <div className="min-w-0">
+                    <p className="text-xs text-muted-foreground">{t("gabinet.employees.detailedData.accountAccess")}</p>
+                    <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+                      <span className="text-sm font-medium">{userEmail || "—"}</span>
+                      <Badge variant={employee.isActive ? "default" : "secondary"} className="text-xs h-5">
+                        {employee.isActive
+                          ? t("gabinet.employees.detailedData.accountActive")
+                          : t("gabinet.employees.detailedData.accountInactive")}
+                      </Badge>
+                    </div>
+                  </div>
+                  {onChangePassword && (
+                    <Button variant="outline" size="sm" onClick={onChangePassword} className="shrink-0">
+                      {t("gabinet.employees.changePassword")}
+                    </Button>
+                  )}
+                </div>
+              )}
             </div>
           )}
         </CardContent>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3329.

Closes #3329

---

## Claude summary

Done. Here's a summary of what was changed:

**3 files modified:**

`src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx`
- Removed "Zmień hasło" from the Actions dropdown menu (lines 562–575 were the old admin/owner block)
- Added `role` and `onChangePassword` props to `DetailedDataTab`
- Passed those props down from `EmployeeDetail`, wiring `onChangePassword` to open the existing password dialog (same logic that was in the Actions menu)
- Added the compact "Konto i dostęp" row at the bottom of the read-only "Dane osobowe" grid — spans both columns, shows login email + active/inactive badge + "Zmień hasło" button; visible to admin/owner only

`public/locales/pl/translation.json` and `public/locales/en/translation.json`
- Added three keys under `gabinet.employees.detailedData`: `accountAccess` ("Konto i dostęp" / "Account & Access"), `accountActive` ("Aktywne" / "Active"), `accountInactive` ("Nieaktywne" / "Inactive")

The feature reuses the existing `changeEmployeePassword` Convex action and dialog — no new mechanism was introduced.