### PR TITLE
Za szerokie menu boczne pracownika 

### DIFF
--- a/src/components/crm/entity-detail-layout.tsx
+++ b/src/components/crm/entity-detail-layout.tsx
@@ -231,6 +231,8 @@ interface EntityDetailLayoutProps {
   sidebarExtra?: React.ReactNode;
   /** Quick action items to include in the sidebar actions dropdown (sidebar-slot variant only). */
   quickActionItems?: { key: string; label: string; icon?: React.ReactNode; onClick: () => void }[];
+  /** Initial width of the resizable left sidebar in pixels (default: 420). */
+  initialSidebarWidth?: number;
 }
 
 export function EntityDetailLayout({
@@ -262,12 +264,13 @@ export function EntityDetailLayout({
   breadcrumbs,
   sidebarExtra,
   quickActionItems,
+  initialSidebarWidth = 420,
 }: EntityDetailLayoutProps) {
   const { t } = useTranslation();
   const [showAllFields, setShowAllFields] = useState(false);
 
   // Resizable sidebar width (hooks must be before early returns)
-  const [sidebarWidth, setSidebarWidth] = useState(420);
+  const [sidebarWidth, setSidebarWidth] = useState(initialSidebarWidth);
   const isResizing = useRef(false);
 
   const handleResizeStart = useCallback((e: React.MouseEvent) => {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -874,6 +874,7 @@ function EmployeeDetail() {
         tabs={visibleTabs}
         activeTab={activeTab}
         onTabChange={setActiveTab}
+        initialSidebarWidth={300}
         beforeTabs={
           <EmployeeNavGroups
             activeGroup={activeNavGroup}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3576.

Closes #3576

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a971494 fix(gabinet): narrow employee detail sidebar from 420px to 300px (closes #3576)

### Files changed

```
 src/components/crm/entity-detail-layout.tsx                          | 5 ++++-
 .../_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx   | 1 +
 2 files changed, 5 insertions(+), 1 deletion(-)
```