### PR TITLE
Migrate `emailTemplates` read in `getTemplateAndLayout` to Supabase

### DIFF
--- a/convex/emailSending.ts
+++ b/convex/emailSending.ts
@@ -94,9 +94,10 @@ export const getTemplateAndLayout = internalQuery({
     templateId: v.string(),
     organizationId: v.id("organizations"),
   },
-  handler: async (ctx, args) => {
-    const template = await ctx.db.get(args.templateId as any);
-    if (!template || template.organizationId !== args.organizationId)
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
+    const template = await db.get("emailTemplates", args.templateId);
+    if (!template || String(template.organizationId) !== String(args.organizationId))
       return null;
     return { template };
   },

--- a/convex/emailTemplates.ts
+++ b/convex/emailTemplates.ts
@@ -96,7 +96,7 @@ export const listVariableSources = query({
 export const renderTemplate = query({
   args: {
     organizationId: v.id("organizations"),
-    templateId: v.id("emailTemplates"),
+    templateId: v.string(),
     // CRM entities
     contactId: v.optional(v.id("contacts")),
     companyId: v.optional(v.id("companies")),
@@ -109,8 +109,9 @@ export const renderTemplate = query({
   handler: async (ctx, args) => {
     const { user } = await verifyOrgAccess(ctx, args.organizationId);
 
-    const template = await ctx.db.get(args.templateId);
-    if (!template || template.organizationId !== args.organizationId) {
+    const db = createSupabaseDb();
+    const template = await db.get("emailTemplates", args.templateId);
+    if (!template || String(template.organizationId) !== String(args.organizationId)) {
       throw new Error("Email template not found");
     }
 

--- a/src/components/email/compose-dialog.tsx
+++ b/src/components/email/compose-dialog.tsx
@@ -107,7 +107,7 @@ export function ComposeDialog({
   const { data: renderedTemplate } = useQuery({
     ...convexQuery(api.emailTemplates.renderTemplate, {
       organizationId,
-      templateId: selectedTemplateId as Id<"emailTemplates">,
+      templateId: selectedTemplateId,
       contactId,
       companyId,
       leadId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3964.

Closes #3964

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 1c6d941 fix(email): migrate emailTemplates reads in getTemplateAndLayout and renderTemplate to Supabase (closes #3964)

### Files changed

```
 convex/emailSending.ts                  | 7 ++++---
 convex/emailTemplates.ts                | 7 ++++---
 src/components/email/compose-dialog.tsx | 2 +-
 3 files changed, 9 insertions(+), 7 deletions(-)
```