### PR TITLE
Extend junction-treatment fetch to `useSupabaseGabinetAppointmentsByEmployee`

### DIFF
--- a/src/hooks/use-supabase-gabinet-appointments.ts
+++ b/src/hooks/use-supabase-gabinet-appointments.ts
@@ -199,7 +199,47 @@ export function useSupabaseGabinetAppointmentsByEmployee(
         .limit(limit);
 
       if (error) throw error;
-      return (data ?? []).map(mapGabinetAppointmentFromSupabase);
+      const mapped = (data ?? []).map(mapGabinetAppointmentFromSupabase);
+
+      const apptIds = mapped.map((a) => a._id);
+      if (apptIds.length > 0) {
+        const { data: junctionRows } = await client
+          .from("gabinet_appointment_treatments")
+          .select(
+            "id,appointment_id,treatment_id,variant_id,price_at_booking,sort_order",
+          )
+          .in("appointment_id", apptIds)
+          .order("sort_order", { ascending: true });
+        const byAppt = new Map<
+          string,
+          NonNullable<MappedGabinetAppointment["treatments"]>
+        >();
+        for (const row of (junctionRows ?? []) as Array<{
+          id: string;
+          appointment_id: string;
+          treatment_id: string | null;
+          variant_id: string | null;
+          price_at_booking: number | null;
+          sort_order: number;
+        }>) {
+          const list = byAppt.get(row.appointment_id) ?? [];
+          list.push({
+            _id: row.id,
+            appointmentId: row.appointment_id,
+            treatmentId: row.treatment_id ?? undefined,
+            variantId: row.variant_id ?? undefined,
+            priceAtBooking: row.price_at_booking ?? undefined,
+            sortOrder: row.sort_order,
+            createdAt: 0,
+            updatedAt: 0,
+          });
+          byAppt.set(row.appointment_id, list);
+        }
+        for (const appt of mapped) {
+          appt.treatments = byAppt.get(appt._id) ?? [];
+        }
+      }
+      return mapped;
     },
     enabled: enabled && isReady && !!organizationId && !!employeeId,
   } satisfies UseQueryOptions<MappedGabinetAppointment[], Error>);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3543.

Closes #3543

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 064c730 fix(gabinet): fetch junction treatments in useSupabaseGabinetAppointmentsByEmployee (closes #3543)

### Files changed

```
 src/hooks/use-supabase-gabinet-appointments.ts | 42 +++++++++++++++++++++++++-
 1 file changed, 41 insertions(+), 1 deletion(-)
```