### PR TITLE
Wydzielenie Danych i zatrudnienia w grupie Dane pracownika

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2973,6 +2973,7 @@
         "appointments": "Appointments",
         "patients": "Clients",
         "activities": "Activities",
+        "dataAndEmployment": "Data and Employment",
         "detailedData": "Detailed Data",
         "schedule": "Schedule",
         "grafikPracy": "Work Schedule",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2993,6 +2993,7 @@
         "appointments": "Wizyty",
         "patients": "Klienci",
         "activities": "Aktywności",
+        "dataAndEmployment": "Dane i zatrudnienie",
         "detailedData": "Dane szczegółowe",
         "schedule": "Grafik",
         "grafikPracy": "Grafik pracy",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -179,7 +179,7 @@ function EmployeeDetail() {
     } else if (group === "schedule") {
       setActiveTab(t("gabinet.employees.tabs.grafikPracy"));
     } else if (group === "employeeData") {
-      setActiveTab(t("gabinet.employees.tabs.detailedData"));
+      setActiveTab(t("gabinet.employees.tabs.dataAndEmployment"));
     } else if (group === "documentsAndAssets") {
       setActiveTab(t("gabinet.employees.tabs.documents", "Dokumenty"));
     } else if (group === "accountAndAccess") {
@@ -749,6 +749,30 @@ function EmployeeDetail() {
       ),
     },
     {
+      label: t("gabinet.employees.tabs.dataAndEmployment"),
+      content: (
+        <DetailedDataTab
+          employee={employee}
+          userEmail={user?.email}
+          treatments={treatments}
+          treatmentMap={treatmentMap}
+          organizationId={organizationId}
+          role={role}
+          onChangePassword={() => {
+            setNewPassword("");
+            setConfirmPassword("");
+            setChangePasswordError(null);
+            setChangePasswordOpen(true);
+          }}
+          onUpdate={async (a) => { await updateEmployee(a); invalidateEmployeeCache(); }}
+          onSetTreatments={async (a) => { await setQualifiedTreatments(a); invalidateEmployeeCache(); }}
+          t={t}
+          i18nLanguage={i18n.language}
+          limitedView={true}
+        />
+      ),
+    },
+    {
       label: t("gabinet.employees.tabs.detailedData"),
       content: (
         <DetailedDataTab
@@ -858,7 +882,7 @@ function EmployeeDetail() {
       case "employeeData":
         return tabs.filter(
           tab =>
-            tab.label === t("gabinet.employees.tabs.detailedData") ||
+            tab.label === t("gabinet.employees.tabs.dataAndEmployment") ||
             tab.label === t("gabinet.employees.tabs.notes")
         );
       case "documentsAndAssets":
@@ -1917,6 +1941,7 @@ function DetailedDataTab({
   onSetTreatments,
   t,
   i18nLanguage,
+  limitedView,
 }: {
   employee: MappedGabinetEmployee;
   userEmail?: string | null;
@@ -1929,6 +1954,7 @@ function DetailedDataTab({
   onSetTreatments: (args: FunctionArgs<typeof api.gabinet.employees.setQualifiedTreatments>) => Promise<void>;
   t: TFunction;
   i18nLanguage: string;
+  limitedView?: boolean;
 }) {
   const [editing, setEditing] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -2428,6 +2454,7 @@ function DetailedDataTab({
         </CardContent>
       </Card>
 
+      {!limitedView && <>
       {/* Section: Kwalifikacje (Qualifications) */}
       <Card>
         <CardContent className="pt-6">
@@ -2712,6 +2739,7 @@ function DetailedDataTab({
           )}
         </CardContent>
       </Card>
+      </>}
     </div>
   );
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3433.

Closes #3433

---

## Claude summary

Done. Here's a summary of what changed and why:

**Changed files (3):**

`src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx`
- Added `limitedView?: boolean` prop to `DetailedDataTab` — when `true`, the Kwalifikacje, Przypisane zabiegi, and Wynagrodzenie sections are hidden via `{!limitedView && <> ... </>}`.
- Added a new `"dataAndEmployment"` tab entry that renders `DetailedDataTab` with `limitedView={true}`. The existing `"detailedData"` tab remains in the tabs array but is no longer attached to any nav group.
- Updated `handleNavGroupChange` for `"employeeData"` to set the active tab to `dataAndEmployment` instead of `detailedData`.
- Updated `visibleTabs` for `"employeeData"` to filter on `dataAndEmployment` and `notes`.

`public/locales/pl/translation.json` — added `"dataAndEmployment": "Dane i zatrudnienie"` under `gabinet.employees.tabs`.

`public/locales/en/translation.json` — added `"dataAndEmployment": "Data and Employment"` under `gabinet.employees.tabs`.

**Result:** The "Dane pracownika" group now shows two subviews — "Dane i zatrudnienie" (with only Dane osobowe + Zatrudnienie sections, including their Edit buttons, validation and save logic unchanged) and "Notatki". No forms were duplicated, no data moved, no database changes.