### PR TITLE
fix(gabinet): pass boolean isGift directly to avoid NOT NULL violation (closes #3477)

### DIFF
--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -676,7 +676,7 @@ export const purchasePackage = action({
       treatmentsUsed,
       paidAmount: args.paidAmount,
       paymentMethod: args.paymentMethod ?? null,
-      isGift: isGift || null,
+      isGift,
       voucherCode,
       giftRecipientName: args.giftRecipientName ?? null,
       giftRecipientPhone: args.giftRecipientPhone ?? null,


### PR DESCRIPTION
## Summary

- In `purchasePackage`, `isGift` is derived as `const isGift = args.isGift === true` — always `true | false`, never `null`
- The expression `isGift || null` incorrectly returns `null` when `isGift` is `false` (the common case: non-gift purchase)
- `gabinet_package_usage.is_gift` is `BOOLEAN NOT NULL DEFAULT FALSE` (migration 00065), so inserting `null` throws a Postgres constraint violation
- Fix: use `isGift` directly — the boolean is always valid and no coercion is needed

## Test plan

- [ ] Sell a package to a patient (non-gift) — should complete without error
- [ ] Sell a gift package — should still work correctly
- [ ] Verify `is_gift = false` row appears in `gabinet_package_usage` for normal purchase
- [ ] Verify `is_gift = true` row appears for gift purchase

🤖 Generated with [Claude Code](https://claude.com/claude-code)