### PR TITLE
Fix unawaited Promise in data table `onAction` callback

### DIFF
--- a/src/components/crm/enhanced-data-table.tsx
+++ b/src/components/crm/enhanced-data-table.tsx
@@ -40,7 +40,7 @@ export interface CrmColumn<TData> {
 
 interface RowAction<TData> {
   label: string;
-  onClick: (item: TData) => void;
+  onClick: (item: TData) => void | Promise<void>;
   icon?: React.ReactNode;
 }
 
@@ -294,7 +294,7 @@ export function CrmDataTable<TData>({
                                   <Dropdown.Item
                                     key={a.label}
                                     label={a.label}
-                                    onAction={() => a.onClick(item)}
+                                    onAction={async () => { await a.onClick(item); }}
                                   />
                                 ))}
                               </Dropdown.Menu>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3335.

Closes #3335

---

## Claude summary

Done. Two changes in `src/components/crm/enhanced-data-table.tsx`:

1. **Line 43** — `RowAction.onClick` type updated from `(item: TData) => void` to `(item: TData) => void | Promise<void>` to accurately reflect that callers (patients delete, treatments deactivate/activate) already pass async functions.

2. **Line 297** — `onAction={() => a.onClick(item)}` changed to `onAction={async () => { await a.onClick(item); }}` so the Promise is awaited rather than fire-and-forgotten, ensuring the Promise chain is properly established and unhandled rejections surface visibly.