### PR TITLE
feat(rbac): add gabinet_receipts to RBAC permission matrix

### DIFF
--- a/convex/_helpers/gabinetRolePermissions.ts
+++ b/convex/_helpers/gabinetRolePermissions.ts
@@ -71,6 +71,7 @@ function buildGabinet(
     "gabinet_packages",
     "gabinet_employees",
     "gabinet_payments",
+    "gabinet_receipts",
     "gabinet_reports",
     "gabinet_financial_reports",
     "gabinet_purchase_prices",
@@ -110,6 +111,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_packages: { view: "all" },
     gabinet_employees: { view: "all" },
     gabinet_payments: { view: "all" },
+    gabinet_receipts: { view: "all" },
     gabinet_photos: { view: "all", create: "all", edit: "own", delete: "own" },
     gabinet_settings: {},
   }),
@@ -120,6 +122,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_packages: { view: "all" },
     gabinet_employees: { view: "all" },
     gabinet_payments: { view: "all" },
+    gabinet_receipts: { view: "all" },
     gabinet_photos: { view: "all", create: "all", edit: "own", delete: "own" },
     gabinet_settings: {},
   }),
@@ -130,6 +133,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_packages: { view: "all" },
     gabinet_employees: { view: "all" },
     gabinet_payments: { view: "all" },
+    gabinet_receipts: { view: "all" },
     gabinet_photos: { view: "all", create: "all", edit: "own", delete: "own" },
     gabinet_settings: {},
   }),
@@ -140,6 +144,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_packages: { view: "all" },
     gabinet_employees: { view: "all" },
     gabinet_payments: { view: "all" },
+    gabinet_receipts: { view: "all" },
     gabinet_photos: { view: "all", create: "all", edit: "own" },
     gabinet_settings: {},
   }),
@@ -152,6 +157,8 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     // Recepcja może rejestrować wpłaty i edytować je, ale NIE robi zwrotów —
     // zwrot wymaga osobnej autoryzacji administratora (issue #1690).
     gabinet_payments: { view: "all", create: "all", edit: "all" },
+    // Recepcja może drukować paragony, ale NIE unieważnia ich.
+    gabinet_receipts: { view: "all", create: "all" },
     gabinet_photos: { view: "all" },
     gabinet_online_booking: { view: "all" },
     gabinet_inventory: { view: "all" },
@@ -168,6 +175,8 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_packages: { view: "all", create: "all", edit: "all" },
     gabinet_employees: { view: "all" },
     gabinet_payments: { view: "all", create: "all", edit: "all" },
+    // Manager może drukować i unieważniać paragony (delete = void).
+    gabinet_receipts: { view: "all", create: "all", edit: "all", delete: "all" },
     gabinet_reports: { view: "all" },
     gabinet_financial_reports: { view: "all" },
     gabinet_purchase_prices: { view: "all" },
@@ -183,6 +192,8 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_packages: { view: "all", create: "all", edit: "all", delete: "all" },
     gabinet_employees: { view: "all", create: "all", edit: "all", delete: "all" },
     gabinet_payments: { view: "all", create: "all", edit: "all", delete: "all", refund: "all" },
+    // Admin może drukować i unieważniać paragony (delete = void).
+    gabinet_receipts: { view: "all", create: "all", edit: "all", delete: "all" },
     gabinet_reports: { view: "all" },
     gabinet_financial_reports: { view: "all" },
     gabinet_purchase_prices: { view: "all", create: "all", edit: "all" },
@@ -198,6 +209,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_packages: { view: "all" },
     gabinet_employees: { view: "all" },
     gabinet_payments: { view: "all" },
+    gabinet_receipts: { view: "all" },
     gabinet_settings: {},
   }),
 };

--- a/convex/_helpers/permissionTypes.ts
+++ b/convex/_helpers/permissionTypes.ts
@@ -20,6 +20,7 @@ export const FEATURES = [
   "gabinet_packages",
   "gabinet_employees",
   "gabinet_payments",
+  "gabinet_receipts",
   "gabinet_reports",
   "gabinet_financial_reports",
   "gabinet_purchase_prices",

--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -50,6 +50,22 @@ DEFAULT_PERMISSIONS.viewer.gabinet_payments = {
   view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
 };
 
+// --- Per-feature overrides for gabinet_receipts ---
+// Receipts are financial documents tied to payments. view = view/print; delete = void.
+// owner/admin: full control incl. void; member: view+print (no void); viewer: view only.
+DEFAULT_PERMISSIONS.owner.gabinet_receipts = {
+  view: "all", create: "all", edit: "all", delete: "all", approve: "none", sign: "none", refund: "none",
+};
+DEFAULT_PERMISSIONS.admin.gabinet_receipts = {
+  view: "all", create: "all", edit: "all", delete: "all", approve: "none", sign: "none", refund: "none",
+};
+DEFAULT_PERMISSIONS.member.gabinet_receipts = {
+  view: "all", create: "all", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
+};
+DEFAULT_PERMISSIONS.viewer.gabinet_receipts = {
+  view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
+};
+
 // --- Per-feature overrides for gabinet_reports ---
 // owner/admin: all (default). member: view only (reports are read-only).
 // viewer: no access by default — financial summaries are sensitive.

--- a/src/routes/_app/_auth/dashboard/_layout.settings.permissions.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.permissions.tsx
@@ -42,6 +42,7 @@ const FEATURES = [
   { key: "gabinet_packages", labelKey: "permissions.features.gabinet_packages", label: "Gabinet: Packages" },
   { key: "gabinet_employees", labelKey: "permissions.features.gabinet_employees", label: "Gabinet: Employees" },
   { key: "gabinet_payments", labelKey: "permissions.features.gabinet_payments", label: "Gabinet: Payments" },
+  { key: "gabinet_receipts", labelKey: "permissions.features.gabinet_receipts", label: "Gabinet: Receipts" },
   { key: "gabinet_reports", labelKey: "permissions.features.gabinet_reports", label: "Gabinet: Reports" },
   { key: "gabinet_financial_reports", labelKey: "permissions.features.gabinet_financial_reports", label: "Gabinet: Financial Reports" },
   { key: "gabinet_purchase_prices", labelKey: "permissions.features.gabinet_purchase_prices", label: "Gabinet: Purchase Prices" },


### PR DESCRIPTION
## Summary
- Adds `gabinet_receipts` to the `FEATURES` constant in `convex/_helpers/permissionTypes.ts` (single source of truth for all permission feature keys)
- Adds org-role defaults in `convex/_helpers/permissions.ts`: owner/admin have full control including void (`delete`); member can view and print (`create`) but not void; viewer can only view
- Adds gabinet-role defaults in `convex/_helpers/gabinetRolePermissions.ts`: clinical roles (doctor/cosmetologist/therapist/nurse/other) get view-only; receptionist gets view+create (print, no void); manager and gabinet admin get full view/create/edit/delete (void)
- Adds `gabinet_receipts` entry to the settings permissions UI (`_layout.settings.permissions.tsx`) so admins can override the defaults per role

Closes #3735

## Test plan
- [ ] Open Settings → Permissions — "Gabinet: Receipts" row appears for both member and viewer role tabs
- [ ] A user with `member` org-role and no gabinet membership is denied `delete` on `gabinet_receipts` via `checkPermission`
- [ ] A user with gabinet `admin` role gets `delete: "all"` after max-merge
- [ ] A user with gabinet `receptionist` role gets `create: "all"` but `delete: "none"` (no void)

🤖 Generated with [Claude Code](https://claude.com/claude-code)