### PR TITLE
Remove dead `reactivate` key from treatmentDetail locale

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2702,7 +2702,6 @@
       "description": "Description",
       "instructions": "Instructions",
       "delete": "Delete",
-      "reactivate": "Reactivate",
       "recentAppointments": "Recent Appointments",
       "noAppointments": "No appointments for this treatment",
       "overview": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2718,7 +2718,6 @@
       "description": "Opis",
       "instructions": "Instrukcje",
       "delete": "Usuń",
-      "reactivate": "Reaktywuj",
       "recentAppointments": "Ostatnie wizyty",
       "noAppointments": "Brak wizyt dla tego zabiegu",
       "overview": {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3559.

Closes #3559

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c9219c3 fix(gabinet): remove dead reactivate key from treatmentDetail locale (closes #3559)

### Files changed

```
 public/locales/en/translation.json | 1 -
 public/locales/pl/translation.json | 1 -
 2 files changed, 2 deletions(-)
```