### PR TITLE
Polityka retencji + mechanizm usuwania i anonimizacji danych pacjenta

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -44,4 +44,13 @@ crons.hourly(
   internal.gabinet.receipts._backfillOrphanedPdfReceipts,
 );
 
+// GDPR patient retention: auto-anonymize inactive gabinet patients whose
+// updatedAt exceeds the org's patientRetentionMonths setting (#3785).
+// Runs nightly at 02:15 UTC (off-peak, offset from other daily jobs).
+crons.daily(
+  "purge-expired-patients-gdpr",
+  { hourUTC: 2, minuteUTC: 15 },
+  internal.gabinet.patients._purgeExpiredPatients,
+);
+
 export default crons;

--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -1,4 +1,4 @@
-import { action, internalMutation } from "../_generated/server";
+import { action, internalAction, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
@@ -1213,6 +1213,126 @@ export const _gdprEraseSideEffects = internalMutation({
       description: "RODO: dane klienta zostały usunięte",
       performedBy: erasedByUserId,
     });
+  },
+});
+
+// Nightly GDPR retention cron: anonymizes inactive patients whose updatedAt is
+// older than the org's patientRetentionMonths setting. Processes up to 50
+// patients per org per run to stay within action time limits.
+export const _purgeExpiredPatients = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const db = createSupabaseDb();
+    const nowMs = Date.now();
+
+    type OrgSettingsRow = { organizationId: string; patientRetentionMonths: number };
+    const orgsWithPolicy = (await db
+      .query<OrgSettingsRow>("orgSettings")
+      .gt("patientRetentionMonths", 0)
+      .collect()) as OrgSettingsRow[];
+
+    for (const { organizationId: orgId, patientRetentionMonths } of orgsWithPolicy) {
+      const cutoffMs = nowMs - patientRetentionMonths * 30 * 24 * 60 * 60 * 1000;
+
+      type MemberRow = { userId: string; role: string };
+      const owners = (await db
+        .query<MemberRow>("teamMemberships")
+        .eq("organizationId", orgId)
+        .eq("role", "owner")
+        .collect()) as MemberRow[];
+      const performedBy = owners[0]?.userId;
+      if (!performedBy) continue;
+
+      type PatientRow = { id: string; firstName: string; lastName: string };
+      const expiredPatients = (await db
+        .query<PatientRow>("gabinetPatients")
+        .eq("organizationId", orgId)
+        .eq("isActive", false)
+        .lt("updatedAt", cutoffMs)
+        .neq("firstName", "ANONIMOWY")
+        .take(50)
+        .collect()) as PatientRow[];
+
+      const client = db.raw();
+      const GDPR_REDACTED = "[RODO: dane usunięte]";
+
+      for (const patient of expiredPatients) {
+        const anonSuffix = patient.id.slice(-6).toUpperCase();
+
+        await db.patch("gabinetPatients", patient.id, {
+          firstName: "ANONIMOWY",
+          lastName: `#${anonSuffix}`,
+          email: `deleted-${anonSuffix}@gdpr.invalid`,
+          phone: null,
+          pesel: null,
+          dateOfBirth: null,
+          address: null,
+          medicalNotes: null,
+          allergies: null,
+          bloodType: null,
+          emergencyContactName: null,
+          emergencyContactPhone: null,
+          referralSource: null,
+          referredByPatientId: null,
+          contactId: null,
+          tags: null,
+          tagIds: null,
+          categoryId: null,
+          customFields: null,
+          updatedAt: nowMs,
+        });
+
+        await client
+          .from("gabinet_portal_sessions")
+          .delete()
+          .eq("organization_id", orgId)
+          .eq("patient_id", patient.id);
+
+        await client
+          .from("activities")
+          .update({ description: GDPR_REDACTED })
+          .eq("organization_id", orgId)
+          .eq("entity_type", "gabinetPatient")
+          .eq("entity_id", patient.id);
+
+        await client
+          .from("notes")
+          .update({ content: GDPR_REDACTED, updated_at: nowMs })
+          .eq("organization_id", orgId)
+          .eq("entity_type", "gabinetPatient")
+          .eq("entity_id", patient.id);
+
+        await client
+          .from("gabinet_appointments")
+          .update({
+            interview_notes: null,
+            notes: null,
+            internal_notes: null,
+            clinical_remarks: null,
+            body_chart_data: null,
+            treatment_parameter_values: null,
+          })
+          .eq("organization_id", orgId)
+          .eq("patient_id", patient.id);
+
+        const originalName = `${patient.firstName} ${patient.lastName}`.trim();
+        try {
+          await ctx.runMutation(internal.gabinet.patients._gdprEraseSideEffects, {
+            patientId: patient.id,
+            organizationId: orgId as Id<"organizations">,
+            originalName,
+            erasedBy: performedBy,
+          });
+        } catch (e) {
+          console.error(
+            "[patients._purgeExpiredPatients] Side effects failed for patient",
+            patient.id,
+            ":",
+            e,
+          );
+        }
+      }
+    }
   },
 });
 

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -677,6 +677,9 @@ export function createCrmTables({
     reminderSms24h: v.optional(v.boolean()),
     reminderEmail48h: v.optional(v.boolean()),
     reminderEmail24h: v.optional(v.boolean()),
+    // GDPR retention: months of inactivity after which inactive patients are
+    // auto-anonymized by the nightly retention cron (#3785). null = disabled.
+    patientRetentionMonths: v.optional(v.number()),
     createdAt: v.number(),
     updatedAt: v.number(),
   }).index("by_org", ["organizationId"]),

