### PR TITLE
Remove stale Convex `listMine`/`listAll`/`getOrgDefault` queries once pre-migrat

### DIFF
--- a/convex/google/calendarSync.ts
+++ b/convex/google/calendarSync.ts
@@ -3,7 +3,6 @@ import { v } from "convex/values";
 import { action, internalAction } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { auth } from "@cvx/auth";
-import type { Doc } from "../_generated/dataModel";
 import { getValidAccessTokenForConnection } from "./_helpers";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import {
@@ -56,18 +55,13 @@ function parseGoogleDateTime(dt?: {
 }
 
 export const syncCalendarConfig = internalAction({
-  args: { configId: v.id("googleCalendarSyncConfigs") },
+  args: { configId: v.string() },
   handler: async (ctx, args) => {
-    const config = await ctx.runQuery(
-      internal.googleCalendarSyncConfigs.getById,
-      { configId: args.configId }
-    );
+    const db = createSupabaseDb();
+    const config = await db.get("googleCalendarSyncConfigs", args.configId);
     if (!config || !config.syncEnabled) return { synced: 0 };
 
-    await ctx.runMutation(
-      internal.googleCalendarSyncConfigs.updateSyncState,
-      { configId: args.configId, syncStatus: "syncing" }
-    );
+    await db.patch("googleCalendarSyncConfigs", args.configId, { syncStatus: "syncing" });
 
     try {
       const auth = await getValidAccessTokenForConnection(
@@ -75,14 +69,10 @@ export const syncCalendarConfig = internalAction({
         config.connectionId
       );
       if (!auth) {
-        await ctx.runMutation(
-          internal.googleCalendarSyncConfigs.updateSyncState,
-          {
-            configId: args.configId,
-            syncStatus: "error",
-            syncError: "OAuth token unavailable",
-          }
-        );
+        await db.patch("googleCalendarSyncConfigs", args.configId, {
+          syncStatus: "error",
+          syncError: "OAuth token unavailable",
+        });
         return { synced: 0, error: "OAuth token unavailable" };
       }
 
@@ -126,10 +116,10 @@ export const syncCalendarConfig = internalAction({
 
         if (resp.status === 410) {
           // syncToken invalidated — clear it and retry with full sync
-          await ctx.runMutation(
-            internal.googleCalendarSyncConfigs.resetSyncToken,
-            { configId: args.configId }
-          );
+          await db.patch("googleCalendarSyncConfigs", args.configId, {
+            lastSyncToken: null,
+            syncStatus: "idle",
+          });
           await ctx.scheduler.runAfter(
             0,
             internal.google.calendarSync.syncCalendarConfig,
@@ -154,7 +144,6 @@ export const syncCalendarConfig = internalAction({
       } while (pageToken);
 
       // Handle cancelled events — delete corresponding records (Supabase-primary)
-      const db = createSupabaseDb();
       const cancelledEvents = allEvents.filter(
         (e) => e.status === "cancelled"
       );
@@ -182,37 +171,24 @@ export const syncCalendarConfig = internalAction({
         synced = await resolveGabinetEvents(ctx, config, validEvents);
       }
 
-      const syncStateUpdate: {
-        configId: typeof args.configId;
-        syncStatus: "idle";
-        lastSyncAt: number;
-        lastSyncToken?: string;
-      } = {
-        configId: args.configId,
-        syncStatus: "idle" as const,
+      const syncPatch: Record<string, unknown> = {
+        syncStatus: "idle",
         lastSyncAt: Date.now(),
+        syncError: null,
       };
       if (nextSyncToken) {
-        syncStateUpdate.lastSyncToken = nextSyncToken;
+        syncPatch.lastSyncToken = nextSyncToken;
       }
-
-      await ctx.runMutation(
-        internal.googleCalendarSyncConfigs.updateSyncState,
-        syncStateUpdate
-      );
+      await db.patch("googleCalendarSyncConfigs", args.configId, syncPatch);
 
       return { synced };
     } catch (error) {
       const errorMsg =
         error instanceof Error ? error.message : "Unknown error";
-      await ctx.runMutation(
-        internal.googleCalendarSyncConfigs.updateSyncState,
-        {
-          configId: args.configId,
-          syncStatus: "error",
-          syncError: errorMsg,
-        }
-      );
+      await db.patch("googleCalendarSyncConfigs", args.configId, {
+        syncStatus: "error",
+        syncError: errorMsg,
+      });
       return { synced: 0, error: errorMsg };
     }
   },
@@ -220,7 +196,7 @@ export const syncCalendarConfig = internalAction({
 
 async function resolveCrmEvents(
   ctx: any,
-  config: Doc<"googleCalendarSyncConfigs">,
+  config: Record<string, unknown>,
   events: GoogleCalendarEvent[]
 ): Promise<number> {
   const activityType = config.targetActivityType ?? "meeting";
@@ -279,7 +255,7 @@ async function resolveCrmEvents(
 
 async function resolveGabinetEvents(
   _ctx: any,
-  config: Doc<"googleCalendarSyncConfigs">,
+  config: Record<string, unknown>,
   events: GoogleCalendarEvent[]
 ): Promise<number> {
   const db = createSupabaseDb();
@@ -407,15 +383,17 @@ async function resolveGabinetEvents(
 export const syncAll = internalAction({
   args: {},
   handler: async (ctx): Promise<{ scheduled: number }> => {
-    const configs = await ctx.runQuery(
-      internal.googleCalendarSyncConfigs.getEnabledConfigs,
-      { limit: 5 }
-    );
+    const db = createSupabaseDb();
+    const configs = await db
+      .query("googleCalendarSyncConfigs")
+      .eq("syncEnabled", true)
+      .take(5)
+      .collect();
 
     for (const config of configs) {
       await ctx.scheduler.runAfter(0,
         internal.google.calendarSync.syncCalendarConfig,
-        { configId: config._id }
+        { configId: String(config._id) }
       );
     }
 
@@ -429,19 +407,21 @@ export const syncMyCalendars = action({
     const userId = await auth.getUserId(ctx);
     if (!userId) throw new Error("Not authenticated");
 
-    const configs = await ctx.runQuery(
-      internal.googleCalendarSyncConfigs.getByOrgAndUser,
-      { organizationId: args.organizationId, userId }
-    );
+    const db = createSupabaseDb();
+    const configs = await db
+      .query("googleCalendarSyncConfigs")
+      .eq("organizationId", String(args.organizationId))
+      .eq("userId", String(userId))
+      .collect();
 
     const results: { calendarName: string | null; scheduled: boolean }[] = [];
     for (const config of configs) {
       if (!config.syncEnabled) continue;
       await ctx.scheduler.runAfter(0,
         internal.google.calendarSync.syncCalendarConfig,
-        { configId: config._id }
+        { configId: String(config._id) }
       );
-      results.push({ calendarName: config.googleCalendarName, scheduled: true });
+      results.push({ calendarName: config.googleCalendarName as string | null, scheduled: true });
     }
 
     return results;

--- a/convex/googleCalendarSyncConfigs.ts
+++ b/convex/googleCalendarSyncConfigs.ts
@@ -1,53 +1,7 @@
 import { v } from "convex/values";
-import { query, action, internalQuery, internalMutation } from "./_generated/server";
+import { action } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
-import { verifyOrgAccess } from "./_helpers/auth";
-
-// List all sync configs for the current user in an org
-export const listMine = query({
-  args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
-    const { user } = await verifyOrgAccess(ctx, args.organizationId);
-    return await ctx.db
-      .query("googleCalendarSyncConfigs")
-      .withIndex("by_orgAndUser", (q) =>
-        q.eq("organizationId", args.organizationId).eq("userId", user._id)
-      )
-      .collect();
-  },
-});
-
-// List all sync configs in an org (admin view only)
-export const listAll = query({
-  args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
-    const { membership } = await verifyOrgAccess(ctx, args.organizationId);
-    if (membership.role !== "owner" && membership.role !== "admin") {
-      throw new Error("Only admins can view all calendar configs");
-    }
-    return await ctx.db
-      .query("googleCalendarSyncConfigs")
-      .withIndex("by_orgAndUser", (q) =>
-        q.eq("organizationId", args.organizationId)
-      )
-      .collect();
-  },
-});
-
-// Get org default calendar config
-export const getOrgDefault = query({
-  args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    return await ctx.db
-      .query("googleCalendarSyncConfigs")
-      .withIndex("by_orgDefault", (q) =>
-        q.eq("organizationId", args.organizationId).eq("isOrgDefault", true)
-      )
-      .first();
-  },
-});
 
 export const create = action({
   args: {
@@ -110,218 +64,27 @@ export const update = action({
   },
   handler: async (ctx, args) => {
     const db = createSupabaseDb();
-
-    // Try Supabase first (records created after the Supabase migration).
-    const supabaseConfig = await db.get("googleCalendarSyncConfigs", args.configId);
-    if (supabaseConfig) {
-      const authResult = await ctx.runQuery(
-        internal._helpers.authAction.verifyOrgAccess,
-        { organizationId: supabaseConfig.organizationId as any },
-      );
-
-      const isOwner = supabaseConfig.userId === String(authResult.userId);
-      const isAdmin = authResult.role === "owner" || authResult.role === "admin";
-      if (!isOwner && !isAdmin) throw new Error("You can only modify your own calendar configs");
-      if (args.visibility !== undefined && !isOwner) throw new Error("Only the calendar owner can change visibility settings");
-
-      if (args.isOrgDefault === true) {
-        const existing = await db
-          .query("googleCalendarSyncConfigs")
-          .eq("organizationId", supabaseConfig.organizationId as string)
-          .eq("isOrgDefault", true)
-          .first();
-        if (existing && existing._id !== args.configId) {
-          await db.patch("googleCalendarSyncConfigs", existing._id as string, { isOrgDefault: false });
-        }
-      }
-
-      const patch: Record<string, unknown> = {};
-      if (args.targetModule !== undefined) patch.targetModule = args.targetModule;
-      if (args.targetActivityType !== undefined) patch.targetActivityType = args.targetActivityType;
-      if (args.visibility !== undefined) patch.visibility = args.visibility;
-      if (args.syncEnabled !== undefined) patch.syncEnabled = args.syncEnabled;
-      if (args.isOrgDefault !== undefined) patch.isOrgDefault = args.isOrgDefault;
-      await db.patch("googleCalendarSyncConfigs", args.configId, patch);
-      return;
-    }
-
-    // Fall back to Convex for pre-migration records.
-    const config = await ctx.runQuery(
-      internal.googleCalendarSyncConfigs.getById,
-      { configId: args.configId as any },
-    );
+    const config = await db.get("googleCalendarSyncConfigs", args.configId);
     if (!config) throw new Error("Config not found");
 
     const authResult = await ctx.runQuery(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: config.organizationId },
+      { organizationId: config.organizationId as any },
     );
 
-    const isOwner = config.userId === authResult.userId;
+    const isOwner = config.userId === String(authResult.userId);
     const isAdmin = authResult.role === "owner" || authResult.role === "admin";
-    if (!isOwner && !isAdmin) {
-      throw new Error("You can only modify your own calendar configs");
-    }
-    if (args.visibility !== undefined && !isOwner) {
-      throw new Error("Only the calendar owner can change visibility settings");
-    }
+    if (!isOwner && !isAdmin) throw new Error("You can only modify your own calendar configs");
+    if (args.visibility !== undefined && !isOwner) throw new Error("Only the calendar owner can change visibility settings");
 
-    await ctx.runMutation(
-      internal.googleCalendarSyncConfigs.updateConfig,
-      {
-        configId: args.configId as any,
-        organizationId: config.organizationId,
-        targetModule: args.targetModule,
-        targetActivityType: args.targetActivityType,
-        visibility: args.visibility,
-        syncEnabled: args.syncEnabled,
-        isOrgDefault: args.isOrgDefault,
-      },
-    );
-  },
-});
-
-export const remove = action({
-  args: { configId: v.string() },
-  handler: async (ctx, args) => {
-    const db = createSupabaseDb();
-
-    // Try Supabase first (records created after the Supabase migration).
-    const supabaseConfig = await db.get("googleCalendarSyncConfigs", args.configId);
-    if (supabaseConfig) {
-      const authResult = await ctx.runQuery(
-        internal._helpers.authAction.verifyOrgAccess,
-        { organizationId: supabaseConfig.organizationId as any },
-      );
-
-      const isOwner = supabaseConfig.userId === String(authResult.userId);
-      const isAdmin = authResult.role === "owner" || authResult.role === "admin";
-      if (!isOwner && !isAdmin) throw new Error("You can only remove your own calendar configs");
-
-      await db.delete("googleCalendarSyncConfigs", args.configId);
-      return;
-    }
-
-    // Fall back to Convex for pre-migration records.
-    const config = await ctx.runQuery(
-      internal.googleCalendarSyncConfigs.getById,
-      { configId: args.configId as any },
-    );
-    if (!config) throw new Error("Config not found");
-
-    const authResult = await ctx.runQuery(
-      internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: config.organizationId },
-    );
-
-    const isOwner = config.userId === authResult.userId;
-    const isAdmin = authResult.role === "owner" || authResult.role === "admin";
-    if (!isOwner && !isAdmin) {
-      throw new Error("You can only remove your own calendar configs");
-    }
-
-    await ctx.runMutation(
-      internal.googleCalendarSyncConfigs.deleteConfig,
-      { configId: args.configId as any },
-    );
-  },
-});
-
-// --- Internal queries/mutations for sync pipeline ---
-
-export const getEnabledConfigs = internalQuery({
-  args: { limit: v.number() },
-  handler: async (ctx, args) => {
-    return await ctx.db
-      .query("googleCalendarSyncConfigs")
-      .withIndex("by_syncEnabled", (q) => q.eq("syncEnabled", true))
-      .order("asc")
-      .take(args.limit);
-  },
-});
-
-export const getById = internalQuery({
-  args: { configId: v.id("googleCalendarSyncConfigs") },
-  handler: async (ctx, args) => {
-    return await ctx.db.get(args.configId);
-  },
-});
-
-export const getByOrgAndUser = internalQuery({
-  args: {
-    organizationId: v.id("organizations"),
-    userId: v.id("users"),
-  },
-  handler: async (ctx, args) => {
-    return await ctx.db
-      .query("googleCalendarSyncConfigs")
-      .withIndex("by_orgAndUser", (q) =>
-        q.eq("organizationId", args.organizationId).eq("userId", args.userId)
-      )
-      .collect();
-  },
-});
-
-export const updateSyncState = internalMutation({
-  args: {
-    configId: v.id("googleCalendarSyncConfigs"),
-    syncStatus: v.optional(v.union(v.literal("idle"), v.literal("syncing"), v.literal("error"))),
-    syncError: v.optional(v.string()),
-    lastSyncToken: v.optional(v.string()),
-    lastSyncAt: v.optional(v.number()),
-  },
-  handler: async (ctx, args) => {
-    const { configId, ...updates } = args;
-    const patch: Record<string, unknown> = {};
-    if (updates.syncStatus !== undefined) patch.syncStatus = updates.syncStatus;
-    if (updates.syncError !== undefined) {
-      patch.syncError = updates.syncError;
-    } else if (updates.syncStatus === "idle") {
-      patch.syncError = undefined;
-    }
-    if (updates.lastSyncToken !== undefined) patch.lastSyncToken = updates.lastSyncToken;
-    if (updates.lastSyncAt !== undefined) patch.lastSyncAt = updates.lastSyncAt;
-    await ctx.db.patch(configId, patch);
-  },
-});
-
-export const resetSyncToken = internalMutation({
-  args: { configId: v.id("googleCalendarSyncConfigs") },
-  handler: async (ctx, args) => {
-    await ctx.db.patch(args.configId, {
-      lastSyncToken: undefined,
-      syncStatus: "idle",
-    });
-  },
-});
-
-export const deleteConfig = internalMutation({
-  args: { configId: v.id("googleCalendarSyncConfigs") },
-  handler: async (ctx, args) => {
-    await ctx.db.delete(args.configId);
-  },
-});
-
-export const updateConfig = internalMutation({
-  args: {
-    configId: v.id("googleCalendarSyncConfigs"),
-    organizationId: v.id("organizations"),
-    targetModule: v.optional(v.union(v.literal("crm"), v.literal("gabinet"))),
-    targetActivityType: v.optional(v.string()),
-    visibility: v.optional(v.union(v.literal("full"), v.literal("busy_only"), v.literal("hidden"))),
-    syncEnabled: v.optional(v.boolean()),
-    isOrgDefault: v.optional(v.boolean()),
-  },
-  handler: async (ctx, args) => {
     if (args.isOrgDefault === true) {
-      const existing = await ctx.db
+      const existing = await db
         .query("googleCalendarSyncConfigs")
-        .withIndex("by_orgDefault", (q) =>
-          q.eq("organizationId", args.organizationId).eq("isOrgDefault", true)
-        )
+        .eq("organizationId", config.organizationId as string)
+        .eq("isOrgDefault", true)
         .first();
       if (existing && existing._id !== args.configId) {
-        await ctx.db.patch(existing._id, { isOrgDefault: false });
+        await db.patch("googleCalendarSyncConfigs", existing._id as string, { isOrgDefault: false });
       }
     }
 
@@ -331,7 +94,27 @@ export const updateConfig = internalMutation({
     if (args.visibility !== undefined) patch.visibility = args.visibility;
     if (args.syncEnabled !== undefined) patch.syncEnabled = args.syncEnabled;
     if (args.isOrgDefault !== undefined) patch.isOrgDefault = args.isOrgDefault;
-
-    await ctx.db.patch(args.configId, patch);
+    await db.patch("googleCalendarSyncConfigs", args.configId, patch);
   },
 });
+
+export const remove = action({
+  args: { configId: v.string() },
+  handler: async (ctx, args) => {
+    const db = createSupabaseDb();
+    const config = await db.get("googleCalendarSyncConfigs", args.configId);
+    if (!config) throw new Error("Config not found");
+
+    const authResult = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: config.organizationId as any },
+    );
+
+    const isOwner = config.userId === String(authResult.userId);
+    const isAdmin = authResult.role === "owner" || authResult.role === "admin";
+    if (!isOwner && !isAdmin) throw new Error("You can only remove your own calendar configs");
+
+    await db.delete("googleCalendarSyncConfigs", args.configId);
+  },
+});
+


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3625.

Closes #3625

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 049826d feat(google-calendar): migrate sync pipeline to Supabase, remove stale Convex queries (closes #3625)

### Files changed

```
 convex/google/calendarSync.ts       |  96 +++++--------
 convex/googleCalendarSyncConfigs.ts | 273 ++++--------------------------------
 2 files changed, 66 insertions(+), 303 deletions(-)
```