### PR TITLE
Fix inaccurate whitelist comment in `check-convex-db-reads.mjs

### DIFF
--- a/scripts/check-convex-db-reads.mjs
+++ b/scripts/check-convex-db-reads.mjs
@@ -76,10 +76,15 @@ const WHITELIST_PATHS = new Set([
   "seedTemplates",
 
   // Auth/permissions helpers called from QueryCtx — Convex queries cannot
-  // make HTTP calls, so createSupabaseDb() is unavailable. Mutation callers
-  // have been migrated to action-based variants (authAction.ts for auth/perms,
-  // seatLimits.checkSeatLimitAction for seat checks). Only query-context
-  // callers remain here (getSeatUsage, verifyOrgAccess in queries, etc.).
+  // make HTTP calls, so createSupabaseDb() is unavailable. Many mutation
+  // callers have been migrated to action-based variants (authAction.ts for
+  // auth/perms, seatLimits.checkSeatLimitAction for seat checks). Some
+  // mutation-context callers also legitimately read these tables via ctx.db
+  // for the same reason (mutations cannot use fetch in the Convex runtime);
+  // e.g. automation.ts:getAutomationEditPermission uses a fake actorCtx to
+  // read teamMemberships/orgPermissions — it is exempt via MULTILINE_PENDING
+  // rather than this whitelist. Primary query-context callers here:
+  // getSeatUsage, verifyOrgAccess in queries.
   "_helpers/auth",
   "_helpers/permissions",
   "_helpers/seatLimits",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3897.

Closes #3897

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 96ad51d fix(ci): correct inaccurate whitelist comment in check-convex-db-reads.mjs (closes #3897)

### Files changed

```
 scripts/check-convex-db-reads.mjs | 13 +++++++++----
 1 file changed, 9 insertions(+), 4 deletions(-)
```