### PR TITLE
Gate all edit buttons in gabinet settings routes (equipment, scheduling, locatio

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
@@ -41,7 +41,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
-import { PermissionGate } from "@/hooks/use-permission";
+import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { Skeleton } from "@/components/ui/skeleton";
 
 function EquipmentSettingsSkeleton() {
@@ -255,6 +255,8 @@ function EquipmentCard({
   const [transferNotes, setTransferNotes] = useState("");
   const [transferring, setTransferring] = useState(false);
 
+  const { allowed: canEdit } = usePermission("gabinet_settings", "edit");
+
   const updateEquipment = useAction(api.gabinet.equipment.updateEquipment);
   const transferEquipment = useAction(api.gabinet.equipment.transferEquipment);
 
@@ -377,25 +379,29 @@ function EquipmentCard({
         />
 
         <div className="flex items-center gap-1 ml-1">
-          <Button
-            size="sm"
-            variant="ghost"
-            className="h-7 px-2 text-xs"
-            onClick={() => {
-              setExpanded(true);
-            }}
-          >
-            {t("common.edit")}
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            className="h-7 px-2 text-xs"
-            onClick={() => setTransferOpen(true)}
-          >
-            <ArrowRight className="mr-1 h-3 w-3" variant="stroke" />
-            {t("gabinet.equipment.transfer")}
-          </Button>
+          {canEdit && (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 px-2 text-xs"
+              onClick={() => {
+                setExpanded(true);
+              }}
+            >
+              {t("common.edit")}
+            </Button>
+          )}
+          {canEdit && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 px-2 text-xs"
+              onClick={() => setTransferOpen(true)}
+            >
+              <ArrowRight className="mr-1 h-3 w-3" variant="stroke" />
+              {t("gabinet.equipment.transfer")}
+            </Button>
+          )}
         </div>
       </div>
 
@@ -484,13 +490,15 @@ function EquipmentCard({
                   <ChevronRight className="h-3 w-3" variant="stroke" />
                 )}
               </Button>
-              <Button
-                size="sm"
-                onClick={handleSave}
-                disabled={saving || !editName.trim()}
-              >
-                {saving ? t("common.saving") : t("common.save")}
-              </Button>
+              {canEdit && (
+                <Button
+                  size="sm"
+                  onClick={handleSave}
+                  disabled={saving || !editName.trim()}
+                >
+                  {saving ? t("common.saving") : t("common.save")}
+                </Button>
+              )}
             </div>
 
             {historyOpen && (
@@ -603,6 +611,8 @@ function EquipmentSettingsPage() {
   const [newParameterUnits, setNewParameterUnits] = useState<string[]>([]);
   const [creating, setCreating] = useState(false);
 
+  const { allowed: canCreate } = usePermission("gabinet_settings", "create");
+
   const queryClient = useQueryClient();
 
   const { data: equipment } = useSupabaseGabinetEquipmentList(organizationId);
@@ -669,10 +679,12 @@ function EquipmentSettingsPage() {
               {t("gabinet.equipment.title")}
             </SectionHeader.Heading>
             <SectionHeader.Actions>
-              <Button size="sm" onClick={() => setCreateOpen(true)}>
-                <Plus className="mr-2 h-4 w-4" variant="stroke" />
-                {t("gabinet.equipment.addEquipment")}
-              </Button>
+              {canCreate && (
+                <Button size="sm" onClick={() => setCreateOpen(true)}>
+                  <Plus className="mr-2 h-4 w-4" variant="stroke" />
+                  {t("gabinet.equipment.addEquipment")}
+                </Button>
+              )}
             </SectionHeader.Actions>
           </SectionHeader.Group>
           <UntitledAlert>{t("gabinet.equipment.description", "Zarządzaj sprzętem i zasobami gabinetu.")}</UntitledAlert>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
@@ -34,7 +34,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
-import { PermissionGate } from "@/hooks/use-permission";
+import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { Skeleton } from "@/components/ui/skeleton";
 
 function LocationsSettingsSkeleton() {
@@ -88,6 +88,9 @@ function LocationCard({
   onDeleted: () => void;
 }) {
   const { t } = useTranslation();
+  const { allowed: canEdit } = usePermission("gabinet_settings", "edit");
+  const { allowed: canDelete } = usePermission("gabinet_settings", "delete");
+  const { allowed: canCreate } = usePermission("gabinet_settings", "create");
   const queryClient = useQueryClient();
   const [expanded, setExpanded] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -385,17 +388,21 @@ function LocationCard({
             </div>
 
             <div className="flex items-center justify-between pt-2">
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={() => setDeleteOpen(true)}
-              >
-                <Trash2 className="mr-2 h-4 w-4" variant="stroke" />
-                {t("common.delete")}
-              </Button>
-              <Button size="sm" onClick={handleSave} disabled={saving || !editName?.trim()}>
-                {saving ? t("common.saving") : t("common.save")}
-              </Button>
+              {canDelete && (
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => setDeleteOpen(true)}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" variant="stroke" />
+                  {t("common.delete")}
+                </Button>
+              )}
+              {canEdit && (
+                <Button size="sm" onClick={handleSave} disabled={saving || !editName?.trim()}>
+                  {saving ? t("common.saving") : t("common.save")}
+                </Button>
+              )}
             </div>
 
             <Separator />
@@ -404,14 +411,16 @@ function LocationCard({
             <div className="space-y-2">
               <div className="flex items-center justify-between">
                 <h4 className="text-sm font-medium">{t("gabinet.locations.rooms")}</h4>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => setAddRoomOpen(true)}
-                >
-                  <Plus className="mr-1.5 h-3.5 w-3.5" variant="stroke" />
-                  {t("gabinet.locations.addRoom")}
-                </Button>
+                {canCreate && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setAddRoomOpen(true)}
+                  >
+                    <Plus className="mr-1.5 h-3.5 w-3.5" variant="stroke" />
+                    {t("gabinet.locations.addRoom")}
+                  </Button>
+                )}
               </div>
 
               {location.rooms.length === 0 ? (
@@ -426,29 +435,45 @@ function LocationCard({
                           {t("gabinet.locations.floor")}: {room.floor}
                         </span>
                       )}
-                      <button
-                        type="button"
-                        onClick={() => handleToggleRoom(room._id, room.isActive)}
-                        className="text-xs"
-                      >
-                        {room.isActive ? (
-                          <Badge variant="default" className="text-[10px] cursor-pointer">
-                            {t("common.active")}
-                          </Badge>
-                        ) : (
-                          <Badge variant="secondary" className="text-[10px] cursor-pointer">
-                            {t("common.inactive")}
-                          </Badge>
-                        )}
-                      </button>
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                        onClick={() => handleDeleteRoom(room._id)}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" variant="stroke" />
-                      </Button>
+                      {canEdit ? (
+                        <button
+                          type="button"
+                          onClick={() => handleToggleRoom(room._id, room.isActive)}
+                          className="text-xs"
+                        >
+                          {room.isActive ? (
+                            <Badge variant="default" className="text-[10px] cursor-pointer">
+                              {t("common.active")}
+                            </Badge>
+                          ) : (
+                            <Badge variant="secondary" className="text-[10px] cursor-pointer">
+                              {t("common.inactive")}
+                            </Badge>
+                          )}
+                        </button>
+                      ) : (
+                        <span className="text-xs">
+                          {room.isActive ? (
+                            <Badge variant="default" className="text-[10px]">
+                              {t("common.active")}
+                            </Badge>
+                          ) : (
+                            <Badge variant="secondary" className="text-[10px]">
+                              {t("common.inactive")}
+                            </Badge>
+                          )}
+                        </span>
+                      )}
+                      {canDelete && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                          onClick={() => handleDeleteRoom(room._id)}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" variant="stroke" />
+                        </Button>
+                      )}
                     </div>
                   ))}
                 </div>
@@ -523,6 +548,7 @@ function LocationCard({
 function LocationsSettingsPage() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
+  const { allowed: canCreate } = usePermission("gabinet_settings", "create");
   const [createOpen, setCreateOpen] = useState(false);
   const [newName, setNewName] = useState("");
   const [newPhone, setNewPhone] = useState("");
@@ -579,10 +605,12 @@ function LocationsSettingsPage() {
               {t("gabinet.locations.title")}
             </SectionHeader.Heading>
             <SectionHeader.Actions>
-              <Button size="sm" onClick={() => setCreateOpen(true)}>
-                <Plus className="mr-2 h-4 w-4" variant="stroke" />
-                {t("gabinet.locations.addLocation")}
-              </Button>
+              {canCreate && (
+                <Button size="sm" onClick={() => setCreateOpen(true)}>
+                  <Plus className="mr-2 h-4 w-4" variant="stroke" />
+                  {t("gabinet.locations.addLocation")}
+                </Button>
+              )}
             </SectionHeader.Actions>
           </SectionHeader.Group>
           <UntitledAlert>{t("gabinet.locations.description", "Zarządzaj lokalizacjami gabinetu.")}</UntitledAlert>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.reminders.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.reminders.tsx
@@ -12,7 +12,7 @@ import { Separator } from "@/components/ui/separator";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { PermissionGate } from "@/hooks/use-permission";
+import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { Skeleton } from "@/components/ui/skeleton";
 
 function ReminderSettingsSkeleton() {
@@ -77,6 +77,7 @@ function ChannelToggle({
 function ReminderSettings() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
+  const { allowed: canEdit } = usePermission("gabinet_settings", "edit");
   const upsertSettings = useAction(api.orgSettings.upsert);
   const [saving, setSaving] = useState(false);
 
@@ -143,6 +144,7 @@ function ReminderSettings() {
             description={t("gabinet.reminders.sms48hDesc")}
             checked={config.sms48h}
             onCheckedChange={toggle("sms48h")}
+            disabled={!canEdit}
           />
           <ChannelToggle
             id="sms24h"
@@ -150,6 +152,7 @@ function ReminderSettings() {
             description={t("gabinet.reminders.sms24hDesc")}
             checked={config.sms24h}
             onCheckedChange={toggle("sms24h")}
+            disabled={!canEdit}
           />
         </div>
 
@@ -163,6 +166,7 @@ function ReminderSettings() {
             description={t("gabinet.reminders.email48hDesc")}
             checked={config.email48h}
             onCheckedChange={toggle("email48h")}
+            disabled={!canEdit}
           />
           <ChannelToggle
             id="email24h"
@@ -170,6 +174,7 @@ function ReminderSettings() {
             description={t("gabinet.reminders.email24hDesc")}
             checked={config.email24h}
             onCheckedChange={toggle("email24h")}
+            disabled={!canEdit}
           />
         </div>
 
@@ -177,11 +182,13 @@ function ReminderSettings() {
           {t("gabinet.reminders.noContactWarning")}
         </p>
 
-        <div className="flex justify-end">
-          <Button onClick={handleSave} disabled={saving}>
-            {saving ? t("common.saving") : t("common.save")}
-          </Button>
-        </div>
+        {canEdit && (
+          <div className="flex justify-end">
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? t("common.saving") : t("common.save")}
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.roles.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.roles.tsx
@@ -20,7 +20,7 @@ import { Badge } from "@/components/ui/badge";
 import { RotateCcw } from "@/lib/ez-icons";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
-import { PermissionGate } from "@/hooks/use-permission";
+import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { Skeleton } from "@/components/ui/skeleton";
 
 function GabinetRolesSettingsSkeleton() {
@@ -168,6 +168,7 @@ function RolePermissionPanel({
   isSystem: boolean;
 }) {
   const { t } = useTranslation();
+  const { allowed: canEdit } = usePermission("gabinet_settings", "edit");
   const rawPerms = useQuery(api.gabinetRoles.getPermissions, {
     organizationId: organizationId as never,
     gabinetRole: roleKey,
@@ -287,6 +288,7 @@ function RolePermissionPanel({
                         <ScopeSelect
                           value={scope}
                           onChange={(v) => handleChange(feature.key, action, v)}
+                          disabled={!canEdit}
                         />
                       ) : (
                         <span className="text-xs text-muted-foreground/40">—</span>
@@ -300,36 +302,38 @@ function RolePermissionPanel({
         </table>
       </div>
 
-      <div className="flex items-center justify-between pt-2 border-t">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleReset}
-          disabled={resetting}
-        >
-          <RotateCcw className="mr-2 h-3.5 w-3.5" variant="stroke" />
-          {resetting
-            ? t("common.loading", "Loading…")
-            : isSystem
-            ? t("gabinet.roles.resetButton", "Reset to defaults")
-            : t("gabinet.roles.clearButton", "Clear permissions")}
-        </Button>
-        <Button
-          size="sm"
-          onClick={handleSave}
-          disabled={!dirty || saving}
-        >
-          {saving ? t("common.saving", "Saving…") : t("common.save", "Save")}
-        </Button>
-      </div>
+      {canEdit && (
+        <div className="flex items-center justify-between pt-2 border-t">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleReset}
+            disabled={resetting}
+          >
+            <RotateCcw className="mr-2 h-3.5 w-3.5" variant="stroke" />
+            {resetting
+              ? t("common.loading", "Loading…")
+              : isSystem
+              ? t("gabinet.roles.resetButton", "Reset to defaults")
+              : t("gabinet.roles.clearButton", "Clear permissions")}
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={!dirty || saving}
+          >
+            {saving ? t("common.saving", "Saving…") : t("common.save", "Save")}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }
 
-function ScopeSelect({ value, onChange }: { value: Scope; onChange: (v: Scope) => void }) {
+function ScopeSelect({ value, onChange, disabled }: { value: Scope; onChange: (v: Scope) => void; disabled?: boolean }) {
   const { t } = useTranslation();
   return (
-    <Select value={value} onValueChange={(v) => onChange(v as Scope)}>
+    <Select value={value} onValueChange={(v) => onChange(v as Scope)} disabled={disabled}>
       <SelectTrigger className="h-7 w-24 text-xs">
         <SelectValue />
       </SelectTrigger>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
@@ -19,7 +19,7 @@ import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
-import { PermissionGate } from "@/hooks/use-permission";
+import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { Skeleton } from "@/components/ui/skeleton";
 
 function SchedulingSettingsSkeleton() {
@@ -67,6 +67,7 @@ const DEFAULT_HOURS: DayHours[] = Array.from({ length: 7 }, (_, i) => ({
 function SchedulingSettings() {
   const { t, i18n } = useTranslation();
   const { organizationId } = useOrganization();
+  const { allowed: canEdit } = usePermission("gabinet_settings", "edit");
   const bulkSet = useAction(api.gabinet.scheduling.bulkSetWorkingHours);
   const [saving, setSaving] = useState(false);
 
@@ -297,11 +298,13 @@ function SchedulingSettings() {
         })}
       </div>
 
-      <div className="flex justify-end">
-        <Button onClick={handleSave} disabled={saving || validationErrors.length > 0 || breakErrors.length > 0}>
-          {saving ? t("common.saving") : t("common.save")}
-        </Button>
-      </div>
+      {canEdit && (
+        <div className="flex justify-end">
+          <Button onClick={handleSave} disabled={saving || validationErrors.length > 0 || breakErrors.length > 0}>
+            {saving ? t("common.saving") : t("common.save")}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
@@ -60,7 +60,7 @@ import type { MappedGabinetEmployee } from "@/lib/supabase/mappers/gabinet/emplo
 import type { MappedGabinetEmployeeSchedule } from "@/lib/supabase/mappers/gabinet/employee-schedules";
 import type { MappedGabinetWorkingHours } from "@/lib/supabase/mappers/gabinet/working-hours";
 import type { MappedGabinetLeave } from "@/lib/supabase/mappers/gabinet/leaves";
-import { PermissionGate } from "@/hooks/use-permission";
+import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { Skeleton } from "@/components/ui/skeleton";
 
 function TimetablePageSkeleton() {
@@ -316,6 +316,7 @@ function formatMinutesAsHours(minutes: number): string {
 function TimetablePage() {
   const { t, i18n } = useTranslation();
   const { organizationId } = useOrganization();
+  const { allowed: canEdit } = usePermission("gabinet_settings", "edit");
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
@@ -882,18 +883,20 @@ function TimetablePage() {
                                 </span>
                               </td>
                               <td className="px-1.5 py-2 text-right align-top">
-                                <Button
-                                  size="sm"
-                                  variant="outline"
-                                  onClick={() => setEditingEmployee(emp)}
-                                  aria-label={t("common.edit")}
-                                >
-                                  <Pencil
-                                    className="mr-1 h-4 w-4"
-                                    variant="stroke"
-                                  />
-                                  {t("common.edit")}
-                                </Button>
+                                {canEdit && (
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => setEditingEmployee(emp)}
+                                    aria-label={t("common.edit")}
+                                  >
+                                    <Pencil
+                                      className="mr-1 h-4 w-4"
+                                      variant="stroke"
+                                    />
+                                    {t("common.edit")}
+                                  </Button>
+                                )}
                               </td>
                             </tr>
                           );
@@ -957,19 +960,21 @@ function TimetablePage() {
                                 )}
                               </div>
                             </div>
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => setEditingEmployee(emp)}
-                              aria-label={t("common.edit")}
-                              className="shrink-0"
-                            >
-                              <Pencil
-                                className="mr-1 h-4 w-4"
-                                variant="stroke"
-                              />
-                              {t("common.edit")}
-                            </Button>
+                            {canEdit && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => setEditingEmployee(emp)}
+                                aria-label={t("common.edit")}
+                                className="shrink-0"
+                              >
+                                <Pencil
+                                  className="mr-1 h-4 w-4"
+                                  variant="stroke"
+                                />
+                                {t("common.edit")}
+                              </Button>
+                            )}
                           </div>
 
                           <div className="flex flex-col text-sm border-t border-b">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3659.

Closes #3659

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 48096f6 feat(gabinet): gate edit/create/delete buttons in settings routes by permission (closes #3659)

### Files changed

```
 .../_layout.gabinet.settings.equipment.tsx         |  74 +++++++------
 .../_layout.gabinet.settings.locations.tsx         | 122 +++++++++++++--------
 .../_layout.gabinet.settings.reminders.tsx         |  19 +++-
 .../dashboard/_layout.gabinet.settings.roles.tsx   |  54 ++++-----
 .../_layout.gabinet.settings.scheduling.tsx        |  15 ++-
 .../_layout.gabinet.settings.timetable.tsx         |  57 +++++-----
 6 files changed, 200 insertions(+), 141 deletions(-)
```