### PR TITLE
`gabinet.employees.tabs.documents` translation key is missing in `public/locales

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2977,6 +2977,8 @@
         "schedule": "Schedule",
         "assignedItems": "Materials",
         "notes": "Notes",
+        "documents": "Documents",
+        "permissions": "Permissions",
         "noPatients": "No clients seen yet."
       },
       "agenda": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2997,6 +2997,8 @@
         "schedule": "Grafik",
         "assignedItems": "Materiały",
         "notes": "Notatki",
+        "documents": "Dokumenty",
+        "permissions": "Uprawnienia",
         "noPatients": "Brak obsługiwanych klientów."
       },
       "agenda": {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3420.

Closes #3420

---

## Claude summary

The issue was real and is now fixed. Both `gabinet.employees.tabs.documents` and `gabinet.employees.tabs.permissions` were missing from both PL and EN translation files, while the component at `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx` used them with hardcoded fallbacks (`"Dokumenty"`/`"Uprawnienia"` and `"Documents"`/`"Permissions"`). The fix adds both keys to `public/locales/pl/translation.json` and `public/locales/en/translation.json`.

## Follow-ups

- Add `gabinet.employees.tabs.permissions` was also missing alongside `documents`: already fixed in this PR, but the component at `_layout.gabinet.employees.$employeeId.tsx:186,838,867` used a hardcoded fallback "Uprawnienia"/"Permissions" — now resolved by the same commit.