### PR TITLE
Remove `allowUnqualified` arg from `create` UI call site

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1184,10 +1184,6 @@ export const create = action({
     // explicit warning before the user opts in. Hard constraints (working
     // hours, approved leave, clinic closed) still block creation. Issue #1526.
     allowConflict: v.optional(v.boolean()),
-    // When true, allow booking even if the employee is not qualified for one or
-    // more of the selected treatments. The UI shows a warning; this flag lets
-    // the user proceed anyway. Per issue #3356 clarification: warn-not-block.
-    allowUnqualified: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     try {

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -508,17 +508,6 @@ export function AppointmentDialog({
     );
   }, [employees, treatmentId]);
 
-  // Warning: selected employee is unqualified for one or more additional treatments.
-  const hasQualificationWarning = useMemo(() => {
-    if (!employeeId || !employees || selectedTreatments.length <= 1) return false;
-    const emp = employees.find((e) => e.userId === employeeId);
-    if (!emp || emp.qualifiedTreatmentIds.length === 0) return false;
-    return selectedTreatments.some(
-      (t) =>
-        !emp.qualifiedTreatmentIds.includes(t.treatmentId as Id<"gabinetTreatments">),
-    );
-  }, [employees, employeeId, selectedTreatments]);
-
   // Filter patients by search
   const filteredPatients = useMemo(() => {
     const all = patients?.page ?? [];
@@ -992,7 +981,6 @@ export function AppointmentDialog({
         packageTreatmentId: packageTreatmentId ?? undefined,
         allowPast: recordWalkIn || undefined,
         allowConflict: hasBookingConflict || undefined,
-        allowUnqualified: hasQualificationWarning || undefined,
       });
       // Refresh the calendar immediately — Convex actions don't invalidate
       // the Supabase React Query cache automatically.
@@ -1034,7 +1022,6 @@ export function AppointmentDialog({
     packageTreatmentId,
     recordWalkIn,
     hasBookingConflict,
-    hasQualificationWarning,
     onOpenChange,
     queryClient,
     t,
@@ -1425,16 +1412,6 @@ export function AppointmentDialog({
                     triggerTestId="appointment-treatment-trigger"
                   />
                 </div>
-
-                {/* Qualification warning for multi-treatment */}
-                {hasQualificationWarning && (
-                  <p className="text-xs text-amber-600 dark:text-amber-400">
-                    {t(
-                      "gabinet.appointments.warnings.qualificationPartial",
-                      "Pracownik nie ma kwalifikacji do wszystkich wybranych zabiegów",
-                    )}
-                  </p>
-                )}
 
                 {/* Eligible patient packages — render one selector per selected
                     treatment so packages are discovered regardless of which


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3695.

Closes #3695

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 5ec09be fix(gabinet): remove allowUnqualified arg and dead warn-UI (closes #3695)

### Files changed

```
 convex/gabinet/appointments.ts                     |  4 ----
 .../gabinet/calendar/appointment-dialog.tsx        | 23 ----------------------
 2 files changed, 27 deletions(-)
```