### PR TITLE
feat(gabinet): add per-treatment deduction flags to junction table (closes #3361)

### DIFF
--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -505,6 +505,11 @@ export function createGabinetTables({
     variantId: v.optional(v.id("gabinetTreatmentVariants")),
     priceAtBooking: v.optional(v.number()),
     sortOrder: v.number(),
+    // Per-treatment deduction flags (#3361). Replace the appointment-level
+    // stockDeducted / packageDeducted booleans which become ambiguous when an
+    // appointment has multiple treatments.
+    stockDeducted: v.optional(v.boolean()),
+    packageDeducted: v.optional(v.boolean()),
     createdAt: v.number(),
     updatedAt: v.number(),
   })

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -74,6 +74,7 @@
  *   • 00067_gabinet_employee_locations_role.sql
  *   • 00068_gabinet_package_usage_by_package_idx.sql
  *   • 00069_gabinet_appointment_treatments.sql
+ *   • 00070_appointment_treatments_deduction_flags.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -4968,6 +4969,8 @@ export interface Database {
           variant_id: string | null;
           price_at_booking: number | null;
           sort_order: number;
+          stock_deducted: boolean;
+          package_deducted: boolean;
           created_at: number;
           updated_at: number;
         };
@@ -4979,6 +4982,8 @@ export interface Database {
           variant_id?: string | null;
           price_at_booking?: number | null;
           sort_order?: number;
+          stock_deducted?: boolean;
+          package_deducted?: boolean;
           created_at: number;
           updated_at: number;
         };
@@ -4990,6 +4995,8 @@ export interface Database {
           variant_id?: string | null;
           price_at_booking?: number | null;
           sort_order?: number;
+          stock_deducted?: boolean;
+          package_deducted?: boolean;
           created_at?: number;
           updated_at?: number;
         };

--- a/supabase/migrations/00070_appointment_treatments_deduction_flags.sql
+++ b/supabase/migrations/00070_appointment_treatments_deduction_flags.sql
@@ -1,0 +1,39 @@
+-- Move stock_deducted and package_deducted tracking to the per-treatment
+-- junction table (closes #3361).
+--
+-- The scalar stock_deducted / package_deducted columns on gabinet_appointments
+-- are appointment-level booleans that made sense when each appointment had a
+-- single treatment.  Now that gabinet_appointment_treatments holds one row per
+-- treatment, a single boolean is ambiguous: it cannot say which treatments had
+-- their stock or package entry deducted.
+--
+-- This migration:
+--   1. Adds stock_deducted and package_deducted to gabinet_appointment_treatments.
+--   2. Backfills the new columns from the parent appointment's flags so that
+--      existing completed appointments remain consistent.
+--
+-- The appointment-level columns (stock_deducted, package_deducted) are left
+-- in place for the current CAS guards in updateStatus — they will be removed
+-- as a follow-up once the deduction logic migrates to per-treatment rows.
+
+ALTER TABLE gabinet_appointment_treatments
+  ADD COLUMN IF NOT EXISTS stock_deducted   BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS package_deducted BOOLEAN NOT NULL DEFAULT false;
+
+-- ---------------------------------------------------------------------------
+-- Backfill: propagate the appointment-level flags to the matching junction rows.
+-- Only junction rows whose parent appointment already has the flag set get
+-- marked true; new rows start at false (the column default).
+-- ---------------------------------------------------------------------------
+
+UPDATE gabinet_appointment_treatments jt
+SET stock_deducted = true
+FROM gabinet_appointments a
+WHERE jt.appointment_id = a.id
+  AND a.stock_deducted = true;
+
+UPDATE gabinet_appointment_treatments jt
+SET package_deducted = true
+FROM gabinet_appointments a
+WHERE jt.appointment_id = a.id
+  AND a.package_deducted = true;


### PR DESCRIPTION
## Summary

- Adds `stock_deducted` and `package_deducted` columns to `gabinet_appointment_treatments` (migration 00070) so each treatment row can track its own deduction state independently
- Backfills existing junction rows from the parent appointment's flags so completed appointments stay consistent
- Updates Convex schema (`gabinetAppointmentTreatments`) and Supabase database types to reflect the new columns
- Appointment-level `stock_deducted` / `package_deducted` are left in place for the current CAS guards in `updateStatus`; they will be removed once the deduction logic migrates to per-treatment rows (#3356)

## Test plan

- [ ] Migration applies cleanly; existing `gabinet_appointment_treatments` rows for appointments with `stock_deducted=true` or `package_deducted=true` are backfilled correctly
- [ ] New appointments with multiple treatments can set per-row deduction flags independently
- [ ] Existing single-treatment appointment deduction flow (`updateStatus` → CAS on `gabinet_appointments`) still works as before (no logic change in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)