### PR TITLE
feat(gabinet): rebuild packages tab with table view, saved views, tags/categories (closes #3343)

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -1,18 +1,35 @@
-import { createFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  useNavigate,
+  useSearch,
+} from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
-import { useSupabaseGabinetTreatmentPackagesList, useSupabaseGabinetPackageUsageActive, useSupabaseGabinetPackageUsageUnassigned } from "@/hooks/use-supabase-gabinet-packages";
+import {
+  useSupabaseGabinetTreatmentPackagesList,
+  useSupabaseGabinetPackageUsageActive,
+  useSupabaseGabinetPackageUsageUnassigned,
+} from "@/hooks/use-supabase-gabinet-packages";
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
+import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
+import { PatientForm } from "@/components/forms/patient-form";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { PageHeader } from "@/components/layout/page-header";
+import {
+  CrmDataTable,
+  useColumnVisibility,
+  useAllColumns,
+} from "@/components/crm/enhanced-data-table";
+import type { CrmColumn } from "@/components/crm/enhanced-data-table";
+import { DataListFilterBar } from "@/components/crm/data-list-filter-bar";
 import { SidePanel } from "@/components/crm/side-panel";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { RichTextEditor, plateJsonToText } from "@/components/gabinet/rich-text-editor";
+import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -30,57 +47,69 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Progress } from "@/components/ui/progress";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Plus, Trash2, Package, Pencil, X, Gift, Search } from "@/lib/ez-icons";
+import {
+  Plus,
+  Trash2,
+  Package,
+  Pencil,
+  X,
+  Gift,
+  Search,
+  ChevronDown,
+  ChevronUp,
+} from "@/lib/ez-icons";
 import { useState, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
-
 import { EmptyState } from "@/components/layout/empty-state";
-import { QuickActionBar } from "@/components/crm/quick-action-bar";
 import { SellPackagePanel } from "@/components/gabinet/sell-package-panel";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import type { MappedGabinetTreatmentPackage } from "@/lib/supabase/mappers/gabinet/treatment-packages";
 import type { MappedGabinetPackageUsage } from "@/lib/supabase/mappers/gabinet/package-usage";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
-import { PatientForm } from "@/components/forms/patient-form";
+import type {
+  SavedView,
+  FieldDef,
+  FilterCondition,
+} from "@/components/crm/types";
+import type { SortDescriptor } from "react-aria-components";
+import { Id } from "@cvx/_generated/dataModel";
+import { useSavedViews, applyFilterConditions } from "@/hooks/use-saved-views";
+import { useTagDefinitions } from "@/hooks/use-tag-definitions";
+import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
+import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
+import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
+import { TagsPicker } from "@/components/categories-tags/tags-picker";
+import { CategoryPicker } from "@/components/categories-tags/category-picker";
+import { PermissionGate, usePermission } from "@/hooks/use-permission";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 
 // shadcn/studio statistics blocks
 import StatisticsOrderCard from "@/components/shadcn-studio/blocks/statistics-order-card";
 import StatisticsProfitCard from "@/components/shadcn-studio/blocks/statistics-profit-card";
 import StatisticsImpressionCard from "@/components/shadcn-studio/blocks/statistics-impression-card";
-import { PermissionGate } from "@/hooks/use-permission";
-import { Skeleton } from "@/components/ui/skeleton";
 
-// Type alias for Convex mutation compatibility (Knowledge Pattern #9/#12)
 type TreatmentPackage = MappedGabinetTreatmentPackage;
-
 type PackagesNudgeFilter = "expiring" | "no-usage";
 
-function PackagesIndexSkeleton() {
+function PackagesListSkeleton() {
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex flex-col gap-4 p-6">
       <div className="flex items-center justify-between">
-        <Skeleton className="h-7 w-40" />
-        <Skeleton className="h-9 w-28" />
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-9 w-32" />
       </div>
-      <div className="grid gap-4 sm:grid-cols-3">
-        <Skeleton className="h-28" />
-        <Skeleton className="h-28" />
-        <Skeleton className="h-28" />
-      </div>
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <Skeleton key={i} className="h-40" />
+      <Skeleton className="h-10 w-full" />
+      <div className="flex flex-col gap-2">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full" />
         ))}
       </div>
     </div>
@@ -88,10 +117,14 @@ function PackagesIndexSkeleton() {
 }
 
 export const Route = createFileRoute(
-  "/_app/_auth/dashboard/_layout/gabinet/packages/"
+  "/_app/_auth/dashboard/_layout/gabinet/packages/",
 )({
   component: () => (
-    <PermissionGate feature="gabinet_packages" action="view" loadingFallback={<PackagesIndexSkeleton />}>
+    <PermissionGate
+      feature="gabinet_packages"
+      action="view"
+      loadingFallback={<PackagesListSkeleton />}
+    >
       <PackagesIndex />
     </PermissionGate>
   ),
@@ -107,11 +140,12 @@ export const Route = createFileRoute(
 });
 
 // ---------------------------------------------------------------------------
-// Client-side aggregation helpers (replace Convex server-side queries)
+// Client-side aggregation helpers
 // ---------------------------------------------------------------------------
 
-/** Build { [packageId]: activeCount } from raw usage rows */
-function buildActiveUsageCounts(usages: MappedGabinetPackageUsage[]): Record<string, number> {
+function buildActiveUsageCounts(
+  usages: MappedGabinetPackageUsage[],
+): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const u of usages) {
     counts[u.packageId] = (counts[u.packageId] ?? 0) + 1;
@@ -119,49 +153,29 @@ function buildActiveUsageCounts(usages: MappedGabinetPackageUsage[]): Record<str
   return counts;
 }
 
-/** Build per-package treatment progress from raw usage rows */
-function buildActiveUsageDetails(
-  usages: MappedGabinetPackageUsage[],
-): Record<string, { count: number; treatmentProgress: Record<string, { usedCount: number; totalCount: number }> }> {
-  const byPackage: Record<
-    string,
-    { count: number; treatmentProgress: Record<string, { usedCount: number; totalCount: number }> }
-  > = {};
-
-  for (const u of usages) {
-    if (!byPackage[u.packageId]) {
-      byPackage[u.packageId] = { count: 0, treatmentProgress: {} };
-    }
-    byPackage[u.packageId].count += 1;
-    for (const t of u.treatmentsUsed) {
-      const key = t.treatmentId;
-      if (!byPackage[u.packageId].treatmentProgress[key]) {
-        byPackage[u.packageId].treatmentProgress[key] = { usedCount: 0, totalCount: 0 };
-      }
-      byPackage[u.packageId].treatmentProgress[key].usedCount += t.usedCount;
-      byPackage[u.packageId].treatmentProgress[key].totalCount += t.totalCount;
-    }
-  }
-
-  return byPackage;
-}
-
-/** Derive KPIs from packages list + active usage data */
 function derivePackageKpis(
   packages: MappedGabinetTreatmentPackage[],
   activeUsages: MappedGabinetPackageUsage[],
-): { totalPackages: number; activePackages: number; soldActiveUsages: number; expiringPackages: number } {
+): { totalPackages: number; activePackages: number; expiringPackages: number } {
   const now = Date.now();
   const thirtyDays = 30 * 24 * 60 * 60 * 1000;
-
   return {
     totalPackages: packages.length,
     activePackages: packages.filter((p) => p.isActive).length,
-    soldActiveUsages: activeUsages.length,
     expiringPackages: activeUsages.filter(
-      (u) => u.expiresAt != null && u.expiresAt > now && u.expiresAt <= now + thirtyDays,
+      (u) =>
+        u.expiresAt != null &&
+        u.expiresAt > now &&
+        u.expiresAt <= now + thirtyDays,
     ).length,
   };
+}
+
+function formatCurrency(amount: number, currency?: string): string {
+  return new Intl.NumberFormat("pl-PL", {
+    style: "currency",
+    currency: currency ?? "PLN",
+  }).format(amount);
 }
 
 function PackagesIndex() {
@@ -171,79 +185,394 @@ function PackagesIndex() {
   const navigate = useNavigate();
   const { nudge: nudgeFilter } = useSearch({ from: Route.id });
 
-  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen
   const createPkg = useAction(api.gabinet.packages.create);
-  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen
   const updatePkg = useAction(api.gabinet.packages.update);
-  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen
   const removePkg = useAction(api.gabinet.packages.remove);
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen
+  const assignGift = useAction(api.gabinet.packages.assignGiftPackage);
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen
+  const createPatient = useAction(api.gabinet.patients.create);
 
-  // Supabase-backed queries (replacing convexQuery)
-  const { data: packagesData } = useSupabaseGabinetTreatmentPackagesList(organizationId);
-  const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId, { isActive: true });
-  const { data: activeUsagesData } = useSupabaseGabinetPackageUsageActive(organizationId);
+  const { allowed: canEdit } = usePermission("gabinet_packages", "edit");
+  const { allowed: canDelete } = usePermission("gabinet_packages", "delete");
 
-  const treatments = useMemo(
-    () => treatmentsData ?? [],
-    [treatmentsData],
+  const { tags } = useTagDefinitions(organizationId);
+  const { categories } = useCategoryDefinitions(
+    organizationId,
+    "gabinetPackage",
   );
+  const [tagsSlideoutOpen, setTagsSlideoutOpen] = useState(false);
+  const [categoriesSlideoutOpen, setCategoriesSlideoutOpen] = useState(false);
+  const [filterSlideoutOpen, setFilterSlideoutOpen] = useState(false);
+  const [sortDescriptor, setSortDescriptor] = useState<
+    SortDescriptor | undefined
+  >(undefined);
+  const [showStatsMobile, setShowStatsMobile] = useState(false);
 
-  // Client-side aggregation (replaces getActiveUsageCounts, getActiveUsageDetails, getPackagesKpis)
+  const { data: packagesData, isLoading } =
+    useSupabaseGabinetTreatmentPackagesList(organizationId);
+  const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(
+    organizationId,
+    { isActive: true },
+  );
+  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId);
+  const { data: unassignedUsagesData } =
+    useSupabaseGabinetPackageUsageUnassigned(organizationId);
+  const { data: activeUsagesData } =
+    useSupabaseGabinetPackageUsageActive(organizationId);
+
+  const treatments = useMemo(() => treatmentsData ?? [], [treatmentsData]);
+
   const activeUsageCounts = useMemo(
     () => buildActiveUsageCounts(activeUsagesData ?? []),
     [activeUsagesData],
   );
-  const activeUsageDetails = useMemo(
-    () => buildActiveUsageDetails(activeUsagesData ?? []),
-    [activeUsagesData],
-  );
+
   const pkgKpis = useMemo(
     () => derivePackageKpis(packagesData ?? [], activeUsagesData ?? []),
     [packagesData, activeUsagesData],
   );
 
-  const { data: unassignedGiftData } = useSupabaseGabinetPackageUsageUnassigned(organizationId);
-  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId);
+  const expiringPackageIds = useMemo(() => {
+    const now = Date.now();
+    const thirtyDays = 30 * 24 * 60 * 60 * 1000;
+    const ids = new Set<string>();
+    for (const u of activeUsagesData ?? []) {
+      if (
+        u.expiresAt != null &&
+        u.expiresAt > now &&
+        u.expiresAt <= now + thirtyDays
+      ) {
+        ids.add(u.packageId);
+      }
+    }
+    return ids;
+  }, [activeUsagesData]);
 
-  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
-  const assignGiftPkg = useAction(api.gabinet.packages.assignGiftPackage);
-  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
-  const createPatient = useAction(api.gabinet.patients.create);
+  const treatmentNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const tr of treatments) map.set(tr._id, tr.name);
+    return map;
+  }, [treatments]);
 
