### PR TITLE
Update `ChangeEmployeeModal` to accept `treatmentIds

### DIFF
--- a/src/components/gabinet/change-employee-modal.tsx
+++ b/src/components/gabinet/change-employee-modal.tsx
@@ -49,7 +49,7 @@ interface ChangeEmployeeModalProps {
   onOpenChange: (open: boolean) => void;
   organizationId: Id<"organizations">;
   appointmentId: Id<"gabinetAppointments">;
-  treatmentId: Id<"gabinetTreatments">;
+  treatmentIds: Id<"gabinetTreatments">[];
   currentEmployeeId: Id<"users">;
   appointmentDate: string; // YYYY-MM-DD
   startTime: string; // HH:MM
@@ -122,7 +122,7 @@ export function ChangeEmployeeModal({
   onOpenChange,
   organizationId,
   appointmentId,
-  treatmentId,
+  treatmentIds,
   currentEmployeeId,
   appointmentDate,
   startTime,
@@ -157,7 +157,7 @@ export function ChangeEmployeeModal({
             : "—";
         const isQualified =
           e.qualifiedTreatmentIds.length === 0 ||
-          e.qualifiedTreatmentIds.includes(treatmentId);
+          treatmentIds.every((id) => e.qualifiedTreatmentIds.includes(id));
         return {
           employeeDoc: e as EmployeeRow["employeeDoc"],
           name,
@@ -166,7 +166,7 @@ export function ChangeEmployeeModal({
           isQualified,
         };
       });
-  }, [employeesList, currentEmployeeId, treatmentId]);
+  }, [employeesList, currentEmployeeId, treatmentIds]);
 
   // For the selected employee, check availability at current slot (action → Supabase)
   const getAvailableSlots = useAction(api.gabinet.appointments.getAvailableSlotsQuery);

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -2670,8 +2670,8 @@ function AppointmentDetail() {
           onOpenChange={setChangeEmployeeOpen}
           organizationId={organizationId}
           appointmentId={appointmentId as Id<"gabinetAppointments">}
-          treatmentId={
-            detail.treatments?.[0]?.treatmentId as Id<"gabinetTreatments">
+          treatmentIds={
+            (detail.treatments?.map((t) => t.treatmentId) ?? []) as Id<"gabinetTreatments">[]
           }
           currentEmployeeId={detail.appointment.employeeId}
           appointmentDate={detail.appointment.date}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3513.

Closes #3513

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 32ec018 fix(gabinet): accept treatmentIds array in ChangeEmployeeModal (closes #3513)

### Files changed

```
 src/components/gabinet/change-employee-modal.tsx                  | 8 ++++----
 .../_layout.gabinet.appointments.$appointmentId.lazy.tsx          | 4 ++--
 2 files changed, 6 insertions(+), 6 deletions(-)
```