### PR TITLE
Add `permissions` to `WHITELIST_PATHS` in `check-convex-db-reads.mjs` instead of

### DIFF
--- a/scripts/check-convex-db-reads.mjs
+++ b/scripts/check-convex-db-reads.mjs
@@ -91,6 +91,14 @@ const WHITELIST_PATHS = new Set([
   // the primary read path for the bell and notification page stays on Convex.
   // Resolved via issue #3904 (option A).
   "notifications",
+
+  // permissions — _writeOrgPermissionsToConvex (internalMutation) dual-writes
+  // orgPermissions to ctx.db so that _helpers/permissions.ts (QueryCtx) can
+  // read them via ctx.db. Convex queries cannot make HTTP calls, so
+  // createSupabaseDb() is permanently unavailable in QueryCtx. This dual-write
+  // is NOT a migration backlog item; it is a permanent architectural necessity.
+  // See convex/permissions.ts lines 68-73 for the inline rationale.
+  "permissions",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -173,7 +181,6 @@ const MULTILINE_PENDING = new Set([
   "notes",
   "organizations",
   "payments",
-  "permissions",
   "pipelineStageActions",
   "relationships",
   "signatureRequests",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3888.

Closes #3888

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 085939b fix(ci): move permissions from MULTILINE_PENDING to WHITELIST_PATHS in check-convex-db-reads.mjs (closes #3888)

### Files changed

```
 scripts/check-convex-db-reads.mjs | 9 ++++++++-
 1 file changed, 8 insertions(+), 1 deletion(-)
```