### PR TITLE
Fix `org_isolation` RLS on `delivery_name_mappings`

### DIFF
--- a/session_state.json
+++ b/session_state.json
@@ -1,9 +1,9 @@
 {
-  "session_id": "S0112",
-  "started_at": "2026-08-06T08:30:00Z",
-  "last_updated": "2026-08-06T08:35:00Z",
+  "session_id": "S0113",
+  "started_at": "2026-08-06T08:40:00Z",
+  "last_updated": "2026-08-06T08:45:00Z",
   "status": "completed",
-  "focus": "Issue #3806: Fix org_isolation RLS on gabinet_appointment_treatments",
+  "focus": "Issue #3807: Fix org_isolation RLS on delivery_name_mappings",
   "tasks_snapshot": {
     "total": 1,
     "not_started": 0,
@@ -14,5 +14,5 @@
   },
   "active_task_ids": [],
   "blockers": [],
-  "notes": "S0112: Created 00095_gabinet_appointment_treatments_rls.sql — drops the old ALL-operation org_isolation policy on gabinet_appointment_treatments, replaces with four per-command policies (SELECT/INSERT/UPDATE/DELETE). INSERT and UPDATE now carry explicit WITH CHECK (current_org_id() = organization_id), closing the write-guard gap."
+  "notes": "S0113: Created 00096_delivery_name_mappings_rls.sql — drops the old ALL-operation org_isolation policy on delivery_name_mappings, replaces with four per-command policies (SELECT/INSERT/UPDATE/DELETE). INSERT and UPDATE now carry explicit WITH CHECK (current_org_id() = organization_id), closing the write-guard gap."
 }

--- a/supabase/migrations/00096_delivery_name_mappings_rls.sql
+++ b/supabase/migrations/00096_delivery_name_mappings_rls.sql
@@ -1,0 +1,20 @@
+-- Upgrade RLS on delivery_name_mappings to the per-command pattern established
+-- in 00002_rls_policies.sql.
+--
+-- Migration 00061 created this table with a single ALL-operation org_isolation
+-- policy (USING only, no WITH CHECK). Without WITH CHECK, INSERT and UPDATE
+-- bypass the cross-org write guard, allowing a compromised service role to
+-- write rows into a different org's namespace. This migration brings the table
+-- in line with every other table in the project (closes #3807).
+
+DROP POLICY IF EXISTS org_isolation ON delivery_name_mappings;
+
+CREATE POLICY delivery_name_mappings_select ON delivery_name_mappings
+  FOR SELECT USING (current_org_id() = organization_id);
+CREATE POLICY delivery_name_mappings_insert ON delivery_name_mappings
+  FOR INSERT WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY delivery_name_mappings_update ON delivery_name_mappings
+  FOR UPDATE USING (current_org_id() = organization_id)
+  WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY delivery_name_mappings_delete ON delivery_name_mappings
+  FOR DELETE USING (current_org_id() = organization_id);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3807.

Closes #3807

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 667f1a2 fix(rls): upgrade delivery_name_mappings to per-command policies with WITH CHECK (closes #3807)

### Files changed

```
 session_state.json                                   | 10 +++++-----
 .../migrations/00096_delivery_name_mappings_rls.sql  | 20 ++++++++++++++++++++
 2 files changed, 25 insertions(+), 5 deletions(-)
```