### PR TITLE
Add a migration to drop the orphaned `appointment_workflow_config` column from `

### DIFF
--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -568,7 +568,6 @@ export interface Database {
           resource_sharing_enabled: boolean | null;
           reminder_enabled: boolean | null;
           reminder_hours_before: number | null;
-          appointment_workflow_config: string | null;
           created_at: number;
           updated_at: number;
           reminder_sms_48h: boolean | null;
@@ -586,7 +585,6 @@ export interface Database {
           resource_sharing_enabled?: boolean | null;
           reminder_enabled?: boolean | null;
           reminder_hours_before?: number | null;
-          appointment_workflow_config?: string | null;
           created_at: number;
           updated_at: number;
           reminder_sms_48h?: boolean | null;
@@ -604,7 +602,6 @@ export interface Database {
           resource_sharing_enabled?: boolean | null;
           reminder_enabled?: boolean | null;
           reminder_hours_before?: number | null;
-          appointment_workflow_config?: string | null;
           created_at?: number;
           updated_at?: number;
           reminder_sms_48h?: boolean | null;

--- a/supabase/migrations/00080_drop_org_settings_appointment_workflow_config.sql
+++ b/supabase/migrations/00080_drop_org_settings_appointment_workflow_config.sql
@@ -1,0 +1,5 @@
+-- Drop orphaned column removed from application code in issue #3678.
+-- The per-org JSON blob approach for appointment notifications was never wired up
+-- (dispatchAppointmentCreated was never called); notification dispatch is handled
+-- entirely by the automation engine (convex/automation.ts).
+ALTER TABLE org_settings DROP COLUMN IF EXISTS appointment_workflow_config;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3686.

Closes #3686

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 327fdf4 fix(gabinet): drop orphaned appointment_workflow_config column from org_settings (closes #3686)

### Files changed

```
 src/lib/supabase/database.types.ts                                   | 3 ---
 .../00080_drop_org_settings_appointment_workflow_config.sql          | 5 +++++
 2 files changed, 5 insertions(+), 3 deletions(-)
```