### PR TITLE
feat(gabinet): wider 2-col SettlementForm layout + type cleanup (closes #3527)

### DIFF
--- a/src/components/gabinet/appointment-shared/settlement-form.tsx
+++ b/src/components/gabinet/appointment-shared/settlement-form.tsx
@@ -34,12 +34,12 @@ export interface PackageUsageEntry {
 }
 
 export interface JunctionTreatment {
-  treatmentId: string;
+  treatmentId: string | null;
   priceAtBooking?: number | null;
 }
 
 export interface SettlementFormProps {
-  organizationId: string;
+  organizationId: Id<"organizations">;
   appointmentId: string;
   patientId: string;
   /** Junction treatment rows — used to compute the canonical amount due. */
@@ -177,7 +177,7 @@ export function SettlementForm({
 
   // Only show active packages that cover at least one treatment of this visit.
   const visitTreatmentIds = new Set(
-    junctionTreatments.map((jt) => jt.treatmentId),
+    junctionTreatments.filter((jt) => jt.treatmentId != null).map((jt) => jt.treatmentId!),
   );
   const eligiblePackages = patientPackageUsage.filter(
     (pkg) =>
@@ -359,7 +359,7 @@ export function SettlementForm({
 
   return (
     <>
-      <div className="space-y-4 py-4">
+      <div className="grid sm:grid-cols-2 gap-x-4 gap-y-4 py-4">
         {!splitPayment && !isFixedAmountMethod && outstanding > 0 && (
           <div>
             <Label>{t("gabinet.payments.discount")}</Label>
@@ -521,7 +521,7 @@ export function SettlementForm({
         )}
 
         {!splitPayment && paymentMethod === "package" && (
-          <div className="space-y-3 rounded-md border p-3">
+          <div className="space-y-3 rounded-md border p-3 sm:col-span-2">
             <div>
               <Label>{t("gabinet.packages.selectPackage")}</Label>
               {eligiblePackages.length === 0 ? (
@@ -625,7 +625,7 @@ export function SettlementForm({
         )}
 
         {/* Split payment toggle */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 sm:col-span-2">
           <input
             type="checkbox"
             id="settlement-split-payment"
@@ -648,7 +648,7 @@ export function SettlementForm({
         </div>
 
         {splitPayment && (
-          <div className="rounded-lg border p-3 space-y-3">
+          <div className="rounded-lg border p-3 space-y-3 sm:col-span-2">
             <div className="grid grid-cols-2 gap-3">
               <div className="rounded-md border p-2 space-y-2">
                 <Label className="text-xs font-medium">
@@ -901,7 +901,7 @@ export function SettlementForm({
           </div>
         )}
 
-        <div>
+        <div className="sm:col-span-2">
           <Label>{t("common.notes")}</Label>
           <RichTextEditor
             value={paymentNote}
@@ -912,7 +912,7 @@ export function SettlementForm({
         </div>
 
         {showMarkCompleted && (
-          <label className="flex items-start gap-2 text-sm cursor-pointer">
+          <label className="flex items-start gap-2 text-sm cursor-pointer sm:col-span-2">
             <input
               type="checkbox"
               className="mt-1"

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -412,15 +412,8 @@ export function AppointmentPreviewContent({
     setEndTime(appt.endTime.slice(0, 5));
     setNotes(appt.notes ?? "");
     setInternalNotes(appt.internalNotes ?? "");
-    const junctionTreatmentId = detail.treatments?.[0]?.treatmentId ?? null;
-    setTreatmentId(
-      junctionTreatmentId
-        ? junctionTreatmentId
-        : appt.treatmentId
-          ? String(appt.treatmentId)
-          : "",
-    );
-    setVariantId(appt.variantId ? String(appt.variantId) : "");
+    setTreatmentId(detail.treatments?.[0]?.treatmentId ?? "");
+    setVariantId("");
     setTagIds(
       (appt.tagIds ?? []).map((id) => id as Id<"tagDefinitions">),
     );
@@ -441,12 +434,8 @@ export function AppointmentPreviewContent({
   const initialStatus = appointment.status as AppointmentStatus;
   const junctionTreatments = detail.treatments ?? [];
   const isMultiTreatment = junctionTreatments.length > 1;
-  const initialTreatmentId =
-    detail.treatments?.[0]?.treatmentId ??
-    (appointment.treatmentId ? String(appointment.treatmentId) : "");
-  const initialVariantId = appointment.variantId
-    ? String(appointment.variantId)
-    : "";
+  const initialTreatmentId = detail.treatments?.[0]?.treatmentId ?? "";
+  const initialVariantId = "";
   const availableTransitions = VALID_TRANSITIONS[initialStatus] ?? [];
   const patientFullName = patient
     ? `${patient.firstName ?? ""} ${patient.lastName ?? ""}`.trim()
@@ -1495,7 +1484,7 @@ export function AppointmentPreviewContent({
         <Button
           variant="outline"
           size="sm"
-          onClick={handleSave}
+          onClick={() => void handleSave()}
           disabled={!dirty || saving}
           className="w-full sm:w-auto"
         >
@@ -1615,7 +1604,7 @@ export function AppointmentPreviewContent({
         ref={settleDrag.contentRef}
         onPointerDown={settleDrag.onPointerDown}
         className={cn(
-          "sm:max-w-md",
+          "sm:max-w-2xl",
           settleDrag.isDragging && "cursor-grabbing select-none",
         )}
       >

--- a/src/components/gabinet/calendar/draggable-appointment.tsx
+++ b/src/components/gabinet/calendar/draggable-appointment.tsx
@@ -387,7 +387,7 @@ export function DraggableAppointment({
         // made tall content unreadable. Drag-to-peek is now touch-driven only
         // via the grab pill at the top, which has its own `touch-none` zone.
         className={cn(
-          "w-[553px] max-w-[calc(100vw-24px)] overflow-y-auto p-0 rounded-xl border-border/60 shadow-2xl",
+          "w-[640px] max-w-[calc(100vw-24px)] overflow-y-auto p-0 rounded-xl border-border/60 shadow-2xl",
           isPreviewDragging && "cursor-grabbing select-none",
         )}
         // Cap the popover at whatever vertical space Radix's collision logic has

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -2599,7 +2599,7 @@ function AppointmentDetail() {
 
       {/* Payment Dialog */}
       <Dialog open={paymentDialogOpen} onOpenChange={setPaymentDialogOpen}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="sm:max-w-2xl">
           <DialogHeader>
             <DialogTitle>{t("gabinet.payments.addPayment")}</DialogTitle>
             <DialogDescription>


### PR DESCRIPTION
## Summary

- `SettlementForm`: settle dialog widened from `sm:max-w-md` → `sm:max-w-2xl` (calendar preview + appointment detail)
- `SettlementForm`: form layout changed from `space-y-4` to `grid sm:grid-cols-2` — discount/amount in one row, credit/method in the next; package picker, split section, notes, and mark-completed all span full width
- `SettlementForm`: `organizationId` prop typed as `Id<"organizations">` (fixes 6× TS2322 at Convex action call sites inside the component)
- `SettlementForm`: `JunctionTreatment.treatmentId: string | null` to match the mapper's nullable shape; `visitTreatmentIds` filters nulls before building the Set
- `appointment-preview-content`: `onClick={handleSave}` → `onClick={() => void handleSave()}` — fixes hidden bug where MouseEvent was passed as the `closeAfter` boolean (always truthy → dialog always closed)
- `appointment-preview-content`: prefill simplified to junction-only — removes orphaned scalar `appt.treatmentId` / `appt.variantId` reads after column drop in #3399
- `draggable-appointment`: calendar preview popover `w-[553px]` → `w-[640px]`

## Test plan

- [ ] Open calendar, click an appointment card — preview popover is 640px wide
- [ ] Click "Rozlicz wizytę" in the preview — settle dialog is wider (sm:max-w-2xl), form shows 2-column layout (discount|amount, credit|method)
- [ ] Package picker, split payment section, notes, and mark-completed span full width
- [ ] Clicking "Zapisz zmiany" in the preview saves without closing the popover unexpectedly
- [ ] Open appointment detail page → payment dialog also shows wider layout
- [ ] TypeScript: no new TS errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)