--- a/supabase/migrations/00090_gabinet_patient_retention_policy.sql
+++ b/supabase/migrations/00090_gabinet_patient_retention_policy.sql
@@ -1,0 +1,5 @@
+-- Add patient_retention_months to org_settings for GDPR auto-anonymization (#3785).
+-- When set, the nightly retention cron auto-anonymizes inactive gabinet patients
+-- whose updated_at is older than this many months. NULL = disabled.
+ALTER TABLE org_settings
+  ADD COLUMN IF NOT EXISTS patient_retention_months integer;

--- a/tests/convex/gdprRetention.test.ts
+++ b/tests/convex/gdprRetention.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { internal } from "../../convex/_generated/api";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+import {
+  createTestCtx,
+  seedTestUser,
+  seedGabinetPrereqs,
+} from "../../convex/_test_helpers";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+const THIRTEEN_MONTHS_MS = 13 * 30 * 24 * 60 * 60 * 1000;
+
+describe("gabinet/patients._purgeExpiredPatients — GDPR retention cron", () => {
+  test("anonymizes an inactive patient past the retention cutoff", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    const orgIdStr = String(organizationId);
+    const userIdStr = String(userId);
+    const patientIdStr = String(patientId);
+    const db = createSupabaseDb();
+
+    // Seed retention policy and owner membership in the Supabase mock
+    await db.insert("orgSettings", {
+      organizationId: orgIdStr,
+      patientRetentionMonths: 12,
+      allowCustomLostReason: false,
+      lostReasonRequired: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await db.insert("teamMemberships", {
+      organizationId: orgIdStr,
+      userId: userIdStr,
+      role: "owner",
+      joinedAt: Date.now(),
+    });
+
+    // Mark patient inactive and backdate past the 12-month retention cutoff
+    await db.patch("gabinetPatients", patientIdStr, {
+      isActive: false,
+      updatedAt: Date.now() - THIRTEEN_MONTHS_MS,
+    });
+
+    await t.action(internal.gabinet.patients._purgeExpiredPatients, {});
+
+    const patient = await db.get("gabinetPatients", patientIdStr);
+    expect(patient?.firstName).toBe("ANONIMOWY");
+    expect(String(patient?.email ?? "")).toContain("gdpr.invalid");
+    expect(patient?.phone).toBeNull();
+    expect(patient?.pesel).toBeNull();
+  });
+
+  test("writes an audit log entry with action gdpr_patient_erased", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    const orgIdStr = String(organizationId);
+    const userIdStr = String(userId);
+    const patientIdStr = String(patientId);
+    const db = createSupabaseDb();
+
+    await db.insert("orgSettings", {
+      organizationId: orgIdStr,
+      patientRetentionMonths: 12,
+      allowCustomLostReason: false,
+      lostReasonRequired: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await db.insert("teamMemberships", {
+      organizationId: orgIdStr,
+      userId: userIdStr,
+      role: "owner",
+      joinedAt: Date.now(),
+    });
+
+    await db.patch("gabinetPatients", patientIdStr, {
+      isActive: false,
+      updatedAt: Date.now() - THIRTEEN_MONTHS_MS,
+    });
+
+    await t.action(internal.gabinet.patients._purgeExpiredPatients, {});
+
+    const auditEntries = await t.run(async (ctx) =>
+      ctx.db
+        .query("auditLog")
+        .withIndex("by_org", (q) => q.eq("organizationId", organizationId))
+        .collect(),
+    );
+
+    const erasureEntry = auditEntries.find((e) => e.action === "gdpr_patient_erased");
+    expect(erasureEntry).toBeDefined();
+    expect(erasureEntry?.entityId).toBe(patientIdStr);
+  });
+
+  test("skips active patients regardless of age", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    const orgIdStr = String(organizationId);
+    const userIdStr = String(userId);
+    const patientIdStr = String(patientId);
+    const db = createSupabaseDb();
+
+    await db.insert("orgSettings", {
+      organizationId: orgIdStr,
+      patientRetentionMonths: 12,
+      allowCustomLostReason: false,
+      lostReasonRequired: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await db.insert("teamMemberships", {
+      organizationId: orgIdStr,
+      userId: userIdStr,
+      role: "owner",
+      joinedAt: Date.now(),
+    });
+
+    // Patient remains active — backdate updatedAt but keep isActive: true
+    await db.patch("gabinetPatients", patientIdStr, {
+      isActive: true,
+      updatedAt: Date.now() - THIRTEEN_MONTHS_MS,
+    });
+
+    await t.action(internal.gabinet.patients._purgeExpiredPatients, {});
+
+    const patient = await db.get("gabinetPatients", patientIdStr);
+    expect(patient?.firstName).toBe("Jan");
+  });
+
+  test("skips inactive patients still within the retention window", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    const orgIdStr = String(organizationId);
+    const userIdStr = String(userId);
+    const patientIdStr = String(patientId);
+    const db = createSupabaseDb();
+
+    await db.insert("orgSettings", {
+      organizationId: orgIdStr,
+      patientRetentionMonths: 12,
+      allowCustomLostReason: false,
+      lostReasonRequired: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await db.insert("teamMemberships", {
+      organizationId: orgIdStr,
+      userId: userIdStr,
+      role: "owner",
+      joinedAt: Date.now(),
+    });
+
+    // Inactive but only 6 months old — within the 12-month retention window
+    await db.patch("gabinetPatients", patientIdStr, {
+      isActive: false,
+      updatedAt: Date.now() - 6 * 30 * 24 * 60 * 60 * 1000,
+    });
+
+    await t.action(internal.gabinet.patients._purgeExpiredPatients, {});
+
+    const patient = await db.get("gabinetPatients", patientIdStr);
+    expect(patient?.firstName).toBe("Jan");
+  });
+
+  test("is a no-op when no org has retention configured", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    const patientIdStr = String(patientId);
+    const db = createSupabaseDb();
+
+    // No orgSettings seeded — no retention policy anywhere
+    await db.patch("gabinetPatients", patientIdStr, {
+      isActive: false,
+      updatedAt: Date.now() - THIRTEEN_MONTHS_MS,
+    });
+
+    await t.action(internal.gabinet.patients._purgeExpiredPatients, {});
+
+    const patient = await db.get("gabinetPatients", patientIdStr);
+    expect(patient?.firstName).toBe("Jan");
+  });
+
+  test("skips already-anonymized patients (idempotent)", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    const orgIdStr = String(organizationId);
+    const userIdStr = String(userId);
+    const patientIdStr = String(patientId);
+    const db = createSupabaseDb();
+
+    await db.insert("orgSettings", {
+      organizationId: orgIdStr,
+      patientRetentionMonths: 12,
+      allowCustomLostReason: false,
+      lostReasonRequired: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await db.insert("teamMemberships", {
+      organizationId: orgIdStr,
+      userId: userIdStr,
+      role: "owner",
+      joinedAt: Date.now(),
+    });
+
+    // Pre-anonymize the patient (simulates a prior GDPR erasure)
+    const anonSuffix = patientIdStr.slice(-6).toUpperCase();
+    await db.patch("gabinetPatients", patientIdStr, {
+      firstName: "ANONIMOWY",
+      lastName: `#${anonSuffix}`,
+      isActive: false,
+      updatedAt: Date.now() - THIRTEEN_MONTHS_MS,
+    });
+
+    // Should not throw and should not re-process the already-anonymized patient
+    await t.action(internal.gabinet.patients._purgeExpiredPatients, {});
+
+    const patient = await db.get("gabinetPatients", patientIdStr);
+    expect(patient?.firstName).toBe("ANONIMOWY");
+    expect(patient?.lastName).toBe(`#${anonSuffix}`);
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3785.

Closes #3785

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b7cd36d feat(gabinet): GDPR patient retention policy with nightly auto-anonymization cron (closes #3785)

### Files changed

```
 convex/crons.ts                                    |   9 +
 convex/gabinet/patients.ts                         | 122 ++++++++++-
 convex/schema/crm.ts                               |   3 +
 .../00090_gabinet_patient_retention_policy.sql     |   5 +
 tests/convex/gdprRetention.test.ts                 | 237 +++++++++++++++++++++
 5 files changed, 375 insertions(+), 1 deletion(-)
```