### PR TITLE
Pakiet powiązany z wizytą ma być wybieralny w rozliczeniu — ręczna dedukcja wygrywa CAS z automatem

### DIFF
--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -450,9 +450,7 @@ export const updatePackageUsage = action({
       perm.scope === "own" &&
       String(usage.createdBy) !== String(authResult.userId)
     ) {
-      throw new Error(
-        "Permission denied: you can only edit your own records",
-      );
+      throw new Error("Permission denied: you can only edit your own records");
     }
 
     const updates: Record<string, unknown> = { updatedAt: Date.now() };
@@ -1014,6 +1012,22 @@ export const usePackageTreatmentsBatch = action({
       status: allUsed ? "completed" : "active",
       updatedAt: Date.now(),
     });
+
+    // Manual redemption wins the CAS race with completion-time auto-deduct
+    // (#3535): mark the junction rows for the redeemed treatments as
+    // package_deducted so updateStatus(completed/no_show) skips them and the
+    // entry is not deducted twice.
+    if (args.appointmentId) {
+      for (const item of args.items) {
+        await db
+          .raw()
+          .from("gabinet_appointment_treatments")
+          .update({ package_deducted: true })
+          .eq("appointment_id", args.appointmentId)
+          .eq("treatment_id", item.treatmentId)
+          .eq("package_deducted", false);
+      }
+    }
 
     // Log activity via internalMutation
     try {

--- a/src/components/gabinet/appointment-shared/settlement-form.tsx
+++ b/src/components/gabinet/appointment-shared/settlement-form.tsx
@@ -184,6 +184,31 @@ export function SettlementForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [organizationId, patientId]);
 
+  // Visit booked against a package: preselect it so the quantity panel is one
+  // click away. Manual redemption marks the junction rows as deducted, so the
+  // completion-time auto-deduct skips them (no double deduction).
+  useEffect(() => {
+    if (!linkedPackageUsageId) return;
+    const linked = patientPackageUsage.find(
+      (p) => p._id === linkedPackageUsageId && p.status === "active",
+    );
+    if (!linked) return;
+    setPaymentMethod("package");
+    setPaymentPackageId(linked._id);
+    setPaymentPackageItems(
+      linked.treatmentsUsed
+        .filter((e) => (e.usedCount ?? 0) < (e.totalCount ?? 0))
+        .map((e) => ({
+          treatmentId: e.treatmentId,
+          variantId: e.variantId,
+          treatmentName: e.treatmentName ?? t("gabinet.packages.treatment"),
+          remaining: (e.totalCount ?? 0) - (e.usedCount ?? 0),
+          qty: 0,
+        })),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [linkedPackageUsageId, patientPackageUsage.length]);
+
   // Amount due = sum of junction treatment prices (priceAtBooking ?? catalog),
   // with fallback to legacy single-treatment price for pre-junction appointments.
   const treatmentPrice =
@@ -690,27 +715,15 @@ export function SettlementForm({
           )}
           {!splitPayment && linkedPackageUsageId && (
             <div className="rounded-md border bg-sky-50/50 p-2.5 dark:bg-sky-950/20">
-              <p className="text-sm font-medium">
-                {t(
-                  "gabinet.payments.linkedPackageTitle",
-                  "Wizyta powiązana z pakietem",
-                )}
-                {(() => {
-                  const linked = patientPackageUsage.find(
-                    (p) => p._id === linkedPackageUsageId,
-                  );
-                  return linked?.packageName ? `: ${linked.packageName}` : "";
-                })()}
-              </p>
-              <p className="text-xs text-muted-foreground mt-1">
+              <p className="text-xs text-muted-foreground">
                 {t(
                   "gabinet.payments.linkedPackageHint",
-                  "Zużycie zostanie odliczone z pakietu automatycznie przy zakończeniu wizyty — ręczne rozliczenie jest wyłączone, żeby nie odliczyć podwójnie.",
+                  "Wizyta powiązana z pakietem — rozliczenie tutaj oznaczy zużycie, a przy zakończeniu wizyty nie zostanie ono odliczone ponownie.",
                 )}
               </p>
             </div>
           )}
-          {!splitPayment && !linkedPackageUsageId && (
+          {!splitPayment && (
             <div>
               <Label>
                 {t("gabinet.payments.redeemFromPackage", "Pakiet / karnet")}

--- a/tests/convex/gdprErase.test.ts
+++ b/tests/convex/gdprErase.test.ts
@@ -49,9 +49,9 @@ describe("gabinet/patients.gdprErase — activity and note anonymization", () =>
       ctx.db
         .query("activities")
         .withIndex("by_entity", (q) =>
-          q.eq("entityType", "gabinetPatient").eq("entityId", patientIdStr)
+          q.eq("entityType", "gabinetPatient").eq("entityId", patientIdStr),
         )
-        .collect()
+        .collect(),
     );
 
     for (const activity of activities) {
@@ -90,9 +90,9 @@ describe("gabinet/patients.gdprErase — activity and note anonymization", () =>
       ctx.db
         .query("notes")
         .withIndex("by_entity", (q) =>
-          q.eq("entityType", "gabinetPatient").eq("entityId", patientIdStr)
+          q.eq("entityType", "gabinetPatient").eq("entityId", patientIdStr),
         )
-        .collect()
+        .collect(),
     );
 
     expect(notes).toHaveLength(1);
@@ -104,7 +104,11 @@ describe("gabinet/patients.gdprErase — activity and note anonymization", () =>
   test("nulls out clinical text fields on appointments for the erased patient", async () => {
     const t = createTestCtx();
     const { organizationId, userId, identity } = await seedTestUser(t);
-    const { patientId, treatmentId } = await seedGabinetPrereqs(t, organizationId, userId);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
     const patientIdStr = String(patientId);
 
     await t.run(async (ctx) => {
@@ -112,7 +116,6 @@ describe("gabinet/patients.gdprErase — activity and note anonymization", () =>
       await ctx.db.insert("gabinetAppointments", {
         organizationId,
         patientId,
-        treatmentId,
         employeeId: userId,
         date: "2026-01-15",
         startTime: "09:00",
@@ -123,7 +126,9 @@ describe("gabinet/patients.gdprErase — activity and note anonymization", () =>
         interviewNotes: "Pacjent Jan Kowalski skarżył się na ból pleców.",
         clinicalRemarks: "Kowalski ma alergię na lateks.",
         bodyChartData: JSON.stringify({ marks: ["lower_back"] }),
-        treatmentParameterValues: JSON.stringify([{ name: "Waga", value: "85kg" }]),
+        treatmentParameterValues: JSON.stringify([
+          { name: "Waga", value: "85kg" },
+        ]),
         isRecurring: false,
         createdBy: userId,
         createdAt: now,
@@ -140,9 +145,9 @@ describe("gabinet/patients.gdprErase — activity and note anonymization", () =>
       ctx.db
         .query("gabinetAppointments")
         .withIndex("by_orgAndPatient", (q) =>
-          q.eq("organizationId", organizationId).eq("patientId", patientId)
+          q.eq("organizationId", organizationId).eq("patientId", patientId),
         )
-        .collect()
+        .collect(),
     );
 
     expect(appointments).toHaveLength(1);
@@ -169,9 +174,9 @@ describe("gabinet/patients.gdprErase — activity and note anonymization", () =>
       ctx.db
         .query("activities")
         .withIndex("by_entity", (q) =>
-          q.eq("entityType", "gabinetPatient").eq("entityId", patientIdStr)
+          q.eq("entityType", "gabinetPatient").eq("entityId", patientIdStr),
         )
-        .collect()
+        .collect(),
     );
 
     // Every activity entry — including the new deletion event — must be PII-free


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3537.

Closes #3537

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e2944b5 feat(gabinet): package linked to visit is selectable in settlement — manual deduction wins CAS over auto (closes #3537)

### Files changed

```
 convex/gabinet/packages.ts                         | 16 ++++++
 .../gabinet/appointment-shared/settlement-form.tsx | 61 ++++++++++++----------
 tests/convex/gdprErase.test.ts                     |  3 +-
 3 files changed, 50 insertions(+), 30 deletions(-)
```