### PR TITLE
Add emitEvent idempotency via Supabase

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -1489,8 +1489,18 @@ export const processRun = internalAction({
     const payload = JSON.parse(run.payloadSnapshot) as Record<string, unknown>;
     const processRunDb = createSupabaseDb();
 
-    // Write run record to Supabase. The UNIQUE constraint on eventIdempotencyKey
-    // prevents duplicate rows; upsert-on-id handles action retries safely.
+    // Idempotency guard: if another processRun already claimed this eventIdempotencyKey
+    // (e.g. emitEvent was called twice due to a Convex mutation retry), skip silently.
+    // The Supabase UNIQUE constraint on event_idempotency_key is the last-line defence,
+    // but relying on it alone means the second action throws a 23505 error rather than
+    // returning cleanly. This explicit check restores the graceful early-exit behaviour
+    // that the old ctx.db dedup provided.
+    const existingRun = await processRunDb
+      .query("automationRuns")
+      .eq("eventIdempotencyKey", args.eventIdempotencyKey)
+      .first();
+    if (existingRun) return;
+
     await processRunDb.insert("automationRuns", {
       _id: args.runId,
       organizationId: args.organizationId as string,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3942.

Closes #3942

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- afdfcc6 fix(automation): add emitEvent idempotency guard in processRun (closes #3942)

### Files changed

```
 convex/automation.ts | 14 ++++++++++++--
 1 file changed, 12 insertions(+), 2 deletions(-)
```