### PR TITLE
GH users management

### DIFF
--- a/automation/worker/.env.example
+++ b/automation/worker/.env.example
@@ -13,3 +13,13 @@ PORT=9090
 
 # SQLite queue location (must be on the same disk as the worker)
 DB_PATH=/home/claude-bot/worker/queue.db
+
+# --- GitHub author queue controls (comma-separated GitHub logins) ---
+# PAUSED_LOGINS: hard stop. Jobs from these logins are never claimed — they
+#   stay `pending` (nothing is lost); unpause = remove the login and restart.
+PAUSED_LOGINS=
+# THROTTLED_LOGINS: rate limit. Jobs from these logins are picked at most once
+#   per THROTTLE_INTERVAL_MS, otherwise they wait. Non-listed users unaffected.
+THROTTLED_LOGINS=
+# THROTTLE_INTERVAL_MS: cooldown window for THROTTLED_LOGINS (default 1h).
+THROTTLE_INTERVAL_MS=3600000

--- a/automation/worker/worker.mjs
+++ b/automation/worker/worker.mjs
@@ -26,6 +26,16 @@ const THROTTLE_INTERVAL_MS = parseInt(
   10,
 );
 
+// Full pickup pause. Jobs whose `trigger_login` is on this list are never
+// claimed — they stay `pending` (and new webhook events still enqueue), so
+// nothing is lost and unpausing is just removing the login from the env and
+// restarting the daemon. Unlike THROTTLED_LOGINS this is a hard stop, not a
+// rate limit. Configured via env (comma-separated), empty by default.
+const PAUSED_LOGINS = (process.env.PAUSED_LOGINS ?? "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
 fs.mkdirSync(LOG_DIR, { recursive: true });
 
 const db = new Database(DB_PATH);
@@ -38,6 +48,10 @@ db.pragma("journal_mode = WAL");
 const claimNextStmt = db.prepare(`
   SELECT * FROM jobs
   WHERE status = 'pending'
+    AND (
+      trigger_login IS NULL
+      OR trigger_login NOT IN (${PAUSED_LOGINS.map(() => "?").join(",") || "''"})
+    )
     AND (
       trigger_login IS NULL
       OR trigger_login NOT IN (${THROTTLED_LOGINS.map(() => "?").join(",") || "''"})
@@ -53,7 +67,7 @@ const claimNextStmt = db.prepare(`
 `);
 const claimNext = db.transaction(() => {
   const cutoff = Date.now() - THROTTLE_INTERVAL_MS;
-  const job = claimNextStmt.get(...THROTTLED_LOGINS, cutoff);
+  const job = claimNextStmt.get(...PAUSED_LOGINS, ...THROTTLED_LOGINS, cutoff);
   if (!job) return null;
   db.prepare(
     `UPDATE jobs SET status = 'running', started_at = ? WHERE id = ?`


### PR DESCRIPTION
## Summary

Versions the automation worker's per-author **hard pause** mechanism, which until now was patched directly on the production server and existed nowhere in the repo. That gap meant the block list was invisible to code readers and a redeploy from `git` would silently wipe it.

This backports the running `worker.mjs` **byte-identical** to the deployed daemon — no behaviour change on the server, purely bringing the repo in sync.

## What's in the queue-control model

Two independent, env-driven controls keyed on the GitHub `trigger_login` of an issue/comment:

- **`PAUSED_LOGINS`** — hard stop. Jobs from these logins are never claimed; they stay `pending` (new webhook events still enqueue, so nothing is lost). Unpausing is just removing the login from the env and restarting the daemon.
- **`THROTTLED_LOGINS`** — rate limit. Jobs from these logins are picked at most once per `THROTTLE_INTERVAL_MS` (default 1h); others are unaffected.

## Changes

- `automation/worker/worker.mjs` — add the `PAUSED_LOGINS` constant, exclude paused logins in the `claimNext` SQL, and bind the params. Verbatim match of the deployed worker.
- `automation/worker/.env.example` — document `PAUSED_LOGINS`, `THROTTLED_LOGINS`, `THROTTLE_INTERVAL_MS` so the queue controls are discoverable.

## Notes

- The actual login lists live in the server `.env` (not committed) and are unchanged by this PR.
- `node --check` passes; the repo file now diffs clean against the live daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)