### PR TITLE
Missing `afterCompletionDialogOpen` trigger on settlement mark-complete in detai

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -2667,6 +2667,7 @@ function AppointmentDetail() {
                   toast.warning(t("gabinet.stock.negativeWarning"));
                 }
                 await invalidateAppointmentCaches();
+                setTimeout(() => setAfterCompletionDialogOpen(true), 500);
               }}
               onSuccess={() => {
                 setPaymentDialogOpen(false);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3588.

Closes #3588

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b0209aa fix(gabinet): trigger after-completion dialog when completing via settlement in detail view (closes #3588)

### Files changed

```
 .../_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx | 1 +
 1 file changed, 1 insertion(+)
```