### PR TITLE
fix(orgSettings): route reads from empty Convex table to Supabase (closes #3832)

### DIFF
--- a/convex/gabinet/appointmentReminders.ts
+++ b/convex/gabinet/appointmentReminders.ts
@@ -38,7 +38,7 @@ export const scheduleReminder = action({
     }
 
     // Get org settings for reminder config
-    const orgSettings = await ctx.runQuery(
+    const orgSettings = await ctx.runAction(
       internal.gabinet.appointments._getOrgSettings,
       { organizationId: args.organizationId },
     ) as Record<string, unknown> | null;
@@ -425,13 +425,12 @@ export const scheduleReminderInternal = internalMutation({
     if (!appointment) return null;
 
     // Get org settings for reminder config
-    const orgSettings = await ctx.db
-      .query("orgSettings")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .unique();
+    const orgSettings = await db.query("orgSettings")
+      .eq("organizationId", String(args.organizationId))
+      .first();
 
     const reminderHours =
-      orgSettings?.reminderHoursBefore ?? DEFAULT_REMINDER_HOURS;
+      (orgSettings as any)?.reminderHoursBefore ?? DEFAULT_REMINDER_HOURS;
 
     const appointmentMs = new Date(
       `${appointment.date}T${appointment.startTime}:00`

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1,4 +1,4 @@
-import { query, action, internalMutation, internalQuery, MutationCtx } from "../_generated/server";
+import { query, action, internalMutation, internalQuery, internalAction, MutationCtx } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import {
@@ -771,13 +771,13 @@ export const checkQualification = action({
 // Internal helpers for the create action (actions can't access ctx.db)
 // ---------------------------------------------------------------------------
 
-export const _getOrgSettings = internalQuery({
+export const _getOrgSettings = internalAction({
   args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
-    return await ctx.db
-      .query("orgSettings")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .unique();
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
+    return await db.query("orgSettings")
+      .eq("organizationId", String(args.organizationId))
+      .first() as Record<string, unknown> | null;
   },
 });
 
@@ -1039,11 +1039,7 @@ export const _createSideEffects = internalMutation({
           if (need24h) timingsHours.push(24);
         } else {
           // Legacy: single reminder at configured hours (default 24)
-          const orgSettings = await ctx.db
-            .query("orgSettings")
-            .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-            .unique();
-          const reminderHours = (orgSettings as any)?.reminderHoursBefore ?? 24;
+          const reminderHours = (supaOrgSettings?.reminderHoursBefore as number) ?? 24;
           timingsHours = [reminderHours];
         }
 
@@ -1248,7 +1244,7 @@ export const create = action({
     }
 
     // --- Org settings (reminder default) ---
-    const orgSettings = await ctx.runQuery(
+    const orgSettings = await ctx.runAction(
       internal.gabinet.appointments._getOrgSettings,
       { organizationId: args.organizationId },
     );

--- a/convex/orgSettings.ts
+++ b/convex/orgSettings.ts
@@ -1,4 +1,4 @@
-import { query, action, internalQuery } from "./_generated/server";
+import { query, action, internalQuery, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
@@ -91,5 +91,34 @@ export const upsert = action({
     });
 
     return settingsId;
+  },
+});
+
+// Mirrors resourceSharingEnabled into the Convex table so the public
+// getResourceSharingEnabled query (which can't reach Supabase) stays in sync.
+export const _syncResourceSharingToConvex = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    resourceSharingEnabled: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("orgSettings")
+      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+      .unique();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        resourceSharingEnabled: args.resourceSharingEnabled,
+      });
+    } else {
+      await ctx.db.insert("orgSettings", {
+        organizationId: args.organizationId,
+        allowCustomLostReason: false,
+        lostReasonRequired: false,
+        resourceSharingEnabled: args.resourceSharingEnabled,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    }
   },
 });

--- a/convex/permissions.ts
+++ b/convex/permissions.ts
@@ -152,5 +152,11 @@ export const setResourceSharingEnabled = action({
         updatedAt: now,
       });
     }
+
+    // Mirror to Convex so the getResourceSharingEnabled query stays in sync.
+    await ctx.runMutation(internal.orgSettings._syncResourceSharingToConvex, {
+      organizationId: args.organizationId,
+      resourceSharingEnabled: args.enabled,
+    });
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
         "openai": "^6.46.0",
         "oslo": "^1.2.1",
         "papaparse": "^5.5.3",
+        "pdf-lib": "^1.17.1",
         "platejs": "^52.3.4",
         "primereact": "^11.0.0-alpha.1",
         "radix-ui": "^1.4.3",
@@ -4026,6 +4027,24 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -15961,6 +15980,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/papaparse": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
@@ -16084,6 +16109,24 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/peberminta": {
       "version": "0.9.0",

--- a/tests/convex/orgSettingsEffect.test.ts
+++ b/tests/convex/orgSettingsEffect.test.ts
@@ -147,9 +147,9 @@ describe("reminderEnabled: controls whether appointment creation schedules a rem
       userId,
     );
 
-    // Seed reminderEnabled=true in Convex (read by _getOrgSettings internalQuery).
-    // No Supabase 4-toggle config → falls through to legacy 24h mode in _createSideEffects.
-    await seedConvexOrgSettings(t, organizationId, { reminderEnabled: true });
+    // Seed reminderEnabled=true in Supabase (read by _getOrgSettings internalAction).
+    // No 4-toggle config → falls through to legacy 24h mode in _createSideEffects.
+    await seedSupabaseOrgSettings(String(organizationId), { reminderEnabled: true });
 
     // Create appointment without an explicit sendReminder arg so the action
     // picks up the value from orgSettings.reminderEnabled.
@@ -177,7 +177,7 @@ describe("reminderEnabled: controls whether appointment creation schedules a rem
       userId,
     );
 
-    await seedConvexOrgSettings(t, organizationId, { reminderEnabled: false });
+    await seedSupabaseOrgSettings(String(organizationId), { reminderEnabled: false });
 
     await createFutureAppointment(t, identity, {
       organizationId,
@@ -207,8 +207,8 @@ describe("reminderHoursBefore: controls legacy single-reminder offset", () => {
       userId,
     );
 
-    // Seed 48h offset. No Supabase 4-toggle config → legacy mode uses this value.
-    await seedConvexOrgSettings(t, organizationId, { reminderHoursBefore: 48 });
+    // Seed 48h offset in Supabase. No 4-toggle config → legacy mode uses this value.
+    await seedSupabaseOrgSettings(String(organizationId), { reminderHoursBefore: 48 });
 
     await createFutureAppointment(t, identity, {
       organizationId,


### PR DESCRIPTION
## Summary

- `_getOrgSettings` in `appointments.ts` converted from `internalQuery` (reads empty Convex table) to `internalAction` that reads from Supabase directly; callers updated from `ctx.runQuery` → `ctx.runAction`
- `_createSideEffects` legacy reminder-hours path no longer re-queries Convex — uses already-fetched `supaOrgSettings`
- `scheduleReminderInternal` mutation now reads `reminderHoursBefore` via `db.query()` (Supabase) instead of `ctx.db`
- `getResourceSharingEnabled` public query must stay a query (frontend uses `useQuery`), so a new `_syncResourceSharingToConvex` internalMutation mirrors the value to Convex whenever `setResourceSharingEnabled` writes to Supabase
- `getWorkflowConfigInternal` was already removed in #3678 — no-op
- Test file updated: `reminderEnabled` and `reminderHoursBefore` tests now seed the in-memory Supabase store (all 18 tests pass)

## Test plan

- [x] All 18 `orgSettingsEffect` tests pass
- [x] Full test suite: no regressions introduced (8 pre-existing failures in patientPortalIsolation / bookFromPortal / payments are unrelated to this PR)
- [x] TypeScript: clean (`tsc --noEmit` exits 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)