### PR TITLE
Fix `org_isolation` RLS on `warehouse_deliveries` and `warehouse_delivery_items`

### DIFF
--- a/session_state.json
+++ b/session_state.json
@@ -1,9 +1,9 @@
 {
-  "session_id": "S0110",
-  "started_at": "2026-08-06T08:00:00Z",
-  "last_updated": "2026-08-06T08:10:00Z",
+  "session_id": "S0111",
+  "started_at": "2026-08-06T08:15:00Z",
+  "last_updated": "2026-08-06T08:20:00Z",
   "status": "completed",
-  "focus": "Issue #3801: Upgrade gabinet_treatment_products RLS to per-command policies with WITH CHECK",
+  "focus": "Issue #3805: Fix org_isolation RLS on warehouse_deliveries and warehouse_delivery_items",
   "tasks_snapshot": {
     "total": 1,
     "not_started": 0,
@@ -14,5 +14,5 @@
   },
   "active_task_ids": [],
   "blockers": [],
-  "notes": "S0110: Created 00092_gabinet_treatment_products_rls.sql — drops the old ALL-operation org_isolation policy and replaces with four per-command policies (SELECT/INSERT/UPDATE/DELETE). INSERT and UPDATE now carry explicit WITH CHECK (current_org_id() = organization_id), closing the write-guard gap."
+  "notes": "S0111: Created 00094_warehouse_deliveries_rls.sql — drops the old ALL-operation org_isolation policies on warehouse_deliveries and warehouse_delivery_items, replaces with four per-command policies each (SELECT/INSERT/UPDATE/DELETE). INSERT and UPDATE now carry explicit WITH CHECK (current_org_id() = organization_id), closing the write-guard gap."
 }

--- a/supabase/migrations/00094_warehouse_deliveries_rls.sql
+++ b/supabase/migrations/00094_warehouse_deliveries_rls.sql
@@ -1,0 +1,32 @@
+-- Upgrade RLS on warehouse_deliveries and warehouse_delivery_items to the
+-- per-command pattern established in 00002_rls_policies.sql.
+--
+-- Migration 00051 created these tables with a single ALL-operation org_isolation
+-- policy (USING only, no WITH CHECK). Without WITH CHECK, INSERT and UPDATE
+-- bypass the cross-org write guard, allowing a compromised service role to
+-- write rows into a different org's namespace. This migration brings both
+-- tables in line with every other table in the project (closes #3805).
+
+DROP POLICY IF EXISTS org_isolation ON warehouse_deliveries;
+
+CREATE POLICY warehouse_deliveries_select ON warehouse_deliveries
+  FOR SELECT USING (current_org_id() = organization_id);
+CREATE POLICY warehouse_deliveries_insert ON warehouse_deliveries
+  FOR INSERT WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY warehouse_deliveries_update ON warehouse_deliveries
+  FOR UPDATE USING (current_org_id() = organization_id)
+  WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY warehouse_deliveries_delete ON warehouse_deliveries
+  FOR DELETE USING (current_org_id() = organization_id);
+
+DROP POLICY IF EXISTS org_isolation ON warehouse_delivery_items;
+
+CREATE POLICY warehouse_delivery_items_select ON warehouse_delivery_items
+  FOR SELECT USING (current_org_id() = organization_id);
+CREATE POLICY warehouse_delivery_items_insert ON warehouse_delivery_items
+  FOR INSERT WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY warehouse_delivery_items_update ON warehouse_delivery_items
+  FOR UPDATE USING (current_org_id() = organization_id)
+  WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY warehouse_delivery_items_delete ON warehouse_delivery_items
+  FOR DELETE USING (current_org_id() = organization_id);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3805.

Closes #3805

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3e92d8c fix(rls): upgrade warehouse_deliveries and warehouse_delivery_items to per-command policies with WITH CHECK (closes #3805)

### Files changed

```
 session_state.json                                 | 10 +++----
 .../migrations/00094_warehouse_deliveries_rls.sql  | 32 ++++++++++++++++++++++
 2 files changed, 37 insertions(+), 5 deletions(-)
```