### PR TITLE
Convex deploy blokowany po dropie #3399 — legacy dokumenty z treatmentId nie przechodzą walidacji schematu

### DIFF
--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -424,6 +424,14 @@ export function createGabinetTables({
     organizationId: v.id("organizations"),
     patientId: v.id("gabinetPatients"),
     employeeId: v.id("users"),
+    // DEPRECATED (#3399): replaced by gabinetAppointmentTreatments junction
+    // rows; the Supabase columns are dropped and no code reads these. They
+    // must stay optional here because legacy documents in the Convex dev
+    // deployment still carry the fields — removing them entirely makes every
+    // `convex deploy` fail schema validation.
+    treatmentId: v.optional(v.id("gabinetTreatments")),
+    variantId: v.optional(v.id("gabinetTreatmentVariants")),
+    priceAtBooking: v.optional(v.float64()),
     date: v.string(), // YYYY-MM-DD
     startTime: v.string(), // HH:MM
     endTime: v.string(),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3539.

Closes #3539

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 07f4807 fix(gabinet): restore deprecated fields as v.optional to unblock Convex deploy (closes #3539)

### Files changed

```
 convex/schema/gabinet.ts | 5 +++++
 1 file changed, 5 insertions(+)
```