### PR TITLE
Add `usePermission("gabinet_appointments", "delete")` guard to the calendar dele

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -93,6 +93,7 @@ import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useDraggableDialog } from "@/hooks/use-draggable-dialog";
 import { useSidebarActions } from "@/components/layout/sidebar-context";
+import { usePermission } from "@/hooks/use-permission";
 import {
   useSupabaseGabinetFirstAppointmentIdsByPatient,
   useSupabaseGabinetAppointmentPackagePositions,
@@ -219,6 +220,7 @@ export function AppointmentPreviewContent({
 }: AppointmentPreviewContentProps) {
   const { t, i18n } = useTranslation();
   const { organizationId } = useOrganization();
+  const { allowed: canDelete } = usePermission("gabinet_appointments", "delete");
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
@@ -495,7 +497,10 @@ export function AppointmentPreviewContent({
   const isMultiTreatment = junctionTreatments.length > 1;
   const initialTreatmentId = detail.treatments?.[0]?.treatmentId ?? "";
   const initialVariantId = "";
-  const availableTransitions = VALID_TRANSITIONS[initialStatus] ?? [];
+  const allTransitions = VALID_TRANSITIONS[initialStatus] ?? [];
+  const availableTransitions = canDelete
+    ? allTransitions
+    : allTransitions.filter((s) => s !== "cancelled");
   const patientFullName = patient
     ? `${patient.firstName ?? ""} ${patient.lastName ?? ""}`.trim()
     : "-";


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3751.

Closes #3751

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f15a39c feat(gabinet): add usePermission("gabinet_appointments","delete") guard to calendar cancel action (closes #3751)

### Files changed

```
 src/components/gabinet/calendar/appointment-preview-content.tsx | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)
```