### PR TITLE
Migrate `app.getCurrentUser` isPlatformAdmin read off ctx.db.get

### DIFF
--- a/convex/_helpers/authAction.ts
+++ b/convex/_helpers/authAction.ts
@@ -187,20 +187,18 @@ export const checkPermission = internalAction({
   },
 });
 
-// Platform-admin guard for action handlers. Actions cannot call
-// requirePlatformAdmin directly (V8-only), so they delegate here via
-// ctx.runQuery(internal._helpers.authAction.verifyPlatformAdmin, {}).
-// verifyPlatformAdmin reads only `users` via ctx.db.get (auth-authoritative,
-// not flagged by the TABLE_MAP gate) so it stays as internalQuery.
-export const verifyPlatformAdmin = internalQuery({
+// Platform-admin guard for action handlers. Reads isPlatformAdmin from
+// Supabase (authoritative post-migration). Call via
+// ctx.runAction(internal._helpers.authAction.verifyPlatformAdmin, {}).
+export const verifyPlatformAdmin = internalAction({
   args: {},
-  returns: v.object({ userId: v.id("users") }),
-  handler: async (ctx) => {
+  handler: async (ctx): Promise<{ userId: Id<"users"> }> => {
     const userId = await auth.getUserId(ctx);
     if (!userId) throw new Error("Not authenticated");
-    const user = await ctx.db.get(userId);
+    const db = createSupabaseDb();
+    const user = await db.get("users", String(userId));
     if (!user) throw new Error("User not found");
     if (!user.isPlatformAdmin) throw new Error("Platform admin access required");
-    return { userId: user._id };
+    return { userId: userId as Id<"users"> };
   },
 });

--- a/convex/app.ts
+++ b/convex/app.ts
@@ -5,6 +5,7 @@ import { currencyValidator, PLANS } from "@cvx/schema";
 import { asyncMap } from "convex-helpers";
 import { v } from "convex/values";
 import { User } from "~/types";
+import { createSupabaseDb } from "./_helpers/supabaseDb";
 
 export const getCurrentUser = query({
   args: {},
@@ -29,8 +30,10 @@ export const getCurrentUser = query({
     const avatarUrl = user.imageId
       ? await ctx.storage.getUrl(user.imageId)
       : user.image;
+    // Exclude isPlatformAdmin — read it from Supabase via getIsPlatformAdmin action.
+    const { isPlatformAdmin: _omit, ...userFields } = user;
     return {
-      ...user,
+      ...userFields,
       avatarUrl: avatarUrl || undefined,
       subscription:
         subscription && plan
@@ -40,6 +43,20 @@ export const getCurrentUser = query({
             }
           : undefined,
     };
+  },
+});
+
+// Returns whether the current user has the platform-admin flag, reading from
+// Supabase (the authoritative store for isPlatformAdmin post-migration).
+// Call this instead of user.isPlatformAdmin from getCurrentUser.
+export const getIsPlatformAdmin = action({
+  args: {},
+  handler: async (ctx): Promise<{ isPlatformAdmin: boolean }> => {
+    const userId = await auth.getUserId(ctx);
+    if (!userId) return { isPlatformAdmin: false };
+    const db = createSupabaseDb();
+    const user = await db.get("users", String(userId));
+    return { isPlatformAdmin: Boolean(user?.isPlatformAdmin) };
   },
 });
 

--- a/convex/platformAdmins.ts
+++ b/convex/platformAdmins.ts
@@ -9,7 +9,7 @@ import { createSupabaseDb } from "./_helpers/supabaseDb";
 export const list = action({
   args: {},
   handler: async (ctx) => {
-    await ctx.runQuery(internal._helpers.authAction.verifyPlatformAdmin, {});
+    await ctx.runAction(internal._helpers.authAction.verifyPlatformAdmin, {});
     const db = createSupabaseDb();
     const users = await db.query("users").collect();
     return users
@@ -37,7 +37,7 @@ export const setRole = action({
     isPlatformAdmin: v.boolean(),
   },
   handler: async (ctx, args) => {
-    const { userId: actorId } = await ctx.runQuery(
+    const { userId: actorId } = await ctx.runAction(
       internal._helpers.authAction.verifyPlatformAdmin,
       {},
     );

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -103,6 +103,12 @@ export function AppSidebar() {
   const { data: activeProducts } = useQuery(convexQuery(api.productSubscriptions.getActiveProducts, { organizationId }));
   const { data: currentUser } = useQuery(convexQuery(api.app.getCurrentUser, {}));
 
+  const getIsPlatformAdmin = useAction(api.app.getIsPlatformAdmin);
+  const { data: adminStatus } = useQuery({
+    queryKey: ["isPlatformAdmin"],
+    queryFn: () => getIsPlatformAdmin({}),
+  });
+
   const visibleModules = getVisibleModules(activeProducts);
   const hasGabinet = visibleModules.some((module) => module.id === "gabinet");
 
@@ -129,7 +135,7 @@ export function AppSidebar() {
     .flatMap((module) => module.settingsNav)
     .filter((item) => {
       if (item.adminOnly && !isAdmin) return false;
-      if (item.platformAdminOnly && !currentUser?.isPlatformAdmin) return false;
+      if (item.platformAdminOnly && !adminStatus?.isPlatformAdmin) return false;
       if (item.permissionFeature && !canView(item.permissionFeature)) return false;
       return true;
     });

--- a/src/routes/_app/_auth/admin.email-config.tsx
+++ b/src/routes/_app/_auth/admin.email-config.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation } from "@tanstack/react-query";
 import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
-import { useMutation } from "@tanstack/react-query";
+import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
@@ -27,9 +27,11 @@ type ProviderChoice = "env" | "resend" | "mailgun";
 
 function AdminEmailConfig() {
   const { t } = useTranslation();
-  const { data: user, isLoading: userLoading } = useQuery(
-    convexQuery(api.app.getCurrentUser, {}),
-  );
+  const getIsPlatformAdmin = useAction(api.app.getIsPlatformAdmin);
+  const { data: adminStatus, isLoading: userLoading } = useQuery({
+    queryKey: ["isPlatformAdmin"],
+    queryFn: () => getIsPlatformAdmin({}),
+  });
   const { data: settings, isLoading: settingsLoading } = useQuery(
     convexQuery(api.platformSettings.get, {}),
   );
@@ -77,7 +79,7 @@ function AdminEmailConfig() {
     return <div className="p-8 text-sm text-muted-foreground">Loading…</div>;
   }
 
-  if (!user?.isPlatformAdmin) {
+  if (!adminStatus?.isPlatformAdmin) {
     return (
       <div className="mx-auto max-w-2xl p-8">
         <Card>

--- a/src/routes/_app/_auth/admin.errors.tsx
+++ b/src/routes/_app/_auth/admin.errors.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
+import { useAction } from "convex/react";
 import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -21,9 +22,11 @@ export const Route = createFileRoute("/_app/_auth/admin/errors")({
 type SourceFilter = "all" | "convex" | "frontend";
 
 function AdminErrors() {
-  const { data: viewer, isLoading: viewerLoading } = useQuery(
-    convexQuery(api.app.getCurrentUser, {}),
-  );
+  const getIsPlatformAdmin = useAction(api.app.getIsPlatformAdmin);
+  const { data: adminStatus, isLoading: viewerLoading } = useQuery({
+    queryKey: ["isPlatformAdmin"],
+    queryFn: () => getIsPlatformAdmin({}),
+  });
 
   const [source, setSource] = useState<SourceFilter>("all");
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -33,7 +36,7 @@ function AdminErrors() {
       limit: 200,
       source: source === "all" ? undefined : source,
     }),
-    enabled: Boolean(viewer?.isPlatformAdmin),
+    enabled: Boolean(adminStatus?.isPlatformAdmin),
     refetchInterval: 5000,
   });
 
@@ -41,7 +44,7 @@ function AdminErrors() {
     return <div className="p-8 text-sm text-muted-foreground">Loading…</div>;
   }
 
-  if (!viewer?.isPlatformAdmin) {
+  if (!adminStatus?.isPlatformAdmin) {
     return (
       <div className="mx-auto max-w-2xl p-8">
         <Card>

--- a/src/routes/_app/_auth/admin.index.tsx
+++ b/src/routes/_app/_auth/admin.index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
-import { convexQuery } from "@convex-dev/react-query";
+import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -9,15 +9,17 @@ export const Route = createFileRoute("/_app/_auth/admin/")({
 });
 
 function AdminIndex() {
-  const { data: user, isLoading } = useQuery(
-    convexQuery(api.app.getCurrentUser, {}),
-  );
+  const getIsPlatformAdmin = useAction(api.app.getIsPlatformAdmin);
+  const { data: adminStatus, isLoading } = useQuery({
+    queryKey: ["isPlatformAdmin"],
+    queryFn: () => getIsPlatformAdmin({}),
+  });
 
   if (isLoading) {
     return <div className="p-8 text-sm text-muted-foreground">Loading…</div>;
   }
 
-  if (!user?.isPlatformAdmin) {
+  if (!adminStatus?.isPlatformAdmin) {
     return (
       <div className="mx-auto max-w-2xl p-8">
         <Card>

--- a/src/routes/_app/_auth/admin.users.tsx
+++ b/src/routes/_app/_auth/admin.users.tsx
@@ -23,11 +23,17 @@ function AdminUsers() {
     convexQuery(api.app.getCurrentUser, {}),
   );
 
+  const getIsPlatformAdmin = useAction(api.app.getIsPlatformAdmin);
+  const { data: adminStatus, isLoading: adminLoading } = useQuery({
+    queryKey: ["isPlatformAdmin"],
+    queryFn: () => getIsPlatformAdmin({}),
+  });
+
   const listAction = useAction(api.platformAdmins.list);
   const usersQuery = useQuery({
     queryKey: ["platformAdmins", "list"],
     queryFn: () => listAction({}),
-    enabled: Boolean(viewer?.isPlatformAdmin),
+    enabled: Boolean(adminStatus?.isPlatformAdmin),
   });
 
   const setRoleAction = useAction(api.platformAdmins.setRole);
@@ -47,11 +53,11 @@ function AdminUsers() {
     },
   });
 
-  if (viewerLoading) {
+  if (viewerLoading || adminLoading) {
     return <div className="p-8 text-sm text-muted-foreground">Loading…</div>;
   }
 
-  if (!viewer?.isPlatformAdmin) {
+  if (!adminStatus?.isPlatformAdmin) {
     return (
       <div className="mx-auto max-w-2xl p-8">
         <Card>
@@ -108,7 +114,7 @@ function AdminUsers() {
               <div className="p-6 text-sm text-muted-foreground">No users found.</div>
             )}
             {users.map((u) => {
-              const isSelf = u._id === viewer._id;
+              const isSelf = u._id === viewer?._id;
               return (
                 <div
                   key={u._id}

--- a/types.ts
+++ b/types.ts
@@ -1,7 +1,9 @@
 import { Doc } from "~/convex/_generated/dataModel";
 import { PlanKey } from "~/convex/schema";
 
-export type User = Doc<"users"> & {
+// isPlatformAdmin is excluded — read it via api.app.getIsPlatformAdmin action
+// (Supabase-authoritative post-migration; not spread by getCurrentUser query).
+export type User = Omit<Doc<"users">, "isPlatformAdmin"> & {
   avatarUrl?: string;
   subscription?: Doc<"subscriptions"> & {
     planKey: PlanKey;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3863.

Closes #3863

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a473220 feat(platformAdmin): migrate isPlatformAdmin read off ctx.db.get to Supabase (closes #3863)

### Files changed

```
 convex/_helpers/authAction.ts                | 18 ++++++++----------
 convex/app.ts                                | 19 ++++++++++++++++++-
 convex/platformAdmins.ts                     |  4 ++--
 src/components/layout/app-sidebar.tsx        |  8 +++++++-
 src/routes/_app/_auth/admin.email-config.tsx | 14 ++++++++------
 src/routes/_app/_auth/admin.errors.tsx       | 13 ++++++++-----
 src/routes/_app/_auth/admin.index.tsx        | 12 +++++++-----
 src/routes/_app/_auth/admin.users.tsx        | 14 ++++++++++----
 types.ts                                     |  4 +++-
 9 files changed, 71 insertions(+), 35 deletions(-)
```