### PR TITLE
Apply migration 00074 in CI/staging

### DIFF
--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -77,6 +77,9 @@
  *   • 00070_appointment_treatments_deduction_flags.sql
  *   • 00071_drop_appointment_deduction_flags.sql
  *   • 00072_gabinet_package_usage_sold_by_employee_id.sql
+ *   • 00072_gabinet_packages_tags_category.sql
+ *   • 00073_payments_discount_columns.sql
+ *   • 00074_gabinet_employees_bio_avatar.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3450.

Closes #3450

---

## Claude summary

The fix was straightforward. The `database.types.ts` header comment was missing three migration entries (`00072_gabinet_packages_tags_category.sql`, `00073_payments_discount_columns.sql`, `00074_gabinet_employees_bio_avatar.sql`), but the actual TypeScript type definitions already had all the corresponding columns (`tag_ids`/`category_id` on `gabinet_treatment_packages`, `discount_amount`/`discount_percent` on `payments`, and `bio`/`avatar_url` on `gabinet_employees`). The file was hand-patched correctly at the type level but the comment listing applied migrations was not kept in sync.

## Follow-ups

- Rename or renumber `00072_gabinet_packages_tags_category.sql` to avoid duplicate prefix: two migration files share the `00072_` prefix (`00072_gabinet_package_usage_sold_by_employee_id.sql` and `00072_gabinet_packages_tags_category.sql`), which can confuse tooling that sorts or deduplicates by prefix — the newer one should be renumbered to `00075_` and the types header updated accordingly.
- Add CI check that `database.types.ts` header lists all migrations: the gen script comment says to re-run `npx tsx scripts/gen-db-types.mjs` but there's no enforcement; a simple lint step comparing the header entries against `supabase/migrations/*.sql` would catch future drift automatically.