### PR TITLE
Remove unreachable package-deduction dead code block in `applySmsReplyTransition

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2671,45 +2671,6 @@ export const applySmsReplyTransition = internalMutation({
     }
     await db.patch("gabinetAppointments", args.appointmentId, supabasePatch);
 
-    // Package deduction: mirror the CAS block in updateStatus so that if this
-    // function ever gains no_show/completed intents the deduction fires here
-    // too. Currently unreachable (intent is locked to confirm/cancel → targetStatus
-    // is always "confirmed"|"cancelled"). Cast to string so TS2367 doesn't fire
-    // and the guard becomes live automatically when the intent union is extended.
-    // CAS now lives on gabinet_appointment_treatments.package_deducted per
-    // junction row (#3367). Closes #3222.
-    const _targetStatusStr: string = targetStatus;
-    if (
-      (_targetStatusStr === "completed" || _targetStatusStr === "no_show") &&
-      appointment.packageUsageId &&
-      appointment.treatmentId
-    ) {
-      const { data: pkgCasRows } = await db.raw()
-        .from("gabinet_appointment_treatments")
-        .update({ package_deducted: true })
-        .eq("appointment_id", args.appointmentId)
-        .eq("treatment_id", String(appointment.treatmentId))
-        .eq("package_deducted", false)
-        .select("id");
-      const wonPkgRace = Array.isArray(pkgCasRows) && pkgCasRows.length > 0;
-      if (wonPkgRace) {
-        try {
-          await deductPackageEntry(db, {
-            packageUsageId: String(appointment.packageUsageId),
-            treatmentId: String(appointment.treatmentId),
-            variantId: appointment.variantId ? String(appointment.variantId) : undefined,
-          });
-        } catch (e) {
-          console.error(
-            "[applySmsReplyTransition] package entry deduction FAILED for appointment",
-            args.appointmentId,
-            ":",
-            e,
-          );
-        }
-      }
-    }
-
     // --- Side effects (activity log, audit, notifications, automation) ---
     const appointmentProxy = {
       _id: args.appointmentId as Id<"gabinetAppointments">,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3499.

Closes #3499

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 658a614 fix(gabinet/appointments): remove unreachable package-deduction dead code in applySmsReplyTransition (#3499)

### Files changed

```
 convex/gabinet/appointments.ts | 39 ---------------------------------------
 1 file changed, 39 deletions(-)
```