### PR TITLE
Migrate `customFields.getDefinitions` to Supabase hook

### DIFF
--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -1,11 +1,11 @@
 import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
-import { convexQuery } from "@convex-dev/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
+import { useSupabaseCustomFieldDefinitions } from "@/hooks/use-supabase-custom-fields";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -105,23 +105,10 @@ export function EmployeeForm({
     enabled: !!organizationId,
   }) as { data: Array<{ _id: string; name: string; isActive: boolean }> | undefined };
 
-  const { data: customFieldDefs } = useQuery({
-    ...convexQuery(
-      api.customFields.getDefinitions,
-      { organizationId: organizationId!, entityType: "gabinetEmployee" as const },
-    ),
-    enabled: !!organizationId,
-  }) as {
-    data: Array<{
-      _id: string;
-      name: string;
-      fieldKey: string;
-      fieldType: any;
-      options?: string[];
-      isRequired?: boolean;
-      group?: string;
-    }> | undefined;
-  };
+  const { data: customFieldDefs } = useSupabaseCustomFieldDefinitions(
+    organizationId,
+    "gabinetEmployee",
+  );
 
   const [firstName, setFirstName] = useState(initialData?.firstName ?? "");
   const [lastName, setLastName] = useState(initialData?.lastName ?? "");

--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -1,11 +1,11 @@
 import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
-import { convexQuery } from "@convex-dev/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useSupabasePendingInvitations } from "@/hooks/use-supabase-invitations";
 import { useSupabaseSeatUsage } from "@/hooks/use-supabase-organizations";
+import { useSupabaseCustomFieldDefinitions } from "@/hooks/use-supabase-custom-fields";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
 import { Button } from "@/components/ui/button";
@@ -140,26 +140,11 @@ export function UserInvitationForm({
     }>;
   };
 
-  const { data: customFieldDefs } = useQuery(
-    convexQuery(
-      api.customFields.getDefinitions,
-      module === "gabinet"
-        ? { organizationId, entityType: "gabinetEmployee" }
-        : ("skip" as any),
-    ),
-  ) as {
-    data:
-      | Array<{
-          _id: string;
-          name: string;
-          fieldKey: string;
-          fieldType: any;
-          options?: string[];
-          isRequired?: boolean;
-          group?: string;
-        }>
-      | undefined;
-  };
+  const { data: customFieldDefs } = useSupabaseCustomFieldDefinitions(
+    organizationId,
+    "gabinetEmployee",
+    { enabled: module === "gabinet" },
+  );
 
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<OrgRole>("member");


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3961.

Closes #3961

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0888d0c fix(custom-fields): migrate getDefinitions to Supabase hook in employee and invitation forms (closes #3961)

### Files changed

```
 src/components/forms/employee-form.tsx        | 23 +++++------------------
 src/components/forms/user-invitation-form.tsx | 27 ++++++---------------------
 2 files changed, 11 insertions(+), 39 deletions(-)
```