### PR TITLE
Rename `tokenHash` arg to `token` in `logoutPortal` and `getPortalSession` API s

### DIFF
--- a/convex/gabinet/patientAuth.ts
+++ b/convex/gabinet/patientAuth.ts
@@ -291,7 +291,7 @@ export const getOrgBySlug = query({
 // `ctx.db` would never see rows written by the OTP flow (#540).
 export const getPortalSession = action({
   args: {
-    tokenHash: v.string(),
+    token: v.string(),
   },
   handler: async (_ctx, args): Promise<{
     patientId: string;
@@ -303,7 +303,7 @@ export const getPortalSession = action({
 
     let validated: { patientId: string; organizationId: string };
     try {
-      validated = await validatePortalSessionSupabase(db, args.tokenHash);
+      validated = await validatePortalSessionSupabase(db, args.token);
     } catch {
       return null;
     }
@@ -322,11 +322,11 @@ export const getPortalSession = action({
 
 export const logoutPortal = action({
   args: {
-    tokenHash: v.string(),
+    token: v.string(),
   },
   handler: async (_ctx, args) => {
     const db = createSupabaseDb();
-    const hashedToken = await sha256(args.tokenHash);
+    const hashedToken = await sha256(args.token);
 
     const session = await db.query("gabinetPortalSessions")
       .eq("tokenHash", hashedToken)

--- a/src/routes/_app/patient/_layout.documents.tsx
+++ b/src/routes/_app/patient/_layout.documents.tsx
@@ -41,7 +41,7 @@ function PatientDocuments() {
   const getPortalSession = useAction(api.gabinet.patientAuth.getPortalSession);
   const { data: portalSession } = useQuery({
     queryKey: ["gabinet.patientAuth.getPortalSession", tokenHash],
-    queryFn: () => getPortalSession({ tokenHash }),
+    queryFn: () => getPortalSession({ token: tokenHash }),
     enabled: !!tokenHash,
   });
 

--- a/src/routes/_app/patient/_layout.tsx
+++ b/src/routes/_app/patient/_layout.tsx
@@ -21,7 +21,7 @@ function PatientLayout() {
 
   const { data: session, isLoading } = useQuery({
     queryKey: ["gabinet.patientAuth.getPortalSession", token ?? ""],
-    queryFn: () => getPortalSession({ tokenHash: token ?? "" }),
+    queryFn: () => getPortalSession({ token: token ?? "" }),
     enabled: !!token,
   });
 
@@ -35,7 +35,7 @@ function PatientLayout() {
   const handleLogout = useCallback(async () => {
     if (token) {
       try {
-        await logout({ tokenHash: token });
+        await logout({ token });
       } catch { /* logout may fail if token expired */ }
     }
     localStorage.removeItem("patientPortalToken");

--- a/tests/convex/patientAuth.test.ts
+++ b/tests/convex/patientAuth.test.ts
@@ -388,7 +388,7 @@ describe("getPortalSession", () => {
 
     const session = await t.withIdentity(identity).action(
       api.gabinet.patientAuth.getPortalSession,
-      { tokenHash: rawToken },
+      { token: rawToken },
     );
 
     expect(session).not.toBeNull();
@@ -412,7 +412,7 @@ describe("getPortalSession", () => {
 
     const session = await t.withIdentity(identity).action(
       api.gabinet.patientAuth.getPortalSession,
-      { tokenHash: rawToken },
+      { token: rawToken },
     );
 
     expect(session).toBeNull();
@@ -435,7 +435,7 @@ describe("getPortalSession", () => {
 
     const session = await t.withIdentity(identity).action(
       api.gabinet.patientAuth.getPortalSession,
-      { tokenHash: rawToken },
+      { token: rawToken },
     );
 
     expect(session).toBeNull();
@@ -459,7 +459,7 @@ describe("getPortalSession", () => {
     const before = Date.now();
     const session = await t.withIdentity(identity).action(
       api.gabinet.patientAuth.getPortalSession,
-      { tokenHash: rawToken },
+      { token: rawToken },
     );
     const after = Date.now();
 
@@ -518,7 +518,7 @@ describe("full OTP auth flow", () => {
     // Logout receives the raw token, hashes it internally, deactivates the session
     await t.withIdentity(identity).action(
       api.gabinet.patientAuth.logoutPortal,
-      { tokenHash: sessionToken },
+      { token: sessionToken },
     );
 
     const afterLogout = await db


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3826.

Closes #3826

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0f6f9ff refactor(patientPortal): rename tokenHash arg to token in logoutPortal and getPortalSession (closes #3826)

### Files changed

```
 convex/gabinet/patientAuth.ts                 |  8 ++++----
 src/routes/_app/patient/_layout.documents.tsx |  2 +-
 src/routes/_app/patient/_layout.tsx           |  4 ++--
 tests/convex/patientAuth.test.ts              | 10 +++++-----
 4 files changed, 12 insertions(+), 12 deletions(-)
```