### PR TITLE
Usuwanie zabiegu

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -349,7 +349,17 @@ function EmployeesIndex() {
         icon: <Trash2 className="h-4 w-4" variant="stroke" />,
         onClick: async () => {
           if (window.confirm(t("gabinet.employees.confirmDelete"))) {
-            await removeEmployee({ organizationId, employeeId: row._id as Id<"gabinetEmployees"> });
+            try {
+              await removeEmployee({ organizationId, employeeId: row._id as Id<"gabinetEmployees"> });
+              toast.success(t("common.deleted"));
+            } catch (e) {
+              toast.error(
+                formatActionError(e, t, {
+                  key: "gabinet.employees.errors.deleteFailed",
+                  defaultValue: "Nie udało się usunąć pracownika.",
+                }),
+              );
+            }
           }
         },
       },
@@ -360,8 +370,18 @@ function EmployeesIndex() {
   const handleBulkAction = useCallback(
     async (action: string, selectedRows: Employee[]) => {
       if (action === "delete") {
-        for (const row of selectedRows) {
-          await removeEmployee({ organizationId, employeeId: row._id as Id<"gabinetEmployees"> });
+        try {
+          for (const row of selectedRows) {
+            await removeEmployee({ organizationId, employeeId: row._id as Id<"gabinetEmployees"> });
+          }
+          toast.success(t("common.deleted"));
+        } catch (e) {
+          toast.error(
+            formatActionError(e, t, {
+              key: "gabinet.employees.errors.deleteFailed",
+              defaultValue: "Nie udało się usunąć pracownika.",
+            }),
+          );
         }
       } else if (action === "addEvent") {
         // EventDialog identifies employees by userId (it creates one
@@ -374,7 +394,7 @@ function EmployeesIndex() {
         if (first) navigate({ to: `/dashboard/gabinet/employees/${first._id}` });
       }
     },
-    [removeEmployee, organizationId, navigate]
+    [removeEmployee, organizationId, navigate, t]
   );
 
   return (

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -517,8 +517,18 @@ function PatientsIndex() {
   const handleBulkAction = useCallback(
     async (action: string, selectedRows: Patient[]) => {
       if (action === "delete") {
-        for (const row of selectedRows) {
-          await removePatient({ organizationId, patientId: row._id as Id<"gabinetPatients"> });
+        try {
+          for (const row of selectedRows) {
+            await removePatient({ organizationId, patientId: row._id as Id<"gabinetPatients"> });
+          }
+          toast.success(t("common.deleted"));
+        } catch (e) {
+          toast.error(
+            formatActionError(e, t, {
+              key: "gabinet.patients.errors.deleteFailed",
+              defaultValue: "Nie udało się usunąć pacjenta.",
+            }),
+          );
         }
       } else if (action === "merge") {
         if (selectedRows.length !== 2) {
@@ -556,7 +566,17 @@ function PatientsIndex() {
         icon: <Trash2 className="h-4 w-4" variant="stroke" />,
         onClick: async () => {
           if (window.confirm(t("gabinet.patients.confirmDelete"))) {
-            await removePatient({ organizationId, patientId: row._id as Id<"gabinetPatients"> });
+            try {
+              await removePatient({ organizationId, patientId: row._id as Id<"gabinetPatients"> });
+              toast.success(t("common.deleted"));
+            } catch (e) {
+              toast.error(
+                formatActionError(e, t, {
+                  key: "gabinet.patients.errors.deleteFailed",
+                  defaultValue: "Nie udało się usunąć pacjenta.",
+                }),
+              );
+            }
           }
         },
       },

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -648,12 +648,22 @@ function TreatmentsIndex() {
   const handleBulkAction = useCallback(
     async (action: string, selectedRows: Treatment[]) => {
       if (action === "delete") {
-        for (const row of selectedRows) {
-          await removeTreatment({ organizationId, treatmentId: row._id as Id<"gabinetTreatments"> });
+        try {
+          for (const row of selectedRows) {
+            await removeTreatment({ organizationId, treatmentId: row._id as Id<"gabinetTreatments"> });
+          }
+          toast.success(t("common.deleted"));
+        } catch (e) {
+          toast.error(
+            formatTreatmentError(e, t, {
+              key: "gabinet.treatments.errors.deleteFailed",
+              defaultValue: "Nie udało się usunąć zabiegu.",
+            }),
+          );
         }
       }
     },
-    [removeTreatment, organizationId],
+    [removeTreatment, organizationId, t],
   );
 
   const rowActions = useCallback(
@@ -685,7 +695,17 @@ function TreatmentsIndex() {
               icon: <Trash2 className="h-4 w-4" variant="stroke" />,
               onClick: async () => {
                 if (window.confirm(t("gabinet.treatments.confirmDelete"))) {
-                  await removeTreatment({ organizationId, treatmentId: row._id as Id<"gabinetTreatments"> });
+                  try {
+                    await removeTreatment({ organizationId, treatmentId: row._id as Id<"gabinetTreatments"> });
+                    toast.success(t("common.deleted"));
+                  } catch (e) {
+                    toast.error(
+                      formatTreatmentError(e, t, {
+                        key: "gabinet.treatments.errors.deleteFailed",
+                        defaultValue: "Nie udało się usunąć zabiegu.",
+                      }),
+                    );
+                  }
                 }
               },
             },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3333.

Closes #3333

---

## Claude summary

The fix is committed. Here's what was wrong and what was changed:

**Root cause:** In all three Gabinet list pages (treatments, patients, employees), the delete row action was an `async` function that called the Convex `remove` action with no `try/catch` and no toast notifications. The data table's `onAction` callback is synchronous and doesn't await the returned Promise, so any error thrown by the Convex action was silently swallowed — the user saw neither a success confirmation nor an error message. The confirmation dialog (`window.confirm`) did appear correctly, but after clicking OK nothing visible happened.

**Files changed:**
- `_layout.gabinet.treatments.index.tsx` — row delete and bulk delete
- `_layout.gabinet.patients.index.tsx` — row delete and bulk delete
- `_layout.gabinet.employees.index.tsx` — row delete and bulk delete (also added `t` to `handleBulkAction` deps)

The fix wraps each delete handler in `try/catch` and calls `toast.success(t("common.deleted"))` on success and `toast.error(formatActionError(...))` on failure, matching the existing correct pattern in `_layout.gabinet.packages.index.tsx`.

## Follow-ups

- Fix unawaited Promise in data table `onAction` callback: `enhanced-data-table.tsx` line 297 calls `a.onClick(item)` synchronously — if the onClick is async, errors can still be lost if the try/catch inside the handler is missing; making `onAction` async/awaited would provide an extra safety net
- Add toast notifications to documents delete action: `_layout.gabinet.documents.index.tsx` `handleDeleteConfirm` has a try/catch but only logs to console — it needs `toast.success`/`toast.error` like the other pages