### PR TITLE
Add toast notifications to documents delete action

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -606,17 +606,22 @@ function GabinetDocumentsPage() {
     });
   };
 
-  const handleDeleteConfirm = () => {
+  const handleDeleteConfirm = async () => {
     if (!docToDelete) return;
     try {
-      removeDocument({
+      await removeDocument({
         organizationId,
         documentId: docToDelete as any,
       });
+      await queryClient.invalidateQueries({
+        queryKey: supabaseKeys.formDocuments.all,
+      });
       setDeleteDialogOpen(false);
       setDocToDelete(null);
+      toast.success(t("gabinet.formDocuments.deleteSuccess", "Dokument został usunięty"));
     } catch (error) {
-      console.error("Failed to delete document:", error);
+      const message = error instanceof Error ? error.message : t("common.error", "Wystąpił błąd");
+      toast.error(message);
     }
   };
 
@@ -625,18 +630,29 @@ function GabinetDocumentsPage() {
     setDeleteDialogOpen(true);
   };
 
-  const handleBulkDelete = (items: any[]) => {
+  const handleBulkDelete = async (items: any[]) => {
     if (!items.length) return;
-    items.forEach((item) => {
+    let errorCount = 0;
+    for (const item of items) {
       try {
-        removeDocument({
+        await removeDocument({
           organizationId,
           documentId: item._id as any,
         });
-      } catch (error) {
-        console.error("Failed to delete document:", error);
+      } catch {
+        errorCount++;
       }
+    }
+    await queryClient.invalidateQueries({
+      queryKey: supabaseKeys.formDocuments.all,
     });
+    const successCount = items.length - errorCount;
+    if (successCount > 0) {
+      toast.success(t("gabinet.formDocuments.bulkDeleteSuccess", "Usunięto {{count}} dokumentów", { count: successCount }));
+    }
+    if (errorCount > 0) {
+      toast.error(t("gabinet.formDocuments.bulkDeleteError", "Nie udało się usunąć {{count}} dokumentów", { count: errorCount }));
+    }
   };
 
   // --- Render ---


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3336.

Closes #3336

---

## Claude summary

The fix is committed. Here's what changed in `_layout.gabinet.documents.index.tsx`:

`handleDeleteConfirm` (line 609): made `async`, added `await` on `removeDocument`, added `queryClient.invalidateQueries` to refresh the list, `toast.success` on success, and `toast.error` with the error message in the catch block instead of `console.error`.

`handleBulkDelete` (line 633): made `async`, switched from `forEach` to a `for...of` loop so each removal is `await`ed in sequence, tracks success/error counts, invalidates the query cache after all deletions complete, and shows separate `toast.success`/`toast.error` toasts depending on outcome.