### PR TITLE
Dodanie pięciu głównych grup nawigacji na karcie pracownika

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3095,6 +3095,13 @@
         "createFailed": "Could not add the employee.",
         "saveFailed": "Could not save employee changes.",
         "noteFailed": "Could not add the note."
+      },
+      "navGroups": {
+        "clientsAndVisits": "Clients and Visits",
+        "schedule": "Schedule",
+        "employeeData": "Employee Data",
+        "documentsAndAssets": "Documents and Assets",
+        "accountAndAccess": "Account and Access"
       }
     },
     "leaveTypes": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3115,6 +3115,13 @@
         "createFailed": "Nie udało się dodać pracownika.",
         "saveFailed": "Nie udało się zapisać zmian pracownika.",
         "noteFailed": "Nie udało się dodać notatki."
+      },
+      "navGroups": {
+        "clientsAndVisits": "Klienci i wizyty",
+        "schedule": "Grafik",
+        "employeeData": "Dane pracownika",
+        "documentsAndAssets": "Dokumenty i mienie",
+        "accountAndAccess": "Konto i dostęp"
       }
     },
     "leaveTypes": {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -168,6 +168,9 @@ function EmployeeDetail() {
   const [newNote, setNewNote] = useState("");
   const [isAddingNote, setIsAddingNote] = useState(false);
 
+  // Main navigation groups (preparatory layer for future micro-tasks)
+  const [activeNavGroup, setActiveNavGroup] = useState<string>("clientsAndVisits");
+
   // Feature 1: Appointments view mode (calendar vs list)
   const [appointmentsView, setAppointmentsView] = useState<"calendar" | "list">("calendar");
   const [calendarWeekStart, setCalendarWeekStart] = useState<string>(() => {
@@ -844,6 +847,13 @@ function EmployeeDetail() {
         sidebarExtra={sidebarExtra}
         tabs={tabs}
         defaultTab={t("gabinet.employees.tabs.agenda")}
+        beforeTabs={
+          <EmployeeNavGroups
+            activeGroup={activeNavGroup}
+            onGroupChange={setActiveNavGroup}
+            t={t}
+          />
+        }
       />
 
       {/* Edit employee drawer */}
@@ -940,6 +950,51 @@ function EmployeeDetail() {
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+// --- Employee main navigation groups ---
+
+const EMPLOYEE_NAV_GROUPS = [
+  "clientsAndVisits",
+  "schedule",
+  "employeeData",
+  "documentsAndAssets",
+  "accountAndAccess",
+] as const;
+
+function EmployeeNavGroups({
+  activeGroup,
+  onGroupChange,
+  t,
+}: {
+  activeGroup: string;
+  onGroupChange: (group: string) => void;
+  t: TFunction;
+}) {
+  return (
+    <div className="-mx-4 mb-1 overflow-x-auto px-4 scrollbar-none">
+      <div className="flex min-w-max gap-1 pb-1">
+        {EMPLOYEE_NAV_GROUPS.map((group) => {
+          const isActive = activeGroup === group;
+          return (
+            <button
+              key={group}
+              type="button"
+              onClick={() => onGroupChange(group)}
+              className={[
+                "shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground",
+              ].join(" ")}
+            >
+              {t(`gabinet.employees.navGroups.${group}`)}
+            </button>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3354.

Closes #3354

---

## Claude summary

Done. Here's a summary of what was changed:

**Files modified (3):**

1. `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx`
   - Added `activeNavGroup` state (defaults to `"clientsAndVisits"`)
   - Added `EmployeeNavGroups` component with 5 buttons styled as a pill-style group nav
   - Passed it as `beforeTabs` to `EntityDetailLayout` — renders above the existing tab row, inside the same bordered panel area
   - The `beforeTabs` slot was already provided by `EntityDetailLayout` (line 339), so no layout changes were needed

2. `public/locales/pl/translation.json` — added `gabinet.employees.navGroups` with Polish labels
3. `public/locales/en/translation.json` — added `gabinet.employees.navGroups` with English labels

**Behavior:**
- The 5 groups appear as a scrollable horizontal pill bar above the existing tabs on all screen sizes (horizontal overflow scrolls on mobile, no wrapping)
- Clicking a group highlights it (active = `bg-primary text-primary-foreground`, inactive = muted hover style)
- All existing tabs, routing, forms, and permissions are completely untouched
- `EmployeeNavGroup` is a preparatory state layer — content filtering per group is left for subsequent micro-tasks