### PR TITLE
Write junction row on appointment update

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1722,6 +1722,43 @@ export const update = action({
     console.info("[update] patching appointment in Supabase:", appointmentId);
     await db.patch("gabinetAppointments", appointmentId, patch);
 
+    // --- Upsert junction row in gabinetAppointmentTreatments when treatment changes ---
+    // The update action was patching treatmentId only on the scalar column and
+    // never touching the junction table, causing divergence over time. Closes #3473.
+    if (args.treatmentId !== undefined) {
+      const existingJunctionRows = await db
+        .query("gabinetAppointmentTreatments")
+        .eq("appointmentId", appointmentId)
+        .collect();
+      for (const row of existingJunctionRows) {
+        await db.delete("gabinetAppointmentTreatments", String((row as Record<string, unknown>).id));
+      }
+      if (args.treatmentId) {
+        const effectiveVariantId =
+          args.variantId !== undefined
+            ? args.variantId
+            : (appt.variantId as string | null | undefined) ?? null;
+        const newTreatment = (await db.get("gabinetTreatments", args.treatmentId)) as GabinetTreatmentRow | null;
+        let priceAtBooking: number | null = (newTreatment?.price as number | undefined) ?? null;
+        if (effectiveVariantId) {
+          const variant = await db.get("gabinetTreatmentVariants", effectiveVariantId);
+          if (variant && String(variant.organizationId) === String(args.organizationId)) {
+            priceAtBooking = (variant.price as number | null | undefined) ?? priceAtBooking;
+          }
+        }
+        await db.insert("gabinetAppointmentTreatments", {
+          organizationId: String(args.organizationId),
+          appointmentId,
+          treatmentId: args.treatmentId,
+          variantId: effectiveVariantId,
+          priceAtBooking,
+          sortOrder: 0,
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+    }
+
     // --- Sync scheduledActivity in Supabase (moved out of _updateSideEffects mutation) ---
     const scheduledActivityIdStr = (appt.scheduledActivityId as string) ?? undefined;
     const dateChanged = !!(args.date || args.startTime || args.endTime);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3473.

Closes #3473

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a701e18 fix(gabinet): upsert junction row on appointment update (closes #3473)

### Files changed

```
 convex/gabinet/appointments.ts | 37 +++++++++++++++++++++++++++++++++++++
 1 file changed, 37 insertions(+)
```