### PR TITLE
Dodanie podwidoku Konto w grupie Konto i dostęp

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2961,6 +2961,10 @@
       "passwordTooShort": "Password must be at least 8 characters.",
       "passwordNeedsUppercase": "Password must contain at least 1 uppercase letter.",
       "passwordNeedsDigit": "Password must contain at least 1 digit.",
+      "loginEmail": "Login email address",
+      "accountStatus": "Account status",
+      "accountActive": "Active",
+      "accountInactive": "Inactive",
       "details": "Details",
       "activity": "Activity",
       "qualifications": "Treatment Qualifications",
@@ -2983,6 +2987,7 @@
         "notes": "Notes",
         "documents": "Documents",
         "permissions": "Permissions",
+        "account": "Account",
         "noPatients": "No clients seen yet."
       },
       "agenda": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2981,6 +2981,10 @@
       "passwordTooShort": "Hasło musi mieć co najmniej 8 znaków.",
       "passwordNeedsUppercase": "Hasło musi zawierać co najmniej 1 wielką literę.",
       "passwordNeedsDigit": "Hasło musi zawierać co najmniej 1 cyfrę.",
+      "loginEmail": "Adres e-mail do logowania",
+      "accountStatus": "Status konta",
+      "accountActive": "Aktywny",
+      "accountInactive": "Nieaktywny",
       "details": "Szczegóły",
       "activity": "Aktywność",
       "qualifications": "Kwalifikacje zabiegowe",
@@ -3003,6 +3007,7 @@
         "notes": "Notatki",
         "documents": "Dokumenty",
         "permissions": "Uprawnienia",
+        "account": "Konto",
         "noPatients": "Brak obsługiwanych klientów."
       },
       "agenda": {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -187,7 +187,7 @@ function EmployeeDetail() {
     } else if (group === "documentsAndAssets") {
       setActiveTab(t("gabinet.employees.tabs.documents", "Dokumenty"));
     } else if (group === "accountAndAccess") {
-      setActiveTab(t("gabinet.employees.tabs.permissions", "Uprawnienia"));
+      setActiveTab(t("gabinet.employees.tabs.account", "Konto"));
     } else {
       setActiveTab("");
     }
@@ -870,6 +870,39 @@ function EmployeeDetail() {
       ),
     },
     {
+      label: t("gabinet.employees.tabs.account", "Konto"),
+      content: (
+        <Card>
+          <CardContent className="pt-6 space-y-4">
+            <div>
+              <p className="text-xs text-muted-foreground">{t("gabinet.employees.loginEmail", "Adres e-mail do logowania")}</p>
+              <p className="text-sm font-medium">{employee.email || user?.email || "—"}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">{t("gabinet.employees.accountStatus", "Status konta")}</p>
+              <Badge variant={employee.isActive ? "default" : "secondary"}>
+                {employee.isActive ? t("gabinet.employees.accountActive", "Aktywny") : t("gabinet.employees.accountInactive", "Nieaktywny")}
+              </Badge>
+            </div>
+            {(role === "admin" || role === "owner") && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setNewPassword("");
+                  setConfirmPassword("");
+                  setChangePasswordError(null);
+                  setChangePasswordOpen(true);
+                }}
+              >
+                {t("gabinet.employees.changePassword")}
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      ),
+    },
+    {
       label: t("gabinet.employees.activity"),
       content: (
         <ActivityFeed
@@ -917,6 +950,7 @@ function EmployeeDetail() {
       case "accountAndAccess":
         return tabs.filter(
           tab =>
+            tab.label === t("gabinet.employees.tabs.account", "Konto") ||
             tab.label === t("gabinet.employees.activity") ||
             tab.label === t("gabinet.employees.tabs.permissions", "Uprawnienia")
         );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3441.

Closes #3441

---

## Claude summary

Done. Here's a summary of what was changed:

**Changed files (3):**

1. `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx` — three edits:
   - `handleNavGroupChange`: when switching to `accountAndAccess`, the default active tab is now `"Konto"` instead of `"Uprawnienia"`
   - Tabs array: added a new `"Konto"` tab (inserted before `"Aktywność"`) that renders the login email, account status badge (`isActive`), and — for `admin`/`owner` only — a "Zmień hasło" button that opens the existing change-password dialog
   - `visibleTabs`: the `accountAndAccess` case now includes `"Konto"` as the first matched tab, before `"Aktywność"` and `"Uprawnienia"`

2. `public/locales/pl/translation.json` — added `tabs.account: "Konto"`, `loginEmail`, `accountStatus`, `accountActive`, `accountInactive`

3. `public/locales/en/translation.json` — same keys in English

The result is: navigating to "Konto i dostęp" now shows three subtabs — **Konto → Aktywność → Uprawnienia** — and entering "Konto" shows the login email, active/inactive badge, and the change-password button (admin/owner only) that opens the pre-existing dialog. No new auth mechanism, no schema changes, no changes to other nav groups.