### PR TITLE
Pełnoekranowy wybór przypisanych zabiegów bez wewnętrznego przewijania

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -2767,51 +2767,17 @@ function DetailedDataTab({
       {/* Section: Przypisane zabiegi (Assigned Treatments) */}
       <Card>
         <CardContent className="pt-6">
-          {sectionHeader(
-            t("gabinet.employees.detailedData.assignedTreatments"),
-            "treatments",
-            <ClipboardList className="h-4 w-4" />,
-          )}
-          {editing === "treatments" ? (
-            <div className="space-y-3">
-              <div className="flex items-center w-full rounded-md border bg-transparent">
-                <Search className="ml-2 h-4 w-4 shrink-0 text-muted-foreground" variant="stroke" />
-                <input
-                  type="text"
-                  className="h-8 w-full bg-transparent px-2 text-sm outline-none placeholder:text-muted-foreground"
-                  placeholder={t("gabinet.employees.searchTreatments")}
-                  value={treatmentSearchLocal}
-                  onChange={(e) => setTreatmentSearchLocal(e.target.value)}
-                />
-              </div>
-              <div className="max-h-64 overflow-y-auto rounded-md border">
-                {filteredTreatmentsLocal.length === 0 ? (
-                  <p className="py-3 px-3 text-sm text-muted-foreground text-center">
-                    {t("detail.relationships.noResults")}
-                  </p>
-                ) : (
-                  filteredTreatmentsLocal.map((tr) => (
-                    <label
-                      key={tr._id}
-                      className="flex items-center gap-3 px-3 py-2 hover:bg-accent cursor-pointer"
-                    >
-                      <Checkbox
-                        checked={pendingTreatmentIds.includes(tr._id)}
-                        onCheckedChange={(checked) => {
-                          if (checked) {
-                            setPendingTreatmentIds([...pendingTreatmentIds, tr._id]);
-                          } else {
-                            setPendingTreatmentIds(pendingTreatmentIds.filter((id) => id !== tr._id));
-                          }
-                        }}
-                      />
-                      <span className="text-sm">{tr.name}</span>
-                    </label>
-                  ))
-                )}
-              </div>
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-2">
+              <span className="text-primary"><ClipboardList className="h-4 w-4" /></span>
+              <h4 className="text-base font-semibold">{t("gabinet.employees.detailedData.assignedTreatments")}</h4>
             </div>
-          ) : employee.qualifiedTreatmentIds.length > 0 ? (
+            <Button variant="ghost" size="sm" onClick={() => startEdit("treatments")}>
+              <Pencil className="h-3.5 w-3.5 mr-1" variant="stroke" />
+              {t("common.edit")}
+            </Button>
+          </div>
+          {employee.qualifiedTreatmentIds.length > 0 ? (
             <div className="flex flex-wrap gap-1.5">
               {employee.qualifiedTreatmentIds.map((tid) => (
                 <Badge key={tid} variant="secondary">
@@ -2826,6 +2792,58 @@ function DetailedDataTab({
           )}
         </CardContent>
       </Card>
+
+      <Dialog open={editing === "treatments"} onOpenChange={(open) => { if (!open) cancelEdit(); }}>
+        <DialogContent className="max-w-2xl flex flex-col overflow-hidden gap-4">
+          <DialogHeader>
+            <DialogTitle>{t("gabinet.employees.detailedData.assignedTreatments")}</DialogTitle>
+          </DialogHeader>
+          <div className="flex items-center w-full rounded-md border bg-transparent shrink-0">
+            <Search className="ml-2 h-4 w-4 shrink-0 text-muted-foreground" variant="stroke" />
+            <input
+              type="text"
+              className="h-8 w-full bg-transparent px-2 text-sm outline-none placeholder:text-muted-foreground"
+              placeholder={t("gabinet.employees.searchTreatments")}
+              value={treatmentSearchLocal}
+              onChange={(e) => setTreatmentSearchLocal(e.target.value)}
+            />
+          </div>
+          <div className="flex-1 overflow-y-auto rounded-md border min-h-0">
+            {filteredTreatmentsLocal.length === 0 ? (
+              <p className="py-3 px-3 text-sm text-muted-foreground text-center">
+                {t("detail.relationships.noResults")}
+              </p>
+            ) : (
+              filteredTreatmentsLocal.map((tr) => (
+                <label
+                  key={tr._id}
+                  className="flex items-center gap-3 px-3 py-2 hover:bg-accent cursor-pointer"
+                >
+                  <Checkbox
+                    checked={pendingTreatmentIds.includes(tr._id)}
+                    onCheckedChange={(checked) => {
+                      if (checked) {
+                        setPendingTreatmentIds([...pendingTreatmentIds, tr._id]);
+                      } else {
+                        setPendingTreatmentIds(pendingTreatmentIds.filter((id) => id !== tr._id));
+                      }
+                    }}
+                  />
+                  <span className="text-sm">{tr.name}</span>
+                </label>
+              ))
+            )}
+          </div>
+          <DialogFooter className="shrink-0">
+            <Button variant="ghost" onClick={cancelEdit}>
+              {t("common.cancel")}
+            </Button>
+            <Button onClick={() => saveSection("treatments")} disabled={saving}>
+              {saving ? t("common.saving") : t("common.save")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {!qualificationsOnlyView && <>
       {/* Section: Wynagrodzenie (Compensation) */}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3443.

Closes #3443

---

## Claude summary

Done. Here's a summary of what changed:

**File changed:** `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx`

**What changed:**

1. The "Przypisane zabiegi" card now always shows the read-only badge view (no more inline edit mode inside the card). The "Edytuj" button always appears in the card header.

2. Clicking "Edytuj" calls `startEdit("treatments")` which opens a full-height `Dialog` (up to `max-h-[calc(100dvh-2rem)]` — nearly the full viewport):
   - **DialogHeader** with section title
   - **Search input** pinned at the top (`shrink-0`)
   - **Scrollable treatment list** (`flex-1 overflow-y-auto min-h-0`) that fills all remaining space — no more fixed 256px box
   - **Cancel and Save buttons** in `DialogFooter` always visible at the bottom (`shrink-0`)

3. All save/cancel logic is unchanged — `saveSection("treatments")` and `cancelEdit()` are called exactly as before. Pressing Escape or clicking outside the dialog calls `cancelEdit()`.

The Dialog uses `flex flex-col overflow-hidden` to make the flex layout work: the search and footer are fixed-height, and the list grows to fill the rest.