### PR TITLE
Migrate `requirePlatformAdmin` in `convex/_helpers/auth.ts` off `ctx.db.get`

### DIFF
--- a/convex/_helpers/auth.ts
+++ b/convex/_helpers/auth.ts
@@ -44,13 +44,3 @@ export async function requireOrgAdmin(
   return { user, membership };
 }
 
-// Platform-level admin guard. Used by /admin pages and the platformSettings
-// mutation. Distinct from organization roles — a platform admin can configure
-// global settings (e.g. invitation From address) regardless of org membership.
-export async function requirePlatformAdmin(ctx: QueryCtx | MutationCtx) {
-  const user = await requireUser(ctx);
-  if (!user.isPlatformAdmin) {
-    throw new Error("Platform admin access required");
-  }
-  return user;
-}

--- a/convex/errorLogs.ts
+++ b/convex/errorLogs.ts
@@ -1,10 +1,12 @@
 import { v } from "convex/values";
 import {
+  action,
   mutation,
   internalMutation,
-  query,
+  internalQuery,
 } from "./_generated/server";
-import { requirePlatformAdmin, getCurrentUser } from "./_helpers/auth";
+import { internal } from "./_generated/api";
+import { getCurrentUser } from "./_helpers/auth";
 
 const MAX_STACK = 8000;
 const MAX_ARGS = 4000;
