### PR TITLE
Fix `gabinet.packages.confirmDeleteDescription` implies reactivation is possible

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3476,7 +3476,7 @@
       "inactive": "Inactive",
       "created": "Package created",
       "editPackage": "Edit Package",
-      "confirmDeleteDescription": "The package will be deactivated. It can be reactivated later.",
+      "confirmDeleteDescription": "This action cannot be undone.",
       "emptyTitle": "No packages yet",
       "emptyDescription": "Create treatment packages to offer bundles",
       "activeUses": "active uses",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3497,7 +3497,7 @@
       "inactive": "Nieaktywny",
       "created": "Pakiet utworzony",
       "editPackage": "Edytuj pakiet",
-      "confirmDeleteDescription": "Pakiet zostanie dezaktywowany. Można go będzie aktywować ponownie.",
+      "confirmDeleteDescription": "Tej operacji nie można cofnąć.",
       "emptyTitle": "Brak pakietów",
       "emptyDescription": "Utwórz pakiety zabiegów, aby oferować zestawy",
       "activeUses": "aktywnych użyć",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3565.

Closes #3565

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- fe559db fix(gabinet): update packages confirmDeleteDescription to not imply reactivation is possible (closes #3565)

### Files changed

```
 public/locales/en/translation.json | 2 +-
 public/locales/pl/translation.json | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```