### PR TITLE
Fix documentAnalysisJobs.test.ts environment

### DIFF
--- a/convex/_ai/documentAnalyzer.ts
+++ b/convex/_ai/documentAnalyzer.ts
@@ -8,7 +8,6 @@
 // Current implementation: OpenAIDocumentAnalyzer when OPENAI_API_KEY is set,
 // NullDocumentTransport otherwise.
 
-import { OpenAIDocumentAnalyzer } from "./providers/openaiDocumentAnalyzer";
 
 // ---------------------------------------------------------------------------
 // Input — ordered pages that together form one document (#3035).
@@ -146,10 +145,15 @@ class NullDocumentTransport implements DocumentTransport {
 // NullDocumentTransport. The model can be overridden via OPENAI_INVOICE_MODEL.
 // `fetchFile` is provided by the calling action (ctx.storage.get) so the
 // provider can fetch bytes server-side without exposing public URLs.
-export function getDocumentTransport(fetchFile: StorageFetcher): DocumentTransport {
+//
+// Dynamic import ensures the `openai` npm package is only resolved at runtime
+// when the API key is actually set — keeping the module loadable in test
+// environments where the package is not installed.
+export async function getDocumentTransport(fetchFile: StorageFetcher): Promise<DocumentTransport> {
   const apiKey = process.env.OPENAI_API_KEY;
   if (apiKey) {
     const model = process.env.OPENAI_INVOICE_MODEL ?? "gpt-4o";
+    const { OpenAIDocumentAnalyzer } = await import("./providers/openaiDocumentAnalyzer");
     return new OpenAIDocumentAnalyzer(apiKey, model, fetchFile);
   }
   return new NullDocumentTransport();

--- a/convex/documentAnalysisJobs.ts
+++ b/convex/documentAnalysisJobs.ts
@@ -108,7 +108,7 @@ export const runJob = action({
       }
     }
 
-    const transport = getDocumentTransport(
+    const transport = await getDocumentTransport(
       (id: string) => ctx.storage.get(id as unknown as Id<"_storage">),
     );
     const res = await analyzeDocument(transport, kind, pages, context);

--- a/convex/warehouseDeliveries.ts
+++ b/convex/warehouseDeliveries.ts
@@ -522,7 +522,7 @@ export const analyzeDeliveryInvoice = action({
       .slice()
       .sort((a, b) => a.position - b.position);
 
-    const transport = getDocumentTransport(
+    const transport = await getDocumentTransport(
       (id: string) => ctx.storage.get(id as unknown as Id<"_storage">),
     );
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3681.

Closes #3681

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b7bfa82 fix(test): lazy-load openai provider to fix documentAnalysisJobs test environment (closes #3681)

### Files changed

```
 convex/_ai/documentAnalyzer.ts | 8 ++++++--
 convex/documentAnalysisJobs.ts | 2 +-
 convex/warehouseDeliveries.ts  | 2 +-
 3 files changed, 8 insertions(+), 4 deletions(-)
```