@@ -86,7 +88,7 @@ export const _recordInternal = internalMutation({
 
 // Platform-admin only — list recent errors. Hydrates the userId field
 // with email so the admin UI doesn't need to round-trip per row.
-export const list = query({
+export const list = action({
   args: {
     limit: v.optional(v.number()),
     scope: v.optional(v.string()),
@@ -94,7 +96,19 @@ export const list = query({
     sinceTs: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    await requirePlatformAdmin(ctx);
+    await ctx.runAction(internal._helpers.authAction.verifyPlatformAdmin, {});
+    return await ctx.runQuery(internal.errorLogs._listInternal, args);
+  },
+});
+
+export const _listInternal = internalQuery({
+  args: {
+    limit: v.optional(v.number()),
+    scope: v.optional(v.string()),
+    source: v.optional(v.union(v.literal("convex"), v.literal("frontend"))),
+    sinceTs: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
     const limit = Math.min(args.limit ?? 100, 500);
 
     let rows;
@@ -129,10 +143,17 @@ export const list = query({
   },
 });
 
-export const get = query({
+export const get = action({
   args: { id: v.id("errorLogs") },
   handler: async (ctx, args) => {
-    await requirePlatformAdmin(ctx);
+    await ctx.runAction(internal._helpers.authAction.verifyPlatformAdmin, {});
+    return await ctx.runQuery(internal.errorLogs._getInternal, args);
+  },
+});
+
+export const _getInternal = internalQuery({
+  args: { id: v.id("errorLogs") },
+  handler: async (ctx, args) => {
     const row = await ctx.db.get(args.id);
     if (!row) return null;
     const user = row.userId ? await ctx.db.get(row.userId) : null;

--- a/convex/platformAdmins.ts
+++ b/convex/platformAdmins.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { action, internalMutation } from "./_generated/server";
+import { action } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 
@@ -63,11 +63,6 @@ export const setRole = action({
     await db.patch("users", String(args.userId), {
       isPlatformAdmin: args.isPlatformAdmin,
     });
-    // Dual-write to Convex so requirePlatformAdmin (ctx.db.get path) stays in sync.
-    await ctx.runMutation(internal.platformAdmins._patchAdminInConvex, {
-      userId: args.userId,
-      isPlatformAdmin: args.isPlatformAdmin,
-    });
     return {
       userId: args.userId,
       isPlatformAdmin: args.isPlatformAdmin,
@@ -76,14 +71,3 @@ export const setRole = action({
   },
 });
 
-// Convex-side patch called by setRole to keep ctx.db in sync with the
-// Supabase write. Required because requirePlatformAdmin reads from ctx.db.
-export const _patchAdminInConvex = internalMutation({
-  args: {
-    userId: v.id("users"),
-    isPlatformAdmin: v.boolean(),
-  },
-  handler: async (ctx, args) => {
-    await ctx.db.patch(args.userId, { isPlatformAdmin: args.isPlatformAdmin });
-  },
-});

--- a/convex/platformSettings.ts
+++ b/convex/platformSettings.ts
@@ -1,12 +1,12 @@
 import { v } from "convex/values";
 import {
   query,
-  mutation,
+  action,
   internalQuery,
+  internalMutation,
   internalAction,
 } from "./_generated/server";
 import { internal } from "./_generated/api";
-import { requirePlatformAdmin } from "./_helpers/auth";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 
 // Get the current platform settings (singleton). Returns null if not yet
@@ -41,7 +41,7 @@ export const _getInternal = internalQuery({
 // Upsert the singleton settings row. Platform admin only.
 // The frontend admin form sends the full set of fields each save;
 // undefined keys clear the override and fall back to env-based defaults.
-export const set = mutation({
+export const set = action({
   args: {
     invitationFromName: v.optional(v.string()),
     invitationFromEmail: v.optional(v.string()),
@@ -57,7 +57,34 @@ export const set = mutation({
     ),
   },
   handler: async (ctx, args) => {
-    const user = await requirePlatformAdmin(ctx);
+    const { userId } = await ctx.runAction(
+      internal._helpers.authAction.verifyPlatformAdmin,
+      {},
+    );
+    return await ctx.runMutation(internal.platformSettings._setInternal, {
+      ...args,
+      updatedBy: userId,
+    });
+  },
+});
+
+export const _setInternal = internalMutation({
+  args: {
+    invitationFromName: v.optional(v.string()),
+    invitationFromEmail: v.optional(v.string()),
+    invitationReplyToEmail: v.optional(v.string()),
+    provider: v.optional(
+      v.union(v.literal("resend"), v.literal("mailgun")),
+    ),
+    resendApiKey: v.optional(v.string()),
+    mailgunApiKey: v.optional(v.string()),
+    mailgunDomain: v.optional(v.string()),
+    mailgunRegion: v.optional(
+      v.union(v.literal("us"), v.literal("eu")),
+    ),
+    updatedBy: v.id("users"),
+  },
+  handler: async (ctx, args) => {
     const existing = await ctx.db.query("platformSettings").first();
     const now = Date.now();
     // API key fields: undefined in args = "don't touch" (preserve existing);
@@ -82,7 +109,7 @@ export const set = mutation({
       mailgunDomain: args.mailgunDomain,
       mailgunRegion: args.mailgunRegion,
       updatedAt: now,
-      updatedBy: user._id,
+      updatedBy: args.updatedBy,
     };
     if (existing) {
       await ctx.db.patch(existing._id, payload);
@@ -103,11 +130,6 @@ export const _grantPlatformAdmin = internalAction({
     const user = await db.query("users").eq("email", args.email).unique();
     if (!user) throw new Error(`No user found for email ${args.email}`);
     await db.patch("users", String(user._id), { isPlatformAdmin: true });
-    // Keep Convex in sync — requirePlatformAdmin reads isPlatformAdmin from ctx.db.
-    await ctx.runMutation(internal.platformAdmins._patchAdminInConvex, {
-      userId: user._id,
-      isPlatformAdmin: true,
-    });
     return { userId: user._id, email: args.email };
   },
 });

--- a/src/routes/_app/_auth/admin.email-config.tsx
+++ b/src/routes/_app/_auth/admin.email-config.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useQuery, useMutation } from "@tanstack/react-query";
-import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { convexQuery } from "@convex-dev/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { toast } from "sonner";
@@ -61,7 +61,7 @@ function AdminEmailConfig() {
   }, [settings]);
 
   const saveMutation = useMutation({
-    mutationFn: useConvexMutation(api.platformSettings.set),
+    mutationFn: useAction(api.platformSettings.set),
     onSuccess: () => {
       toast.success("Platform email settings saved");
     },

--- a/src/routes/_app/_auth/admin.errors.tsx
+++ b/src/routes/_app/_auth/admin.errors.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -31,11 +30,10 @@ function AdminErrors() {
   const [source, setSource] = useState<SourceFilter>("all");
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
+  const listErrors = useAction(api.errorLogs.list);
   const errorsQuery = useQuery({
-    ...convexQuery(api.errorLogs.list, {
-      limit: 200,
-      source: source === "all" ? undefined : source,
-    }),
+    queryKey: ["errorLogs", "list", source],
+    queryFn: () => listErrors({ limit: 200, source: source === "all" ? undefined : source }),
     enabled: Boolean(adminStatus?.isPlatformAdmin),
     refetchInterval: 5000,
   });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3869.

Closes #3869

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 08c678a feat(platformAdmin): migrate requirePlatformAdmin off ctx.db.get to Supabase (closes #3869)

### Files changed

```
 convex/_helpers/auth.ts                      | 10 -------
 convex/errorLogs.ts                          | 33 ++++++++++++++++++----
 convex/platformAdmins.ts                     | 18 +-----------
 convex/platformSettings.ts                   | 42 +++++++++++++++++++++-------
 src/routes/_app/_auth/admin.email-config.tsx |  4 +--
 src/routes/_app/_auth/admin.errors.tsx       |  8 ++----
 6 files changed, 65 insertions(+), 50 deletions(-)
```