### PR TITLE
Migrate `organizations.getMyOrganizations` to Supabase hook

### DIFF
--- a/convex/supabase/jwt.ts
+++ b/convex/supabase/jwt.ts
@@ -1,6 +1,7 @@
 import { SignJWT } from "jose";
 import { v } from "convex/values";
 import { action } from "@cvx/_generated/server";
+import { auth } from "@cvx/auth";
 import { internal } from "@cvx/_generated/api";
 import { SUPABASE_JWT_SECRET } from "@cvx/env";
 
@@ -39,6 +40,49 @@ export const mintSupabaseToken = action({
     console.info(
       `JWT minted for user=${membership.userId} org=${args.organizationId}`
     );
+
+    return { token, expiresAt };
+  },
+});
+
+/**
+ * Mint a user-scoped Supabase JWT with no org context.
+ *
+ * Used by the bootstrap "my organizations" query in DashboardLayout, which
+ * must run before OrgProvider (and therefore before SupabaseProvider) is
+ * mounted. The resulting token carries only `sub` — no `org_id` claim — so
+ * it works with the user-own SELECT policies on team_memberships and
+ * organizations (migration 00102).
+ */
+export const mintUserToken = action({
+  args: {},
+  returns: v.object({ token: v.string(), expiresAt: v.number() }),
+  handler: async (ctx, _args): Promise<{ token: string; expiresAt: number }> => {
+    const userId = await auth.getUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const user = await ctx.runQuery(internal._helpers.authAction._getAuthUser, { userId });
+    if (!user) throw new Error("User not found");
+
+    if (!SUPABASE_JWT_SECRET) {
+      throw new Error("SUPABASE_JWT_SECRET not configured");
+    }
+
+    const secret = new TextEncoder().encode(SUPABASE_JWT_SECRET);
+    const now = Math.floor(Date.now() / 1000);
+    const expiresAt = now + 3600;
+
+    const token: string = await new SignJWT({
+      sub: String(userId),
+      role: "authenticated",
+    })
+      .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+      .setIssuer("supabase")
+      .setIssuedAt(now)
+      .setExpirationTime(expiresAt)
+      .sign(secret);
+
+    console.info(`User-scoped JWT minted for user=${String(userId)}`);
 
     return { token, expiresAt };
   },

--- a/src/hooks/use-supabase-organizations.ts
+++ b/src/hooks/use-supabase-organizations.ts
@@ -3,7 +3,10 @@
  */
 
 import { useQuery } from "@tanstack/react-query";
+import { useAction } from "convex/react";
+import { api } from "@cvx/_generated/api";
 import { useSupabase } from "@/components/supabase-provider";
+import { createSupabaseClient, SUPABASE_URL } from "@/lib/supabase/client";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import {
   mapOrganizationFromSupabase,
@@ -11,6 +14,56 @@ import {
   type MappedOrganization,
   type MappedOrgSettings,
 } from "@/lib/supabase/mappers";
+
+// ── My Organizations (bootstrap — no org context in JWT) ─────────────────────
+
+export interface MyOrganization extends MappedOrganization {
+  role: string;
+}
+
+/**
+ * Fetches the list of organizations the current user belongs to, sorted
+ * most-recently-joined first.
+ *
+ * This hook is intentionally called ABOVE SupabaseProvider (in DashboardLayout,
+ * before OrgProvider is mounted). It mints a user-scoped token (no org_id
+ * claim) and creates its own short-lived Supabase client so the org bootstrap
+ * query can hit Supabase instead of reading stale Convex data.
+ *
+ * Requires migration 00102 (user-own SELECT policies on team_memberships and
+ * organizations) to be applied.
+ */
+export function useSupabaseMyOrganizations(userId: string | undefined) {
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known)
+  const mintUserToken = useAction(api.supabase.jwt.mintUserToken);
+
+  return useQuery<MyOrganization[], Error>({
+    queryKey: ["supabase", "organizations", "my", userId ?? ""],
+    queryFn: async () => {
+      const { token } = await mintUserToken({});
+      const client = createSupabaseClient(SUPABASE_URL, token);
+
+      const { data, error } = await (client
+        .from("team_memberships")
+        .select(`
+          role,
+          joined_at,
+          organizations!team_memberships_organization_id_fkey (*)
+        `)
+        .order("joined_at", { ascending: false }) as any);
+
+      if (error) throw error;
+
+      return ((data as any[]) ?? [])
+        .filter((row: any) => row.organizations)
+        .map((row: any) => ({
+          ...mapOrganizationFromSupabase(row.organizations as any),
+          role: row.role as string,
+        }));
+    },
+    enabled: !!userId,
+  });
+}
 
 // ── Organization Detail ───────────────────────────────────────────────────────
 

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -9,6 +9,7 @@ import { useSupabase } from "@/components/supabase-provider";
 import { supabaseGlobalSearch } from "@/hooks/use-supabase-search";
 import { useSupabaseScheduledActivityById } from "@/hooks/use-supabase-scheduled-activities";
 import { useSupabaseCustomFieldDefinitions } from "@/hooks/use-supabase-custom-fields";
+import { useSupabaseMyOrganizations } from "@/hooks/use-supabase-organizations";
 import { AppSidebar } from "@/components/layout/app-sidebar";
 import { AppFooter } from "@/components/layout/app-footer";
 import { RouteErrorBoundary } from "@/components/layout/route-error-boundary";
@@ -1085,9 +1086,7 @@ function DashboardLayoutInner({ user, orgs }: DashboardLayoutInnerProps) {
 function DashboardLayout() {
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
   const { data: user } = useQuery(convexQuery(api.app.getCurrentUser, {}));
-  const { data: orgs } = useQuery(
-    convexQuery(api.organizations.getMyOrganizations, {})
-  );
+  const { data: orgs } = useSupabaseMyOrganizations(user?._id);
   if (!user || !orgs) return null;
   const savedOrgId = localStorage.getItem(getOrgStorageKey(user._id));
   const firstOrg =

--- a/supabase/migrations/00102_my_orgs_user_policies.sql
+++ b/supabase/migrations/00102_my_orgs_user_policies.sql
@@ -1,0 +1,31 @@
+-- ============================================================
+-- Migration 00102: User-own SELECT policies for org bootstrap
+-- ============================================================
+--
+-- The "my organizations" bootstrap query in DashboardLayout runs before
+-- OrgProvider is mounted, so the Supabase JWT has no org_id claim. The
+-- existing org_isolation policies on team_memberships and organizations
+-- both gate on current_org_id(), which is null at that point.
+--
+-- This migration adds supplementary SELECT-only policies keyed on the JWT
+-- `sub` (current_user_id()) so a user can enumerate their own memberships
+-- and the organizations those memberships belong to — even without an
+-- org context in the token.
+--
+-- All INSERT / UPDATE / DELETE paths still require a valid org context.
+
+-- Allow a user to SELECT their own team_memberships across all orgs.
+CREATE POLICY team_memberships_own_user_select ON team_memberships
+  FOR SELECT
+  USING (user_id = current_user_id());
+
+-- Allow a user to SELECT any organization they are a member of.
+CREATE POLICY organizations_member_user_select ON organizations
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM team_memberships tm
+      WHERE tm.organization_id = organizations.id
+        AND tm.user_id = current_user_id()
+    )
+  );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3959.

Closes #3959

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c63be99 fix(orgs): migrate getMyOrganizations to Supabase hook (closes #3959)

### Files changed

```
 convex/supabase/jwt.ts                             | 44 ++++++++++++++++++
 src/hooks/use-supabase-organizations.ts            | 53 ++++++++++++++++++++++
 src/routes/_app/_auth/dashboard/_layout.tsx        |  5 +-
 .../migrations/00102_my_orgs_user_policies.sql     | 31 +++++++++++++
 4 files changed, 130 insertions(+), 3 deletions(-)
```