### PR TITLE
Upgrade `product_stock_levels` and `product_stock_movements` to per-command poli

### DIFF
--- a/supabase/migrations/00091_product_stock_rls.sql
+++ b/supabase/migrations/00091_product_stock_rls.sql
@@ -1,0 +1,34 @@
+-- Upgrade RLS on product_stock_levels and product_stock_movements to the
+-- per-command pattern established in 00002_rls_policies.sql.
+--
+-- Migration 00013 created these tables with a single ALL-operation org_isolation
+-- policy (USING only, no WITH CHECK). That broad pattern was replaced project-
+-- wide by 00002, but the stock tables were introduced afterwards and inherited
+-- the old shape. Without WITH CHECK, INSERT and UPDATE bypass the cross-org
+-- write guard, allowing a compromised service role to write rows into a
+-- different org's namespace. This migration brings both tables in line with
+-- every other table in the project (closes #3800).
+
+DROP POLICY IF EXISTS org_isolation ON product_stock_levels;
+
+CREATE POLICY product_stock_levels_select ON product_stock_levels
+  FOR SELECT USING (current_org_id() = organization_id);
+CREATE POLICY product_stock_levels_insert ON product_stock_levels
+  FOR INSERT WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY product_stock_levels_update ON product_stock_levels
+  FOR UPDATE USING (current_org_id() = organization_id)
+  WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY product_stock_levels_delete ON product_stock_levels
+  FOR DELETE USING (current_org_id() = organization_id);
+
+DROP POLICY IF EXISTS org_isolation ON product_stock_movements;
+
+CREATE POLICY product_stock_movements_select ON product_stock_movements
+  FOR SELECT USING (current_org_id() = organization_id);
+CREATE POLICY product_stock_movements_insert ON product_stock_movements
+  FOR INSERT WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY product_stock_movements_update ON product_stock_movements
+  FOR UPDATE USING (current_org_id() = organization_id)
+  WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY product_stock_movements_delete ON product_stock_movements
+  FOR DELETE USING (current_org_id() = organization_id);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3800.

Closes #3800

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- fa9d29f fix(rls): upgrade product_stock_levels and product_stock_movements to per-command policies with WITH CHECK (closes #3800)

### Files changed

```
 supabase/migrations/00091_product_stock_rls.sql | 34 +++++++++++++++++++++++++
 1 file changed, 34 insertions(+)
```