### PR TITLE
Status płatności ratalnej

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -2160,7 +2160,9 @@ function AppointmentDetail() {
                                   variant={
                                     payment.status === "completed"
                                       ? "default"
-                                      : "secondary"
+                                      : payment.status === "refunded"
+                                        ? "destructive"
+                                        : "secondary"
                                   }
                                 >
                                   {t(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3358.

Closes #3358

---

## Claude summary

Fixed. The right-panel payment table at line 2482 was using a 2-way `completed → default / else → secondary` check, so refunded installment payments displayed as a neutral gray badge instead of the red `destructive` badge shown in the main payment table on the left. Added the missing `payment.status === "refunded" ? "destructive"` branch to make both sides consistent.