### PR TITLE
Fix English locale value for `gabinet.employees.tabs.terminarz`

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2969,7 +2969,7 @@
       "showMore": "Show {{count}} more",
       "showLess": "Show less",
       "tabs": {
-        "terminarz": "Terminarz",
+        "terminarz": "Calendar",
         "appointments": "Appointments",
         "patients": "Clients",
         "activities": "Activities",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3417.

Closes #3417

---

## Claude summary

Fixed. The EN translation at `public/locales/en/translation.json:2972` now reads `"terminarz": "Calendar"` instead of the Polish `"Terminarz"`. "Calendar" was chosen over "Schedule" because the `schedule` key in the same block already maps to "Schedule" (which corresponds to the Polish "Grafik" = work rota), while "Terminarz" in Polish means an appointment calendar/planner — a semantically distinct concept.