### PR TITLE
Wire remaining nav groups to their tabs when ready

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -176,6 +176,14 @@ function EmployeeDetail() {
     setActiveNavGroup(group);
     if (group === "clientsAndVisits") {
       setActiveTab(t("gabinet.employees.tabs.terminarz"));
+    } else if (group === "schedule") {
+      setActiveTab(t("gabinet.employees.tabs.schedule"));
+    } else if (group === "employeeData") {
+      setActiveTab(t("gabinet.employees.tabs.detailedData"));
+    } else if (group === "documentsAndAssets") {
+      setActiveTab(t("gabinet.employees.tabs.documents", "Dokumenty"));
+    } else if (group === "accountAndAccess") {
+      setActiveTab(t("gabinet.employees.tabs.permissions", "Uprawnienia"));
     } else {
       setActiveTab("");
     }
@@ -841,8 +849,26 @@ function EmployeeDetail() {
       : []),
   ];
 
-  // Show only the 3 sub-tabs for "Klienci i wizyty"; other groups have no connected views yet
-  const visibleTabs = activeNavGroup === "clientsAndVisits" ? tabs.slice(0, 3) : [];
+  const visibleTabs = (() => {
+    switch (activeNavGroup) {
+      case "clientsAndVisits":
+        return tabs.slice(0, 3);
+      case "schedule":
+        return tabs.filter(tab => tab.label === t("gabinet.employees.tabs.schedule"));
+      case "employeeData":
+        return tabs.filter(tab => tab.label === t("gabinet.employees.tabs.detailedData"));
+      case "documentsAndAssets":
+        return tabs.filter(
+          tab =>
+            tab.label === t("gabinet.employees.tabs.documents", "Dokumenty") ||
+            tab.label === t("gabinet.employees.tabs.assignedItems")
+        );
+      case "accountAndAccess":
+        return tabs.filter(tab => tab.label === t("gabinet.employees.tabs.permissions", "Uprawnienia"));
+      default:
+        return [];
+    }
+  })();
 
   return (
     <>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3419.

Closes #3419

---

## Claude summary

The fix is committed. Here's a summary:

**Root cause:** In `_layout.gabinet.employees.$employeeId.tsx`, the `visibleTabs` computation (formerly line 845) always returned `[]` for any nav group other than `clientsAndVisits`, and `handleNavGroupChange` set `activeTab` to `""` for those same groups. This is because the comment explicitly said "other groups have no connected views yet."

**Fix — two changes in one file:**

1. `handleNavGroupChange` now sets the correct first tab when switching to each group: `schedule` → schedule tab, `employeeData` → detailedData tab, `documentsAndAssets` → documents tab, `accountAndAccess` → permissions tab.

2. `visibleTabs` now uses a `switch` to filter tabs by their translated label for each group:
   - `clientsAndVisits` → terminarz + appointments + patients (first 3 tabs)
   - `schedule` → schedule tab only
   - `employeeData` → detailedData tab only
   - `documentsAndAssets` → documents + assignedItems tabs
   - `accountAndAccess` → permissions tab (only visible if role is admin/owner, since the tab itself is conditionally added)