### PR TITLE
Upgrade `gabinet_treatment_products` (00025) to per-command policies with WITH C

### DIFF
--- a/session_state.json
+++ b/session_state.json
@@ -1,9 +1,9 @@
 {
-  "session_id": "S0109",
-  "started_at": "2026-08-06T00:00:00Z",
-  "last_updated": "2026-08-06T00:05:00Z",
+  "session_id": "S0110",
+  "started_at": "2026-08-06T08:00:00Z",
+  "last_updated": "2026-08-06T08:10:00Z",
   "status": "completed",
-  "focus": "Issue #3604: gabinet treatment CREATE fails with FK violation on created_by",
+  "focus": "Issue #3801: Upgrade gabinet_treatment_products RLS to per-command policies with WITH CHECK",
   "tasks_snapshot": {
     "total": 1,
     "not_started": 0,
@@ -14,5 +14,5 @@
   },
   "active_task_ids": [],
   "blockers": [],
-  "notes": "S0109: Root cause: users created before Supabase migration (2026-04) lack a row in the Supabase users table. gabinet_treatments.created_by has a NOT NULL FK to users(id). The create action inserts created_by but had no self-heal for the user row (unlike the org self-heal that already existed). UPDATE never touches created_by so it never triggered the FK. Fix: added user self-heal block in convex/gabinet/treatments.ts create handler, after the org self-heal. Uses the same db.raw() client + internal.supabase.backfill._getUser pattern."
+  "notes": "S0110: Created 00092_gabinet_treatment_products_rls.sql — drops the old ALL-operation org_isolation policy and replaces with four per-command policies (SELECT/INSERT/UPDATE/DELETE). INSERT and UPDATE now carry explicit WITH CHECK (current_org_id() = organization_id), closing the write-guard gap."
 }

--- a/supabase/migrations/00092_gabinet_treatment_products_rls.sql
+++ b/supabase/migrations/00092_gabinet_treatment_products_rls.sql
@@ -1,0 +1,20 @@
+-- Upgrade RLS on gabinet_treatment_products to the per-command pattern
+-- established in 00002_rls_policies.sql.
+--
+-- Migration 00025 created this table with a single ALL-operation org_isolation
+-- policy (USING only, no WITH CHECK). Without WITH CHECK, INSERT and UPDATE
+-- bypass the cross-org write guard, allowing a compromised service role to
+-- write rows into a different org's namespace. This migration brings the table
+-- in line with every other table in the project (closes #3801).
+
+DROP POLICY IF EXISTS org_isolation ON gabinet_treatment_products;
+
+CREATE POLICY gabinet_treatment_products_select ON gabinet_treatment_products
+  FOR SELECT USING (current_org_id() = organization_id);
+CREATE POLICY gabinet_treatment_products_insert ON gabinet_treatment_products
+  FOR INSERT WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY gabinet_treatment_products_update ON gabinet_treatment_products
+  FOR UPDATE USING (current_org_id() = organization_id)
+  WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY gabinet_treatment_products_delete ON gabinet_treatment_products
+  FOR DELETE USING (current_org_id() = organization_id);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3801.

Closes #3801

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- fda686b fix(rls): upgrade gabinet_treatment_products to per-command policies with WITH CHECK (closes #3801)

### Files changed

```
 session_state.json                                   | 10 +++++-----
 .../00092_gabinet_treatment_products_rls.sql         | 20 ++++++++++++++++++++
 2 files changed, 25 insertions(+), 5 deletions(-)
```