### PR TITLE
Gate create/edit/delete buttons in gabinet appointments, employees, and other ga

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -119,7 +119,7 @@ import {
 import { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
 import { Link } from "@tanstack/react-router";
-import { PermissionGate } from "@/hooks/use-permission";
+import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { TagsPicker } from "@/components/categories-tags/tags-picker";

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -41,7 +41,7 @@ import { PlateText } from "@/components/plate-text";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { EmployeeForm } from "@/components/forms/employee-form";
 import { EventDialog } from "@/components/gabinet/calendar/event-dialog";
-import { PermissionGate } from "@/hooks/use-permission";
+import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   FlexibleScheduleEditor,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3662.

Closes #3662

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 98ed619 fix(gabinet): add missing usePermission import in employees index and appointment detail

### Files changed

```
 .../dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx      | 2 +-
 src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx     | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```