### PR TITLE
Move `packageDeducted` / `stockDeducted` booleans to per-treatment rows in junct

### DIFF
--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -477,8 +477,6 @@ export function createGabinetTables({
     requiresCompletion: v.optional(v.boolean()),
     contraindicationAlertsReviewed: v.optional(v.boolean()),
     priceAtBooking: v.optional(v.number()),
-    stockDeducted: v.optional(v.boolean()),
-    packageDeducted: v.optional(v.boolean()),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3400.

Closes #3400

---

## Claude summary

The issue was largely already resolved by prior work; this commit completes it by removing the last stale remnant.

Here's what I found:

The migration chain and business logic were fully implemented before this issue was assigned:

- **Migration `00070`** added `stock_deducted` / `package_deducted` to `gabinet_appointment_treatments` (the junction table) and backfilled them from the old appointment-level flags.
- **Migration `00071`** dropped the old columns from `gabinet_appointments` (closes #3368).
- **`convex/gabinet/appointments.ts`** already uses per-treatment CAS guards on the junction rows (lines 2248-2254 for stock, 2332-2338 for packages) — no appointment-level flag is read or written in business logic.

The only remaining gap was that `convex/schema/gabinet.ts` still declared `stockDeducted` and `packageDeducted` as fields on `gabinetAppointments` (lines 480-481), making the Convex schema inconsistent with the Supabase table that migration 00071 already modified. This commit removes those two stale declarations.