### PR TITLE
Fix `org_isolation` RLS on `gabinet_receipts`

### DIFF
--- a/supabase/migrations/00097_gabinet_receipts_rls.sql
+++ b/supabase/migrations/00097_gabinet_receipts_rls.sql
@@ -1,0 +1,20 @@
+-- Upgrade RLS on gabinet_receipts to the per-command pattern established
+-- in 00002_rls_policies.sql.
+--
+-- Migration 00083 created this table with a single ALL-operation org_isolation
+-- policy (USING only, no WITH CHECK). Without WITH CHECK, INSERT and UPDATE
+-- bypass the cross-org write guard, allowing a compromised service role to
+-- write rows into a different org's namespace. This migration brings the table
+-- in line with every other table in the project (closes #3808).
+
+DROP POLICY IF EXISTS org_isolation ON gabinet_receipts;
+
+CREATE POLICY gabinet_receipts_select ON gabinet_receipts
+  FOR SELECT USING (current_org_id() = organization_id);
+CREATE POLICY gabinet_receipts_insert ON gabinet_receipts
+  FOR INSERT WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY gabinet_receipts_update ON gabinet_receipts
+  FOR UPDATE USING (current_org_id() = organization_id)
+  WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY gabinet_receipts_delete ON gabinet_receipts
+  FOR DELETE USING (current_org_id() = organization_id);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3808.

Closes #3808

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d8bd883 fix(rls): upgrade gabinet_receipts to per-command policies with WITH CHECK (closes #3808)

### Files changed

```
 supabase/migrations/00097_gabinet_receipts_rls.sql | 20 ++++++++++++++++++++
 1 file changed, 20 insertions(+)
```