### PR TITLE
`getApptTreatmentDisplay` / `getApptPrice` are duplicated logic with what `appoi

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -59,6 +59,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { getAppointmentJunctionPrice } from "@/lib/gabinet/appointment-display";
 import {
   BadgeCheck,
   Calendar,
@@ -711,13 +712,11 @@ export function AppointmentPreviewContent({
   // Sum prices across all junction treatments; fall back to the legacy scalar
   // for pre-junction single-treatment appointments. Fixes the "!"-unpaid
   // indicator and isSettled check for multi-treatment visits (issue #3517).
-  const treatmentPrice =
-    junctionTreatments.length > 0
-      ? junctionTreatments.reduce((sum, jt) => {
-          const tr = treatments?.find((t) => t._id === jt.treatmentId);
-          return sum + (jt.priceAtBooking ?? tr?.price ?? 0);
-        }, 0)
-      : (treatment?.price ?? 0);
+  const treatmentPrice = getAppointmentJunctionPrice(
+    junctionTreatments,
+    treatments,
+    treatment?.price,
+  );
   // Credit applied from the patient's overpayment balance (issue #1059) counts
   // toward the paid total — a visit settled purely from credit lands as
   // `amount=0, creditApplied=price` (#1856), so without summing creditApplied

--- a/src/lib/gabinet/appointment-display.ts
+++ b/src/lib/gabinet/appointment-display.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared display/price helpers for gabinet appointments.
+ *
+ * Both the patient card and the appointment preview popover compute treatment
+ * names and prices from the junction table — keeping the logic here prevents
+ * the two call-sites from drifting apart.
+ */
+
+export interface JunctionTreatmentRef {
+  treatmentId?: string | null;
+  variantId?: string | null;
+  priceAtBooking?: number | null;
+}
+
+export interface TreatmentCatalogItem {
+  _id: string;
+  name: string;
+  price?: number | null;
+}
+
+/**
+ * Returns a compact display string for an appointment's treatment(s).
+ * Primary treatment name + optional variant, with "+N" suffix for multi-treatment visits.
+ */
+export function getAppointmentTreatmentDisplay(
+  junctionTreatments: JunctionTreatmentRef[],
+  treatmentCatalog: TreatmentCatalogItem[] | null | undefined,
+  variantNameLookup?: (variantId: string) => string | undefined,
+): string | undefined {
+  const primary = junctionTreatments[0];
+  if (!primary) return undefined;
+  const name = primary.treatmentId
+    ? treatmentCatalog?.find((tr) => tr._id === primary.treatmentId)?.name
+    : undefined;
+  if (!name) return undefined;
+  const variantName =
+    primary.variantId && variantNameLookup
+      ? variantNameLookup(primary.variantId)
+      : undefined;
+  const base = variantName ? `${name} · ${variantName}` : name;
+  return junctionTreatments.length > 1
+    ? `${base} +${junctionTreatments.length - 1}`
+    : base;
+}
+
+/**
+ * Sums the price across all junction treatment rows.
+ * Uses priceAtBooking when available, falls back to the catalog price.
+ * If there are no junction rows, returns legacyFallbackPrice (pre-junction appointments).
+ */
+export function getAppointmentJunctionPrice(
+  junctionTreatments: JunctionTreatmentRef[],
+  treatmentCatalog: TreatmentCatalogItem[] | null | undefined,
+  legacyFallbackPrice?: number | null,
+): number {
+  if (junctionTreatments.length === 0) {
+    return legacyFallbackPrice ?? 0;
+  }
+  return junctionTreatments.reduce((sum, jt) => {
+    const catalogPrice = jt.treatmentId
+      ? (treatmentCatalog?.find((tr) => tr._id === jt.treatmentId)?.price ?? 0)
+      : 0;
+    return sum + (jt.priceAtBooking ?? catalogPrice);
+  }, 0);
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -4,6 +4,10 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
+import {
+  getAppointmentTreatmentDisplay,
+  getAppointmentJunctionPrice,
+} from "@/lib/gabinet/appointment-display";
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
@@ -331,34 +335,19 @@ function PatientDetail() {
   }, [allVariantsData]);
 
   // Treatment info comes from the junction rows (#3399 dropped the scalar
-  // treatment_id column). Display: primary treatment name (+variant), with a
-  // "+N" suffix for multi-treatment visits. Price: sum over junction rows
-  // (priceAtBooking frozen at booking, catalog price as fallback).
+  // treatment_id column). Delegates to shared utilities in
+  // src/lib/gabinet/appointment-display.ts (issue #3544).
   const getApptTreatmentDisplay = (
     apt?: MappedGabinetAppointment | null,
-  ): string | undefined => {
-    const rows = apt?.treatments ?? [];
-    const primary = rows[0];
-    const name = primary?.treatmentId
-      ? treatmentsData?.find((tr) => tr._id === primary.treatmentId)?.name
-      : undefined;
-    if (!name) return undefined;
-    const variantName = primary?.variantId
-      ? variantNameMap.get(primary.variantId)
-      : undefined;
-    const base = variantName ? `${name} · ${variantName}` : name;
-    return rows.length > 1 ? `${base} +${rows.length - 1}` : base;
-  };
+  ): string | undefined =>
+    getAppointmentTreatmentDisplay(
+      apt?.treatments ?? [],
+      treatmentsData,
+      (variantId) => variantNameMap.get(variantId),
+    );
 
-  const getApptPrice = (apt?: MappedGabinetAppointment | null): number => {
-    const rows = apt?.treatments ?? [];
-    return rows.reduce((sum, jt) => {
-      const catalog = jt.treatmentId
-        ? (treatmentsData?.find((tr) => tr._id === jt.treatmentId)?.price ?? 0)
-        : 0;
-      return sum + (jt.priceAtBooking ?? catalog);
-    }, 0);
-  };
+  const getApptPrice = (apt?: MappedGabinetAppointment | null): number =>
+    getAppointmentJunctionPrice(apt?.treatments ?? [], treatmentsData);
 
   const { data: patientPayments } = useSupabasePaymentsByPatient(
     organizationId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3544.

Closes #3544

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 77ca06d refactor(gabinet): extract shared appointment price/display utilities (closes #3544)

### Files changed

```
 .../calendar/appointment-preview-content.tsx       | 13 ++---
 src/lib/gabinet/appointment-display.ts             | 65 ++++++++++++++++++++++
 .../_layout.gabinet.patients.$patientId.tsx        | 39 +++++--------
 3 files changed, 85 insertions(+), 32 deletions(-)
```