### PR TITLE
Rozliczanie w jednym oknie dwóch zabiegów (jedna wizyta)

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -96,6 +96,7 @@ import {
   useSupabaseGabinetFirstAppointmentIdsByPatient,
   useSupabaseGabinetAppointmentPackagePositions,
   useSupabaseGabinetAppointmentRecurringPositions,
+  useSupabaseGabinetSameDayAppointments,
 } from "@/hooks/use-supabase-gabinet-appointments";
 import {
   AppointmentIndicatorBadge,
@@ -302,6 +303,15 @@ export function AppointmentPreviewContent({
         }>
       | undefined;
   };
+
+  // Other appointments for the same patient on the same date — used to warn
+  // staff that more visits may need settling after this one (issue #3578).
+  const { data: sameDayOtherAppointments } = useSupabaseGabinetSameDayAppointments(
+    organizationId,
+    patientIdForPackages || undefined,
+    detail?.appointment.date,
+    appointmentId,
+  );
 
   const [status, setStatus] = useState<AppointmentStatus | "">("");
   const [date, setDate] = useState("");
@@ -1648,6 +1658,33 @@ export function AppointmentPreviewContent({
               })}
             </DialogDescription>
           </DialogHeader>
+
+          {sameDayOtherAppointments && sameDayOtherAppointments.length > 0 && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30 p-3 flex gap-2 text-sm">
+              <AlertTriangle className="size-4 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+              <div className="text-amber-700 dark:text-amber-300">
+                <p className="font-medium">
+                  {t(
+                    "gabinet.appointments.otherAppointmentsTodayTitle",
+                    "Inne wizyty pacjenta w tym dniu",
+                  )}
+                </p>
+                <p className="text-xs mt-0.5 text-amber-600 dark:text-amber-400">
+                  {sameDayOtherAppointments
+                    .map(
+                      (a) =>
+                        `${a.startTime.slice(0, 5)}–${a.endTime.slice(0, 5)}`,
+                    )
+                    .join(", ")}
+                  {" — "}
+                  {t(
+                    "gabinet.appointments.otherAppointmentsTodayHint",
+                    "pamiętaj o ich rozliczeniu",
+                  )}
+                </p>
+              </div>
+            </div>
+          )}
 
           <div className="rounded-md border bg-muted/30 p-3 text-xs space-y-1 mt-2">
             {(isMultiTreatment

--- a/src/hooks/use-supabase-gabinet-appointments.ts
+++ b/src/hooks/use-supabase-gabinet-appointments.ts
@@ -639,6 +639,72 @@ export function useSupabaseGabinetNextAppointmentByPatient(
 }
 
 // ---------------------------------------------------------------------------
+// Same-day Appointments for a Patient (settlement warning — issue #3578)
+// ---------------------------------------------------------------------------
+
+export interface SameDayAppointmentInfo {
+  id: string;
+  startTime: string;
+  endTime: string;
+  status: string;
+}
+
+/**
+ * Returns other non-cancelled, non-no-show appointments for the same patient
+ * on the same date, excluding the current appointment. Used by the settlement
+ * dialog to warn when more appointments remain to be settled (issue #3578).
+ */
+export function useSupabaseGabinetSameDayAppointments(
+  organizationId: string,
+  patientId: string | undefined,
+  date: string | undefined,
+  excludeAppointmentId: string,
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  return useQuery<SameDayAppointmentInfo[], Error>({
+    queryKey: [
+      ...supabaseKeys.gabinetAppointments.list(organizationId),
+      "sameDay",
+      patientId ?? "",
+      date ?? "",
+      excludeAppointmentId,
+    ],
+    queryFn: async (): Promise<SameDayAppointmentInfo[]> => {
+      if (!client || !patientId || !date) return [];
+      const { data, error } = await client
+        .from("gabinet_appointments")
+        .select("id, start_time, end_time, status")
+        .eq("organization_id", organizationId)
+        .eq("patient_id", patientId)
+        .eq("date", date)
+        .neq("id", excludeAppointmentId)
+        .not("status", "in", '("cancelled","no_show")')
+        .order("start_time");
+      if (error) throw error;
+      return (
+        (
+          data ?? []
+        ) as Array<{
+          id: string;
+          start_time: string;
+          end_time: string;
+          status: string;
+        }>
+      ).map((r) => ({
+        id: r.id,
+        startTime: r.start_time,
+        endTime: r.end_time,
+        status: r.status,
+      }));
+    },
+    enabled: enabled && isReady && !!organizationId && !!patientId && !!date,
+  } satisfies UseQueryOptions<SameDayAppointmentInfo[], Error>);
+}
+
+// ---------------------------------------------------------------------------
 // Single Appointment
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3578.

Closes #3578

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 03a955e fix(gabinet): warn when patient has other appointments to settle on same day (closes #3578)

### Files changed

```
 .../calendar/appointment-preview-content.tsx       | 37 ++++++++++++
 src/hooks/use-supabase-gabinet-appointments.ts     | 66 ++++++++++++++++++++++
 2 files changed, 103 insertions(+)
```