### PR TITLE
Move `orgSettings._getSettings` reads from Convex to Supabase

### DIFF
--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -323,7 +323,7 @@ export const update = action({
 
     // Enforce lostReasonRequired when marking a lead as lost
     if (args.status === "lost") {
-      const settings = await ctx.runQuery(internal.orgSettings._getSettings, {
+      const settings = await ctx.runAction(internal.orgSettings._getSettings, {
         organizationId: args.organizationId,
       });
       if (settings?.lostReasonRequired && !args.lostReason) {

--- a/convex/lostReasons.ts
+++ b/convex/lostReasons.ts
@@ -32,7 +32,7 @@ export const create = action({
       { organizationId: args.organizationId },
     );
 
-    const settings = await ctx.runQuery(internal.orgSettings._getSettings, {
+    const settings = await ctx.runAction(internal.orgSettings._getSettings, {
       organizationId: args.organizationId,
     });
     if (settings?.allowCustomLostReason === false) {

--- a/convex/orgSettings.ts
+++ b/convex/orgSettings.ts
@@ -1,16 +1,16 @@
-import { query, action, internalQuery, internalMutation } from "./_generated/server";
+import { query, action, internalAction, internalQuery, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
 import { verifyOrgAccess } from "./_helpers/auth";
 
-export const _getSettings = internalQuery({
+export const _getSettings = internalAction({
   args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
-    return await ctx.db
-      .query("orgSettings")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .unique();
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
+    return await db.query("orgSettings")
+      .eq("organizationId", String(args.organizationId))
+      .first() as Record<string, unknown> | null;
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3837.

Closes #3837

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- af75a86 fix(orgSettings): route _getSettings reads from Supabase (closes #3837)

### Files changed

```
 convex/leads.ts       |  2 +-
 convex/lostReasons.ts |  2 +-
 convex/orgSettings.ts | 14 +++++++-------
 3 files changed, 9 insertions(+), 9 deletions(-)
```