### PR TITLE
feat(gabinet): create gabinet_appointment_treatments junction table with backfill (#3360)

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -55,6 +55,7 @@ const TABLE_MAP: Record<string, string> = {
   categoryDefinitions: "category_definitions",
   gabinetPatients: "gabinet_patients",
   gabinetAppointments: "gabinet_appointments",
+  gabinetAppointmentTreatments: "gabinet_appointment_treatments",
   gabinetTreatments: "gabinet_treatments",
   gabinetTreatmentVariants: "gabinet_treatment_variants",
   gabinetTreatmentProducts: "gabinet_treatment_products",

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -494,6 +494,24 @@ export function createGabinetTables({
     .index("by_orgAndRoomAndDate", ["organizationId", "roomId", "date"])
     .index("by_requiresCompletion", ["organizationId", "requiresCompletion"]),
 
+  // Junction table: appointment → treatment(s) (#3360).
+  // Backfilled from the scalar treatmentId/variantId/priceAtBooking columns
+  // on gabinetAppointments. New rows are written here by the multi-treatment
+  // model introduced in #3356.
+  gabinetAppointmentTreatments: defineTable({
+    organizationId: v.id("organizations"),
+    appointmentId: v.id("gabinetAppointments"),
+    treatmentId: v.optional(v.id("gabinetTreatments")),
+    variantId: v.optional(v.id("gabinetTreatmentVariants")),
+    priceAtBooking: v.optional(v.number()),
+    sortOrder: v.number(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_appointment", ["appointmentId"])
+    .index("by_org", ["organizationId"])
+    .index("by_orgAndTreatment", ["organizationId", "treatmentId"]),
+
   // --- Gabinet: Packages & Loyalty (Phase 4) ---
 
   gabinetTreatmentPackages: defineTable({

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -71,6 +71,9 @@
  *   • 00064_gabinet_appointments_package_deducted.sql
  *   • 00065_gabinet_package_usage_gift.sql
  *   • 00066_product_sale_price.sql
+ *   • 00067_gabinet_employee_locations_role.sql
+ *   • 00068_gabinet_package_usage_by_package_idx.sql
+ *   • 00069_gabinet_appointment_treatments.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -4949,6 +4952,71 @@ export interface Database {
           },
           {
             foreignKeyName: "gabinet_appointments_variant_id_fkey";
+            columns: ["variant_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_treatment_variants";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      gabinet_appointment_treatments: {
+        Row: {
+          id: string;
+          organization_id: string;
+          appointment_id: string;
+          treatment_id: string | null;
+          variant_id: string | null;
+          price_at_booking: number | null;
+          sort_order: number;
+          created_at: number;
+          updated_at: number;
+        };
+        Insert: {
+          id?: string;
+          organization_id: string;
+          appointment_id: string;
+          treatment_id?: string | null;
+          variant_id?: string | null;
+          price_at_booking?: number | null;
+          sort_order?: number;
+          created_at: number;
+          updated_at: number;
+        };
+        Update: {
+          id?: string;
+          organization_id?: string;
+          appointment_id?: string;
+          treatment_id?: string | null;
+          variant_id?: string | null;
+          price_at_booking?: number | null;
+          sort_order?: number;
+          created_at?: number;
+          updated_at?: number;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "gabinet_appointment_treatments_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organizations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gabinet_appointment_treatments_appointment_id_fkey";
+            columns: ["appointment_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_appointments";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gabinet_appointment_treatments_treatment_id_fkey";
+            columns: ["treatment_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_treatments";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gabinet_appointment_treatments_variant_id_fkey";
             columns: ["variant_id"];
             isOneToOne: false;
             referencedRelation: "gabinet_treatment_variants";

--- a/supabase/migrations/00069_gabinet_appointment_treatments.sql
+++ b/supabase/migrations/00069_gabinet_appointment_treatments.sql
@@ -1,0 +1,80 @@
+-- Gabinet appointment → treatment(s) junction table (#3360).
+--
+-- Existing appointments store a single treatment via scalar columns
+-- `treatment_id`, `variant_id`, and `price_at_booking` on
+-- gabinet_appointments.  The forthcoming multi-treatment model (#3356)
+-- requires a junction table so that each appointment can have N treatments.
+--
+-- This migration:
+--   1. Creates gabinet_appointment_treatments.
+--   2. Backfills one row per existing appointment that already has a
+--      treatment_id set.  The backfilled rows use gen_random_uuid()::text
+--      as their IDs (the table is keyed by appointment_id in practice).
+--
+-- The scalar columns on gabinet_appointments are intentionally left in
+-- place so that read paths built before #3356 continue to work during the
+-- transition.  Dropping them is a separate cleanup step.
+
+CREATE TABLE IF NOT EXISTS gabinet_appointment_treatments (
+  id              TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  appointment_id  TEXT NOT NULL REFERENCES gabinet_appointments(id) ON DELETE CASCADE,
+  treatment_id    TEXT REFERENCES gabinet_treatments(id) ON DELETE SET NULL,
+  variant_id      TEXT REFERENCES gabinet_treatment_variants(id) ON DELETE SET NULL,
+  price_at_booking NUMERIC,
+  sort_order      INTEGER NOT NULL DEFAULT 0,
+  created_at      BIGINT NOT NULL,
+  updated_at      BIGINT NOT NULL
+);
+
+-- ---------------------------------------------------------------------------
+-- Indexes
+-- ---------------------------------------------------------------------------
+
+CREATE INDEX IF NOT EXISTS gabinet_appointment_treatments_appointment_idx
+  ON gabinet_appointment_treatments (appointment_id);
+
+CREATE INDEX IF NOT EXISTS gabinet_appointment_treatments_org_idx
+  ON gabinet_appointment_treatments (organization_id);
+
+CREATE INDEX IF NOT EXISTS gabinet_appointment_treatments_org_treatment_idx
+  ON gabinet_appointment_treatments (organization_id, treatment_id);
+
+-- ---------------------------------------------------------------------------
+-- RLS: org-scoped access, same pattern as all other gabinet tables.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE gabinet_appointment_treatments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY org_isolation ON gabinet_appointment_treatments
+  USING (organization_id = current_org_id());
+
+-- ---------------------------------------------------------------------------
+-- Backfill: one row per existing appointment that has treatment_id set.
+-- Rows without treatment_id (appointments booked with no specific treatment)
+-- are intentionally skipped — they have nothing to migrate.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO gabinet_appointment_treatments (
+  id,
+  organization_id,
+  appointment_id,
+  treatment_id,
+  variant_id,
+  price_at_booking,
+  sort_order,
+  created_at,
+  updated_at
+)
+SELECT
+  gen_random_uuid()::text,
+  organization_id,
+  id,
+  treatment_id,
+  variant_id,
+  price_at_booking,
+  0,
+  created_at,
+  updated_at
+FROM gabinet_appointments
+WHERE treatment_id IS NOT NULL;


### PR DESCRIPTION
## Summary

- Creates `gabinet_appointment_treatments` junction table in migration `00069` to support the forthcoming multi-treatment-per-appointment model (#3356)
- Backfills one row per existing appointment that has `treatment_id` set, preserving `variant_id` and `price_at_booking`
- Registers the table in the Convex schema (`gabinetAppointmentTreatments`), `TABLE_MAP` in `supabaseDb.ts`, and `database.types.ts`
- Scalar columns (`treatment_id`, `variant_id`, `price_at_booking`) on `gabinet_appointments` are intentionally left in place for backwards compatibility until #3356 migrates all write paths

## Test plan

- [ ] Migration applies cleanly on a fresh DB and on a DB with existing appointment rows
- [ ] After migration, every `gabinet_appointments` row where `treatment_id IS NOT NULL` has exactly one corresponding `gabinet_appointment_treatments` row
- [ ] `gabinet_appointments` rows with `treatment_id IS NULL` have no corresponding junction rows
- [ ] RLS policy (`current_org_id()`) scopes reads correctly per organisation
- [ ] TypeScript compiles without errors after the `database.types.ts` update

Closes #3360

🤖 Generated with [Claude Code](https://claude.com/claude-code)