### PR TITLE
1. Synchronizacja przypisań (najpierw)

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx
@@ -683,6 +683,11 @@ function TreatmentDetail() {
     toast.success(t("common.saved"));
   };
 
+  const invalidateTreatmentEmployeeCache = () => {
+    void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetEmployees.list(organizationId) });
+    void queryClient.invalidateQueries({ queryKey: ["gabinet.treatments.getTreatmentEmployees", organizationId, treatmentId] });
+  };
+
   const handleAssignEmployee = async (employeeId: string) => {
     const emp = allEmps.find((e) => e._id === employeeId);
     if (!emp) return;
@@ -692,6 +697,7 @@ function TreatmentDetail() {
       employeeId: employeeId as Id<"gabinetEmployees">,
       treatmentIds: updated,
     });
+    invalidateTreatmentEmployeeCache();
     setEmpSearchQuery("");
     toast.success(t("common.saved"));
   };
@@ -705,6 +711,7 @@ function TreatmentDetail() {
       employeeId: employeeId as Id<"gabinetEmployees">,
       treatmentIds: updated as Id<"gabinetTreatments">[],
     });
+    invalidateTreatmentEmployeeCache();
     toast.success(t("common.saved"));
   };
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3601.

Closes #3601

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 805897b fix(gabinet): invalidate employee/treatment caches after assignment changes on treatment page (closes #3601)

### Files changed

```
 .../_auth/dashboard/_layout.gabinet.treatments.$treatmentId.tsx    | 7 +++++++
 1 file changed, 7 insertions(+)
```