### PR TITLE
`generatePdfReceipt` idempotency check doesn't cover sequence-number gaps

### DIFF
--- a/convex/gabinet/receipts.ts
+++ b/convex/gabinet/receipts.ts
@@ -356,6 +356,28 @@ export const _storePdfAndCreateReceipt = internalAction({
     createdBy: v.id("users"),
   },
   handler: async (ctx, args) => {
+    // Idempotency guard: if a receipt already exists for this payment do not
+    // consume another sequence number. This prevents gaps when
+    // generatePdfReceipt retries after a partial _storePdfAndCreateReceipt
+    // failure — the outer idempotency check would pass (no committed row) but
+    // this inner check catches the same case right before the counter is
+    // incremented (#3791).
+    const dbCheck = createSupabaseDb();
+    const clientCheck = dbCheck.raw();
+    const { data: existingReceipt } = await clientCheck
+      .from("gabinet_receipts")
+      .select("id, pdf_url, receipt_number")
+      .eq("payment_id", args.paymentId)
+      .limit(1)
+      .maybeSingle();
+    if (existingReceipt) {
+      return {
+        receiptId: existingReceipt.id as string,
+        pdfUrl: (existingReceipt.pdf_url as string | null) ?? "",
+        receiptNumber: existingReceipt.receipt_number as string,
+      };
+    }
+
     // Increment the sequence and generate the PDF in one action so that a
     // failure in either step does not leave a consumed sequence number without
     // a corresponding receipt row (the gap described in #3790).


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3791.

Closes #3791

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 079047f fix(gabinet): add idempotency guard in _storePdfAndCreateReceipt to prevent sequence gaps on retry (closes #3791)

### Files changed

```
 convex/gabinet/receipts.ts | 22 ++++++++++++++++++++++
 1 file changed, 22 insertions(+)
```