### PR TITLE
Use gabinet_receipt_sequences for atomic receipt numbering

### DIFF
--- a/convex/gabinet/receipts.ts
+++ b/convex/gabinet/receipts.ts
@@ -82,7 +82,12 @@ function paymentMethodPL(method: string): string {
 
 /**
  * Returns the next sequential receipt number for the org in the given year.
- * Format: REC/YYYY/NNNNN (e.g. REC/2026/00001).
+ * Format: PREFIX/YYYY/NNNNN (e.g. REC/2026/00001, KOR/2026/00001).
+ *
+ * Delegates to the `next_gabinet_receipt_number` Postgres function (migration
+ * 00085) which uses INSERT ... ON CONFLICT DO UPDATE RETURNING for an atomic
+ * counter increment — no read-modify-write race condition under concurrent
+ * writes (fixes #3766).
  */
 async function nextReceiptNumber(
   orgId: string,
@@ -91,22 +96,13 @@ async function nextReceiptNumber(
 ): Promise<string> {
   const db = createSupabaseDb();
   const client = db.raw();
-  const fullPrefix = `${prefix}/${year}/`;
-  const { data } = await client
-    .from("gabinet_receipts")
-    .select("receipt_number")
-    .eq("organization_id", orgId)
-    .like("receipt_number", `${fullPrefix}%`)
-    .order("receipt_number", { ascending: false })
-    .limit(1);
-
-  let next = 1;
-  if (data && data.length > 0) {
-    const last = (data[0].receipt_number as string).slice(fullPrefix.length);
-    const parsed = parseInt(last, 10);
-    if (!isNaN(parsed)) next = parsed + 1;
-  }
-  return `${fullPrefix}${String(next).padStart(5, "0")}`;
+  const { data, error } = await client.rpc("next_gabinet_receipt_number", {
+    p_org_id: orgId,
+    p_year: year,
+    p_prefix: prefix,
+  });
+  if (error) throw new Error(`nextReceiptNumber: ${error.message}`);
+  return data as string;
 }
 
 // ---------------------------------------------------------------------------

--- a/supabase/migrations/00085_gabinet_receipt_sequence_fn.sql
+++ b/supabase/migrations/00085_gabinet_receipt_sequence_fn.sql
@@ -1,0 +1,37 @@
+-- Partial unique index so that INSERT ... ON CONFLICT works for the
+-- location_id IS NULL case (standard UNIQUE constraints treat each NULL as
+-- distinct, so the existing UNIQUE (organization_id, location_id, year)
+-- constraint cannot deduplicate null-location rows in an atomic upsert).
+CREATE UNIQUE INDEX IF NOT EXISTS gabinet_receipt_sequences_org_year_noloc_idx
+  ON gabinet_receipt_sequences (organization_id, year)
+  WHERE location_id IS NULL;
+
+-- Atomically returns the next formatted receipt number for the given org,
+-- year, and prefix (default "REC").  Uses INSERT ... ON CONFLICT DO UPDATE
+-- RETURNING so the counter is incremented in a single round-trip without any
+-- application-level locking or read-modify-write race condition.
+CREATE OR REPLACE FUNCTION next_gabinet_receipt_number(
+  p_org_id TEXT,
+  p_year   INT,
+  p_prefix TEXT DEFAULT 'REC'
+) RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_next BIGINT;
+  v_ts   BIGINT := (EXTRACT(EPOCH FROM NOW()) * 1000)::BIGINT;
+BEGIN
+  INSERT INTO gabinet_receipt_sequences
+    (id, organization_id, location_id, year, last_number, updated_at)
+  VALUES
+    (gen_random_uuid()::TEXT, p_org_id, NULL, p_year, 1, v_ts)
+  ON CONFLICT (organization_id, year) WHERE location_id IS NULL
+  DO UPDATE SET
+    last_number = gabinet_receipt_sequences.last_number + 1,
+    updated_at  = v_ts
+  RETURNING last_number INTO v_next;
+
+  RETURN p_prefix || '/' || p_year::TEXT || '/' || LPAD(v_next::TEXT, 5, '0');
+END;
+$$;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3766.

Closes #3766

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- bac7b9d fix(gabinet): use atomic sequence counter for receipt numbering (closes #3766)

### Files changed

```
 convex/gabinet/receipts.ts                         | 30 ++++++++----------
 .../00085_gabinet_receipt_sequence_fn.sql          | 37 ++++++++++++++++++++++
 2 files changed, 50 insertions(+), 17 deletions(-)
```