### PR TITLE
Fix misleading "Deactivate" label on treatment hard-delete action

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2701,7 +2701,7 @@
       "revenue": "Revenue",
       "description": "Description",
       "instructions": "Instructions",
-      "deactivate": "Delete",
+      "delete": "Delete",
       "reactivate": "Reactivate",
       "recentAppointments": "Recent Appointments",
       "noAppointments": "No appointments for this treatment",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2717,7 +2717,7 @@
       "revenue": "Przychód",
       "description": "Opis",
       "instructions": "Instrukcje",
-      "deactivate": "Usuń",
+      "delete": "Usuń",
       "reactivate": "Reaktywuj",
       "recentAppointments": "Ostatnie wizyty",
       "noAppointments": "Brak wizyt dla tego zabiegu",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -448,7 +448,7 @@ function TreatmentDetail() {
 
   // --- Handlers (after hooks, before render) ---
 
-  const handleDeactivate = async () => {
+  const handleDelete = async () => {
     if (window.confirm(t("gabinet.treatments.confirmDelete"))) {
       await removeTreatment({
         organizationId,
@@ -1560,8 +1560,8 @@ function TreatmentDetail() {
         }}
         secondaryActions={[
           {
-            label: t("gabinet.treatmentDetail.deactivate"),
-            onClick: handleDeactivate,
+            label: t("gabinet.treatmentDetail.delete"),
+            onClick: handleDelete,
             variant: "destructive" as const,
           },
         ]}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3556.

Closes #3556

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- acacc72 fix(gabinet): rename handleDeactivate to handleDelete in treatment detail (closes #3556)

### Files changed

```
 public/locales/en/translation.json                                  | 2 +-
 public/locales/pl/translation.json                                  | 2 +-
 .../_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx     | 6 +++---
 3 files changed, 5 insertions(+), 5 deletions(-)
```