### PR TITLE
Generowanie PDF paragonu dla pacjenta

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -93,6 +93,7 @@ const TABLE_MAP: Record<string, string> = {
   automationRunSteps: "automation_run_steps",
   organizations: "organizations",
   teamMemberships: "team_memberships",
+  gabinetReceipts: "gabinet_receipts",
 };
 
 function toSnakeCase(str: string): string {

--- a/convex/gabinet/receipts.ts
+++ b/convex/gabinet/receipts.ts
@@ -1,0 +1,584 @@
+import {
+  action,
+  internalMutation,
+  internalQuery,
+} from "../_generated/server";
+import { internal } from "../_generated/api";
+import { v } from "convex/values";
+import { createSupabaseDb } from "../_helpers/supabaseDb";
+import { logAudit } from "../auditLog";
+import type { Id } from "../_generated/dataModel";
+
+// VAT multipliers for each Polish fiscal rate code.
+// A=23%, B=8%, C=5%, D=ZW (exempt, 0% — applies to medical services).
+const VAT_RATES: Record<string, number> = {
+  A: 0.23,
+  B: 0.08,
+  C: 0.05,
+  D: 0,
+};
+
+// Default PKWiU for health/medical services not otherwise classified.
+const DEFAULT_PKWIU = "86.90.19";
+
+interface ReceiptLineItem {
+  name: string;
+  pkwiu: string;
+  quantity: number;
+  unitPriceGross: number;
+  vatRate: string; // "A"|"B"|"C"|"D"
+  netAmount: number;
+  vatAmount: number;
+  grossAmount: number;
+}
+
+function computeLineItem(
+  name: string,
+  quantity: number,
+  unitPriceGross: number,
+  vatRate: string,
+  pkwiu?: string,
+): ReceiptLineItem {
+  const rate = VAT_RATES[vatRate] ?? 0;
+  const grossAmount = Math.round(unitPriceGross * quantity * 100) / 100;
+  const netAmount = Math.round((grossAmount / (1 + rate)) * 100) / 100;
+  const vatAmount = Math.round((grossAmount - netAmount) * 100) / 100;
+  return {
+    name,
+    pkwiu: pkwiu ?? DEFAULT_PKWIU,
+    quantity,
+    unitPriceGross,
+    vatRate,
+    netAmount,
+    vatAmount,
+    grossAmount,
+  };
+}
+
+function formatPLN(amount: number): string {
+  return amount.toFixed(2).replace(".", ",") + " zl";
+}
+
+function formatDate(ms: number): string {
+  return new Date(ms).toLocaleDateString("pl-PL", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+function paymentMethodPL(method: string): string {
+  const map: Record<string, string> = {
+    cash: "Gotowka",
+    card: "Karta platnicza",
+    transfer: "Przelew bankowy",
+    package: "Pakiet",
+    gratis: "Gratis",
+    barter: "Barter",
+    other: "Inne",
+  };
+  return map[method] ?? method;
+}
+
+/**
+ * Returns the next sequential receipt number for the org in the given year.
+ * Format: REC/YYYY/NNNNN (e.g. REC/2026/00001).
+ */
+async function nextReceiptNumber(
+  orgId: string,
+  year: number,
+): Promise<string> {
+  const db = createSupabaseDb();
+  const client = db.raw();
+  const prefix = `REC/${year}/`;
+  const { data } = await client
+    .from("gabinet_receipts")
+    .select("receipt_number")
+    .eq("organization_id", orgId)
+    .like("receipt_number", `${prefix}%`)
+    .order("receipt_number", { ascending: false })
+    .limit(1);
+
+  let next = 1;
+  if (data && data.length > 0) {
+    const last = (data[0].receipt_number as string).slice(prefix.length);
+    const parsed = parseInt(last, 10);
+    if (!isNaN(parsed)) next = parsed + 1;
+  }
+  return `${prefix}${String(next).padStart(5, "0")}`;
+}
+
+// ---------------------------------------------------------------------------
+// PDF generator
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a PDF receipt using pdf-lib. Attempts to embed Roboto from Google
+ * Fonts (supports Polish diacritics: ą ę ó ś ź ż ć ń ł). Falls back to the
+ * built-in Helvetica when the network call fails.
+ */
+async function buildReceiptPdf(params: {
+  receiptNumber: string;
+  issuedAt: number;
+  organizationName: string;
+  organizationNip?: string;
+  organizationAddress?: string;
+  items: ReceiptLineItem[];
+  totalNet: number;
+  totalVat: number;
+  totalGross: number;
+  paymentMethod: string;
+  fiscalReceiptId?: string;
+}): Promise<Uint8Array> {
+  const { PDFDocument, rgb, StandardFonts } = await import("pdf-lib");
+
+  const pdfDoc = await PDFDocument.create();
+
+  // Embed a font with Latin Extended coverage for Polish characters.
+  let font;
+  try {
+    const fontRes = await fetch(
+      "https://fonts.gstatic.com/s/roboto/v32/KFOmCnqEu92Fr1Me5g.ttf",
+    );
+    if (fontRes.ok) {
+      const fontBytes = await fontRes.arrayBuffer();
+      font = await pdfDoc.embedFont(fontBytes);
+    }
+  } catch {
+    // Network unreachable — fall through.
+  }
+  if (!font) {
+    font = await pdfDoc.embedStandardFont(StandardFonts.Helvetica);
+  }
+
+  const page = pdfDoc.addPage([595, 842]); // A4 portrait
+  const { width, height } = page.getSize();
+  const margin = 50;
+  let y = height - margin;
+
+  const draw = (
+    text: string,
+    x: number,
+    yPos: number,
+    size = 10,
+    color = rgb(0, 0, 0),
+  ) => {
+    page.drawText(text, { x, y: yPos, size, font, color });
+  };
+
+  const hline = (yPos: number) => {
+    page.drawLine({
+      start: { x: margin, y: yPos },
+      end: { x: width - margin, y: yPos },
+      thickness: 0.5,
+      color: rgb(0.7, 0.7, 0.7),
+    });
+  };
+
+  // --- Header: org details ---
+  draw(params.organizationName, margin, y, 14, rgb(0.1, 0.1, 0.1));
+  y -= 20;
+  if (params.organizationNip) {
+    draw(`NIP: ${params.organizationNip}`, margin, y, 9, rgb(0.4, 0.4, 0.4));
+    y -= 13;
+  }
+  if (params.organizationAddress) {
+    draw(params.organizationAddress, margin, y, 9, rgb(0.4, 0.4, 0.4));
+    y -= 13;
+  }
+
+  // --- Receipt title ---
+  y -= 10;
+  hline(y);
+  y -= 20;
+  draw("PARAGON", margin, y, 20, rgb(0.1, 0.1, 0.1));
+  y -= 24;
+  draw(`Nr: ${params.receiptNumber}`, margin, y, 10);
+  draw(`Data: ${formatDate(params.issuedAt)}`, width / 2, y, 10);
+  y -= 16;
+  hline(y);
+
+  // --- Items table header ---
+  y -= 16;
+  const col = {
+    lp:        margin,
+    name:      margin + 22,
+    pkwiu:     margin + 230,
+    qty:       margin + 310,
+    unitPrice: margin + 342,
+    vatRate:   margin + 390,
+    net:       margin + 420,
+    vatAmt:    margin + 458,
+    gross:     margin + 490,
+  };
+
+  const grey = rgb(0.35, 0.35, 0.35);
+  draw("Lp.", col.lp, y, 7, grey);
+  draw("Nazwa uslugi", col.name, y, 7, grey);
+  draw("PKWiU", col.pkwiu, y, 7, grey);
+  draw("Ilosc", col.qty, y, 7, grey);
+  draw("Cena br.", col.unitPrice, y, 7, grey);
+  draw("VAT", col.vatRate, y, 7, grey);
+  draw("Netto", col.net, y, 7, grey);
+  draw("VAT zl", col.vatAmt, y, 7, grey);
+  draw("Brutto", col.gross, y, 7, grey);
+  y -= 4;
+  hline(y);
+
+  // --- Items rows ---
+  for (let i = 0; i < params.items.length; i++) {
+    const it = params.items[i];
+    y -= 14;
+    draw(`${i + 1}.`, col.lp, y, 9);
+    const name = it.name.length > 30 ? it.name.slice(0, 28) + ".." : it.name;
+    draw(name, col.name, y, 9);
+    draw(it.pkwiu, col.pkwiu, y, 9);
+    draw(String(it.quantity), col.qty, y, 9);
+    draw(formatPLN(it.unitPriceGross), col.unitPrice, y, 9);
+    const vatLabel =
+      it.vatRate === "D"
+        ? "ZW"
+        : `${Math.round((VAT_RATES[it.vatRate] ?? 0) * 100)}%`;
+    draw(vatLabel, col.vatRate, y, 9);
+    draw(formatPLN(it.netAmount), col.net, y, 9);
+    draw(formatPLN(it.vatAmount), col.vatAmt, y, 9);
+    draw(formatPLN(it.grossAmount), col.gross, y, 9);
+  }
+
+  // --- Totals ---
+  y -= 6;
+  hline(y);
+  y -= 16;
+  draw("RAZEM:", col.vatRate - 50, y, 10);
+  draw(formatPLN(params.totalNet), col.net, y, 10);
+  draw(formatPLN(params.totalVat), col.vatAmt, y, 10);
+  draw(formatPLN(params.totalGross), col.gross, y, 10);
+  y -= 4;
+  hline(y);
+
+  // --- Payment method ---
+  y -= 18;
+  draw(
+    `Forma platnosci: ${paymentMethodPL(params.paymentMethod)}`,
+    margin,
+    y,
+    10,
+  );
+
+  // --- Fiscal receipt reference ---
+  if (params.fiscalReceiptId) {
+    y -= 14;
+    draw(
+      `Nr paragonu fiskalnego: ${params.fiscalReceiptId}`,
+      margin,
+      y,
+      9,
+      rgb(0.4, 0.4, 0.4),
+    );
+  }
+
+  // --- Footer ---
+  y -= 30;
+  draw(
+    "Dokument wystawiony zgodnie z ustawa o podatku od towarow i uslug.",
+    margin,
+    y,
+    7,
+    rgb(0.6, 0.6, 0.6),
+  );
+
+  return pdfDoc.save();
+}
+
+// ---------------------------------------------------------------------------
+// Internal: fetch org name from Convex native DB (organizations stay in Convex)
+// ---------------------------------------------------------------------------
+
+export const _getOrgName = internalQuery({
+  args: { organizationId: v.id("organizations") },
+  handler: async (ctx, args) => {
+    const org = await ctx.db.get(args.organizationId);
+    return (org as Record<string, unknown> | null)?.name as string | undefined;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Internal mutation: store PDF in Convex file storage + insert receipt row
+// ---------------------------------------------------------------------------
+
+export const _storePdfAndCreateReceipt = internalMutation({
+  args: {
+    pdfData: v.bytes(),
+    organizationId: v.id("organizations"),
+    paymentId: v.string(),
+    appointmentId: v.optional(v.string()),
+    patientId: v.optional(v.string()),
+    receiptNumber: v.string(),
+    issuedAt: v.number(),
+    organizationName: v.string(),
+    organizationNip: v.optional(v.string()),
+    organizationAddress: v.optional(v.string()),
+    totalNet: v.number(),
+    totalVat: v.number(),
+    totalGross: v.number(),
+    paymentMethod: v.string(),
+    itemsJson: v.string(),
+    fiscalReceiptId: v.optional(v.string()),
+    createdBy: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const blob = new Blob([args.pdfData], { type: "application/pdf" });
+    const storageId = await ctx.storage.store(blob);
+    const pdfUrl = await ctx.storage.getUrl(storageId);
+
+    const db = createSupabaseDb();
+    const now = Date.now();
+    const receiptId = await db.insert("gabinetReceipts", {
+      organizationId: args.organizationId as string,
+      paymentId: args.paymentId,
+      appointmentId: args.appointmentId ?? null,
+      patientId: args.patientId ?? null,
+      receiptNumber: args.receiptNumber,
+      issuedAt: args.issuedAt,
+      organizationName: args.organizationName,
+      organizationNip: args.organizationNip ?? null,
+      organizationAddress: args.organizationAddress ?? null,
+      totalNet: args.totalNet,
+      totalVat: args.totalVat,
+      totalGross: args.totalGross,
+      paymentMethod: args.paymentMethod,
+      itemsJson: args.itemsJson,
+      fiscalReceiptId: args.fiscalReceiptId ?? null,
+      pdfStorageId: storageId,
+      pdfUrl: pdfUrl ?? null,
+      createdBy: args.createdBy as string,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return { receiptId, pdfUrl: pdfUrl ?? "" };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Internal mutation: write audit log entry
+// ---------------------------------------------------------------------------
+
+export const _auditReceiptGenerated = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    userId: v.id("users"),
+    receiptId: v.string(),
+    paymentId: v.string(),
+    receiptNumber: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: args.userId,
+      action: "receipt_pdf_generated",
+      entityType: "payment",
+      entityId: args.paymentId,
+      details: JSON.stringify({
+        receiptId: args.receiptId,
+        receiptNumber: args.receiptNumber,
+      }),
+    });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Public action: generate (or retrieve) PDF receipt for a payment
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a PDF receipt for a completed gabinet payment and stores it in
+ * Convex file storage. Creates a `gabinet_receipts` row with all data required
+ * by Polish fiscal law so the document can be verified or re-downloaded later.
+ *
+ * Idempotent: if a receipt already exists for `paymentId` the existing record
+ * is returned without re-generating the PDF.
+ *
+ * Requires gabinet_receipts.create permission.
+ */
+export const generatePdfReceipt = action({
+  args: {
+    organizationId: v.id("organizations"),
+    paymentId: v.string(),
+    /** NIP (tax ID) of the issuing organisation. Printed on the PDF. */
+    organizationNip: v.optional(v.string()),
+    /** Single-line address of the issuing organisation. */
+    organizationAddress: v.optional(v.string()),
+    /**
+     * Line items with VAT breakdown. If omitted a single "Usługa medyczna"
+     * line is generated for the full payment amount at rate D (ZW exempt).
+     */
+    items: v.optional(
+      v.array(
+        v.object({
+          name: v.string(),
+          pkwiu: v.optional(v.string()),
+          quantity: v.number(),
+          unitPriceGross: v.number(),
+          vatRate: v.union(
+            v.literal("A"),
+            v.literal("B"),
+            v.literal("C"),
+            v.literal("D"),
+          ),
+        }),
+      ),
+    ),
+  },
+  handler: async (ctx, args) => {
+    // --- Auth + permission ---
+    const authResult = await ctx.runQuery(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    const perm = await ctx.runQuery(
+      internal._helpers.authAction.checkPermission,
+      {
+        organizationId: args.organizationId,
+        feature: "gabinet_receipts",
+        action: "create",
+      },
+    );
+    if (!perm.allowed) {
+      throw new Error("Not authorised to generate PDF receipts");
+    }
+
+    // --- Load payment ---
+    const db = createSupabaseDb();
+    const payment = await db.get("payments", args.paymentId);
+    if (
+      !payment ||
+      String(payment.organizationId) !== String(args.organizationId)
+    ) {
+      throw new Error("Payment not found");
+    }
+    if (payment.status !== "completed") {
+      throw new Error(
+        "PDF receipt can only be generated for a completed payment",
+      );
+    }
+
+    // --- Idempotency: return existing receipt without regenerating ---
+    const client = db.raw();
+    const { data: existing } = await client
+      .from("gabinet_receipts")
+      .select("id, pdf_url, receipt_number")
+      .eq("payment_id", args.paymentId)
+      .limit(1)
+      .maybeSingle();
+
+    if (existing) {
+      return {
+        receiptId: existing.id as string,
+        pdfUrl: (existing.pdf_url as string | null) ?? "",
+        receiptNumber: existing.receipt_number as string,
+      };
+    }
+
+    // --- Org name from Convex native DB ---
+    const orgName =
+      (await ctx.runQuery(internal.gabinet.receipts._getOrgName, {
+        organizationId: args.organizationId,
+      })) ?? "Placówka medyczna";
+
+    // --- Build line items ---
+    const now = Date.now();
+    const year = new Date(now).getFullYear();
+
+    const lineItems: ReceiptLineItem[] = args.items
+      ? args.items.map((it) =>
+          computeLineItem(
+            it.name,
+            it.quantity,
+            it.unitPriceGross,
+            it.vatRate,
+            it.pkwiu,
+          ),
+        )
+      : [
+          computeLineItem(
+            "Usluga medyczna",
+            1,
+            payment.amount as number,
+            "D",
+            DEFAULT_PKWIU,
+          ),
+        ];
+
+    const totalGross =
+      Math.round(lineItems.reduce((s, i) => s + i.grossAmount, 0) * 100) / 100;
+    const totalNet =
+      Math.round(lineItems.reduce((s, i) => s + i.netAmount, 0) * 100) / 100;
+    const totalVat =
+      Math.round(lineItems.reduce((s, i) => s + i.vatAmount, 0) * 100) / 100;
+
+    // --- Sequential receipt number ---
+    const receiptNumber = await nextReceiptNumber(
+      String(args.organizationId),
+      year,
+    );
+
+    // --- Generate PDF bytes ---
+    const pdfBytes = await buildReceiptPdf({
+      receiptNumber,
+      issuedAt: now,
+      organizationName: orgName,
+      organizationNip: args.organizationNip,
+      organizationAddress: args.organizationAddress,
+      items: lineItems,
+      totalNet,
+      totalVat,
+      totalGross,
+      paymentMethod: payment.paymentMethod as string,
+      fiscalReceiptId:
+        (payment.fiscalReceiptId as string | null | undefined) ?? undefined,
+    });
+
+    // --- Store PDF + persist receipt record ---
+    const { receiptId, pdfUrl } = await ctx.runMutation(
+      internal.gabinet.receipts._storePdfAndCreateReceipt,
+      {
+        pdfData: pdfBytes.buffer as ArrayBuffer,
+        organizationId: args.organizationId,
+        paymentId: args.paymentId,
+        appointmentId:
+          (payment.appointmentId as string | null | undefined) ?? undefined,
+        patientId:
+          (payment.patientId as string | null | undefined) ?? undefined,
+        receiptNumber,
+        issuedAt: now,
+        organizationName: orgName,
+        organizationNip: args.organizationNip,
+        organizationAddress: args.organizationAddress,
+        totalNet,
+        totalVat,
+        totalGross,
+        paymentMethod: payment.paymentMethod as string,
+        itemsJson: JSON.stringify(lineItems),
+        fiscalReceiptId:
+          (payment.fiscalReceiptId as string | null | undefined) ?? undefined,
+        createdBy: authResult.userId,
+      },
+    );
+
+    // --- Audit log (best-effort) ---
+    try {
+      await ctx.runMutation(internal.gabinet.receipts._auditReceiptGenerated, {
+        organizationId: args.organizationId,
+        userId: authResult.userId,
+        receiptId,
+        paymentId: args.paymentId,
+        receiptNumber,
+      });
+    } catch {
+      // non-critical
+    }
+
+    return { receiptId, pdfUrl, receiptNumber };
+  },
+});

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -1004,5 +1004,39 @@ export function createGabinetTables({
     .index("by_equipment", ["equipmentId"])
     .index("by_org", ["organizationId"])
     .index("by_orgAndTime", ["organizationId", "transferredAt"]),
+
+  // --- Gabinet: PDF Receipts (issue #3739) ---
+
+  gabinetReceipts: defineTable({
+    organizationId: v.id("organizations"),
+    paymentId: v.string(),
+    appointmentId: v.optional(v.string()),
+    patientId: v.optional(v.string()),
+    receiptNumber: v.string(), // e.g. REC/2026/00001
+    issuedAt: v.number(),
+    // Org data captured at issuance time so the receipt can be reproduced later.
+    organizationName: v.string(),
+    organizationNip: v.optional(v.string()),
+    organizationAddress: v.optional(v.string()),
+    // Monetary totals in PLN
+    totalNet: v.number(),
+    totalVat: v.number(),
+    totalGross: v.number(),
+    paymentMethod: v.string(),
+    // Line items serialised as JSON at issuance time:
+    // [{ name, pkwiu, quantity, unitPriceGross, vatRate, netAmount, vatAmount, grossAmount }]
+    itemsJson: v.string(),
+    // Fiscal reference: copied from payment.fiscalReceiptId when available.
+    fiscalReceiptId: v.optional(v.string()),
+    // PDF stored in Convex file storage.
+    pdfStorageId: v.optional(v.id("_storage")),
+    pdfUrl: v.optional(v.string()),
+    createdBy: v.id("users"),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_org", ["organizationId"])
+    .index("by_payment", ["paymentId"])
+    .index("by_orgAndNumber", ["organizationId", "receiptNumber"]),
   };
 }

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "openai": "^6.46.0",
     "oslo": "^1.2.1",
     "papaparse": "^5.5.3",
+    "pdf-lib": "^1.17.1",
     "platejs": "^52.3.4",
     "primereact": "^11.0.0-alpha.1",
     "radix-ui": "^1.4.3",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -4062,6 +4062,15 @@
         "settings": "Settings",
         "dashboard": "Dashboard"
       }
+    },
+    "receipts": {
+      "download": "Download receipt",
+      "generating": "Generating...",
+      "noUrl": "Receipt PDF URL not available",
+      "title": "Receipt",
+      "receiptNumber": "Receipt number",
+      "issuedAt": "Issued at",
+      "totalGross": "Total (gross)"
     }
   },
   "customFields": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -4083,6 +4083,15 @@
         "settings": "Ustawienia",
         "dashboard": "Pulpit"
       }
+    },
+    "receipts": {
+      "download": "Pobierz paragon",
+      "generating": "Generowanie...",
+      "noUrl": "Brak URL paragonu PDF",
+      "title": "Paragon",
+      "receiptNumber": "Nr paragonu",
+      "issuedAt": "Data wystawienia",
+      "totalGross": "Kwota brutto"
     }
   },
   "customFields": {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -249,6 +249,7 @@ function AppointmentDetail() {
   const { allowed: canCreatePayment } = usePermission("gabinet_payments", "create");
   const { allowed: canEditPayment } = usePermission("gabinet_payments", "edit");
   const { allowed: canRefundPayment } = usePermission("gabinet_payments", "refund");
+  const { allowed: canGenerateReceipt } = usePermission("gabinet_receipts", "create");
 
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [cancelReason, setCancelReason] = useState("");
@@ -327,6 +328,8 @@ function AppointmentDetail() {
   // Payment actions (Supabase-primary)
   const markPaymentPaid = useAction(api.payments.markPaid);
   const refundPayment = useAction(api.payments.refund);
+  const generatePdfReceipt = useAction(api.gabinet.receipts.generatePdfReceipt);
+  const [generatingReceiptFor, setGeneratingReceiptFor] = useState<string | null>(null);
 
   // Package usage mutation
   const usePackageTreatmentsBatch = useAction(
@@ -1051,6 +1054,26 @@ function AppointmentDetail() {
     } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
+    }
+  };
+
+  const handleDownloadReceipt = async (paymentId: string) => {
+    setGeneratingReceiptFor(paymentId);
+    try {
+      const result = await generatePdfReceipt({
+        organizationId,
+        paymentId,
+      });
+      if (result.pdfUrl) {
+        window.open(result.pdfUrl, "_blank", "noopener,noreferrer");
+      } else {
+        toast.error(t("gabinet.receipts.noUrl"));
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : t("common.error");
+      toast.error(msg);
+    } finally {
+      setGeneratingReceiptFor(null);
     }
   };
 
@@ -1868,6 +1891,20 @@ function AppointmentDetail() {
                                   }
                                 >
                                   {t("gabinet.payments.refund")}
+                                </Button>
+                              )}
+                              {payment.status === "completed" && canGenerateReceipt && (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  disabled={generatingReceiptFor === (payment._id as string)}
+                                  onClick={() =>
+                                    handleDownloadReceipt(payment._id as string)
+                                  }
+                                >
+                                  {generatingReceiptFor === (payment._id as string)
+                                    ? t("gabinet.receipts.generating")
+                                    : t("gabinet.receipts.download")}
                                 </Button>
                               )}
                             </td>

--- a/supabase/migrations/00083_gabinet_receipts.sql
+++ b/supabase/migrations/00083_gabinet_receipts.sql
@@ -1,0 +1,60 @@
+-- gabinet_receipts: tracks PDF receipts issued for gabinet payments (issue #3739).
+--
+-- Each row represents one receipt document issued to a patient. It captures all
+-- the data required by Polish fiscal law at the time of issuance so that the PDF
+-- can be regenerated later (or verified) without joining back to other tables.
+--
+-- receipt_number: human-readable sequential number in the format
+--   REC/YYYY/NNNNN (e.g. REC/2026/00001). Unique per organization.
+--
+-- items_json: JSON array of line items serialised at issuance time:
+--   [{ name, pkwiu, quantity, unitPriceGross, vatRate, netAmount, vatAmount, grossAmount }]
+--
+-- pdf_storage_id: Convex _storage ID of the PDF file. Null when the PDF has
+--   not yet been stored server-side (generated client-side on demand).
+--
+-- pdf_url: pre-signed or permanent URL derived from pdf_storage_id. Kept as a
+--   convenience so clients don't need to call Convex just to download the file.
+--
+-- fiscal_receipt_id: copied from payments.fiscal_receipt_id when the payment
+--   has already been fiscalised — included on the printed PDF for reference.
+
+CREATE TABLE gabinet_receipts (
+  id                  TEXT PRIMARY KEY,
+  organization_id     TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  payment_id          TEXT NOT NULL REFERENCES payments(id) ON DELETE CASCADE,
+  appointment_id      TEXT REFERENCES gabinet_appointments(id) ON DELETE SET NULL,
+  patient_id          TEXT REFERENCES gabinet_patients(id) ON DELETE SET NULL,
+  receipt_number      TEXT NOT NULL,
+  issued_at           BIGINT NOT NULL,
+  -- Org data captured at issuance time
+  organization_name   TEXT NOT NULL,
+  organization_nip    TEXT,
+  organization_address TEXT,
+  -- Amounts in PLN (numeric to avoid floating-point drift)
+  total_net           NUMERIC(10, 2) NOT NULL,
+  total_vat           NUMERIC(10, 2) NOT NULL,
+  total_gross         NUMERIC(10, 2) NOT NULL,
+  payment_method      TEXT NOT NULL,
+  -- Line items (JSON)
+  items_json          TEXT NOT NULL,
+  -- Fiscal reference (copied from payment when available)
+  fiscal_receipt_id   TEXT,
+  -- PDF storage
+  pdf_storage_id      TEXT,
+  pdf_url             TEXT,
+  -- Metadata
+  created_by          TEXT NOT NULL REFERENCES users(id),
+  created_at          BIGINT NOT NULL,
+  updated_at          BIGINT NOT NULL,
+  UNIQUE (organization_id, receipt_number)
+);
+
+CREATE INDEX gabinet_receipts_org_idx        ON gabinet_receipts (organization_id);
+CREATE INDEX gabinet_receipts_payment_idx    ON gabinet_receipts (payment_id);
+CREATE INDEX gabinet_receipts_patient_idx    ON gabinet_receipts (patient_id);
+CREATE INDEX gabinet_receipts_appointment_idx ON gabinet_receipts (appointment_id);
+
+ALTER TABLE gabinet_receipts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY org_isolation ON gabinet_receipts
+  USING (organization_id = current_setting('app.current_org_id', true));


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3739.

Closes #3739

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3fe1565 feat(gabinet): generate PDF receipt compliant with Polish fiscal law (closes #3739)

### Files changed

```
 convex/_helpers/supabaseDb.ts                      |   1 +
 convex/gabinet/receipts.ts                         | 584 +++++++++++++++++++++
 convex/schema/gabinet.ts                           |  34 ++
 package.json                                       |   1 +
 public/locales/en/translation.json                 |  11 +-
 public/locales/pl/translation.json                 |  11 +-
 ...ut.gabinet.appointments.$appointmentId.lazy.tsx |  37 ++
 supabase/migrations/00083_gabinet_receipts.sql     |  60 +++
 8 files changed, 737 insertions(+), 2 deletions(-)
```