### PR TITLE
Add PDF back-fill retry mechanism

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -35,4 +35,13 @@ crons.hourly(
   internal.documents.documents.expireSigningTokens,
 );
 
+// Back-fill pdf_url on receipt rows created with a NULL pdf_url (issue #3797).
+// Rows are left orphaned when blob storage fails after the atomic DB insert.
+// Runs hourly at :30 so it doesn't cluster with other hourly jobs (:15).
+crons.hourly(
+  "backfill-orphaned-pdf-receipts",
+  { minuteUTC: 30 },
+  internal.gabinet.receipts._backfillOrphanedPdfReceipts,
+);
+
 export default crons;

--- a/convex/gabinet/receipts.ts
+++ b/convex/gabinet/receipts.ts
@@ -679,6 +679,74 @@ export const generatePdfReceipt = action({
 });
 
 // ---------------------------------------------------------------------------
+// Internal action: back-fill pdf_storage_id / pdf_url on orphaned receipt rows.
+//
+// A receipt row can end up with pdf_url = NULL when blob storage fails after
+// the atomic Postgres insert (issue #3797). This action finds up to 50 such
+// rows and regenerates their PDFs from the data already committed to the DB —
+// all fields required to reproduce the PDF are stored in each row at issuance
+// time. Designed to be called from a cron job (crons.ts, hourly). Idempotent:
+// rows that already have a pdf_url are skipped by the Postgres query filter.
+// ---------------------------------------------------------------------------
+
+export const _backfillOrphanedPdfReceipts = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const db = createSupabaseDb();
+    const client = db.raw();
+
+    const { data: orphans } = await client
+      .from("gabinet_receipts")
+      .select(
+        "id, receipt_number, issued_at, organization_name, organization_nip, organization_address, total_net, total_vat, total_gross, payment_method, items_json, fiscal_receipt_id",
+      )
+      .is("pdf_url", null)
+      .is("pdf_storage_id", null)
+      .eq("status", "issued")
+      .limit(50);
+
+    if (!orphans || orphans.length === 0) return { processed: 0 };
+
+    let processed = 0;
+    const now = Date.now();
+
+    for (const row of orphans as Record<string, unknown>[]) {
+      try {
+        const lineItems = JSON.parse(row.items_json as string) as ReceiptLineItem[];
+        const pdfBytes = await buildReceiptPdf({
+          receiptNumber:     row.receipt_number as string,
+          issuedAt:          Number(row.issued_at),
+          organizationName:  row.organization_name as string,
+          organizationNip:   (row.organization_nip as string | null) ?? undefined,
+          organizationAddress: (row.organization_address as string | null) ?? undefined,
+          items:             lineItems,
+          totalNet:          Number(row.total_net),
+          totalVat:          Number(row.total_vat),
+          totalGross:        Number(row.total_gross),
+          paymentMethod:     row.payment_method as string,
+          fiscalReceiptId:   (row.fiscal_receipt_id as string | null) ?? undefined,
+        });
+
+        const blob = new Blob([pdfBytes.buffer as ArrayBuffer], { type: "application/pdf" });
+        const storageId = await ctx.storage.store(blob);
+        const pdfUrl = await ctx.storage.getUrl(storageId);
+
+        await client
+          .from("gabinet_receipts")
+          .update({ pdf_storage_id: storageId, pdf_url: pdfUrl, updated_at: now })
+          .eq("id", row.id as string);
+
+        processed++;
+      } catch {
+        // Continue to the next orphan; transient failures are retried next run.
+      }
+    }
+
+    return { processed };
+  },
+});
+
+// ---------------------------------------------------------------------------
 // Internal mutation: auto-create a gabinet_receipts row for a payment.
 // Scheduled via ctx.scheduler from convex/payments.ts after each completed
 // payment so that every payment path produces a receipt record.

--- a/supabase/migrations/00089_gabinet_receipt_orphan_pdf_idx.sql
+++ b/supabase/migrations/00089_gabinet_receipt_orphan_pdf_idx.sql
@@ -1,0 +1,13 @@
+-- Partial index to accelerate the orphaned-receipt back-fill query (issue #3797).
+--
+-- A receipt row is "orphaned" when blob storage fails after the atomic
+-- insert_gabinet_receipt_with_number transaction commits: the row exists with
+-- pdf_url = NULL and pdf_storage_id = NULL. The hourly back-fill cron job
+-- (convex/crons.ts → _backfillOrphanedPdfReceipts) scans for these rows.
+--
+-- Without this index the scan is a sequential table scan filtered in Postgres;
+-- with it, only the (typically empty) orphan set is touched.
+
+CREATE INDEX IF NOT EXISTS gabinet_receipts_orphan_pdf_idx
+  ON gabinet_receipts (status)
+  WHERE pdf_url IS NULL AND pdf_storage_id IS NULL;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3797.

Closes #3797

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- ff68237 fix(gabinet): add hourly cron to back-fill orphaned PDF receipts (closes #3797)

### Files changed

```
 convex/crons.ts                                    |  9 +++
 convex/gabinet/receipts.ts                         | 68 ++++++++++++++++++++++
 .../00089_gabinet_receipt_orphan_pdf_idx.sql       | 13 +++++
 3 files changed, 90 insertions(+)
```