### PR TITLE
Dodanie pola Bio / Opis pracownika

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3069,7 +3069,7 @@
         "commissionPercent": "Commission %",
         "bankAccount": "Bank Account",
         "noCompensationYet": "No compensation data added yet.",
-        "bio": "Bio",
+        "bio": "Bio / Employee Description",
         "bioPlaceholder": "Short employee description...",
         "bioHint": "Max. 1000 characters",
         "profilePhoto": "Profile Photo",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3089,7 +3089,7 @@
         "commissionPercent": "Prowizja %",
         "bankAccount": "Numer konta bankowego",
         "noCompensationYet": "Brak danych o wynagrodzeniu.",
-        "bio": "Bio",
+        "bio": "Bio / Opis pracownika",
         "bioPlaceholder": "Krótki opis pracownika...",
         "bioHint": "Maks. 1000 znaków",
         "profilePhoto": "Zdjęcie profilowe",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3446.

Closes #3446

---

## Claude summary

The bio/employee description field was already fully implemented in PR #3439 (commit `87cdae3`). It exists as:

- Database column `bio TEXT` in `gabinet_employees` (migration `00074_gabinet_employees_bio_avatar.sql`)
- Mapped through `MappedGabinetEmployee.bio` in `src/lib/supabase/mappers/gabinet/employees.ts:48`
- Displayed in view mode at `_layout.gabinet.employees.$employeeId.tsx:2485–2492`
- Editable via a `<Textarea>` in edit mode at the same file, lines 2435–2447
- Saved to the database via the `section === "personal"` branch at line 2184

The only thing missing was the exact label text requested in this issue. The label was "Bio" — the issue specifies it must read "Bio / Opis pracownika". I've updated both translation files to match that requirement.

Changed files:
- `public/locales/pl/translation.json` — `"bio": "Bio"` → `"bio": "Bio / Opis pracownika"`
- `public/locales/en/translation.json` — `"bio": "Bio"` → `"bio": "Bio / Employee Description"`