### PR TITLE
Add `usePermission("gabinet_appointments", "delete")` guard to the appointment d

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -246,6 +246,7 @@ function AppointmentDetail() {
   const navigate = useNavigate();
   const { t, i18n } = useTranslation();
   const { allowed: canEdit } = usePermission("gabinet_appointments", "edit");
+  const { allowed: canDelete } = usePermission("gabinet_appointments", "delete");
   const { allowed: canCreatePayment } = usePermission("gabinet_payments", "create");
   const { allowed: canEditPayment } = usePermission("gabinet_payments", "edit");
   const { allowed: canRefundPayment } = usePermission("gabinet_payments", "refund");
@@ -1105,7 +1106,10 @@ function AppointmentDetail() {
     );
   const outstanding = treatmentPrice - totalPaid;
 
-  const availableTransitions = VALID_TRANSITIONS[appointment.status] ?? [];
+  const allTransitions = VALID_TRANSITIONS[appointment.status] ?? [];
+  const availableTransitions = canDelete
+    ? allTransitions
+    : allTransitions.filter((s) => s !== "cancelled");
   const latestOutboundSms = smsEvents.find(
     (event: Record<string, unknown>) =>
       event.direction === "outbound" &&


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3757.

Closes #3757

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 467c453 feat(gabinet): add usePermission("gabinet_appointments","delete") guard to appointment detail status dropdown (closes #3757)

### Files changed

```
 .../dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx  | 6 +++++-
 1 file changed, 5 insertions(+), 1 deletion(-)
```