### PR TITLE
Appointment edit pre-population from junction table

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -3141,11 +3141,25 @@ export type AppointmentFullDetailEmployee = GabinetEmployeeRow & {
   image?: string;
 };
 
+/** Junction row shape returned within `AppointmentFullDetail.treatments`. */
+export interface AppointmentFullDetailTreatment {
+  id: string;
+  treatmentId: string | null;
+  variantId: string | null;
+  priceAtBooking: number | null;
+  sortOrder: number;
+}
+
 /** Full DTO returned by `getFullDetail`. */
 export interface AppointmentFullDetail {
   appointment: GabinetAppointmentRow;
   patient: GabinetPatientRow | null;
   treatment: GabinetTreatmentRow | null;
+  /** Rows from `gabinet_appointment_treatments` ordered by sort_order.  Empty
+   *  for appointments created before the junction table shipped (pre-#3356).
+   *  Edit paths should prefer this array and fall back to `appointment.treatmentId`
+   *  when the array is empty (issue #3469). */
+  treatments: AppointmentFullDetailTreatment[];
   employee: AppointmentFullDetailEmployee | null;
   documents: FormDocumentRow[];
   payments: PaymentRow[];
@@ -3214,6 +3228,7 @@ export const getFullDetail = action({
       allPatientPaymentsRaw,
       patientCreditRowsRaw,
       workflowHistoryRaw,
+      appointmentTreatmentsRaw,
     ] = await Promise.all([
       db.get("gabinetPatients", patientId),
       treatmentId ? db.get("gabinetTreatments", treatmentId) : Promise.resolve(null),
@@ -3268,6 +3283,10 @@ export const getFullDetail = action({
         .eq("appointmentId", args.appointmentId)
         .order("createdAt", false)
         .collect(),
+      db.query("gabinetAppointmentTreatments")
+        .eq("appointmentId", args.appointmentId)
+        .order("sortOrder", true)
+        .collect(),
     ]);
 
     const patient = patientRaw as unknown as GabinetPatientRow | null;
@@ -3290,6 +3309,15 @@ export const getFullDetail = action({
       : null;
     const documents = documentsRaw as unknown as FormDocumentRow[];
     const payments = paymentsRaw as unknown as PaymentRow[];
+    const appointmentTreatments: AppointmentFullDetailTreatment[] = (
+      (appointmentTreatmentsRaw as unknown as Array<Record<string, unknown>>) ?? []
+    ).map((row) => ({
+      id: String(row.id ?? row._id),
+      treatmentId: row.treatmentId ? String(row.treatmentId) : null,
+      variantId: row.variantId ? String(row.variantId) : null,
+      priceAtBooking: row.priceAtBooking != null ? Number(row.priceAtBooking) : null,
+      sortOrder: Number(row.sortOrder ?? 0),
+    }));
     const patientPackageUsage = patientPackageUsageRaw as unknown as GabinetPackageUsageRow[];
     const patientHistoryRaw = patientHistoryRawAll as unknown as GabinetAppointmentRow[];
     const loyaltyTransactions = loyaltyTransactionsRaw as unknown as GabinetLoyaltyTransactionRow[];
@@ -3375,6 +3403,7 @@ export const getFullDetail = action({
       appointment,
       patient,
       treatment,
+      treatments: appointmentTreatments,
       employee,
       documents,
       payments,

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -443,7 +443,14 @@ export function AppointmentPreviewContent({
     setEndTime(appt.endTime.slice(0, 5));
     setNotes(appt.notes ?? "");
     setInternalNotes(appt.internalNotes ?? "");
-    setTreatmentId(appt.treatmentId ? String(appt.treatmentId) : "");
+    const junctionTreatmentId = detail.treatments?.[0]?.treatmentId ?? null;
+    setTreatmentId(
+      junctionTreatmentId
+        ? junctionTreatmentId
+        : appt.treatmentId
+          ? String(appt.treatmentId)
+          : "",
+    );
     setVariantId(appt.variantId ? String(appt.variantId) : "");
     setTagIds(
       (appt.tagIds ?? []).map((id) => id as Id<"tagDefinitions">),
@@ -463,9 +470,9 @@ export function AppointmentPreviewContent({
 
   const { appointment, patient, treatment } = detail;
   const initialStatus = appointment.status as AppointmentStatus;
-  const initialTreatmentId = appointment.treatmentId
-    ? String(appointment.treatmentId)
-    : "";
+  const initialTreatmentId =
+    detail.treatments?.[0]?.treatmentId ??
+    (appointment.treatmentId ? String(appointment.treatmentId) : "");
   const initialVariantId = appointment.variantId
     ? String(appointment.variantId)
     : "";

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -417,7 +417,14 @@ function AppointmentDetail() {
     if (schedulingInitRef.current === detail.appointment._id) return;
     schedulingInitRef.current = detail.appointment._id;
     const appt = detail.appointment as Record<string, unknown>;
-    setEditTreatmentId(appt.treatmentId ? String(appt.treatmentId) : "");
+    const junctionTreatmentId = detail.treatments?.[0]?.treatmentId ?? null;
+    setEditTreatmentId(
+      junctionTreatmentId
+        ? junctionTreatmentId
+        : appt.treatmentId
+          ? String(appt.treatmentId)
+          : "",
+    );
     setEditDate((appt.date as string) ?? "");
     setEditStartTime(((appt.startTime as string) ?? "").slice(0, 5));
     setEditEndTime(((appt.endTime as string) ?? "").slice(0, 5));


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3469.

Closes #3469

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- ab3c034 fix(gabinet): read treatmentId from junction table in appointment edit pre-population (closes #3469)

### Files changed

```
 convex/gabinet/appointments.ts                     | 29 ++++++++++++++++++++++
 .../calendar/appointment-preview-content.tsx       | 15 ++++++++---
 ...ut.gabinet.appointments.$appointmentId.lazy.tsx |  9 ++++++-
 3 files changed, 48 insertions(+), 5 deletions(-)
```