### PR TITLE
Audit `convex/supabase/jwt.ts` teamMemberships read

### DIFF
--- a/convex/supabase/jwt.ts
+++ b/convex/supabase/jwt.ts
@@ -1,51 +1,19 @@
 import { SignJWT } from "jose";
 import { v } from "convex/values";
-import { action, internalQuery } from "@cvx/_generated/server";
-import { auth } from "@cvx/auth";
+import { action } from "@cvx/_generated/server";
 import { internal } from "@cvx/_generated/api";
 import { SUPABASE_JWT_SECRET } from "@cvx/env";
-
-// Internal query: get authenticated user for use from actions
-export const _getCurrentUser = internalQuery({
-  args: {},
-  handler: async (ctx) => {
-    const userId = await auth.getUserId(ctx);
-    if (!userId) return null;
-    return ctx.db.get(userId);
-  },
-});
-
-// Internal query: verify org membership for use from actions
-export const _verifyOrgMembership = internalQuery({
-  args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
-    const userId = await auth.getUserId(ctx);
-    if (!userId) throw new Error("Not authenticated");
-    const user = await ctx.db.get(userId);
-    if (!user) throw new Error("Not authenticated");
-
-    const membership = await ctx.db
-      .query("teamMemberships")
-      .withIndex("by_orgAndUser", (q) =>
-        q.eq("organizationId", args.organizationId).eq("userId", user._id)
-      )
-      .unique();
-
-    if (!membership) throw new Error("Not a member of this organization");
-    return { userId: user._id, membershipId: membership._id };
-  },
-});
 
 export const mintSupabaseToken = action({
   args: { organizationId: v.id("organizations") },
   returns: v.object({ token: v.string(), expiresAt: v.number() }),
   handler: async (ctx, args): Promise<{ token: string; expiresAt: number }> => {
-    // Verify auth + org membership via internal queries
+    // Verify auth + org membership via Supabase (authoritative post-migration).
+    // teamMemberships lives in Supabase; reading from ctx.db would be stale.
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore -- TS2589: type instantiation depth in generated api types
-    const verifyOrgRef = internal.supabase.jwt._verifyOrgMembership;
     const membership: { userId: string; membershipId: string } =
-      await ctx.runQuery(verifyOrgRef, {
+      await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
         organizationId: args.organizationId,
       });
 

--- a/scripts/check-convex-db-reads.mjs
+++ b/scripts/check-convex-db-reads.mjs
@@ -175,7 +175,6 @@ const MULTILINE_PENDING = new Set([
   "signatureRequests",
   "sms",
   "stripe",
-  "supabase/jwt",
   "tagDefinitions",
 ]);
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3885.

Closes #3885

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 9be8203 fix(jwt): read teamMemberships from Supabase in mintSupabaseToken (closes #3885)

### Files changed

```
 convex/supabase/jwt.ts            | 40 ++++-----------------------------------
 scripts/check-convex-db-reads.mjs |  1 -
 2 files changed, 4 insertions(+), 37 deletions(-)
```