### PR TITLE
Add `fiscalRegisterId` / terminal concept to `gabinetLocations`

### DIFF
--- a/convex/gabinet/locations.ts
+++ b/convex/gabinet/locations.ts
@@ -67,6 +67,7 @@ export const createLocation = action({
     phone: v.optional(v.union(v.string(), v.null())),
     email: v.optional(v.union(v.string(), v.null())),
     color: v.optional(v.union(v.string(), v.null())),
+    fiscalRegisterId: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
     try {
@@ -122,6 +123,7 @@ export const createLocation = action({
       phone: args.phone ?? null,
       email: args.email ?? null,
       color: args.color ?? null,
+      fiscalRegisterId: args.fiscalRegisterId ?? null,
       isActive: true,
       createdBy: String(authResult.userId),
       createdAt: now,
@@ -164,6 +166,7 @@ export const updateLocation = action({
     phone: v.optional(v.union(v.string(), v.null())),
     email: v.optional(v.union(v.string(), v.null())),
     color: v.optional(v.union(v.string(), v.null())),
+    fiscalRegisterId: v.optional(v.union(v.string(), v.null())),
     isActive: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -946,6 +946,7 @@ export function createGabinetTables({
     phone: v.optional(v.string()),
     email: v.optional(v.string()),
     color: v.optional(v.string()),
+    fiscalRegisterId: v.optional(v.string()),
     isActive: v.boolean(),
     createdBy: v.id("users"),
     createdAt: v.number(),

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
@@ -69,6 +69,7 @@ type LocationWithRooms = {
   phone?: string;
   email?: string;
   color?: string;
+  fiscalRegisterId?: string;
   isActive: boolean;
   rooms: Array<{
     _id: Id<"gabinetRooms">;
@@ -101,6 +102,7 @@ function LocationCard({
   const [editPhone, setEditPhone] = useState<string | null>(null);
   const [editEmail, setEditEmail] = useState<string | null>(null);
   const [editColor, setEditColor] = useState<string | null>(null);
+  const [editFiscalRegisterId, setEditFiscalRegisterId] = useState<string | null>(null);
   const [editStreet, setEditStreet] = useState<string | null>(null);
   const [editCity, setEditCity] = useState<string | null>(null);
   const [editPostal, setEditPostal] = useState<string | null>(null);
@@ -134,6 +136,7 @@ function LocationCard({
         setEditPhone(displayData.phone ?? "");
         setEditEmail(displayData.email ?? "");
         setEditColor(displayData.color ?? "");
+        setEditFiscalRegisterId(displayData.fiscalRegisterId ?? "");
         setEditStreet(displayData.address?.street ?? "");
         setEditCity(displayData.address?.city ?? "");
         setEditPostal(displayData.address?.postalCode ?? "");
@@ -148,6 +151,7 @@ function LocationCard({
     setEditPhone(data.phone ?? "");
     setEditEmail(data.email ?? "");
     setEditColor(data.color ?? "");
+    setEditFiscalRegisterId(data.fiscalRegisterId ?? "");
     setEditStreet(data.address?.street ?? "");
     setEditCity(data.address?.city ?? "");
     setEditPostal(data.address?.postalCode ?? "");
@@ -170,6 +174,7 @@ function LocationCard({
         phone: editPhone?.trim() || null,
         email: editEmail?.trim() || null,
         color: editColor?.trim() || null,
+        fiscalRegisterId: editFiscalRegisterId?.trim() || null,
         address: {
           street: editStreet?.trim() || null,
           city: editCity?.trim() || null,
@@ -358,6 +363,15 @@ function LocationCard({
                     className="flex-1"
                   />
                 </div>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor={`loc-fiscal-${locationId}`}>{t("gabinet.locations.fiscalRegisterId", "Nr kasy fiskalnej")}</Label>
+                <Input
+                  id={`loc-fiscal-${locationId}`}
+                  value={editFiscalRegisterId ?? ""}
+                  onChange={(e) => setEditFiscalRegisterId(e.target.value)}
+                  placeholder="KFP-01"
+                />
               </div>
             </div>
 
@@ -554,6 +568,7 @@ function LocationsSettingsPage() {
   const [newPhone, setNewPhone] = useState("");
   const [newEmail, setNewEmail] = useState("");
   const [newCity, setNewCity] = useState("");
+  const [newFiscalRegisterId, setNewFiscalRegisterId] = useState("");
   const [creating, setCreating] = useState(false);
   const [deletedIds, setDeletedIds] = useState<Set<string>>(new Set());
   const queryClient = useQueryClient();
@@ -572,6 +587,7 @@ function LocationsSettingsPage() {
         phone: newPhone.trim() || null,
         email: newEmail.trim() || null,
         address: newCity.trim() ? { city: newCity.trim() } : null,
+        fiscalRegisterId: newFiscalRegisterId.trim() || null,
       });
       toast.success(t("gabinet.locations.addLocation"));
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetLocations.list(organizationId) });
@@ -580,6 +596,7 @@ function LocationsSettingsPage() {
       setNewPhone("");
       setNewEmail("");
       setNewCity("");
+      setNewFiscalRegisterId("");
     } catch (e) {
       toast.error(
         formatActionError(e, t, {
@@ -671,6 +688,14 @@ function LocationsSettingsPage() {
               <Input
                 value={newCity}
                 onChange={(e) => setNewCity(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>{t("gabinet.locations.fiscalRegisterId", "Nr kasy fiskalnej")}</Label>
+              <Input
+                value={newFiscalRegisterId}
+                onChange={(e) => setNewFiscalRegisterId(e.target.value)}
+                placeholder="KFP-01"
               />
             </div>
             <div className="flex justify-end gap-2">

--- a/supabase/migrations/00081_gabinet_locations_fiscal_register_id.sql
+++ b/supabase/migrations/00081_gabinet_locations_fiscal_register_id.sql
@@ -1,0 +1,9 @@
+-- Add fiscal_register_id to gabinet_locations.
+-- Multi-location clinics need a per-location fiscal register / POS terminal
+-- identifier so that receipt counters remain independent per location.
+-- The value is a free-form string (e.g. "KFP1", "POS-02") set by the clinic
+-- administrator; uniqueness is not enforced at DB level because identifiers
+-- may be assigned by the fiscal device manufacturer and the clinic may have
+-- its own numbering scheme.
+ALTER TABLE gabinet_locations
+  ADD COLUMN IF NOT EXISTS fiscal_register_id TEXT;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3734.

Closes #3734

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- efdf82b feat(gabinet): add fiscalRegisterId to gabinetLocations (closes #3734)

### Files changed

```
 convex/gabinet/locations.ts                        |  3 +++
 convex/schema/gabinet.ts                           |  1 +
 .../_layout.gabinet.settings.locations.tsx         | 25 ++++++++++++++++++++++
 .../00081_gabinet_locations_fiscal_register_id.sql |  9 ++++++++
 4 files changed, 38 insertions(+)
```