### PR TITLE
Update `use-supabase-gabinet-dashboard.ts` treatment stat query to join via `gab

### DIFF
--- a/src/hooks/use-supabase-gabinet-dashboard.ts
+++ b/src/hooks/use-supabase-gabinet-dashboard.ts
@@ -295,17 +295,34 @@ export function useSupabaseGabinetTopTreatments(organizationId: string, location
     queryFn: async () => {
       if (!client) throw new Error("Supabase client not ready");
 
-      let apptQuery = client
-        .from("gabinet_appointments")
+      // When filtering by location, resolve appointment IDs first (junction table has no location_id)
+      let appointmentIds: string[] | null = null;
+      if (locationId) {
+        const locRes = await client
+          .from("gabinet_appointments")
+          .select("id")
+          .eq("organization_id", organizationId)
+          .eq("location_id", locationId);
+        if (locRes.error) throw locRes.error;
+        appointmentIds = ((locRes.data ?? []) as { id: string }[]).map((r) => r.id);
+      }
+
+      let junctionQuery = client
+        .from("gabinet_appointment_treatments")
         .select("treatment_id")
         .eq("organization_id", organizationId)
         .not("treatment_id", "is", null);
 
-      if (locationId) apptQuery = apptQuery.eq("location_id", locationId);
+      if (appointmentIds !== null) {
+        junctionQuery = junctionQuery.in(
+          "appointment_id",
+          appointmentIds.length ? appointmentIds : [""],
+        );
+      }
 
-      // Fetch appointment treatment_ids and treatment names in parallel
+      // Fetch treatment_ids and treatment names in parallel
       const [apptRes, treatRes] = await Promise.all([
-        apptQuery,
+        junctionQuery,
         client
           .from("gabinet_treatments")
           .select("id, name")


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3401.

Closes #3401

---

## Claude summary

The bug was real and is now fixed. Here's a summary:

**What was wrong:** `useSupabaseGabinetTopTreatments` in `src/hooks/use-supabase-gabinet-dashboard.ts:300` was reading `treatment_id` from `gabinet_appointments` directly. Migration `00069_gabinet_appointment_treatments.sql` created a `gabinet_appointment_treatments` junction table for the multi-treatment model, and once the scalar `treatment_id` column on `gabinet_appointments` is dropped, this query would break with zero results (or an error).

**Fix:** The query now reads from `gabinet_appointment_treatments` instead. Since the junction table has no `location_id` column, the `locationId` filter is handled by a sequential pre-fetch of appointment IDs for that location, after which the junction and treatment-name queries run in parallel as before. An `.in("appointment_id", [""])` guard handles the empty-result edge case.