### PR TITLE
Fix `org_isolation` RLS on `gabinet_appointment_treatments`

### DIFF
--- a/session_state.json
+++ b/session_state.json
@@ -1,9 +1,9 @@
 {
-  "session_id": "S0111",
-  "started_at": "2026-08-06T08:15:00Z",
-  "last_updated": "2026-08-06T08:20:00Z",
+  "session_id": "S0112",
+  "started_at": "2026-08-06T08:30:00Z",
+  "last_updated": "2026-08-06T08:35:00Z",
   "status": "completed",
-  "focus": "Issue #3805: Fix org_isolation RLS on warehouse_deliveries and warehouse_delivery_items",
+  "focus": "Issue #3806: Fix org_isolation RLS on gabinet_appointment_treatments",
   "tasks_snapshot": {
     "total": 1,
     "not_started": 0,
@@ -14,5 +14,5 @@
   },
   "active_task_ids": [],
   "blockers": [],
-  "notes": "S0111: Created 00094_warehouse_deliveries_rls.sql — drops the old ALL-operation org_isolation policies on warehouse_deliveries and warehouse_delivery_items, replaces with four per-command policies each (SELECT/INSERT/UPDATE/DELETE). INSERT and UPDATE now carry explicit WITH CHECK (current_org_id() = organization_id), closing the write-guard gap."
+  "notes": "S0112: Created 00095_gabinet_appointment_treatments_rls.sql — drops the old ALL-operation org_isolation policy on gabinet_appointment_treatments, replaces with four per-command policies (SELECT/INSERT/UPDATE/DELETE). INSERT and UPDATE now carry explicit WITH CHECK (current_org_id() = organization_id), closing the write-guard gap."
 }

--- a/supabase/migrations/00095_gabinet_appointment_treatments_rls.sql
+++ b/supabase/migrations/00095_gabinet_appointment_treatments_rls.sql
@@ -1,0 +1,20 @@
+-- Upgrade RLS on gabinet_appointment_treatments to the per-command pattern
+-- established in 00002_rls_policies.sql.
+--
+-- Migration 00069 created this table with a single ALL-operation org_isolation
+-- policy (USING only, no WITH CHECK). Without WITH CHECK, INSERT and UPDATE
+-- bypass the cross-org write guard, allowing a compromised service role to
+-- write rows into a different org's namespace. This migration brings the table
+-- in line with every other table in the project (closes #3806).
+
+DROP POLICY IF EXISTS org_isolation ON gabinet_appointment_treatments;
+
+CREATE POLICY gabinet_appointment_treatments_select ON gabinet_appointment_treatments
+  FOR SELECT USING (current_org_id() = organization_id);
+CREATE POLICY gabinet_appointment_treatments_insert ON gabinet_appointment_treatments
+  FOR INSERT WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY gabinet_appointment_treatments_update ON gabinet_appointment_treatments
+  FOR UPDATE USING (current_org_id() = organization_id)
+  WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY gabinet_appointment_treatments_delete ON gabinet_appointment_treatments
+  FOR DELETE USING (current_org_id() = organization_id);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3806.

Closes #3806

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 82c2106 fix(rls): upgrade gabinet_appointment_treatments to per-command policies with WITH CHECK (closes #3806)

### Files changed

```
 session_state.json                                   | 10 +++++-----
 .../00095_gabinet_appointment_treatments_rls.sql     | 20 ++++++++++++++++++++
 2 files changed, 25 insertions(+), 5 deletions(-)
```