### PR TITLE
Add discount fields to add-payment `handleAddPayment` call

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -839,6 +839,16 @@ function PatientDetail() {
           creditEarned = Math.round((amount - outstanding) * 100) / 100;
         }
       }
+      const discountRaw =
+        parseFloat(addPaymentDiscountValue.replace(",", ".")) || 0;
+      const discountAmount =
+        addPaymentDiscountType === "amount" && discountRaw > 0
+          ? discountRaw
+          : undefined;
+      const discountPercent =
+        addPaymentDiscountType === "percent" && discountRaw > 0
+          ? Math.min(discountRaw, 100)
+          : undefined;
       await createPaymentAction({
         organizationId,
         patientId,
@@ -848,6 +858,8 @@ function PatientDetail() {
         paymentMethod: addPaymentMethod,
         notes: addPaymentNotes.trim() ? addPaymentNotes.trim() : undefined,
         creditEarned: creditEarned > 0 ? creditEarned : undefined,
+        discountAmount,
+        discountPercent,
       });
       toast.success(t("gabinet.payments.created"));
       setAddPaymentOpen(false);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3393.

Closes #3393

---

## Claude summary

The fix is committed. The `handleAddPayment` function now extracts `discountAmount` and `discountPercent` from the existing `addPaymentDiscountType`/`addPaymentDiscountValue` state and forwards them to `createPaymentAction`, so discounts entered in the add-payment dialog are now persisted to the database via migration 00073's columns.