### PR TITLE
Fix `org_isolation` RLS on `gabinet_receipt_sequences`

### DIFF
--- a/supabase/migrations/00098_gabinet_receipt_sequences_rls.sql
+++ b/supabase/migrations/00098_gabinet_receipt_sequences_rls.sql
@@ -1,0 +1,20 @@
+-- Upgrade RLS on gabinet_receipt_sequences to the per-command pattern
+-- established in 00002_rls_policies.sql.
+--
+-- Migration 00084 created this table with a single ALL-operation org_isolation
+-- policy (USING only, no WITH CHECK). Without WITH CHECK, INSERT and UPDATE
+-- bypass the cross-org write guard, allowing a compromised service role to
+-- write rows into a different org's namespace. This migration brings the table
+-- in line with every other table in the project (closes #3809).
+
+DROP POLICY IF EXISTS org_isolation ON gabinet_receipt_sequences;
+
+CREATE POLICY gabinet_receipt_sequences_select ON gabinet_receipt_sequences
+  FOR SELECT USING (current_org_id() = organization_id);
+CREATE POLICY gabinet_receipt_sequences_insert ON gabinet_receipt_sequences
+  FOR INSERT WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY gabinet_receipt_sequences_update ON gabinet_receipt_sequences
+  FOR UPDATE USING (current_org_id() = organization_id)
+  WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY gabinet_receipt_sequences_delete ON gabinet_receipt_sequences
+  FOR DELETE USING (current_org_id() = organization_id);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3809.

Closes #3809

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a1384d5 fix(rls): upgrade gabinet_receipt_sequences to per-command policies with WITH CHECK (closes #3809)

### Files changed

```
 .../00098_gabinet_receipt_sequences_rls.sql          | 20 ++++++++++++++++++++
 1 file changed, 20 insertions(+)
```