### PR TITLE
Polskie nazwy technicznych uprawnień pracownika

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -4006,6 +4006,11 @@
         "employees": "Employees",
         "payments": "Payments",
         "reports": "Reports",
+        "financial_reports": "Financial Reports",
+        "purchase_prices": "Purchase Prices",
+        "photos": "Photos",
+        "online_booking": "Online Booking",
+        "inventory": "Inventory",
         "settings": "Settings",
         "dashboard": "Dashboard"
       }

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -4027,6 +4027,11 @@
         "employees": "Pracownicy",
         "payments": "Płatności",
         "reports": "Raporty",
+        "financial_reports": "Raporty finansowe",
+        "purchase_prices": "Ceny zakupu",
+        "photos": "Zdjęcia",
+        "online_booking": "Rezerwacje online",
+        "inventory": "Magazyn",
         "settings": "Ustawienia",
         "dashboard": "Pulpit"
       }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3331.

Closes #3331

---

## Claude summary

Done. The fix was purely additive — 5 missing i18n keys added to both locale files.

**Root cause:** `t(feature.labelKey, feature.key)` falls back to the second argument (the technical key, e.g. `gabinet_financial_reports`) when the translation key is absent. The `gabinet.roles.features` object in both locale files had 9 entries but was missing 5 newer features.

**Changed files:**
- `public/locales/pl/translation.json` — added `financial_reports`, `purchase_prices`, `photos`, `online_booking`, `inventory` under `gabinet.roles.features`
- `public/locales/en/translation.json` — same 5 keys with English labels

These keys are consumed by both the employee "Uprawnienia" tab (`_layout.gabinet.employees.$employeeId.tsx:2942-2946`) and the roles settings page (`_layout.gabinet.settings.roles.tsx:91-111`), so both views are fixed by this change. No logic, schema, or component structure was touched.