### PR TITLE
`_grantPlatformAdmin` in platformSettings.ts has an unused `ctx` parameter in it

### DIFF
--- a/convex/platformSettings.ts
+++ b/convex/platformSettings.ts
@@ -125,7 +125,7 @@ export const _setInternal = internalMutation({
 // can be granted via the admin UI once one exists.
 export const _grantPlatformAdmin = internalAction({
   args: { email: v.string() },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     const db = createSupabaseDb();
     const user = await db.query("users").eq("email", args.email).unique();
     if (!user) throw new Error(`No user found for email ${args.email}`);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3877.

Closes #3877

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 16fa460 fix(platformSettings): rename unused ctx to _ctx in _grantPlatformAdmin (closes #3877)

### Files changed

```
 convex/platformSettings.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```