### PR TITLE
Store discount on the payment record

### DIFF
--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -133,6 +133,11 @@ export const create = action({
     // exceed the patient's current available balance.
     creditEarned: v.optional(v.number()),
     creditApplied: v.optional(v.number()),
+    // Discount applied at point of sale (issue #3383).
+    // discountAmount: absolute discount value in the payment currency.
+    // discountPercent: percentage discount (0–100).
+    discountAmount: v.optional(v.number()),
+    discountPercent: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runQuery(
@@ -201,6 +206,10 @@ export const create = action({
     };
     if (creditEarned !== null) insertRow.creditEarned = creditEarned;
     if (creditApplied !== null) insertRow.creditApplied = creditApplied;
+    if (args.discountAmount !== undefined && args.discountAmount > 0)
+      insertRow.discountAmount = args.discountAmount;
+    if (args.discountPercent !== undefined && args.discountPercent > 0)
+      insertRow.discountPercent = args.discountPercent;
 
     const paymentId = await db.insert("payments", insertRow);
 

--- a/src/components/gabinet/package-purchase-drawer.tsx
+++ b/src/components/gabinet/package-purchase-drawer.tsx
@@ -189,6 +189,17 @@ export function PackagePurchaseDrawer({
         soldByEmployeeId: soldByEmployeeId || undefined,
       });
 
+      const discountFields =
+        discountAmount > 0
+          ? {
+              discountAmount,
+              discountPercent:
+                discountType === "percent"
+                  ? parsedDiscountValue
+                  : Math.round((discountAmount / basePrice) * 10000) / 100,
+            }
+          : {};
+
       if (isInstallment) {
         if (splitPayment) {
           const parts: Array<{ method: typeof firstSplitMethod; amount: number }> = [];
@@ -196,7 +207,8 @@ export function PackagePurchaseDrawer({
             parts.push({ method: firstSplitMethod, amount: parsedFirstSplit });
           if (parsedSecondSplit > 0)
             parts.push({ method: secondSplitMethod, amount: parsedSecondSplit });
-          for (const part of parts) {
+          for (let i = 0; i < parts.length; i++) {
+            const part = parts[i];
             await createPayment({
               organizationId,
               patientId: patientId as Id<"gabinetPatients">,
@@ -205,6 +217,7 @@ export function PackagePurchaseDrawer({
               currency,
               paymentMethod: part.method,
               notes: `Package: ${selectedPkg.name} (installment 1/${parsedInstallmentCount} split: ${part.method})`,
+              ...(i === 0 ? discountFields : {}),
             });
           }
         } else {
@@ -216,6 +229,7 @@ export function PackagePurchaseDrawer({
             currency,
             paymentMethod: paymentMethod as "cash" | "card" | "transfer" | "other",
             notes: `Package: ${selectedPkg.name} (installment 1/${parsedInstallmentCount})`,
+            ...discountFields,
           });
         }
         for (let i = 2; i <= parsedInstallmentCount; i++) {
@@ -236,7 +250,8 @@ export function PackagePurchaseDrawer({
           parts.push({ method: firstSplitMethod, amount: parsedFirstSplit });
         if (parsedSecondSplit > 0)
           parts.push({ method: secondSplitMethod, amount: parsedSecondSplit });
-        for (const part of parts) {
+        for (let i = 0; i < parts.length; i++) {
+          const part = parts[i];
           await createPayment({
             organizationId,
             patientId: patientId as Id<"gabinetPatients">,
@@ -245,6 +260,7 @@ export function PackagePurchaseDrawer({
             currency,
             paymentMethod: part.method,
             notes: `Package: ${selectedPkg.name} (split: ${part.method})`,
+            ...(i === 0 ? discountFields : {}),
           });
         }
       } else {
@@ -256,6 +272,7 @@ export function PackagePurchaseDrawer({
           currency,
           paymentMethod: paymentMethod as "cash" | "card" | "transfer",
           notes: `Package: ${selectedPkg.name}`,
+          ...discountFields,
         });
       }
 

--- a/src/components/gabinet/sell-treatment-panel.tsx
+++ b/src/components/gabinet/sell-treatment-panel.tsx
@@ -175,6 +175,16 @@ export function SellTreatmentPanel({
       });
 
       const treatmentName = selectedTreatment.name;
+      const discountFields =
+        discountAmount > 0
+          ? {
+              discountAmount,
+              discountPercent:
+                discountType === "percent"
+                  ? parsedDiscountValue
+                  : Math.round((discountAmount / totalPrice) * 10000) / 100,
+            }
+          : {};
 
       if (isInstallment) {
         if (splitPayment) {
@@ -183,7 +193,8 @@ export function SellTreatmentPanel({
             parts.push({ method: firstSplitMethod, amount: parsedFirstSplit });
           if (parsedSecondSplit > 0)
             parts.push({ method: secondSplitMethod, amount: parsedSecondSplit });
-          for (const part of parts) {
+          for (let i = 0; i < parts.length; i++) {
+            const part = parts[i];
             await createPayment({
               organizationId,
               patientId: patientId as Id<"gabinetPatients">,
@@ -192,6 +203,7 @@ export function SellTreatmentPanel({
               currency,
               paymentMethod: part.method,
               notes: `Treatment: ${treatmentName} (installment 1/${parsedInstallmentCount} split: ${part.method})`,
+              ...(i === 0 ? discountFields : {}),
             });
           }
         } else {
@@ -203,6 +215,7 @@ export function SellTreatmentPanel({
             currency,
             paymentMethod,
             notes: `Treatment: ${treatmentName} (installment 1/${parsedInstallmentCount})`,
+            ...discountFields,
           });
         }
         for (let i = 2; i <= parsedInstallmentCount; i++) {
@@ -223,7 +236,8 @@ export function SellTreatmentPanel({
           parts.push({ method: firstSplitMethod, amount: parsedFirstSplit });
         if (parsedSecondSplit > 0)
           parts.push({ method: secondSplitMethod, amount: parsedSecondSplit });
-        for (const part of parts) {
+        for (let i = 0; i < parts.length; i++) {
+          const part = parts[i];
           await createPayment({
             organizationId,
             patientId: patientId as Id<"gabinetPatients">,
@@ -232,6 +246,7 @@ export function SellTreatmentPanel({
             currency,
             paymentMethod: part.method,
             notes: `Treatment: ${treatmentName} (split: ${part.method})`,
+            ...(i === 0 ? discountFields : {}),
           });
         }
       } else {
@@ -243,6 +258,7 @@ export function SellTreatmentPanel({
           currency,
           paymentMethod,
           notes: `Treatment: ${treatmentName}`,
+          ...discountFields,
         });
       }
 

--- a/src/components/gabinet/treatment-purchase-drawer.tsx
+++ b/src/components/gabinet/treatment-purchase-drawer.tsx
@@ -177,6 +177,16 @@ export function TreatmentPurchaseDrawer({
       });
 
       const treatmentName = selectedTreatment.name;
+      const discountFields =
+        discountAmount > 0
+          ? {
+              discountAmount,
+              discountPercent:
+                discountType === "percent"
+                  ? parsedDiscountValue
+                  : Math.round((discountAmount / totalPrice) * 10000) / 100,
+            }
+          : {};
 
       if (isInstallment) {
         if (splitPayment) {
@@ -185,7 +195,8 @@ export function TreatmentPurchaseDrawer({
             parts.push({ method: firstSplitMethod, amount: parsedFirstSplit });
           if (parsedSecondSplit > 0)
             parts.push({ method: secondSplitMethod, amount: parsedSecondSplit });
-          for (const part of parts) {
+          for (let i = 0; i < parts.length; i++) {
+            const part = parts[i];
             await createPayment({
               organizationId,
               patientId: patientId as Id<"gabinetPatients">,
@@ -194,6 +205,7 @@ export function TreatmentPurchaseDrawer({
               currency,
               paymentMethod: part.method,
               notes: `Treatment: ${treatmentName} (installment 1/${parsedInstallmentCount} split: ${part.method})`,
+              ...(i === 0 ? discountFields : {}),
             });
           }
         } else {
@@ -205,6 +217,7 @@ export function TreatmentPurchaseDrawer({
             currency,
             paymentMethod,
             notes: `Treatment: ${treatmentName} (installment 1/${parsedInstallmentCount})`,
+            ...discountFields,
           });
         }
         for (let i = 2; i <= parsedInstallmentCount; i++) {
@@ -225,7 +238,8 @@ export function TreatmentPurchaseDrawer({
           parts.push({ method: firstSplitMethod, amount: parsedFirstSplit });
         if (parsedSecondSplit > 0)
           parts.push({ method: secondSplitMethod, amount: parsedSecondSplit });
-        for (const part of parts) {
+        for (let i = 0; i < parts.length; i++) {
+          const part = parts[i];
           await createPayment({
             organizationId,
             patientId: patientId as Id<"gabinetPatients">,
@@ -234,6 +248,7 @@ export function TreatmentPurchaseDrawer({
             currency,
             paymentMethod: part.method,
             notes: `Treatment: ${treatmentName} (split: ${part.method})`,
+            ...(i === 0 ? discountFields : {}),
           });
         }
       } else {
@@ -245,6 +260,7 @@ export function TreatmentPurchaseDrawer({
           currency,
           paymentMethod,
           notes: `Treatment: ${treatmentName}`,
+          ...discountFields,
         });
       }
 

--- a/supabase/migrations/00073_payments_discount_columns.sql
+++ b/supabase/migrations/00073_payments_discount_columns.sql
@@ -1,0 +1,18 @@
+-- Store discount on payment records (issue #3383).
+--
+-- Discounts are currently a UI-only computation: admins viewing payment history
+-- see only the final amount with no indication a discount was granted.
+-- Adding discount_amount and discount_percent makes discounts auditable.
+--
+-- Both columns are nullable so existing rows remain valid without backfill.
+
+ALTER TABLE payments
+  ADD COLUMN IF NOT EXISTS discount_amount  NUMERIC,
+  ADD COLUMN IF NOT EXISTS discount_percent NUMERIC;
+
+-- Optional: ensure percent is within a sane range when present.
+ALTER TABLE payments
+  DROP CONSTRAINT IF EXISTS payments_discount_percent_check;
+ALTER TABLE payments
+  ADD CONSTRAINT payments_discount_percent_check
+  CHECK (discount_percent IS NULL OR (discount_percent >= 0 AND discount_percent <= 100));


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3383.

Closes #3383

---

## Claude summary

The fix is committed. Here's a summary of what was done and why:

**Triage:** The bug is real. All three payment drawers compute `discountAmount` locally from user input but never pass it to the `payments.create` backend action. The resulting payment row in Supabase contains only the post-discount `amount`, with no trace of the original price reduction.

**Changes made:**

`supabase/migrations/00073_payments_discount_columns.sql` — Adds two nullable columns: `discount_amount NUMERIC` and `discount_percent NUMERIC`. Nullable so existing rows need no backfill. Includes a check constraint keeping percent in 0–100.

`convex/payments.ts` — The `create` action now accepts optional `discountAmount` and `discountPercent` args and writes them to the insert row defensively (only when > 0), following the same pattern as the existing `creditEarned`/`creditApplied` columns from migration 00008.

`src/components/gabinet/sell-treatment-panel.tsx`, `treatment-purchase-drawer.tsx`, `package-purchase-drawer.tsx` — Each computes a `discountFields` object (both `discountAmount` and `discountPercent`, always derived together regardless of whether the user typed a percent or an amount) and spreads it into the primary payment row only: the single one-time payment, the first installment, or the first part of a split. Deferred installment rows (2+) and the second split sub-row don't carry the discount since they're just ledger entries for the already-discounted total.