### PR TITLE
fix(automation): survive stale local branch when creating job worktree

### DIFF
--- a/automation/worker/run-claude.sh
+++ b/automation/worker/run-claude.sh
@@ -83,10 +83,15 @@ if git show-ref --verify --quiet "refs/remotes/origin/${BRANCH}"; then
   git worktree add -B "$BRANCH" "$WT_DIR" "origin/${BRANCH}"
 else
   echo "creating new branch $BRANCH from origin/main"
-  git worktree add -b "$BRANCH" "$WT_DIR" origin/main
+  # -B (not -b): cleanup_worktree removes the worktree but never deletes the
+  # local branch, so a retry of an already-merged issue (remote branch deleted
+  # by --delete-branch, local branch still present) would fatal with -b and
+  # fall through into REPO_DIR — Claude would then run inside the base repo.
+  git worktree add -B "$BRANCH" "$WT_DIR" origin/main
 fi
 
-cd "$WT_DIR"
+# Hard guard: never run the job in REPO_DIR if worktree setup failed.
+cd "$WT_DIR" || { echo "FATAL: worktree dir $WT_DIR missing after setup"; exit 1; }
 git config user.name "Claude Bot"
 git config user.email "${BOT_GIT_EMAIL:-claude-bot@example.com}"
 


### PR DESCRIPTION
## Problem

`cleanup_worktree` usuwa worktree, ale nigdy nie kasuje lokalnego brancha w bazowym repo bota. Gdy issue jest retryowane PO tym, jak jego branch został już skasowany na originie (squash-merge z kasowaniem brancha), ścieżka `-b` w kroku 4 wali fatalem ("A branch named 'claude/issue-N' already exists"), `cd` do nieistniejącego worktree cicho zawodzi i cały job leci dalej **w katalogu REPO_DIR** — na tym branchu, który bazowe repo akurat ma wyczekoutowany.

Skutki zaobserwowane na prodzie (joby 2038 i wcześniejszy dla #3343, log `job-2038.log`):
- commity Claude'a strandują na przypadkowym lokalnym branchu (`claude/issue-2422` — 12 niewypchniętych commitów z issues #3161–#3343),
- `git push -u origin claude/issue-N` wypycha stary, pusty lokalny branch,
- `gh pr create` pada (brak commitów), `PR_NUM` jest pusty i `gh pr merge ""` rozwiązuje PR z bieżącego brancha katalogu → zamknięty PR #3165 → fałszywy `claude:conflict`.

## Fix

- `git worktree add -B` (zamiast `-b`) w ścieżce "nowy branch" — force-reset osieroconego lokalnego brancha,
- twardy guard na `cd $WT_DIR` — job kończy się jawnym błędem zamiast działać w bazowym repo.

## Deploy

Plik trzeba też wgrać na atlasa: `cp automation/worker/run-claude.sh /home/claude-bot/worker/run-claude.sh` (i przy okazji: `git -C /home/claude-bot/repo checkout main` + wyczyścić osierocone lokalne branche `claude/issue-*`).

## Test plan
- [ ] `bash -n` OK (sprawdzone)
- [ ] retry zmergowanego wcześniej issue tworzy worktree zamiast fatala
- [ ] job z celowo zepsutym `worktree add` kończy się exit 1, bez commitów w REPO_DIR

https://claude.ai/code/session_01SYe8ZRFD8uYUCN3gikUNMj