### PR TITLE
Stan magazynowy powiązanego materiału do zabiegu po rozliczeniu wizyty

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -2656,6 +2656,18 @@ function AppointmentDetail() {
               payments={payments as Array<Record<string, unknown>>}
               patientPackageUsage={patientPackageUsage}
               linkedPackageUsageId={appointment.packageUsageId ?? null}
+              showMarkCompleted={availableTransitions.includes("completed")}
+              onMarkCompleted={async () => {
+                const result = await updateStatus({
+                  organizationId,
+                  appointmentId: appointment._id,
+                  status: "completed",
+                });
+                if (result?.warnings?.length) {
+                  toast.warning(t("gabinet.stock.negativeWarning"));
+                }
+                await invalidateAppointmentCaches();
+              }}
               onSuccess={() => {
                 setPaymentDialogOpen(false);
                 refetch();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3583.

Closes #3583

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c4cfe12 fix(gabinet): deduct treatment materials on settlement in appointment detail view (closes #3583)

### Files changed

```
 .../_layout.gabinet.appointments.$appointmentId.lazy.tsx     | 12 ++++++++++++
 1 file changed, 12 insertions(+)
```