### PR TITLE
Fix missing org filter in `notes.listByEntity`

### DIFF
--- a/convex/notes.ts
+++ b/convex/notes.ts
@@ -19,8 +19,11 @@ export const listByEntity = query({
 
     const notes = await ctx.db
       .query("notes")
-      .withIndex("by_entity", (q) =>
-        q.eq("entityType", args.entityType).eq("entityId", args.entityId)
+      .withIndex("by_org_and_entity", (q) =>
+        q
+          .eq("organizationId", args.organizationId)
+          .eq("entityType", args.entityType)
+          .eq("entityId", args.entityId)
       )
       .collect();
 

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -1061,7 +1061,8 @@ export function createCrmTables({
     updatedAt: v.number(),
   })
     .index("by_entity", ["entityType", "entityId"])
-    .index("by_org", ["organizationId"]),
+    .index("by_org", ["organizationId"])
+    .index("by_org_and_entity", ["organizationId", "entityType", "entityId"]),
 
   };
 }

--- a/tests/convex/tenantIsolation.test.ts
+++ b/tests/convex/tenantIsolation.test.ts
@@ -247,6 +247,35 @@ describe("tenant isolation — notes", () => {
     ).rejects.toThrow("Not a member of this organization");
   });
 
+  test("listByEntity: org A user cannot read org B notes sharing the same entityId", async () => {
+    const t = createTestCtx();
+    const { organizationId: orgAId, userId: userAId, identity: identityA } = await seedTestUser(t);
+    const { organizationId: orgBId, userId: userBId } = await seedOrgB(t);
+
+    const sharedEntityId = "contact-shared-id";
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("notes", {
+        organizationId: orgBId,
+        entityType: "contact",
+        entityId: sharedEntityId,
+        content: "Secret note from Org B",
+        isPinned: false,
+        createdBy: userBId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    const results = await t.withIdentity(identityA).query(api.notes.listByEntity, {
+      organizationId: orgAId,
+      entityType: "contact",
+      entityId: sharedEntityId,
+    });
+
+    expect(results).toHaveLength(0);
+  });
+
   test("getById: org A user cannot fetch an org B note by ID", async () => {
     const t = createTestCtx();
     const { organizationId: orgAId, identity: identityA } = await seedTestUser(t);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3713.

Closes #3713

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f066b7d fix(security): add org filter to notes.listByEntity to prevent cross-tenant note leak (closes #3713)

### Files changed

```
 convex/notes.ts                      |  7 +++++--
 convex/schema/crm.ts                 |  3 ++-
 tests/convex/tenantIsolation.test.ts | 29 +++++++++++++++++++++++++++++
 3 files changed, 36 insertions(+), 3 deletions(-)
```