### PR TITLE
Fix `getAutomationEditPermission` calling `createSupabaseDb()` from within `proc

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -356,12 +356,16 @@ async function getAutomationEditPermission(
     };
   }
 
-  const db = createSupabaseDb();
-
-  const membership = await db
+  // teamMemberships and orgPermissions are dual-written to Convex
+  // (_writeOrgPermissionsToConvex, ctx.db.insert in teams/invitations).
+  // ctx.db reads are the permanent pattern for mutation callers — identical
+  // to checkPermission in _helpers/permissions.ts. Do NOT replace with
+  // createSupabaseDb(): mutations cannot use fetch in the Convex runtime.
+  const membership = await ctx.db
     .query("teamMemberships")
-    .eq("organizationId", String(organizationId))
-    .eq("userId", String(actorUserId))
+    .withIndex("by_orgAndUser", (q) =>
+      q.eq("organizationId", organizationId).eq("userId", actorUserId),
+    )
     .unique();
 
   if (!membership) {
@@ -386,11 +390,12 @@ async function getAutomationEditPermission(
     };
   }
 
-  // Org-level permission override (reads from Supabase, TABLE_MAP primary)
-  const override = await db
+  // orgPermissions is kept in sync via dual-write; ctx.db is permanent here.
+  const override = await ctx.db
     .query("orgPermissions")
-    .eq("organizationId", String(organizationId))
-    .eq("role", role)
+    .withIndex("by_orgAndRole", (q) =>
+      q.eq("organizationId", organizationId).eq("role", role),
+    )
     .unique();
 
   let orgScope: Scope;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3914.

Closes #3914

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e2db1ea fix(arch): migrate getAutomationEditPermission back to ctx.db for mutation safety (closes #3914)

### Files changed

```
 convex/automation.ts | 23 ++++++++++++++---------
 1 file changed, 14 insertions(+), 9 deletions(-)
```