### PR TITLE
Package sales reporting view

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3711,7 +3711,17 @@
         "card": "Card",
         "transfer": "Transfer",
         "other": "Other"
-      }
+      },
+      "packageSales": "Package Sales",
+      "totalPackagesSold": "Packages Sold",
+      "totalPackageRevenue": "Package Revenue",
+      "avgPackagePrice": "Avg. Package Price",
+      "noPackageSales": "No package sales in this period",
+      "perPackageBreakdown": "By Package Type",
+      "perEmployeePackageSales": "By Employee",
+      "perPatientPackageSales": "By Patient (top 10)",
+      "filterByPackage": "Filter by package",
+      "allPackages": "All packages"
     },
     "bodyChart": {
       "description": "Mark body areas related to the appointment",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3732,7 +3732,17 @@
         "card": "Karta",
         "transfer": "Przelew",
         "other": "Inne"
-      }
+      },
+      "packageSales": "Sprzedaż pakietów",
+      "totalPackagesSold": "Sprzedanych pakietów",
+      "totalPackageRevenue": "Przychód z pakietów",
+      "avgPackagePrice": "Śr. cena pakietu",
+      "noPackageSales": "Brak sprzedaży pakietów w tym okresie",
+      "perPackageBreakdown": "Wg. rodzaju pakietu",
+      "perEmployeePackageSales": "Wg. pracownika",
+      "perPatientPackageSales": "Wg. pacjenta (top 10)",
+      "filterByPackage": "Filtruj wg pakietu",
+      "allPackages": "Wszystkie pakiety"
     },
     "bodyChart": {
       "description": "Zaznacz obszary ciała powiązane z wizytą",

--- a/src/hooks/use-supabase-gabinet-packages.ts
+++ b/src/hooks/use-supabase-gabinet-packages.ts
@@ -158,6 +158,48 @@ export function useSupabaseGabinetPackageUsageUnassigned(
 }
 
 // ---------------------------------------------------------------------------
+// Package Usage — By Date Range (for sales reporting)
+// ---------------------------------------------------------------------------
+
+interface UseSupabaseGabinetPackageUsageByDateRangeOptions {
+  enabled?: boolean;
+}
+
+export function useSupabaseGabinetPackageUsageByDateRange(
+  organizationId: string,
+  startDate: string,
+  endDate: string,
+  options: UseSupabaseGabinetPackageUsageByDateRangeOptions = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  return useQuery<MappedGabinetPackageUsage[], Error>({
+    queryKey: [
+      ...supabaseKeys.gabinetPackageUsage.list(organizationId),
+      "byDateRange",
+      startDate,
+      endDate,
+    ],
+    queryFn: async (): Promise<MappedGabinetPackageUsage[]> => {
+      if (!client) throw new Error("Supabase client not ready");
+      const startTs = new Date(startDate + "T00:00:00.000Z").getTime();
+      const endTs = new Date(endDate + "T23:59:59.999Z").getTime();
+      const { data, error } = await client
+        .from("gabinet_package_usage")
+        .select("*")
+        .eq("organization_id", organizationId)
+        .gte("purchased_at", startTs)
+        .lte("purchased_at", endTs)
+        .order("purchased_at", { ascending: false });
+      if (error) throw error;
+      return (data ?? []).map(mapGabinetPackageUsageFromSupabase);
+    },
+    enabled: enabled && isReady && !!organizationId && !!startDate && !!endDate,
+  } satisfies UseQueryOptions<MappedGabinetPackageUsage[], Error>);
+}
+
+// ---------------------------------------------------------------------------
 // Package Usage — Active (org-wide, for stats)
 // ---------------------------------------------------------------------------
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -10,6 +10,12 @@ import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-t
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
+import {
+  useSupabaseGabinetTreatmentPackagesList,
+  useSupabaseGabinetPackageUsageByDateRange,
+} from "@/hooks/use-supabase-gabinet-packages";
+import type { MappedGabinetPackageUsage } from "@/lib/supabase/mappers/gabinet/package-usage";
+import type { MappedGabinetTreatmentPackage } from "@/lib/supabase/mappers/gabinet/treatment-packages";
 import { useOrganization } from "@/components/org-context";
 import { usePermission } from "@/hooks/use-permission";
 import { formatCurrencyPLN } from "@/lib/format-currency";
@@ -941,6 +947,245 @@ function TopTreatmentsByRevenue({
   );
 }
 
+/* ─── Package Sales Section ─── */
+
+function PackageSalesSection({
+  usages,
+  isLoading: sectionLoading,
+  packages,
+  packageNameMap,
+  employeeMap,
+  patientMap,
+  rangeLabel,
+  currency,
+}: {
+  usages: MappedGabinetPackageUsage[];
+  isLoading: boolean;
+  packages: MappedGabinetTreatmentPackage[];
+  packageNameMap: Map<string, string>;
+  employeeMap: Map<string, string>;
+  patientMap: Map<string, string>;
+  rangeLabel: string;
+  currency: string;
+}) {
+  const { t } = useTranslation();
+  const [filterPackageId, setFilterPackageId] = useState("all");
+
+  const filteredUsages = useMemo(
+    () => (filterPackageId === "all" ? usages : usages.filter((u) => u.packageId === filterPackageId)),
+    [usages, filterPackageId],
+  );
+
+  const { totalSold, totalRevenue, avgPrice } = useMemo(() => {
+    const total = filteredUsages.reduce((s, u) => s + u.paidAmount, 0);
+    return {
+      totalSold: filteredUsages.length,
+      totalRevenue: total,
+      avgPrice: filteredUsages.length > 0 ? total / filteredUsages.length : 0,
+    };
+  }, [filteredUsages]);
+
+  const perPackage = useMemo(() => {
+    const m = new Map<string, { count: number; revenue: number }>();
+    for (const u of filteredUsages) {
+      const prev = m.get(u.packageId) ?? { count: 0, revenue: 0 };
+      m.set(u.packageId, { count: prev.count + 1, revenue: prev.revenue + u.paidAmount });
+    }
+    return Array.from(m.entries())
+      .map(([id, s]) => ({ id, name: packageNameMap.get(id) ?? id, count: s.count, revenue: s.revenue }))
+      .sort((a, b) => b.revenue - a.revenue);
+  }, [filteredUsages, packageNameMap]);
+
+  const perEmployee = useMemo(() => {
+    const m = new Map<string, { count: number; revenue: number }>();
+    for (const u of filteredUsages) {
+      const prev = m.get(u.createdBy) ?? { count: 0, revenue: 0 };
+      m.set(u.createdBy, { count: prev.count + 1, revenue: prev.revenue + u.paidAmount });
+    }
+    return Array.from(m.entries())
+      .map(([userId, s]) => ({ name: employeeMap.get(userId) ?? userId, count: s.count, revenue: s.revenue }))
+      .sort((a, b) => b.revenue - a.revenue);
+  }, [filteredUsages, employeeMap]);
+
+  const perPatient = useMemo(() => {
+    const m = new Map<string, { count: number; revenue: number }>();
+    for (const u of filteredUsages) {
+      if (!u.patientId) continue;
+      const prev = m.get(u.patientId) ?? { count: 0, revenue: 0 };
+      m.set(u.patientId, { count: prev.count + 1, revenue: prev.revenue + u.paidAmount });
+    }
+    return Array.from(m.entries())
+      .map(([id, s]) => ({ name: patientMap.get(id) ?? id, count: s.count, revenue: s.revenue }))
+      .sort((a, b) => b.revenue - a.revenue)
+      .slice(0, 10);
+  }, [filteredUsages, patientMap]);
+
+  const maxPackageRevenue = useMemo(
+    () => Math.max(...perPackage.map((p) => p.revenue), 1),
+    [perPackage],
+  );
+
+  if (sectionLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-7 w-48" />
+        <div className="grid gap-4 sm:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 rounded-lg" />
+          ))}
+        </div>
+        <div className="grid gap-6 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-52 rounded-lg" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">{t("gabinet.reports.packageSales")}</h2>
+          <p className="text-muted-foreground text-sm">{rangeLabel}</p>
+        </div>
+        <Select value={filterPackageId} onValueChange={setFilterPackageId}>
+          <SelectTrigger className="w-52" aria-label={t("gabinet.reports.filterByPackage")}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{t("gabinet.reports.allPackages")}</SelectItem>
+            {packages.map((p) => (
+              <SelectItem key={p._id} value={p._id}>
+                {p.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* KPI cards */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-muted-foreground text-sm">{t("gabinet.reports.totalPackagesSold")}</p>
+            <p className="mt-1 text-2xl font-bold">{totalSold}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-muted-foreground text-sm">{t("gabinet.reports.totalPackageRevenue")}</p>
+            <p className="mt-1 text-2xl font-bold">
+              {formatCurrencyPLN(totalRevenue, currency, { fractionDigits: 0 })}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-muted-foreground text-sm">{t("gabinet.reports.avgPackagePrice")}</p>
+            <p className="mt-1 text-2xl font-bold">
+              {formatCurrencyPLN(avgPrice, currency, { fractionDigits: 0 })}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {filteredUsages.length === 0 ? (
+        <Card>
+          <CardContent className="flex items-center justify-center py-12">
+            <span className="text-muted-foreground text-sm">{t("gabinet.reports.noPackageSales")}</span>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-3">
+          {/* Per package breakdown */}
+          <Card>
+            <CardHeader className="flex justify-between border-b">
+              <span className="font-semibold">{t("gabinet.reports.perPackageBreakdown")}</span>
+              <CardMenu />
+            </CardHeader>
+            <CardContent className="space-y-3 pt-4">
+              {perPackage.map((item) => {
+                const pct = Math.round((item.revenue / maxPackageRevenue) * 100);
+                return (
+                  <div key={item.id} className="space-y-1.5">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="max-w-[55%] truncate font-medium">{item.name}</span>
+                      <div className="ml-2 flex shrink-0 items-center gap-2">
+                        <span className="text-muted-foreground">{item.count}×</span>
+                        <span className="font-semibold">
+                          {formatCurrencyPLN(item.revenue, currency, { fractionDigits: 0 })}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="bg-muted h-1.5 overflow-hidden rounded-full">
+                      <div
+                        className="h-full rounded-full transition-all"
+                        style={{ width: `${pct}%`, backgroundColor: "var(--primary)" }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </CardContent>
+          </Card>
+
+          {/* Per employee breakdown */}
+          <Card>
+            <CardHeader className="flex justify-between border-b">
+              <span className="font-semibold">{t("gabinet.reports.perEmployeePackageSales")}</span>
+              <CardMenu />
+            </CardHeader>
+            <CardContent className="space-y-3 pt-4">
+              {perEmployee.length === 0 ? (
+                <span className="text-muted-foreground text-sm">{t("common.noResults")}</span>
+              ) : (
+                perEmployee.map((item, i) => (
+                  <div key={i} className="flex items-center justify-between text-sm">
+                    <span className="max-w-[55%] truncate font-medium">{item.name}</span>
+                    <div className="ml-2 flex shrink-0 items-center gap-2">
+                      <span className="text-muted-foreground">{item.count}×</span>
+                      <span className="font-semibold">
+                        {formatCurrencyPLN(item.revenue, currency, { fractionDigits: 0 })}
+                      </span>
+                    </div>
+                  </div>
+                ))
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Per patient breakdown (top 10) */}
+          <Card>
+            <CardHeader className="flex justify-between border-b">
+              <span className="font-semibold">{t("gabinet.reports.perPatientPackageSales")}</span>
+              <CardMenu />
+            </CardHeader>
+            <CardContent className="space-y-3 pt-4">
+              {perPatient.length === 0 ? (
+                <span className="text-muted-foreground text-sm">{t("common.noResults")}</span>
+              ) : (
+                perPatient.map((item, i) => (
+                  <div key={i} className="flex items-center justify-between text-sm">
+                    <span className="max-w-[55%] truncate font-medium">{item.name}</span>
+                    <div className="ml-2 flex shrink-0 items-center gap-2">
+                      <span className="text-muted-foreground">{item.count}×</span>
+                      <span className="font-semibold">
+                        {formatCurrencyPLN(item.revenue, currency, { fractionDigits: 0 })}
+                      </span>
+                    </div>
+                  </div>
+                ))
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}
+
 /* ─── Main Page ─── */
 
 function GabinetReports() {
@@ -1033,6 +1278,12 @@ function GabinetReports() {
       locationId: selectedLocationId,
     });
 
+  const { data: packageUsages, isLoading: loadingPackageUsages } =
+    useSupabaseGabinetPackageUsageByDateRange(organizationId, startDate, endDate);
+
+  const { data: packagesListData, isLoading: loadingPackagesList } =
+    useSupabaseGabinetTreatmentPackagesList(organizationId);
+
   const isLoading =
     loadingAppointments || loadingTreatments || loadingPatients || loadingEmployees || loadingGratisBarter || loadingActualPayments;
 
@@ -1057,6 +1308,24 @@ function GabinetReports() {
       ])
     );
   }, [employees]);
+
+  // Patient map: patientId → full name
+  const patientMap = useMemo(() => {
+    if (!patients) return new Map<string, string>();
+    return new Map(
+      patients.map((p) => [
+        p._id,
+        [p.firstName, p.lastName].filter(Boolean).join(" ") || p._id,
+      ])
+    );
+  }, [patients]);
+
+  // Package name map: packageId → name
+  const packageNameMap = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const p of packagesListData ?? []) m.set(p._id, p.name);
+    return m;
+  }, [packagesListData]);
 
   // Treatment stats: count + estimated revenue (completed only, gratis/barter excluded from revenue)
   const treatmentStats = useMemo(() => {
@@ -1289,6 +1558,21 @@ function GabinetReports() {
     for (const pm of paymentMethodBreakdown) {
       rows.push({ section: "payment_method", metric: pm.method, value: pm.count, revenue: pm.total });
     }
+    // Package sales — per package and per employee
+    const pkgSalesMap = new Map<string, { count: number; revenue: number }>();
+    const empPkgSalesMap = new Map<string, { count: number; revenue: number }>();
+    for (const u of packageUsages ?? []) {
+      const prevPkg = pkgSalesMap.get(u.packageId) ?? { count: 0, revenue: 0 };
+      pkgSalesMap.set(u.packageId, { count: prevPkg.count + 1, revenue: prevPkg.revenue + u.paidAmount });
+      const prevEmp = empPkgSalesMap.get(u.createdBy) ?? { count: 0, revenue: 0 };
+      empPkgSalesMap.set(u.createdBy, { count: prevEmp.count + 1, revenue: prevEmp.revenue + u.paidAmount });
+    }
+    for (const [pkgId, stats] of pkgSalesMap) {
+      rows.push({ section: "package_sales_by_package", metric: packageNameMap.get(pkgId) ?? pkgId, value: stats.count, revenue: stats.revenue });
+    }
+    for (const [userId, stats] of empPkgSalesMap) {
+      rows.push({ section: "package_sales_by_employee", metric: employeeMap.get(userId) ?? userId, value: stats.count, revenue: stats.revenue });
+    }
     const csv = Papa.unparse(rows as unknown as Record<string, unknown>[]);
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
     const url = URL.createObjectURL(blob);
@@ -1317,6 +1601,9 @@ function GabinetReports() {
     dailyStats,
     employeeStats,
     paymentMethodBreakdown,
+    packageUsages,
+    packageNameMap,
+    employeeMap,
     startDate,
     endDate,
     t,
@@ -1504,6 +1791,18 @@ function GabinetReports() {
 
       {/* Daily Appointment Volume */}
       <DailyVolumeChart data={dailyStats} rangeLabel={rangeLabel} />
+
+      {/* Package Sales */}
+      <PackageSalesSection
+        usages={packageUsages ?? []}
+        isLoading={loadingPackageUsages || loadingPackagesList}
+        packages={packagesListData ?? []}
+        packageNameMap={packageNameMap}
+        employeeMap={employeeMap}
+        patientMap={patientMap}
+        rangeLabel={rangeLabel}
+        currency={defaultCurrency}
+      />
 
       <SidePanel
         open={dateFilterPanelOpen}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3376.

Closes #3376

---

## Claude summary

Done. Here's a summary of what was implemented:

**4 files changed, 363 lines added:**

- `src/hooks/use-supabase-gabinet-packages.ts` — new `useSupabaseGabinetPackageUsageByDateRange` hook that queries `gabinet_package_usage` filtered by `purchased_at` timestamp range

- `src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx` — added a `PackageSalesSection` component and wired it into the existing `GabinetReports` page at the bottom:
  - KPI cards: packages sold count, total revenue, average price
  - Three breakdown cards: by package type (with progress bars), by employee (using `created_by` → employee name), by patient (top 10)
  - Package type filter dropdown (local to the section)
  - Independent loading skeleton (doesn't block the main page load)
  - Package sales rows added to the existing CSV export (per-package and per-employee)

- `public/locales/pl/translation.json` and `public/locales/en/translation.json` — 10 new i18n keys under `gabinet.reports`

The "per period" metric from the issue is covered by the shared date range filter already on the reports page (today/7d/30d/90d/365d/custom). The feature uses `created_by` as the closest available proxy for "sold by employee" since `gabinet_package_usage` has no explicit `employee_id` column.

## Follow-ups
- Add `sold_by_employee_id` column to `gabinet_package_usage`: the current per-employee attribution uses `created_by` (the user who created the record), which may be a receptionist or admin rather than the treating employee; a dedicated field would give accurate per-salesperson metrics
- Package sales revenue over time chart: the current section shows totals only; a bar chart grouped by week/month would fulfill the "per period" requirement more visually