### PR TITLE
Migrate stock deduction logic to use per-treatment junction rows

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2122,17 +2122,18 @@ export const updateStatus = action({
     }
 
     // Stock return: when reverting from "completed" to any other status, undo the
-    // auto-deductions created at completion time. Uses the same CAS pattern as
-    // the deduction guard below — atomically flips stock_deducted back to false;
-    // only the winner proceeds with creating return movements. Closes #3009.
-    if (appt.status === "completed" && appt.stockDeducted === true && appt.treatmentId) {
+    // auto-deductions created at completion time. CAS is now per-junction-row on
+    // gabinet_appointment_treatments.stock_deducted (#3366). The batch UPDATE
+    // atomically flips every deducted row back to false; only the first concurrent
+    // caller gets rows back and proceeds with creating return movements.
+    if (appt.status === "completed") {
       const { data: returnCasRows } = await db.raw()
-        .from("gabinet_appointments")
+        .from("gabinet_appointment_treatments")
         .update({ stock_deducted: false })
-        .eq("id", args.appointmentId)
+        .eq("appointment_id", args.appointmentId)
         .eq("stock_deducted", true)
         .select("id");
-      const wonReturnRace = Array.isArray(returnCasRows) && returnCasRows.length === 1;
+      const wonReturnRace = Array.isArray(returnCasRows) && returnCasRows.length > 0;
       if (wonReturnRace) {
         try {
           // Secondary guard: if appointment_return movements already exist for this
@@ -2231,29 +2232,32 @@ export const updateStatus = action({
       }
     }
 
-    // Auto-deduct stock on visit completion. Guard against double-deduction
-    // using an atomic CAS update (WHERE stock_deducted = false). Two concurrent
-    // updateStatus calls can both read stockDeducted=false from the earlier
-    // Supabase read, but only one can win the conditional UPDATE — Postgres row
-    // locking ensures only one writer updates a row matching the predicate.
-    // The loser gets 0 rows back and skips deduction entirely. Closes #2917.
-    // (Previous guard used !appt.stockDeducted from the stale read, which both
-    // concurrent calls saw as false, leading to double deduction.)
+    // Auto-deduct stock on visit completion. CAS guard now lives on
+    // gabinet_appointment_treatments.stock_deducted per junction row (#3366),
+    // replacing the old appointment-level stock_deducted flag. Each junction row
+    // represents one treatment; concurrent calls race per-row so only one winner
+    // per treatment deducts stock. Closes #2917, migrates guard from #3361.
     const stockWarnings: string[] = [];
-    if (args.status === "completed" && appt.treatmentId) {
-      const { data: casRows } = await db.raw()
-        .from("gabinet_appointments")
-        .update({ stock_deducted: true })
-        .eq("id", args.appointmentId)
-        .eq("stock_deducted", false)
-        .select("id");
-      const wonRace = Array.isArray(casRows) && casRows.length === 1;
-      if (wonRace) {
+    if (args.status === "completed") {
+      const { data: junctionRows } = await db.raw()
+        .from("gabinet_appointment_treatments")
+        .select("id, treatment_id")
+        .eq("appointment_id", args.appointmentId);
+      for (const jt of (junctionRows ?? []) as Array<{ id: string; treatment_id: string | null }>) {
+        if (!jt.treatment_id) continue;
+        const { data: casRows } = await db.raw()
+          .from("gabinet_appointment_treatments")
+          .update({ stock_deducted: true })
+          .eq("id", jt.id)
+          .eq("stock_deducted", false)
+          .select("id");
+        const wonRace = Array.isArray(casRows) && casRows.length === 1;
+        if (!wonRace) continue;
         try {
           const links = await db
             .query("gabinetTreatmentProducts")
             .eq("organizationId", String(args.organizationId))
-            .eq("treatmentId", String(appt.treatmentId))
+            .eq("treatmentId", jt.treatment_id)
             .collect();
           for (const link of links) {
             if (!link.quantity || Number(link.quantity) <= 0) continue;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3366.

Closes #3366

---

## Claude summary

The fix is committed. Here's what changed in `convex/gabinet/appointments.ts`:

**Stock deduction** (completion path): Replaced the single appointment-level CAS on `gabinet_appointments.stock_deducted` + scalar `appt.treatmentId` lookup with a loop over `gabinet_appointment_treatments` rows. Each junction row gets its own CAS flip on its `stock_deducted` column, and products are queried for that row's `treatment_id`. This correctly handles appointments with multiple treatments (future multi-treatment support from #3356) and guards against double-deduction per treatment rather than per appointment.

**Stock return** (revert-from-completed path): Replaced the appointment-level CAS with a single batch `UPDATE ... WHERE appointment_id = ? AND stock_deducted = true RETURNING id` on `gabinet_appointment_treatments`. If any rows are returned (we won the race), the existing movement-inversion logic runs unchanged — since `product_stock_movements` is still keyed at appointment level, no changes were needed there.

## Follow-ups

- Migrate package deduction CAS to per-treatment junction rows: the `package_deducted` flag on `gabinet_appointments` still guards the package deduction/return paths in `updateStatus` (lines ~2204-2232, ~2327-2350); migration `00070` added `package_deducted` to `gabinet_appointment_treatments` but the CAS in the code was not updated, same pattern as this issue
- Remove stale appointment-level `stock_deducted` / `package_deducted` columns: once both CAS guards are migrated off the appointment-level flags, the columns `gabinet_appointments.stock_deducted` and `gabinet_appointments.package_deducted` can be dropped in a cleanup migration