### PR TITLE
Migrate package deduction logic to use per-treatment junction rows

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2199,21 +2199,21 @@ export const updateStatus = action({
     }
 
     // Package return: when reverting from completed or no_show, restore one
-    // package entry. Uses the same CAS pattern as stock return above.
-    // Closes #3206.
+    // package entry. CAS now lives on gabinet_appointment_treatments.package_deducted
+    // per junction row (#3367), replacing the old appointment-level flag.
     if (
       (appt.status === "completed" || appt.status === "no_show") &&
-      appt.packageDeducted === true &&
-      appt.packageUsageId
+      appt.packageUsageId &&
+      appt.treatmentId
     ) {
       const { data: pkgReturnCasRows } = await db.raw()
-        .from("gabinet_appointments")
+        .from("gabinet_appointment_treatments")
         .update({ package_deducted: false })
-        .eq("id", args.appointmentId)
+        .eq("appointment_id", args.appointmentId)
+        .eq("treatment_id", String(appt.treatmentId))
         .eq("package_deducted", true)
         .select("id");
-      const wonPkgReturnRace =
-        Array.isArray(pkgReturnCasRows) && pkgReturnCasRows.length === 1;
+      const wonPkgReturnRace = Array.isArray(pkgReturnCasRows) && pkgReturnCasRows.length > 0;
       if (wonPkgReturnRace) {
         try {
           await returnPackageEntry(db, {
@@ -2321,20 +2321,22 @@ export const updateStatus = action({
       }
     }
 
-    // Package deduction: completed and no_show both consume one entry. CAS on
-    // package_deducted prevents double-deduction on concurrent calls or on
-    // completed → rescheduled → completed round-trips. Closes #3206.
+    // Package deduction: completed and no_show both consume one entry. CAS now
+    // lives on gabinet_appointment_treatments.package_deducted per junction row
+    // (#3367), replacing the old appointment-level flag. Closes #3206.
     if (
       (args.status === "completed" || args.status === "no_show") &&
-      appt.packageUsageId
+      appt.packageUsageId &&
+      appt.treatmentId
     ) {
       const { data: pkgCasRows } = await db.raw()
-        .from("gabinet_appointments")
+        .from("gabinet_appointment_treatments")
         .update({ package_deducted: true })
-        .eq("id", args.appointmentId)
+        .eq("appointment_id", args.appointmentId)
+        .eq("treatment_id", String(appt.treatmentId))
         .eq("package_deducted", false)
         .select("id");
-      const wonPkgRace = Array.isArray(pkgCasRows) && pkgCasRows.length === 1;
+      const wonPkgRace = Array.isArray(pkgCasRows) && pkgCasRows.length > 0;
       if (wonPkgRace) {
         try {
           await deductPackageEntry(db, {
@@ -2520,19 +2522,22 @@ export const applySmsReplyTransition = internalMutation({
     // too. Currently unreachable (intent is locked to confirm/cancel → targetStatus
     // is always "confirmed"|"cancelled"). Cast to string so TS2367 doesn't fire
     // and the guard becomes live automatically when the intent union is extended.
-    // Closes #3222.
+    // CAS now lives on gabinet_appointment_treatments.package_deducted per
+    // junction row (#3367). Closes #3222.
     const _targetStatusStr: string = targetStatus;
     if (
       (_targetStatusStr === "completed" || _targetStatusStr === "no_show") &&
-      appointment.packageUsageId
+      appointment.packageUsageId &&
+      appointment.treatmentId
     ) {
       const { data: pkgCasRows } = await db.raw()
-        .from("gabinet_appointments")
+        .from("gabinet_appointment_treatments")
         .update({ package_deducted: true })
-        .eq("id", args.appointmentId)
+        .eq("appointment_id", args.appointmentId)
+        .eq("treatment_id", String(appointment.treatmentId))
         .eq("package_deducted", false)
         .select("id");
-      const wonPkgRace = Array.isArray(pkgCasRows) && pkgCasRows.length === 1;
+      const wonPkgRace = Array.isArray(pkgCasRows) && pkgCasRows.length > 0;
       if (wonPkgRace) {
         try {
           await deductPackageEntry(db, {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3367.

Closes #3367

---

## Claude summary

The fix is committed. Here's a summary of what was changed and why:

**The problem:** The `deductPackageEntry` / `returnPackageEntry` calls were using a CAS (compare-and-swap) guard on `gabinet_appointments.package_deducted` — a single boolean on the appointment row. After issue #3361 added `package_deducted` to the `gabinet_appointment_treatments` junction table, this appointment-level flag became redundant and ambiguous (it can't say *which* treatment's package entry was deducted).

**The fix:** Three sites in `convex/gabinet/appointments.ts` were updated to CAS on `gabinet_appointment_treatments.package_deducted` instead, filtering by `appointment_id` + `treatment_id`:

1. **Package return path** (line ~2201, in `updateStatus`): CAS now flips the junction row's flag from `true → false` instead of the appointment-level flag. Removed the stale `appt.packageDeducted === true` pre-check (the CAS itself provides that guard).

2. **Package deduction path** (line ~2324, in `updateStatus`): CAS now sets the junction row's flag `false → true` for the matching `treatment_id`. Added `appt.treatmentId` as an explicit guard condition.

3. **Package deduction path** (line ~2518, in `applySmsReplyTransition`): Same migration, matching the change in `updateStatus`.

This is the exact same pattern used for stock deduction in #3366, and uses the `package_deducted` column on `gabinet_appointment_treatments` that was added by migration `00070_appointment_treatments_deduction_flags.sql` in #3361.