### PR TITLE
Reset edit form state when the dialog re-opens for a different package

### DIFF
--- a/src/components/gabinet/patient-packages-card.tsx
+++ b/src/components/gabinet/patient-packages-card.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
@@ -740,6 +740,12 @@ function PackageDetailDialog({
   const [editExpiresAt, setEditExpiresAt] = useState("");
   const [editStatus, setEditStatus] = useState("");
   const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    setEditMode(false);
+    setEditExpiresAt("");
+    setEditStatus("");
+  }, [usage?._id]);
 
   const updatePackageUsage = useAction(api.gabinet.packages.updatePackageUsage);
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3493.

Closes #3493

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 2777fbe fix(gabinet): reset edit form state when PackageDetailDialog opens for different package

### Files changed

```
 src/components/gabinet/patient-packages-card.tsx | 8 +++++++-
 1 file changed, 7 insertions(+), 1 deletion(-)
```