### PR TITLE
Migrate packages KPI cards to use real package sales data (not just catalog coun

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -150,13 +150,14 @@ function buildActiveUsageDetails(
 function derivePackageKpis(
   packages: MappedGabinetTreatmentPackage[],
   activeUsages: MappedGabinetPackageUsage[],
-): { totalPackages: number; activePackages: number; expiringPackages: number } {
+): { totalPackages: number; activePackages: number; soldActiveUsages: number; expiringPackages: number } {
   const now = Date.now();
   const thirtyDays = 30 * 24 * 60 * 60 * 1000;
 
   return {
     totalPackages: packages.length,
     activePackages: packages.filter((p) => p.isActive).length,
+    soldActiveUsages: activeUsages.length,
     expiringPackages: activeUsages.filter(
       (u) => u.expiresAt != null && u.expiresAt > now && u.expiresAt <= now + thirtyDays,
     ).length,
@@ -489,7 +490,7 @@ function PackagesIndex() {
         <StatisticsProfitCard
           title={t("gabinet.packages.activePackages", "Aktywne wykupione")}
           description={t("gabinet.packages.inUse", "W użyciu")}
-          value={String(pkgKpis.activePackages)}
+          value={String(pkgKpis.soldActiveUsages)}
           changePercentage={t("gabinet.packages.byPatients", "u klientów")}
         />
         <StatisticsImpressionCard


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3345.

Closes #3345

---

## Claude summary

The fix is committed. Here's what was wrong and what changed:

**Root cause:** `derivePackageKpis` computed `activePackages` as `packages.filter((p) => p.isActive).length` — counting catalog entries marked active. This value was being shown in the `StatisticsProfitCard` labeled "Aktywne wykupione / W użyciu" (Active purchased / In use), which misleadingly implied it counted real patient usages.

**Fix:** Added a new `soldActiveUsages` field to `derivePackageKpis` computed as `activeUsages.length` — the length of the `activeUsagesData` array from `useSupabaseGabinetPackageUsageActive`, which fetches actual sold and currently-active package usage records per patient. The `StatisticsProfitCard` now uses this value. The first card (`StatisticsOrderCard`) continues to show `activePackages` (catalog count) as its subtitle, which is the correct semantic there.