### PR TITLE
Add deactivation path for packages with existing usages

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -58,6 +58,7 @@ import {
   Trash2,
   Package,
   Pencil,
+  Power,
   X,
   Gift,
   Search,
@@ -856,6 +857,32 @@ function PackagesIndex() {
     }
   };
 
+  const handleToggleActive = useCallback(
+    async (pkg: TreatmentPackage) => {
+      try {
+        await updatePkg({
+          organizationId,
+          packageId: pkg._id,
+          isActive: !pkg.isActive,
+        });
+        toast.success(
+          pkg.isActive
+            ? t("gabinet.packages.deactivated", "Pakiet dezaktywowany")
+            : t("gabinet.packages.activated", "Pakiet aktywowany"),
+        );
+        invalidatePackages();
+      } catch (e) {
+        toast.error(
+          formatActionError(e, t, {
+            key: "gabinet.packages.errors.toggleActiveFailed",
+            defaultValue: "Nie udało się zmienić statusu pakietu.",
+          }),
+        );
+      }
+    },
+    [updatePkg, organizationId, t, invalidatePackages],
+  );
+
   const handleBulkAction = useCallback(
     async (action: string, selectedRows: TreatmentPackage[]) => {
       if (action === "delete") {
@@ -877,6 +904,13 @@ function PackagesIndex() {
               icon: <Pencil className="h-4 w-4" variant="stroke" />,
               onClick: () => openEdit(row),
             },
+            {
+              label: row.isActive
+                ? t("common.deactivate", "Dezaktywuj")
+                : t("common.activate", "Aktywuj"),
+              icon: <Power className="h-4 w-4" variant="stroke" />,
+              onClick: () => handleToggleActive(row),
+            },
           ]
         : []),
       ...(canDelete
@@ -889,7 +923,7 @@ function PackagesIndex() {
           ]
         : []),
     ],
-    [t, canEdit, canDelete, openEdit],
+    [t, canEdit, canDelete, openEdit, handleToggleActive],
   );
 
   const handleAssignGift = async () => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3569.

Closes #3569

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 6dfbbc6 fix(gabinet): add deactivate/activate action for packages with usages (closes #3569)

### Files changed

```
 .../dashboard/_layout.gabinet.packages.index.tsx   | 36 +++++++++++++++++++++-
 1 file changed, 35 insertions(+), 1 deletion(-)
```