### PR TITLE
Naprawa usunięcia zabiegu

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -468,11 +468,12 @@ export const remove = action({
       throw new Error("Permission denied: you can only delete your own records");
     }
 
-    // --- Soft-delete: PATCH isActive=false in Supabase ---
-    await db.patch("gabinetTreatments", args.treatmentId, {
-      isActive: false,
-      updatedAt: Date.now(),
-    });
+    // --- Hard-delete the treatment row from Supabase ---
+    // FK dependencies: gabinet_treatment_variants and gabinet_treatment_products
+    // cascade; gabinet_appointment_treatments sets treatment_id to NULL;
+    // gabinet_treatment_packages.auto_generated_for_treatment_id sets to NULL
+    // (via migration 00077).
+    await db.delete("gabinetTreatments", args.treatmentId);
 
     // --- Delegate post-write side effects ---
     try {

--- a/supabase/migrations/00077_gabinet_treatments_hard_delete.sql
+++ b/supabase/migrations/00077_gabinet_treatments_hard_delete.sql
@@ -1,0 +1,16 @@
+-- Allow hard-deleting treatments (closes #3549).
+--
+-- gabinet_treatment_packages.auto_generated_for_treatment_id currently has no
+-- ON DELETE clause (defaults to NO ACTION), which prevents deleting a treatment
+-- that was used to auto-generate a package.  The column is nullable so SET NULL
+-- is the right semantic: the package survives the treatment deletion with its
+-- reference cleared.
+
+ALTER TABLE gabinet_treatment_packages
+  DROP CONSTRAINT IF EXISTS gabinet_treatment_packages_auto_generated_for_treatment_id_fkey;
+
+ALTER TABLE gabinet_treatment_packages
+  ADD CONSTRAINT gabinet_treatment_packages_auto_generated_for_treatment_id_fkey
+  FOREIGN KEY (auto_generated_for_treatment_id)
+  REFERENCES gabinet_treatments(id)
+  ON DELETE SET NULL;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3549.

Closes #3549

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e2db099 fix(gabinet): hard-delete treatments instead of soft-deactivating (closes #3549)

### Files changed

```
 convex/gabinet/treatments.ts                             | 11 ++++++-----
 .../migrations/00077_gabinet_treatments_hard_delete.sql  | 16 ++++++++++++++++
 2 files changed, 22 insertions(+), 5 deletions(-)
```