+  const categoryNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const cat of categories) map.set(cat._id, cat.name);
+    return map;
+  }, [categories]);
+
+  // ---- Form state ----
   const [panelOpen, setPanelOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [filterPanelOpen, setFilterPanelOpen] = useState(false);
-  const [statusFilter, setStatusFilter] = useState<"all" | "active" | "inactive">("all");
-  const [expiringOnly, setExpiringOnly] = useState(false);
-  const [assignPanelOpen, setAssignPanelOpen] = useState(false);
-  const [giftSearch, setGiftSearch] = useState("");
-  const [assigningGiftId, setAssigningGiftId] = useState<string | null>(null);
-  const [assignPatientId, setAssignPatientId] = useState("");
-  const [assignSubmitting, setAssignSubmitting] = useState(false);
-  const [createPatientPanelOpen, setCreatePatientPanelOpen] = useState(false);
-  const [creatingPatient, setCreatingPatient] = useState(false);
-
-  useSidebarDispatch("openFilter", () => setFilterPanelOpen(true));
-  useSidebarDispatch("viewExpiring", () => setExpiringOnly(true));
-  useSidebarDispatch("assignPackage", () => setAssignPanelOpen(true));
-
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [totalPrice, setTotalPrice] = useState("");
   const [validityDays, setValidityDays] = useState("");
   const [discountPercent, setDiscountPercent] = useState("");
   const [loyaltyPoints, setLoyaltyPoints] = useState("");
-  const [selectedTreatments, setSelectedTreatments] = useState<Array<{ treatmentId: string; quantity: number }>>([]);
+  const [selectedTreatments, setSelectedTreatments] = useState<
+    Array<{ treatmentId: string; quantity: number }>
+  >([]);
+  const [tagIds, setTagIds] = useState<Id<"tagDefinitions">[]>([]);
+  const [categoryId, setCategoryId] = useState<
+    Id<"categoryDefinitions"> | undefined
+  >(undefined);
   const [submitting, setSubmitting] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
-  // Cache invalidation helper
+  // ---- Gift / voucher assignment state ----
+  const [assignPanelOpen, setAssignPanelOpen] = useState(false);
+  const [giftSearch, setGiftSearch] = useState("");
+  const [assigningGiftId, setAssigningGiftId] = useState<string | null>(null);
+  const [assignPatientId, setAssignPatientId] = useState<string>("");
+  const [assignSubmitting, setAssignSubmitting] = useState(false);
+  const [createPatientPanelOpen, setCreatePatientPanelOpen] = useState(false);
+  const [creatingPatient, setCreatingPatient] = useState(false);
+
+  // ---- Saved views + filter ----
+  const [activeFilters, setActiveFilters] = useState<FilterCondition[]>([]);
+  const [searchValue, setSearchValue] = useState("");
+
+  useSidebarDispatch("manageTags", () => setTagsSlideoutOpen(true));
+  useSidebarDispatch("manageCategories", () => setCategoriesSlideoutOpen(true));
+  useSidebarDispatch("openFilter", () => setFilterSlideoutOpen(true));
+  useSidebarDispatch("assignPackage", () => setAssignPanelOpen(true));
+  useSidebarDispatch("viewExpiring", () => {
+    // Navigate to expiring nudge filter
+    void navigate({
+      to: "/dashboard/gabinet/packages",
+      search: { nudge: "expiring" },
+    });
+  });
+
+  const systemViews = useMemo(
+    (): SavedView[] => [
+      {
+        id: "all",
+        name: t("gabinet.packages.views.all", "Wszystkie pakiety"),
+        isSystem: true,
+        isDefault: true,
+      },
+      {
+        id: "active",
+        name: t("gabinet.packages.views.active", "Aktywne"),
+        isSystem: true,
+        isDefault: false,
+      },
+      {
+        id: "inactive",
+        name: t("gabinet.packages.views.inactive", "Nieaktywne"),
+        isSystem: true,
+        isDefault: false,
+      },
+    ],
+    [t],
+  );
+
+  const filterableFields = useMemo(
+    (): FieldDef[] => [
+      { id: "name", label: t("gabinet.packages.name", "Nazwa"), type: "text" },
+      {
+        id: "totalPrice",
+        label: t("gabinet.packages.totalPrice", "Cena"),
+        type: "number",
+      },
+      {
+        id: "validityDays",
+        label: t("gabinet.packages.validityDays", "Ważność (dni)"),
+        type: "number",
+      },
+      {
+        id: "discountPercent",
+        label: t("gabinet.packages.discountPercent", "Rabat (%)"),
+        type: "number",
+      },
+      {
+        id: "isActive",
+        label: t("common.active", "Aktywny"),
+        type: "select",
+        options: [
+          { label: t("common.yes", "Tak"), value: "true" },
+          { label: t("common.no", "Nie"), value: "false" },
+        ],
+      },
+      {
+        id: "createdAt",
+        label: t("common.created", "Utworzono"),
+        type: "date",
+      },
+      {
+        id: "tagIds",
+        label: t("common.tags", "Tagi"),
+        type: "multiSelect" as const,
+        options: tags.map((tag) => ({ label: tag.name, value: tag._id })),
+      },
+      {
+        id: "categoryId",
+        label: t("common.category", "Kategoria"),
+        type: "select" as const,
+        options: categories.map((cat) => ({ label: cat.name, value: cat._id })),
+      },
+    ],
+    [t, tags, categories],
+  );
+
+  const {
+    views,
+    activeViewId,
+    onViewChange,
+    onCreateView,
+    onDeleteView,
+    applyFilters,
+  } = useSavedViews({
+    organizationId,
+    entityType: "gabinetPackage",
+    systemViews,
+  });
+
+  const filteredPackages = useMemo(() => {
+    let data: TreatmentPackage[];
+    switch (activeViewId) {
+      case "active":
+        data = (packagesData ?? []).filter((p) => p.isActive);
+        break;
+      case "inactive":
+        data = (packagesData ?? []).filter((p) => !p.isActive);
+        break;
+      default:
+        data = packagesData ?? [];
+    }
+    if (nudgeFilter === "expiring") {
+      data = data.filter((p) => expiringPackageIds.has(p._id));
+    }
+    if (nudgeFilter === "no-usage") {
+      data = data.filter(
+        (p) => p.isActive && (activeUsageCounts[p._id] ?? 0) === 0,
+      );
+    }
+    data = applyFilters(data);
+    data = applyFilterConditions(data, activeFilters);
+    if (searchValue.trim()) {
+      const q = searchValue.trim().toLowerCase();
+      data = data.filter((p) => p.name.toLowerCase().includes(q));
+    }
+    return data;
+  }, [
+    packagesData,
+    activeViewId,
+    nudgeFilter,
+    expiringPackageIds,
+    activeUsageCounts,
+    applyFilters,
+    activeFilters,
+    searchValue,
+  ]);
+
+  // ---- Columns ----
+  const columns: CrmColumn<TreatmentPackage>[] = useMemo(
+    () => [
+      {
+        id: "name",
+        label: t("gabinet.packages.name", "Nazwa"),
+        sortable: true,
+        isRowHeader: true,
+        className: "min-w-[200px]",
+        render: (item) => (
+          <div className="flex items-center gap-2 pl-2 md:pl-0">
+            <span className="font-medium text-fg-primary">{item.name}</span>
+            {!item.isActive && (
+              <Badge variant="outline" className="text-xs text-fg-quaternary">
+                {t("common.inactive", "Nieaktywny")}
+              </Badge>
+            )}
+          </div>
+        ),
+        getSortValue: (item) => item.name,
+      },
+      {
+        id: "totalPrice",
+        label: t("gabinet.packages.totalPrice", "Cena"),
+        sortable: true,
+        className: "min-w-[120px]",
+        render: (item) =>
+          formatCurrency(item.totalPrice, item.currency ?? undefined),
+        getSortValue: (item) => item.totalPrice,
+      },
+      {
+        id: "treatments",
+        label: t("gabinet.packages.treatments", "Zabiegi"),
+        sortable: true,
+        className: "min-w-[100px]",
+        render: (item) => {
+          const count = item.treatments.length;
+          const names = item.treatments
+            .map((tr) => treatmentNameMap.get(tr.treatmentId))
+            .filter(Boolean)
+            .join(", ");
+          return (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge variant="secondary">
+                    {count} {t("gabinet.packages.treatmentsCount", "zabiegów")}
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {names || t("gabinet.packages.treatments", "Zabiegi")}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          );
+        },
+        getSortValue: (item) => item.treatments.length,
+      },
+      {
+        id: "validityDays",
+        label: t("gabinet.packages.validityDays", "Ważność"),
+        sortable: true,
+        className: "min-w-[100px]",
+        render: (item) =>
+          item.validityDays
+            ? `${item.validityDays} ${t("gabinet.packages.days", "dni")}`
+            : "—",
+        getSortValue: (item) => item.validityDays ?? 0,
+      },
+      {
+        id: "discountPercent",
+        label: t("gabinet.packages.discountPercent", "Rabat"),
+        sortable: true,
+        className: "min-w-[80px]",
+        render: (item) =>
+          item.discountPercent ? `${item.discountPercent}%` : "—",
+        getSortValue: (item) => item.discountPercent ?? 0,
+      },
+      {
+        id: "activeUses",
+        label: t("gabinet.packages.activeUses", "Aktywne użycia"),
+        sortable: true,
+        className: "min-w-[120px]",
+        render: (item) => {
+          const count = activeUsageCounts[item._id] ?? 0;
+          return count > 0 ? (
+            <Badge variant="outline">{count}</Badge>
+          ) : (
+            <span className="text-fg-quaternary">0</span>
+          );
+        },
+        getSortValue: (item) => activeUsageCounts[item._id] ?? 0,
+      },
+      {
+        id: "category",
+        label: t("common.category", "Kategoria"),
+        sortable: true,
+        className: "min-w-[140px]",
+        render: (item) => {
+          if (item.categoryId) {
+            const name = categoryNameById.get(item.categoryId);
+            if (name) return name;
+          }
+          return "—";
+        },
+        getSortValue: (item) =>
+          item.categoryId ? (categoryNameById.get(item.categoryId) ?? "") : "",
+      },
+      {
+        id: "isActive",
+        label: t("common.active", "Aktywny"),
+        render: (item) => (
+          <span
+            className={`inline-block h-2.5 w-2.5 rounded-full ${
+              item.isActive ? "bg-green-500" : "bg-gray-300"
+            }`}
+          />
+        ),
+      },
+    ],
+    [t, treatmentNameMap, activeUsageCounts, categoryNameById],
+  );
+
+  const { allColumns, defaultHidden } = useAllColumns(
+    columns,
+    filterableFields,
+  );
+  const { hiddenColumnIds, toggleColumn, setHiddenColumns } =
+    useColumnVisibility(defaultHidden, "gabinet-packages");
+
+  // ---- Invalidation ----
   const invalidatePackages = useCallback(() => {
-    void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatmentPackages.list(organizationId) });
-    void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetPackageUsage.list(organizationId) });
+    void queryClient.invalidateQueries({
+      queryKey: supabaseKeys.gabinetTreatmentPackages.list(organizationId),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: supabaseKeys.gabinetPackageUsage.list(organizationId),
+    });
   }, [queryClient, organizationId]);
 
