### PR TITLE
Resolve architectural decision for `notifications.list`/`getUnreadCount` and `sm

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -32,7 +32,6 @@ const TABLE_MAP: Record<string, string> = {
   pipelineStageActions: "pipeline_stage_actions",
   scheduledActivities: "scheduled_activities",
   savedViews: "saved_views",
-  notifications: "notifications",
   auditLog: "audit_log",
   customFieldDefinitions: "custom_field_definitions",
   customFieldValues: "custom_field_values",

--- a/convex/gabinet/appointmentSms.ts
+++ b/convex/gabinet/appointmentSms.ts
@@ -404,6 +404,7 @@ export const markEventFailed = internalMutation({
 
 export const processIncomingMessage = internalMutation({
   args: {
+    organizationId: v.string(),
     provider: v.union(v.literal("twilio"), v.literal("smsapi")),
     to: v.string(),
     from: v.string(),
@@ -437,22 +438,6 @@ export const processIncomingMessage = internalMutation({
       };
     }
 
-    const config: Doc<"orgSmsConfig"> | null = await ctx.runQuery(
-      internal.sms.getConfigForInbound,
-      {
-        provider: args.provider,
-        recipient: args.to,
-      },
-    );
-
-    if (!config) {
-      return {
-        duplicate: false,
-        processingStatus: "ignored" as const,
-        reason: "No matching SMS configuration for inbound recipient",
-      };
-    }
-
     const normalizedPhone = normalizePhoneNumber(args.from);
     const normalizedBody = normalizeSmsBody(args.body);
     const parsedIntent = parseAppointmentSmsIntent(args.body);
@@ -460,7 +445,7 @@ export const processIncomingMessage = internalMutation({
 
     const outboundEvents = (await db
       .query("appointmentSmsEvents")
-      .eq("organizationId", String(config.organizationId))
+      .eq("organizationId", args.organizationId)
       .eq("normalizedPhone", normalizedPhone)
       .order("createdAt", false)
       .collect()) as Array<Doc<"appointmentSmsEvents">>;
@@ -473,7 +458,7 @@ export const processIncomingMessage = internalMutation({
     );
 
     const eventId: string = await db.insert("appointmentSmsEvents", {
-      organizationId: config.organizationId,
+      organizationId: args.organizationId,
       appointmentId: matchingOutbound?.appointmentId,
       patientId: matchingOutbound?.patientId,
       normalizedPhone,
@@ -509,7 +494,7 @@ export const processIncomingMessage = internalMutation({
       : null;
     const matchingAppointmentBelongsToOrg =
       !!matchingAppointment &&
-      String(matchingAppointment.organizationId) === String(config.organizationId);
+      String(matchingAppointment.organizationId) === String(args.organizationId);
     const matchingAppointmentEmployeeId =
       matchingAppointmentBelongsToOrg && matchingAppointment?.employeeId
         ? (matchingAppointment.employeeId as Id<"users">)
@@ -521,7 +506,7 @@ export const processIncomingMessage = internalMutation({
       (matchingAppointmentId || matchingPatientId)
     ) {
       await logSmsSharedActivities(ctx, {
-        organizationId: config.organizationId,
+        organizationId: args.organizationId,
         appointmentId: matchingAppointmentId,
         patientId: matchingPatientId,
         action: "sms_received",
@@ -541,7 +526,7 @@ export const processIncomingMessage = internalMutation({
     }
 
     await ctx.runMutation(internal.automation.emitEvent, {
-      organizationId: config.organizationId,
+      organizationId: args.organizationId,
       module: "gabinet",
       eventType: "gabinet.appointment.sms_reply_received",
       entityType: matchingOutbound?.appointmentId ? "gabinetAppointment" : undefined,
@@ -550,9 +535,9 @@ export const processIncomingMessage = internalMutation({
         : undefined,
       actorUserId: matchingAppointmentEmployeeId,
       correlationKey: matchingOutbound?.correlationKey,
-      eventIdempotencyKey: `automation-event:${config.organizationId}:${args.idempotencyKey}`,
+      eventIdempotencyKey: `automation-event:${args.organizationId}:${args.idempotencyKey}`,
       payload: JSON.stringify({
-        organizationId: String(config.organizationId),
+        organizationId: String(args.organizationId),
         appointmentId: matchingOutbound?.appointmentId
           ? String(matchingOutbound.appointmentId)
           : null,
@@ -594,7 +579,7 @@ export const processIncomingMessage = internalMutation({
       processingStatus: "processed" | "ignored";
       reason?: string;
     } = await ctx.runMutation(internal.gabinet.appointments.applySmsReplyTransition, {
-      organizationId: config.organizationId,
+      organizationId: args.organizationId,
       appointmentId: String(matchingOutbound.appointmentId),
       intent: parsedIntent,
       smsEventId: eventId,

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -542,16 +542,23 @@ http.route({
         return new Response("Unsupported SMS provider", { status: 400 });
       }
 
+      // Look up the SMS config for this recipient to get the organization.
+      // For Twilio we also verify the webhook signature here.
+      const config = await ctx.runAction(internal.sms.getConfigForInbound, {
+        provider,
+        recipient: to,
+      });
+
+      if (!config) {
+        return new Response("No matching SMS configuration", { status: 200 });
+      }
+
       let webhookSignatureVerified: boolean | undefined;
       if (provider === "twilio") {
-        const config = await ctx.runQuery(internal.sms.getConfigForInbound, {
-          provider,
-          recipient: to,
-        });
-        if (!config?.apiSecret) {
+        if (!config.apiSecret) {
           return new Response("No matching Twilio configuration", { status: 200 });
         }
-        webhookSignatureVerified = await verifyTwilioRequest(request, payload, config.apiSecret);
+        webhookSignatureVerified = await verifyTwilioRequest(request, payload, config.apiSecret as string);
         if (!webhookSignatureVerified) {
           return new Response("Invalid Twilio signature", { status: 401 });
         }
@@ -562,6 +569,7 @@ http.route({
         : `${provider}:${to}:${from}:${body.trim()}`;
 
       await ctx.runMutation(internal.gabinet.appointmentSms.processIncomingMessage, {
+        organizationId: config.organizationId as string,
         provider,
         to,
         from,

--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -1,6 +1,5 @@
 import { query, action, internalMutation, MutationCtx } from "./_generated/server";
 import { internal } from "./_generated/api";
-import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
 import { Id } from "./_generated/dataModel";
 import { requireUser } from "./_helpers/auth";
@@ -44,25 +43,22 @@ export const getUnreadCount = query({
 
 export const markAsRead = action({
   args: {
-    notificationId: v.string(),
+    notificationId: v.id("notifications"),
   },
   handler: async (ctx, args): Promise<string> => {
-    await ctx.runAction(
-      internal._helpers.authAction.verifyOrgAccess,
-      // notifications are user-scoped, we pass a dummy org to verify auth
-      // Actually notifications use requireUser, not verifyOrgAccess
-      // We'll use a simpler pattern here
-      { organizationId: "skip" as any },
-    ).catch(() => null);
-
-    const db = createSupabaseDb();
-    const notification = await db.get("notifications", args.notificationId);
-    if (!notification) {
-      throw new Error("Notification not found");
-    }
-
-    await db.patch("notifications", args.notificationId, { isRead: true });
+    await ctx.runMutation(internal.notifications._markAsReadInternal, {
+      notificationId: args.notificationId,
+    });
     return args.notificationId;
+  },
+});
+
+export const _markAsReadInternal = internalMutation({
+  args: { notificationId: v.id("notifications") },
+  handler: async (ctx, args) => {
+    const notification = await ctx.db.get(args.notificationId);
+    if (!notification) return;
+    await ctx.db.patch(args.notificationId, { isRead: true });
   },
 });
 
@@ -71,22 +67,25 @@ export const markAllRead = action({
     organizationId: v.id("organizations"),
   },
   handler: async (ctx, args): Promise<number> => {
-    const authResult = await ctx.runAction(
-      internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: args.organizationId },
-    );
+    return await ctx.runMutation(internal.notifications._markAllReadInternal, {
+      organizationId: args.organizationId,
+    });
+  },
+});
 
-    const db = createSupabaseDb();
-    const unread = await db
+export const _markAllReadInternal = internalMutation({
+  args: { organizationId: v.id("organizations") },
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const unread = await ctx.db
       .query("notifications")
-      .eq("userId", String(authResult.userId))
-      .eq("isRead", false)
+      .withIndex("by_userAndRead", (q) =>
+        q.eq("userId", user._id).eq("isRead", false)
+      )
       .collect();
-
     for (const notification of unread) {
-      await db.patch("notifications", notification._id as string, { isRead: true });
+      await ctx.db.patch(notification._id, { isRead: true });
     }
-
     return unread.length;
   },
 });
@@ -122,13 +121,10 @@ export async function createNotificationDirect(
     metadata?: unknown;
   }
 ) {
-  // Still write to Convex DB for real-time subscriptions
+  // Notifications live in Convex for real-time push (live queries on the bell).
   await ctx.db.insert("notifications", {
     ...data,
     isRead: false,
     createdAt: Date.now(),
   });
-
-  // Also write to Supabase (best-effort, no scheduler needed since we're in a mutation)
-  // This stays as a Convex DB write because notifications need real-time reactivity
 }

--- a/convex/sms.ts
+++ b/convex/sms.ts
@@ -1,26 +1,43 @@
-import { action, query, internalAction, internalQuery } from "./_generated/server";
+import { action, internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { api, internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
+
+type OrgSmsConfigRow = {
+  _id: string;
+  organizationId: string;
+  provider: "smsapi" | "twilio";
+  apiToken: string;
+  apiSecret?: string | null;
+  senderId?: string | null;
+  fromNumber?: string | null;
+  isActive: boolean;
+  createdAt: number;
+  updatedAt: number;
+};
 
 // ---------------------------------------------------------------------------
 // SMS Config (authenticated, org-scoped)
 // ---------------------------------------------------------------------------
 
-export const getConfig = query({
+export const getConfig = action({
   args: { organizationId: v.id("organizations") },
   handler: async (ctx, args) => {
-    const config = await ctx.db
-      .query("orgSmsConfig")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .unique();
+    await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const db = createSupabaseDb();
+    const config = await db
+      .query<OrgSmsConfigRow>("orgSmsConfig")
+      .eq("organizationId", String(args.organizationId))
+      .first();
     if (!config) return null;
     // Never return the raw API token to the client
     return {
       _id: config._id,
       provider: config.provider,
-      senderId: config.senderId,
-      fromNumber: config.fromNumber,
+      senderId: config.senderId ?? undefined,
+      fromNumber: config.fromNumber ?? undefined,
       isActive: config.isActive,
       hasToken: !!config.apiToken,
       hasSecret: !!config.apiSecret,
@@ -117,8 +134,7 @@ export const sendOtpSms = action({
     code: v.string(),
   },
   handler: async (ctx, args) => {
-    // Load SMS config via internal query
-    const config = await ctx.runQuery(internal.sms.getConfigInternal, {
+    const config = await ctx.runAction(internal.sms.getConfigInternal, {
       organizationId: args.organizationId,
     });
     if (!config) throw new Error("SMS not configured for this organization");
@@ -139,14 +155,15 @@ export const sendOtpSms = action({
   },
 });
 
-/** Internal query to get full SMS config (with secrets) — only callable from internal functions. */
-export const getConfigInternal = internalQuery({
+/** Internal action to get full SMS config (with secrets) — only callable from internal functions. */
+export const getConfigInternal = internalAction({
   args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
-    return await ctx.db
-      .query("orgSmsConfig")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .unique();
+  handler: async (_ctx, args): Promise<OrgSmsConfigRow | null> => {
+    const db = createSupabaseDb();
+    return await db
+      .query<OrgSmsConfigRow>("orgSmsConfig")
+      .eq("organizationId", String(args.organizationId))
+      .first();
   },
 });
 
@@ -168,29 +185,26 @@ function normalizePhoneNumber(phone: string): string {
   return `+${digits}`;
 }
 
-export const getConfigForInbound = internalQuery({
+export const getConfigForInbound = internalAction({
   args: {
     provider: v.union(v.literal("smsapi"), v.literal("twilio")),
     recipient: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args): Promise<OrgSmsConfigRow | null> => {
+    const db = createSupabaseDb();
     if (args.provider === "twilio") {
-      return await ctx.db
-        .query("orgSmsConfig")
-        .withIndex("by_providerAndFromNumber", (q) =>
-          q
-            .eq("provider", args.provider)
-            .eq("fromNumber", normalizePhoneNumber(args.recipient)),
-        )
-        .unique();
+      return await db
+        .query<OrgSmsConfigRow>("orgSmsConfig")
+        .eq("provider", args.provider)
+        .eq("fromNumber", normalizePhoneNumber(args.recipient))
+        .first();
     }
 
-    return await ctx.db
-      .query("orgSmsConfig")
-      .withIndex("by_providerAndSenderId", (q) =>
-        q.eq("provider", args.provider).eq("senderId", args.recipient),
-      )
-      .unique();
+    return await db
+      .query<OrgSmsConfigRow>("orgSmsConfig")
+      .eq("provider", args.provider)
+      .eq("senderId", args.recipient)
+      .first();
   },
 });
 
@@ -309,7 +323,7 @@ export const sendSigningLinkSms = internalAction({
     expiresAt: v.number(),
   },
   handler: async (ctx, args) => {
-    const config = await ctx.runQuery(internal.sms.getConfigInternal, {
+    const config = await ctx.runAction(internal.sms.getConfigInternal, {
       organizationId: args.organizationId,
     });
     if (!config || !config.isActive) {
@@ -347,7 +361,7 @@ export const sendAppointmentSms = internalAction({
     eventId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const config = await ctx.runQuery(internal.sms.getConfigInternal, {
+    const config = await ctx.runAction(internal.sms.getConfigInternal, {
       organizationId: args.organizationId,
     });
 

--- a/scripts/check-convex-db-reads.mjs
+++ b/scripts/check-convex-db-reads.mjs
@@ -83,6 +83,14 @@ const WHITELIST_PATHS = new Set([
   "_helpers/auth",
   "_helpers/permissions",
   "_helpers/seatLimits",
+
+  // notifications — Convex is the authoritative real-time store for in-app
+  // notifications. Writes go through ctx.db so that the notification bell
+  // receives live-query push updates without polling. The Supabase table
+  // exists for long-term archival / RLS-scoped reads by the portal, but
+  // the primary read path for the bell and notification page stays on Convex.
+  // Resolved via issue #3904 (option A).
+  "notifications",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -166,14 +174,12 @@ const MULTILINE_PENDING = new Set([
   "lostReasons",
   "mailProviders",
   "notes",
-  "notifications",
   "organizations",
   "payments",
   "permissions",
   "pipelineStageActions",
   "relationships",
   "signatureRequests",
-  "sms",
   "stripe",
   "tagDefinitions",
 ]);

--- a/src/components/settings/sms-config-card.tsx
+++ b/src/components/settings/sms-config-card.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
-import { useQuery } from "convex/react";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { Id } from "@cvx/_generated/dataModel";
+import { useSupabaseSmsConfig } from "@/hooks/use-supabase-sms-config";
 import {
   Card,
   CardContent,
@@ -32,7 +32,7 @@ interface SmsConfigCardProps {
 
 export function SmsConfigCard({ organizationId }: SmsConfigCardProps) {
   const { t } = useTranslation();
-  const config = useQuery(api.sms.getConfig, { organizationId });
+  const { data: config } = useSupabaseSmsConfig(String(organizationId));
   const saveConfig = useAction(api.sms.saveConfig);
 
   const [provider, setProvider] = useState<"smsapi" | "twilio">("smsapi");

--- a/src/hooks/use-supabase-sms-config.ts
+++ b/src/hooks/use-supabase-sms-config.ts
@@ -1,0 +1,51 @@
+import { useQuery } from "@tanstack/react-query";
+import { useSupabase } from "@/components/supabase-provider";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
+
+export type SmsConfigSummary = {
+  id: string;
+  provider: "smsapi" | "twilio";
+  senderId: string | null;
+  fromNumber: string | null;
+  isActive: boolean;
+  hasToken: boolean;
+  hasSecret: boolean;
+};
+
+export function useSupabaseSmsConfig(
+  organizationId: string,
+  options?: { enabled?: boolean },
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options ?? {};
+
+  return useQuery<SmsConfigSummary | null, Error>({
+    queryKey: supabaseKeys.orgSmsConfig.detail(organizationId, "config"),
+    queryFn: async () => {
+      if (!client) throw new Error("Supabase client not ready");
+
+      // Select only non-sensitive columns; derive hasToken / hasSecret server-side.
+      const { data, error } = await client
+        .from("org_sms_config")
+        .select(
+          "id, provider, sender_id, from_number, is_active, (api_token is not null and api_token != '') as has_token, (api_secret is not null and api_secret != '') as has_secret",
+        )
+        .eq("organization_id", organizationId)
+        .maybeSingle();
+
+      if (error) throw error;
+      if (!data) return null;
+
+      return {
+        id: data.id as string,
+        provider: data.provider as "smsapi" | "twilio",
+        senderId: data.sender_id as string | null,
+        fromNumber: data.from_number as string | null,
+        isActive: data.is_active as boolean,
+        hasToken: data.has_token as boolean,
+        hasSecret: data.has_secret as boolean,
+      };
+    },
+    enabled: enabled && isReady && !!organizationId,
+  });
+}

--- a/src/lib/supabase/query-keys.ts
+++ b/src/lib/supabase/query-keys.ts
@@ -104,6 +104,7 @@ export const supabaseKeys = {
   notifications: entityKeys("notifications"),
   recentlyViewed: entityKeys("recentlyViewed"),
   orgSettings: entityKeys("orgSettings"),
+  orgSmsConfig: entityKeys("orgSmsConfig"),
   auditLog: entityKeys("auditLog"),
   activityTypes: entityKeys("activityTypes"),
 } as const;

--- a/src/routes/_app/_auth/dashboard/_layout.settings.sms.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.sms.tsx
@@ -1,11 +1,10 @@
 import { useState, useEffect } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
+import { useSupabaseSmsConfig } from "@/hooks/use-supabase-sms-config";
 import { SectionHeader } from "@untitled/app/section-headers/section-headers";
 import { UntitledAlert } from "@/components/ui/untitled-alert";
 import { Card, CardContent } from "@/components/ui/card";
@@ -35,9 +34,7 @@ function SmsSettings() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
 
-  const { data: config } = useQuery(
-    convexQuery(api.sms.getConfig, { organizationId })
-  );
+  const { data: config } = useSupabaseSmsConfig(String(organizationId));
 
   const saveConfig = useAction(api.sms.saveConfig);
   const toggleActive = useAction(api.sms.toggleActive);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3904.

Closes #3904

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 9409c55 fix(arch): resolve ctx.db reads for notifications and sms.getConfig (closes #3904)

### Files changed

```
 convex/_helpers/supabaseDb.ts                      |  1 -
 convex/gabinet/appointmentSms.ts                   | 33 +++------
 convex/http.ts                                     | 20 ++++--
 convex/notifications.ts                            | 60 ++++++++--------
 convex/sms.ts                                      | 84 +++++++++++++---------
 scripts/check-convex-db-reads.mjs                  | 10 ++-
 src/components/settings/sms-config-card.tsx        |  4 +-
 src/hooks/use-supabase-sms-config.ts               | 51 +++++++++++++
 src/lib/supabase/query-keys.ts                     |  1 +
 .../_app/_auth/dashboard/_layout.settings.sms.tsx  |  7 +-
 10 files changed, 164 insertions(+), 107 deletions(-)
```