### PR TITLE
Wąski audyt niedziałającej edycji profilu pracownika

### DIFF
--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -42,6 +42,15 @@ const COLUMN_LABEL_MAP: Record<string, string> = {
   catalog_number: "Nr katalogowy",
   stock_note: "Notatka magazynowa",
   purchase_price: "Cena zakupu",
+  // Gabinet employees (#3437)
+  bio: "Bio / Opis pracownika",
+  avatar_url: "Zdjęcie profilowe",
+  date_of_birth: "Data urodzenia",
+  years_of_experience: "Lata doświadczenia",
+  base_salary: "Wynagrodzenie podstawowe",
+  commission_percent: "Prowizja (%)",
+  bank_account: "Numer konta bankowego",
+  show_in_calendar: "Widoczny w kalendarzu",
 };
 
 function humanFieldLabel(rawField: string): string {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -443,7 +443,10 @@ function EmployeeDetail() {
       setNewPassword("");
       setConfirmPassword("");
     } catch (e) {
-      setChangePasswordError(formatActionError(e));
+      setChangePasswordError(formatActionError(e, t, {
+        key: "gabinet.employees.errors.changePasswordFailed",
+        defaultValue: "Nie udało się zmienić hasła.",
+      }));
     } finally {
       setChangePasswordSubmitting(false);
     }
@@ -2057,9 +2060,14 @@ function DetailedDataTab({
         const url = await getStorageUrl({ storageId: storageId as Id<"_storage"> });
         if (url) {
           await onUpdate({ organizationId, employeeId: employee._id, avatarUrl: url });
+        } else {
+          toast.error(t("gabinet.employees.errors.photoUploadFailed", { defaultValue: "Nie udało się przetworzyć zdjęcia. Spróbuj ponownie." }));
         }
-      } catch {
-        toast.error(t("gabinet.employees.detailedData.profilePhoto") + ": upload failed");
+      } catch (e) {
+        toast.error(formatActionError(e, t, {
+          key: "gabinet.employees.errors.photoUploadFailed",
+          defaultValue: "Nie udało się zapisać zdjęcia profilowego.",
+        }));
       } finally {
         setPhotoUploading(false);
         if (photoFileRef.current) photoFileRef.current.value = "";
@@ -2067,7 +2075,7 @@ function DetailedDataTab({
     },
     onUploadError: () => {
       setPhotoUploading(false);
-      toast.error(t("gabinet.employees.detailedData.profilePhoto") + ": upload failed");
+      toast.error(t("gabinet.employees.errors.photoUploadFailed", { defaultValue: "Nie udało się przesłać zdjęcia profilowego." }));
     },
   });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3448.

Closes #3448

---

## Claude summary

---

## Audit Results

### Root cause of "Nieprawidłowe dane. Sprawdź formularz i spróbuj ponownie."

**Primary cause: migration `00074_gabinet_employees_bio_avatar.sql` not applied to the database.**

`saveSection("personal")` in `_layout.gabinet.employees.$employeeId.tsx:2184` always sends `bio: null` (even when bio is empty). The Convex `update` action (`convex/gabinet/employees.ts:711`) passes all args to `db.patch("gabinetEmployees", ...)`. If the `bio` column doesn't exist in Postgres, the UPDATE fails with `column "bio" of relation "gabinet_employees" does not exist`. This error flows through `formatActionError` → matches the `column .* does not exist` pattern → tries to look up `"bio"` in `COLUMN_LABEL_MAP` (not found before this fix) → falls back to the generic Polish message. The basic edit drawer (name/role/color) does **not** send `bio`, so it would succeed even without migration 00074.

**Next repair step: run `npm run migrations:apply` (or equivalent) to apply migration 00074.**

### Root cause of "Zdjęcie profilowe: upload failed"

**Same underlying cause, different catch path.** After a file is uploaded to Convex storage, `onUpdate({ ..., avatarUrl: url })` (line 2059) tries to write `avatar_url` to Postgres. Without migration 00074, that column also doesn't exist and the `onUpdate` throws. The local catch block at line 2061 caught the error and showed a hardcoded English `": upload failed"`. This is the **same migration problem**, not a separate issue.

There was also a silent failure: if `getStorageUrl` returned null, the upload appeared to succeed with no feedback at all.

### Code bugs fixed in this commit

Three secondary bugs fixed (all in 2 files):

1. `_layout.gabinet.employees.$employeeId.tsx:446` — `formatActionError(e)` called without the required `t` and `fallback` args. Caused `TypeError: t is not a function` at runtime, making the change-password error handler completely non-functional.
2. `_layout.gabinet.employees.$employeeId.tsx:2062,2070` — hardcoded English `": upload failed"` replaced with Polish strings via `formatActionError` and `t()`. Silent null-URL case now shows a proper Polish error toast.
3. `format-action-error.ts:33–45` — `bio`, `avatar_url`, `date_of_birth`, `years_of_experience`, `base_salary`, `commission_percent`, `bank_account`, `show_in_calendar` added to `COLUMN_LABEL_MAP`. After migration 00074 is applied, if any of these columns cause future validator errors, the user will see the field name in Polish instead of the raw column name.

### Files that needed changes

- `src/lib/format-action-error.ts` — add employee column labels
- `src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx` — fix formatActionError call and upload error messages

## Follow-ups

- Apply migration 00074 in CI/staging: `00074_gabinet_employees_bio_avatar.sql` adds `bio` and `avatar_url` to `gabinet_employees`; the code and types already expect these columns but the database header in `database.types.ts` only lists migrations through `00072`, indicating the types file was hand-patched rather than regenerated — the gen script should be re-run to keep the header accurate.
- Regenerate database.types.ts after migration 00074: the file header lists migrations only through `00072` but the Row type already contains `bio`/`avatar_url`, meaning it was manually edited; running `node scripts/gen-db-types.mjs` would sync the header and catch any other drift.