### PR TITLE
Schemat Convex: tabela `gabinet_receipts` i sekwencja numerów paragonów

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -94,6 +94,7 @@ const TABLE_MAP: Record<string, string> = {
   organizations: "organizations",
   teamMemberships: "team_memberships",
   gabinetReceipts: "gabinet_receipts",
+  gabinetReceiptSequences: "gabinet_receipt_sequences",
 };
 
 function toSnakeCase(str: string): string {

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -1012,8 +1012,11 @@ export function createGabinetTables({
     paymentId: v.string(),
     appointmentId: v.optional(v.string()),
     patientId: v.optional(v.string()),
-    receiptNumber: v.string(), // e.g. REC/2026/00001
+    locationId: v.optional(v.id("gabinetLocations")),
+    receiptNumber: v.string(), // e.g. 2026/001/LOC
     issuedAt: v.number(),
+    // Receipt lifecycle: issued (default) | void
+    status: v.union(v.literal("issued"), v.literal("void")),
     // Org data captured at issuance time so the receipt can be reproduced later.
     organizationName: v.string(),
     organizationNip: v.optional(v.string()),
@@ -1037,6 +1040,22 @@ export function createGabinetTables({
   })
     .index("by_org", ["organizationId"])
     .index("by_payment", ["paymentId"])
-    .index("by_orgAndNumber", ["organizationId", "receiptNumber"]),
+    .index("by_orgAndNumber", ["organizationId", "receiptNumber"])
+    .index("by_orgAndLocation", ["organizationId", "locationId"]),
+
+  // --- Gabinet: Receipt Sequences (issue #3736) ---
+  // Atomic per-location-per-year counter for generating legally-compliant
+  // receipt numbers in the format YYYY/NNN/LOC.
+  // lastNumber is incremented inside a Convex mutation (serialised by Convex's
+  // OCC) so no two receipts can get the same number within an org+location+year.
+  gabinetReceiptSequences: defineTable({
+    organizationId: v.id("organizations"),
+    locationId: v.optional(v.id("gabinetLocations")),
+    year: v.number(),
+    lastNumber: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_org", ["organizationId"])
+    .index("by_orgLocationYear", ["organizationId", "locationId", "year"]),
   };
 }

--- a/supabase/migrations/00084_gabinet_receipt_sequences.sql
+++ b/supabase/migrations/00084_gabinet_receipt_sequences.sql
@@ -1,0 +1,57 @@
+-- gabinet_receipt_sequences: atomic per-location-per-year counter for
+-- generating legally-compliant receipt numbers (issue #3736).
+--
+-- Receipt numbers follow the format YYYY/NNN/LOC where:
+--   YYYY  — calendar year (e.g. 2026)
+--   NNN   — zero-padded sequential number within the year and location
+--   LOC   — location code (derived from gabinetLocations at call time)
+--
+-- The lastNumber column is incremented atomically via
+--   UPDATE gabinet_receipt_sequences SET last_number = last_number + 1 ...
+--   RETURNING last_number
+-- which avoids any race condition under concurrent writes. The Convex
+-- mutation layer also benefits from OCC, but the Postgres UPDATE+RETURNING
+-- approach is the canonical guarantee.
+--
+-- location_id is nullable so orgs without multi-location setup can have a
+-- single sequence (location_id IS NULL) per year.
+
+CREATE TABLE gabinet_receipt_sequences (
+  id              TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  location_id     TEXT REFERENCES gabinet_locations(id) ON DELETE SET NULL,
+  year            INTEGER NOT NULL,
+  last_number     INTEGER NOT NULL DEFAULT 0,
+  updated_at      BIGINT NOT NULL,
+  UNIQUE (organization_id, location_id, year)
+);
+
+CREATE INDEX gabinet_receipt_sequences_org_idx
+  ON gabinet_receipt_sequences (organization_id);
+
+ALTER TABLE gabinet_receipt_sequences ENABLE ROW LEVEL SECURITY;
+CREATE POLICY org_isolation ON gabinet_receipt_sequences
+  USING (organization_id = current_setting('app.current_org_id', true));
+
+-- Add locationId and status columns to gabinet_receipts (issue #3736).
+--
+-- location_id: links the receipt to the gabinet location where the service
+--   was rendered. Optional so existing rows (created before this migration)
+--   remain valid.
+--
+-- status: lifecycle of the receipt document.
+--   issued — default state for newly created receipts.
+--   void   — receipt has been voided (edge case; Polish fiscal law limits this).
+
+ALTER TABLE gabinet_receipts
+  ADD COLUMN IF NOT EXISTS location_id TEXT REFERENCES gabinet_locations(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS status      TEXT NOT NULL DEFAULT 'issued';
+
+ALTER TABLE gabinet_receipts
+  DROP CONSTRAINT IF EXISTS gabinet_receipts_status_check;
+ALTER TABLE gabinet_receipts
+  ADD CONSTRAINT gabinet_receipts_status_check
+  CHECK (status IN ('issued', 'void'));
+
+CREATE INDEX IF NOT EXISTS gabinet_receipts_location_idx
+  ON gabinet_receipts (organization_id, location_id);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3736.

Closes #3736

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- baa4718 feat(gabinet): add gabinetReceiptSequences table and extend gabinetReceipts schema (closes #3736)

### Files changed

```
 convex/_helpers/supabaseDb.ts                      |  1 +
 convex/schema/gabinet.ts                           | 23 ++++++++-
 .../migrations/00084_gabinet_receipt_sequences.sql | 57 ++++++++++++++++++++++
 3 files changed, 79 insertions(+), 2 deletions(-)
```