### PR TITLE
Migrate `_grantPlatformAdmin` away from `ctx.db.query("users")` multiline split

### DIFF
--- a/convex/platformAdmins.ts
+++ b/convex/platformAdmins.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { action, internalAction, internalMutation } from "./_generated/server";
+import { action, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 
@@ -85,18 +85,5 @@ export const _patchAdminInConvex = internalMutation({
   },
   handler: async (ctx, args) => {
     await ctx.db.patch(args.userId, { isPlatformAdmin: args.isPlatformAdmin });
-  },
-});
-
-// Supabase-side patch called by _grantPlatformAdmin (internalMutation) which
-// cannot reach Supabase directly (V8 runtime). Scheduled via ctx.scheduler.
-export const _syncAdminFlagToSupabase = internalAction({
-  args: {
-    userId: v.string(),
-    isPlatformAdmin: v.boolean(),
-  },
-  handler: async (_ctx, args) => {
-    const db = createSupabaseDb();
-    await db.patch("users", args.userId, { isPlatformAdmin: args.isPlatformAdmin });
   },
 });

--- a/convex/platformSettings.ts
+++ b/convex/platformSettings.ts
@@ -3,10 +3,11 @@ import {
   query,
   mutation,
   internalQuery,
-  internalMutation,
+  internalAction,
 } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { requirePlatformAdmin } from "./_helpers/auth";
+import { createSupabaseDb } from "./_helpers/supabaseDb";
 
 // Get the current platform settings (singleton). Returns null if not yet
 // configured. Reading is allowed for any authenticated context but API key
@@ -95,22 +96,18 @@ export const set = mutation({
 // Intended to be called via `npx convex run` (requires admin token), exactly
 // once per environment, to seed the first platform admin. Subsequent admins
 // can be granted via the admin UI once one exists.
-export const _grantPlatformAdmin = internalMutation({
+export const _grantPlatformAdmin = internalAction({
   args: { email: v.string() },
   handler: async (ctx, args) => {
-    const user = await ctx.db
-      .query("users")
-      .withIndex("email", (q) => q.eq("email", args.email))
-      .unique();
+    const db = createSupabaseDb();
+    const user = await db.query("users").eq("email", args.email).unique();
     if (!user) throw new Error(`No user found for email ${args.email}`);
-    await ctx.db.patch(user._id, { isPlatformAdmin: true });
-    // Sync the flag to Supabase asynchronously — internalMutation runs in the
-    // V8 runtime and cannot call Supabase directly.
-    await ctx.scheduler.runAfter(
-      0,
-      internal.platformAdmins._syncAdminFlagToSupabase,
-      { userId: String(user._id), isPlatformAdmin: true },
-    );
+    await db.patch("users", String(user._id), { isPlatformAdmin: true });
+    // Keep Convex in sync — requirePlatformAdmin reads isPlatformAdmin from ctx.db.
+    await ctx.runMutation(internal.platformAdmins._patchAdminInConvex, {
+      userId: user._id,
+      isPlatformAdmin: true,
+    });
     return { userId: user._id, email: args.email };
   },
 });

--- a/scripts/check-convex-db-reads.mjs
+++ b/scripts/check-convex-db-reads.mjs
@@ -115,6 +115,15 @@ function relToModuleKey(relPath) {
 //
 // Only ctx.db.query is flagged. A bare db.query where db = createSupabaseDb()
 // is the correct Supabase read path and is intentionally not matched here.
+//
+// Known gap: the regex below only matches single-line
+//   ctx.db.query("table")
+// patterns. Multiline splits like
+//   ctx.db
+//     .query("table")
+// are not detected. Many auth helper functions (auth.ts, permissions.ts,
+// seatLimits.ts) use the multiline style and would require a separate
+// bulk-migration effort to address. See issue #3857 for context.
 // ---------------------------------------------------------------------------
 function findViolations(content, tableMapKeys) {
   const violations = [];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3857.

Closes #3857

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c637a25 fix(platformSettings): migrate _grantPlatformAdmin to internalAction (closes #3857)

### Files changed

```
 convex/platformAdmins.ts          | 15 +--------------
 convex/platformSettings.ts        | 25 +++++++++++--------------
 scripts/check-convex-db-reads.mjs |  9 +++++++++
 3 files changed, 21 insertions(+), 28 deletions(-)
```