### PR TITLE
Remove stale comment at `automation.ts

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -29,8 +29,6 @@ import {
   resolveRuleTrigger,
 } from "./automationRegistry";
 
-// Supabase-primary write refs — these are the sole write path for
-// automationRuns and automationRunSteps; ctx.db writes removed (#3933).
 // @ts-ignore
 const writeRunRef = internal.supabase.automationRuns.writeRun;
 // @ts-ignore


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3937.

Closes #3937

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c6eecd7 fix(automation): remove stale migration comment at automation.ts:32-33 (closes #3937)

### Files changed

```
 convex/automation.ts | 2 --
 1 file changed, 2 deletions(-)
```