### PR TITLE
Drop appointment-level `stock_deducted` and `package_deducted` columns

### DIFF
--- a/src/lib/supabase/database.columns.ts
+++ b/src/lib/supabase/database.columns.ts
@@ -71,6 +71,11 @@
  *   • 00064_gabinet_appointments_package_deducted.sql
  *   • 00065_gabinet_package_usage_gift.sql
  *   • 00066_product_sale_price.sql
+ *   • 00067_gabinet_employee_locations_role.sql
+ *   • 00068_gabinet_package_usage_by_package_idx.sql
+ *   • 00069_gabinet_appointment_treatments.sql
+ *   • 00070_appointment_treatments_deduction_flags.sql
+ *   • 00071_drop_appointment_deduction_flags.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  */
@@ -253,7 +258,7 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   gabinet_leaves: new Set(["id", "organization_id", "user_id", "type", "leave_type_id", "start_date", "end_date", "start_time", "end_time", "status", "reason", "approved_by", "approved_at", "created_by", "created_at", "updated_at"]),
   gabinet_overtime: new Set(["id", "organization_id", "user_id", "date", "hours", "reason", "status", "approved_by", "approved_at", "created_by", "created_at", "updated_at"]),
   gabinet_patients: new Set(["id", "organization_id", "contact_id", "first_name", "last_name", "pesel", "date_of_birth", "gender", "email", "phone", "address", "medical_notes", "allergies", "blood_type", "emergency_contact_name", "emergency_contact_phone", "referral_source", "referred_by_patient_id", "is_active", "tags", "tag_ids", "category_id", "custom_fields", "created_by", "created_at", "updated_at", "preferred_location_id", "sms_consent"]),
-  gabinet_appointments: new Set(["id", "organization_id", "patient_id", "treatment_id", "employee_id", "date", "start_time", "end_time", "status", "notes", "internal_notes", "body_chart_data", "treatment_parameter_values", "interview_notes", "clinical_remarks", "photos", "color", "is_recurring", "recurring_rule", "recurring_group_id", "recurring_index", "prepayment_required", "prepayment_amount", "prepayment_status", "prepayment_paid_at", "package_usage_id", "scheduled_activity_id", "reminder_sent_at", "send_reminder", "cancelled_at", "cancelled_by", "cancellation_reason", "booked_from_portal", "booked_by_patient_id", "location_id", "room_id", "tag_ids", "category_id", "requires_completion", "created_by", "created_at", "updated_at", "contraindication_alerts_reviewed", "price_at_booking", "reminder_overrides", "variant_id", "stock_deducted", "package_deducted"]),
+  gabinet_appointments: new Set(["id", "organization_id", "patient_id", "treatment_id", "employee_id", "date", "start_time", "end_time", "status", "notes", "internal_notes", "body_chart_data", "treatment_parameter_values", "interview_notes", "clinical_remarks", "photos", "color", "is_recurring", "recurring_rule", "recurring_group_id", "recurring_index", "prepayment_required", "prepayment_amount", "prepayment_status", "prepayment_paid_at", "package_usage_id", "scheduled_activity_id", "reminder_sent_at", "send_reminder", "cancelled_at", "cancelled_by", "cancellation_reason", "booked_from_portal", "booked_by_patient_id", "location_id", "room_id", "tag_ids", "category_id", "requires_completion", "created_by", "created_at", "updated_at", "contraindication_alerts_reviewed", "price_at_booking", "reminder_overrides", "variant_id"]),
   gabinet_treatment_packages: new Set(["id", "organization_id", "name", "description", "treatments", "total_price", "currency", "discount_percent", "validity_days", "is_active", "loyalty_points_awarded", "auto_generated_for_treatment_id", "created_by", "created_at", "updated_at"]),
   gabinet_package_usage: new Set(["id", "organization_id", "patient_id", "package_id", "purchased_at", "expires_at", "status", "treatments_used", "paid_amount", "payment_method", "created_by", "created_at", "updated_at", "is_gift", "voucher_code", "gift_recipient_name", "gift_recipient_phone", "gift_recipient_email"]),
   gabinet_loyalty_points: new Set(["id", "organization_id", "patient_id", "balance", "lifetime_earned", "lifetime_spent", "tier", "created_at", "updated_at"]),

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -75,6 +75,7 @@
  *   • 00068_gabinet_package_usage_by_package_idx.sql
  *   • 00069_gabinet_appointment_treatments.sql
  *   • 00070_appointment_treatments_deduction_flags.sql
+ *   • 00071_drop_appointment_deduction_flags.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -4763,8 +4764,6 @@ export interface Database {
           price_at_booking: number | null;
           reminder_overrides: string | null;
           variant_id: string | null;
-          stock_deducted: boolean;
-          package_deducted: boolean;
         };
         Insert: {
           id?: string;
@@ -4813,8 +4812,6 @@ export interface Database {
           price_at_booking?: number | null;
           reminder_overrides?: string | null;
           variant_id?: string | null;
-          stock_deducted?: boolean;
-          package_deducted?: boolean;
         };
         Update: {
           id?: string;
@@ -4863,8 +4860,6 @@ export interface Database {
           price_at_booking?: number | null;
           reminder_overrides?: string | null;
           variant_id?: string | null;
-          stock_deducted?: boolean;
-          package_deducted?: boolean;
         };
         Relationships: [
           {

--- a/supabase/migrations/00071_drop_appointment_deduction_flags.sql
+++ b/supabase/migrations/00071_drop_appointment_deduction_flags.sql
@@ -1,0 +1,9 @@
+-- Drop appointment-level stock_deducted and package_deducted columns from
+-- gabinet_appointments. The deduction guard was migrated to per-treatment rows
+-- in gabinet_appointment_treatments (00070_appointment_treatments_deduction_flags.sql).
+-- The per-treatment CAS replaced the per-appointment CAS in issues #3366 and #3367.
+-- Closes #3368.
+
+ALTER TABLE gabinet_appointments
+  DROP COLUMN IF EXISTS stock_deducted,
+  DROP COLUMN IF EXISTS package_deducted;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3368.

Closes #3368

---

## Claude summary

Done. Here's what was done:

**Migration `00071_drop_appointment_deduction_flags.sql`** — runs `ALTER TABLE gabinet_appointments DROP COLUMN IF EXISTS stock_deducted, DROP COLUMN IF EXISTS package_deducted`. The data was already backfilled to `gabinet_appointment_treatments` in migration 00070, and the CAS logic was migrated in #3366/#3367.

**`src/lib/supabase/database.types.ts`** — removed `stock_deducted: boolean` and `package_deducted: boolean` from the `gabinet_appointments` Row, Insert, and Update sections. The same fields on `gabinet_appointment_treatments` are untouched (they're the live ones).

**`src/lib/supabase/database.columns.ts`** — removed the two field names from the `gabinet_appointments` column set, and updated the stale header comment to include migrations 00067–00071.