### PR TITLE
Audit `convex/permissions.ts

### DIFF
--- a/convex/permissions.ts
+++ b/convex/permissions.ts
@@ -62,7 +62,12 @@ export const getOrgPermissionOverrides = query({
   },
 });
 
-// orgPermissions is an AUTH table — stays as mutation in Convex DB
+// orgPermissions is in TABLE_MAP (Supabase-owned). The ctx.db reads in
+// getOrgPermissionOverrides and _helpers/permissions.ts are intentional:
+// QueryCtx and MutationCtx cannot make HTTP calls, so createSupabaseDb() is
+// unavailable. Migrating to the Supabase read/write path requires converting
+// these to actions (see _helpers/auth.ts → authAction.ts as prior art).
+// The ctx.db writes below are a known gap — tracked: issue #3884.
 export const updateOrgPermissions = mutation({
   args: {
     organizationId: v.id("organizations"),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3884.

Closes #3884

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3e19c44 fix(permissions): correct misleading comment — orgPermissions is Supabase-owned (closes #3884)

### Files changed

```
 convex/permissions.ts | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)
```