### PR TITLE
Podłączenie istniejącego Grafiku pracy do grupy Grafik

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2975,6 +2975,7 @@
         "activities": "Activities",
         "detailedData": "Detailed Data",
         "schedule": "Schedule",
+        "grafikPracy": "Work Schedule",
         "assignedItems": "Materials",
         "notes": "Notes",
         "documents": "Documents",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2995,6 +2995,7 @@
         "activities": "Aktywności",
         "detailedData": "Dane szczegółowe",
         "schedule": "Grafik",
+        "grafikPracy": "Grafik pracy",
         "assignedItems": "Materiały",
         "notes": "Notatki",
         "documents": "Dokumenty",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -177,7 +177,7 @@ function EmployeeDetail() {
     if (group === "clientsAndVisits") {
       setActiveTab(t("gabinet.employees.tabs.terminarz"));
     } else if (group === "schedule") {
-      setActiveTab(t("gabinet.employees.tabs.schedule"));
+      setActiveTab(t("gabinet.employees.tabs.grafikPracy"));
     } else if (group === "employeeData") {
       setActiveTab(t("gabinet.employees.tabs.detailedData"));
     } else if (group === "documentsAndAssets") {
@@ -772,7 +772,7 @@ function EmployeeDetail() {
       ),
     },
     {
-      label: t("gabinet.employees.tabs.schedule"),
+      label: t("gabinet.employees.tabs.grafikPracy"),
       content: (
         <FlexibleScheduleEditor
           organizationId={organizationId}
@@ -854,7 +854,7 @@ function EmployeeDetail() {
       case "clientsAndVisits":
         return tabs.slice(0, 3);
       case "schedule":
-        return tabs.filter(tab => tab.label === t("gabinet.employees.tabs.schedule"));
+        return tabs.filter(tab => tab.label === t("gabinet.employees.tabs.grafikPracy"));
       case "employeeData":
         return tabs.filter(tab => tab.label === t("gabinet.employees.tabs.detailedData"));
       case "documentsAndAssets":


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3421.

Closes #3421

---

## Claude summary

Done. Here's a summary of what was changed:

**Files changed (3):**

1. `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx` — 3 places updated:
   - Tab label: `t("gabinet.employees.tabs.schedule")` → `t("gabinet.employees.tabs.grafikPracy")`
   - `handleNavGroupChange` for `"schedule"` group: sets `activeTab` to the new key
   - `visibleTabs` case `"schedule"`: filters tabs by the new label

2. `public/locales/pl/translation.json` — added `"grafikPracy": "Grafik pracy"` inside `gabinet.employees.tabs`

3. `public/locales/en/translation.json` — added `"grafikPracy": "Work Schedule"` inside `gabinet.employees.tabs`

**Effect:** Clicking the "Grafik" nav group now shows a single submenu tab labeled "Grafik pracy". Opening it displays the existing `FlexibleScheduleEditor` with the "Zarządzaj urlopami" button unchanged. The "Terminarz/Wizyty/Klienci" submenu items from "Klienci i wizyty" are not visible when "Grafik" is active. No view was copied or created.