### PR TITLE
Migrate `organizations.getSeatUsage` to Supabase

### DIFF
--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -500,3 +500,31 @@ export const getSeatUsage = query({
     return await checkSeatLimit(ctx, args);
   },
 });
+
+// Returns only the seat limit (from subscriptions/plans, which are Convex-only tables).
+// Seat counts (team_memberships + invitations) are read from Supabase by the frontend hook.
+export const getSeatLimit = query({
+  args: { organizationId: v.id("organizations") },
+  handler: async (ctx, args) => {
+    await verifyOrgAccess(ctx, args.organizationId);
+
+    const org = await ctx.db.get(args.organizationId);
+    if (!org) throw new Error("Organization not found");
+
+    const subscription = await ctx.db
+      .query("subscriptions")
+      .withIndex("userId", (q) => q.eq("userId", org.ownerId))
+      .filter((q) =>
+        q.or(
+          q.eq(q.field("status"), "active"),
+          q.eq(q.field("status"), "trialing"),
+        ),
+      )
+      .first();
+
+    if (!subscription) return { seatLimit: 20 };
+
+    const plan = await ctx.db.get(subscription.planId);
+    return { seatLimit: plan?.seatLimit ?? 20 };
+  },
+});

--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -5,6 +5,7 @@ import { convexQuery } from "@convex-dev/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useSupabasePendingInvitations } from "@/hooks/use-supabase-invitations";
+import { useSupabaseSeatUsage } from "@/hooks/use-supabase-organizations";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
 import { Button } from "@/components/ui/button";
@@ -103,9 +104,7 @@ export function UserInvitationForm({
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
 
-  const { data: seatUsage } = useQuery(
-    convexQuery(api.organizations.getSeatUsage, { organizationId })
-  ) as { data: { currentSeats: number; seatLimit: number; canAddMore: boolean } | undefined };
+  const { data: seatUsage } = useSupabaseSeatUsage(organizationId);
   const { data: pendingInvitations } = useSupabasePendingInvitations(organizationId);
 
   // Gabinet-specific data sources — only fetched lazily once Gabinet is picked.

--- a/src/hooks/use-supabase-organizations.ts
+++ b/src/hooks/use-supabase-organizations.ts
@@ -2,7 +2,9 @@
  * React Query hooks for fetching organizations, members, settings, and usage from Supabase.
  */
 
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { convexQuery } from "@convex-dev/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useSupabase } from "@/components/supabase-provider";
@@ -227,4 +229,52 @@ export function useSupabaseOrgUsageStats(organizationId: string, options?: { ena
     },
     enabled: enabled && isReady && !!organizationId,
   });
+}
+
+// ── Seat Usage ────────────────────────────────────────────────────────────────
+
+export interface SeatUsage {
+  currentSeats: number;
+  seatLimit: number;
+  canAddMore: boolean;
+}
+
+/**
+ * Reads seat counts (team_memberships + pending invitations) from Supabase and
+ * seat limit from Convex (subscriptions/plans are Convex-only tables).
+ */
+export function useSupabaseSeatUsage(organizationId: string, options?: { enabled?: boolean }) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options ?? {};
+
+  const countsQuery = useQuery<{ memberCount: number; pendingCount: number }, Error>({
+    queryKey: [...supabaseKeys.teamMemberships.list(organizationId), "seatCounts"],
+    queryFn: async () => {
+      if (!client) throw new Error("Supabase client not ready");
+      const [members, invitations] = await Promise.all([
+        client.from("team_memberships").select("id", { count: "exact", head: true }).eq("organization_id", organizationId),
+        client.from("invitations").select("id", { count: "exact", head: true }).eq("organization_id", organizationId).eq("status", "pending"),
+      ]);
+      if (members.error) throw members.error;
+      if (invitations.error) throw invitations.error;
+      return { memberCount: members.count ?? 0, pendingCount: invitations.count ?? 0 };
+    },
+    enabled: enabled && isReady && !!organizationId,
+  });
+
+  // @ts-ignore — TS2589: convexQuery type instantiation too deep, runtime is correct
+  const limitQuery = useQuery(convexQuery(api.organizations.getSeatLimit, { organizationId }));
+
+  const data = useMemo<SeatUsage | undefined>(() => {
+    if (!countsQuery.data || !limitQuery.data) return undefined;
+    const currentSeats = countsQuery.data.memberCount + countsQuery.data.pendingCount;
+    const seatLimit = (limitQuery.data as { seatLimit: number }).seatLimit;
+    return { currentSeats, seatLimit, canAddMore: currentSeats < seatLimit };
+  }, [countsQuery.data, limitQuery.data]);
+
+  return {
+    data,
+    isLoading: countsQuery.isLoading || limitQuery.isLoading,
+    error: countsQuery.error ?? limitQuery.error ?? null,
+  };
 }

--- a/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.team.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useState } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
-import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
-import { useSupabaseOrganizationMembers } from "@/hooks/use-supabase-organizations";
+import { useSupabaseOrganizationMembers, useSupabaseSeatUsage } from "@/hooks/use-supabase-organizations";
 import { useSupabasePendingInvitations } from "@/hooks/use-supabase-invitations";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { SectionHeader } from "@untitled/app/section-headers/section-headers";
@@ -72,11 +71,7 @@ function TeamSettings() {
 
   const { data: invitations } = useSupabasePendingInvitations(organizationId);
 
-  // Seat usage stays on Convex — involves plan/subscription lookup logic
-  const { data: seatUsage } = useQuery(
-    // @ts-ignore — TS2589: convexQuery type instantiation too deep, runtime is correct
-    convexQuery(api.organizations.getSeatUsage, { organizationId })
-  ) as { data: { currentSeats: number; seatLimit: number; canAddMore: boolean } | undefined };
+  const { data: seatUsage } = useSupabaseSeatUsage(organizationId);
 
   const seatPercentage = seatUsage
     ? Math.round((seatUsage.currentSeats / seatUsage.seatLimit) * 100)


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3960.

Closes #3960

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 9fd8d7f fix(orgs): migrate getSeatUsage to Supabase hook (closes #3960)

### Files changed

```
 convex/organizations.ts                            | 28 ++++++++++++
 src/components/forms/user-invitation-form.tsx      |  5 +--
 src/hooks/use-supabase-organizations.ts            | 50 ++++++++++++++++++++++
 .../_app/_auth/dashboard/_layout.settings.team.tsx | 11 ++---
 4 files changed, 83 insertions(+), 11 deletions(-)
```