### PR TITLE
`gabinetPackageUsage` has no index on `packageId` alone

### DIFF
--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -551,7 +551,8 @@ export function createGabinetTables({
     .index("by_org", ["organizationId"])
     .index("by_orgAndPatient", ["organizationId", "patientId"])
     .index("by_orgAndStatus", ["organizationId", "status"])
-    .index("by_orgPatientAndPackage", ["organizationId", "patientId", "packageId"]),
+    .index("by_orgPatientAndPackage", ["organizationId", "patientId", "packageId"])
+    .index("by_package", ["packageId"]),
 
   gabinetLoyaltyPoints: defineTable({
     organizationId: v.id("organizations"),

--- a/supabase/migrations/00068_gabinet_package_usage_by_package_idx.sql
+++ b/supabase/migrations/00068_gabinet_package_usage_by_package_idx.sql
@@ -1,0 +1,4 @@
+-- Add index on package_id alone to gabinet_package_usage so that queries
+-- filtering by package (e.g. counting sold usages per package) don't full-scan.
+-- Mirrors the new by_package Convex index added in convex/schema/gabinet.ts.
+CREATE INDEX gabinet_package_usage_package_idx ON gabinet_package_usage (package_id);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3346.

Closes #3346

---

## Claude summary

Done. Two changes were made:

1. `convex/schema/gabinet.ts`: Added `.index("by_package", ["packageId"])` to the `gabinetPackageUsage` table definition (line 555).

2. `supabase/migrations/00068_gabinet_package_usage_by_package_idx.sql`: New migration that creates `gabinet_package_usage_package_idx ON gabinet_package_usage (package_id)` in Postgres.

The existing `by_orgPatientAndPackage` composite index `(organization_id, patient_id, package_id)` can't serve queries that filter by `package_id` alone (e.g. the KPI `getPackageSoldCounts` action that groups all active usages by `packageId`), so the standalone index is necessary.