### PR TITLE
Fix `_storePdfAndCreateReceipt` receipt-storage architecture

### DIFF
--- a/convex/gabinet/receipts.ts
+++ b/convex/gabinet/receipts.ts
@@ -356,33 +356,46 @@ export const _storePdfAndCreateReceipt = internalAction({
     const storageId = await ctx.storage.store(blob);
     const pdfUrl = await ctx.storage.getUrl(storageId);
 
-    const db = createSupabaseDb();
-    const now = Date.now();
-    const receiptId = await db.insert("gabinetReceipts", {
-      organizationId: args.organizationId as string,
-      paymentId: args.paymentId,
-      appointmentId: args.appointmentId ?? null,
-      patientId: args.patientId ?? null,
-      receiptNumber: args.receiptNumber,
-      issuedAt: args.issuedAt,
-      organizationName: args.organizationName,
-      organizationNip: args.organizationNip ?? null,
-      organizationAddress: args.organizationAddress ?? null,
-      totalNet: args.totalNet,
-      totalVat: args.totalVat,
-      totalGross: args.totalGross,
-      paymentMethod: args.paymentMethod,
-      itemsJson: args.itemsJson,
-      fiscalReceiptId: args.fiscalReceiptId ?? null,
-      receiptType: "original",
-      pdfStorageId: storageId,
-      pdfUrl: pdfUrl ?? null,
-      createdBy: args.createdBy as string,
-      createdAt: now,
-      updatedAt: now,
-    });
+    try {
+      const db = createSupabaseDb();
+      const now = Date.now();
+      const receiptId = await db.insert("gabinetReceipts", {
+        organizationId: args.organizationId as string,
+        paymentId: args.paymentId,
+        appointmentId: args.appointmentId ?? null,
+        patientId: args.patientId ?? null,
+        receiptNumber: args.receiptNumber,
+        issuedAt: args.issuedAt,
+        organizationName: args.organizationName,
+        organizationNip: args.organizationNip ?? null,
+        organizationAddress: args.organizationAddress ?? null,
+        totalNet: args.totalNet,
+        totalVat: args.totalVat,
+        totalGross: args.totalGross,
+        paymentMethod: args.paymentMethod,
+        itemsJson: args.itemsJson,
+        fiscalReceiptId: args.fiscalReceiptId ?? null,
+        receiptType: "original",
+        pdfStorageId: storageId,
+        pdfUrl: pdfUrl ?? null,
+        createdBy: args.createdBy as string,
+        createdAt: now,
+        updatedAt: now,
+      });
 
-    return { receiptId, pdfUrl: pdfUrl ?? "" };
+      return { receiptId, pdfUrl: pdfUrl ?? "" };
+    } catch (err) {
+      // Compensating cleanup: the blob was already written to Convex storage but
+      // the receipt row in Supabase failed. Delete the orphaned blob so it doesn't
+      // leak storage. Best-effort — if the delete also fails we still re-throw
+      // the original error so the caller can retry.
+      try {
+        await ctx.storage.delete(storageId);
+      } catch {
+        // ignore secondary failure
+      }
+      throw err;
+    }
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3787.

Closes #3787

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- fe1db62 fix(gabinet): add compensating blob cleanup on receipt DB insert failure (closes #3787)

### Files changed

```
 convex/gabinet/receipts.ts | 65 +++++++++++++++++++++++++++-------------------
 1 file changed, 39 insertions(+), 26 deletions(-)
```