### PR TITLE
Clarify dual-write permanence for queries in `_helpers/permissions.ts`

### DIFF
--- a/convex/permissions.ts
+++ b/convex/permissions.ts
@@ -67,7 +67,10 @@ export const getOrgPermissionOverrides = action({
 
 // Internal mutation that syncs the write to Convex so _helpers/permissions.ts
 // (called from QueryCtx/MutationCtx, which cannot reach Supabase) stays
-// accurate until those callers are fully migrated to actions.
+// accurate. NOTE: Convex queries cannot access Supabase at all, so query
+// callers (getMyPermissions, contacts.list, companies.list, etc.) will
+// permanently rely on ctx.db for orgPermissions — this dual-write is NOT a
+// temporary migration shim; it is a permanent necessity for the query path.
 export const _writeOrgPermissionsToConvex = internalMutation({
   args: {
     organizationId: v.id("organizations"),
@@ -146,7 +149,8 @@ export const updateOrgPermissions = action({
       });
     }
 
-    // Dual-write to Convex so _helpers/permissions.ts (used in mutations) stays accurate.
+    // Dual-write to Convex so _helpers/permissions.ts stays accurate.
+    // Query callers cannot reach Supabase and rely on ctx.db permanently.
     await ctx.runMutation(internal.permissions._writeOrgPermissionsToConvex, {
       organizationId: args.organizationId,
       role: args.role,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3893.

Closes #3893

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3d0b27e docs(permissions): clarify dual-write permanence for query callers (closes #3893)

### Files changed

```
 convex/permissions.ts | 8 ++++++--
 1 file changed, 6 insertions(+), 2 deletions(-)
```