### PR TITLE
Backend ignores `packageTreatmentId` argument in appointments.create

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1399,6 +1399,7 @@ export const create = action({
       prepaymentAmount: args.prepaymentAmount ?? null,
       prepaymentStatus: args.prepaymentRequired ? "pending" : null,
       packageUsageId: resolvedPackageUsageId ?? null,
+      packageTreatmentId: args.packageTreatmentId ?? null,
       sendReminder: shouldSendReminder,
       reminderOverrides: args.reminderOverrides ?? null,
       locationId: resolvedLocationId ?? null,
@@ -2367,11 +2368,15 @@ export const updateStatus = action({
     // Package return: when reverting from completed or no_show, restore one
     // package entry per junction treatment. CAS lives on
     // gabinet_appointment_treatments.package_deducted per junction row (#3367).
+    // If packageTreatmentId is set, only the covered treatment is returned (#3590).
     if (
       (appt.status === "completed" || appt.status === "no_show") &&
       appt.packageUsageId
     ) {
-      for (const jt of statusJunctionRows) {
+      const pkgReturnRows = appt.packageTreatmentId
+        ? statusJunctionRows.filter((jt) => jt.treatmentId === String(appt.packageTreatmentId))
+        : statusJunctionRows;
+      for (const jt of pkgReturnRows) {
         const { data: pkgReturnCasRows } = await db.raw()
           .from("gabinet_appointment_treatments")
           .update({ package_deducted: false })
@@ -2491,11 +2496,15 @@ export const updateStatus = action({
     // Package deduction: completed and no_show both consume one entry per junction
     // treatment. CAS lives on gabinet_appointment_treatments.package_deducted per
     // junction row (#3367), replacing the old appointment-level flag. Closes #3206.
+    // If packageTreatmentId is set, only the covered treatment is deducted (#3590).
     if (
       (args.status === "completed" || args.status === "no_show") &&
       appt.packageUsageId
     ) {
-      for (const jt of statusJunctionRows) {
+      const pkgDeductRows = appt.packageTreatmentId
+        ? statusJunctionRows.filter((jt) => jt.treatmentId === String(appt.packageTreatmentId))
+        : statusJunctionRows;
+      for (const jt of pkgDeductRows) {
         const { data: pkgCasRows } = await db.raw()
           .from("gabinet_appointment_treatments")
           .update({ package_deducted: true })

--- a/supabase/migrations/00078_gabinet_appointments_package_treatment_id.sql
+++ b/supabase/migrations/00078_gabinet_appointments_package_treatment_id.sql
@@ -1,0 +1,17 @@
+-- Store which treatment a package covers in a multi-treatment appointment (closes #3590).
+--
+-- When booking a multi-treatment appointment with a package, the frontend sends
+-- packageTreatmentId to identify which of the N treatments is covered.
+-- Previously the backend declared the field in the validator but never persisted it,
+-- so at completion time the package deduction loop set package_deducted=true on ALL
+-- junction rows rather than only the one covered by the package.
+--
+-- This migration adds the column so appointments.create can persist the value and
+-- updateStatus can filter its deduction/return loops accordingly.
+
+ALTER TABLE gabinet_appointments
+  ADD COLUMN IF NOT EXISTS package_treatment_id TEXT REFERENCES gabinet_treatments(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS gabinet_appointments_package_treatment_id_idx
+  ON gabinet_appointments (organization_id, package_treatment_id)
+  WHERE package_treatment_id IS NOT NULL;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3590.

Closes #3590

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c683a9a fix(gabinet): persist and use packageTreatmentId in appointments.create (closes #3590)

### Files changed

```
 convex/gabinet/appointments.ts                          | 13 +++++++++++--
 .../00078_gabinet_appointments_package_treatment_id.sql | 17 +++++++++++++++++
 2 files changed, 28 insertions(+), 2 deletions(-)
```