### PR TITLE
fix(gabinet): packages table UX — row click, usage stats column, filter slideout footer (closes #3343)

### DIFF
--- a/src/components/application/slideout-menus/slideout-menu.tsx
+++ b/src/components/application/slideout-menus/slideout-menu.tsx
@@ -1,115 +1,175 @@
-import { type ComponentPropsWithRef, type ReactNode, type RefAttributes } from "react";
+import {
+  type ComponentPropsWithRef,
+  type ReactNode,
+  type RefAttributes,
+} from "react";
 import type {
-    DialogProps as AriaDialogProps,
-    ModalOverlayProps as AriaModalOverlayProps,
-    ModalRenderProps as AriaModalRenderProps,
+  DialogProps as AriaDialogProps,
+  ModalOverlayProps as AriaModalOverlayProps,
+  ModalRenderProps as AriaModalRenderProps,
 } from "react-aria-components";
-import { Dialog as AriaDialog, DialogTrigger as AriaDialogTrigger, Modal as AriaModal, ModalOverlay as AriaModalOverlay } from "react-aria-components";
+import {
+  Dialog as AriaDialog,
+  DialogTrigger as AriaDialogTrigger,
+  Modal as AriaModal,
+  ModalOverlay as AriaModalOverlay,
+} from "react-aria-components";
 import { CloseButton } from "@untitled/base/buttons/close-button";
 import { cx } from "@/lib/utils/cx";
 
-interface ModalOverlayProps extends AriaModalOverlayProps, RefAttributes<HTMLDivElement> {}
+interface ModalOverlayProps
+  extends AriaModalOverlayProps,
+    RefAttributes<HTMLDivElement> {}
 
 export const ModalOverlay = (props: ModalOverlayProps) => {
-    return (
-        <AriaModalOverlay
-            {...props}
-            className={(state) =>
-                cx(
-                    "fixed inset-0 flex min-h-dvh w-full items-center justify-end bg-overlay/70 pl-6 outline-hidden ease-linear md:pl-10",
-                    state.isEntering && "duration-300 animate-in fade-in",
-                    state.isExiting && "duration-500 animate-out fade-out",
-                    typeof props.className === "function" ? props.className(state) : props.className,
-                )
-            }
-        />
-    );
+  return (
+    <AriaModalOverlay
+      {...props}
+      className={(state) =>
+        cx(
+          "fixed inset-0 flex min-h-dvh w-full items-center justify-end bg-overlay/70 pl-6 outline-hidden ease-linear md:pl-10",
+          state.isEntering && "duration-300 animate-in fade-in",
+          state.isExiting && "duration-500 animate-out fade-out",
+          typeof props.className === "function"
+            ? props.className(state)
+            : props.className,
+        )
+      }
+    />
+  );
 };
 ModalOverlay.displayName = "ModalOverlay";
 
-interface ModalProps extends AriaModalOverlayProps, RefAttributes<HTMLDivElement> {}
+interface ModalProps
+  extends AriaModalOverlayProps,
+    RefAttributes<HTMLDivElement> {}
 
 export const Modal = (props: ModalProps) => (
-    <AriaModal
-        {...props}
-        className={(state) =>
-            cx(
-                "inset-y-0 right-0 h-full w-full max-w-100 shadow-xl transition",
-                state.isEntering && "duration-300 animate-in slide-in-from-right",
-                state.isExiting && "duration-500 animate-out slide-out-to-right",
-                typeof props.className === "function" ? props.className(state) : props.className,
-            )
-        }
-    />
+  <AriaModal
+    {...props}
+    className={(state) =>
+      cx(
+        "inset-y-0 right-0 h-full w-full max-w-100 shadow-xl transition",
+        state.isEntering && "duration-300 animate-in slide-in-from-right",
+        state.isExiting && "duration-500 animate-out slide-out-to-right",
+        typeof props.className === "function"
+          ? props.className(state)
+          : props.className,
+      )
+    }
+  />
 );
 Modal.displayName = "Modal";
 
 interface DialogProps extends AriaDialogProps, RefAttributes<HTMLElement> {}
 
 export const Dialog = (props: DialogProps) => (
-    <AriaDialog
-        role="dialog"
-        aria-label="Slideout menu"
-        {...props}
-        className={cx(
-            "relative flex size-full flex-col items-start gap-6 overflow-y-auto bg-bg-primary ring-1 ring-border-secondary_alt outline-hidden",
-            props.className,
-        )}
-    />
+  <AriaDialog
+    role="dialog"
+    aria-label="Slideout menu"
+    {...props}
+    className={cx(
+      "relative flex size-full flex-col items-start gap-6 overflow-y-auto bg-bg-primary ring-1 ring-border-secondary_alt outline-hidden",
+      props.className,
+    )}
+  />
 );
 Dialog.displayName = "Dialog";
 
-interface SlideoutMenuProps extends Omit<AriaModalOverlayProps, "children">, RefAttributes<HTMLDivElement> {
-    children: ReactNode | ((children: AriaModalRenderProps & { close: () => void }) => ReactNode);
-    dialogClassName?: string;
+interface SlideoutMenuProps
+  extends Omit<AriaModalOverlayProps, "children">,
+    RefAttributes<HTMLDivElement> {
+  children:
+    | ReactNode
+    | ((children: AriaModalRenderProps & { close: () => void }) => ReactNode);
+  dialogClassName?: string;
 }
 
 const Menu = ({ children, dialogClassName, ...props }: SlideoutMenuProps) => {
-    return (
-        <ModalOverlay {...props}>
-            <Modal className={(state) => cx(typeof props.className === "function" ? props.className(state) : props.className)}>
-                {(state) => (
-                    <Dialog className={dialogClassName}>
-                        {({ close }) => {
-                            return typeof children === "function" ? children({ ...state, close }) : children;
-                        }}
-                    </Dialog>
-                )}
-            </Modal>
-        </ModalOverlay>
-    );
+  return (
+    <ModalOverlay {...props}>
+      <Modal
+        className={(state) =>
+          cx(
+            typeof props.className === "function"
+              ? props.className(state)
+              : props.className,
+          )
+        }
+      >
+        {(state) => (
+          <Dialog className={dialogClassName}>
+            {({ close }) => {
+              return typeof children === "function"
+                ? children({ ...state, close })
+                : children;
+            }}
+          </Dialog>
+        )}
+      </Modal>
+    </ModalOverlay>
+  );
 };
 Menu.displayName = "SlideoutMenu";
 
 const Content = ({ role = "main", ...props }: ComponentPropsWithRef<"div">) => {
-    return <div role={role} {...props} className={cx("flex size-full flex-col gap-6 overflow-y-auto overscroll-auto px-4 md:px-6", props.className)} />;
+  return (
+    <div
+      role={role}
+      {...props}
+      className={cx(
+        "flex min-h-0 w-full flex-1 flex-col gap-6 overflow-y-auto overscroll-auto px-4 md:px-6",
+        props.className,
+      )}
+    />
+  );
 };
 Content.displayName = "SlideoutContent";
 
 interface SlideoutHeaderProps extends ComponentPropsWithRef<"header"> {
-    onClose?: () => void;
+  onClose?: () => void;
 }
 
-const Header = ({ className, children, onClose, ...props }: SlideoutHeaderProps) => {
-    return (
-        <header {...props} className={cx("relative z-1 w-full px-4 pt-6 md:px-6", className)}>
-            {children}
-            <CloseButton size="sm" className="absolute top-3 right-3 shrink-0" onClick={onClose} />
-        </header>
-    );
+const Header = ({
+  className,
+  children,
+  onClose,
+  ...props
+}: SlideoutHeaderProps) => {
+  return (
+    <header
+      {...props}
+      className={cx("relative z-1 w-full px-4 pt-6 md:px-6", className)}
+    >
+      {children}
+      <CloseButton
+        size="sm"
+        className="absolute top-3 right-3 shrink-0"
+        onClick={onClose}
+      />
+    </header>
+  );
 };
 Header.displayName = "SlideoutHeader";
 
 const Footer = (props: ComponentPropsWithRef<"footer">) => {
-    return <footer {...props} className={cx("w-full p-4 shadow-[inset_0px_1px_0px_0px] shadow-border-secondary md:px-6", props.className)} />;
+  return (
+    <footer
+      {...props}
+      className={cx(
+        "w-full p-4 shadow-[inset_0px_1px_0px_0px] shadow-border-secondary md:px-6",
+        props.className,
+      )}
+    />
+  );
 };
 Footer.displayName = "SlideoutFooter";
 
 const SlideoutMenu = Menu as typeof Menu & {
-    Trigger: typeof AriaDialogTrigger;
-    Content: typeof Content;
-    Header: typeof Header;
-    Footer: typeof Footer;
+  Trigger: typeof AriaDialogTrigger;
+  Content: typeof Content;
+  Header: typeof Header;
+  Footer: typeof Footer;
 };
 SlideoutMenu.displayName = "SlideoutMenu";
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -153,6 +153,48 @@ function buildActiveUsageCounts(
   return counts;
 }
 
+function buildActiveUsageDetails(usages: MappedGabinetPackageUsage[]): Record<
+  string,
+  {
+    count: number;
+    treatmentProgress: Record<
+      string,
+      { usedCount: number; totalCount: number }
+    >;
+  }
+> {
+  const byPackage: Record<
+    string,
+    {
+      count: number;
+      treatmentProgress: Record<
+        string,
+        { usedCount: number; totalCount: number }
+      >;
+    }
+  > = {};
+
+  for (const u of usages) {
+    if (!byPackage[u.packageId]) {
+      byPackage[u.packageId] = { count: 0, treatmentProgress: {} };
+    }
+    byPackage[u.packageId].count += 1;
+    for (const t of u.treatmentsUsed) {
+      const key = t.treatmentId;
+      if (!byPackage[u.packageId].treatmentProgress[key]) {
+        byPackage[u.packageId].treatmentProgress[key] = {
+          usedCount: 0,
+          totalCount: 0,
+        };
+      }
+      byPackage[u.packageId].treatmentProgress[key].usedCount += t.usedCount;
+      byPackage[u.packageId].treatmentProgress[key].totalCount += t.totalCount;
+    }
+  }
+
+  return byPackage;
+}
+
 function derivePackageKpis(
   packages: MappedGabinetTreatmentPackage[],
   activeUsages: MappedGabinetPackageUsage[],
@@ -228,6 +270,11 @@ function PackagesIndex() {
 
   const activeUsageCounts = useMemo(
     () => buildActiveUsageCounts(activeUsagesData ?? []),
+    [activeUsagesData],
+  );
+
+  const activeUsageDetails = useMemo(
+    () => buildActiveUsageDetails(activeUsagesData ?? []),
     [activeUsagesData],
   );
 
@@ -526,6 +573,80 @@ function PackagesIndex() {
         getSortValue: (item) => activeUsageCounts[item._id] ?? 0,
       },
       {
+        id: "usage",
+        label: t("gabinet.packages.usageProgress", "Wykorzystanie"),
+        sortable: true,
+        className: "min-w-[160px]",
+        render: (item) => {
+          const detail = activeUsageDetails[item._id];
+          const progress = detail
+            ? Object.values(detail.treatmentProgress)
+            : [];
+          const overallUsed = progress.reduce((s, p) => s + p.usedCount, 0);
+          const overallTotal = progress.reduce((s, p) => s + p.totalCount, 0);
+          if (!detail || overallTotal === 0) {
+            return <span className="text-fg-quaternary">—</span>;
+          }
+          const percent = Math.round((overallUsed / overallTotal) * 100);
+          const remainingRatio = 1 - overallUsed / overallTotal;
+          const barColor =
+            remainingRatio <= 0.1
+              ? "bg-red-500"
+              : remainingRatio < 0.3
+                ? "bg-amber-500"
+                : "bg-emerald-500";
+          return (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="w-36 space-y-1">
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="tabular-nums">
+                        {overallUsed} / {overallTotal}
+                      </span>
+                      <span className="text-fg-quaternary tabular-nums">
+                        {percent}%
+                      </span>
+                    </div>
+                    <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                      <div
+                        className={`h-full rounded-full ${barColor}`}
+                        style={{ width: `${percent}%` }}
+                      />
+                    </div>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <div className="space-y-1">
+                    {item.treatments.map((tr) => {
+                      const p = detail.treatmentProgress[tr.treatmentId];
+                      const nm =
+                        treatmentNameMap.get(tr.treatmentId) ??
+                        t("gabinet.packages.treatment", "Zabieg");
+                      return (
+                        <p key={tr.treatmentId} className="text-xs">
+                          {nm}: {p?.usedCount ?? 0} / {p?.totalCount ?? 0}
+                        </p>
+                      );
+                    })}
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          );
+        },
+        getSortValue: (item) => {
+          const detail = activeUsageDetails[item._id];
+          if (!detail) return -1;
+          const progress = Object.values(detail.treatmentProgress);
+          const total = progress.reduce((s, p) => s + p.totalCount, 0);
+          if (total === 0) return -1;
+          return Math.round(
+            (progress.reduce((s, p) => s + p.usedCount, 0) / total) * 100,
+          );
+        },
+      },
+      {
         id: "category",
         label: t("common.category", "Kategoria"),
         sortable: true,
@@ -552,7 +673,13 @@ function PackagesIndex() {
         ),
       },
     ],
-    [t, treatmentNameMap, activeUsageCounts, categoryNameById],
+    [
+      t,
+      treatmentNameMap,
+      activeUsageCounts,
+      activeUsageDetails,
+      categoryNameById,
+    ],
   );
 
   const { allColumns, defaultHidden } = useAllColumns(
@@ -986,6 +1113,10 @@ function PackagesIndex() {
               },
             ]}
             onBulkAction={handleBulkAction}
+            onRowAction={(rowId) => {
+              const pkg = (packagesData ?? []).find((p) => p._id === rowId);
+              if (pkg) openEdit(pkg);
+            }}
             rowActions={rowActions}
             emptyTitle={t("gabinet.packages.emptyTitle", "Brak pakietów")}
             emptyDescription={t(


### PR DESCRIPTION
## Summary

Follow-up UX fixes to the packages table rebuild from PR #3480, reported on production:

- Row click on the packages table now opens the edit panel (`onRowAction`) instead of toggling checkbox selection; checkboxes still handle bulk selection
- Per-treatment usage statistics from the old card view are restored as a new sortable "Wykorzystanie" column: overall used/total progress bar (colored green → amber → red by remaining %), with per-treatment tooltip breakdown
- `SlideoutMenu.Content` used `size-full` inside a flex column, pushing the Apply/Clear footer buttons past the bottom of the window in the filters slideout — changed to `flex-1 min-h-0` so the footer stays pinned and content scrolls within bounds (fixes all slideouts with a footer)

## Test plan

- [ ] Open Packages tab, click a row → edit panel opens (not checkbox toggle)
- [ ] Column "Wykorzystanie" visible in table, shows progress bar for packages with active usages, "—" for unsold packages
- [ ] Hover utilization bar → tooltip shows per-treatment breakdown (e.g. "Masaż: 2/5")
- [ ] Open Filters slideout → Apply/Clear buttons visible at bottom without scrolling
- [ ] Bulk select via checkboxes still works (row click doesn't interfere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)