+  // ---- Form helpers ----
   const resetForm = useCallback(() => {
     setName("");
     setDescription("");
@@ -252,6 +581,8 @@ function PackagesIndex() {
     setDiscountPercent("");
     setLoyaltyPoints("");
     setSelectedTreatments([]);
+    setTagIds([]);
+    setCategoryId(undefined);
     setEditingId(null);
   }, []);
 
@@ -267,33 +598,45 @@ function PackagesIndex() {
     setTotalPrice(String(pkg.totalPrice));
     setValidityDays(pkg.validityDays ? String(pkg.validityDays) : "");
     setDiscountPercent(pkg.discountPercent ? String(pkg.discountPercent) : "");
-    setLoyaltyPoints(pkg.loyaltyPointsAwarded ? String(pkg.loyaltyPointsAwarded) : "");
-    setSelectedTreatments(
-      pkg.treatments.map((t) => ({ treatmentId: t.treatmentId, quantity: t.quantity }))
+    setLoyaltyPoints(
+      pkg.loyaltyPointsAwarded ? String(pkg.loyaltyPointsAwarded) : "",
     );
+    setSelectedTreatments(
+      pkg.treatments.map((tr) => ({
+        treatmentId: tr.treatmentId,
+        quantity: tr.quantity,
+      })),
+    );
+    setTagIds((pkg.tagIds as Id<"tagDefinitions">[]) ?? []);
+    setCategoryId(pkg.categoryId as Id<"categoryDefinitions"> | undefined);
     setPanelOpen(true);
   }, []);
 
-  const addTreatment = () => {
+  const addTreatmentRow = () => {
     setSelectedTreatments((prev) => [
       ...prev,
-      { treatmentId: treatments?.[0]?._id ?? "", quantity: 1 },
+      { treatmentId: treatments[0]?._id ?? "", quantity: 1 },
     ]);
   };
 
-  const removeTreatment = (index: number) => {
+  const removeTreatmentRow = (index: number) => {
     setSelectedTreatments((prev) => prev.filter((_, i) => i !== index));
   };
 
-  const updateTreatment = (index: number, field: "treatmentId" | "quantity", value: string | number) => {
+  const updateTreatmentRow = (
+    index: number,
+    field: "treatmentId" | "quantity",
+    value: string | number,
+  ) => {
     setSelectedTreatments((prev) =>
-      prev.map((t, i) => (i === index ? { ...t, [field]: value } : t))
+      prev.map((t, i) => (i === index ? { ...t, [field]: value } : t)),
     );
   };
 
   const handleSubmit = async () => {
     if (!name || !totalPrice || selectedTreatments.length === 0) return;
-    if (selectedTreatments.some((t) => !t.treatmentId || t.quantity < 1)) return;
+    if (selectedTreatments.some((t) => !t.treatmentId || t.quantity < 1))
+      return;
     setSubmitting(true);
     try {
       const treatmentsList = selectedTreatments.map((t) => ({
@@ -312,8 +655,10 @@ function PackagesIndex() {
           validityDays: validityDays ? parseInt(validityDays) : null,
           discountPercent: discountPercent ? parseFloat(discountPercent) : null,
           loyaltyPointsAwarded: loyaltyPoints ? parseInt(loyaltyPoints) : null,
+          tagIds: tagIds.length > 0 ? tagIds : null,
+          categoryId: categoryId ?? null,
         });
-        toast.success(t("common.saved"));
+        toast.success(t("common.saved", "Zapisano"));
       } else {
         await createPkg({
           organizationId,
@@ -324,8 +669,10 @@ function PackagesIndex() {
           validityDays: validityDays ? parseInt(validityDays) : null,
           discountPercent: discountPercent ? parseFloat(discountPercent) : null,
           loyaltyPointsAwarded: loyaltyPoints ? parseInt(loyaltyPoints) : null,
+          tagIds: tagIds.length > 0 ? tagIds : null,
+          categoryId: categoryId ?? null,
         });
-        toast.success(t("gabinet.packages.created"));
+        toast.success(t("gabinet.packages.created", "Pakiet utworzony"));
       }
       invalidatePackages();
       setPanelOpen(false);
@@ -351,7 +698,7 @@ function PackagesIndex() {
     if (!deletingId) return;
     try {
       await removePkg({ organizationId, packageId: deletingId });
-      toast.success(t("common.deleted"));
+      toast.success(t("common.deleted", "Usunięto"));
       invalidatePackages();
     } catch (e) {
       toast.error(
@@ -366,13 +713,57 @@ function PackagesIndex() {
     }
   };
 
+  const handleBulkAction = useCallback(
+    async (action: string, selectedRows: TreatmentPackage[]) => {
+      if (action === "delete") {
+        for (const row of selectedRows) {
+          await removePkg({ organizationId, packageId: row._id });
+        }
+        invalidatePackages();
+      }
+    },
+    [removePkg, organizationId, invalidatePackages],
+  );
+
+  const rowActions = useCallback(
+    (row: TreatmentPackage) => [
+      ...(canEdit
+        ? [
+            {
+              label: t("common.edit", "Edytuj"),
+              icon: <Pencil className="h-4 w-4" variant="stroke" />,
+              onClick: () => openEdit(row),
+            },
+          ]
+        : []),
+      ...(canDelete
+        ? [
+            {
+              label: t("common.delete", "Usuń"),
+              icon: <Trash2 className="h-4 w-4" variant="stroke" />,
+              onClick: () => confirmDelete(row._id),
+            },
+          ]
+        : []),
+    ],
+    [t, canEdit, canDelete, openEdit],
+  );
+
   const handleAssignGift = async () => {
     if (!assigningGiftId || !assignPatientId) return;
     setAssignSubmitting(true);
     try {
-      await assignGiftPkg({ organizationId, usageId: assigningGiftId, patientId: assignPatientId });
-      toast.success(t("gabinet.packages.giftAssigned", "Voucher przypisany do pacjenta."));
-      void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetPackageUsage.list(organizationId) });
+      await assignGift({
+        organizationId,
+        usageId: assigningGiftId,
+        patientId: assignPatientId,
+      });
+      toast.success(
+        t("gabinet.packages.giftAssigned", "Voucher przypisany do pacjenta."),
+      );
+      void queryClient.invalidateQueries({
+        queryKey: supabaseKeys.gabinetPackageUsage.list(organizationId),
+      });
       setAssigningGiftId(null);
       setAssignPatientId("");
     } catch (e) {
@@ -407,9 +798,13 @@ function PackagesIndex() {
     try {
       const newId = await createPatient({ organizationId, ...formData });
       setAssignPatientId(String(newId));
-      void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetPatients.list(organizationId) });
+      void queryClient.invalidateQueries({
+        queryKey: supabaseKeys.gabinetPatients.list(organizationId),
+      });
       setCreatePatientPanelOpen(false);
-      toast.success(t("gabinet.patients.created", { defaultValue: "Klient utworzony" }));
+      toast.success(
+        t("gabinet.patients.created", { defaultValue: "Klient utworzony" }),
+      );
     } catch (e) {
       toast.error(
         formatActionError(e, t, {
@@ -423,7 +818,7 @@ function PackagesIndex() {
   };
 
   const filteredGiftPackages = useMemo(() => {
-    const usages = unassignedGiftData ?? [];
+    const usages = unassignedUsagesData ?? [];
     if (!giftSearch.trim()) return usages;
     const q = giftSearch.toLowerCase();
     return usages.filter(
@@ -433,54 +828,106 @@ function PackagesIndex() {
         (u.giftRecipientPhone ?? "").toLowerCase().includes(q) ||
         (u.giftRecipientEmail ?? "").toLowerCase().includes(q),
     );
-  }, [unassignedGiftData, giftSearch]);
-
-  const expiringPackageIds = useMemo(() => {
-    const now = Date.now();
-    const thirtyDays = 30 * 24 * 60 * 60 * 1000;
-    const ids = new Set<string>();
-    for (const u of activeUsagesData ?? []) {
-      if (u.expiresAt != null && u.expiresAt > now && u.expiresAt <= now + thirtyDays) {
-        ids.add(u.packageId);
-      }
-    }
-    return ids;
-  }, [activeUsagesData]);
-
-  const items = useMemo(() => {
-    let all = packagesData ?? [];
-    if (statusFilter === "active") all = all.filter((p) => p.isActive);
-    else if (statusFilter === "inactive") all = all.filter((p) => !p.isActive);
-    if (expiringOnly || nudgeFilter === "expiring") {
-      all = all.filter((p) => expiringPackageIds.has(p._id));
-    }
-    if (nudgeFilter === "no-usage") {
-      all = all.filter((p) => p.isActive && (activeUsageCounts[p._id] ?? 0) === 0);
-    }
-    return all;
-  }, [packagesData, statusFilter, expiringOnly, expiringPackageIds, nudgeFilter, activeUsageCounts]);
-
-  // Build a treatment name lookup from loaded treatments
-  const treatmentNameMap = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const tr of treatments ?? []) {
-      map.set(tr._id, tr.name);
-    }
-    return map;
-  }, [treatments]);
+  }, [unassignedUsagesData, giftSearch]);
 
   return (
-    <div className="flex flex-col gap-6 p-6">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <PageHeader title={t("gabinet.packages.title")} description={t("gabinet.packages.description")} />
-        <Button size="sm" onClick={openCreate}>
-          <Plus className="mr-2 h-4 w-4" variant="stroke" />
-          {t("gabinet.packages.addPackage")}
-        </Button>
-      </div>
+    <div className="space-y-4">
+      <PageHeader
+        title={t("gabinet.packages.title", "Pakiety")}
+        description={t(
+          "gabinet.packages.description",
+          "Zarządzaj pakietami zabiegów",
+        )}
+        actions={
+          <PermissionGate feature="gabinet_packages" action="create">
+            <Button onClick={openCreate}>
+              <Plus className="mr-2 h-4 w-4" variant="stroke" />
+              {t("gabinet.packages.addPackage", "Dodaj pakiet")}
+            </Button>
+          </PermissionGate>
+        }
+      />
+
+      {nudgeFilter && (
+        <div className="flex items-center justify-between rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+          <span>
+            {nudgeFilter === "expiring"
+              ? t("gabinet.packages.nudgeFilter.expiring", {
+                  defaultValue:
+                    "Pokazywane są pakiety z użyciami wygasającymi w ciągu 30 dni.",
+                })
+              : t("gabinet.packages.nudgeFilter.noUsage", {
+                  defaultValue:
+                    "Pokazywane są aktywne pakiety bez aktywnych użyć.",
+                })}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 text-xs"
+            onClick={() =>
+              navigate({
+                to: "/dashboard/gabinet/packages",
+                search: { nudge: undefined },
+              })
+            }
+          >
+            <X className="h-3.5 w-3.5" variant="stroke" />
+            {t("common.clearFilters", "Wyczyść filtry")}
+          </Button>
+        </div>
+      )}
+
+      <DataListFilterBar
+        views={views}
+        activeViewId={activeViewId}
+        onViewChange={onViewChange}
+        onCreateView={onCreateView}
+        onDeleteView={onDeleteView}
+        filterableFields={filterableFields}
+        filterSlideoutOpen={filterSlideoutOpen}
+        onFilterSlideoutOpenChange={setFilterSlideoutOpen}
+        searchValue={searchValue}
+        onSearchChange={setSearchValue}
+        searchPlaceholder={t(
+          "gabinet.packages.searchPlaceholder",
+          "Szukaj pakietów...",
+        )}
+        columnDefs={allColumns.map((c) => ({
+          id: c.id,
+          label: c.label ?? c.id,
+        }))}
+        hiddenColumnIds={hiddenColumnIds}
+        onToggleColumn={toggleColumn}
+        onSetHiddenColumns={setHiddenColumns}
+        onTagsManage={() => setTagsSlideoutOpen(true)}
+        onCategoriesManage={() => setCategoriesSlideoutOpen(true)}
+        onFiltersChange={setActiveFilters}
+      />
+
+      {/* Mobile-only KPI toggle */}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setShowStatsMobile((s) => !s)}
+        aria-expanded={showStatsMobile}
+        className="md:hidden w-full justify-between"
+      >
+        {showStatsMobile
+          ? t("common.hideStats", "Ukryj statystyki")
+          : t("common.showStats", "Pokaż statystyki")}
+        {showStatsMobile ? (
+          <ChevronUp className="size-4" />
+        ) : (
+          <ChevronDown className="size-4" />
+        )}
+      </Button>
 
       {/* KPI Statistics Cards */}
-      <div className="grid gap-4 sm:grid-cols-3">
+      <div
+        className={`${showStatsMobile ? "grid" : "hidden md:grid"} gap-4 sm:grid-cols-3`}
+      >
         <StatisticsOrderCard
           title={t("gabinet.packages.totalPackages", "Pakiety")}
           description={t("gabinet.packages.inCatalog", "W ofercie")}
@@ -490,7 +937,7 @@ function PackagesIndex() {
         <StatisticsProfitCard
           title={t("gabinet.packages.activePackages", "Aktywne wykupione")}
           description={t("gabinet.packages.inUse", "W użyciu")}
-          value={String(pkgKpis.soldActiveUsages)}
+          value={String(activeUsagesData?.length ?? 0)}
           changePercentage={t("gabinet.packages.byPatients", "u klientów")}
         />
         <StatisticsImpressionCard
@@ -514,209 +961,52 @@ function PackagesIndex() {
           <TabsTrigger value="gifts">
             <Gift className="mr-1.5 h-4 w-4" variant="stroke" />
             {t("gabinet.packages.tabGifts", "Vouchery")}
-            {(unassignedGiftData?.length ?? 0) > 0 && (
+            {(unassignedUsagesData?.length ?? 0) > 0 && (
               <Badge variant="secondary" className="ml-1.5 text-xs">
-                {unassignedGiftData!.length}
+                {unassignedUsagesData!.length}
               </Badge>
             )}
           </TabsTrigger>
         </TabsList>
 
-        <TabsContent value="catalog" className="mt-4 space-y-4">
-          {expiringOnly && !nudgeFilter && (
-            <div className="flex items-center justify-between rounded-md border bg-amber-50 dark:bg-amber-950/20 px-3 py-2 text-sm">
-              <span>
-                {t("gabinet.packages.expiringFilterActive", {
-                  count: expiringPackageIds.size,
-                  defaultValue: "Showing packages with usages expiring within 30 days ({{count}})",
-                })}
-              </span>
-              <Button variant="ghost" size="sm" onClick={() => setExpiringOnly(false)}>
-                {t("common.clearFilters")}
-              </Button>
-            </div>
-          )}
-
-          {nudgeFilter && (
-            <div className="flex items-center justify-between rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
-              <span>
-                {nudgeFilter === "expiring"
-                  ? t("gabinet.packages.nudgeFilter.expiring", {
-                      defaultValue:
-                        "Pokazywane są pakiety z użyciami wygasającymi w ciągu 30 dni.",
-                    })
-                  : t("gabinet.packages.nudgeFilter.noUsage", {
-                      defaultValue:
-                        "Pokazywane są aktywne pakiety bez aktywnych użyć.",
-                    })}
-              </span>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 gap-1 text-xs"
-                onClick={() =>
-                  navigate({
-                    to: "/dashboard/gabinet/packages",
-                    search: { nudge: undefined },
-                  })
-                }
-              >
-                <X className="h-3.5 w-3.5" variant="stroke" />
-                {t("common.clearFilters")}
-              </Button>
-            </div>
-          )}
-
-          <QuickActionBar
-            actions={[
+        <TabsContent value="catalog" className="mt-4">
+          <CrmDataTable
+            columns={allColumns}
+            data={filteredPackages}
+            isLoading={isLoading}
+            hiddenColumnIds={hiddenColumnIds}
+            sortDescriptor={sortDescriptor}
+            onSortChange={setSortDescriptor}
+            enableBulkSelect
+            bulkActions={[
               {
-                label: t('quickActions.newPackage'),
-                icon: <Plus className="mr-1.5 h-4 w-4" variant="stroke" />,
-                onClick: openCreate,
-                feature: "gabinet_packages",
-                action: "create",
+                label: t("common.delete", "Usuń"),
+                value: "delete",
+                variant: "destructive",
               },
             ]}
+            onBulkAction={handleBulkAction}
+            rowActions={rowActions}
+            emptyTitle={t("gabinet.packages.emptyTitle", "Brak pakietów")}
+            emptyDescription={t(
+              "gabinet.packages.emptyDescription",
+              "Utwórz pierwszy pakiet zabiegów.",
+            )}
           />
-
-          {items.length === 0 ? (
-            <EmptyState
-              icon={Package}
-              title={t("gabinet.packages.emptyTitle")}
-              description={t("gabinet.packages.emptyDescription")}
-            />
-          ) : (
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {items.map((pkg) => {
-            const usageDetail = activeUsageDetails[pkg._id];
-            const activeCount = activeUsageCounts[pkg._id] ?? 0;
-
-            return (
-              <div key={pkg._id} className="rounded-lg border p-4 space-y-3">
-                <div className="flex items-start justify-between">
-                  <div>
-                    <h3 className="font-medium">{pkg.name}</h3>
-                    {pkg.description && (() => {
-                      const descText = plateJsonToText(pkg.description);
-                      return descText ? (
-                        <p className="text-sm text-muted-foreground whitespace-pre-line">{descText}</p>
-                      ) : null;
-                    })()}
-                  </div>
-                  <Badge variant={pkg.isActive ? "default" : "secondary"}>
-                    {pkg.isActive ? t("gabinet.packages.active") : t("gabinet.packages.inactive")}
-                  </Badge>
-                </div>
-                <div className="text-2xl font-bold">{pkg.totalPrice} {pkg.currency ?? "PLN"}</div>
-                <div className="text-xs text-muted-foreground">
-                  {pkg.treatments.length} {t("gabinet.packages.treatments")}
-                  {pkg.validityDays && ` · ${pkg.validityDays} ${t("gabinet.packages.days")}`}
-                  {pkg.discountPercent && ` · ${pkg.discountPercent}% ${t("gabinet.packages.discount")}`}
-                </div>
-
-                {/* Per-treatment progress bars */}
-                {activeCount > 0 && usageDetail && (
-                  <div className="space-y-2 pt-1">
-                    <p className="text-xs font-medium text-muted-foreground">{t("gabinet.packages.treatmentProgress")}</p>
-                    {pkg.treatments.map((tr) => {
-                      const progress = usageDetail.treatmentProgress[tr.treatmentId];
-                      const usedCount = progress?.usedCount ?? 0;
-                      const totalCount = progress?.totalCount ?? 0;
-                      const remaining = totalCount - usedCount;
-                      const percent = totalCount > 0 ? Math.round((usedCount / totalCount) * 100) : 0;
-                      const remainingRatio = totalCount > 0 ? remaining / totalCount : 1;
-                      const treatmentName = treatmentNameMap.get(tr.treatmentId) ?? t("gabinet.packages.treatment");
-
-                      // Color coding: green when plenty, amber when <30%, red when <10%
-                      let progressColor = "bg-emerald-500";
-                      let statusLabel = t("gabinet.packages.plentyRemaining");
-                      if (remainingRatio <= 0) {
-                        progressColor = "bg-red-500";
-                        statusLabel = t("gabinet.packages.fullyUsed");
-                      } else if (remainingRatio < 0.1) {
-                        progressColor = "bg-red-500";
-                        statusLabel = t("gabinet.packages.almostExhausted");
-                      } else if (remainingRatio < 0.3) {
-                        progressColor = "bg-amber-500";
-                        statusLabel = t("gabinet.packages.runningLow");
-                      }
-
-                      return (
-                        <TooltipProvider key={tr.treatmentId}>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <div className="space-y-1">
-                                <div className="flex items-center justify-between text-xs">
-                                  <span className="truncate max-w-[60%]">{treatmentName}</span>
-                                  <span className="text-muted-foreground tabular-nums">
-                                    {usedCount} / {totalCount}
-                                  </span>
-                                </div>
-                                <div className="h-1.5 bg-muted rounded-full overflow-hidden">
-                                  <div
-                                    className={`h-full transition-all rounded-full ${progressColor}`}
-                                    style={{ width: `${percent}%` }}
-                                  />
-                                </div>
-                              </div>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p>{treatmentName}: {statusLabel}</p>
-                              <p className="text-xs text-muted-foreground">
-                                {t("gabinet.packages.totalRemaining", { remaining, total: totalCount })}
-                              </p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      );
-                    })}
-
-                    {/* Overall package completion */}
-                    {(() => {
-                      const overallUsed = Object.values(usageDetail.treatmentProgress).reduce((s, p) => s + p.usedCount, 0);
-                      const overallTotal = Object.values(usageDetail.treatmentProgress).reduce((s, p) => s + p.totalCount, 0);
-                      const overallPercent = overallTotal > 0 ? Math.round((overallUsed / overallTotal) * 100) : 0;
-                      return (
-                        <div className="pt-1 border-t mt-2">
-                          <div className="flex items-center justify-between text-xs">
-                            <span className="font-medium">{t("gabinet.packages.overallProgress")}</span>
-                            <span className="text-muted-foreground tabular-nums">{t("gabinet.packages.completionPercent", { percent: overallPercent })}</span>
-                          </div>
-                          <Progress value={overallPercent} className="h-2 mt-1" />
-                        </div>
-                      );
-                    })()}
-                  </div>
-                )}
-
-                {activeCount > 0 && (
-                  <div className="text-xs">
-                    <Badge variant="outline" className="text-xs">
-                      {activeCount} {t("gabinet.packages.activeUses")}
-                    </Badge>
-                  </div>
-                )}
-                <div className="flex gap-2">
-                  <Button variant="ghost" size="sm" onClick={() => openEdit(pkg)}>
-                    <Pencil className="mr-1 h-4 w-4" variant="stroke" /> {t("detail.actions.edit")}
-                  </Button>
-                  <Button variant="ghost" size="sm" className="text-destructive" onClick={() => confirmDelete(pkg._id)}>
-                    <Trash2 className="mr-1 h-4 w-4" variant="stroke" /> {t("common.delete")}
-                  </Button>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      )}
         </TabsContent>
 
         <TabsContent value="gifts" className="mt-4 space-y-4">
           <div className="relative">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" variant="stroke" />
+            <Search
+              className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              variant="stroke"
+            />
             <Input
               className="pl-9"
-              placeholder={t("gabinet.packages.giftSearch", "Szukaj po kodzie vouchera, nazwisku lub e-mailu...")}
+              placeholder={t(
+                "gabinet.packages.giftSearch",
+                "Szukaj po kodzie vouchera, nazwisku lub e-mailu...",
+              )}
               value={giftSearch}
               onChange={(e) => setGiftSearch(e.target.value)}
             />
@@ -725,20 +1015,39 @@ function PackagesIndex() {
           {filteredGiftPackages.length === 0 ? (
             <EmptyState
               icon={Gift}
-              title={t("gabinet.packages.giftEmptyTitle", "Brak nieprzypisanych voucherów")}
-              description={t("gabinet.packages.giftEmptyDescription", "Sprzedane vouchery podarunkowe, które nie zostały jeszcze przypisane do pacjenta, pojawią się tutaj.")}
+              title={t(
+                "gabinet.packages.giftEmptyTitle",
+                "Brak nieprzypisanych voucherów",
+              )}
+              description={t(
+                "gabinet.packages.giftEmptyDescription",
+                "Sprzedane vouchery podarunkowe, które nie zostały jeszcze przypisane do pacjenta, pojawią się tutaj.",
+              )}
             />
           ) : (
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
               {filteredGiftPackages.map((usage) => {
-                const pkg = (packagesData ?? []).find((p) => p._id === usage.packageId);
+                const pkg = (packagesData ?? []).find(
+                  (p) => p._id === usage.packageId,
+                );
                 return (
-                  <div key={usage._id} className="rounded-lg border p-4 space-y-3">
+                  <div
+                    key={usage._id}
+                    className="rounded-lg border p-4 space-y-3"
+                  >
                     <div className="flex items-start justify-between gap-2">
                       <div className="min-w-0">
-                        <h3 className="font-medium truncate">{pkg?.name ?? t("gabinet.packages.unknownPackage", "Nieznany pakiet")}</h3>
+                        <h3 className="font-medium truncate">
+                          {pkg?.name ??
+                            t(
+                              "gabinet.packages.unknownPackage",
+                              "Nieznany pakiet",
+                            )}
+                        </h3>
                         {usage.voucherCode && (
-                          <p className="text-sm font-mono text-muted-foreground">{usage.voucherCode}</p>
+                          <p className="text-sm font-mono text-muted-foreground">
+                            {usage.voucherCode}
+                          </p>
                         )}
                       </div>
                       <Badge variant="secondary" className="shrink-0">
@@ -746,31 +1055,54 @@ function PackagesIndex() {
                       </Badge>
                     </div>
 
-                    {(usage.giftRecipientName || usage.giftRecipientPhone || usage.giftRecipientEmail) && (
+                    {(usage.giftRecipientName ||
+                      usage.giftRecipientPhone ||
+                      usage.giftRecipientEmail) && (
                       <div className="text-sm text-muted-foreground space-y-0.5">
-                        {usage.giftRecipientName && <p>{usage.giftRecipientName}</p>}
-                        {usage.giftRecipientPhone && <p>{usage.giftRecipientPhone}</p>}
-                        {usage.giftRecipientEmail && <p>{usage.giftRecipientEmail}</p>}
+                        {usage.giftRecipientName && (
+                          <p>{usage.giftRecipientName}</p>
+                        )}
+                        {usage.giftRecipientPhone && (
+                          <p>{usage.giftRecipientPhone}</p>
+                        )}
+                        {usage.giftRecipientEmail && (
+                          <p>{usage.giftRecipientEmail}</p>
+                        )}
                       </div>
                     )}
 
                     <div className="text-xs text-muted-foreground">
-                      {t("gabinet.packages.purchasedAt", "Zakupiono")}: {new Date(usage.purchasedAt).toLocaleDateString("pl-PL")}
+                      {t("gabinet.packages.purchasedAt", "Zakupiono")}:{" "}
+                      {new Date(usage.purchasedAt).toLocaleDateString("pl-PL")}
                       {usage.expiresAt && (
-                        <> · {t("gabinet.packages.expiresAt", "Ważny do")}: {new Date(usage.expiresAt).toLocaleDateString("pl-PL")}</>
+                        <>
+                          {" "}
+                          · {t("gabinet.packages.expiresAt", "Ważny do")}:{" "}
+                          {new Date(usage.expiresAt).toLocaleDateString(
+                            "pl-PL",
+                          )}
+                        </>
                       )}
                     </div>
 
-                    <div className="text-sm font-semibold">{usage.paidAmount} PLN</div>
+                    <div className="text-sm font-semibold">
+                      {usage.paidAmount} PLN
+                    </div>
 
                     <Button
                       size="sm"
                       variant="outline"
                       className="w-full"
-                      onClick={() => { setAssigningGiftId(usage._id); setAssignPatientId(""); }}
+                      onClick={() => {
+                        setAssigningGiftId(usage._id);
+                        setAssignPatientId("");
+                      }}
                     >
                       <Gift className="mr-1.5 h-4 w-4" variant="stroke" />
-                      {t("gabinet.packages.assignToPatient", "Przypisz do pacjenta")}
+                      {t(
+                        "gabinet.packages.assignToPatient",
+                        "Przypisz do pacjenta",
+                      )}
                     </Button>
                   </div>
                 );
@@ -780,53 +1112,126 @@ function PackagesIndex() {
         </TabsContent>
       </Tabs>
 
+      {/* Package create/edit panel */}
       <SidePanel
         open={panelOpen}
-        onOpenChange={(open) => { setPanelOpen(open); if (!open) resetForm(); }}
-        title={editingId ? t("gabinet.packages.editPackage") : t("gabinet.packages.addPackage")}
+        onOpenChange={(open) => {
+          setPanelOpen(open);
+          if (!open) resetForm();
+        }}
+        title={
+          editingId
+            ? t("gabinet.packages.editPackage", "Edytuj pakiet")
+            : t("gabinet.packages.addPackage", "Dodaj pakiet")
+        }
         onSubmit={handleSubmit}
         isSubmitting={submitting}
       >
         <div className="space-y-4">
           <div className="space-y-1.5">
-            <Label>{t("gabinet.packages.name")}</Label>
+            <Label>{t("gabinet.packages.name", "Nazwa")}</Label>
             <Input value={name} onChange={(e) => setName(e.target.value)} />
           </div>
           <div className="space-y-1.5">
-            <Label>{t("gabinet.packages.descriptionField")}</Label>
-            <RichTextEditor value={description} onChange={(val) => setDescription(val ?? "")} minHeight="80px" />
+            <Label>{t("gabinet.packages.descriptionField", "Opis")}</Label>
+            <RichTextEditor
+              value={description}
+              onChange={(val) => setDescription(val ?? "")}
+              minHeight="80px"
+            />
           </div>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div className="space-y-1.5">
-              <Label>{t("gabinet.packages.totalPrice")}</Label>
-              <Input type="number" inputMode="decimal" value={totalPrice} onChange={(e) => setTotalPrice(e.target.value)} />
+              <Label>{t("gabinet.packages.totalPrice", "Cena")}</Label>
+              <Input
+                type="number"
+                inputMode="decimal"
+                value={totalPrice}
+                onChange={(e) => setTotalPrice(e.target.value)}
+              />
             </div>
             <div className="space-y-1.5">
-              <Label>{t("gabinet.packages.validityDays")}</Label>
-              <Input type="number" inputMode="numeric" value={validityDays} onChange={(e) => setValidityDays(e.target.value)} />
+              <Label>
+                {t("gabinet.packages.validityDays", "Ważność (dni)")}
+              </Label>
+              <Input
+                type="number"
+                inputMode="numeric"
+                value={validityDays}
+                onChange={(e) => setValidityDays(e.target.value)}
+              />
             </div>
           </div>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div className="space-y-1.5">
-              <Label>{t("gabinet.packages.discountPercent")}</Label>
-              <Input type="number" inputMode="numeric" value={discountPercent} onChange={(e) => setDiscountPercent(e.target.value)} />
+              <Label>
+                {t("gabinet.packages.discountPercent", "Rabat (%)")}
+              </Label>
+              <Input
+                type="number"
+                inputMode="numeric"
+                value={discountPercent}
+                onChange={(e) => setDiscountPercent(e.target.value)}
+              />
             </div>
             <div className="space-y-1.5">
-              <Label>{t("gabinet.packages.loyaltyPoints")}</Label>
-              <Input type="number" inputMode="numeric" value={loyaltyPoints} onChange={(e) => setLoyaltyPoints(e.target.value)} />
+              <Label>
+                {t("gabinet.packages.loyaltyPoints", "Punkty lojalnościowe")}
+              </Label>
+              <Input
+                type="number"
+                inputMode="numeric"
+                value={loyaltyPoints}
+                onChange={(e) => setLoyaltyPoints(e.target.value)}
+              />
             </div>
           </div>
 
+          {/* Category picker */}
+          <div className="space-y-1.5">
+            <Label>{t("common.category", "Kategoria")}</Label>
+            <CategoryPicker
+              categories={categories}
+              selectedId={categoryId}
+              onChange={setCategoryId}
+              organizationId={organizationId}
+              entityType="gabinetPackage"
+            />
+          </div>
+
+          {/* Tags picker */}
+          {tags.length > 0 && (
+            <div className="space-y-1.5">
+              <Label>{t("common.tags", "Tagi")}</Label>
+              <TagsPicker
+                tags={tags}
+                selectedIds={tagIds}
+                onChange={setTagIds}
+              />
+            </div>
+          )}
+
           <div className="space-y-2">
             <div className="flex items-center justify-between">
-              <Label>{t("gabinet.packages.treatmentsInPackage")}</Label>
-              <Button type="button" variant="outline" size="sm" onClick={addTreatment}>
-                <Plus className="mr-1 h-4 w-4" variant="stroke" /> {t("common.add")}
+              <Label>
+                {t(
+                  "gabinet.packages.treatmentsInPackage",
+                  "Zabiegi w pakiecie",
+                )}
+              </Label>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={addTreatmentRow}
+              >
+                <Plus className="mr-1 h-4 w-4" variant="stroke" />{" "}
+                {t("common.add", "Dodaj")}
               </Button>
             </div>
             {selectedTreatments.length === 0 && (
               <p className="text-sm text-muted-foreground py-1">
-                {t("gabinet.packages.noTreatments")}
+                {t("gabinet.packages.noTreatments", "Brak zabiegów")}
               </p>
             )}
             {selectedTreatments.map((st, i) => (
@@ -834,20 +1239,35 @@ function PackagesIndex() {
                 <div className="flex items-end gap-2">
                   <div className="flex-1 min-w-0 space-y-1">
                     <Label className="text-xs text-muted-foreground">
-                      {t("gabinet.packages.treatment")}
+                      {t("gabinet.packages.treatment", "Zabieg")}
                     </Label>
-                    <Select value={st.treatmentId} onValueChange={(val) => updateTreatment(i, "treatmentId", val)}>
+                    <Select
+                      value={st.treatmentId}
+                      onValueChange={(val) =>
+                        updateTreatmentRow(i, "treatmentId", val)
+                      }
+                    >
                       <SelectTrigger>
-                        <SelectValue placeholder={t("gabinet.packages.treatment")} />
+                        <SelectValue
+                          placeholder={t(
+                            "gabinet.packages.treatment",
+                            "Zabieg",
+                          )}
+                        />
                       </SelectTrigger>
                       <SelectContent>
-                        {(treatments ?? []).length === 0 ? (
+                        {treatments.length === 0 ? (
                           <SelectItem value="__none__" disabled>
-                            {t("gabinet.packages.noTreatmentsAvailable")}
+                            {t(
+                              "gabinet.packages.noTreatmentsAvailable",
+                              "Brak dostępnych zabiegów",
+                            )}
                           </SelectItem>
                         ) : (
-                          (treatments ?? []).map((tr) => (
-                            <SelectItem key={tr._id} value={tr._id}>{tr.name}</SelectItem>
+                          treatments.map((tr) => (
+                            <SelectItem key={tr._id} value={tr._id}>
+                              {tr.name}
+                            </SelectItem>
                           ))
                         )}
                       </SelectContent>
@@ -855,13 +1275,19 @@ function PackagesIndex() {
                   </div>
                   <div className="w-24 shrink-0 space-y-1">
                     <Label className="text-xs text-muted-foreground">
-                      {t("gabinet.packages.quantity")}
+                      {t("gabinet.packages.quantity", "Ilość")}
                     </Label>
                     <Input
                       type="number"
                       inputMode="numeric"
                       value={st.quantity}
-                      onChange={(e) => updateTreatment(i, "quantity", parseInt(e.target.value) || 1)}
+                      onChange={(e) =>
+                        updateTreatmentRow(
+                          i,
+                          "quantity",
+                          parseInt(e.target.value) || 1,
+                        )
+                      }
                       min={1}
                     />
                   </div>
@@ -870,8 +1296,8 @@ function PackagesIndex() {
                     variant="ghost"
                     size="sm"
                     className="shrink-0"
-                    onClick={() => removeTreatment(i)}
-                    aria-label={t("common.delete")}
+                    onClick={() => removeTreatmentRow(i)}
+                    aria-label={t("common.delete", "Usuń")}
                   >
                     <Trash2 className="h-4 w-4" variant="stroke" />
                   </Button>
@@ -882,66 +1308,34 @@ function PackagesIndex() {
         </div>
       </SidePanel>
 
-      <SidePanel
-        open={filterPanelOpen}
-        onOpenChange={setFilterPanelOpen}
-        title={t("nav.actions.filterByStatus")}
-      >
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label>{t("common.status")}</Label>
-            <RadioGroup
-              value={statusFilter}
-              onValueChange={(val) => setStatusFilter(val as "all" | "active" | "inactive")}
-            >
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="all" id="package-filter-all" />
-                <Label htmlFor="package-filter-all" className="font-normal">
-                  {t("common.all")}
-                </Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="active" id="package-filter-active" />
-                <Label htmlFor="package-filter-active" className="font-normal">
-                  {t("gabinet.packages.active")}
-                </Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="inactive" id="package-filter-inactive" />
-                <Label htmlFor="package-filter-inactive" className="font-normal">
-                  {t("gabinet.packages.inactive")}
-                </Label>
-              </div>
-            </RadioGroup>
-          </div>
-          {statusFilter !== "all" && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setStatusFilter("all")}
-            >
-              {t("common.clearFilters")}
-            </Button>
-          )}
-        </div>
-      </SidePanel>
-
       <SellPackagePanel
         organizationId={organizationId}
         open={assignPanelOpen}
         onOpenChange={setAssignPanelOpen}
       />
 
+      {/* Gift assignment panel */}
       <SidePanel
         open={assigningGiftId !== null}
-        onOpenChange={(open) => { if (!open) { setAssigningGiftId(null); setAssignPatientId(""); } }}
-        title={t("gabinet.packages.assignGiftTitle", "Przypisz voucher do pacjenta")}
+        onOpenChange={(open) => {
+          if (!open) {
+            setAssigningGiftId(null);
+            setAssignPatientId("");
+          }
+        }}
+        title={t(
+          "gabinet.packages.assignGiftTitle",
+          "Przypisz voucher do pacjenta",
+        )}
         onSubmit={handleAssignGift}
         isSubmitting={assignSubmitting}
       >
         <div className="space-y-4">
           <p className="text-sm text-muted-foreground">
-            {t("gabinet.packages.assignGiftDescription", "Wybierz pacjenta, do którego zostanie przypisany voucher. Pakiet stanie się aktywny dla wybranego pacjenta.")}
+            {t(
+              "gabinet.packages.assignGiftDescription",
+              "Wybierz pacjenta, do którego zostanie przypisany voucher. Pakiet stanie się aktywny dla wybranego pacjenta.",
+            )}
           </p>
           <div className="space-y-1.5">
             <div className="flex items-center justify-between">
@@ -959,7 +1353,12 @@ function PackagesIndex() {
             </div>
             <Select value={assignPatientId} onValueChange={setAssignPatientId}>
               <SelectTrigger>
-                <SelectValue placeholder={t("gabinet.packages.selectPatient", "Wybierz pacjenta...")} />
+                <SelectValue
+                  placeholder={t(
+                    "gabinet.packages.selectPatient",
+                    "Wybierz pacjenta...",
+                  )}
+                />
               </SelectTrigger>
               <SelectContent>
                 {(patientsData ?? []).length === 0 ? (
@@ -979,11 +1378,15 @@ function PackagesIndex() {
         </div>
       </SidePanel>
 
+      {/* New patient creation panel */}
       <SidePanel
         open={createPatientPanelOpen}
         onOpenChange={setCreatePatientPanelOpen}
         title={t("gabinet.patients.createPatient", "Nowy pacjent")}
-        description={t("gabinet.patients.createDescription", "Wypełnij dane nowego pacjenta.")}
+        description={t(
+          "gabinet.patients.createDescription",
+          "Wypełnij dane nowego pacjenta.",
+        )}
       >
         <PatientForm
           onSubmit={handleCreatePatient}
@@ -993,18 +1396,42 @@ function PackagesIndex() {
         />
       </SidePanel>
 
+      <TagsManagerSlideout
+        isOpen={tagsSlideoutOpen}
+        onOpenChange={setTagsSlideoutOpen}
+        organizationId={organizationId}
+        tags={tags}
+      />
+      <CategoriesManagerSlideout
+        isOpen={categoriesSlideoutOpen}
+        onOpenChange={setCategoriesSlideoutOpen}
+        organizationId={organizationId}
+        entityType="gabinetPackage"
+        categories={categories}
+      />
+
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{t("common.confirmDelete")}</AlertDialogTitle>
+            <AlertDialogTitle>
+              {t("common.confirmDelete", "Potwierdź usunięcie")}
+            </AlertDialogTitle>
             <AlertDialogDescription>
-              {t("gabinet.packages.confirmDeleteDescription")}
+              {t(
+                "gabinet.packages.confirmDeleteDescription",
+                "Tej operacji nie można cofnąć.",
+              )}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
-            <AlertDialogAction onClick={handleRemove} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
-              {t("common.delete")}
+            <AlertDialogCancel>
+              {t("common.cancel", "Anuluj")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleRemove}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {t("common.delete", "Usuń")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>


### PR DESCRIPTION
## Summary

- Replaces the packages card grid with `CrmDataTable` + `DataListFilterBar` + `useSavedViews` — the same pattern used by treatments, patients, employees, and appointments
- Adds tags (`tagIds`) and category (`categoryId`) support to packages: schema field in `convex/schema/gabinet.ts`, Supabase migration `00075_gabinet_packages_tags_category.sql`, Convex `create`/`update` actions, mapper, and UI pickers in the create/edit form
- System saved views: "Wszystkie pakiety", "Aktywne", "Nieaktywne" (user-configurable, per author's answer)
- Advanced filter conditions: name, price, validity, discount, tags, category, status, created date
- Column visibility toggle, per-column sorting, bulk delete
- Mobile-collapsible KPI cards (using real active-usage data)
- Vouchers tab and `SellPackagePanel` preserved

## Test plan

- [ ] `/dashboard/gabinet/packages` loads the table view without errors
- [ ] Saved views (Aktywne / Nieaktywne) filter the table correctly
- [ ] Full-text search filters package names
- [ ] Advanced filters (price, validity, tags, category) apply correctly
- [ ] Creating a package with tags and category saves and appears in the table
- [ ] Editing a package pre-populates tags and category fields
- [ ] Deleting a package (single row action and bulk) works
- [ ] Vouchers tab still shows unassigned gift usages
- [ ] KPI cards show correct counts (total / active catalog / expiring soon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)