### PR TITLE
Przeniesienie statystyk pod tabele

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -780,55 +780,6 @@ function TreatmentsIndex() {
         onFiltersChange={setActiveFilters}
       />
 
-      {/* Mobile-only toggle: collapse KPI cards by default on small screens */}
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={() => setShowStatsMobile((s) => !s)}
-        aria-expanded={showStatsMobile}
-        className="md:hidden w-full justify-between"
-      >
-        {showStatsMobile ? t("common.hideStats") : t("common.showStats")}
-        {showStatsMobile ? (
-          <ChevronUp className="size-4" />
-        ) : (
-          <ChevronDown className="size-4" />
-        )}
-      </Button>
-
-      {/* KPI Statistics Cards */}
-      <div className={`${showStatsMobile ? "grid" : "hidden md:grid"} gap-4 sm:grid-cols-3`}>
-        <StatisticsOrderCard
-          title={t("gabinet.treatments.totalTreatments", "Zabiegi")}
-          description={t("gabinet.treatments.inCatalog", "W katalogu")}
-          value={String(kpis?.totalTreatments ?? 0)}
-          changePercentage={
-            kpis?.popularTreatment
-              ? `★ ${kpis.popularTreatment}`
-              : ""
-          }
-          chartData={treatmentChartData}
-        />
-        <StatisticsProfitCard
-          title={t("gabinet.treatments.completedThisMonth", "Wykonane w tym mies.")}
-          description={t("gabinet.treatments.thisMonth", "Ten miesiąc")}
-          value={String(kpis?.completedThisMonth ?? 0)}
-          changePercentage={t("gabinet.treatments.appointments", "wizyt")}
-        />
-        <StatisticsSalesGrowthCard
-          title={t("gabinet.treatments.popular", "Najpopularniejszy")}
-          description={t("gabinet.treatments.byAppointments", "Wg wizyt")}
-          value={kpis?.popularTreatment ?? "—"}
-          changePercentage={
-            kpis?.completedThisMonth
-              ? `${kpis.completedThisMonth} ${t("gabinet.treatments.thisMonthShort", "w tym mies.")}`
-              : ""
-          }
-          gradientId="fillTreatments"
-        />
-      </div>
-
       {groupByEquipment && treatmentGroups ? (
         treatmentGroups.length === 0 ? (
           <CrmDataTable
@@ -913,6 +864,55 @@ function TreatmentsIndex() {
           }
         />
       )}
+
+      {/* Mobile-only toggle: collapse KPI cards by default on small screens */}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setShowStatsMobile((s) => !s)}
+        aria-expanded={showStatsMobile}
+        className="md:hidden w-full justify-between"
+      >
+        {showStatsMobile ? t("common.hideStats") : t("common.showStats")}
+        {showStatsMobile ? (
+          <ChevronUp className="size-4" />
+        ) : (
+          <ChevronDown className="size-4" />
+        )}
+      </Button>
+
+      {/* KPI Statistics Cards */}
+      <div className={`${showStatsMobile ? "grid" : "hidden md:grid"} gap-4 sm:grid-cols-3`}>
+        <StatisticsOrderCard
+          title={t("gabinet.treatments.totalTreatments", "Zabiegi")}
+          description={t("gabinet.treatments.inCatalog", "W katalogu")}
+          value={String(kpis?.totalTreatments ?? 0)}
+          changePercentage={
+            kpis?.popularTreatment
+              ? `★ ${kpis.popularTreatment}`
+              : ""
+          }
+          chartData={treatmentChartData}
+        />
+        <StatisticsProfitCard
+          title={t("gabinet.treatments.completedThisMonth", "Wykonane w tym mies.")}
+          description={t("gabinet.treatments.thisMonth", "Ten miesiąc")}
+          value={String(kpis?.completedThisMonth ?? 0)}
+          changePercentage={t("gabinet.treatments.appointments", "wizyt")}
+        />
+        <StatisticsSalesGrowthCard
+          title={t("gabinet.treatments.popular", "Najpopularniejszy")}
+          description={t("gabinet.treatments.byAppointments", "Wg wizyt")}
+          value={kpis?.popularTreatment ?? "—"}
+          changePercentage={
+            kpis?.completedThisMonth
+              ? `${kpis.completedThisMonth} ${t("gabinet.treatments.thisMonthShort", "w tym mies.")}`
+              : ""
+          }
+          gradientId="fillTreatments"
+        />
+      </div>
 
       <SidePanel
         open={columnSettingsOpen}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3598.

Closes #3598

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 972c971 fix(gabinet): move treatment statistics cards below the treatments table (closes #3598)

### Files changed

```
 .../dashboard/_layout.gabinet.treatments.index.tsx | 98 +++++++++++-----------
 1 file changed, 49 insertions(+), 49 deletions(-)
```