### PR TITLE
Dodać pacjentów i zabiegi do wyszukiwania globalnego

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2173,7 +2173,9 @@
       "company": "Companies",
       "lead": "Deals",
       "document": "Documents",
-      "product": "Products"
+      "product": "Products",
+      "patient": "Patients",
+      "treatment": "Treatments"
     }
   },
   "quickCreate": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2186,7 +2186,9 @@
       "company": "Firmy",
       "lead": "Transakcje",
       "document": "Dokumenty",
-      "product": "Produkty"
+      "product": "Produkty",
+      "patient": "Pacjenci",
+      "treatment": "Zabiegi"
     }
   },
   "quickCreate": {

--- a/src/components/crm/global-search.tsx
+++ b/src/components/crm/global-search.tsx
@@ -23,7 +23,9 @@ export interface SearchResult {
     | "document"
     | "product"
     | "call"
-    | "activity";
+    | "activity"
+    | "patient"
+    | "treatment";
   title: string;
   subtitle?: string;
   href: string;

--- a/src/hooks/use-supabase-search.ts
+++ b/src/hooks/use-supabase-search.ts
@@ -18,6 +18,8 @@ type CompanyRow = Database["public"]["Tables"]["companies"]["Row"];
 type LeadRow = Database["public"]["Tables"]["leads"]["Row"];
 type DocumentRow = Database["public"]["Tables"]["documents"]["Row"];
 type ProductRow = Database["public"]["Tables"]["products"]["Row"];
+type GabinetPatientRow = Database["public"]["Tables"]["gabinet_patients"]["Row"];
+type GabinetTreatmentRow = Database["public"]["Tables"]["gabinet_treatments"]["Row"];
 
 // ── Types (match convex/search.ts output shape) ──────────────────────────────
 
@@ -64,8 +66,26 @@ export async function supabaseGlobalSearch(
     );
   }
 
-  const [contactsRes, companiesRes, leadsRes, documentsRes, productsRes] =
-    await Promise.all([
+  let patientsQuery = supabase
+    .from("gabinet_patients")
+    .select("*")
+    .eq("organization_id", orgId);
+  for (const token of tokens) {
+    const tokenPattern = `%${token}%`;
+    patientsQuery = patientsQuery.or(
+      `first_name.ilike.${tokenPattern},last_name.ilike.${tokenPattern}`,
+    );
+  }
+
+  const [
+    contactsRes,
+    companiesRes,
+    leadsRes,
+    documentsRes,
+    productsRes,
+    patientsRes,
+    treatmentsRes,
+  ] = await Promise.all([
       contactsQuery.limit(5),
 
       supabase
@@ -91,6 +111,15 @@ export async function supabaseGlobalSearch(
 
       supabase
         .from("products")
+        .select("*")
+        .eq("organization_id", orgId)
+        .ilike("name", pattern)
+        .limit(5),
+
+      patientsQuery.limit(5),
+
+      supabase
+        .from("gabinet_treatments")
         .select("*")
         .eq("organization_id", orgId)
         .ilike("name", pattern)
@@ -167,6 +196,34 @@ export async function supabaseGlobalSearch(
         title: p.name,
         subtitle: p.unit_price ? `${p.unit_price} PLN` : undefined,
         href: `/dashboard/products`,
+      })),
+    });
+  }
+
+  // Gabinet Patients
+  const patients = (patientsRes.data ?? []) as GabinetPatientRow[];
+  if (patients.length > 0) {
+    groups.push({
+      type: "patient",
+      results: patients.map((p) => ({
+        id: p.id,
+        title: [p.first_name, p.last_name].filter(Boolean).join(" "),
+        subtitle: p.email ?? undefined,
+        href: `/dashboard/gabinet/patients/${p.id}`,
+      })),
+    });
+  }
+
+  // Gabinet Treatments
+  const treatments = (treatmentsRes.data ?? []) as GabinetTreatmentRow[];
+  if (treatments.length > 0) {
+    groups.push({
+      type: "treatment",
+      results: treatments.map((t) => ({
+        id: t.id,
+        title: t.name,
+        subtitle: t.price ? `${t.price} PLN` : undefined,
+        href: `/dashboard/gabinet/treatments/${t.id}`,
       })),
     });
   }

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -50,6 +50,8 @@ import {
   CalendarCheck,
   BarChart3,
   Check,
+  UserCheck,
+  Stethoscope,
 } from "@/lib/ez-icons";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
@@ -197,6 +199,8 @@ const typeIcons: Record<string, React.ReactNode> = {
   lead: <TrendingUp className="h-4 w-4" variant="stroke" />,
   document: <FileText className="h-4 w-4" variant="stroke" />,
   product: <Package className="h-4 w-4" variant="stroke" />,
+  patient: <UserCheck className="h-4 w-4" variant="stroke" />,
+  treatment: <Stethoscope className="h-4 w-4" variant="stroke" />,
 };
 
 // Inner component runs inside the provider stack so Supabase hooks (e.g.


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3730.

Closes #3730

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- fd3d2af feat(gabinet): add patients and treatments to global search (closes #3730)

### Files changed

```
 public/locales/en/translation.json          |  4 +-
 public/locales/pl/translation.json          |  4 +-
 src/components/crm/global-search.tsx        |  4 +-
 src/hooks/use-supabase-search.ts            | 61 ++++++++++++++++++++++++++++-
 src/routes/_app/_auth/dashboard/_layout.tsx |  4 ++
 5 files changed, 72 insertions(+), 5 deletions(-)
```