### PR TITLE
Remove `isPlatformAdmin` field from Convex schema `users` table

### DIFF
--- a/convex/app.ts
+++ b/convex/app.ts
@@ -30,10 +30,8 @@ export const getCurrentUser = query({
     const avatarUrl = user.imageId
       ? await ctx.storage.getUrl(user.imageId)
       : user.image;
-    // Exclude isPlatformAdmin — read it from Supabase via getIsPlatformAdmin action.
-    const { isPlatformAdmin: _omit, ...userFields } = user;
     return {
-      ...userFields,
+      ...user,
       avatarUrl: avatarUrl || undefined,
       subscription:
         subscription && plan

--- a/convex/schema/platform.ts
+++ b/convex/schema/platform.ts
@@ -34,10 +34,6 @@ export function createPlatformTables({
       v.union(v.literal("light"), v.literal("dark"), v.literal("system")),
     ),
     timezone: v.optional(v.string()),
-    // Platform-level admin flag. Distinct from organization roles; grants
-    // access to the /admin area and ability to configure global platform
-    // settings (e.g. invitation email From address).
-    isPlatformAdmin: v.optional(v.boolean()),
   })
     .index("email", ["email"])
     .index("customerId", ["customerId"]),

--- a/types.ts
+++ b/types.ts
@@ -1,9 +1,7 @@
 import { Doc } from "~/convex/_generated/dataModel";
 import { PlanKey } from "~/convex/schema";
 
-// isPlatformAdmin is excluded — read it via api.app.getIsPlatformAdmin action
-// (Supabase-authoritative post-migration; not spread by getCurrentUser query).
-export type User = Omit<Doc<"users">, "isPlatformAdmin"> & {
+export type User = Doc<"users"> & {
   avatarUrl?: string;
   subscription?: Doc<"subscriptions"> & {
     planKey: PlanKey;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3876.

Closes #3876

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 2002136 feat(schema): remove stale isPlatformAdmin field from Convex users table (closes #3876)

### Files changed

```
 convex/app.ts             | 4 +---
 convex/schema/platform.ts | 4 ----
 types.ts                  | 4 +---
 3 files changed, 2 insertions(+), 10 deletions(-)
```