### PR TITLE
Migrate `triggerEmailEvent` emailSequences read to Supabase

### DIFF
--- a/convex/emailEventTrigger.ts
+++ b/convex/emailEventTrigger.ts
@@ -103,27 +103,15 @@ export const triggerEmailEvent = internalMutation({
     });
 
     // Enroll in any active sequences triggered by this event type.
+    // Delegated to an action so the HTTP call to Supabase is allowed.
     // Silent no-op if no sequences match.
-    const sequences = await ctx.db
-      .query("emailSequences")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .collect();
-
-    for (const sequence of sequences) {
-      if (sequence.isActive && sequence.triggerEventType === args.eventType) {
-        await ctx.scheduler.runAfter(
-          0,
-          internal.emailSequences.enrollRecipient,
-          {
-            sequenceId: sequence._id,
-            organizationId: args.organizationId,
-            recipientEmail: args.recipientEmail,
-            recipientName: args.recipientName,
-            payload: args.payload,
-          },
-        );
-      }
-    }
+    await ctx.scheduler.runAfter(0, internal.emailSequences.enrollForEvent, {
+      organizationId: args.organizationId,
+      eventType: args.eventType,
+      recipientEmail: args.recipientEmail,
+      recipientName: args.recipientName,
+      payload: args.payload,
+    });
 
     return logId;
   },

--- a/convex/emailSequences.ts
+++ b/convex/emailSequences.ts
@@ -257,13 +257,46 @@ export const cancelEnrollment = action({
 // ---------------------------------------------------------------------------
 
 /**
- * Enroll a recipient into a sequence and schedule the first step.
- * Called by emailEventTrigger when a matching sequence is found.
- * Reads steps from Supabase (primary store) and writes enrollment to Supabase.
+ * Reads active sequences from Supabase for the given org + eventType, then
+ * schedules enrollRecipient for each match.  Called by triggerEmailEvent so
+ * the mutation doesn't attempt an HTTP call (mutations can't do I/O).
  */
+export const enrollForEvent = internalAction({
+  args: {
+    organizationId: v.id("organizations"),
+    eventType: v.string(),
+    recipientEmail: v.string(),
+    recipientName: v.optional(v.string()),
+    payload: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const db = createSupabaseDb();
+    const sequences = await db
+      .query("emailSequences")
+      .eq("organizationId", String(args.organizationId))
+      .eq("isActive", true)
+      .eq("triggerEventType", args.eventType)
+      .collect();
+
+    for (const sequence of sequences) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.emailSequences.enrollRecipient,
+        {
+          sequenceId: sequence._id as string,
+          organizationId: args.organizationId,
+          recipientEmail: args.recipientEmail,
+          recipientName: args.recipientName,
+          payload: args.payload,
+        },
+      );
+    }
+  },
+});
+
 export const enrollRecipient = internalAction({
   args: {
-    sequenceId: v.id("emailSequences"),
+    sequenceId: v.string(),
     organizationId: v.id("organizations"),
     recipientEmail: v.string(),
     recipientName: v.optional(v.string()),

--- a/tests/convex/emailSequences.test.ts
+++ b/tests/convex/emailSequences.test.ts
@@ -25,7 +25,7 @@ describe("emailSequences.enrollRecipient", () => {
     });
 
     const result = await t.action(internal.emailSequences.enrollRecipient, {
-      sequenceId: sequenceId as any,
+      sequenceId: sequenceId,
       organizationId,
       recipientEmail: "test@example.com",
     });
@@ -70,7 +70,7 @@ describe("emailSequences.enrollRecipient", () => {
     });
 
     const enrollmentId = await t.action(internal.emailSequences.enrollRecipient, {
-      sequenceId: sequenceId as any,
+      sequenceId: sequenceId,
       organizationId,
       recipientEmail: "patient@example.com",
       recipientName: "Jan Kowalski",
@@ -132,7 +132,7 @@ describe("emailSequences.enrollRecipient", () => {
     });
 
     const enrollmentId = await t.action(internal.emailSequences.enrollRecipient, {
-      sequenceId: sequenceId as any,
+      sequenceId: sequenceId,
       organizationId,
       recipientEmail: "lead@example.com",
     });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3970.

Closes #3970

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 89427a5 fix(email): migrate triggerEmailEvent emailSequences read to Supabase (closes #3970)

### Files changed

```
 convex/emailEventTrigger.ts         | 28 ++++++++-----------------
 convex/emailSequences.ts            | 41 +++++++++++++++++++++++++++++++++----
 tests/convex/emailSequences.test.ts |  6 +++---
 3 files changed, 48 insertions(+), 27 deletions(-)
```