### PR TITLE
Rozliczanie w jednym oknie dwóch zabiegów (jedna wizyta)

### DIFF
--- a/src/components/gabinet/appointment-shared/settlement-form.tsx
+++ b/src/components/gabinet/appointment-shared/settlement-form.tsx
@@ -58,6 +58,13 @@ export interface SettlementFormProps {
    * automatically on completion, and offering it here would double-deduct.
    */
   linkedPackageUsageId?: string | null;
+  /**
+   * Additional same-day appointments to settle in the same operation.
+   * For each entry, a payment is created with the same method and that
+   * appointment's full price. Package and split payment modes are excluded
+   * from batch (those appointments remain for manual individual settlement).
+   */
+  additionalAppointments?: Array<{ id: string; totalPrice: number }>;
   /** Called after a payment is successfully created. Should close the dialog and refetch. */
   onSuccess: () => void;
   /** Called when the user cancels. Should close the dialog. */
@@ -97,6 +104,7 @@ export function SettlementForm({
   payments,
   patientPackageUsage,
   linkedPackageUsageId,
+  additionalAppointments = [],
   onSuccess,
   onCancel,
   onBeforeSubmit,
@@ -524,6 +532,29 @@ export function SettlementForm({
           creditEarned: creditEarned > 0 ? creditEarned : undefined,
           creditApplied: creditApplied > 0 ? creditApplied : undefined,
         });
+      }
+
+      // Batch-settle additional same-day appointments with the same payment
+      // method (non-package, non-split only — complex redemptions must be
+      // done individually). Issue #3578.
+      if (
+        additionalAppointments.length > 0 &&
+        !isPackageMode &&
+        !splitPayment
+      ) {
+        const batchMethod = paymentMethod as (typeof PAYMENT_METHODS)[number];
+        for (const appt of additionalAppointments) {
+          if (appt.totalPrice <= 0) continue;
+          await createPayment({
+            organizationId,
+            patientId: patientId as Id<"gabinetPatients">,
+            appointmentId: appt.id as Id<"gabinetAppointments">,
+            amount: appt.totalPrice,
+            currency: "PLN",
+            paymentMethod: batchMethod,
+            notes: paymentNote || undefined,
+          });
+        }
       }
 
       if (showMarkCompleted && markCompleted && onMarkCompleted) {

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { useTranslation } from "react-i18next";
@@ -52,6 +52,7 @@ import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
 import { DocumentGateDialog } from "@/components/documents/document-gate-dialog";
 import { useAppointmentDocumentCounts } from "@/components/documents/appointment-document-checklist";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Tooltip,
   TooltipContent,
@@ -304,26 +305,43 @@ export function AppointmentPreviewContent({
       | undefined;
   };
 
-  // Other appointments for the same patient on the same date — used to warn
-  // staff that more visits may need settling after this one (issue #3578).
-  // Suppressed for multi-treatment (junction) appointments: all treatments are
-  // already in one appointment, so the warning would be misleading (#3594).
+  // Other appointments for the same patient on the same date — shown in the
+  // settlement dialog so staff can batch-settle multiple visits at once (#3578).
   const { data: sameDayOtherAppointments } = useSupabaseGabinetSameDayAppointments(
     organizationId,
     patientIdForPackages || undefined,
     detail?.appointment.date,
     appointmentId,
-    { enabled: !detail?.treatments || detail.treatments.length <= 1 },
   );
-  // First same-day appointment to settle next (sorted by start_time from the query).
-  const nextSameDayAppointment = sameDayOtherAppointments?.[0] ?? null;
+
+  // Track which additional same-day appointments the staff wants to include in
+  // the batch settlement. Pre-select all by default when the data first arrives.
+  const [selectedAdditionalIds, setSelectedAdditionalIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const prevSameDayLengthRef = useRef<number>(-1);
+  useEffect(() => {
+    if (!sameDayOtherAppointments) return;
+    // Only auto-select on first load; don't clobber user's manual selections.
+    if (prevSameDayLengthRef.current === sameDayOtherAppointments.length) return;
+    prevSameDayLengthRef.current = sameDayOtherAppointments.length;
+    setSelectedAdditionalIds(new Set(sameDayOtherAppointments.map((a) => a.id)));
+  }, [sameDayOtherAppointments]);
+
+  const toggleAdditional = useCallback((id: string, checked: boolean) => {
+    setSelectedAdditionalIds((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  }, []);
 
   const [status, setStatus] = useState<AppointmentStatus | "">("");
   const [date, setDate] = useState("");
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
   const [changeHistoryOpen, setChangeHistoryOpen] = useState(false);
-  const [settleNextEnabled, setSettleNextEnabled] = useState(false);
 
   // Appointment change history (issue #1837). Activities are recorded by the
   // backend on every update — we surface only the ones that meaningfully
@@ -1666,48 +1684,43 @@ export function AppointmentPreviewContent({
           </DialogHeader>
 
           {sameDayOtherAppointments && sameDayOtherAppointments.length > 0 && (
-            <div className="rounded-md border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30 p-3 flex gap-2 text-sm">
-              <AlertTriangle className="size-4 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
-              <div className="flex-1 text-amber-700 dark:text-amber-300">
-                <p className="font-medium">
-                  {t(
-                    "gabinet.appointments.otherAppointmentsTodayTitle",
-                    "Inne wizyty pacjenta w tym dniu",
-                  )}
-                </p>
-                <p className="text-xs mt-0.5 text-amber-600 dark:text-amber-400">
-                  {sameDayOtherAppointments
-                    .map(
-                      (a) =>
-                        `${a.startTime.slice(0, 5)}–${a.endTime.slice(0, 5)}`,
-                    )
-                    .join(", ")}
-                  {" — "}
-                  {t(
-                    "gabinet.appointments.otherAppointmentsTodayHint",
-                    "pamiętaj o ich rozliczeniu",
-                  )}
-                </p>
-                {nextSameDayAppointment && (
-                  <button
-                    type="button"
-                    onClick={() => setSettleNextEnabled((v) => !v)}
-                    className={cn(
-                      "mt-2 inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium transition-colors",
-                      settleNextEnabled
-                        ? "border-amber-500 bg-amber-100 text-amber-800 dark:border-amber-500 dark:bg-amber-900/40 dark:text-amber-200"
-                        : "border-amber-300 bg-transparent text-amber-700 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-400 dark:hover:bg-amber-900/30",
-                    )}
-                  >
-                    {settleNextEnabled && <Check className="size-3" />}
-                    {t("gabinet.appointments.settleNext", {
-                      defaultValue:
-                        "Po rozliczeniu → {{time}}",
-                      time: `${nextSameDayAppointment.startTime.slice(0, 5)}–${nextSameDayAppointment.endTime.slice(0, 5)}`,
-                    })}
-                  </button>
+            <div className="rounded-md border bg-muted/20 p-3 space-y-2 text-sm">
+              <p className="font-medium text-muted-foreground">
+                {t(
+                  "gabinet.appointments.batchSettleTitle",
+                  "Inne wizyty tego pacjenta w tym dniu — uwzględnij w rozliczeniu:",
                 )}
-              </div>
+              </p>
+              {sameDayOtherAppointments.map((appt) => (
+                <div key={appt.id} className="flex items-start gap-2">
+                  <Checkbox
+                    id={`batch-${appt.id}`}
+                    checked={selectedAdditionalIds.has(appt.id)}
+                    onCheckedChange={(checked) =>
+                      toggleAdditional(appt.id, Boolean(checked))
+                    }
+                    className="mt-0.5"
+                  />
+                  <label
+                    htmlFor={`batch-${appt.id}`}
+                    className="cursor-pointer leading-snug"
+                  >
+                    <span className="font-medium">
+                      {appt.startTime.slice(0, 5)}–{appt.endTime.slice(0, 5)}
+                    </span>
+                    {appt.treatmentNames.length > 0 && (
+                      <span className="text-muted-foreground ml-1">
+                        · {appt.treatmentNames.join(", ")}
+                      </span>
+                    )}
+                    {appt.totalPrice > 0 && (
+                      <span className="text-muted-foreground ml-1">
+                        · {formatCurrencyPLN(appt.totalPrice)}
+                      </span>
+                    )}
+                  </label>
+                </div>
+              ))}
             </div>
           )}
 
@@ -1810,6 +1823,11 @@ export function AppointmentPreviewContent({
               patientPackageUsage={packageUsageForSettle}
               linkedPackageUsageId={appointment.packageUsageId ?? null}
               showMarkCompleted={canMarkCompleted}
+              additionalAppointments={
+                (sameDayOtherAppointments ?? [])
+                  .filter((a) => selectedAdditionalIds.has(a.id))
+                  .map((a) => ({ id: a.id, totalPrice: a.totalPrice }))
+              }
               onMarkCompleted={async () => {
                 const result = await updateStatus({
                   organizationId,
@@ -1856,13 +1874,6 @@ export function AppointmentPreviewContent({
                 await refetch();
                 setSettleDialogOpen(false);
                 onClose();
-                if (settleNextEnabled && nextSameDayAppointment) {
-                  void navigate({
-                    to: "/dashboard/gabinet/appointments/$appointmentId",
-                    params: { appointmentId: nextSameDayAppointment.id },
-                    search: { tab: "payments" },
-                  });
-                }
               }}
               onCancel={() => setSettleDialogOpen(false)}
               extraFooterContent={

--- a/src/hooks/use-supabase-gabinet-appointments.ts
+++ b/src/hooks/use-supabase-gabinet-appointments.ts
@@ -639,7 +639,7 @@ export function useSupabaseGabinetNextAppointmentByPatient(
 }
 
 // ---------------------------------------------------------------------------
-// Same-day Appointments for a Patient (settlement warning — issue #3578)
+// Same-day Appointments for a Patient (batch settlement — issue #3578)
 // ---------------------------------------------------------------------------
 
 export interface SameDayAppointmentInfo {
@@ -647,12 +647,16 @@ export interface SameDayAppointmentInfo {
   startTime: string;
   endTime: string;
   status: string;
+  /** Names of all treatments assigned to this appointment via the junction table. */
+  treatmentNames: string[];
+  /** Sum of junction treatment prices (priceAtBooking ?? catalog price). */
+  totalPrice: number;
 }
 
 /**
  * Returns other non-cancelled, non-no-show appointments for the same patient
- * on the same date, excluding the current appointment. Used by the settlement
- * dialog to warn when more appointments remain to be settled (issue #3578).
+ * on the same date, excluding the current appointment. Includes treatment names
+ * and total price to support batch settlement in one dialog (issue #3578).
  */
 export function useSupabaseGabinetSameDayAppointments(
   organizationId: string,
@@ -676,7 +680,9 @@ export function useSupabaseGabinetSameDayAppointments(
       if (!client || !patientId || !date) return [];
       const { data, error } = await client
         .from("gabinet_appointments")
-        .select("id, start_time, end_time, status")
+        .select(
+          "id, start_time, end_time, status, gabinet_appointment_treatments(price_at_booking, gabinet_treatments(name, price))",
+        )
         .eq("organization_id", organizationId)
         .eq("patient_id", patientId)
         .eq("date", date)
@@ -684,21 +690,36 @@ export function useSupabaseGabinetSameDayAppointments(
         .not("status", "in", '("cancelled","no_show")')
         .order("start_time");
       if (error) throw error;
-      return (
-        (
-          data ?? []
-        ) as Array<{
-          id: string;
-          start_time: string;
-          end_time: string;
-          status: string;
-        }>
-      ).map((r) => ({
-        id: r.id,
-        startTime: r.start_time,
-        endTime: r.end_time,
-        status: r.status,
-      }));
+      type RawRow = {
+        id: string;
+        start_time: string;
+        end_time: string;
+        status: string;
+        gabinet_appointment_treatments: Array<{
+          price_at_booking: number | null;
+          gabinet_treatments: { name: string; price: number | null } | null;
+        }> | null;
+      };
+      return (data ?? []).map((raw) => {
+        const r = raw as unknown as RawRow;
+        const junctions = r.gabinet_appointment_treatments ?? [];
+        const treatmentNames = junctions
+          .map((t) => t.gabinet_treatments?.name)
+          .filter((n): n is string => Boolean(n));
+        const totalPrice = junctions.reduce(
+          (sum, t) =>
+            sum + (t.price_at_booking ?? t.gabinet_treatments?.price ?? 0),
+          0,
+        );
+        return {
+          id: r.id,
+          startTime: r.start_time,
+          endTime: r.end_time,
+          status: r.status,
+          treatmentNames,
+          totalPrice,
+        };
+      });
     },
     enabled: enabled && isReady && !!organizationId && !!patientId && !!date,
   } satisfies UseQueryOptions<SameDayAppointmentInfo[], Error>);

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import {
   createLazyFileRoute,
   useNavigate,
@@ -116,7 +116,6 @@ import {
   Building2,
   Clock,
 } from "@/lib/ez-icons";
-import { AlertTriangle } from "lucide-react";
 import { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
 import { Link } from "@tanstack/react-router";
@@ -452,17 +451,36 @@ function AppointmentDetail() {
   );
 
   // Same-day appointments for the same patient — used to warn staff that more
-  // visits may need settling after this one (issue #3581, mirrors #3578).
-  // Suppressed for multi-treatment (junction) appointments: all treatments are
-  // already in one appointment, so the warning would be misleading (#3594).
+  // Other same-day appointments for the same patient — shown in the settlement
+  // dialog so staff can batch-settle multiple visits at once (issue #3578).
   const { data: sameDayOtherAppointments } =
     useSupabaseGabinetSameDayAppointments(
       organizationId,
       detail?.patient?._id ?? undefined,
       detail?.appointment?.date,
       appointmentId,
-      { enabled: !detail?.treatments || detail.treatments.length <= 1 },
     );
+
+  // Which additional same-day appointments to include in the batch settlement.
+  const [selectedAdditionalIds, setSelectedAdditionalIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const prevSameDayLengthRef2 = useRef<number>(-1);
+  useEffect(() => {
+    if (!sameDayOtherAppointments) return;
+    if (prevSameDayLengthRef2.current === sameDayOtherAppointments.length) return;
+    prevSameDayLengthRef2.current = sameDayOtherAppointments.length;
+    setSelectedAdditionalIds(new Set(sameDayOtherAppointments.map((a) => a.id)));
+  }, [sameDayOtherAppointments]);
+
+  const toggleAdditional = useCallback((id: string, checked: boolean) => {
+    setSelectedAdditionalIds((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  }, []);
 
   // Equipment list used to surface parameter units on the Documentation tab —
   // when the appointment's treatment lists required equipment, the editor
@@ -2623,29 +2641,43 @@ function AppointmentDetail() {
             </DialogDescription>
           </DialogHeader>
           {sameDayOtherAppointments && sameDayOtherAppointments.length > 0 && (
-            <div className="rounded-md border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30 p-3 flex gap-2 text-sm">
-              <AlertTriangle className="size-4 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
-              <div className="text-amber-700 dark:text-amber-300">
-                <p className="font-medium">
-                  {t(
-                    "gabinet.appointments.otherAppointmentsTodayTitle",
-                    "Inne wizyty pacjenta w tym dniu",
-                  )}
-                </p>
-                <p className="text-xs mt-0.5 text-amber-600 dark:text-amber-400">
-                  {sameDayOtherAppointments
-                    .map(
-                      (a) =>
-                        `${a.startTime.slice(0, 5)}–${a.endTime.slice(0, 5)}`,
-                    )
-                    .join(", ")}
-                  {" — "}
-                  {t(
-                    "gabinet.appointments.otherAppointmentsTodayHint",
-                    "pamiętaj o ich rozliczeniu",
-                  )}
-                </p>
-              </div>
+            <div className="rounded-md border bg-muted/20 p-3 space-y-2 text-sm">
+              <p className="font-medium text-muted-foreground">
+                {t(
+                  "gabinet.appointments.batchSettleTitle",
+                  "Inne wizyty tego pacjenta w tym dniu — uwzględnij w rozliczeniu:",
+                )}
+              </p>
+              {sameDayOtherAppointments.map((appt) => (
+                <div key={appt.id} className="flex items-start gap-2">
+                  <Checkbox
+                    id={`batch-detail-${appt.id}`}
+                    checked={selectedAdditionalIds.has(appt.id)}
+                    onCheckedChange={(checked) =>
+                      toggleAdditional(appt.id, Boolean(checked))
+                    }
+                    className="mt-0.5"
+                  />
+                  <label
+                    htmlFor={`batch-detail-${appt.id}`}
+                    className="cursor-pointer leading-snug"
+                  >
+                    <span className="font-medium">
+                      {appt.startTime.slice(0, 5)}–{appt.endTime.slice(0, 5)}
+                    </span>
+                    {appt.treatmentNames.length > 0 && (
+                      <span className="text-muted-foreground ml-1">
+                        · {appt.treatmentNames.join(", ")}
+                      </span>
+                    )}
+                    {appt.totalPrice > 0 && (
+                      <span className="text-muted-foreground ml-1">
+                        · {formatCurrencyPLN(appt.totalPrice)}
+                      </span>
+                    )}
+                  </label>
+                </div>
+              ))}
             </div>
           )}
           {paymentDialogOpen && (
@@ -2659,6 +2691,11 @@ function AppointmentDetail() {
               payments={payments as Array<Record<string, unknown>>}
               patientPackageUsage={patientPackageUsage}
               linkedPackageUsageId={appointment.packageUsageId ?? null}
+              additionalAppointments={
+                (sameDayOtherAppointments ?? [])
+                  .filter((a) => selectedAdditionalIds.has(a.id))
+                  .map((a) => ({ id: a.id, totalPrice: a.totalPrice }))
+              }
               showMarkCompleted={availableTransitions.includes("completed")}
               onMarkCompleted={async () => {
                 const result = await updateStatus({


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3578.

Closes #3578

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 36fc1e4 fix(gabinet): batch settlement of multiple same-day appointments in one dialog (closes #3578)

### Files changed

```
 .../gabinet/appointment-shared/settlement-form.tsx |  31 +++++
 .../calendar/appointment-preview-content.tsx       | 125 +++++++++++----------
 src/hooks/use-supabase-gabinet-appointments.ts     |  59 ++++++----
 ...ut.gabinet.appointments.$appointmentId.lazy.tsx |  95 +++++++++++-----
 4 files changed, 205 insertions(+), 105 deletions(-)
```