### PR TITLE
feat(automation): PAUSED_LOGINS — hard per-user pause of job pickup

### DIFF
--- a/automation/worker/.env.example
+++ b/automation/worker/.env.example
@@ -13,3 +13,9 @@ PORT=9090
 
 # SQLite queue location (must be on the same disk as the worker)
 DB_PATH=/home/claude-bot/worker/queue.db
+
+# Hard pause per user (comma-separated GitHub logins). Jobs triggered by these
+# logins are never picked up — they stay pending until the login is removed
+# from this list and claude-worker is restarted. Empty = nobody paused.
+# Not the same as THROTTLED_LOGINS (rate limit, worker.mjs) — this is a full stop.
+PAUSED_LOGINS=

--- a/automation/worker/worker.mjs
+++ b/automation/worker/worker.mjs
@@ -26,6 +26,16 @@ const THROTTLE_INTERVAL_MS = parseInt(
   10,
 );
 
+// Full pickup pause. Jobs whose `trigger_login` is on this list are never
+// claimed — they stay `pending` (and new webhook events still enqueue), so
+// nothing is lost and unpausing is just removing the login from the env and
+// restarting the daemon. Unlike THROTTLED_LOGINS this is a hard stop, not a
+// rate limit. Configured via env (comma-separated), empty by default.
+const PAUSED_LOGINS = (process.env.PAUSED_LOGINS ?? "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
 fs.mkdirSync(LOG_DIR, { recursive: true });
 
 const db = new Database(DB_PATH);
@@ -38,6 +48,10 @@ db.pragma("journal_mode = WAL");
 const claimNextStmt = db.prepare(`
   SELECT * FROM jobs
   WHERE status = 'pending'
+    AND (
+      trigger_login IS NULL
+      OR trigger_login NOT IN (${PAUSED_LOGINS.map(() => "?").join(",") || "''"})
+    )
     AND (
       trigger_login IS NULL
       OR trigger_login NOT IN (${THROTTLED_LOGINS.map(() => "?").join(",") || "''"})
@@ -53,7 +67,7 @@ const claimNextStmt = db.prepare(`
 `);
 const claimNext = db.transaction(() => {
   const cutoff = Date.now() - THROTTLE_INTERVAL_MS;
-  const job = claimNextStmt.get(...THROTTLED_LOGINS, cutoff);
+  const job = claimNextStmt.get(...PAUSED_LOGINS, ...THROTTLED_LOGINS, cutoff);
   if (!job) return null;
   db.prepare(
     `UPDATE jobs SET status = 'running', started_at = ? WHERE id = ?`


### PR DESCRIPTION
## Po co

`THROTTLED_LOGINS` tylko ogranicza tempo (1 job / interwał). Potrzebny jest twardy wyłącznik per użytkownik — worker ma się skupić na zadaniach od wskazanych osób, a joby pozostałych mają czekać.

## Jak działa

- `PAUSED_LOGINS` (env, comma-separated) — joby z `trigger_login` z tej listy nigdy nie są claimowane; zostają `pending`.
- Webhook dalej enqueuje zdarzenia od spauzowanych userów — nic nie ginie.
- Odwieszenie = usunięcie loginu z env + `systemctl restart claude-worker`; zaległe joby ruszają od najstarszego.

## Deploy (atlas)

```
cp automation/worker/worker.mjs /home/claude-bot/worker/worker.mjs
echo 'PAUSED_LOGINS=aslocka2026' >> /home/claude-bot/worker/.env
systemctl restart claude-worker   # najlepiej gdy nic nie jest 'running'
```

## Test plan
- [x] `node --check` OK
- [ ] job od spauzowanego usera zostaje pending mimo wolnego workera
- [ ] joby innych userów przetwarzane normalnie
- [ ] po zdjęciu pauzy zaległe joby ruszają

https://claude.ai/code/session_01SYe8ZRFD8uYUCN3gikUNMj