### PR TITLE
Migrate `emailSending.ts` internal action to read emailBrandConfig/emailLayouts 

### DIFF
--- a/convex/emailSending.ts
+++ b/convex/emailSending.ts
@@ -4,6 +4,7 @@ import { internal } from "./_generated/api";
 import { Resend } from "resend";
 import { RESEND_API_KEY, RESEND_FROM } from "@cvx/env";
 import { buildEmailHtml } from "./mail/emailShell";
+import { createSupabaseDb } from "./_helpers/supabaseDb";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -97,20 +98,7 @@ export const getTemplateAndLayout = internalQuery({
     const template = await ctx.db.get(args.templateId);
     if (!template || template.organizationId !== args.organizationId)
       return null;
-
-    // Load brand config (new) — preferred over legacy layout
-    const brandConfig = await ctx.db
-      .query("emailBrandConfig")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .first();
-
-    // Legacy layout fallback
-    const layout = await ctx.db
-      .query("emailLayouts")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .first();
-
-    return { template, layout, brandConfig };
+    return { template };
   },
 });
 
@@ -156,7 +144,21 @@ export const sendTemplateEmail = internalAction({
       return;
     }
 
-    const { template, layout, brandConfig } = data;
+    const { template } = data;
+
+    const db = createSupabaseDb();
+
+    // Load brand config (new) — preferred over legacy layout, read from Supabase
+    const brandConfig = await db
+      .query("emailBrandConfig")
+      .eq("organizationId", String(args.organizationId))
+      .first();
+
+    // Legacy layout fallback from Supabase
+    const layout = await db
+      .query("emailLayouts")
+      .eq("organizationId", String(args.organizationId))
+      .first();
 
     let variables: Record<string, string> = {};
     try {

--- a/scripts/check-convex-db-reads.mjs
+++ b/scripts/check-convex-db-reads.mjs
@@ -166,7 +166,6 @@ const MULTILINE_PENDING = new Set([
   "emailEventBindings",
   "emailEventTrigger",
   "emailEvents",
-  "emailSending",
   "emailSequences",
   "emails",
   "emails_internal",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3954.

Closes #3954

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 23a9302 fix(email): migrate emailBrandConfig/emailLayouts reads to Supabase in emailSending.ts (closes #3954)

### Files changed

```
 convex/emailSending.ts            | 32 +++++++++++++++++---------------
 scripts/check-convex-db-reads.mjs |  1 -
 2 files changed, 17 insertions(+), 16 deletions(-)
```