### PR TITLE
Fix NULL uniqueness gap in gabinet_receipt_sequences for non-null location_id

### DIFF
--- a/convex/gabinet/receipts.ts
+++ b/convex/gabinet/receipts.ts
@@ -91,23 +91,43 @@ function paymentMethodPL(method: string): string {
  * Returns the next sequential receipt number for the org in the given year.
  * Format: PREFIX/YYYY/NNNNN (e.g. REC/2026/00001, KOR/2026/00001).
  *
- * Delegates to the `next_gabinet_receipt_number` Postgres function (migration
- * 00085) which uses INSERT ... ON CONFLICT DO UPDATE RETURNING for an atomic
- * counter increment — no read-modify-write race condition under concurrent
- * writes (fixes #3766).
+ * When locationId is provided, delegates to
+ * `next_gabinet_receipt_number_for_location` (migration 00087) which keys the
+ * counter on (org, location, year) — each location gets its own independent
+ * sequence. When locationId is omitted, delegates to
+ * `next_gabinet_receipt_number` (migration 00085) keyed on (org, year) for
+ * orgs without multi-location setup.
+ *
+ * Both functions use INSERT ... ON CONFLICT DO UPDATE RETURNING for an atomic
+ * counter increment with no read-modify-write race condition (fixes #3766).
  */
 async function nextReceiptNumber(
   orgId: string,
   year: number,
   prefix = "REC",
+  locationId?: string,
 ): Promise<string> {
   const db = createSupabaseDb();
   const client = db.raw();
-  const { data, error } = await client.rpc("next_gabinet_receipt_number", {
-    p_org_id: orgId,
-    p_year: year,
-    p_prefix: prefix,
-  });
+  let data: unknown;
+  let error: { message: string } | null;
+  if (locationId) {
+    ({ data, error } = await client.rpc(
+      "next_gabinet_receipt_number_for_location",
+      {
+        p_org_id: orgId,
+        p_year: year,
+        p_prefix: prefix,
+        p_location_id: locationId,
+      },
+    ));
+  } else {
+    ({ data, error } = await client.rpc("next_gabinet_receipt_number", {
+      p_org_id: orgId,
+      p_year: year,
+      p_prefix: prefix,
+    }));
+  }
   if (error) throw new Error(`nextReceiptNumber: ${error.message}`);
   return data as string;
 }

--- a/supabase/migrations/00087_gabinet_receipt_sequence_location_fn.sql
+++ b/supabase/migrations/00087_gabinet_receipt_sequence_location_fn.sql
@@ -1,0 +1,40 @@
+-- Location-aware receipt sequence function for multi-location orgs (issue #3770).
+--
+-- The existing next_gabinet_receipt_number function (migration 00085) only
+-- handles location_id IS NULL via the partial unique index
+-- gabinet_receipt_sequences_org_year_noloc_idx.  For orgs with multiple
+-- locations, each location needs its own independent counter so that receipt
+-- numbers are sequential within each location (e.g. LOC-A gets REC/2026/00001
+-- through REC/2026/00042, LOC-B gets its own REC/2026/00001 etc.).
+--
+-- For non-null location_id, the regular UNIQUE (organization_id, location_id,
+-- year) constraint on gabinet_receipt_sequences already guarantees uniqueness
+-- (standard equality comparison works for non-null values), so ON CONFLICT
+-- (organization_id, location_id, year) works correctly without a separate
+-- partial index.
+CREATE OR REPLACE FUNCTION next_gabinet_receipt_number_for_location(
+  p_org_id      TEXT,
+  p_year        INT,
+  p_location_id TEXT,
+  p_prefix      TEXT DEFAULT 'REC'
+) RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_next BIGINT;
+  v_ts   BIGINT := (EXTRACT(EPOCH FROM NOW()) * 1000)::BIGINT;
+BEGIN
+  INSERT INTO gabinet_receipt_sequences
+    (id, organization_id, location_id, year, last_number, updated_at)
+  VALUES
+    (gen_random_uuid()::TEXT, p_org_id, p_location_id, p_year, 1, v_ts)
+  ON CONFLICT (organization_id, location_id, year)
+  DO UPDATE SET
+    last_number = gabinet_receipt_sequences.last_number + 1,
+    updated_at  = v_ts
+  RETURNING last_number INTO v_next;
+
+  RETURN p_prefix || '/' || p_year::TEXT || '/' || LPAD(v_next::TEXT, 5, '0');
+END;
+$$;

--- a/tests/convex/_supabase_inmemory.ts
+++ b/tests/convex/_supabase_inmemory.ts
@@ -165,18 +165,25 @@ function createInMemoryRawClient() {
       return new InMemoryRawQuery(snakeToCamel(table));
     },
 
-    // Minimal stub for the `next_gabinet_receipt_number` Postgres function
-    // used by receipts.ts. Returns a formatted receipt number using an
-    // in-memory counter so receipt-related mutations work under vitest.
+    // Minimal stub for the `next_gabinet_receipt_number` and
+    // `next_gabinet_receipt_number_for_location` Postgres functions used by
+    // receipts.ts. Uses an in-memory counter keyed on
+    // `${orgId}:${locationId}:${year}:${prefix}` so each (org, location, year,
+    // prefix) combination has an independent sequence — matching production
+    // behaviour (fixes #3770).
     async rpc(
       fn: string,
       params: Record<string, unknown>,
     ): Promise<{ data: unknown; error: null | { message: string } }> {
-      if (fn === "next_gabinet_receipt_number") {
+      if (
+        fn === "next_gabinet_receipt_number" ||
+        fn === "next_gabinet_receipt_number_for_location"
+      ) {
         const orgId = String(params.p_org_id ?? "");
         const year = Number(params.p_year ?? new Date().getFullYear());
         const prefix = String(params.p_prefix ?? "REC");
-        const key = `${orgId}:${year}:${prefix}`;
+        const locationId = params.p_location_id ? String(params.p_location_id) : "";
+        const key = `${orgId}:${locationId}:${year}:${prefix}`;
         const next = (receiptSequenceCounters.get(key) ?? 0) + 1;
         receiptSequenceCounters.set(key, next);
         const formatted = `${prefix}/${year}/${String(next).padStart(5, "0")}`;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3770.

Closes #3770

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- dc15b52 feat(gabinet): add location-aware receipt sequence function (closes #3770)

### Files changed

```
 convex/gabinet/receipts.ts                         | 38 +++++++++++++++-----
 .../00087_gabinet_receipt_sequence_location_fn.sql | 40 ++++++++++++++++++++++
 tests/convex/_supabase_inmemory.ts                 | 17 ++++++---
 3 files changed, 81 insertions(+), 14 deletions(-)
```