### PR TITLE
Resolve fate of query callers of `checkPermission`/`getEffectivePermissions` (contacts, companies, documents, leads)

### DIFF
--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -165,6 +165,12 @@ DEFAULT_PERMISSIONS.viewer.categoryDefinitions = {
 
 // --- checkPermission ---
 
+// Accepts both QueryCtx and MutationCtx. The ctx.db reads for orgPermissions,
+// gabinetMemberships, gabinetRolePermissions, and gabinetMembershipPermissions
+// are PERMANENT for query callers — Convex queries cannot access Supabase, so
+// orgPermissions is kept in sync via dual-write (_writeOrgPermissionsToConvex
+// in convex/permissions.ts). This is not a migration TODO; it is the intended
+// architecture for the query read path. See #3893 and #3896.
 export async function checkPermission(
   ctx: QueryCtx | MutationCtx,
   orgId: Id<"organizations">,
@@ -239,6 +245,8 @@ export async function checkPermission(
 
 // --- getEffectivePermissions ---
 
+// Same dual-path note as checkPermission above: ctx.db reads are permanent
+// for query callers. (#3893 / #3896)
 export async function getEffectivePermissions(
   ctx: QueryCtx | MutationCtx,
   orgId: Id<"organizations">,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3896.

Closes #3896

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8022a54 docs(permissions): document permanent ctx.db read path in checkPermission/getEffectivePermissions (closes #3896)

### Files changed

```
 convex/_helpers/permissions.ts | 8 ++++++++
 1 file changed, 8 insertions(+)
```