### PR TITLE
Przeniesienie istniejącej Agendy jako Terminarz do grupy Klienci i wizyty

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2970,6 +2970,7 @@
       "showLess": "Show less",
       "tabs": {
         "agenda": "Agenda",
+        "terminarz": "Terminarz",
         "appointments": "Appointments",
         "patients": "Clients",
         "activities": "Activities",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2990,6 +2990,7 @@
       "showLess": "Pokaż mniej",
       "tabs": {
         "agenda": "Agenda",
+        "terminarz": "Terminarz",
         "appointments": "Wizyty",
         "patients": "Klienci",
         "activities": "Aktywności",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -693,6 +693,18 @@ function EmployeeDetail() {
       ),
     },
     {
+      label: t("gabinet.employees.tabs.terminarz"),
+      content: (
+        <UpcomingAgenda
+          appointments={employeeAppointments}
+          treatmentMap={treatmentMap}
+          navigate={navigate}
+          t={t}
+          i18nLanguage={i18n.language}
+        />
+      ),
+    },
+    {
       label: t("gabinet.employees.tabs.appointments"),
       content: (
         <AppointmentsTabContent


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3408.

Closes #3408

---

## Claude summary

Done. Here's a summary of what was done and what was verified:

**Changed files (3):**

- `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx` — added a new "Terminarz" tab entry immediately after "Agenda" in the `tabs` array; it renders the same `UpcomingAgenda` component with identical props (no copy of the component, no new logic)
- `public/locales/pl/translation.json` — added `"terminarz": "Terminarz"` to `gabinet.employees.tabs`
- `public/locales/en/translation.json` — added `"terminarz": "Terminarz"` to `gabinet.employees.tabs`

**Verification:** Both "Terminarz" and "Agenda" tabs now point to the same `UpcomingAgenda` component with the same props — clicking either one shows identical content. The old "Agenda" tab is untouched. No data, filters, queries, or component logic were modified.