### PR TITLE
Remove stale `gabinet.employees.tabs.agenda` translation key

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2969,7 +2969,6 @@
       "showMore": "Show {{count}} more",
       "showLess": "Show less",
       "tabs": {
-        "agenda": "Agenda",
         "terminarz": "Terminarz",
         "appointments": "Appointments",
         "patients": "Clients",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2989,7 +2989,6 @@
       "showMore": "Pokaż {{count}} więcej",
       "showLess": "Pokaż mniej",
       "tabs": {
-        "agenda": "Agenda",
         "terminarz": "Terminarz",
         "appointments": "Wizyty",
         "patients": "Klienci",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3412.

Closes #3412

---

## Claude summary

Done. Removed the stale `gabinet.employees.tabs.agenda` key from both `public/locales/en/translation.json` (was line 2972) and `public/locales/pl/translation.json` (was line 2992). No source file references this key — it was left over after issue #3409 renamed the tab to `terminarz`.