### PR TITLE
Show "already settled" appointments as disabled (greyed-out) checkboxes rather t

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -325,7 +325,10 @@ export function AppointmentPreviewContent({
     // Only auto-select on first load; don't clobber user's manual selections.
     if (prevSameDayLengthRef.current === sameDayOtherAppointments.length) return;
     prevSameDayLengthRef.current = sameDayOtherAppointments.length;
-    setSelectedAdditionalIds(new Set(sameDayOtherAppointments.map((a) => a.id)));
+    // Pre-select only unsettled appointments; already-settled ones show as disabled.
+    setSelectedAdditionalIds(
+      new Set(sameDayOtherAppointments.filter((a) => !a.isSettled).map((a) => a.id)),
+    );
   }, [sameDayOtherAppointments]);
 
   const toggleAdditional = useCallback((id: string, checked: boolean) => {
@@ -1692,10 +1695,14 @@ export function AppointmentPreviewContent({
                 )}
               </p>
               {sameDayOtherAppointments.map((appt) => (
-                <div key={appt.id} className="flex items-start gap-2">
+                <div
+                  key={appt.id}
+                  className={`flex items-start gap-2 ${appt.isSettled ? "opacity-50" : ""}`}
+                >
                   <Checkbox
                     id={`batch-${appt.id}`}
-                    checked={selectedAdditionalIds.has(appt.id)}
+                    checked={!appt.isSettled && selectedAdditionalIds.has(appt.id)}
+                    disabled={appt.isSettled}
                     onCheckedChange={(checked) =>
                       toggleAdditional(appt.id, Boolean(checked))
                     }
@@ -1703,7 +1710,7 @@ export function AppointmentPreviewContent({
                   />
                   <label
                     htmlFor={`batch-${appt.id}`}
-                    className="cursor-pointer leading-snug"
+                    className={`leading-snug ${appt.isSettled ? "cursor-not-allowed" : "cursor-pointer"}`}
                   >
                     <span className="font-medium">
                       {appt.startTime.slice(0, 5)}–{appt.endTime.slice(0, 5)}
@@ -1716,6 +1723,11 @@ export function AppointmentPreviewContent({
                     {appt.totalPrice > 0 && (
                       <span className="text-muted-foreground ml-1">
                         · {formatCurrencyPLN(appt.totalPrice)}
+                      </span>
+                    )}
+                    {appt.isSettled && (
+                      <span className="text-muted-foreground ml-1">
+                        · {t("gabinet.appointments.alreadySettled", "rozliczona")}
                       </span>
                     )}
                   </label>

--- a/src/hooks/use-supabase-gabinet-appointments.ts
+++ b/src/hooks/use-supabase-gabinet-appointments.ts
@@ -651,12 +651,16 @@ export interface SameDayAppointmentInfo {
   treatmentNames: string[];
   /** Sum of junction treatment prices (priceAtBooking ?? catalog price). */
   totalPrice: number;
+  /** True when the appointment is completed and fully paid — show as a disabled checkbox. */
+  isSettled: boolean;
 }
 
 /**
  * Returns other non-cancelled, non-no-show appointments for the same patient
  * on the same date, excluding the current appointment. Includes treatment names
  * and total price to support batch settlement in one dialog (issue #3578).
+ * Already-settled appointments are included so they render as disabled checkboxes
+ * rather than being hidden (issue #3609).
  */
 export function useSupabaseGabinetSameDayAppointments(
   organizationId: string,
@@ -681,7 +685,7 @@ export function useSupabaseGabinetSameDayAppointments(
       const { data, error } = await client
         .from("gabinet_appointments")
         .select(
-          "id, start_time, end_time, status, gabinet_appointment_treatments(price_at_booking, gabinet_treatments(name, price))",
+          "id, start_time, end_time, status, gabinet_appointment_treatments(price_at_booking, gabinet_treatments(name, price)), payments(amount, credit_applied, status)",
         )
         .eq("organization_id", organizationId)
         .eq("patient_id", patientId)
@@ -699,6 +703,11 @@ export function useSupabaseGabinetSameDayAppointments(
           price_at_booking: number | null;
           gabinet_treatments: { name: string; price: number | null } | null;
         }> | null;
+        payments: Array<{
+          amount: number;
+          credit_applied: number | null;
+          status: string;
+        }> | null;
       };
       return (data ?? []).map((raw) => {
         const r = raw as unknown as RawRow;
@@ -711,6 +720,12 @@ export function useSupabaseGabinetSameDayAppointments(
             sum + (t.price_at_booking ?? t.gabinet_treatments?.price ?? 0),
           0,
         );
+        const completedPaid = (r.payments ?? [])
+          .filter((p) => p.status === "completed")
+          .reduce((sum, p) => sum + p.amount + (p.credit_applied ?? 0), 0);
+        const isSettled =
+          r.status === "completed" &&
+          (totalPrice === 0 || completedPaid >= totalPrice);
         return {
           id: r.id,
           startTime: r.start_time,
@@ -718,6 +733,7 @@ export function useSupabaseGabinetSameDayAppointments(
           status: r.status,
           treatmentNames,
           totalPrice,
+          isSettled,
         };
       });
     },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3609.

Closes #3609

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- ba87fb0 fix(gabinet): show already-settled same-day appointments as disabled checkboxes (closes #3609)

### Files changed

```
 .../gabinet/calendar/appointment-preview-content.tsx | 20 ++++++++++++++++----
 src/hooks/use-supabase-gabinet-appointments.ts       | 18 +++++++++++++++++-
 2 files changed, 33 insertions(+), 5 deletions(-)
```