### PR TITLE
Podłączenie istniejących widoków do grupy Dokumenty i mienie

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2976,7 +2976,7 @@
         "detailedData": "Detailed Data",
         "schedule": "Schedule",
         "grafikPracy": "Work Schedule",
-        "assignedItems": "Materials",
+        "assignedItems": "Issued materials",
         "notes": "Notes",
         "documents": "Documents",
         "permissions": "Permissions",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2996,7 +2996,7 @@
         "detailedData": "Dane szczegółowe",
         "schedule": "Grafik",
         "grafikPracy": "Grafik pracy",
-        "assignedItems": "Materiały",
+        "assignedItems": "Wydane materiały",
         "notes": "Notatki",
         "documents": "Dokumenty",
         "permissions": "Uprawnienia",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3425.

Closes #3425

---

## Claude summary

Done. Here's a summary of what was done and verified:

**Triage:** The issue is real. The "Dokumenty i mienie" nav group was wired to the correct tabs (Documents + AssignedItems) in PR #3419, but the "Materiały" tab label was not yet renamed to "Wydane materiały" as required.

**Root cause:** `gabinet.employees.tabs.assignedItems` translation key had value "Materiały" (PL) / "Materials" (EN), but the issue requires it to show as "Wydane materiały" in the nav.

**Fix:** Changed the translation values only — the technical key `assignedItems` is preserved exactly as required by the guardrails.

**Files changed:**
- `public/locales/pl/translation.json` — `assignedItems` tab label: `"Materiały"` → `"Wydane materiały"`
- `public/locales/en/translation.json` — `assignedItems` tab label: `"Materials"` → `"Issued materials"`

**No code logic changes needed** — the `visibleTabs` filter at line 864-869 uses `t("gabinet.employees.tabs.assignedItems")` for both the tab label and the filter comparison, so they always match regardless of the translation value.

**Verification:** The `visibleTabs` switch-case for `"documentsAndAssets"` already correctly shows only "Dokumenty" and "assignedItems" tabs when that nav group is active, satisfying all the guardrails (no other group's submenu is visible, no views duplicated, no DB changes).