### PR TITLE
Podłączenie podmenu Klienci i wizyty

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -168,8 +168,18 @@ function EmployeeDetail() {
   const [newNote, setNewNote] = useState("");
   const [isAddingNote, setIsAddingNote] = useState(false);
 
-  // Main navigation groups (preparatory layer for future micro-tasks)
+  // Main navigation groups: controls which sub-tabs are visible
   const [activeNavGroup, setActiveNavGroup] = useState<string>("clientsAndVisits");
+  const [activeTab, setActiveTab] = useState<string>(t("gabinet.employees.tabs.terminarz"));
+
+  const handleNavGroupChange = (group: string) => {
+    setActiveNavGroup(group);
+    if (group === "clientsAndVisits") {
+      setActiveTab(t("gabinet.employees.tabs.terminarz"));
+    } else {
+      setActiveTab("");
+    }
+  };
 
   // Feature 1: Appointments view mode (calendar vs list)
   const [appointmentsView, setAppointmentsView] = useState<"calendar" | "list">("calendar");
@@ -831,6 +841,9 @@ function EmployeeDetail() {
       : []),
   ];
 
+  // Show only the 3 sub-tabs for "Klienci i wizyty"; other groups have no connected views yet
+  const visibleTabs = activeNavGroup === "clientsAndVisits" ? tabs.slice(0, 3) : [];
+
   return (
     <>
       <EntityDetailLayout
@@ -845,12 +858,13 @@ function EmployeeDetail() {
         fields={detailFields}
         expandedFieldCount={5}
         sidebarExtra={sidebarExtra}
-        tabs={tabs}
-        defaultTab={t("gabinet.employees.tabs.terminarz")}
+        tabs={visibleTabs}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
         beforeTabs={
           <EmployeeNavGroups
             activeGroup={activeNavGroup}
-            onGroupChange={setActiveNavGroup}
+            onGroupChange={handleNavGroupChange}
             t={t}
           />
         }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3416.

Closes #3416

---

## Claude summary

The fix is committed. Here's a summary of what was done and verified:

**Changed file:** `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx`

**What the problem was:** The `EmployeeNavGroups` component (rendering the 5 main group buttons) was wired to `setActiveNavGroup` but the tabs array was always passed in full — all tabs (Terminarz, Wizyty, Klienci, Dane szczegółowe, Grafik, Dokumenty, etc.) were always visible regardless of the selected group.

**What the fix does:**
1. Adds `activeTab` state (initialized to "Terminarz") and switches `EntityDetailLayout` to controlled-tab mode via `activeTab`/`onTabChange` props.
2. Adds `handleNavGroupChange` which resets `activeTab` to "Terminarz" when switching to "Klienci i wizyty", and to `""` (no selection) when switching to any other group.
3. Computes `visibleTabs = tabs.slice(0, 3)` (Terminarz, Wizyty, Klienci) when the active group is "clientsAndVisits", and `[]` for all other groups — fulfilling the requirement that other groups show no connected views yet.

**Result:** Clicking "Klienci i wizyty" shows exactly Terminarz | Wizyty | Klienci below it. Clicking Grafik, Dane pracownika, Dokumenty i mienie, or Konto i dostęp hides those three items. No views, data logic, or other navigation was modified.

## Follow-ups

- Wire remaining nav groups to their tabs when ready: "Grafik" → schedule tab, "Dane pracownika" → detailedData tab, "Dokumenty i mienie" → documents + assignedItems tabs, "Konto i dostęp" → permissions tab; currently those groups show an empty tab area.
- `gabinet.employees.tabs.documents` translation key is missing in `public/locales/pl/translation.json` (falls back to hardcoded "Dokumenty"); should be added to the translation file like other tab keys.