### PR TITLE
Add refund path for split payments

### DIFF
--- a/convex/gabinet/receipts.ts
+++ b/convex/gabinet/receipts.ts
@@ -608,7 +608,7 @@ export const _createReceiptRowForPayment = internalMutation({
     // Skip if a receipt already exists for this payment (normal path).
     const { data: existing } = await client
       .from("gabinet_receipts")
-      .select("id, status")
+      .select("id, status, payment_method, total_gross")
       .eq("payment_id", args.paymentId)
       .order("issued_at", { ascending: false })
       .limit(1)
@@ -632,19 +632,40 @@ export const _createReceiptRowForPayment = internalMutation({
     const year = new Date(now).getFullYear();
 
     if (args.isRefund) {
-      // Void the most recent issued receipt for this payment.
-      if (existing && (existing as Record<string, unknown>).status === "issued") {
+      const existingRec = existing as Record<string, unknown> | null;
+
+      // A split consolidated receipt has payment_method "firstMethod+secondMethod"
+      // and total_gross covering both legs. Detect it so we can (a) use the
+      // correct full amount for the KOR document and (b) refund the secondary
+      // payment leg that has no receipt of its own.
+      const isSplitReceipt =
+        typeof existingRec?.payment_method === "string" &&
+        (existingRec.payment_method as string).includes("+");
+
+      // Void the most recent issued receipt for this payment. Guard is
+      // "not already void" so that rows without an explicit status (legacy
+      // receipts created before the status column existed) are also voided.
+      if (existingRec && existingRec.status !== "void") {
         await client
           .from("gabinet_receipts")
           .update({ status: "void", updated_at: now })
-          .eq("id", (existing as Record<string, unknown>).id as string);
+          .eq("id", existingRec.id as string);
       }
+
+      // For a consolidated split receipt total_gross covers both legs, so the
+      // KOR must reverse the full transaction amount, not just one leg's amount.
+      const korAmount = existingRec
+        ? Math.abs(Number(existingRec.total_gross))
+        : Math.abs(amount);
+      const korPaymentMethod = isSplitReceipt
+        ? (existingRec!.payment_method as string)
+        : (payment.paymentMethod as string);
 
       // Correction receipt with negative amounts (KOR/ prefix).
       const lineItem = computeLineItem(
         "Korekta: Usluga medyczna",
         1,
-        -Math.abs(amount),
+        -korAmount,
         "D",
         DEFAULT_PKWIU,
       );
@@ -664,13 +685,42 @@ export const _createReceiptRowForPayment = internalMutation({
         totalNet: lineItem.netAmount,
         totalVat: lineItem.vatAmount,
         totalGross: lineItem.grossAmount,
-        paymentMethod: payment.paymentMethod as string,
+        paymentMethod: korPaymentMethod,
         itemsJson: JSON.stringify([lineItem]),
         fiscalReceiptId: null,
         createdBy: String(args.createdBy),
         createdAt: now,
         updatedAt: now,
       });
+
+      // When voiding a consolidated split receipt, mark the secondary payment
+      // leg as refunded so both rows share consistent status. The secondary
+      // shares the same paidAt timestamp as the primary and always has
+      // "split:" in its notes. Narrow further by appointmentId or
+      // packageUsageId when available to guard against astronomically
+      // unlikely same-millisecond collisions between separate transactions.
+      if (isSplitReceipt) {
+        let q = client
+          .from("payments")
+          .select("id")
+          .eq("organization_id", String(args.organizationId))
+          .eq("status", "completed")
+          .eq("paid_at", payment.paidAt as number)
+          .neq("id", args.paymentId)
+          .like("notes", "%split:%");
+        const apptId = payment.appointmentId as string | null;
+        const pkgId = payment.packageUsageId as string | null;
+        if (apptId) q = q.eq("appointment_id", apptId);
+        else if (pkgId) q = q.eq("package_usage_id", pkgId);
+        const { data: secondaryRows } = await q;
+        for (const sp of secondaryRows ?? []) {
+          await client
+            .from("payments")
+            .update({ status: "refunded", updated_at: now })
+            .eq("id", (sp as Record<string, unknown>).id as string);
+        }
+      }
+
       return;
     }
 

--- a/tests/convex/_supabase_inmemory.ts
+++ b/tests/convex/_supabase_inmemory.ts
@@ -249,6 +249,12 @@ class InMemoryRawQuery {
     return this;
   }
 
+  neq(field: string, value: unknown) {
+    const camelField = snakeToCamel(field);
+    this.filters.push((r) => r[camelField] !== value);
+    return this;
+  }
+
   not(field: string, op: string, value: unknown) {
     const camelField = snakeToCamel(field);
     this.filters.push((r) => {
@@ -257,6 +263,23 @@ class InMemoryRawQuery {
       }
       return r[camelField] !== value;
     });
+    return this;
+  }
+
+  like(field: string, pattern: string) {
+    const camelField = snakeToCamel(field);
+    const regexStr = pattern
+      .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+      .replace(/%/g, ".*")
+      .replace(/_/g, ".");
+    const re = new RegExp(`^${regexStr}$`);
+    this.filters.push(
+      (r) => typeof r[camelField] === "string" && re.test(r[camelField] as string),
+    );
+    return this;
+  }
+
+  limit(_n: number) {
     return this;
   }
 

--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -571,6 +571,56 @@ describe("payments", () => {
         }),
       ).rejects.toThrow("Split methods must differ");
     });
+
+    test("refunding primary split leg also refunds the secondary leg (#3772)", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      const paymentId = await t.withIdentity(identity).action(
+        api.payments.create,
+        {
+          organizationId,
+          amount: 100,
+          currency: "PLN",
+          paymentMethod: "cash",
+          status: "pending",
+        },
+      );
+
+      const { firstPaymentId, secondPaymentId } = await t
+        .withIdentity(identity)
+        .action(api.payments.splitMarkPaid, {
+          organizationId,
+          paymentId,
+          firstMethod: "cash",
+          firstAmount: 60,
+          secondMethod: "card",
+          secondAmount: 40,
+        });
+
+      // Refund the primary (cash) leg only.
+      await t.withIdentity(identity).action(api.payments.refund, {
+        organizationId,
+        paymentId: firstPaymentId,
+        reason: "Patient request",
+      });
+
+      // Yield so the scheduled _createReceiptRowForPayment mutation can run.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const all = await t.withIdentity(identity).action(api.payments.list, {
+        organizationId,
+        paginationOpts: { numItems: 10, cursor: null },
+      });
+
+      const primary = all.page.find((p: any) => p._id === firstPaymentId);
+      const secondary = all.page.find((p: any) => p._id === secondPaymentId);
+
+      expect(primary?.status).toBe("refunded");
+      // Secondary leg must also be refunded — a split receipt void covers the
+      // full transaction, so leaving the secondary as "completed" is inconsistent.
+      expect(secondary?.status).toBe("refunded");
+    });
   });
 
   // Inline approve/reject for refund authorization requests (#1722) ---------


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3772.

Closes #3772

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- dd731d7 fix(gabinet): correct split payment refund path (closes #3772)

### Files changed

```
 convex/gabinet/receipts.ts         | 62 ++++++++++++++++++++++++++++++++++----
 tests/convex/_supabase_inmemory.ts | 23 ++++++++++++++
 tests/convex/payments.test.ts      | 50 ++++++++++++++++++++++++++++++
 3 files changed, 129 insertions(+), 6 deletions(-)
```