### PR TITLE
Update `use-supabase-scheduled-activities.ts` to resolve `treatmentId` from junc

### DIFF
--- a/src/hooks/use-supabase-scheduled-activities.ts
+++ b/src/hooks/use-supabase-scheduled-activities.ts
@@ -234,21 +234,22 @@ export function useSupabaseScheduledActivitiesByDateRange(
         ),
       );
 
-      let apptMap = new Map<string, { status: string; patientId: string; treatmentId: string | null }>();
+      let apptMap = new Map<string, { status: string; patientId: string }>();
       let patientMap = new Map<string, string>();
       let treatmentMap = new Map<string, string>();
+      // appointment_id → primary treatment_id (lowest sort_order from junction table)
+      let apptTreatmentMap = new Map<string, string>();
 
       if (gabinetEntityIds.length > 0) {
         const { data: appts, error: apptErr } = await client
           .from("gabinet_appointments")
-          .select("id,status,patient_id,treatment_id")
+          .select("id,status,patient_id")
           .in("id", gabinetEntityIds);
         if (apptErr) throw apptErr;
         const apptRows = (appts ?? []) as Array<{
           id: string;
           status: string | null;
           patient_id: string;
-          treatment_id: string | null;
         }>;
         apptMap = new Map(
           apptRows.map((a) => [
@@ -256,7 +257,6 @@ export function useSupabaseScheduledActivitiesByDateRange(
             {
               status: a.status ?? "scheduled",
               patientId: a.patient_id,
-              treatmentId: a.treatment_id ?? null,
             },
           ]),
         );
@@ -280,13 +280,21 @@ export function useSupabaseScheduledActivitiesByDateRange(
           );
         }
 
-        const treatmentIds = Array.from(
-          new Set(
-            Array.from(apptMap.values())
-              .map((a) => a.treatmentId)
-              .filter((id): id is string => !!id),
-          ),
-        );
+        // Resolve treatment IDs from the junction table (supports multi-treatment appointments).
+        // Rows are ordered by sort_order; first row per appointment_id is the primary treatment.
+        const { data: junctionRows } = await client
+          .from("gabinet_appointment_treatments")
+          .select("appointment_id,treatment_id,sort_order")
+          .in("appointment_id", gabinetEntityIds)
+          .not("treatment_id", "is", null)
+          .order("sort_order", { ascending: true });
+        for (const row of ((junctionRows ?? []) as Array<{ appointment_id: string; treatment_id: string | null; sort_order: number }>)) {
+          if (row.treatment_id && !apptTreatmentMap.has(row.appointment_id)) {
+            apptTreatmentMap.set(row.appointment_id, row.treatment_id);
+          }
+        }
+
+        const treatmentIds = Array.from(new Set(Array.from(apptTreatmentMap.values())));
         if (treatmentIds.length > 0) {
           const { data: treatments } = await client
             .from("gabinet_treatments")
@@ -311,8 +319,9 @@ export function useSupabaseScheduledActivitiesByDateRange(
             metadata.status = appt.status;
             metadata.appointmentId = moduleRef.entityId;
             metadata.patientName = patientMap.get(appt.patientId) ?? undefined;
-            if (appt.treatmentId) {
-              metadata.treatmentName = treatmentMap.get(appt.treatmentId) ?? undefined;
+            const treatmentId = apptTreatmentMap.get(moduleRef.entityId);
+            if (treatmentId) {
+              metadata.treatmentName = treatmentMap.get(treatmentId) ?? undefined;
             }
           }
         }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3403.

Closes #3403

---

## Claude summary

The fix is committed. Here's what changed in `src/hooks/use-supabase-scheduled-activities.ts`:

- **Before**: the query selected `treatment_id` directly from `gabinet_appointments` (the old scalar column, stale since migration #00069 introduced the junction table).
- **After**: `gabinet_appointments` is queried without `treatment_id`; a separate query against `gabinet_appointment_treatments` retrieves all junction rows for the relevant appointment IDs ordered by `sort_order`. The first row per `appointment_id` (lowest `sort_order`) is treated as the primary treatment for display. The `treatmentName` calendar metadata is populated the same way as before, just sourced correctly from the junction table.

This matches the pattern already used in `use-supabase-gabinet-dashboard.ts`.