### PR TITLE
Add `sold_by_employee_id` column to `gabinet_package_usage`

### DIFF
--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -346,6 +346,7 @@ export const purchaseTreatment = action({
     sessionCount: v.number(),
     paidAmount: v.number(),
     paymentMethod: v.optional(v.string()),
+    soldByEmployeeId: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<string> => {
     const authResult = await ctx.runQuery(
@@ -414,6 +415,7 @@ export const purchaseTreatment = action({
       ],
       paidAmount: args.paidAmount,
       paymentMethod: args.paymentMethod ?? null,
+      soldByEmployeeId: args.soldByEmployeeId ?? null,
       createdBy: userIdStr,
       createdAt: now,
       updatedAt: now,
@@ -505,6 +507,7 @@ export const purchasePackage = action({
     giftRecipientName: v.optional(v.string()),
     giftRecipientPhone: v.optional(v.string()),
     giftRecipientEmail: v.optional(v.string()),
+    soldByEmployeeId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(
@@ -573,6 +576,7 @@ export const purchasePackage = action({
       giftRecipientName: args.giftRecipientName ?? null,
       giftRecipientPhone: args.giftRecipientPhone ?? null,
       giftRecipientEmail: args.giftRecipientEmail ?? null,
+      soldByEmployeeId: args.soldByEmployeeId ?? null,
       createdBy: String(authResult.userId),
       createdAt: now,
       updatedAt: now,

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -567,6 +567,7 @@ export function createGabinetTables({
     giftRecipientName: v.optional(v.string()),
     giftRecipientPhone: v.optional(v.string()),
     giftRecipientEmail: v.optional(v.string()),
+    soldByEmployeeId: v.optional(v.id("gabinetEmployees")),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),

--- a/src/components/gabinet/package-purchase-drawer.tsx
+++ b/src/components/gabinet/package-purchase-drawer.tsx
@@ -29,6 +29,7 @@ import { formatActionError } from "@/lib/format-action-error";
 import { formatCurrencyPLN } from "@/lib/format-currency";
 import { usePackagePaymentForm } from "@/hooks/use-package-payment-form";
 import { PackageSplitPaymentSection } from "./package-split-payment-section";
+import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
 
 interface PackagePurchaseDrawerProps {
   patientId: string;
@@ -49,10 +50,13 @@ export function PackagePurchaseDrawer({
   const createPayment = useAction(api.payments.create);
 
   const [selectedPkgId, setSelectedPkgId] = useState<string>("");
+  const [soldByEmployeeId, setSoldByEmployeeId] = useState<string>("");
   const [paymentType, setPaymentType] = useState<"one_time" | "installment">("one_time");
   const [installmentCount, setInstallmentCount] = useState<string>("2");
   const [discountType, setDiscountType] = useState<"amount" | "percent">("amount");
   const [discountValue, setDiscountValue] = useState<string>("");
+
+  const { data: employeesData } = useSupabaseGabinetEmployeesList(String(organizationId), { activeOnly: true, enabled: open });
 
   const listActivePackages = useAction(api.gabinet.packages.listActive);
   const { data: activePackages } = useQuery({
@@ -131,6 +135,7 @@ export function PackagePurchaseDrawer({
 
   const resetForm = () => {
     setSelectedPkgId("");
+    setSoldByEmployeeId("");
     setPaymentType("one_time");
     setInstallmentCount("2");
     setDiscountType("amount");
@@ -181,6 +186,7 @@ export function PackagePurchaseDrawer({
         packageId: selectedPkg._id,
         paidAmount: finalPrice,
         paymentMethod: usagePaymentMethod,
+        soldByEmployeeId: soldByEmployeeId || undefined,
       });
 
       if (isInstallment) {
@@ -289,6 +295,24 @@ export function PackagePurchaseDrawer({
         </SheetHeader>
 
         <div className="flex-1 overflow-y-auto py-4 space-y-5">
+          {(employeesData ?? []).length > 0 && (
+            <div className="space-y-1.5">
+              <Label>{t("gabinet.packages.soldBy", "Sprzedał/a")}</Label>
+              <Select value={soldByEmployeeId} onValueChange={setSoldByEmployeeId}>
+                <SelectTrigger>
+                  <SelectValue placeholder={t("gabinet.packages.soldByPlaceholder", "Wybierz pracownika (opcjonalnie)")} />
+                </SelectTrigger>
+                <SelectContent>
+                  {(employeesData ?? []).map((e) => (
+                    <SelectItem key={e._id} value={e._id}>
+                      {[e.firstName, e.lastName].filter(Boolean).join(" ") || e._id}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
           <div className="space-y-1.5">
             <Label>{t("gabinet.packages.selectPackage", "Package")}</Label>
             <Select value={selectedPkgId} onValueChange={setSelectedPkgId}>

--- a/src/components/gabinet/sell-package-panel.tsx
+++ b/src/components/gabinet/sell-package-panel.tsx
@@ -21,6 +21,7 @@ import { Loader2 } from "@/lib/ez-icons";
 import { useSupabaseGabinetTreatmentPackagesList } from "@/hooks/use-supabase-gabinet-packages";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
+import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatActionError } from "@/lib/format-action-error";
 import { formatCurrencyPLN } from "@/lib/format-currency";
@@ -48,6 +49,7 @@ export function SellPackagePanel({
   const { data: packagesData } = useSupabaseGabinetTreatmentPackagesList(organizationId);
   const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId);
   const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId);
+  const { data: employeesData } = useSupabaseGabinetEmployeesList(String(organizationId), { activeOnly: true });
 
   const treatmentMap = useMemo(
     () => new Map((treatmentsData ?? []).map((tr) => [tr._id, tr.name])),
@@ -56,6 +58,7 @@ export function SellPackagePanel({
 
   const [saleMode, setSaleMode] = useState<SaleMode>("patient");
   const [patientId, setPatientId] = useState<string>("");
+  const [soldByEmployeeId, setSoldByEmployeeId] = useState<string>("");
   const [packageId, setPackageId] = useState<string>("");
   const [giftRecipientName, setGiftRecipientName] = useState("");
   const [giftRecipientPhone, setGiftRecipientPhone] = useState("");
@@ -113,6 +116,7 @@ export function SellPackagePanel({
   const reset = () => {
     setSaleMode("patient");
     setPatientId("");
+    setSoldByEmployeeId("");
     setPackageId("");
     setGiftRecipientName("");
     setGiftRecipientPhone("");
@@ -171,6 +175,7 @@ export function SellPackagePanel({
         giftRecipientName: isGift && giftRecipientName ? giftRecipientName : undefined,
         giftRecipientPhone: isGift && giftRecipientPhone ? giftRecipientPhone : undefined,
         giftRecipientEmail: isGift && giftRecipientEmail ? giftRecipientEmail : undefined,
+        soldByEmployeeId: soldByEmployeeId || undefined,
       });
 
       const paymentPatientId = isGift ? undefined : (patientId as Id<"gabinetPatients">);
@@ -369,6 +374,24 @@ export function SellPackagePanel({
                 placeholder={t("gabinet.packages.giftRecipientEmailPlaceholder", "np. jan@example.com")}
               />
             </div>
+          </div>
+        )}
+
+        {(employeesData ?? []).length > 0 && (
+          <div className="space-y-1.5">
+            <Label>{t("gabinet.packages.soldBy", "Sprzedał/a")}</Label>
+            <Select value={soldByEmployeeId} onValueChange={setSoldByEmployeeId}>
+              <SelectTrigger>
+                <SelectValue placeholder={t("gabinet.packages.soldByPlaceholder", "Wybierz pracownika (opcjonalnie)")} />
+              </SelectTrigger>
+              <SelectContent>
+                {(employeesData ?? []).map((e) => (
+                  <SelectItem key={e._id} value={e._id}>
+                    {[e.firstName, e.lastName].filter(Boolean).join(" ") || e._id}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
         )}
 

--- a/src/components/gabinet/sell-treatment-panel.tsx
+++ b/src/components/gabinet/sell-treatment-panel.tsx
@@ -20,6 +20,7 @@ import {
 import { Loader2 } from "@/lib/ez-icons";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
+import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatActionError } from "@/lib/format-action-error";
 import { formatCurrencyPLN } from "@/lib/format-currency";
@@ -46,8 +47,10 @@ export function SellTreatmentPanel({
 
   const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId);
   const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId, { isActive: true });
+  const { data: employeesData } = useSupabaseGabinetEmployeesList(String(organizationId), { activeOnly: true });
 
   const [patientId, setPatientId] = useState<string>("");
+  const [soldByEmployeeId, setSoldByEmployeeId] = useState<string>("");
   const [treatmentId, setTreatmentId] = useState<string>("");
   const [sessionCount, setSessionCount] = useState<string>("1");
   const [paymentType, setPaymentType] = useState<"one_time" | "installment">("one_time");
@@ -118,6 +121,7 @@ export function SellTreatmentPanel({
 
   const reset = useCallback(() => {
     setPatientId("");
+    setSoldByEmployeeId("");
     setTreatmentId("");
     setSessionCount("1");
     setPaymentType("one_time");
@@ -167,6 +171,7 @@ export function SellTreatmentPanel({
         sessionCount: parsedSessionCount,
         paidAmount: finalPrice,
         paymentMethod: usagePaymentMethod,
+        soldByEmployeeId: soldByEmployeeId || undefined,
       });
 
       const treatmentName = selectedTreatment.name;
@@ -289,6 +294,24 @@ export function SellTreatmentPanel({
             </SelectContent>
           </Select>
         </div>
+
+        {(employeesData ?? []).length > 0 && (
+          <div className="space-y-1.5">
+            <Label>{t("gabinet.packages.soldBy", "Sprzedał/a")}</Label>
+            <Select value={soldByEmployeeId} onValueChange={setSoldByEmployeeId}>
+              <SelectTrigger>
+                <SelectValue placeholder={t("gabinet.packages.soldByPlaceholder", "Wybierz pracownika (opcjonalnie)")} />
+              </SelectTrigger>
+              <SelectContent>
+                {(employeesData ?? []).map((e) => (
+                  <SelectItem key={e._id} value={e._id}>
+                    {[e.firstName, e.lastName].filter(Boolean).join(" ") || e._id}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
 
         <div className="space-y-1.5">
           <Label>{t("gabinet.treatments.selectTreatment", "Zabieg")}</Label>

--- a/src/components/gabinet/treatment-purchase-drawer.tsx
+++ b/src/components/gabinet/treatment-purchase-drawer.tsx
@@ -26,6 +26,7 @@ import {
 import { Loader2 } from "@/lib/ez-icons";
 import { formatActionError } from "@/lib/format-action-error";
 import { formatCurrencyPLN } from "@/lib/format-currency";
+import { useSupabaseGabinetEmployeesList } from "@/hooks/use-supabase-gabinet-employees";
 
 interface TreatmentPurchaseDrawerProps {
   patientId: string;
@@ -49,6 +50,7 @@ export function TreatmentPurchaseDrawer({
   const createPayment = useAction(api.payments.create);
 
   const [selectedTreatmentId, setSelectedTreatmentId] = useState<string>("");
+  const [soldByEmployeeId, setSoldByEmployeeId] = useState<string>("");
   const [sessionCount, setSessionCount] = useState<string>("1");
   const [paymentType, setPaymentType] = useState<"one_time" | "installment">("one_time");
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("cash");
@@ -61,6 +63,8 @@ export function TreatmentPurchaseDrawer({
   const [submitting, setSubmitting] = useState(false);
   const [discountType, setDiscountType] = useState<"amount" | "percent">("amount");
   const [discountValue, setDiscountValue] = useState<string>("");
+
+  const { data: employeesData } = useSupabaseGabinetEmployeesList(String(organizationId), { activeOnly: true, enabled: open });
 
   const listActiveTreatments = useAction(api.gabinet.treatments.listActive);
   const { data: treatments } = useQuery({
@@ -117,6 +121,7 @@ export function TreatmentPurchaseDrawer({
 
   const resetForm = () => {
     setSelectedTreatmentId("");
+    setSoldByEmployeeId("");
     setSessionCount("1");
     setPaymentType("one_time");
     setPaymentMethod("cash");
@@ -168,6 +173,7 @@ export function TreatmentPurchaseDrawer({
         sessionCount: parsedSessionCount,
         paidAmount: finalPrice,
         paymentMethod: usagePaymentMethod,
+        soldByEmployeeId: soldByEmployeeId || undefined,
       });
 
       const treatmentName = selectedTreatment.name;
@@ -280,6 +286,24 @@ export function TreatmentPurchaseDrawer({
         </SheetHeader>
 
         <div className="flex-1 overflow-y-auto py-4 space-y-5">
+          {(employeesData ?? []).length > 0 && (
+            <div className="space-y-1.5">
+              <Label>{t("gabinet.packages.soldBy", "Sprzedał/a")}</Label>
+              <Select value={soldByEmployeeId} onValueChange={setSoldByEmployeeId}>
+                <SelectTrigger>
+                  <SelectValue placeholder={t("gabinet.packages.soldByPlaceholder", "Wybierz pracownika (opcjonalnie)")} />
+                </SelectTrigger>
+                <SelectContent>
+                  {(employeesData ?? []).map((e) => (
+                    <SelectItem key={e._id} value={e._id}>
+                      {[e.firstName, e.lastName].filter(Boolean).join(" ") || e._id}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
           <div className="space-y-1.5">
             <Label>{t("gabinet.treatments.selectTreatment", "Zabieg")}</Label>
             <Select value={selectedTreatmentId} onValueChange={setSelectedTreatmentId}>

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -76,6 +76,7 @@
  *   • 00069_gabinet_appointment_treatments.sql
  *   • 00070_appointment_treatments_deduction_flags.sql
  *   • 00071_drop_appointment_deduction_flags.sql
+ *   • 00072_gabinet_package_usage_sold_by_employee_id.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -5119,6 +5120,7 @@ export interface Database {
           gift_recipient_name: string | null;
           gift_recipient_phone: string | null;
           gift_recipient_email: string | null;
+          sold_by_employee_id: string | null;
           created_by: string;
           created_at: number;
           updated_at: number;
@@ -5139,6 +5141,7 @@ export interface Database {
           gift_recipient_name?: string | null;
           gift_recipient_phone?: string | null;
           gift_recipient_email?: string | null;
+          sold_by_employee_id?: string | null;
           created_by: string;
           created_at: number;
           updated_at: number;
@@ -5159,6 +5162,7 @@ export interface Database {
           gift_recipient_name?: string | null;
           gift_recipient_phone?: string | null;
           gift_recipient_email?: string | null;
+          sold_by_employee_id?: string | null;
           created_by?: string;
           created_at?: number;
           updated_at?: number;
@@ -5183,6 +5187,13 @@ export interface Database {
             columns: ["package_id"];
             isOneToOne: false;
             referencedRelation: "gabinet_treatment_packages";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gabinet_package_usage_sold_by_employee_id_fkey";
+            columns: ["sold_by_employee_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_employees";
             referencedColumns: ["id"];
           },
           {

--- a/src/lib/supabase/mappers/gabinet/package-usage.ts
+++ b/src/lib/supabase/mappers/gabinet/package-usage.ts
@@ -33,6 +33,7 @@ export interface MappedGabinetPackageUsage {
   giftRecipientName?: string;
   giftRecipientPhone?: string;
   giftRecipientEmail?: string;
+  soldByEmployeeId?: string;
   createdBy: string;
   createdAt: number;
   updatedAt: number;
@@ -59,6 +60,7 @@ export function mapGabinetPackageUsageFromSupabase(
     giftRecipientName: row.gift_recipient_name ?? undefined,
     giftRecipientPhone: row.gift_recipient_phone ?? undefined,
     giftRecipientEmail: row.gift_recipient_email ?? undefined,
+    soldByEmployeeId: row.sold_by_employee_id ?? undefined,
   };
 }
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -955,6 +955,7 @@ function PackageSalesSection({
   packages,
   packageNameMap,
   employeeMap,
+  employeeMapById,
   patientMap,
   rangeLabel,
   currency,
@@ -964,6 +965,7 @@ function PackageSalesSection({
   packages: MappedGabinetTreatmentPackage[];
   packageNameMap: Map<string, string>;
   employeeMap: Map<string, string>;
+  employeeMapById: Map<string, string>;
   patientMap: Map<string, string>;
   rangeLabel: string;
   currency: string;
@@ -997,15 +999,23 @@ function PackageSalesSection({
   }, [filteredUsages, packageNameMap]);
 
   const perEmployee = useMemo(() => {
-    const m = new Map<string, { count: number; revenue: number }>();
+    const m = new Map<string, { count: number; revenue: number; isByEmployeeId: boolean }>();
     for (const u of filteredUsages) {
-      const prev = m.get(u.createdBy) ?? { count: 0, revenue: 0 };
-      m.set(u.createdBy, { count: prev.count + 1, revenue: prev.revenue + u.paidAmount });
+      const key = u.soldByEmployeeId ?? u.createdBy;
+      const isByEmployeeId = !!u.soldByEmployeeId;
+      const prev = m.get(key) ?? { count: 0, revenue: 0, isByEmployeeId };
+      m.set(key, { count: prev.count + 1, revenue: prev.revenue + u.paidAmount, isByEmployeeId });
     }
     return Array.from(m.entries())
-      .map(([userId, s]) => ({ name: employeeMap.get(userId) ?? userId, count: s.count, revenue: s.revenue }))
+      .map(([key, s]) => ({
+        name: s.isByEmployeeId
+          ? (employeeMapById.get(key) ?? key)
+          : (employeeMap.get(key) ?? key),
+        count: s.count,
+        revenue: s.revenue,
+      }))
       .sort((a, b) => b.revenue - a.revenue);
-  }, [filteredUsages, employeeMap]);
+  }, [filteredUsages, employeeMap, employeeMapById]);
 
   const perPatient = useMemo(() => {
     const m = new Map<string, { count: number; revenue: number }>();
@@ -1298,13 +1308,24 @@ function GabinetReports() {
     );
   }, [treatments]);
 
-  // Employee map: userId → name
+  // Employee map: userId → name (for fallback attribution via createdBy)
   const employeeMap = useMemo(() => {
     if (!employees) return new Map<string, string>();
     return new Map(
       employees.map((e) => [
         e.userId,
         [e.firstName, e.lastName].filter(Boolean).join(" ") || e.userId,
+      ])
+    );
+  }, [employees]);
+
+  // Employee map: employeeId → name (for soldByEmployeeId attribution)
+  const employeeMapById = useMemo(() => {
+    if (!employees) return new Map<string, string>();
+    return new Map(
+      employees.map((e) => [
+        e._id,
+        [e.firstName, e.lastName].filter(Boolean).join(" ") || e._id,
       ])
     );
   }, [employees]);
@@ -1560,18 +1581,23 @@ function GabinetReports() {
     }
     // Package sales — per package and per employee
     const pkgSalesMap = new Map<string, { count: number; revenue: number }>();
-    const empPkgSalesMap = new Map<string, { count: number; revenue: number }>();
+    const empPkgSalesMap = new Map<string, { count: number; revenue: number; isByEmployeeId: boolean }>();
     for (const u of packageUsages ?? []) {
       const prevPkg = pkgSalesMap.get(u.packageId) ?? { count: 0, revenue: 0 };
       pkgSalesMap.set(u.packageId, { count: prevPkg.count + 1, revenue: prevPkg.revenue + u.paidAmount });
-      const prevEmp = empPkgSalesMap.get(u.createdBy) ?? { count: 0, revenue: 0 };
-      empPkgSalesMap.set(u.createdBy, { count: prevEmp.count + 1, revenue: prevEmp.revenue + u.paidAmount });
+      const empKey = u.soldByEmployeeId ?? u.createdBy;
+      const isByEmployeeId = !!u.soldByEmployeeId;
+      const prevEmp = empPkgSalesMap.get(empKey) ?? { count: 0, revenue: 0, isByEmployeeId };
+      empPkgSalesMap.set(empKey, { count: prevEmp.count + 1, revenue: prevEmp.revenue + u.paidAmount, isByEmployeeId });
     }
     for (const [pkgId, stats] of pkgSalesMap) {
       rows.push({ section: "package_sales_by_package", metric: packageNameMap.get(pkgId) ?? pkgId, value: stats.count, revenue: stats.revenue });
     }
-    for (const [userId, stats] of empPkgSalesMap) {
-      rows.push({ section: "package_sales_by_employee", metric: employeeMap.get(userId) ?? userId, value: stats.count, revenue: stats.revenue });
+    for (const [key, stats] of empPkgSalesMap) {
+      const name = stats.isByEmployeeId
+        ? (employeeMapById.get(key) ?? key)
+        : (employeeMap.get(key) ?? key);
+      rows.push({ section: "package_sales_by_employee", metric: name, value: stats.count, revenue: stats.revenue });
     }
     const csv = Papa.unparse(rows as unknown as Record<string, unknown>[]);
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
@@ -1604,6 +1630,7 @@ function GabinetReports() {
     packageUsages,
     packageNameMap,
     employeeMap,
+    employeeMapById,
     startDate,
     endDate,
     t,
@@ -1799,6 +1826,7 @@ function GabinetReports() {
         packages={packagesListData ?? []}
         packageNameMap={packageNameMap}
         employeeMap={employeeMap}
+        employeeMapById={employeeMapById}
         patientMap={patientMap}
         rangeLabel={rangeLabel}
         currency={defaultCurrency}

--- a/supabase/migrations/00072_gabinet_package_usage_sold_by_employee_id.sql
+++ b/supabase/migrations/00072_gabinet_package_usage_sold_by_employee_id.sql
@@ -1,0 +1,8 @@
+-- Add sold_by_employee_id to gabinet_package_usage for accurate per-salesperson metrics.
+-- The existing created_by field tracks who created the record (may be a receptionist/admin);
+-- this column explicitly records the employee who made the sale.
+ALTER TABLE gabinet_package_usage
+  ADD COLUMN sold_by_employee_id TEXT REFERENCES gabinet_employees(id) ON DELETE SET NULL;
+
+CREATE INDEX gabinet_package_usage_sold_by_employee_idx
+  ON gabinet_package_usage (organization_id, sold_by_employee_id);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3379.

Closes #3379

---

## Claude summary

The implementation is complete. Here's what was done:

**Migration** (`supabase/migrations/00072_gabinet_package_usage_sold_by_employee_id.sql`): Adds `sold_by_employee_id TEXT REFERENCES gabinet_employees(id) ON DELETE SET NULL` with a composite index on `(organization_id, sold_by_employee_id)`.

**Backend (Convex):**
- `convex/schema/gabinet.ts`: Added `soldByEmployeeId: v.optional(v.id("gabinetEmployees"))` to `gabinetPackageUsage`
- `convex/gabinet/packages.ts`: Added `soldByEmployeeId` optional argument to both `purchasePackage` and `purchaseTreatment` actions, passed through to `db.insert`

**Types:**
- `src/lib/supabase/database.types.ts`: Added `sold_by_employee_id` field to Row/Insert/Update and its FK relationship
- `src/lib/supabase/mappers/gabinet/package-usage.ts`: Added `soldByEmployeeId?: string` to `MappedGabinetPackageUsage` and mapped from `row.sold_by_employee_id`

**Frontend forms** (all four sale panels now show an optional employee selector when active employees exist, and pass `soldByEmployeeId` to the mutation):
- `sell-package-panel.tsx`, `sell-treatment-panel.tsx`, `package-purchase-drawer.tsx`, `treatment-purchase-drawer.tsx`

**Reports page** (`_layout.gabinet.reports.lazy.tsx`): Per-employee package sales now prefer `soldByEmployeeId` (looked up by employee `_id`) with fallback to `createdBy` (looked up by user ID). The CSV export follows the same logic.