### PR TITLE
Remove same-day appointments search when appointment has junction treatments

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -306,11 +306,14 @@ export function AppointmentPreviewContent({
 
   // Other appointments for the same patient on the same date — used to warn
   // staff that more visits may need settling after this one (issue #3578).
+  // Suppressed for multi-treatment (junction) appointments: all treatments are
+  // already in one appointment, so the warning would be misleading (#3594).
   const { data: sameDayOtherAppointments } = useSupabaseGabinetSameDayAppointments(
     organizationId,
     patientIdForPackages || undefined,
     detail?.appointment.date,
     appointmentId,
+    { enabled: !detail?.treatments || detail.treatments.length <= 1 },
   );
   // First same-day appointment to settle next (sorted by start_time from the query).
   const nextSameDayAppointment = sameDayOtherAppointments?.[0] ?? null;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3594.

Closes #3594

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f89eb3c fix(gabinet): suppress same-day appointments warning for multi-treatment visits (closes #3594)

### Files changed

```
 src/components/gabinet/calendar/appointment-preview-content.tsx | 3 +++
 1 file changed, 3 insertions(+)
```