### PR TITLE
System płatności ratalnej

### DIFF
--- a/src/components/gabinet/package-purchase-drawer.tsx
+++ b/src/components/gabinet/package-purchase-drawer.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { Id } from "@cvx/_generated/dataModel";
@@ -43,6 +43,7 @@ export function PackagePurchaseDrawer({
   onOpenChange,
 }: PackagePurchaseDrawerProps) {
   const { t } = useTranslation();
+  const queryClient = useQueryClient();
   const purchasePackage = useAction(api.gabinet.packages.purchasePackage);
   const createPayment = useAction(api.payments.create);
 
@@ -238,6 +239,12 @@ export function PackagePurchaseDrawer({
       }
 
       toast.success(t("gabinet.packages.purchased", "Package purchased successfully"));
+      await queryClient.invalidateQueries({
+        queryKey: ["gabinet.packages.getPatientPackages", organizationId, patientId],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["gabinet.packages.listActive", organizationId],
+      });
       resetForm();
       onOpenChange(false);
     } catch (e) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3344.

Closes #3344

---

## Claude summary

The bug was in `src/components/gabinet/package-purchase-drawer.tsx`. After successfully purchasing a package (whether with one-time or installment payment), the component called `toast.success` and closed the drawer — but never invalidated the TanStack Query cache for `getPatientPackages`. So the patient's packages card kept showing the old (pre-purchase) data until the user reloaded the page.

The fix mirrors what `treatment-purchase-drawer.tsx:233-238` already does correctly: invalidate both `["gabinet.packages.getPatientPackages", organizationId, patientId]` (to refresh the patient card and the `PackageUsageSelector` in the appointment dialog) and `["gabinet.packages.listActive", organizationId]` (to keep the available packages list in sync).

The installment payment logic itself (creating pending payment records, the "Mark Paid" button, etc.) was all implemented correctly and continues to work as-is.

## Follow-ups

- Missing installment option in `sell-package-panel.tsx`: the `SellPackagePanel` (accessible from the main Gabinet packages list) has no installment payment type toggle, unlike `PackagePurchaseDrawer`. Users selling from that panel cannot set up installments at all.