### PR TITLE
Audit whether `editTreatmentId`/TreatmentPicker on the detail page is wired to a

### DIFF
--- a/src/components/gabinet/appointment-shared/treatment-picker.tsx
+++ b/src/components/gabinet/appointment-shared/treatment-picker.tsx
@@ -47,6 +47,7 @@ interface TreatmentPickerProps {
   triggerIcon?: ReactNode;
   triggerClassName?: string;
   triggerTestId?: string;
+  disabled?: boolean;
 }
 
 export function TreatmentPicker({
@@ -66,6 +67,7 @@ export function TreatmentPicker({
   triggerIcon,
   triggerClassName,
   triggerTestId,
+  disabled,
 }: TreatmentPickerProps) {
   const list = treatments ?? [];
   const filtered = (() => {
@@ -98,6 +100,7 @@ export function TreatmentPicker({
           aria-expanded={open}
           className={cn("w-full justify-between font-normal", triggerClassName)}
           data-testid={triggerTestId}
+          disabled={disabled}
         >
           {triggerIcon ? (
             <span className="flex items-center gap-2 truncate">

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -261,6 +261,7 @@ function AppointmentDetail() {
   const [editTreatmentId, setEditTreatmentId] = useState("");
   const [treatmentPickerOpen, setTreatmentPickerOpen] = useState(false);
   const [treatmentSearch, setTreatmentSearch] = useState("");
+  const [isSavingTreatment, setIsSavingTreatment] = useState(false);
 
   const { tags: tagDefinitions } = useTagDefinitions(organizationId);
 
@@ -1055,6 +1056,25 @@ function AppointmentDetail() {
     }
   };
 
+  const handleSaveTreatment = async (newTreatmentId: string) => {
+    if (!newTreatmentId) return;
+    setIsSavingTreatment(true);
+    try {
+      await updateAppointment({
+        organizationId,
+        appointmentId: appointment._id,
+        treatmentId: newTreatmentId,
+      });
+      toast.success(t("common.saved"));
+      refetch();
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : t("common.error");
+      toast.error(msg);
+    } finally {
+      setIsSavingTreatment(false);
+    }
+  };
+
   const handleMarkPaid = async (paymentId: string) => {
     try {
       await markPaymentPaid({
@@ -1323,32 +1343,41 @@ function AppointmentDetail() {
                   <Label className="text-xs uppercase tracking-wide text-muted-foreground">
                     {t("common.name")}
                   </Label>
-                  <TreatmentPicker
-                    treatments={treatmentsList}
-                    value={editTreatmentId}
-                    onSelect={(id) => {
-                      setEditTreatmentId(id);
-                      setTreatmentPickerOpen(false);
-                      setTreatmentSearch("");
-                    }}
-                    open={treatmentPickerOpen}
-                    onOpenChange={setTreatmentPickerOpen}
-                    search={treatmentSearch}
-                    onSearchChange={setTreatmentSearch}
-                    formatPrice={(price, currency) =>
-                      formatCurrencyPLN(price ?? 0, currency ?? "PLN")
-                    }
-                    placeholder={t("gabinet.appointments.selectTreatment")}
-                    searchPlaceholder={t(
-                      "gabinet.appointments.searchTreatment",
-                    )}
-                    emptyText={t("common.noResults")}
-                    closeLabel={t("common.close")}
-                    selectedLabel={treatment?.name}
-                    triggerIcon={
+                  {canEdit ? (
+                    <TreatmentPicker
+                      treatments={treatmentsList}
+                      value={editTreatmentId}
+                      onSelect={(id) => {
+                        setEditTreatmentId(id);
+                        setTreatmentPickerOpen(false);
+                        setTreatmentSearch("");
+                        void handleSaveTreatment(id);
+                      }}
+                      open={treatmentPickerOpen}
+                      onOpenChange={setTreatmentPickerOpen}
+                      search={treatmentSearch}
+                      onSearchChange={setTreatmentSearch}
+                      formatPrice={(price, currency) =>
+                        formatCurrencyPLN(price ?? 0, currency ?? "PLN")
+                      }
+                      placeholder={t("gabinet.appointments.selectTreatment")}
+                      searchPlaceholder={t(
+                        "gabinet.appointments.searchTreatment",
+                      )}
+                      emptyText={t("common.noResults")}
+                      closeLabel={t("common.close")}
+                      selectedLabel={treatment?.name}
+                      triggerIcon={
+                        <Stethoscope className="size-4 shrink-0 text-primary" />
+                      }
+                      disabled={isSavingTreatment}
+                    />
+                  ) : (
+                    <span className="flex items-center gap-2 text-sm font-medium">
                       <Stethoscope className="size-4 shrink-0 text-primary" />
-                    }
-                  />
+                      {treatment?.name ?? "-"}
+                    </span>
+                  )}
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-muted-foreground">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3702.

Closes #3702

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 76cba55 fix(gabinet): wire TreatmentPicker on appointment detail to save action (closes #3702)

### Files changed

```
 .../appointment-shared/treatment-picker.tsx        |  3 +
 ...ut.gabinet.appointments.$appointmentId.lazy.tsx | 79 +++++++++++++++-------
 2 files changed, 57 insertions(+), 25 deletions(-)
```