### PR TITLE
Rozstrzygnąć RLS dla tabel users i subscriptions

### DIFF
--- a/session_state.json
+++ b/session_state.json
@@ -1,9 +1,9 @@
 {
-  "session_id": "S0113",
-  "started_at": "2026-08-06T08:40:00Z",
-  "last_updated": "2026-08-06T08:45:00Z",
+  "session_id": "S0114",
+  "started_at": "2026-08-06T09:00:00Z",
+  "last_updated": "2026-08-06T09:15:00Z",
   "status": "completed",
-  "focus": "Issue #3807: Fix org_isolation RLS on delivery_name_mappings",
+  "focus": "Issue #3822: Tighten RLS for users and subscriptions tables",
   "tasks_snapshot": {
     "total": 1,
     "not_started": 0,
@@ -14,5 +14,5 @@
   },
   "active_task_ids": [],
   "blockers": [],
-  "notes": "S0113: Created 00096_delivery_name_mappings_rls.sql — drops the old ALL-operation org_isolation policy on delivery_name_mappings, replaces with four per-command policies (SELECT/INSERT/UPDATE/DELETE). INSERT and UPDATE now carry explicit WITH CHECK (current_org_id() = organization_id), closing the write-guard gap."
+  "notes": "S0114: Created 00099_users_subscriptions_rls.sql — drops the overly permissive users_select policy (USING true, any authenticated user could read all user PII), replaces with org-scoped policy: service role OR self OR EXISTS(team_memberships in current_org_id). Subscriptions policy from 00002 is already correct (user_id = current_user_id OR service_role); no change needed there."
 }

--- a/supabase/migrations/00099_users_subscriptions_rls.sql
+++ b/supabase/migrations/00099_users_subscriptions_rls.sql
@@ -1,0 +1,42 @@
+-- ============================================================
+-- Migration 00099: Tighten RLS for users table (closes #3822)
+-- ============================================================
+--
+-- Context (issue #3822 — PK6 production launch checklist):
+--   Migration 00002 already enables RLS on both `users` and
+--   `subscriptions` and creates policies, but the `users` SELECT
+--   policy used USING (true) — any authenticated browser session
+--   could read personal data (email, phone, name) for any user on
+--   the platform, not just members of their own org.
+--
+-- Fix:
+--   Scope `users` SELECT to:
+--     1. The caller's own record (self)
+--     2. Other users who share a team_membership in the caller's
+--        current org (member directory, assignee name resolution)
+--     3. Service role (backend unrestricted access)
+--
+-- No change to subscriptions:
+--   The subscriptions table has no organization_id; it links to
+--   users via user_id (Stripe user-level subscription). The
+--   existing policy from 00002 —
+--     USING (user_id = current_user_id() OR is_service_role())
+--   — already correctly scopes reads to the owner's own row.
+--   No mutation is needed here.
+-- ============================================================
+
+-- Drop the overly permissive global-read policy
+DROP POLICY IF EXISTS users_select ON users;
+
+-- Org-scoped read: self + org co-members + service role
+CREATE POLICY users_select ON users
+  FOR SELECT
+  USING (
+    is_service_role()
+    OR id = current_user_id()
+    OR EXISTS (
+      SELECT 1 FROM team_memberships
+      WHERE team_memberships.user_id    = users.id
+        AND team_memberships.organization_id = current_org_id()
+    )
+  );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3822.

Closes #3822

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- bb6a113 fix(rls): tighten users SELECT policy — scope to org members (closes #3822)

### Files changed

```
 session_state.json                                 | 10 +++---
 .../migrations/00099_users_subscriptions_rls.sql   | 42 ++++++++++++++++++++++
 2 files changed, 47 insertions(+), 5 deletions(-)
```