### PR TITLE
Legacy scalar treatment: pozostali konsumenci → junction (część 2/3 z #3399)

### DIFF
--- a/convex/documents/scopeResolver_supabase.ts
+++ b/convex/documents/scopeResolver_supabase.ts
@@ -12,6 +12,7 @@
 
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import type { EntityType, ScopeData } from "./scopeResolver";
+import { getJunctionTreatmentIds } from "../gabinet/_helpers/junctionTreatments";
 
 type SupabaseDb = ReturnType<typeof createSupabaseDb>;
 
@@ -70,8 +71,11 @@ async function fetchAppointmentScope(
     }
   }
 
-  if (appointment.treatmentId) {
-    const treatment = await db.get("gabinetTreatments", String(appointment.treatmentId));
+  const scopeJunctionMap = await getJunctionTreatmentIds(db, [appointmentId]);
+  const scopeJunctionRows = scopeJunctionMap.get(appointmentId) ?? [];
+  const scopeTreatmentId = scopeJunctionRows[0]?.treatmentId ?? (appointment.treatmentId ? String(appointment.treatmentId) : null);
+  if (scopeTreatmentId) {
+    const treatment = await db.get("gabinetTreatments", scopeTreatmentId);
     if (treatment) {
       scope.treatment = flattenEntity(treatment);
       await resolveTreatmentCategoryName(db, scope.treatment, treatment.categoryId);

--- a/convex/documents/signing.ts
+++ b/convex/documents/signing.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { createSupabaseDb, type SupabaseDb } from "../_helpers/supabaseDb";
+import { getJunctionTreatmentIds } from "../gabinet/_helpers/junctionTreatments";
 import { getValidAccessToken } from "../google/_helpers";
 import { Resend } from "resend";
 import { sendViaResend, sendViaMailgun } from "../email/providers";
@@ -126,11 +127,11 @@ export const sendSigningEmailInternal = internalAction({
           ).getTime();
           appointmentDate = !isNaN(ts) ? formatDatePl(ts) : String(appointment.date);
         }
-        if (appointment.treatmentId) {
-          const treatment = await db.get(
-            "gabinetTreatments",
-            String(appointment.treatmentId),
-          );
+        const signingJunctionMap = await getJunctionTreatmentIds(db, [String(doc.entityId)]);
+        const signingJunctionRows = signingJunctionMap.get(String(doc.entityId)) ?? [];
+        const signingTreatmentId = signingJunctionRows[0]?.treatmentId ?? (appointment.treatmentId ? String(appointment.treatmentId) : null);
+        if (signingTreatmentId) {
+          const treatment = await db.get("gabinetTreatments", signingTreatmentId);
           if (treatment) {
             treatmentName = treatment.name as string | undefined;
           }

--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -11,6 +11,7 @@ import {
   checkEmployeeQualificationSupabase,
   checkConflictSupabase,
 } from "./_availability_supabase";
+import { getJunctionTreatmentIds } from "./_helpers/junctionTreatments";
 
 // ---------------------------------------------------------------------------
 // Patient-portal reads (actions — gabinetPortalSessions and all dependent
@@ -142,13 +143,20 @@ export const getMyAppointments = action({
       .eq("patientId", patientId)
       .collect();
 
-    // Resolve treatment names in one batch to avoid N+1 reads against Supabase.
+    // Resolve treatment IDs via junction table, falling back to scalar for
+    // old appointments that pre-date the junction migration.
+    const portalApptIds = appointments.map((a) => String(a._id));
+    const portalJunctionMap = await getJunctionTreatmentIds(db, portalApptIds);
+    const apptTreatmentId = new Map<string, string | null>();
+    for (const appt of appointments) {
+      const apptId = String(appt._id);
+      const junctionRows = portalJunctionMap.get(apptId) ?? [];
+      const tid = junctionRows[0]?.treatmentId ?? (appt.treatmentId as string | null | undefined) ?? null;
+      apptTreatmentId.set(apptId, tid);
+    }
+
     const treatmentIds = Array.from(
-      new Set(
-        appointments
-          .map((a) => a.treatmentId)
-          .filter((id): id is NonNullable<typeof id> => typeof id === "string" && id.length > 0),
-      ),
+      new Set([...apptTreatmentId.values()].filter((id): id is string => typeof id === "string" && id.length > 0)),
     );
     const treatments = await db.getMany("gabinetTreatments", treatmentIds);
     const treatmentNameById = new Map<string, string>();
@@ -157,7 +165,7 @@ export const getMyAppointments = action({
     }
 
     const enriched = appointments.map((appt) => {
-      const treatmentId = appt.treatmentId as string | null | undefined;
+      const treatmentId = apptTreatmentId.get(String(appt._id));
       return {
         _id: String(appt._id),
         date: appt.date as string,
@@ -667,8 +675,11 @@ export const requestReschedule = action({
       ? `${patient.firstName} ${patient.lastName}`
       : "Patient";
 
-    const treatment = appt.treatmentId
-      ? await db.get("gabinetTreatments", String(appt.treatmentId))
+    const reschedJunctionMap = await getJunctionTreatmentIds(db, [args.appointmentId]);
+    const reschedJunctionRows = reschedJunctionMap.get(args.appointmentId) ?? [];
+    const reschedTreatmentId = reschedJunctionRows[0]?.treatmentId ?? (appt.treatmentId ? String(appt.treatmentId) : null);
+    const treatment = reschedTreatmentId
+      ? await db.get("gabinetTreatments", reschedTreatmentId)
       : null;
     const treatmentName = (treatment?.name as string) ?? "appointment";
 

--- a/convex/gabinet/sidebarWidgets.ts
+++ b/convex/gabinet/sidebarWidgets.ts
@@ -2,6 +2,7 @@ import { action } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { v } from "convex/values";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
+import { getJunctionTreatmentIds } from "./_helpers/junctionTreatments";
 
 // All widgets are Supabase-primary actions — the underlying business tables
 // (gabinet_appointments, gabinet_patients, gabinet_employees, ...) live in
@@ -401,11 +402,17 @@ export const getDayAgenda = action({
       String(a.startTime).localeCompare(String(b.startTime)),
     );
 
+    const sortedIds = sorted.map((a) => String(a._id ?? a.id ?? ""));
+    const junctionMap = await getJunctionTreatmentIds(db, sortedIds);
+
     const enriched = await Promise.all(
-      sorted.map(async (appt) => {
+      sorted.map(async (appt, i) => {
+        const apptId = sortedIds[i];
+        const junctionRows = junctionMap.get(apptId) ?? [];
+        const treatmentId = junctionRows[0]?.treatmentId ?? (appt.treatmentId ? String(appt.treatmentId) : null);
         const [patient, treatment, employee] = await Promise.all([
           appt.patientId ? db.get("gabinetPatients", String(appt.patientId)).catch(() => null) : null,
-          appt.treatmentId ? db.get("gabinetTreatments", String(appt.treatmentId)).catch(() => null) : null,
+          treatmentId ? db.get("gabinetTreatments", treatmentId).catch(() => null) : null,
           appt.employeeId
             ? db
                 .get<{ name?: string | null; email?: string | null }>(
@@ -571,11 +578,18 @@ export const getTopTreatments = action({
       db.query("gabinetTreatments").eq("organizationId", orgId).collect(),
     ]);
 
+    const topApptIds = (appointments as any[]).map((a) => String(a._id ?? a.id ?? ""));
+    const topJunctionMap = await getJunctionTreatmentIds(db, topApptIds);
+
     const treatmentCounts = new Map<string, number>();
     for (const appt of appointments as any[]) {
-      if (appt.treatmentId) {
-        const key = String(appt.treatmentId);
-        treatmentCounts.set(key, (treatmentCounts.get(key) ?? 0) + 1);
+      const apptId = String(appt._id ?? appt.id ?? "");
+      const junctionRows = topJunctionMap.get(apptId) ?? [];
+      const tids = junctionRows.length > 0
+        ? junctionRows.map((r) => r.treatmentId)
+        : appt.treatmentId ? [String(appt.treatmentId)] : [];
+      for (const tid of tids) {
+        treatmentCounts.set(tid, (treatmentCounts.get(tid) ?? 0) + 1);
       }
     }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3504.

Closes #3504

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 89feac7 feat(gabinet): migrate remaining scalar treatmentId reads to junction table (closes #3504)

### Files changed

```
 convex/documents/scopeResolver_supabase.ts |  8 ++++++--
 convex/documents/signing.ts                | 11 ++++++-----
 convex/gabinet/patientPortal.ts            | 29 ++++++++++++++++++++---------
 convex/gabinet/sidebarWidgets.ts           | 24 +++++++++++++++++++-----
 4 files changed, 51 insertions(+), 21 deletions(-)
```