### PR TITLE
ci(typecheck): add app-typecheck job for tsconfig.app.json (#3745)

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,8 +1,11 @@
-name: Convex Typecheck
+name: Typecheck
 
-# Catches type errors in convex/ on every PR so they cannot silently freeze
-# production deploys for ~24h (see #1015 → #1119). Runs the same tsconfig
-# Convex itself uses to typecheck function code at deploy time.
+# Catches type errors on every PR.
+# convex-typecheck: checks convex/ backend — same tsconfig Convex uses at
+#   deploy time, so errors here freeze production for ~24h (see #1015 → #1119).
+# app-typecheck: checks the React frontend (tsconfig.app.json) and Vite config
+#   (tsconfig.node.json). Previously only run inside E2E, so UI type regressions
+#   passed CI whenever E2E was skipped (see #3745).
 
 on:
   pull_request:
@@ -32,3 +35,25 @@ jobs:
 
       - name: Check convex/_generated/api.d.ts is in sync
         run: npm run check:convex-codegen
+
+  app-typecheck:
+    name: tsc -p tsconfig.app.json
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Typecheck app (src/)
+        run: npx tsc -p tsconfig.app.json
+
+      - name: Typecheck node config (vite.config.ts)
+        run: npx tsc -p tsconfig.node.json


### PR DESCRIPTION
## Summary

- Adds a new `app-typecheck` job to `.github/workflows/typecheck.yml` that runs `tsc -p tsconfig.app.json` and `tsc -p tsconfig.node.json` on every PR and push to main
- The existing `convex-typecheck` job is unchanged; both jobs run in parallel

**Root cause:** `tsconfig.app.json` (React frontend) was only typechecked inside the E2E workflow, which is skippable. UI type regressions could land on main whenever E2E was not run.

## Test plan

- [ ] Confirm `app-typecheck` job appears and passes on this PR
- [ ] After merging, add `tsc -p tsconfig.app.json` as a required status check in branch protection settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)