### PR TITLE
Zmiana nazwy Agenda na Terminarz w nowej nawigacji

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -681,18 +681,6 @@ function EmployeeDetail() {
   // Tabs definition
   const tabs = !employee ? [] : [
     {
-      label: t("gabinet.employees.tabs.agenda"),
-      content: (
-        <UpcomingAgenda
-          appointments={employeeAppointments}
-          treatmentMap={treatmentMap}
-          navigate={navigate}
-          t={t}
-          i18nLanguage={i18n.language}
-        />
-      ),
-    },
-    {
       label: t("gabinet.employees.tabs.terminarz"),
       content: (
         <UpcomingAgenda
@@ -858,7 +846,7 @@ function EmployeeDetail() {
         expandedFieldCount={5}
         sidebarExtra={sidebarExtra}
         tabs={tabs}
-        defaultTab={t("gabinet.employees.tabs.agenda")}
+        defaultTab={t("gabinet.employees.tabs.terminarz")}
         beforeTabs={
           <EmployeeNavGroups
             activeGroup={activeNavGroup}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3409.

Closes #3409

---

## Claude summary

Done. Here's a summary of what changed and how it was verified.

**Changed file:** `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx`

Two edits:
1. Removed the old "Agenda" tab entry (lines 682–694 before the patch) — it was a duplicate of the "Terminarz" tab added in #3408 and served only as a temporary safety fallback.
2. Changed `defaultTab` from `t("gabinet.employees.tabs.agenda")` → `t("gabinet.employees.tabs.terminarz")` so the page opens on the renamed sub-view.

**Untouched:** SmartAgenda widget (`src/components/sidebar-widgets/smart-agenda.tsx`), AgendaStrip (`src/components/layout/agenda-strip.tsx`), and all other `Agenda`-named components in the app remain exactly as-is. The `gabinet.employees.tabs.agenda` translation key in both locale files is now unused but harmless.

## Follow-ups

- Remove stale `gabinet.employees.tabs.agenda` translation key: The key exists in `public/locales/en/translation.json:2972` and `public/locales/pl/translation.json:2992` but is no longer referenced anywhere in source — clean it up to avoid confusion.