### PR TITLE
Remove `googleCalendarSyncConfigs` from Convex schema once the Convex table is c

### DIFF
--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -527,7 +527,7 @@ export function createCrmTables({
     lastGoogleSyncAt: v.optional(v.number()),
     requiresCompletion: v.optional(v.boolean()),
     sourceType: v.optional(v.union(v.literal("manual"), v.literal("google"), v.literal("system"))),
-    syncConfigId: v.optional(v.id("googleCalendarSyncConfigs")),
+    syncConfigId: v.optional(v.string()),
     visibilityOverride: v.optional(v.union(v.literal("full"), v.literal("busy_only"), v.literal("hidden"))),
     // Link to module extension record (e.g. gabinetAppointment)
     moduleRef: v.optional(
@@ -1064,26 +1064,5 @@ export function createCrmTables({
     .index("by_entity", ["entityType", "entityId"])
     .index("by_org", ["organizationId"]),
 
-  // --- Google Calendar Sync Configs ---
-
-  googleCalendarSyncConfigs: defineTable({
-    organizationId: v.id("organizations"),
-    userId: v.id("users"),
-    connectionId: v.id("oauthConnections"),
-    googleCalendarId: v.string(),
-    googleCalendarName: v.string(),
-    isOrgDefault: v.boolean(),
-    targetModule: v.union(v.literal("crm"), v.literal("gabinet")),
-    targetActivityType: v.optional(v.string()),
-    visibility: v.union(v.literal("full"), v.literal("busy_only"), v.literal("hidden")),
-    syncEnabled: v.boolean(),
-    lastSyncToken: v.optional(v.string()),
-    lastSyncAt: v.optional(v.number()),
-    syncStatus: v.optional(v.union(v.literal("idle"), v.literal("syncing"), v.literal("error"))),
-    syncError: v.optional(v.string()),
-  })
-    .index("by_orgAndUser", ["organizationId", "userId"])
-    .index("by_orgDefault", ["organizationId", "isOrgDefault"])
-    .index("by_syncEnabled", ["syncEnabled", "lastSyncAt"]),
   };
 }

--- a/convex/supabase/backfill.ts
+++ b/convex/supabase/backfill.ts
@@ -374,16 +374,6 @@ export const _listInvitations = internalQuery({
   },
 });
 
-export const _listGoogleCalendarSyncConfigs = internalQuery({
-  args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
-    return ctx.db
-      .query("googleCalendarSyncConfigs")
-      .withIndex("by_orgAndUser", (q) => q.eq("organizationId", args.organizationId))
-      .collect();
-  },
-});
-
 // ---------------------------------------------------------------------------
 // Backfill actions
 // ---------------------------------------------------------------------------
@@ -631,41 +621,6 @@ export const backfillEmployees = internalAction({
   },
 });
 
-export const backfillGoogleCalendarSyncConfigs = internalAction({
-  args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args): Promise<{ synced: number; errors: string[] }> => {
-    const configs = await ctx.runQuery(
-      internal.supabase.backfill._listGoogleCalendarSyncConfigs,
-      { organizationId: args.organizationId },
-    );
-
-    const rows = configs.map((c) => ({
-      id: c._id,
-      organization_id: String(c.organizationId),
-      user_id: String(c.userId),
-      connection_id: String(c.connectionId),
-      google_calendar_id: c.googleCalendarId,
-      google_calendar_name: c.googleCalendarName,
-      is_org_default: c.isOrgDefault,
-      target_module: c.targetModule,
-      target_activity_type: c.targetActivityType ?? null,
-      visibility: c.visibility,
-      sync_enabled: c.syncEnabled,
-      last_sync_token: c.lastSyncToken ?? null,
-      last_sync_at: c.lastSyncAt ?? null,
-      sync_status: c.syncStatus ?? null,
-      sync_error: c.syncError ?? null,
-    }));
-
-    const result = await upsertBatch("google_calendar_sync_configs", rows);
-    console.info(
-      `Backfill googleCalendarSyncConfigs: ${result.synced}/${rows.length} synced`,
-    );
-    if (result.errors.length > 0) console.error("Errors:", result.errors);
-    return result;
-  },
-});
-
 // ---------------------------------------------------------------------------
 // Run all backfills in dependency order
 // ---------------------------------------------------------------------------
@@ -800,7 +755,6 @@ export const backfillAll = internalAction({
     employees: number;
     appointments: number;
     invitations: number;
-    googleCalendarSyncConfigs: number;
     totalErrors: number;
   }> => {
     const orgId = args.organizationId;
@@ -871,15 +825,6 @@ export const backfillAll = internalAction({
     if (invitations.errors.length > 0)
       console.error("Invitation errors:", invitations.errors);
 
-    // google_calendar_sync_configs after oauth_connections (connection_id FK dep).
-    const googleCalendarSyncConfigs = await ctx.runAction(
-      internal.supabase.backfill.backfillGoogleCalendarSyncConfigs,
-      { organizationId: orgId },
-    );
-    console.info(`GoogleCalendarSyncConfigs: ${googleCalendarSyncConfigs.synced} synced, ${googleCalendarSyncConfigs.errors.length} errors`);
-    if (googleCalendarSyncConfigs.errors.length > 0)
-      console.error("GoogleCalendarSyncConfigs errors:", googleCalendarSyncConfigs.errors);
-
     console.info("=== BACKFILL COMPLETE ===");
 
     return {
@@ -889,11 +834,9 @@ export const backfillAll = internalAction({
       employees: employees.synced,
       appointments: appointments.synced,
       invitations: invitations.synced,
-      googleCalendarSyncConfigs: googleCalendarSyncConfigs.synced,
       totalErrors: usersResult.errors.length + patients.errors.length +
         treatments.errors.length + employees.errors.length +
-        appointments.errors.length + invitations.errors.length +
-        googleCalendarSyncConfigs.errors.length,
+        appointments.errors.length + invitations.errors.length,
     };
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3630.

Closes #3630

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3ac9cb6 feat(schema): remove googleCalendarSyncConfigs from Convex schema (closes #3630)

### Files changed

```
 convex/schema/crm.ts        | 23 +-----------------
 convex/supabase/backfill.ts | 59 +--------------------------------------------
 2 files changed, 2 insertions(+), 80 deletions(-)
```