### PR TITLE
Podłączenie istniejących widoków do grupy Dane pracownika

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -856,7 +856,11 @@ function EmployeeDetail() {
       case "schedule":
         return tabs.filter(tab => tab.label === t("gabinet.employees.tabs.grafikPracy"));
       case "employeeData":
-        return tabs.filter(tab => tab.label === t("gabinet.employees.tabs.detailedData"));
+        return tabs.filter(
+          tab =>
+            tab.label === t("gabinet.employees.tabs.detailedData") ||
+            tab.label === t("gabinet.employees.tabs.notes")
+        );
       case "documentsAndAssets":
         return tabs.filter(
           tab =>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3423.

Closes #3423

---

## Claude summary

Done. One file changed, one targeted fix.

**What was changed:** `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx` line 859 — the `employeeData` case in `visibleTabs` now includes both `detailedData` and `notes` tabs, instead of only `detailedData`.

**How it works:** When the user clicks "Dane pracownika" in the top navigation group bar, the `activeNavGroup` becomes `"employeeData"`. The `visibleTabs` filter now returns both the "Dane szczegółowe" tab (which shows `DetailedDataTab` with all existing sections: dane osobowe, zatrudnienie, kwalifikacje i umiejętności, przypisane zabiegi, wynagrodzenie) and the "Notatki" tab (which shows `NotesTabContent`). The default active tab remains "Dane szczegółowe" as set in `handleNavGroupChange`. No other groups were touched; no views were copied or modified.