### PR TITLE
Gate edit/delete buttons in gabinet.treatments.$treatmentId.tsx and gabinet.pack

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.$packageId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.$packageId.tsx
@@ -16,7 +16,7 @@ import { EmptyState } from "@/components/layout/empty-state";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { plateJsonToText } from "@/components/gabinet/rich-text-editor";
-import { PermissionGate } from "@/hooks/use-permission";
+import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Gift, Package } from "@/lib/ez-icons";
 import type { MappedGabinetPackageUsage } from "@/lib/supabase/mappers/gabinet/package-usage";
@@ -96,6 +96,7 @@ function PackageDetail() {
   const navigate = useNavigate();
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
+  const { allowed: canEdit } = usePermission("gabinet_packages", "edit");
 
   const { data: packagesData, isLoading } =
     useSupabaseGabinetTreatmentPackagesList(organizationId);
@@ -419,12 +420,11 @@ function PackageDetail() {
         </span>
       }
       avatarFallback={pkg?.name?.slice(0, 2).toUpperCase()}
-      onEdit={() =>
+      onEdit={canEdit ? () =>
         navigate({
           to: "/dashboard/gabinet/packages",
           search: { edit: packageId },
-        })
-      }
+        }) : undefined}
       fields={fields}
       expandedFieldCount={6}
       tabs={[

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -67,7 +67,7 @@ import { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatTreatmentError } from "@/lib/format-action-error";
-import { PermissionGate } from "@/hooks/use-permission";
+import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { Skeleton } from "@/components/ui/skeleton";
 
 function TreatmentDetailSkeleton() {
@@ -121,6 +121,8 @@ function TreatmentDetail() {
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const { allowed: canEdit } = usePermission("gabinet_treatments", "edit");
+  const { allowed: canDelete } = usePermission("gabinet_treatments", "delete");
 
   // State
   const [editPanelOpen, setEditPanelOpen] = useState(false);
@@ -1554,17 +1556,17 @@ function TreatmentDetail() {
         title={treatment?.name ?? ""}
         subtitle={categoryName ?? t("gabinet.treatments.treatment")}
         avatarFallback={treatment?.name?.slice(0, 2).toUpperCase()}
-        onEdit={() => {
+        onEdit={canEdit ? () => {
           setEditCategoryId(treatment?.categoryId as Id<"categoryDefinitions"> | undefined);
           setEditPanelOpen(true);
-        }}
-        secondaryActions={[
+        } : undefined}
+        secondaryActions={canDelete ? [
           {
             label: t("gabinet.treatmentDetail.delete"),
             onClick: handleDelete,
             variant: "destructive" as const,
           },
-        ]}
+        ] : undefined}
         fields={detailFields}
         expandedFieldCount={5}
         sidebarExtra={sidebarExtra}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3658.

Closes #3658

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d52fd71 feat(gabinet): gate edit/delete buttons in treatment and package detail by permission (closes #3658)

### Files changed

```
 .../_auth/dashboard/_layout.gabinet.packages.$packageId.tsx  |  8 ++++----
 .../dashboard/_layout.gabinet.treatments.$treatmentId.tsx    | 12 +++++++-----
 2 files changed, 11 insertions(+), 9 deletions(-)
```