### PR TITLE
Block `refund` on the secondary split payment leg directly

### DIFF
--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -688,6 +688,26 @@ export const refund = action({
       throw new Error(`Cannot refund a ${payment.status} payment`);
     }
 
+    // Block refund on the secondary leg of a split payment (issue #3776).
+    // The secondary leg has "split:" in notes but no gabinet_receipts row —
+    // the consolidated receipt lives on the primary leg only. Refunding via
+    // the secondary would emit a partial KOR and leave the consolidated receipt
+    // unvoided; callers must refund the primary leg instead.
+    if (typeof payment.notes === "string" && payment.notes.includes("split:")) {
+      const { data: receiptRow } = await db
+        .raw()
+        .from("gabinet_receipts")
+        .select("id")
+        .eq("payment_id", args.paymentId)
+        .limit(1)
+        .maybeSingle();
+      if (!receiptRow) {
+        throw new Error(
+          "SPLIT_SECONDARY_LEG: cannot refund the secondary leg of a split payment — refund the primary payment instead",
+        );
+      }
+    }
+
     await db.patch("payments", args.paymentId, {
       status: "refunded",
       notes: args.reason

--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -572,6 +572,46 @@ describe("payments", () => {
       ).rejects.toThrow("Split methods must differ");
     });
 
+    test("refunding the secondary split leg directly is rejected (issue #3776)", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      const paymentId = await t.withIdentity(identity).action(
+        api.payments.create,
+        {
+          organizationId,
+          amount: 100,
+          currency: "PLN",
+          paymentMethod: "cash",
+          status: "pending",
+        },
+      );
+
+      const { secondPaymentId } = await t
+        .withIdentity(identity)
+        .action(api.payments.splitMarkPaid, {
+          organizationId,
+          paymentId,
+          firstMethod: "cash",
+          firstAmount: 60,
+          secondMethod: "card",
+          secondAmount: 40,
+        });
+
+      // Yield so the scheduled _createSplitReceiptRow mutation can run,
+      // establishing the consolidated receipt on the primary leg.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Refunding the secondary leg directly must be rejected.
+      await expect(
+        t.withIdentity(identity).action(api.payments.refund, {
+          organizationId,
+          paymentId: secondPaymentId,
+          reason: "test",
+        }),
+      ).rejects.toThrow("SPLIT_SECONDARY_LEG");
+    });
+
     test("refunding primary split leg also refunds the secondary leg (#3772)", async () => {
       const t = createTestCtx();
       const { organizationId, identity } = await seedTestUser(t);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3776.

Closes #3776

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 01133de fix(payments): block refund on secondary split payment leg (closes #3776)

### Files changed

```
 convex/payments.ts            | 20 ++++++++++++++++++++
 tests/convex/payments.test.ts | 40 ++++++++++++++++++++++++++++++++++++++++
 2 files changed, 60 insertions(+)
```