### PR TITLE
New calendar configs created after migration don't appear in the list

### DIFF
--- a/convex/googleCalendarSyncConfigs.ts
+++ b/convex/googleCalendarSyncConfigs.ts
@@ -109,8 +109,43 @@ export const update = action({
     isOrgDefault: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
-    // Records shown by listMine live in Convex (list queries use ctx.db).
-    // Look up via Convex using getById, not db.get() which uses Supabase UUIDs.
+    const db = createSupabaseDb();
+
+    // Try Supabase first (records created after the Supabase migration).
+    const supabaseConfig = await db.get("googleCalendarSyncConfigs", args.configId);
+    if (supabaseConfig) {
+      const authResult = await ctx.runQuery(
+        internal._helpers.authAction.verifyOrgAccess,
+        { organizationId: supabaseConfig.organizationId as any },
+      );
+
+      const isOwner = supabaseConfig.userId === String(authResult.userId);
+      const isAdmin = authResult.role === "owner" || authResult.role === "admin";
+      if (!isOwner && !isAdmin) throw new Error("You can only modify your own calendar configs");
+      if (args.visibility !== undefined && !isOwner) throw new Error("Only the calendar owner can change visibility settings");
+
+      if (args.isOrgDefault === true) {
+        const existing = await db
+          .query("googleCalendarSyncConfigs")
+          .eq("organizationId", supabaseConfig.organizationId as string)
+          .eq("isOrgDefault", true)
+          .first();
+        if (existing && existing._id !== args.configId) {
+          await db.patch("googleCalendarSyncConfigs", existing._id as string, { isOrgDefault: false });
+        }
+      }
+
+      const patch: Record<string, unknown> = {};
+      if (args.targetModule !== undefined) patch.targetModule = args.targetModule;
+      if (args.targetActivityType !== undefined) patch.targetActivityType = args.targetActivityType;
+      if (args.visibility !== undefined) patch.visibility = args.visibility;
+      if (args.syncEnabled !== undefined) patch.syncEnabled = args.syncEnabled;
+      if (args.isOrgDefault !== undefined) patch.isOrgDefault = args.isOrgDefault;
+      await db.patch("googleCalendarSyncConfigs", args.configId, patch);
+      return;
+    }
+
+    // Fall back to Convex for pre-migration records.
     const config = await ctx.runQuery(
       internal.googleCalendarSyncConfigs.getById,
       { configId: args.configId as any },
@@ -149,10 +184,25 @@ export const update = action({
 export const remove = action({
   args: { configId: v.string() },
   handler: async (ctx, args) => {
-    // Records shown by listMine live in Convex (list queries use ctx.db).
-    // The migration moved create/update/remove to Supabase-primary but did not
-    // migrate the list queries, so existing records are Convex-only and their
-    // _id values are Convex IDs — not Supabase UUIDs. Look up via Convex.
+    const db = createSupabaseDb();
+
+    // Try Supabase first (records created after the Supabase migration).
+    const supabaseConfig = await db.get("googleCalendarSyncConfigs", args.configId);
+    if (supabaseConfig) {
+      const authResult = await ctx.runQuery(
+        internal._helpers.authAction.verifyOrgAccess,
+        { organizationId: supabaseConfig.organizationId as any },
+      );
+
+      const isOwner = supabaseConfig.userId === String(authResult.userId);
+      const isAdmin = authResult.role === "owner" || authResult.role === "admin";
+      if (!isOwner && !isAdmin) throw new Error("You can only remove your own calendar configs");
+
+      await db.delete("googleCalendarSyncConfigs", args.configId);
+      return;
+    }
+
+    // Fall back to Convex for pre-migration records.
     const config = await ctx.runQuery(
       internal.googleCalendarSyncConfigs.getById,
       { configId: args.configId as any },

--- a/src/components/settings/google-calendar-sync-settings.tsx
+++ b/src/components/settings/google-calendar-sync-settings.tsx
@@ -1,12 +1,17 @@
 import { useState, useEffect } from "react";
 import { useQuery, useAction } from "convex/react";
-import { useQuery as useTanstackQuery } from "@tanstack/react-query";
+import { useQuery as useTanstackQuery, useQueryClient } from "@tanstack/react-query";
 import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
 import { useRole } from "@/hooks/use-permission";
 import { toast } from "sonner";
+import {
+  useSupabaseGoogleCalendarConfigs,
+  useSupabaseGoogleCalendarOrgDefault,
+} from "@/hooks/use-supabase-google-calendar-configs";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
 import {
   Card,
   CardContent,
@@ -55,6 +60,7 @@ export function GoogleCalendarSyncSettings({
   const { t } = useTranslation();
   const { role } = useRole();
   const isAdmin = role === "owner" || role === "admin";
+  const queryClient = useQueryClient();
 
   const listActivityTypesAction = useAction(api.activityTypes.list);
   const { data: activityTypes } = useTanstackQuery({
@@ -62,22 +68,23 @@ export function GoogleCalendarSyncSettings({
     queryFn: () => listActivityTypesAction({ organizationId }),
     enabled: !!organizationId,
   }) as { data: any[] | undefined };
-  const myConfigs = useQuery(api.googleCalendarSyncConfigs.listMine, {
-    organizationId,
-  });
-  const allConfigs = useQuery(
-    api.googleCalendarSyncConfigs.listAll,
-    isAdmin ? { organizationId } : "skip"
-  );
-  const orgDefault = useQuery(api.googleCalendarSyncConfigs.getOrgDefault, {
-    organizationId,
-  });
-  const myConnection = useQuery(api.oauthConnections.getMyGoogleConnection, {
-    organizationId,
-  });
   const { data: user } = useTanstackQuery(
     convexQuery(api.app.getCurrentUser, {})
   );
+  const { data: myConfigs } = useSupabaseGoogleCalendarConfigs(
+    organizationId,
+    user?._id ? String(user._id) : undefined,
+    { enabled: !!user?._id },
+  );
+  const { data: allConfigs } = useSupabaseGoogleCalendarConfigs(
+    organizationId,
+    undefined,
+    { enabled: isAdmin },
+  );
+  const { data: orgDefault } = useSupabaseGoogleCalendarOrgDefault(organizationId);
+  const myConnection = useQuery(api.oauthConnections.getMyGoogleConnection, {
+    organizationId,
+  });
 
   const createConfig = useAction(api.googleCalendarSyncConfigs.create);
   const updateConfig = useAction(api.googleCalendarSyncConfigs.update);
@@ -163,6 +170,11 @@ export function GoogleCalendarSyncSettings({
     }
   };
 
+  const invalidateConfigs = () =>
+    queryClient.invalidateQueries({
+      queryKey: supabaseKeys.googleCalendarSyncConfigs.all,
+    });
+
   const handleAddCalendar = async (cal: GoogleCalendarInfo) => {
     if (!myConnection) return;
     setAddingCalendarId(cal.id);
@@ -175,6 +187,7 @@ export function GoogleCalendarSyncSettings({
         targetModule: "crm",
         visibility: "full",
       });
+      await invalidateConfigs();
       toast.success(t("googleCalendar.settings.calendarAdded"));
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
@@ -185,7 +198,7 @@ export function GoogleCalendarSyncSettings({
   };
 
   const handleUpdateConfig = async (
-    configId: Id<"googleCalendarSyncConfigs">,
+    configId: string,
     patch: {
       targetModule?: "crm" | "gabinet";
       targetActivityType?: string;
@@ -196,17 +209,17 @@ export function GoogleCalendarSyncSettings({
   ) => {
     try {
       await updateConfig({ configId, ...patch });
+      await invalidateConfigs();
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(message);
     }
   };
 
-  const handleRemoveConfig = async (
-    configId: Id<"googleCalendarSyncConfigs">
-  ) => {
+  const handleRemoveConfig = async (configId: string) => {
     try {
       await removeConfig({ configId });
+      await invalidateConfigs();
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       toast.error(message);

--- a/src/hooks/use-supabase-google-calendar-configs.ts
+++ b/src/hooks/use-supabase-google-calendar-configs.ts
@@ -1,0 +1,59 @@
+import { useQuery } from "@tanstack/react-query";
+import { useSupabase } from "@/components/supabase-provider";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
+import {
+  mapGoogleCalendarSyncConfigFromSupabase,
+  type MappedGoogleCalendarSyncConfig,
+} from "@/lib/supabase/mappers";
+
+export function useSupabaseGoogleCalendarConfigs(
+  organizationId: string,
+  userId?: string,
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  return useQuery<MappedGoogleCalendarSyncConfig[], Error>({
+    queryKey: [...supabaseKeys.googleCalendarSyncConfigs.list(organizationId), userId ?? "all"],
+    queryFn: async () => {
+      if (!client) throw new Error("Supabase client not ready");
+
+      let q = client
+        .from("google_calendar_sync_configs")
+        .select("*")
+        .eq("organization_id", organizationId);
+
+      if (userId) {
+        q = q.eq("user_id", userId);
+      }
+
+      const { data, error } = await q;
+      if (error) throw error;
+      return (data ?? []).map(mapGoogleCalendarSyncConfigFromSupabase);
+    },
+    enabled: enabled && isReady && !!organizationId,
+  });
+}
+
+export function useSupabaseGoogleCalendarOrgDefault(organizationId: string) {
+  const { client, isReady } = useSupabase();
+
+  return useQuery<MappedGoogleCalendarSyncConfig | null, Error>({
+    queryKey: [...supabaseKeys.googleCalendarSyncConfigs.list(organizationId), "orgDefault"],
+    queryFn: async () => {
+      if (!client) throw new Error("Supabase client not ready");
+
+      const { data, error } = await client
+        .from("google_calendar_sync_configs")
+        .select("*")
+        .eq("organization_id", organizationId)
+        .eq("is_org_default", true)
+        .maybeSingle();
+
+      if (error) throw error;
+      return data ? mapGoogleCalendarSyncConfigFromSupabase(data) : null;
+    },
+    enabled: isReady && !!organizationId,
+  });
+}

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -7450,3 +7450,6 @@ export type GabinetLoyaltyPointsUpdate = Database["public"]["Tables"]["gabinet_l
 export type GabinetLoyaltyTransactionRow = Database["public"]["Tables"]["gabinet_loyalty_transactions"]["Row"];
 export type GabinetLoyaltyTransactionInsert = Database["public"]["Tables"]["gabinet_loyalty_transactions"]["Insert"];
 export type GabinetLoyaltyTransactionUpdate = Database["public"]["Tables"]["gabinet_loyalty_transactions"]["Update"];
+export type GoogleCalendarSyncConfigRow = Database["public"]["Tables"]["google_calendar_sync_configs"]["Row"];
+export type GoogleCalendarSyncConfigInsert = Database["public"]["Tables"]["google_calendar_sync_configs"]["Insert"];
+export type GoogleCalendarSyncConfigUpdate = Database["public"]["Tables"]["google_calendar_sync_configs"]["Update"];

--- a/src/lib/supabase/mappers/google-calendar-sync-configs.ts
+++ b/src/lib/supabase/mappers/google-calendar-sync-configs.ts
@@ -1,0 +1,33 @@
+/**
+ * Google Calendar Sync Configs Mapper — Supabase ↔ Frontend
+ */
+
+import type { GoogleCalendarSyncConfigRow } from "../database.types";
+import { createEntityMapper } from "./generic";
+
+export interface MappedGoogleCalendarSyncConfig {
+  _id: string;
+  organizationId: string;
+  userId: string;
+  connectionId: string;
+  googleCalendarId: string;
+  googleCalendarName: string;
+  isOrgDefault: boolean;
+  targetModule: "crm" | "gabinet";
+  targetActivityType?: string;
+  visibility: "full" | "busy_only" | "hidden";
+  syncEnabled: boolean;
+  lastSyncToken?: string;
+  lastSyncAt?: number;
+  syncStatus?: "idle" | "syncing" | "error";
+  syncError?: string;
+  _source: "supabase";
+}
+
+const googleCalendarSyncConfigMapper =
+  createEntityMapper<GoogleCalendarSyncConfigRow, MappedGoogleCalendarSyncConfig>();
+
+export const mapGoogleCalendarSyncConfigFromSupabase = (
+  row: GoogleCalendarSyncConfigRow,
+): MappedGoogleCalendarSyncConfig =>
+  googleCalendarSyncConfigMapper.mapFromSupabase(row);

--- a/src/lib/supabase/mappers/index.ts
+++ b/src/lib/supabase/mappers/index.ts
@@ -293,3 +293,10 @@ export {
   mapGabinetEmployeeScheduleToSupabase,
   type MappedGabinetEmployeeSchedule,
 } from "./gabinet";
+
+// ── Google Calendar ───────────────────────────────────────────────────────────
+
+export {
+  mapGoogleCalendarSyncConfigFromSupabase,
+  type MappedGoogleCalendarSyncConfig,
+} from "./google-calendar-sync-configs";

--- a/src/lib/supabase/query-keys.ts
+++ b/src/lib/supabase/query-keys.ts
@@ -91,6 +91,9 @@ export const supabaseKeys = {
   gabinetLoyaltyTransactions: entityKeys("gabinetLoyaltyTransactions"),
   warehouseDeliveries: entityKeys("warehouseDeliveries"),
 
+  // ── Google Calendar ───────────────────────────────────────────────────────
+  googleCalendarSyncConfigs: entityKeys("googleCalendarSyncConfigs"),
+
   // ── Payments ─────────────────────────────────────────────────────────────
   payments: entityKeys("payments"),
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3619.

Closes #3619

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d854906 fix(google-calendar): new configs not visible after migration (closes #3619)

### Files changed

```
 convex/googleCalendarSyncConfigs.ts                | 62 +++++++++++++++++++---
 .../settings/google-calendar-sync-settings.tsx     | 43 +++++++++------
 src/hooks/use-supabase-google-calendar-configs.ts  | 59 ++++++++++++++++++++
 src/lib/supabase/database.types.ts                 |  3 ++
 .../mappers/google-calendar-sync-configs.ts        | 33 ++++++++++++
 src/lib/supabase/mappers/index.ts                  |  7 +++
 src/lib/supabase/query-keys.ts                     |  3 ++
 7 files changed, 189 insertions(+), 21 deletions(-)
```