### PR TITLE
Enforce `allowCustomLostReason` in backend

### DIFF
--- a/convex/lostReasons.ts
+++ b/convex/lostReasons.ts
@@ -32,6 +32,13 @@ export const create = action({
       { organizationId: args.organizationId },
     );
 
+    const settings = await ctx.runQuery(internal.orgSettings._getSettings, {
+      organizationId: args.organizationId,
+    });
+    if (settings?.allowCustomLostReason === false) {
+      throw new Error("Custom lost reasons are disabled for this organization");
+    }
+
     const db = createSupabaseDb();
     const now = Date.now();
 

--- a/convex/orgSettings.ts
+++ b/convex/orgSettings.ts
@@ -1,8 +1,18 @@
-import { query, action } from "./_generated/server";
+import { query, action, internalQuery } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
 import { verifyOrgAccess } from "./_helpers/auth";
+
+export const _getSettings = internalQuery({
+  args: { organizationId: v.id("organizations") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("orgSettings")
+      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+      .unique();
+  },
+});
 
 export const get = query({
   args: {

--- a/tests/convex/orgSettingsEffect.test.ts
+++ b/tests/convex/orgSettingsEffect.test.ts
@@ -442,3 +442,51 @@ describe("resourceSharingEnabled: controls permissions.getResourceSharingEnabled
     expect(result).toBe(true);
   });
 });
+
+// =============================================================================
+// allowCustomLostReason
+// =============================================================================
+
+describe("allowCustomLostReason: controls whether lostReasons.create is permitted", () => {
+  test("allowCustomLostReason=true allows creating a custom lost reason", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    await seedConvexOrgSettings(t, organizationId, { allowCustomLostReason: true });
+
+    await expect(
+      t.withIdentity(identity).action(api.lostReasons.create, {
+        organizationId,
+        label: "Custom reason",
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  test("allowCustomLostReason=false blocks creating a custom lost reason", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    await seedConvexOrgSettings(t, organizationId, { allowCustomLostReason: false });
+
+    await expect(
+      t.withIdentity(identity).action(api.lostReasons.create, {
+        organizationId,
+        label: "Blocked reason",
+      }),
+    ).rejects.toThrow("Custom lost reasons are disabled");
+  });
+
+  test("allowCustomLostReason defaults to allow (fail-open) when orgSettings not configured", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    // No orgSettings row — lostReasons.create should succeed (settings?.allowCustomLostReason === false is false when settings is null)
+
+    await expect(
+      t.withIdentity(identity).action(api.lostReasons.create, {
+        organizationId,
+        label: "Default allow reason",
+      }),
+    ).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3684.

Closes #3684

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f7e906b fix(crm): enforce allowCustomLostReason in lostReasons.create backend (closes #3684)

### Files changed

```
 convex/lostReasons.ts                  |  7 +++++
 convex/orgSettings.ts                  | 12 ++++++++-
 tests/convex/orgSettingsEffect.test.ts | 48 ++++++++++++++++++++++++++++++++++
 3 files changed, 66 insertions(+), 1 deletion(-)
```