### PR TITLE
Split-payment package rows call `usePackageTreatmentsBatch` but don't guard `out

### DIFF
--- a/src/components/gabinet/appointment-shared/settlement-form.tsx
+++ b/src/components/gabinet/appointment-shared/settlement-form.tsx
@@ -335,6 +335,18 @@ export function SettlementForm({
         );
         return;
       }
+      if (
+        outstanding <= 0 &&
+        (firstSplitMethod === "package" || secondSplitMethod === "package")
+      ) {
+        toast.error(
+          t(
+            "gabinet.payments.alreadySettled",
+            "Wizyta jest już rozliczona — ponowne rozliczenie z pakietu odliczyłoby zabiegi drugi raz.",
+          ),
+        );
+        return;
+      }
     } else if (isPackageMode) {
       if (!paymentPackageId) {
         toast.error(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3545.

Closes #3545

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0013446 fix(gabinet): guard split-package deduction when outstanding <= 0 (closes #3545)

### Files changed

```
 .../gabinet/appointment-shared/settlement-form.tsx           | 12 ++++++++++++
 1 file changed, 12 insertions(+)
```