### PR TITLE
Migrate `permissions.getResourceSharingEnabled` off Convex to Supabase

### DIFF
--- a/convex/orgSettings.ts
+++ b/convex/orgSettings.ts
@@ -1,4 +1,4 @@
-import { action, internalAction, internalMutation } from "./_generated/server";
+import { action, internalAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
@@ -94,31 +94,3 @@ export const upsert = action({
   },
 });
 
-// Mirrors resourceSharingEnabled into the Convex table so the public
-// getResourceSharingEnabled query (which can't reach Supabase) stays in sync.
-export const _syncResourceSharingToConvex = internalMutation({
-  args: {
-    organizationId: v.id("organizations"),
-    resourceSharingEnabled: v.boolean(),
-  },
-  handler: async (ctx, args) => {
-    const existing = await ctx.db
-      .query("orgSettings")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .unique();
-    if (existing) {
-      await ctx.db.patch(existing._id, {
-        resourceSharingEnabled: args.resourceSharingEnabled,
-      });
-    } else {
-      await ctx.db.insert("orgSettings", {
-        organizationId: args.organizationId,
-        allowCustomLostReason: false,
-        lostReasonRequired: false,
-        resourceSharingEnabled: args.resourceSharingEnabled,
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
-      });
-    }
-  },
-});

--- a/convex/permissions.ts
+++ b/convex/permissions.ts
@@ -105,17 +105,20 @@ export const updateOrgPermissions = mutation({
   },
 });
 
-export const getResourceSharingEnabled = query({
+export const getResourceSharingEnabled = action({
   args: { organizationId: v.id("organizations") },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await ctx.runQuery(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
 
-    const settings = await ctx.db
+    const db = createSupabaseDb();
+    const settings = await db
       .query("orgSettings")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .unique();
+      .eq("organizationId", String(args.organizationId))
+      .first();
 
-    return settings?.resourceSharingEnabled ?? true;
+    return (settings?.resourceSharingEnabled as boolean | undefined) ?? true;
   },
 });
 
@@ -153,10 +156,5 @@ export const setResourceSharingEnabled = action({
       });
     }
 
-    // Mirror to Convex so the getResourceSharingEnabled query stays in sync.
-    await ctx.runMutation(internal.orgSettings._syncResourceSharingToConvex, {
-      organizationId: args.organizationId,
-      resourceSharingEnabled: args.enabled,
-    });
   },
 });

--- a/src/components/crm/share-dialog.tsx
+++ b/src/components/crm/share-dialog.tsx
@@ -4,6 +4,7 @@ import { useAction } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
+import { useSupabaseOrgSettings } from "@/hooks/use-supabase-organizations";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Share2, X, Mail } from "@/lib/ez-icons";
@@ -45,12 +46,8 @@ export function ShareDialog({
   const [accessLevel, setAccessLevel] = useState<"viewer" | "editor">("viewer");
   const [isSending, setIsSending] = useState(false);
 
-  const { data: sharingEnabled } = useQuery({
-    ...convexQuery(api.permissions.getResourceSharingEnabled, {
-      organizationId,
-    }),
-    enabled: open && !!organizationId,
-  });
+  const { data: orgSettings } = useSupabaseOrgSettings(organizationId, { enabled: open && !!organizationId });
+  const sharingEnabled = orgSettings?.resourceSharingEnabled ?? true;
 
   const { data: invites } = useQuery({
     ...convexQuery(api.resourceInvites.listByResource, {

--- a/src/routes/_app/_auth/dashboard/_layout.settings.permissions.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.permissions.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useQuery, useMutation, useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
+import { useSupabaseOrgSettings } from "@/hooks/use-supabase-organizations";
 import { SectionHeader } from "@untitled/app/section-headers/section-headers";
 import { UntitledAlert } from "@/components/ui/untitled-alert";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -91,7 +92,8 @@ function PermissionsSettings() {
     api.permissions.getOrgPermissionOverrides,
     isAdmin ? { organizationId } : "skip",
   );
-  const resourceSharingEnabled = useQuery(api.permissions.getResourceSharingEnabled, { organizationId });
+  const { data: orgSettings } = useSupabaseOrgSettings(organizationId);
+  const resourceSharingEnabled = orgSettings?.resourceSharingEnabled ?? true;
 
   const updatePermissions = useMutation(api.permissions.updateOrgPermissions);
   const setResourceSharing = useAction(api.permissions.setResourceSharingEnabled);

--- a/tests/convex/orgSettingsEffect.test.ts
+++ b/tests/convex/orgSettingsEffect.test.ts
@@ -13,8 +13,8 @@
  *   reminderSms24h/48h      → _createSideEffects 4-toggle mode: determines which
  *   reminderEmail24h/48h      timing slots (24h, 48h) are scheduled
  *                             (appointments.ts:1023–1048)
- *   resourceSharingEnabled  → permissions.getResourceSharingEnabled query:
- *                             returned directly to callers (permissions.ts:118)
+ *   resourceSharingEnabled  → permissions.getResourceSharingEnabled action:
+ *                             reads from Supabase, returned directly to callers (permissions.ts:118)
  *
  * Resolved follow-ups (issue #3678):
  *   timezone                — wired up: appointment-dialog now reads orgSettings.timezone
@@ -403,13 +403,13 @@ describe("resourceSharingEnabled: controls permissions.getResourceSharingEnabled
     const t = createTestCtx();
     const { organizationId, identity } = await seedTestUser(t);
 
-    await seedConvexOrgSettings(t, organizationId, {
+    await seedSupabaseOrgSettings(String(organizationId), {
       resourceSharingEnabled: false,
     });
 
     const result = await t
       .withIdentity(identity)
-      .query(api.permissions.getResourceSharingEnabled, { organizationId });
+      .action(api.permissions.getResourceSharingEnabled, { organizationId });
 
     expect(result).toBe(false);
   });
@@ -418,13 +418,13 @@ describe("resourceSharingEnabled: controls permissions.getResourceSharingEnabled
     const t = createTestCtx();
     const { organizationId, identity } = await seedTestUser(t);
 
-    await seedConvexOrgSettings(t, organizationId, {
+    await seedSupabaseOrgSettings(String(organizationId), {
       resourceSharingEnabled: true,
     });
 
     const result = await t
       .withIdentity(identity)
-      .query(api.permissions.getResourceSharingEnabled, { organizationId });
+      .action(api.permissions.getResourceSharingEnabled, { organizationId });
 
     expect(result).toBe(true);
   });
@@ -437,7 +437,7 @@ describe("resourceSharingEnabled: controls permissions.getResourceSharingEnabled
 
     const result = await t
       .withIdentity(identity)
-      .query(api.permissions.getResourceSharingEnabled, { organizationId });
+      .action(api.permissions.getResourceSharingEnabled, { organizationId });
 
     expect(result).toBe(true);
   });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3842.

Closes #3842

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 130759a fix(permissions): migrate getResourceSharingEnabled off Convex to Supabase (closes #3842)

### Files changed

```
 convex/orgSettings.ts                              | 30 +---------------------
 convex/permissions.ts                              | 20 +++++++--------
 src/components/crm/share-dialog.tsx                |  9 +++----
 .../dashboard/_layout.settings.permissions.tsx     |  4 ++-
 tests/convex/orgSettingsEffect.test.ts             | 14 +++++-----
 5 files changed, 23 insertions(+), 54 deletions(-)
```