### PR TITLE
Remove orphaned i18n keys `accountAccess`, `accountActive`, `accountInactive` fr

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3057,10 +3057,7 @@
         "baseSalary": "Base Salary",
         "commissionPercent": "Commission %",
         "bankAccount": "Bank Account",
-        "noCompensationYet": "No compensation data added yet.",
-        "accountAccess": "Account & Access",
-        "accountActive": "Active",
-        "accountInactive": "Inactive"
+        "noCompensationYet": "No compensation data added yet."
       },
       "schedule": {
         "hasOverrides": "This employee has a custom schedule defined.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3077,10 +3077,7 @@
         "baseSalary": "Wynagrodzenie podstawowe",
         "commissionPercent": "Prowizja %",
         "bankAccount": "Numer konta bankowego",
-        "noCompensationYet": "Brak danych o wynagrodzeniu.",
-        "accountAccess": "Konto i dostęp",
-        "accountActive": "Aktywne",
-        "accountInactive": "Nieaktywne"
+        "noCompensationYet": "Brak danych o wynagrodzeniu."
       },
       "schedule": {
         "hasOverrides": "Ten pracownik ma zdefiniowany indywidualny grafik.",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3341.

Closes #3341

---

## Claude summary

Done. Removed the three dead keys (`accountAccess`, `accountActive`, `accountInactive`) from both `public/locales/en/translation.json` and `public/locales/pl/translation.json`. Grep confirmed zero usages in `src/`, so these were pure dead weight left over from the section removed in #3339.