### PR TITLE
Wydzielenie Kwalifikacji i zabiegów w grupie Dane pracownika

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2974,6 +2974,7 @@
         "patients": "Clients",
         "activities": "Activities",
         "dataAndEmployment": "Data and Employment",
+        "qualificationsAndTreatments": "Qualifications and Treatments",
         "detailedData": "Detailed Data",
         "schedule": "Schedule",
         "grafikPracy": "Work Schedule",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2994,6 +2994,7 @@
         "patients": "Klienci",
         "activities": "Aktywności",
         "dataAndEmployment": "Dane i zatrudnienie",
+        "qualificationsAndTreatments": "Kwalifikacje i zabiegi",
         "detailedData": "Dane szczegółowe",
         "schedule": "Grafik",
         "grafikPracy": "Grafik pracy",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -773,6 +773,24 @@ function EmployeeDetail() {
       ),
     },
     {
+      label: t("gabinet.employees.tabs.qualificationsAndTreatments"),
+      content: (
+        <DetailedDataTab
+          employee={employee}
+          userEmail={user?.email}
+          treatments={treatments}
+          treatmentMap={treatmentMap}
+          organizationId={organizationId}
+          role={role}
+          onUpdate={async (a) => { await updateEmployee(a); invalidateEmployeeCache(); }}
+          onSetTreatments={async (a) => { await setQualifiedTreatments(a); invalidateEmployeeCache(); }}
+          t={t}
+          i18nLanguage={i18n.language}
+          qualificationsOnlyView={true}
+        />
+      ),
+    },
+    {
       label: t("gabinet.employees.tabs.detailedData"),
       content: (
         <DetailedDataTab
@@ -883,6 +901,7 @@ function EmployeeDetail() {
         return tabs.filter(
           tab =>
             tab.label === t("gabinet.employees.tabs.dataAndEmployment") ||
+            tab.label === t("gabinet.employees.tabs.qualificationsAndTreatments") ||
             tab.label === t("gabinet.employees.tabs.notes")
         );
       case "documentsAndAssets":
@@ -1942,6 +1961,7 @@ function DetailedDataTab({
   t,
   i18nLanguage,
   limitedView,
+  qualificationsOnlyView,
 }: {
   employee: MappedGabinetEmployee;
   userEmail?: string | null;
@@ -1955,6 +1975,7 @@ function DetailedDataTab({
   t: TFunction;
   i18nLanguage: string;
   limitedView?: boolean;
+  qualificationsOnlyView?: boolean;
 }) {
   const [editing, setEditing] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -2208,6 +2229,7 @@ function DetailedDataTab({
 
   return (
     <div className="space-y-6 max-w-3xl">
+      {!qualificationsOnlyView && <>
       {/* Section: Dane osobowe (Personal Data) */}
       <Card>
         <CardContent className="pt-6">
@@ -2453,8 +2475,9 @@ function DetailedDataTab({
           )}
         </CardContent>
       </Card>
+      </>}
 
-      {!limitedView && <>
+      {(!limitedView || qualificationsOnlyView) && <>
       {/* Section: Kwalifikacje (Qualifications) */}
       <Card>
         <CardContent className="pt-6">
@@ -2671,6 +2694,7 @@ function DetailedDataTab({
         </CardContent>
       </Card>
 
+      {!qualificationsOnlyView && <>
       {/* Section: Wynagrodzenie (Compensation) */}
       <Card>
         <CardContent className="pt-6">
@@ -2739,6 +2763,7 @@ function DetailedDataTab({
           )}
         </CardContent>
       </Card>
+      </>}
       </>}
     </div>
   );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3435.

Closes #3435

---

## Claude summary

Done. Here's a summary of what was changed:

**Files modified (3):**

1. `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx` — three changes:
   - Added `qualificationsOnlyView?: boolean` prop to `DetailedDataTab`. When true, it hides the personal data + employment sections and the compensation section, showing only the Kwalifikacje i umiejętności and Przypisane zabiegi cards. The existing Edit buttons, save logic, and validation remain fully intact.
   - Added a new `Kwalifikacje i zabiegi` tab that renders `DetailedDataTab` with `qualificationsOnlyView={true}`.
   - Wired the new tab into the `employeeData` nav group's `visibleTabs` filter (alongside `Dane i zatrudnienie` and `Notatki`).

2. `public/locales/pl/translation.json` — added `"qualificationsAndTreatments": "Kwalifikacje i zabiegi"` under `gabinet.employees.tabs`.

3. `public/locales/en/translation.json` — added `"qualificationsAndTreatments": "Qualifications and Treatments"` under `gabinet.employees.tabs`.

**Result:** Navigating to `Dane pracownika` now shows three sub-tabs: `Dane i zatrudnienie`, `Kwalifikacje i zabiegi`, and `Notatki`. The `Kwalifikacje i zabiegi` tab displays exactly the two existing sections with their Edit/save functionality unchanged. No database migrations or form add-flow changes were made.