### PR TITLE
Migrate `resourceInvites.listByResource` off ctx.db to Supabase

### DIFF
--- a/convex/resourceInvites.ts
+++ b/convex/resourceInvites.ts
@@ -1,28 +1,27 @@
-import { query, action, internalMutation } from "./_generated/server";
+import { action, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
-import { verifyOrgAccess } from "./_helpers/auth";
 import { createNotificationDirect } from "./notifications";
 import { logAudit } from "./auditLog";
 
-export const listByResource = query({
+export const listByResource = action({
   args: {
     organizationId: v.id("organizations"),
     resourceType: v.string(),
     resourceId: v.string(),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
 
-    const invites = await ctx.db
+    const db = createSupabaseDb();
+    const invites = await db
       .query("resourceInvites")
-      .withIndex("by_orgAndResource", (q) =>
-        q
-          .eq("organizationId", args.organizationId)
-          .eq("resourceType", args.resourceType)
-          .eq("resourceId", args.resourceId)
-      )
+      .eq("organizationId", String(args.organizationId))
+      .eq("resourceType", args.resourceType)
+      .eq("resourceId", args.resourceId)
       .collect();
 
     return invites.filter((i) => i.status !== "revoked");

--- a/src/components/crm/share-dialog.tsx
+++ b/src/components/crm/share-dialog.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseOrgSettings } from "@/hooks/use-supabase-organizations";
@@ -49,12 +48,10 @@ export function ShareDialog({
   const { data: orgSettings } = useSupabaseOrgSettings(organizationId, { enabled: open && !!organizationId });
   const sharingEnabled = orgSettings?.resourceSharingEnabled ?? true;
 
+  const listByResource = useAction(api.resourceInvites.listByResource);
   const { data: invites } = useQuery({
-    ...convexQuery(api.resourceInvites.listByResource, {
-      organizationId,
-      resourceType,
-      resourceId,
-    }),
+    queryKey: ["resourceInvites.listByResource", organizationId, resourceType, resourceId],
+    queryFn: () => listByResource({ organizationId, resourceType, resourceId }),
     enabled: open && !!organizationId,
   });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3873.

Closes #3873

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 214eac3 feat(resourceInvites): migrate listByResource off ctx.db to Supabase (closes #3873)

### Files changed

```
 convex/resourceInvites.ts           | 21 ++++++++++-----------
 src/components/crm/share-dialog.tsx |  9 +++------
 2 files changed, 13 insertions(+), 17 deletions(-)
```