### PR TITLE
Rozliczenie wizyty - rabat 

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3902,7 +3902,11 @@
         "requestRefundDialogDesc": "You don't have permission to refund credit. Your request will be sent to an organization admin.",
         "requestRefundConfirm": "Send request",
         "refundRequestSent": "Refund authorization request sent to admin."
-      }
+      },
+      "discount": "Discount",
+      "discountTypeAmount": "Fixed (PLN)",
+      "discountTypePercent": "Percentage (%)",
+      "discountedPrice": "Price after discount"
     },
     "schedules": {
       "break": "Break",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3923,7 +3923,11 @@
         "requestRefundDialogDesc": "Nie masz uprawnień do bezpośrednich zwrotów. Twoja prośba trafi do administratora organizacji.",
         "requestRefundConfirm": "Wyślij prośbę",
         "refundRequestSent": "Prośba o autoryzację zwrotu wysłana do administratora."
-      }
+      },
+      "discount": "Rabat",
+      "discountTypeAmount": "Kwotowy (PLN)",
+      "discountTypePercent": "Procentowy (%)",
+      "discountedPrice": "Cena po rabacie"
     },
     "schedules": {
       "break": "Przerwa",

--- a/src/components/gabinet/package-purchase-drawer.tsx
+++ b/src/components/gabinet/package-purchase-drawer.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Sheet,
@@ -50,6 +51,8 @@ export function PackagePurchaseDrawer({
   const [selectedPkgId, setSelectedPkgId] = useState<string>("");
   const [paymentType, setPaymentType] = useState<"one_time" | "installment">("one_time");
   const [installmentCount, setInstallmentCount] = useState<string>("2");
+  const [discountType, setDiscountType] = useState<"amount" | "percent">("amount");
+  const [discountValue, setDiscountValue] = useState<string>("");
 
   const listActivePackages = useAction(api.gabinet.packages.listActive);
   const { data: activePackages } = useQuery({
@@ -71,15 +74,25 @@ export function PackagePurchaseDrawer({
 
   const selectedPkg = (activePackages ?? []).find((p) => p._id === selectedPkgId);
 
+  const basePrice = selectedPkg?.totalPrice ?? 0;
+  const parsedDiscountValue = Number.parseFloat(discountValue.replace(",", ".")) || 0;
+  const discountAmount =
+    basePrice > 0
+      ? discountType === "amount"
+        ? Math.min(parsedDiscountValue, basePrice)
+        : Math.round((basePrice * Math.min(parsedDiscountValue, 100)) / 100 * 100) / 100
+      : 0;
+  const finalPrice = Math.round(Math.max(0, basePrice - discountAmount) * 100) / 100;
+
   const isOneTime = paymentType === "one_time";
   const isInstallment = paymentType === "installment";
 
   const parsedInstallmentCount = Math.max(2, Math.min(4, Number.parseInt(installmentCount, 10) || 2));
   const installmentAmount = selectedPkg
-    ? Math.round((selectedPkg.totalPrice / parsedInstallmentCount) * 100) / 100
+    ? Math.round((finalPrice / parsedInstallmentCount) * 100) / 100
     : 0;
   const installmentRemainder = selectedPkg
-    ? Math.round((selectedPkg.totalPrice - installmentAmount * parsedInstallmentCount) * 100) / 100
+    ? Math.round((finalPrice - installmentAmount * parsedInstallmentCount) * 100) / 100
     : 0;
   const firstInstallmentAmount = selectedPkg
     ? Math.round((installmentAmount + installmentRemainder) * 100) / 100
@@ -88,7 +101,7 @@ export function PackagePurchaseDrawer({
   const effectiveTotalForSplit = selectedPkg
     ? isInstallment
       ? firstInstallmentAmount
-      : selectedPkg.totalPrice
+      : finalPrice
     : 0;
 
   const {
@@ -120,6 +133,8 @@ export function PackagePurchaseDrawer({
     setSelectedPkgId("");
     setPaymentType("one_time");
     setInstallmentCount("2");
+    setDiscountType("amount");
+    setDiscountValue("");
     resetPaymentForm();
   };
 
@@ -164,7 +179,7 @@ export function PackagePurchaseDrawer({
         organizationId,
         patientId,
         packageId: selectedPkg._id,
-        paidAmount: selectedPkg.totalPrice,
+        paidAmount: finalPrice,
         paymentMethod: usagePaymentMethod,
       });
 
@@ -231,7 +246,7 @@ export function PackagePurchaseDrawer({
           organizationId,
           patientId: patientId as Id<"gabinetPatients">,
           packageUsageId: usageId,
-          amount: selectedPkg.totalPrice,
+          amount: finalPrice,
           currency,
           paymentMethod: paymentMethod as "cash" | "card" | "transfer",
           notes: `Package: ${selectedPkg.name}`,
@@ -306,9 +321,60 @@ export function PackagePurchaseDrawer({
                   </div>
                 ))}
               </div>
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground">
+                  {t("gabinet.payments.discount")}
+                </span>
+                <div className="flex items-center gap-1.5">
+                  <div className="flex rounded-md border overflow-hidden text-xs">
+                    <button
+                      type="button"
+                      onClick={() => { setDiscountType("amount"); setDiscountValue(""); }}
+                      className={`px-2 py-0.5 transition-colors ${discountType === "amount" ? "bg-primary text-primary-foreground" : "hover:bg-accent"}`}
+                    >
+                      PLN
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { setDiscountType("percent"); setDiscountValue(""); }}
+                      className={`px-2 py-0.5 transition-colors ${discountType === "percent" ? "bg-primary text-primary-foreground" : "hover:bg-accent"}`}
+                    >
+                      %
+                    </button>
+                  </div>
+                  <div className="relative w-20">
+                    <Input
+                      type="text"
+                      inputMode="decimal"
+                      value={discountValue}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                          setDiscountValue(v);
+                        }
+                      }}
+                      placeholder="0"
+                      className={`h-7 text-xs ${discountType === "percent" ? "pr-5" : ""}`}
+                    />
+                    {discountType === "percent" && (
+                      <span className="absolute right-1.5 top-1/2 -translate-y-1/2 text-xs text-muted-foreground pointer-events-none">%</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+              {discountAmount > 0 && (
+                <div className="flex items-center justify-between text-xs text-destructive">
+                  <span>{t("gabinet.payments.discount")}</span>
+                  <span>- {formatCurrencyPLN(discountAmount, selectedPkg.currency ?? "PLN")}</span>
+                </div>
+              )}
               <div className="flex items-center justify-between pt-1 border-t text-sm">
-                <span className="font-medium">{t("gabinet.packages.totalPrice")}</span>
-                <span className="font-bold">{selectedPkg.totalPrice} {selectedPkg.currency ?? "PLN"}</span>
+                <span className="font-medium">
+                  {discountAmount > 0
+                    ? t("gabinet.payments.discountedPrice")
+                    : t("gabinet.packages.totalPrice")}
+                </span>
+                <span className="font-bold">{formatCurrencyPLN(finalPrice, selectedPkg.currency ?? "PLN")}</span>
               </div>
               {selectedPkg.validityDays && (
                 <p className="text-xs text-muted-foreground">

--- a/src/components/gabinet/sell-treatment-panel.tsx
+++ b/src/components/gabinet/sell-treatment-panel.tsx
@@ -59,6 +59,8 @@ export function SellTreatmentPanel({
   const [secondSplitAmount, setSecondSplitAmount] = useState<string>("");
   const [installmentCount, setInstallmentCount] = useState<string>("2");
   const [submitting, setSubmitting] = useState(false);
+  const [discountType, setDiscountType] = useState<"amount" | "percent">("amount");
+  const [discountValue, setDiscountValue] = useState<string>("");
 
   const activeTreatments = useMemo(
     () => treatmentsData ?? [],
@@ -79,15 +81,24 @@ export function SellTreatmentPanel({
   );
   const currency = selectedTreatment?.currency ?? "PLN";
 
+  const parsedDiscountValue = Number.parseFloat(discountValue.replace(",", ".")) || 0;
+  const discountAmount =
+    totalPrice > 0
+      ? discountType === "amount"
+        ? Math.min(parsedDiscountValue, totalPrice)
+        : Math.round((totalPrice * Math.min(parsedDiscountValue, 100)) / 100 * 100) / 100
+      : 0;
+  const finalPrice = Math.round(Math.max(0, totalPrice - discountAmount) * 100) / 100;
+
   const isOneTime = paymentType === "one_time";
   const isInstallment = paymentType === "installment";
 
   const parsedInstallmentCount = Math.max(2, Math.min(4, Number.parseInt(installmentCount, 10) || 2));
   const installmentAmount = selectedTreatment
-    ? Math.round((totalPrice / parsedInstallmentCount) * 100) / 100
+    ? Math.round((finalPrice / parsedInstallmentCount) * 100) / 100
     : 0;
   const installmentRemainder = selectedTreatment
-    ? Math.round((totalPrice - installmentAmount * parsedInstallmentCount) * 100) / 100
+    ? Math.round((finalPrice - installmentAmount * parsedInstallmentCount) * 100) / 100
     : 0;
   const firstInstallmentAmount = selectedTreatment
     ? Math.round((installmentAmount + installmentRemainder) * 100) / 100
@@ -99,7 +110,7 @@ export function SellTreatmentPanel({
   const splitExpectedTotal = selectedTreatment
     ? isInstallment
       ? firstInstallmentAmount
-      : Math.round(totalPrice * 100) / 100
+      : Math.round(finalPrice * 100) / 100
     : 0;
   const splitMismatch = splitPayment && !!selectedTreatment && splitTotal !== splitExpectedTotal;
   const splitMissingAmount = splitPayment && parsedFirstSplit <= 0 && parsedSecondSplit <= 0;
@@ -117,6 +128,8 @@ export function SellTreatmentPanel({
     setFirstSplitAmount("");
     setSecondSplitAmount("");
     setInstallmentCount("2");
+    setDiscountType("amount");
+    setDiscountValue("");
   }, []);
 
   const handleSubmit = async () => {
@@ -152,7 +165,7 @@ export function SellTreatmentPanel({
         patientId,
         treatmentId: selectedTreatment._id,
         sessionCount: parsedSessionCount,
-        paidAmount: totalPrice,
+        paidAmount: finalPrice,
         paymentMethod: usagePaymentMethod,
       });
 
@@ -221,7 +234,7 @@ export function SellTreatmentPanel({
           organizationId,
           patientId: patientId as Id<"gabinetPatients">,
           packageUsageId: usageId,
-          amount: totalPrice,
+          amount: finalPrice,
           currency,
           paymentMethod,
           notes: `Treatment: ${treatmentName}`,
@@ -325,11 +338,60 @@ export function SellTreatmentPanel({
               </span>
               <span>&times;{parsedSessionCount}</span>
             </div>
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-muted-foreground">
+                {t("gabinet.payments.discount")}
+              </span>
+              <div className="flex items-center gap-1.5">
+                <div className="flex rounded-md border overflow-hidden text-xs">
+                  <button
+                    type="button"
+                    onClick={() => { setDiscountType("amount"); setDiscountValue(""); }}
+                    className={`px-2 py-0.5 transition-colors ${discountType === "amount" ? "bg-primary text-primary-foreground" : "hover:bg-accent"}`}
+                  >
+                    PLN
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { setDiscountType("percent"); setDiscountValue(""); }}
+                    className={`px-2 py-0.5 transition-colors ${discountType === "percent" ? "bg-primary text-primary-foreground" : "hover:bg-accent"}`}
+                  >
+                    %
+                  </button>
+                </div>
+                <div className="relative w-20">
+                  <Input
+                    type="text"
+                    inputMode="decimal"
+                    value={discountValue}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                        setDiscountValue(v);
+                      }
+                    }}
+                    placeholder="0"
+                    className={`h-7 text-xs ${discountType === "percent" ? "pr-5" : ""}`}
+                  />
+                  {discountType === "percent" && (
+                    <span className="absolute right-1.5 top-1/2 -translate-y-1/2 text-xs text-muted-foreground pointer-events-none">%</span>
+                  )}
+                </div>
+              </div>
+            </div>
+            {discountAmount > 0 && (
+              <div className="flex items-center justify-between text-xs text-destructive">
+                <span>{t("gabinet.payments.discount")}</span>
+                <span>- {formatCurrencyPLN(discountAmount, currency)}</span>
+              </div>
+            )}
             <div className="flex items-center justify-between pt-1 border-t text-sm">
               <span className="font-medium">
-                {t("gabinet.packages.totalPrice", "Cena całkowita")}
+                {discountAmount > 0
+                  ? t("gabinet.payments.discountedPrice")
+                  : t("gabinet.packages.totalPrice", "Cena całkowita")}
               </span>
-              <span className="font-bold">{formatCurrencyPLN(totalPrice, currency)}</span>
+              <span className="font-bold">{formatCurrencyPLN(finalPrice, currency)}</span>
             </div>
           </div>
         )}

--- a/src/components/gabinet/treatment-purchase-drawer.tsx
+++ b/src/components/gabinet/treatment-purchase-drawer.tsx
@@ -59,6 +59,8 @@ export function TreatmentPurchaseDrawer({
   const [secondSplitAmount, setSecondSplitAmount] = useState<string>("");
   const [installmentCount, setInstallmentCount] = useState<string>("2");
   const [submitting, setSubmitting] = useState(false);
+  const [discountType, setDiscountType] = useState<"amount" | "percent">("amount");
+  const [discountValue, setDiscountValue] = useState<string>("");
 
   const listActiveTreatments = useAction(api.gabinet.treatments.listActive);
   const { data: treatments } = useQuery({
@@ -79,14 +81,23 @@ export function TreatmentPurchaseDrawer({
   );
   const currency = selectedTreatment?.currency ?? "PLN";
 
+  const parsedDiscountValue = Number.parseFloat(discountValue.replace(",", ".")) || 0;
+  const discountAmount =
+    totalPrice > 0
+      ? discountType === "amount"
+        ? Math.min(parsedDiscountValue, totalPrice)
+        : Math.round((totalPrice * Math.min(parsedDiscountValue, 100)) / 100 * 100) / 100
+      : 0;
+  const finalPrice = Math.round(Math.max(0, totalPrice - discountAmount) * 100) / 100;
+
   const isOneTime = paymentType === "one_time";
   const isInstallment = paymentType === "installment";
 
   const parsedInstallmentCount = Math.max(2, Math.min(4, Number.parseInt(installmentCount, 10) || 2));
   const installmentAmount =
-    selectedTreatment ? Math.round((totalPrice / parsedInstallmentCount) * 100) / 100 : 0;
+    selectedTreatment ? Math.round((finalPrice / parsedInstallmentCount) * 100) / 100 : 0;
   const installmentRemainder = selectedTreatment
-    ? Math.round((totalPrice - installmentAmount * parsedInstallmentCount) * 100) / 100
+    ? Math.round((finalPrice - installmentAmount * parsedInstallmentCount) * 100) / 100
     : 0;
   const firstInstallmentAmount = selectedTreatment
     ? Math.round((installmentAmount + installmentRemainder) * 100) / 100
@@ -98,7 +109,7 @@ export function TreatmentPurchaseDrawer({
   const splitExpectedTotal = selectedTreatment
     ? isInstallment
       ? firstInstallmentAmount
-      : Math.round(totalPrice * 100) / 100
+      : Math.round(finalPrice * 100) / 100
     : 0;
   const splitMismatch = splitPayment && selectedTreatment && splitTotal !== splitExpectedTotal;
   const splitMissingAmount = splitPayment && parsedFirstSplit <= 0 && parsedSecondSplit <= 0;
@@ -115,6 +126,8 @@ export function TreatmentPurchaseDrawer({
     setFirstSplitAmount("");
     setSecondSplitAmount("");
     setInstallmentCount("2");
+    setDiscountType("amount");
+    setDiscountValue("");
   };
 
   const handlePurchase = async () => {
@@ -153,7 +166,7 @@ export function TreatmentPurchaseDrawer({
         patientId,
         treatmentId: selectedTreatment._id,
         sessionCount: parsedSessionCount,
-        paidAmount: totalPrice,
+        paidAmount: finalPrice,
         paymentMethod: usagePaymentMethod,
       });
 
@@ -222,7 +235,7 @@ export function TreatmentPurchaseDrawer({
           organizationId,
           patientId: patientId as Id<"gabinetPatients">,
           packageUsageId: usageId,
-          amount: totalPrice,
+          amount: finalPrice,
           currency,
           paymentMethod,
           notes: `Treatment: ${treatmentName}`,
@@ -320,12 +333,61 @@ export function TreatmentPurchaseDrawer({
                 </span>
                 <span>&times;{parsedSessionCount}</span>
               </div>
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground">
+                  {t("gabinet.payments.discount")}
+                </span>
+                <div className="flex items-center gap-1.5">
+                  <div className="flex rounded-md border overflow-hidden text-xs">
+                    <button
+                      type="button"
+                      onClick={() => { setDiscountType("amount"); setDiscountValue(""); }}
+                      className={`px-2 py-0.5 transition-colors ${discountType === "amount" ? "bg-primary text-primary-foreground" : "hover:bg-accent"}`}
+                    >
+                      PLN
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { setDiscountType("percent"); setDiscountValue(""); }}
+                      className={`px-2 py-0.5 transition-colors ${discountType === "percent" ? "bg-primary text-primary-foreground" : "hover:bg-accent"}`}
+                    >
+                      %
+                    </button>
+                  </div>
+                  <div className="relative w-20">
+                    <Input
+                      type="text"
+                      inputMode="decimal"
+                      value={discountValue}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                          setDiscountValue(v);
+                        }
+                      }}
+                      placeholder="0"
+                      className={`h-7 text-xs ${discountType === "percent" ? "pr-5" : ""}`}
+                    />
+                    {discountType === "percent" && (
+                      <span className="absolute right-1.5 top-1/2 -translate-y-1/2 text-xs text-muted-foreground pointer-events-none">%</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+              {discountAmount > 0 && (
+                <div className="flex items-center justify-between text-xs text-destructive">
+                  <span>{t("gabinet.payments.discount")}</span>
+                  <span>- {formatCurrencyPLN(discountAmount, currency)}</span>
+                </div>
+              )}
               <div className="flex items-center justify-between pt-1 border-t text-sm">
                 <span className="font-medium">
-                  {t("gabinet.packages.totalPrice", "Cena całkowita")}
+                  {discountAmount > 0
+                    ? t("gabinet.payments.discountedPrice")
+                    : t("gabinet.packages.totalPrice", "Cena całkowita")}
                 </span>
                 <span className="font-bold">
-                  {formatCurrencyPLN(totalPrice, currency)}
+                  {formatCurrencyPLN(finalPrice, currency)}
                 </span>
               </div>
             </div>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -246,6 +246,8 @@ function AppointmentDetail() {
   const [paymentPackageItems, setPaymentPackageItems] = useState<
     Array<{ treatmentId: string; variantId?: string; treatmentName: string; remaining: number; qty: number }>
   >([]);
+  const [discountType, setDiscountType] = useState<"amount" | "percent">("amount");
+  const [discountValue, setDiscountValue] = useState("");
 
   // Body chart state
 
@@ -893,6 +895,8 @@ function AppointmentDetail() {
     setPaymentUseBalance(false);
     setPaymentPackageId(null);
     setPaymentPackageItems([]);
+    setDiscountType("amount");
+    setDiscountValue("");
     if (patient?._id) {
       try {
         const credit = await getPatientCreditAction({
@@ -983,6 +987,8 @@ function AppointmentDetail() {
       setPaymentUseBalance(false);
       setPaymentPackageId(null);
       setPaymentPackageItems([]);
+      setDiscountType("amount");
+      setDiscountValue("");
       refetch();
       // Refresh credit balance for any further dialog opens.
       if (patient?._id) {
@@ -2318,6 +2324,52 @@ function AppointmentDetail() {
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-4">
+            {!isFixedAmountMethod && outstanding > 0 && (
+              <div>
+                <Label>{t("gabinet.payments.discount")}</Label>
+                <div className="flex gap-2 mt-1">
+                  <Select
+                    value={discountType}
+                    onValueChange={(v) => {
+                      setDiscountType(v as "amount" | "percent");
+                      setDiscountValue("");
+                    }}
+                  >
+                    <SelectTrigger className="w-40">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="amount">{t("gabinet.payments.discountTypeAmount")}</SelectItem>
+                      <SelectItem value="percent">{t("gabinet.payments.discountTypePercent")}</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <div className="relative flex-1">
+                    <Input
+                      type="text"
+                      inputMode="decimal"
+                      value={discountValue}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                          setDiscountValue(v);
+                          const parsed = parseFloat(v.replace(",", ".")) || 0;
+                          const disc =
+                            discountType === "amount"
+                              ? Math.min(parsed, outstanding)
+                              : Math.round(outstanding * Math.min(parsed, 100) / 100 * 100) / 100;
+                          setPaymentAmount(Math.max(0, outstanding - disc).toFixed(2));
+                        }
+                      }}
+                      placeholder={discountType === "percent" ? "0" : "0.00"}
+                      className={discountType === "percent" ? "pr-8" : ""}
+                    />
+                    {discountType === "percent" && (
+                      <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">%</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
             <div>
               <Label>{t("gabinet.payments.amount")}</Label>
               <Input

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -210,6 +210,8 @@ function PatientDetail() {
   const [addPaymentAppointmentId, setAddPaymentAppointmentId] =
     useState<string>("");
   const [isAddPaymentSubmitting, setIsAddPaymentSubmitting] = useState(false);
+  const [addPaymentDiscountType, setAddPaymentDiscountType] = useState<"amount" | "percent">("amount");
+  const [addPaymentDiscountValue, setAddPaymentDiscountValue] = useState("");
 
   // Cancel-payment confirm state.
   const [cancellingPaymentId, setCancellingPaymentId] = useState<string | null>(
@@ -759,6 +761,8 @@ function PatientDetail() {
     setAddPaymentMethod("cash");
     setAddPaymentNotes("");
     setAddPaymentAppointmentId("");
+    setAddPaymentDiscountType("amount");
+    setAddPaymentDiscountValue("");
     setAddPaymentOpen(true);
   };
 
@@ -823,6 +827,8 @@ function PatientDetail() {
       });
       toast.success(t("gabinet.payments.created"));
       setAddPaymentOpen(false);
+      setAddPaymentDiscountType("amount");
+      setAddPaymentDiscountValue("");
       await refetchPatientCredit();
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.payments.all });
     } catch (e) {
@@ -2242,9 +2248,11 @@ function PatientDetail() {
               </Label>
               <Select
                 value={addPaymentAppointmentId || "none"}
-                onValueChange={(v) =>
-                  setAddPaymentAppointmentId(v === "none" ? "" : v)
-                }
+                onValueChange={(v) => {
+                  setAddPaymentAppointmentId(v === "none" ? "" : v);
+                  setAddPaymentDiscountType("amount");
+                  setAddPaymentDiscountValue("");
+                }}
               >
                 <SelectTrigger>
                   <SelectValue />
@@ -2286,6 +2294,88 @@ function PatientDetail() {
                 </p>
               )}
             </div>
+            {addPaymentAppointmentId && (() => {
+              const apt = (patientAppointments ?? []).find(
+                (a) => a._id === addPaymentAppointmentId,
+              );
+              const aptTreatmentPrice = apt?.treatmentId
+                ? (treatmentsData?.find((tr) => tr._id === apt.treatmentId)?.price ?? 0)
+                : 0;
+              const paidForVisit = (patientPayments ?? [])
+                .filter(
+                  (p) =>
+                    p.appointmentId === addPaymentAppointmentId &&
+                    p.status === "completed",
+                )
+                .reduce(
+                  (sum, p) =>
+                    sum +
+                    (p.amount ?? 0) +
+                    ((p as { creditApplied?: number | null }).creditApplied ?? 0),
+                  0,
+                );
+              const outstandingForVisit = Math.max(0, aptTreatmentPrice - paidForVisit);
+              if (outstandingForVisit <= 0) return null;
+              return (
+                <div>
+                  <Label>{t("gabinet.payments.discount")}</Label>
+                  <div className="flex gap-2 mt-1">
+                    <Select
+                      value={addPaymentDiscountType}
+                      onValueChange={(v) => {
+                        setAddPaymentDiscountType(v as "amount" | "percent");
+                        setAddPaymentDiscountValue("");
+                      }}
+                    >
+                      <SelectTrigger className="w-40">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="amount">
+                          {t("gabinet.payments.discountTypeAmount")}
+                        </SelectItem>
+                        <SelectItem value="percent">
+                          {t("gabinet.payments.discountTypePercent")}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <div className="relative flex-1">
+                      <Input
+                        type="text"
+                        inputMode="decimal"
+                        value={addPaymentDiscountValue}
+                        onChange={(e) => {
+                          const v = e.target.value;
+                          if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
+                            setAddPaymentDiscountValue(v);
+                            const parsed = parseFloat(v.replace(",", ".")) || 0;
+                            const disc =
+                              addPaymentDiscountType === "amount"
+                                ? Math.min(parsed, outstandingForVisit)
+                                : Math.round(
+                                    (outstandingForVisit *
+                                      Math.min(parsed, 100)) /
+                                      100 *
+                                      100,
+                                  ) / 100;
+                            setAddPaymentAmount(
+                              Math.max(0, outstandingForVisit - disc).toFixed(2),
+                            );
+                          }
+                        }}
+                        placeholder={addPaymentDiscountType === "percent" ? "0" : "0.00"}
+                        className={addPaymentDiscountType === "percent" ? "pr-8" : ""}
+                      />
+                      {addPaymentDiscountType === "percent" && (
+                        <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">
+                          %
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            })()}
             <div>
               <Label>{t("common.notes")}</Label>
               <Input


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3357.

Closes #3357

---

## Claude summary

Committed `ec078c7`. Here's what was implemented:

**Discount feature added to 5 payment locations across 7 files:**

1. **Appointment checkout dialog** (`_layout.gabinet.appointments.$appointmentId.lazy.tsx`) — A discount section appears above the amount field when there's an outstanding balance. Selecting amount/percent type and entering a value auto-fills the payment amount with the discounted total. Resets on open/close.

2. **Patient-page payment dialog** (`_layout.gabinet.patients.$patientId.tsx`) — Discount section appears after the appointment selector, but only when an appointment is selected and has an outstanding balance. The base for the discount is the computed outstanding for that specific visit. Resets when the appointment selection changes.

3. **Treatment purchase drawer** (`treatment-purchase-drawer.tsx`) — Inline PLN/% toggle with discount input inside the price summary box. Shows the discount amount in red and the post-discount "Cena po rabacie" total. Feeds into installment and split-payment calculations.

4. **Sell treatment panel** (`sell-treatment-panel.tsx`) — Same inline discount UI as the treatment drawer, applied to `totalPrice`.

5. **Package purchase drawer** (`package-purchase-drawer.tsx`) — Same pattern, applied to `selectedPkg.totalPrice`. Installment and split-payment totals also reflect the discounted price.

## Follow-ups

- Store discount on the payment record: the current discount is purely a UI computation — if an admin views the payment history they see only the final amount with no indication a discount was granted. Adding optional `discountAmount`/`discountPercent` columns to the `payments` table would make this auditable.
- Discount on appointment edit-payment dialog: the patient-page edit-payment dialog (`openEditPaymentDialog`) doesn't yet have a discount helper — follow-up to keep parity.