### PR TITLE
Update `backfillAppointments` in `convex/supabase/backfill.ts` to include `varia

### DIFF
--- a/convex/supabase/backfill.ts
+++ b/convex/supabase/backfill.ts
@@ -427,6 +427,8 @@ export const backfillAppointments = internalAction({
       organization_id: a.organizationId,
       patient_id: String(a.patientId),
       treatment_id: a.treatmentId ? String(a.treatmentId) : null,
+      variant_id: a.variantId ? String(a.variantId) : null,
+      price_at_booking: a.priceAtBooking ?? null,
       employee_id: String(a.employeeId),
       date: a.date,
       start_time: a.startTime,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3364.

Closes #3364

---

## Claude summary

The bug was real and the fix is clean. Both `variant_id` and `price_at_booking` exist on the `gabinet_appointments` Supabase table (added in migrations 00047 and 00022 respectively), and both have corresponding fields in the Convex schema (`variantId` and `priceAtBooking` in `convex/schema/gabinet.ts`). The `_listAppointments` query returns all fields from Convex, but the mapping in `backfillAppointments` was simply missing these two, so running the backfill would have silently left those columns as `null` in Supabase for any appointments that had them set in Convex.

The fix adds both fields with the same null-coalescing pattern used by all other optional columns in that same mapping.