### PR TITLE
Split payment receipts should consolidate into one document

### DIFF
--- a/convex/gabinet/receipts.ts
+++ b/convex/gabinet/receipts.ts
@@ -68,6 +68,13 @@ function formatDate(ms: number): string {
 }
 
 function paymentMethodPL(method: string): string {
+  // Handle compound split-payment methods like "cash+card".
+  if (method.includes("+")) {
+    return method
+      .split("+")
+      .map((m) => paymentMethodPL(m.trim()))
+      .join(" + ");
+  }
   const map: Record<string, string> = {
     cash: "Gotowka",
     card: "Karta platnicza",
@@ -693,6 +700,93 @@ export const _createReceiptRowForPayment = internalMutation({
       paymentMethod: payment.paymentMethod as string,
       itemsJson: JSON.stringify([lineItem]),
       fiscalReceiptId: (payment.fiscalReceiptId as string | null) ?? null,
+      createdBy: String(args.createdBy),
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Internal mutation: create ONE consolidated receipt for a split payment.
+//
+// Polish fiscal law requires a single receipt per transaction, regardless of
+// how many payment methods are used. `splitMarkPaid` creates two payment rows
+// (one per method) but must produce only one receipt document (issue #3768).
+//
+// The receipt is linked to the primary (original) payment row and records the
+// combined payment method as "firstMethod+secondMethod" (e.g. "cash+card").
+// The secondary payment row never gets its own receipt row.
+// ---------------------------------------------------------------------------
+
+export const _createSplitReceiptRow = internalMutation({
+  args: {
+    primaryPaymentId: v.string(),
+    organizationId: v.id("organizations"),
+    createdBy: v.id("users"),
+    firstMethod: v.string(),
+    firstAmount: v.number(),
+    secondMethod: v.string(),
+    secondAmount: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const db = createSupabaseDb();
+    const client = db.raw();
+
+    // Idempotency: skip if a receipt already exists for the primary payment.
+    const { data: existing } = await client
+      .from("gabinet_receipts")
+      .select("id")
+      .eq("payment_id", args.primaryPaymentId)
+      .limit(1)
+      .maybeSingle();
+
+    if (existing) return;
+
+    const primaryPayment = await db.get("payments", args.primaryPaymentId);
+    if (!primaryPayment) return;
+
+    const orgDoc = await ctx.db.get(args.organizationId);
+    const orgName =
+      (orgDoc as Record<string, unknown> | null)?.name as string ??
+      "Placówka medyczna";
+
+    const now = Date.now();
+    const year = new Date(now).getFullYear();
+
+    // Full transaction amount is the sum of both legs.
+    const totalAmount =
+      Math.round((args.firstAmount + args.secondAmount) * 100) / 100;
+    const lineItem = computeLineItem(
+      "Usluga medyczna",
+      1,
+      totalAmount,
+      "D",
+      DEFAULT_PKWIU,
+    );
+    const receiptNumber = await nextReceiptNumber(
+      String(args.organizationId),
+      year,
+    );
+
+    // Combined method string (e.g. "cash+card") signals a split transaction.
+    // paymentMethodPL() in the PDF builder handles the "+" separator.
+    const paymentMethod = `${args.firstMethod}+${args.secondMethod}`;
+
+    await db.insert("gabinetReceipts", {
+      organizationId: String(args.organizationId),
+      paymentId: args.primaryPaymentId,
+      appointmentId: (primaryPayment.appointmentId as string | null) ?? null,
+      patientId: (primaryPayment.patientId as string | null) ?? null,
+      receiptNumber,
+      issuedAt: now,
+      organizationName: orgName,
+      totalNet: lineItem.netAmount,
+      totalVat: lineItem.vatAmount,
+      totalGross: lineItem.grossAmount,
+      paymentMethod,
+      itemsJson: JSON.stringify([lineItem]),
+      fiscalReceiptId: null,
       createdBy: String(args.createdBy),
       createdAt: now,
       updatedAt: now,

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -645,17 +645,18 @@ export const splitMarkPaid = action({
       // side effects are best-effort
     }
 
-    // Schedule receipts for both split payment rows (issue #3737).
+    // Polish fiscal law requires one receipt per transaction, regardless of the
+    // number of payment methods used. Schedule a single consolidated receipt
+    // for both split legs instead of two separate ones (issue #3768).
     try {
-      await ctx.runMutation(internal.payments._scheduleReceiptForPayment, {
-        paymentId: args.paymentId,
+      await ctx.runMutation(internal.payments._scheduleSplitReceipt, {
+        primaryPaymentId: args.paymentId,
         organizationId: args.organizationId,
         userId: authResult.userId,
-      });
-      await ctx.runMutation(internal.payments._scheduleReceiptForPayment, {
-        paymentId: newPaymentId,
-        organizationId: args.organizationId,
-        userId: authResult.userId,
+        firstMethod: args.firstMethod,
+        firstAmount: args.firstAmount,
+        secondMethod: args.secondMethod,
+        secondAmount: args.secondAmount,
       });
     } catch {
       // best-effort
@@ -747,6 +748,37 @@ export const _scheduleReceiptForPayment = internalMutation({
         organizationId: args.organizationId,
         createdBy: args.userId,
         isRefund: args.isRefund,
+      },
+    );
+  },
+});
+
+/**
+ * Schedules _createSplitReceiptRow so that a split payment produces exactly
+ * one consolidated receipt document (issue #3768).
+ */
+export const _scheduleSplitReceipt = internalMutation({
+  args: {
+    primaryPaymentId: v.string(),
+    organizationId: v.id("organizations"),
+    userId: v.id("users"),
+    firstMethod: paymentMethodValidator,
+    firstAmount: v.number(),
+    secondMethod: paymentMethodValidator,
+    secondAmount: v.number(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.gabinet.receipts._createSplitReceiptRow,
+      {
+        primaryPaymentId: args.primaryPaymentId,
+        organizationId: args.organizationId,
+        createdBy: args.userId,
+        firstMethod: args.firstMethod,
+        firstAmount: args.firstAmount,
+        secondMethod: args.secondMethod,
+        secondAmount: args.secondAmount,
       },
     );
   },

--- a/tests/convex/_supabase_inmemory.ts
+++ b/tests/convex/_supabase_inmemory.ts
@@ -33,6 +33,7 @@ function getTable(name: string): Map<string, Row> {
 
 export function resetInMemoryStore() {
   inMemoryStore.clear();
+  receiptSequenceCounters.clear();
 }
 
 function withConvexId<T extends Row>(row: T): T {
@@ -154,10 +155,34 @@ function convertKeysToSnake(row: Row): Record<string, unknown> {
  * Returns `{ data, error }` matching PostgREST semantics. `data` contains
  * the matched rows (all fields, camelCase keys matching the in-memory store).
  */
+// In-memory counter for next_gabinet_receipt_number RPC (issue #3768).
+// Key: `${orgId}:${year}:${prefix}`, value: last sequence number issued.
+const receiptSequenceCounters = new Map<string, number>();
+
 function createInMemoryRawClient() {
   return {
     from(table: string) {
       return new InMemoryRawQuery(snakeToCamel(table));
+    },
+
+    // Minimal stub for the `next_gabinet_receipt_number` Postgres function
+    // used by receipts.ts. Returns a formatted receipt number using an
+    // in-memory counter so receipt-related mutations work under vitest.
+    async rpc(
+      fn: string,
+      params: Record<string, unknown>,
+    ): Promise<{ data: unknown; error: null | { message: string } }> {
+      if (fn === "next_gabinet_receipt_number") {
+        const orgId = String(params.p_org_id ?? "");
+        const year = Number(params.p_year ?? new Date().getFullYear());
+        const prefix = String(params.p_prefix ?? "REC");
+        const key = `${orgId}:${year}:${prefix}`;
+        const next = (receiptSequenceCounters.get(key) ?? 0) + 1;
+        receiptSequenceCounters.set(key, next);
+        const formatted = `${prefix}/${year}/${String(next).padStart(5, "0")}`;
+        return { data: formatted, error: null };
+      }
+      return { data: null, error: { message: `rpc stub: unknown function ${fn}` } };
     },
   };
 }

--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -471,6 +471,108 @@ describe("payments", () => {
     expect(result.page[0].paymentMethod).toBe("card");
   });
 
+  // Split payment (#3768) -------------------------------------------------------
+
+  describe("splitMarkPaid", () => {
+    test("creates two completed payment rows that sum to the original amount", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      const paymentId = await t.withIdentity(identity).action(
+        api.payments.create,
+        {
+          organizationId,
+          amount: 100,
+          currency: "PLN",
+          paymentMethod: "cash",
+          status: "pending",
+        },
+      );
+
+      const { firstPaymentId, secondPaymentId } = await t
+        .withIdentity(identity)
+        .action(api.payments.splitMarkPaid, {
+          organizationId,
+          paymentId,
+          firstMethod: "cash",
+          firstAmount: 60,
+          secondMethod: "card",
+          secondAmount: 40,
+        });
+
+      expect(firstPaymentId).toBe(paymentId);
+      expect(secondPaymentId).toBeTruthy();
+
+      const all = await t.withIdentity(identity).action(api.payments.list, {
+        organizationId,
+        paginationOpts: { numItems: 10, cursor: null },
+        status: "completed",
+      });
+
+      expect(all.page).toHaveLength(2);
+      const first = all.page.find((p: any) => p._id === firstPaymentId);
+      const second = all.page.find((p: any) => p._id === secondPaymentId);
+      expect(first?.amount).toBe(60);
+      expect(first?.paymentMethod).toBe("cash");
+      expect(second?.amount).toBe(40);
+      expect(second?.paymentMethod).toBe("card");
+    });
+
+    test("rejects split amounts that do not sum to original", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      const paymentId = await t.withIdentity(identity).action(
+        api.payments.create,
+        {
+          organizationId,
+          amount: 100,
+          currency: "PLN",
+          paymentMethod: "cash",
+          status: "pending",
+        },
+      );
+
+      await expect(
+        t.withIdentity(identity).action(api.payments.splitMarkPaid, {
+          organizationId,
+          paymentId,
+          firstMethod: "cash",
+          firstAmount: 60,
+          secondMethod: "card",
+          secondAmount: 30,
+        }),
+      ).rejects.toThrow("Split amounts must sum to 100");
+    });
+
+    test("rejects identical payment methods", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      const paymentId = await t.withIdentity(identity).action(
+        api.payments.create,
+        {
+          organizationId,
+          amount: 100,
+          currency: "PLN",
+          paymentMethod: "cash",
+          status: "pending",
+        },
+      );
+
+      await expect(
+        t.withIdentity(identity).action(api.payments.splitMarkPaid, {
+          organizationId,
+          paymentId,
+          firstMethod: "cash",
+          firstAmount: 50,
+          secondMethod: "cash",
+          secondAmount: 50,
+        }),
+      ).rejects.toThrow("Split methods must differ");
+    });
+  });
+
   // Inline approve/reject for refund authorization requests (#1722) ---------
 
   describe("refund authorization inline actions", () => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3768.

Closes #3768

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3dbb992 fix(gabinet): consolidate split payment into one receipt document (closes #3768)

### Files changed

```
 convex/gabinet/receipts.ts         |  94 ++++++++++++++++++++++++++++++++++
 convex/payments.ts                 |  48 ++++++++++++++---
 tests/convex/_supabase_inmemory.ts |  25 +++++++++
 tests/convex/payments.test.ts      | 102 +++++++++++++++++++++++++++++++++++++
 4 files changed, 261 insertions(+), 8 deletions(-)
```