### PR TITLE
Clean up soft-delete dead code paths

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -766,7 +766,6 @@ export const listActive = action({
     let results = (await db
       .query("gabinetTreatments")
       .eq("organizationId", String(args.organizationId))
-      .eq("isActive", true)
       .collect()) as GabinetTreatmentRow[];
 
     if (perm.scope === "own") {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -459,17 +459,6 @@ function TreatmentDetail() {
     }
   };
 
-  const handleReactivate = async () => {
-    await updateTreatment({
-      organizationId,
-      treatmentId: treatmentId as Id<"gabinetTreatments">,
-      isActive: true,
-    });
-    void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatments.detail(organizationId, treatmentId) });
-    void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetTreatments.list(organizationId) });
-    toast.success(t("common.saved"));
-  };
-
   const handleAddProduct = async () => {
     const product = (warehouseProducts ?? []).find(p => p._id === addProductSelectedId);
     if (!product) return;
@@ -1570,17 +1559,11 @@ function TreatmentDetail() {
           setEditPanelOpen(true);
         }}
         secondaryActions={[
-          treatment?.isActive === false
-            ? {
-                label: t("gabinet.treatmentDetail.reactivate"),
-                onClick: handleReactivate,
-                variant: "outline" as const,
-              }
-            : {
-                label: t("gabinet.treatmentDetail.deactivate"),
-                onClick: handleDeactivate,
-                variant: "destructive" as const,
-              },
+          {
+            label: t("gabinet.treatmentDetail.deactivate"),
+            onClick: handleDeactivate,
+            variant: "destructive" as const,
+          },
         ]}
         fields={detailFields}
         expandedFieldCount={5}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -180,12 +180,6 @@ function TreatmentsIndex() {
         isSystem: true,
         isDefault: false,
       },
-      {
-        id: "inactive",
-        name: t("gabinet.treatments.views.inactive"),
-        isSystem: true,
-        isDefault: false,
-      },
     ],
     [t],
   );
@@ -256,9 +250,6 @@ function TreatmentsIndex() {
     switch (activeViewId) {
       case "active":
         data = allTreatments.filter((t) => t.isActive);
-        break;
-      case "inactive":
-        data = allTreatments.filter((t) => !t.isActive);
         break;
       default:
         data = allTreatments;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3552.

Closes #3552

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3bae662 fix(gabinet): remove soft-delete dead code paths for treatments (closes #3552)

### Files changed

```
 convex/gabinet/treatments.ts                       |  1 -
 .../_layout.gabinet.treatments.$treatmentId.tsx    | 27 ++++------------------
 .../dashboard/_layout.gabinet.treatments.index.tsx |  9 --------
 3 files changed, 5 insertions(+), 32 deletions(-)
```