### PR TITLE
Podłączenie istniejących widoków do grupy Konto i dostęp

### DIFF
--- a/session_state.json
+++ b/session_state.json
@@ -1,9 +1,9 @@
 {
-  "session_id": "S0105",
-  "started_at": "2026-07-15T10:08:00Z",
-  "last_updated": "2026-07-15T10:08:40Z",
+  "session_id": "S0106",
+  "started_at": "2026-07-22T00:00:00Z",
+  "last_updated": "2026-07-22T00:00:00Z",
   "status": "completed",
-  "focus": "Issue #3182: Add unique constraint violation test cases to format-action-error.test.ts",
+  "focus": "Issue #3426: Wire Aktywność and Uprawnienia to Konto i dostęp nav group",
   "tasks_snapshot": {
     "total": 1,
     "not_started": 0,
@@ -14,5 +14,5 @@
   },
   "active_task_ids": [],
   "blockers": [],
-  "notes": "S0105: Added 3 test cases for the uniqueCon parser in extractFieldValidationDetail: (1) _key suffix with identified column (products_sku_key → sku → SKU), (2) _idx suffix with identified column (products_org_sku_idx → sku → SKU), (3) fallback when column not identified (raw constraint name + 'Pole' label). All 17 tests pass."
+  "notes": "S0106: Added Aktywność tab to the accountAndAccess case in visibleTabs filter. One-line change in _layout.gabinet.employees.$employeeId.tsx line 870-875."
 }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -868,7 +868,11 @@ function EmployeeDetail() {
             tab.label === t("gabinet.employees.tabs.assignedItems")
         );
       case "accountAndAccess":
-        return tabs.filter(tab => tab.label === t("gabinet.employees.tabs.permissions", "Uprawnienia"));
+        return tabs.filter(
+          tab =>
+            tab.label === t("gabinet.employees.activity") ||
+            tab.label === t("gabinet.employees.tabs.permissions", "Uprawnienia")
+        );
       default:
         return [];
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3426.

Closes #3426

---

## Claude summary

Done. Here's what was changed:

**File modified:** `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx` (lines 870-875)

The `accountAndAccess` case in the `visibleTabs` filter previously only included the "Uprawnienia" tab. It now also includes "Aktywność":

```typescript
// Before
case "accountAndAccess":
  return tabs.filter(tab => tab.label === t("gabinet.employees.tabs.permissions", "Uprawnienia"));

// After
case "accountAndAccess":
  return tabs.filter(
    tab =>
      tab.label === t("gabinet.employees.activity") ||
      tab.label === t("gabinet.employees.tabs.permissions", "Uprawnienia")
  );
```

Both views already existed — the "Aktywność" tab was defined at line 827 (renders `ActivityFeed` with the employee's activity entries) and "Uprawnienia" at line 838 (renders `EmployeePermissionsTab`, visible only for admin/owner roles). No content, data, or other nav groups were touched.