### PR TITLE
Enforce `lostReasonRequired` in backend

### DIFF
--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -321,6 +321,16 @@ export const update = action({
       throw new Error("Permission denied: you can only edit your own records");
     }
 
+    // Enforce lostReasonRequired when marking a lead as lost
+    if (args.status === "lost") {
+      const settings = await ctx.runQuery(internal.orgSettings._getSettings, {
+        organizationId: args.organizationId,
+      });
+      if (settings?.lostReasonRequired && !args.lostReason) {
+        throw new Error("A lost reason is required");
+      }
+    }
+
     const now = Date.now();
     const { organizationId, leadId, customFields, ...updates } = args;
 

--- a/tests/convex/orgSettingsEffect.test.ts
+++ b/tests/convex/orgSettingsEffect.test.ts
@@ -490,3 +490,87 @@ describe("allowCustomLostReason: controls whether lostReasons.create is permitte
     ).resolves.toBeDefined();
   });
 });
+
+// =============================================================================
+// lostReasonRequired
+// =============================================================================
+
+describe("lostReasonRequired: blocks leads.update to 'lost' status when no lostReason provided", () => {
+  async function seedLead(organizationId: string, userId: string): Promise<string> {
+    const db = createSupabaseDb();
+    const now = Date.now();
+    return db.insert("leads", {
+      organizationId,
+      title: "Test Lead",
+      status: "open",
+      createdBy: userId,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  test("lostReasonRequired=true blocks marking a lead lost without a reason", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    await seedConvexOrgSettings(t, organizationId, { lostReasonRequired: true });
+    const leadId = await seedLead(String(organizationId), String(userId));
+
+    await expect(
+      t.withIdentity(identity).action(api.leads.update, {
+        organizationId,
+        leadId,
+        status: "lost",
+      }),
+    ).rejects.toThrow("A lost reason is required");
+  });
+
+  test("lostReasonRequired=true allows marking a lead lost when lostReason is provided", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    await seedConvexOrgSettings(t, organizationId, { lostReasonRequired: true });
+    const leadId = await seedLead(String(organizationId), String(userId));
+
+    await expect(
+      t.withIdentity(identity).action(api.leads.update, {
+        organizationId,
+        leadId,
+        status: "lost",
+        lostReason: "Price too high",
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  test("lostReasonRequired=false allows marking a lead lost without a reason", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    await seedConvexOrgSettings(t, organizationId, { lostReasonRequired: false });
+    const leadId = await seedLead(String(organizationId), String(userId));
+
+    await expect(
+      t.withIdentity(identity).action(api.leads.update, {
+        organizationId,
+        leadId,
+        status: "lost",
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  test("lostReasonRequired defaults to not required (fail-open) when orgSettings not configured", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    // No orgSettings row — leads.update to "lost" should succeed without a reason
+    const leadId = await seedLead(String(organizationId), String(userId));
+
+    await expect(
+      t.withIdentity(identity).action(api.leads.update, {
+        organizationId,
+        leadId,
+        status: "lost",
+      }),
+    ).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3685.

Closes #3685

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 98d68a6 fix(crm): enforce lostReasonRequired in leads.update backend (closes #3685)

### Files changed

```
 convex/leads.ts                        | 10 ++++
 tests/convex/orgSettingsEffect.test.ts | 84 ++++++++++++++++++++++++++++++++++
 2 files changed, 94 insertions(+)
```