### PR TITLE
Audit `permissions.ts

### DIFF
--- a/convex/_helpers/authAction.ts
+++ b/convex/_helpers/authAction.ts
@@ -187,6 +187,39 @@ export const checkPermission = internalAction({
   },
 });
 
+// ---------------------------------------------------------------------------
+// checkResourceAccess — reads resourceInvites from Supabase (TABLE_MAP primary).
+// Checks whether the current user has an accepted invite for a given resource.
+// Callers must use ctx.runAction (not ctx.runQuery).
+// ---------------------------------------------------------------------------
+export const checkResourceAccess = internalAction({
+  args: {
+    resourceType: v.string(),
+    resourceId: v.string(),
+  },
+  handler: async (ctx, args): Promise<{ allowed: boolean; accessLevel: "viewer" | "editor" | null }> => {
+    const userId = await auth.getUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const db = createSupabaseDb();
+    const invites = await db
+      .query("resourceInvites")
+      .eq("resourceType", args.resourceType)
+      .eq("resourceId", args.resourceId)
+      .collect();
+
+    const match = invites.find(
+      (inv) => inv.status === "accepted" && inv.userId === String(userId),
+    );
+
+    if (!match) {
+      return { allowed: false, accessLevel: null };
+    }
+
+    return { allowed: true, accessLevel: match.accessLevel };
+  },
+});
+
 // Platform-admin guard for action handlers. Reads isPlatformAdmin from
 // Supabase (authoritative post-migration). Call via
 // ctx.runAction(internal._helpers.authAction.verifyPlatformAdmin, {}).

--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -1,6 +1,6 @@
 import { QueryCtx, MutationCtx } from "../_generated/server";
 import { Id } from "../_generated/dataModel";
-import { verifyOrgAccess, requireUser } from "./auth";
+import { verifyOrgAccess } from "./auth";
 import { OrgRole } from "../schema";
 import {
   FEATURES,
@@ -235,33 +235,6 @@ export async function checkPermission(
   }
 
   return { allowed: effectiveScope !== "none", scope: effectiveScope };
-}
-
-// --- checkResourceAccess ---
-
-export async function checkResourceAccess(
-  ctx: QueryCtx | MutationCtx,
-  resourceType: string,
-  resourceId: string,
-): Promise<{ allowed: boolean; accessLevel: "viewer" | "editor" | null }> {
-  const user = await requireUser(ctx);
-
-  const invites = await ctx.db
-    .query("resourceInvites")
-    .withIndex("by_resource", (q) =>
-      q.eq("resourceType", resourceType).eq("resourceId", resourceId)
-    )
-    .collect();
-
-  const match = invites.find(
-    (inv) => inv.status === "accepted" && inv.userId === user._id
-  );
-
-  if (!match) {
-    return { allowed: false, accessLevel: null };
-  }
-
-  return { allowed: true, accessLevel: match.accessLevel };
 }
 
 // --- getEffectivePermissions ---


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3867.

Closes #3867

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- dfc71ed feat(permissions): migrate checkResourceAccess off ctx.db to Supabase (closes #3867)

### Files changed

```
 convex/_helpers/authAction.ts  | 33 +++++++++++++++++++++++++++++++++
 convex/_helpers/permissions.ts | 29 +----------------------------
 2 files changed, 34 insertions(+), 28 deletions(-)
```