### PR TITLE
Przywrócić sekret SUPABASE_DB_URL w GitHub Actions

### DIFF
--- a/.github/workflows/secrets-health.yml
+++ b/.github/workflows/secrets-health.yml
@@ -1,14 +1,15 @@
 name: Secrets Health Check
 
-# Periodic smoke test that the deployment-critical repository secrets are
-# present. Catches the "silent fail after secret rotation" class of bug where
-# someone rotates/removes a secret in GitHub settings and we only find out
-# when the next push to main can't apply migrations (#983).
+# Periodic smoke test that deployment-critical repository secrets are present.
+# Catches the "silent fail after secret rotation" class of bug (#983).
 #
-# This workflow does NOT connect to the database — it only checks that the
-# secret has a non-empty value in the GitHub Actions environment. A reachability
-# check would either require a long-lived test connection (security risk) or
-# duplicate the work the migrations workflow already does on every push.
+# The Supabase Migrations workflow needs at least one transport fully configured:
+#   HTTP (preferred) — SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (port 443, no DB port needed)
+#   psql (fallback)  — SUPABASE_DB_URL (requires the Postgres/pooler port reachable from runner)
+#
+# This workflow does NOT connect to the database — it only checks that secrets
+# have non-empty values. A reachability check would duplicate what the
+# migrations workflow already does on every push.
 
 on:
   schedule:
@@ -23,15 +24,46 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - name: Check SUPABASE_DB_URL is present
+      - name: Check migration transport secrets
         env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
+          # Determine whether each transport is fully configured.
+          http_ok=true
+          if [ -z "${SUPABASE_URL:-}" ]; then
+            echo "::warning::SUPABASE_URL is unset — HTTP migration transport incomplete."
+            http_ok=false
+          fi
+          if [ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
+            echo "::warning::SUPABASE_SERVICE_ROLE_KEY is unset — HTTP migration transport incomplete."
+            http_ok=false
+          fi
+
+          psql_ok=true
           if [ -z "${SUPABASE_DB_URL:-}" ]; then
-            echo "::error::SUPABASE_DB_URL repository secret is unset or empty."
-            echo "::error::Without it, the Supabase Migrations workflow will fail on"
-            echo "::error::the next push to main and migrations will not be applied."
-            echo "::error::Restore it in Settings -> Secrets and variables -> Actions."
+            psql_ok=false
+          fi
+
+          # At least one complete transport must be present.
+          if [ "$http_ok" = "false" ] && [ "$psql_ok" = "false" ]; then
+            echo "::error::No migration transport is configured."
+            echo "::error::Set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (HTTP, preferred)"
+            echo "::error::OR SUPABASE_DB_URL (psql fallback) in"
+            echo "::error::Settings -> Secrets and variables -> Actions."
+            echo "::error::Without a transport, the Supabase Migrations workflow will fail"
+            echo "::error::on the next push to main and migrations will not be applied."
             exit 1
           fi
-          echo "SUPABASE_DB_URL is present."
+
+          if [ "$http_ok" = "true" ]; then
+            echo "HTTP transport present (SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY)."
+          else
+            echo "::warning::HTTP transport incomplete — only psql fallback is active (SUPABASE_DB_URL)."
+          fi
+          if [ "$psql_ok" = "true" ]; then
+            echo "psql transport present (SUPABASE_DB_URL)."
+          else
+            echo "::warning::SUPABASE_DB_URL is unset — psql fallback unavailable. HTTP transport covers migrations."
+          fi

--- a/.github/workflows/supabase-migrations-healthcheck.yml
+++ b/.github/workflows/supabase-migrations-healthcheck.yml
@@ -92,7 +92,9 @@ jobs:
 
           Common causes:
 
-          1. The \`SUPABASE_DB_URL\` repository secret was rotated, removed, or never set. (The \`Secrets Health Check\` workflow checks for this daily — if it is also failing, that confirms the cause.)
+          1. A migration transport secret was rotated, removed, or never set. The \`Secrets Health Check\` workflow checks for this daily — if it is also failing, that confirms the cause. At least one of these must be fully configured in Settings → Secrets and variables → Actions:
+             - HTTP transport (preferred): \`SUPABASE_URL\` + \`SUPABASE_SERVICE_ROLE_KEY\`
+             - psql transport (fallback): \`SUPABASE_DB_URL\`
           2. A migration under \`supabase/migrations/\` is invalid or conflicts with the deployed schema.
           3. The Supabase instance at the configured URL is unreachable.
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3635.

Closes #3635

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b934955 fix(ci): broaden Secrets Health Check to validate both migration transports (closes #3635)

### Files changed

```
 .github/workflows/secrets-health.yml               | 60 +++++++++++++++++-----
 .../workflows/supabase-migrations-healthcheck.yml  |  4 +-
 2 files changed, 49 insertions(+), 15 deletions(-)
```