### PR TITLE
Migrate `listRules`, `listRuns`, `getRunSteps`, `listEntityRuns` in `automation.

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -931,51 +931,58 @@ async function patchLegacyAppointmentWorkflowHistory(args: {
   });
 }
 
-// automationRules is Convex-primary (createRule writes Convex first, Supabase is the mirror).
-// automationRuns/RunSteps are written to Convex by emitEvent/processRun, then mirrored to
-// Supabase via scheduler. ctx.db reads below are valid; production UI reads use the
-// useSupabaseAutomationRulesList / useSupabaseAutomationRunsList hooks instead.
-export const listRules = query({
+// listRules/listRuns/getRunSteps read from Supabase (primary read path for
+// automationRules/Runs/RunSteps). The production UI uses useSupabaseAutomation*
+// hooks directly; these actions serve the test suite and e2e tests.
+export const listRules = action({
   args: {
     organizationId: v.id("organizations"),
     module: v.optional(automationModuleValidator),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
 
-    const rules = args.module
-      ? await ctx.db
-          .query("automationRules")
-          .withIndex("by_orgAndModule", (q) =>
-            q.eq("organizationId", args.organizationId).eq("module", args.module!),
-          )
-          .order("desc")
-          .collect()
-      : await ctx.db
-          .query("automationRules")
-          .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-          .order("desc")
-          .collect();
+    const db = createSupabaseDb();
+    let rules = await db
+      .query("automationRules")
+      .eq("organizationId", String(args.organizationId))
+      .order("createdAt", false)
+      .collect();
 
-    return await Promise.all(
-      rules.map(async (rule) => {
-        const recentRuns = await ctx.db
-          .query("automationRuns")
-          .withIndex("by_rule", (q) => q.eq("ruleId", rule._id))
-          .order("desc")
-          .take(1);
+    if (args.module) {
+      rules = rules.filter((rule) => rule.module === args.module);
+    }
 
-        return {
-          ...rule,
-          trigger: resolveRuleTrigger(rule),
-          lastRun: recentRuns[0] ?? null,
-        };
-      }),
-    );
+    if (rules.length === 0) return [];
+
+    // Single query for all recent runs; group by ruleId in JS.
+    const ruleIds = rules.map((r) => String(r._id));
+    const recentRuns = await db
+      .query("automationRuns")
+      .eq("organizationId", String(args.organizationId))
+      .in("ruleId", ruleIds)
+      .order("createdAt", false)
+      .collect();
+
+    const latestRunByRule = new Map<string, (typeof recentRuns)[0]>();
+    for (const run of recentRuns) {
+      const ruleId = String(run.ruleId ?? "");
+      if (ruleId && !latestRunByRule.has(ruleId)) {
+        latestRunByRule.set(ruleId, run);
+      }
+    }
+
+    return rules.map((rule) => ({
+      ...rule,
+      trigger: resolveRuleTrigger(rule as Parameters<typeof resolveRuleTrigger>[0]),
+      lastRun: latestRunByRule.get(String(rule._id)) ?? null,
+    }));
   },
 });
 
-export const listRuns = query({
+export const listRuns = action({
   args: {
     organizationId: v.id("organizations"),
     module: v.optional(automationModuleValidator),
@@ -984,39 +991,36 @@ export const listRuns = query({
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
+    await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
     const limit = args.limit ?? 100;
 
-    let runs = await ctx.db
+    let q = createSupabaseDb()
       .query("automationRuns")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .order("desc")
-      .take(limit * 3);
+      .eq("organizationId", String(args.organizationId))
+      .order("createdAt", false);
 
-    if (args.module) {
-      runs = runs.filter((run) => run.module === args.module);
-    }
-    if (args.entityType) {
-      runs = runs.filter((run) => run.entityType === args.entityType);
-    }
-    if (args.entityId) {
-      runs = runs.filter((run) => run.entityId === args.entityId);
-    }
+    if (args.module) q = q.eq("module", args.module);
+    if (args.entityType) q = q.eq("entityType", args.entityType);
+    if (args.entityId) q = q.eq("entityId", args.entityId);
 
-    return runs.slice(0, limit);
+    return await q.take(limit).collect();
   },
 });
 
-export const getRunSteps = query({
+export const getRunSteps = action({
   args: {
     organizationId: v.id("organizations"),
     runId: v.id("automationRuns"),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    return await ctx.db
+    await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    return await createSupabaseDb()
       .query("automationRunSteps")
-      .withIndex("by_run", (q) => q.eq("runId", args.runId))
+      .eq("runId", String(args.runId))
       .collect();
   },
 });

--- a/e2e/gabinet/appointments.spec.ts
+++ b/e2e/gabinet/appointments.spec.ts
@@ -71,7 +71,7 @@ test.describe("Gabinet — Appointments", () => {
   ) {
     const { client, organizationId } = await getConvexClientContext(page);
 
-    const existingRules = await client.query(api.automation.listRules, {
+    const existingRules = await client.action(api.automation.listRules, {
       organizationId,
       module: "gabinet",
     });

--- a/tests/convex/automation.test.ts
+++ b/tests/convex/automation.test.ts
@@ -356,7 +356,7 @@ describe("automation lifecycle", () => {
 
     await flushScheduled(t);
 
-    const runs = await t.withIdentity(identity).query(api.automation.listRuns, {
+    const runs = await t.withIdentity(identity).action(api.automation.listRuns, {
       organizationId,
       module: "gabinet",
       entityType: "gabinetAppointment",
@@ -365,7 +365,7 @@ describe("automation lifecycle", () => {
     });
     const run = runs.find((item) => item.eventType === "gabinet.appointment.created");
     const steps = run
-      ? await t.withIdentity(identity).query(api.automation.getRunSteps, {
+      ? await t.withIdentity(identity).action(api.automation.getRunSteps, {
           organizationId,
           runId: run._id,
         })
@@ -423,7 +423,7 @@ describe("automation lifecycle", () => {
 
     await flushScheduled(t);
 
-    const runs = await t.withIdentity(identity).query(api.automation.listRuns, {
+    const runs = await t.withIdentity(identity).action(api.automation.listRuns, {
       organizationId,
       module: "gabinet",
       entityType: "gabinetPatient",
@@ -432,7 +432,7 @@ describe("automation lifecycle", () => {
     });
     const run = runs.find((item) => item.eventType === "gabinet.patient.created");
     const steps = run
-      ? await t.withIdentity(identity).query(api.automation.getRunSteps, {
+      ? await t.withIdentity(identity).action(api.automation.getRunSteps, {
           organizationId,
           runId: run._id,
         })
@@ -496,7 +496,7 @@ describe("automation lifecycle", () => {
 
     await flushScheduled(t);
 
-    const runs = await t.withIdentity(identity).query(api.automation.listRuns, {
+    const runs = await t.withIdentity(identity).action(api.automation.listRuns, {
       organizationId,
       module: "gabinet",
       entityType: "gabinetAppointment",
@@ -505,7 +505,7 @@ describe("automation lifecycle", () => {
     });
     const run = runs.find((item) => item.eventType === "gabinet.appointment.created");
     const steps = run
-      ? await t.withIdentity(identity).query(api.automation.getRunSteps, {
+      ? await t.withIdentity(identity).action(api.automation.getRunSteps, {
           organizationId,
           runId: run._id,
         })
@@ -762,7 +762,7 @@ describe("automation lifecycle", () => {
       enabled: true,
     });
 
-    const rules = await t.withIdentity(identity).query(api.automation.listRules, {
+    const rules = await t.withIdentity(identity).action(api.automation.listRules, {
       organizationId,
       module: "gabinet",
     });
@@ -831,7 +831,7 @@ describe("automation lifecycle", () => {
 
     await flushScheduled(t);
 
-    const runs = await t.withIdentity(identity).query(api.automation.listRuns, {
+    const runs = await t.withIdentity(identity).action(api.automation.listRuns, {
       organizationId,
       module: "gabinet",
       entityType: "gabinetAppointment",
@@ -840,7 +840,7 @@ describe("automation lifecycle", () => {
     });
     const run = runs.find((item) => item.eventType === "gabinet.appointment.created");
     const steps = run
-      ? await t.withIdentity(identity).query(api.automation.getRunSteps, {
+      ? await t.withIdentity(identity).action(api.automation.getRunSteps, {
           organizationId,
           runId: run._id,
         })
@@ -936,7 +936,7 @@ describe("automation lifecycle", () => {
 
     await flushScheduled(t);
 
-    const runs = await t.withIdentity(identity).query(api.automation.listRuns, {
+    const runs = await t.withIdentity(identity).action(api.automation.listRuns, {
       organizationId,
       module: "gabinet",
       entityType: "gabinetAppointment",
@@ -945,7 +945,7 @@ describe("automation lifecycle", () => {
     });
     const run = runs.find((item) => item.eventType === "gabinet.appointment.created");
     const steps = run
-      ? await t.withIdentity(identity).query(api.automation.getRunSteps, {
+      ? await t.withIdentity(identity).action(api.automation.getRunSteps, {
           organizationId,
           runId: run._id,
         })
@@ -1011,7 +1011,7 @@ describe("automation lifecycle", () => {
 
     await flushScheduled(t);
 
-    const runs = await t.withIdentity(identity).query(api.automation.listRuns, {
+    const runs = await t.withIdentity(identity).action(api.automation.listRuns, {
       organizationId,
       module: "gabinet",
       entityType: "gabinetAppointment",
@@ -1020,7 +1020,7 @@ describe("automation lifecycle", () => {
     });
     const run = runs.find((item) => item.eventType === "gabinet.appointment.created");
     const steps = run
-      ? await t.withIdentity(identity).query(api.automation.getRunSteps, {
+      ? await t.withIdentity(identity).action(api.automation.getRunSteps, {
           organizationId,
           runId: run._id,
         })
@@ -1077,7 +1077,7 @@ describe("automation lifecycle", () => {
 
     await flushScheduled(t);
 
-    const runs = await t.withIdentity(identity).query(api.automation.listRuns, {
+    const runs = await t.withIdentity(identity).action(api.automation.listRuns, {
       organizationId,
       module: "crm",
       entityType: "lead",
@@ -1086,7 +1086,7 @@ describe("automation lifecycle", () => {
     });
     const run = runs.find((item) => item.eventType === "crm.lead.status_changed");
     const steps = run
-      ? await t.withIdentity(identity).query(api.automation.getRunSteps, {
+      ? await t.withIdentity(identity).action(api.automation.getRunSteps, {
           organizationId,
           runId: run._id,
         })
@@ -1141,7 +1141,7 @@ describe("automation lifecycle", () => {
 
     await flushScheduled(t);
 
-    const runs = await t.withIdentity(identity).query(api.automation.listRuns, {
+    const runs = await t.withIdentity(identity).action(api.automation.listRuns, {
       organizationId,
       module: "crm",
       entityType: "lead",
@@ -1150,7 +1150,7 @@ describe("automation lifecycle", () => {
     });
     const run = runs.find((item) => item.eventType === "crm.lead.status_changed");
     const steps = run
-      ? await t.withIdentity(identity).query(api.automation.getRunSteps, {
+      ? await t.withIdentity(identity).action(api.automation.getRunSteps, {
           organizationId,
           runId: run._id,
         })
@@ -1212,7 +1212,7 @@ describe("automation lifecycle", () => {
 
     await flushScheduled(t);
 
-    const runs = await t.withIdentity(admin.identity).query(api.automation.listRuns, {
+    const runs = await t.withIdentity(admin.identity).action(api.automation.listRuns, {
       organizationId: admin.organizationId,
       module: "crm",
       entityType: "lead",
@@ -1221,7 +1221,7 @@ describe("automation lifecycle", () => {
     });
     const run = runs.find((item) => item.eventType === "crm.lead.status_changed");
     const steps = run
-      ? await t.withIdentity(admin.identity).query(api.automation.getRunSteps, {
+      ? await t.withIdentity(admin.identity).action(api.automation.getRunSteps, {
           organizationId: admin.organizationId,
           runId: run._id,
         })
@@ -1279,7 +1279,7 @@ describe("automation lifecycle", () => {
 
     await flushScheduled(t);
 
-    const runs = await t.withIdentity(admin.identity).query(api.automation.listRuns, {
+    const runs = await t.withIdentity(admin.identity).action(api.automation.listRuns, {
       organizationId: admin.organizationId,
       module: "crm",
       entityType: "lead",
@@ -1288,7 +1288,7 @@ describe("automation lifecycle", () => {
     });
     const run = runs.find((item) => item.eventType === "crm.lead.status_changed");
     const steps = run
-      ? await t.withIdentity(admin.identity).query(api.automation.getRunSteps, {
+      ? await t.withIdentity(admin.identity).action(api.automation.getRunSteps, {
           organizationId: admin.organizationId,
           runId: run._id,
         })
@@ -1346,7 +1346,7 @@ describe("automation lifecycle", () => {
 
     await flushScheduled(t);
 
-    const runs = await t.withIdentity(admin.identity).query(api.automation.listRuns, {
+    const runs = await t.withIdentity(admin.identity).action(api.automation.listRuns, {
       organizationId: admin.organizationId,
       module: "crm",
       entityType: "lead",
@@ -1355,7 +1355,7 @@ describe("automation lifecycle", () => {
     });
     const run = runs.find((item) => item.eventType === "crm.lead.status_changed");
     const steps = run
-      ? await t.withIdentity(admin.identity).query(api.automation.getRunSteps, {
+      ? await t.withIdentity(admin.identity).action(api.automation.getRunSteps, {
           organizationId: admin.organizationId,
           runId: run._id,
         })
@@ -1406,7 +1406,7 @@ describe("automation lifecycle", () => {
 
     await flushScheduled(t);
 
-    const runs = await t.withIdentity(identity).query(api.automation.listRuns, {
+    const runs = await t.withIdentity(identity).action(api.automation.listRuns, {
       organizationId,
       module: "gabinet",
       entityType: "gabinetAppointment",
@@ -1415,7 +1415,7 @@ describe("automation lifecycle", () => {
     });
     const run = runs.find((item) => item.eventType === "gabinet.appointment.created");
     const steps = run
-      ? await t.withIdentity(identity).query(api.automation.getRunSteps, {
+      ? await t.withIdentity(identity).action(api.automation.getRunSteps, {
           organizationId,
           runId: run._id,
         })


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3915.

Closes #3915

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a2d20f1 fix(arch): migrate listRules, listRuns, getRunSteps to Supabase reads (closes #3915)

### Files changed

```
 convex/automation.ts             | 114 ++++++++++++++++++++-------------------
 e2e/gabinet/appointments.spec.ts |   2 +-
 tests/convex/automation.test.ts  |  50 ++++++++---------
 3 files changed, 85 insertions(+), 81 deletions(-)
```