### PR TITLE
Status płatności ratalnej

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -2160,7 +2160,9 @@ function AppointmentDetail() {
                                   variant={
                                     payment.status === "completed"
                                       ? "default"
-                                      : "secondary"
+                                      : payment.status === "refunded"
+                                        ? "destructive"
+                                        : "secondary"
                                   }
                                 >
                                   {t(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3358.

Closes #3358

---

## Claude summary

The fix is committed. Here's what was wrong and what was changed:

**Root cause**: The appointment detail page renders payment status badges in two places:
- **Left (main payment table, line 1705–1717)**: correct 3-way logic — `completed → default`, `refunded → destructive`, `else → secondary`
- **Right (patient history sidebar, line 2161–2164)**: incomplete 2-way logic — `completed → default`, `else → secondary` — meaning refunded payments showed as a neutral gray badge instead of red

**Fix**: Added the missing `payment.status === "refunded" ? "destructive"` branch to the patient history panel badge, so a refunded installment payment now shows the same red (`destructive`) badge on the right as it does on the left.

The change is in `src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx` at line 2160–2165.