### PR TITLE
Przycisk „Zmień hasło” obok adresu e-mail pracownika

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -2172,11 +2172,20 @@ function DetailedDataTab({
                 employee.phone ? formatPhoneNumber(employee.phone) : undefined,
                 <Phone className="h-3.5 w-3.5" />,
               )}
-              {readOnlyField(
-                t("gabinet.employees.detailedData.email"),
-                employee.email || userEmail || undefined,
-                <Mail className="h-3.5 w-3.5" />,
-              )}
+              <div className="flex items-start gap-3 py-1.5">
+                <span className="mt-0.5 text-muted-foreground"><Mail className="h-3.5 w-3.5" /></span>
+                <div className="min-w-0 flex-1">
+                  <p className="text-xs text-muted-foreground">{t("gabinet.employees.detailedData.email")}</p>
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <p className="text-sm font-medium">{employee.email || userEmail || "—"}</p>
+                    {(role === "admin" || role === "owner") && userEmail && onChangePassword && (
+                      <Button variant="outline" size="sm" onClick={onChangePassword} className="shrink-0">
+                        {t("gabinet.employees.changePassword")}
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              </div>
               {readOnlyField(
                 t("gabinet.employees.detailedData.dateOfBirth"),
                 employee.dateOfBirth ? formatBirthDate(employee.dateOfBirth) : undefined,
@@ -2190,26 +2199,6 @@ function DetailedDataTab({
                     .join(", "),
                   <MapPin className="h-3.5 w-3.5" />,
                 )}
-              {(role === "admin" || role === "owner") && (
-                <div className="col-span-2 border-t pt-3 mt-1 flex items-center justify-between gap-4">
-                  <div className="min-w-0">
-                    <p className="text-xs text-muted-foreground">{t("gabinet.employees.detailedData.accountAccess")}</p>
-                    <div className="flex items-center gap-2 mt-0.5 flex-wrap">
-                      <span className="text-sm font-medium">{userEmail || "—"}</span>
-                      <Badge variant={employee.isActive ? "default" : "secondary"} className="text-xs h-5">
-                        {employee.isActive
-                          ? t("gabinet.employees.detailedData.accountActive")
-                          : t("gabinet.employees.detailedData.accountInactive")}
-                      </Badge>
-                    </div>
-                  </div>
-                  {onChangePassword && (
-                    <Button variant="outline" size="sm" onClick={onChangePassword} className="shrink-0">
-                      {t("gabinet.employees.changePassword")}
-                    </Button>
-                  )}
-                </div>
-              )}
             </div>
           )}
         </CardContent>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3339.

Closes #3339

---

## Claude summary

Done. Here's a summary of what changed:

**File changed:** `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx`

The "Konto i dostęp" section (separate row at the bottom of the personal-data card, added in #3329) has been removed. In its place, the e-mail read-only field now renders a "Zmień hasło" button inline, immediately to the right of the e-mail address value. The button is conditional on three guards matching simultaneously:
- `role === "admin" || role === "owner"` — only admins/owners see it
- `userEmail` is truthy — employee must have a linked user account
- `onChangePassword` prop is provided — the existing dialog callback exists

The existing password-change dialog, its state, validation, and Convex action are all untouched. Responsiveness is maintained via `flex-wrap` on the value row, so on narrow screens (phone/tablet) the button drops below the email text.

**Manual test steps:**
1. Open an employee detail page → "Dane szczegółowe" tab → "Dane osobowe" section
2. As owner/admin with a linked-user employee: e-mail row shows the address + "Zmień hasło" button; clicking it opens the existing dialog
3. As owner/admin with an employee that has no user account (`userEmail` is empty): button is not visible
4. As a member/viewer role: button is not visible
5. The old "Konto i dostęp" separator row no longer appears

## Follow-ups
- Remove orphaned i18n keys `accountAccess`, `accountActive`, `accountInactive` from translation files: these were used only by the removed "Konto i dostęp" section and are now dead weight in both `public/locales/pl/translation.json` and `public/locales/en/translation.json`