### PR TITLE
feat(gabinet): multi-treatment hover-preview and detail view (#3495)

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -470,6 +470,8 @@ export function AppointmentPreviewContent({
 
   const { appointment, patient, treatment } = detail;
   const initialStatus = appointment.status as AppointmentStatus;
+  const junctionTreatments = detail.treatments ?? [];
+  const isMultiTreatment = junctionTreatments.length > 1;
   const initialTreatmentId =
     detail.treatments?.[0]?.treatmentId ??
     (appointment.treatmentId ? String(appointment.treatmentId) : "");
@@ -1354,6 +1356,25 @@ export function AppointmentPreviewContent({
       {/* Secondary info — treatment, status, indicators, contact links */}
       <div className="space-y-2">
         <div className="flex flex-wrap items-center gap-2">
+          {isMultiTreatment ? (
+            <div className="flex flex-wrap gap-1">
+              {junctionTreatments.map((jt) => {
+                const name =
+                  treatments?.find((tr) => tr._id === jt.treatmentId)?.name ??
+                  treatment?.name ??
+                  t("gabinet.appointments.selectTreatment");
+                return (
+                  <span
+                    key={jt.id}
+                    className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-background px-2 py-1 text-sm font-medium text-foreground"
+                  >
+                    <Stethoscope className="size-3.5 shrink-0 text-primary" />
+                    <span className="truncate">{name}</span>
+                  </span>
+                );
+              })}
+            </div>
+          ) : (
           <Popover
             open={treatmentOpen}
             onOpenChange={(o) => {
@@ -1425,6 +1446,7 @@ export function AppointmentPreviewContent({
               </Command>
             </PopoverContent>
           </Popover>
+          )}
           <Badge variant="outline" className="text-xs">
             <span
               className={`mr-1.5 inline-block h-2 w-2 rounded-full ${STATUS_DOT_COLORS[initialStatus] ?? "bg-muted-foreground"}`}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1236,115 +1236,153 @@ function AppointmentDetail() {
                 {t("gabinet.treatments.treatment")}
               </CardTitle>
             </CardHeader>
-            <CardContent className="space-y-3 px-6 py-4">
-              <div className="space-y-1.5">
-                <Label className="text-xs uppercase tracking-wide text-muted-foreground">
-                  {t("common.name")}
-                </Label>
-                <TreatmentPicker
-                  treatments={treatmentsList}
-                  value={editTreatmentId}
-                  onSelect={(id) => {
-                    setEditTreatmentId(id);
-                    setTreatmentPickerOpen(false);
-                    setTreatmentSearch("");
-                  }}
-                  open={treatmentPickerOpen}
-                  onOpenChange={setTreatmentPickerOpen}
-                  search={treatmentSearch}
-                  onSearchChange={setTreatmentSearch}
-                  formatPrice={(price, currency) =>
-                    formatCurrencyPLN(price ?? 0, currency ?? "PLN")
-                  }
-                  placeholder={t("gabinet.appointments.selectTreatment")}
-                  searchPlaceholder={t("gabinet.appointments.searchTreatment")}
-                  emptyText={t("common.noResults")}
-                  closeLabel={t("common.close")}
-                  selectedLabel={treatment?.name}
-                  triggerIcon={
-                    <Stethoscope className="size-4 shrink-0 text-primary" />
-                  }
-                />
+            {detail.treatments.length > 1 ? (
+              /* Multi-treatment: one row per junction entry, totals at bottom */
+              <CardContent className="space-y-0 divide-y divide-border px-6 py-0">
+                {detail.treatments.map((jt) => {
+                  const tr = treatmentsList?.find((t) => t._id === jt.treatmentId);
+                  const name = tr?.name ?? treatment?.name ?? "-";
+                  const price = jt.priceAtBooking ?? tr?.price ?? null;
+                  return (
+                    <div key={jt.id} className="flex items-center justify-between py-3">
+                      <div className="flex items-center gap-2">
+                        <Stethoscope className="h-4 w-4 shrink-0 text-primary" />
+                        <span className="text-sm font-medium">{name}</span>
+                      </div>
+                      {price != null && (
+                        <span className="text-sm text-muted-foreground">
+                          {formatCurrencyPLN(price)}
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+                <div className="flex items-center justify-between py-3 font-semibold">
+                  <span className="text-sm">
+                    {t("gabinet.appointments.totalDuration", "Łącznie")} · {calculateDuration()} min
+                  </span>
+                  <span className="text-sm">
+                    {formatCurrencyPLN(
+                      detail.treatments.reduce((sum, jt) => {
+                        const tr = treatmentsList?.find((t) => t._id === jt.treatmentId);
+                        return sum + (jt.priceAtBooking ?? tr?.price ?? 0);
+                      }, 0),
+                    )}
+                  </span>
+                </div>
+              </CardContent>
+            ) : (
+              /* Single / legacy treatment */
+              <CardContent className="space-y-3 px-6 py-4">
+                <div className="space-y-1.5">
+                  <Label className="text-xs uppercase tracking-wide text-muted-foreground">
+                    {t("common.name")}
+                  </Label>
+                  <TreatmentPicker
+                    treatments={treatmentsList}
+                    value={editTreatmentId}
+                    onSelect={(id) => {
+                      setEditTreatmentId(id);
+                      setTreatmentPickerOpen(false);
+                      setTreatmentSearch("");
+                    }}
+                    open={treatmentPickerOpen}
+                    onOpenChange={setTreatmentPickerOpen}
+                    search={treatmentSearch}
+                    onSearchChange={setTreatmentSearch}
+                    formatPrice={(price, currency) =>
+                      formatCurrencyPLN(price ?? 0, currency ?? "PLN")
+                    }
+                    placeholder={t("gabinet.appointments.selectTreatment")}
+                    searchPlaceholder={t("gabinet.appointments.searchTreatment")}
+                    emptyText={t("common.noResults")}
+                    closeLabel={t("common.close")}
+                    selectedLabel={treatment?.name}
+                    triggerIcon={
+                      <Stethoscope className="size-4 shrink-0 text-primary" />
+                    }
+                  />
 
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-muted-foreground">
-                  {t("gabinet.treatments.duration")}
-                </span>
-                <span className="font-medium">
-                  {calculateDuration()} min
-                </span>
-              </div>
-              {treatment?.price !== undefined && (
+                </div>
                 <div className="flex items-center justify-between">
                   <span className="text-muted-foreground">
-                    {t("common.price")}
+                    {t("gabinet.treatments.duration")}
                   </span>
                   <span className="font-medium">
-                    {formatCurrencyPLN(treatment.price, treatment.currency ?? "PLN")}
+                    {calculateDuration()} min
                   </span>
                 </div>
-              )}
-              {treatment?.description && (
-                <div className="pt-2">
-                  <span className="text-sm text-muted-foreground">
-                    {t("common.description")}
-                  </span>
-                  <p className="text-sm mt-1">{plateJsonToText(treatment.description)}</p>
-                </div>
-              )}
-              {treatment?.contraindications && (
-                <div className="pt-2 p-3 bg-destructive/10 rounded-lg">
-                  <div className="flex items-center justify-between gap-2 mb-1">
-                    <div className="flex items-center gap-2 text-destructive">
-                      <ShieldAlert className="h-4 w-4" variant="stroke" />
-                      <span className="text-sm font-medium">
-                        {t("gabinet.treatments.contraindications")}
-                      </span>
-                    </div>
-                    {appointment.contraindicationAlertsReviewed ? (
-                      <div className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
-                        <CheckCircle className="h-3.5 w-3.5" variant="stroke" />
-                        <span>{t("gabinet.appointmentDetail.contraindicationDiscussed", "Omówiono")}</span>
-                      </div>
-                    ) : (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-6 px-2 text-xs text-destructive hover:text-destructive"
-                        onClick={async () => {
-                          try {
-                            await updateAppointment({
-                              organizationId,
-                              appointmentId: appointment._id,
-                              contraindicationAlertsReviewed: true,
-                            });
-                            await refetch();
-                            toast.success(t("gabinet.appointmentDetail.contraindicationMarked", "Oznaczono jako omówione"));
-                          } catch {
-                            toast.error(t("common.errorOccurred", "Wystąpił błąd"));
-                          }
-                        }}
-                      >
-                        {t("gabinet.appointmentDetail.markContraindicationAsDiscussed", "Oznacz jako omówione")}
-                      </Button>
-                    )}
-                  </div>
-                  <p className="text-sm">{plateJsonToText(treatment.contraindications)}</p>
-                </div>
-              )}
-              {!!(treatment as Record<string, unknown>)?.aftercare && (
-                <div className="pt-2 p-3 bg-primary/10 rounded-lg">
-                  <div className="flex items-center gap-2 text-primary mb-1">
-                    <Heart className="h-4 w-4" variant="stroke" />
-                    <span className="text-sm font-medium">
-                      {t("gabinet.treatments.aftercare")}
+                {treatment?.price !== undefined && (
+                  <div className="flex items-center justify-between">
+                    <span className="text-muted-foreground">
+                      {t("common.price")}
+                    </span>
+                    <span className="font-medium">
+                      {formatCurrencyPLN(treatment.price, treatment.currency ?? "PLN")}
                     </span>
                   </div>
-                  <p className="text-sm">{plateJsonToText((treatment as Record<string, unknown>).aftercare as string)}</p>
-                </div>
-              )}
-            </CardContent>
+                )}
+                {treatment?.description && (
+                  <div className="pt-2">
+                    <span className="text-sm text-muted-foreground">
+                      {t("common.description")}
+                    </span>
+                    <p className="text-sm mt-1">{plateJsonToText(treatment.description)}</p>
+                  </div>
+                )}
+                {treatment?.contraindications && (
+                  <div className="pt-2 p-3 bg-destructive/10 rounded-lg">
+                    <div className="flex items-center justify-between gap-2 mb-1">
+                      <div className="flex items-center gap-2 text-destructive">
+                        <ShieldAlert className="h-4 w-4" variant="stroke" />
+                        <span className="text-sm font-medium">
+                          {t("gabinet.treatments.contraindications")}
+                        </span>
+                      </div>
+                      {appointment.contraindicationAlertsReviewed ? (
+                        <div className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+                          <CheckCircle className="h-3.5 w-3.5" variant="stroke" />
+                          <span>{t("gabinet.appointmentDetail.contraindicationDiscussed", "Omówiono")}</span>
+                        </div>
+                      ) : (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 px-2 text-xs text-destructive hover:text-destructive"
+                          onClick={async () => {
+                            try {
+                              await updateAppointment({
+                                organizationId,
+                                appointmentId: appointment._id,
+                                contraindicationAlertsReviewed: true,
+                              });
+                              await refetch();
+                              toast.success(t("gabinet.appointmentDetail.contraindicationMarked", "Oznaczono jako omówione"));
+                            } catch {
+                              toast.error(t("common.errorOccurred", "Wystąpił błąd"));
+                            }
+                          }}
+                        >
+                          {t("gabinet.appointmentDetail.markContraindicationAsDiscussed", "Oznacz jako omówione")}
+                        </Button>
+                      )}
+                    </div>
+                    <p className="text-sm">{plateJsonToText(treatment.contraindications)}</p>
+                  </div>
+                )}
+                {!!(treatment as Record<string, unknown>)?.aftercare && (
+                  <div className="pt-2 p-3 bg-primary/10 rounded-lg">
+                    <div className="flex items-center gap-2 text-primary mb-1">
+                      <Heart className="h-4 w-4" variant="stroke" />
+                      <span className="text-sm font-medium">
+                        {t("gabinet.treatments.aftercare")}
+                      </span>
+                    </div>
+                    <p className="text-sm">{plateJsonToText((treatment as Record<string, unknown>).aftercare as string)}</p>
+                  </div>
+                )}
+              </CardContent>
+            )}
           </Card>
 
           {/* Employee Info Card */}


### PR DESCRIPTION
## Summary
- **Hover-preview** (`appointment-preview-content.tsx`): when an appointment has >1 junction rows in `detail.treatments`, renders one read-only badge per treatment (with stethoscope icon) instead of the single editable picker button. The legacy single-treatment picker path is preserved for appointments without junction rows.
- **Detail view** (`_layout.gabinet.appointments.$appointmentId.lazy.tsx`): the Treatment Info Card now shows a per-row list when `detail.treatments.length > 1`, with treatment name and `priceAtBooking` on each line, and a footer row summing total price + appointment duration. Falls back to the existing single-treatment card (with editable `TreatmentPicker`) for legacy appointments.

Both changes use junction `treatments[]` from `getFullDetail` and fall back to the legacy `appointment.treatmentId`/`treatment` row for pre-#3356 appointments.

## Test plan
- [ ] Open calendar hover-preview for a multi-treatment appointment — verify treatment names appear as separate badges
- [ ] Open calendar hover-preview for a legacy appointment — verify existing editable picker still appears
- [ ] Open detail view for a multi-treatment appointment (Details tab) — verify list of treatments with prices and total footer
- [ ] Open detail view for a legacy appointment — verify existing single-treatment card with editable picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)