### PR TITLE
Clarify product spec for batch settlement of separate same-day appointments

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -453,12 +453,15 @@ function AppointmentDetail() {
 
   // Same-day appointments for the same patient — used to warn staff that more
   // visits may need settling after this one (issue #3581, mirrors #3578).
+  // Suppressed for multi-treatment (junction) appointments: all treatments are
+  // already in one appointment, so the warning would be misleading (#3594).
   const { data: sameDayOtherAppointments } =
     useSupabaseGabinetSameDayAppointments(
       organizationId,
       detail?.patient?._id ?? undefined,
       detail?.appointment?.date,
       appointmentId,
+      { enabled: !detail?.treatments || detail.treatments.length <= 1 },
     );
 
   // Equipment list used to surface parameter units on the Documentation tab —


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3595.

Closes #3595

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e4b9bc0 fix(gabinet): suppress same-day warning for multi-treatment visits in detail view (closes #3595)

### Files changed

```
 .../dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx     | 3 +++
 1 file changed, 3 insertions(+)
```