### PR TITLE
Migrate `emailEventLog` writes in `insertSequenceLog` to Supabase

### DIFF
--- a/convex/emailEvents.ts
+++ b/convex/emailEvents.ts
@@ -166,9 +166,9 @@ export const getLogEntry = internalQuery({
   handler: async (ctx, args) => ctx.db.get(args.logId),
 });
 
-export const updateLogStatus = internalMutation({
+export const updateLogStatus = internalAction({
   args: {
-    logId: v.id("emailEventLog"),
+    logId: v.string(),
     status: v.union(
       v.literal("pending"),
       v.literal("sent"),
@@ -181,35 +181,34 @@ export const updateLogStatus = internalMutation({
     renderedBody: v.optional(v.string()),
     errorMessage: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
     const processedAt = Date.now();
-    await ctx.db.patch(args.logId, {
+    await db.patch("emailEventLog", args.logId, {
       status: args.status,
-      bindingId: args.bindingId,
-      templateId: args.templateId,
-      renderedSubject: args.renderedSubject,
-      renderedBody: args.renderedBody,
-      errorMessage: args.errorMessage,
+      bindingId: args.bindingId ?? null,
+      templateId: args.templateId ?? null,
+      renderedSubject: args.renderedSubject ?? null,
+      renderedBody: args.renderedBody ?? null,
+      errorMessage: args.errorMessage ?? null,
       processedAt,
     });
 
-    const entry = await ctx.db.get(args.logId);
+    const entry = await db.get("emailEventLog", args.logId);
 
     if (!entry?.idempotencyKey) return;
 
-    const history = await ctx.db
+    const history = await db
       .query("appointmentWorkflowHistory")
-      .withIndex("by_idempotencyKey", (q) =>
-        q.eq("idempotencyKey", entry.idempotencyKey!),
-      )
+      .eq("idempotencyKey", entry.idempotencyKey as string)
       .unique();
 
     if (history) {
-      await ctx.db.patch(history._id, {
+      await db.patch("appointmentWorkflowHistory", history._id as string, {
         status: args.status,
-        renderedSubject: args.renderedSubject ?? history.renderedSubject,
-        renderedBody: args.renderedBody ?? history.renderedBody,
-        errorMessage: args.errorMessage,
+        renderedSubject: args.renderedSubject ?? (history.renderedSubject as string | null),
+        renderedBody: args.renderedBody ?? (history.renderedBody as string | null),
+        errorMessage: args.errorMessage ?? null,
         processedAt,
         updatedAt: processedAt,
       });
@@ -252,8 +251,8 @@ export const processEvent = internalAction({
       .collect();
 
     if (bindings.length === 0) {
-      await ctx.runMutation(internal.emailEvents.updateLogStatus, {
-        logId: args.logId,
+      await ctx.runAction(internal.emailEvents.updateLogStatus, {
+        logId: args.logId as string,
         status: "skipped",
         errorMessage: "No enabled bindings found for event type",
       });

--- a/convex/emailSending.ts
+++ b/convex/emailSending.ts
@@ -114,7 +114,7 @@ export const getTemplateAndLayout = internalQuery({
  */
 export const sendTemplateEmail = internalAction({
   args: {
-    logId: v.id("emailEventLog"),
+    logId: v.string(),
     templateId: v.string(),
     organizationId: v.id("organizations"),
     recipientEmail: v.string(),
@@ -133,7 +133,7 @@ export const sendTemplateEmail = internalAction({
     );
 
     if (!data) {
-      await ctx.runMutation(internal.emailEvents.updateLogStatus, {
+      await ctx.runAction(internal.emailEvents.updateLogStatus, {
         logId: args.logId,
         status: "failed",
         bindingId: args.bindingId,
@@ -221,7 +221,7 @@ export const sendTemplateEmail = internalAction({
 
     if (!RESEND_API_KEY) {
       console.warn("[emailSending] RESEND_API_KEY not set — skipping send");
-      await ctx.runMutation(internal.emailEvents.updateLogStatus, {
+      await ctx.runAction(internal.emailEvents.updateLogStatus, {
         logId: args.logId,
         status: "failed",
         bindingId: args.bindingId,
@@ -258,7 +258,7 @@ export const sendTemplateEmail = internalAction({
         html,
       });
 
-      await ctx.runMutation(internal.emailEvents.updateLogStatus, {
+      await ctx.runAction(internal.emailEvents.updateLogStatus, {
         logId: args.logId,
         status: "sent",
         bindingId: args.bindingId,
@@ -272,7 +272,7 @@ export const sendTemplateEmail = internalAction({
       });
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : "Unknown send error";
-      await ctx.runMutation(internal.emailEvents.updateLogStatus, {
+      await ctx.runAction(internal.emailEvents.updateLogStatus, {
         logId: args.logId,
         status: "failed",
         bindingId: args.bindingId,

--- a/convex/emailSequences.ts
+++ b/convex/emailSequences.ts
@@ -8,7 +8,6 @@
 
 import {
   action,
-  internalMutation,
   internalAction,
 } from "./_generated/server";
 import { v } from "convex/values";
@@ -370,7 +369,7 @@ export const processNextStep = internalAction({
 
     const step = sortedSteps[enrollment.currentStep];
 
-    const logId = await ctx.runMutation(
+    const logId = await ctx.runAction(
       internal.emailSequences.insertSequenceLog,
       {
         organizationId: enrollment.organizationId,
@@ -414,11 +413,11 @@ export const processNextStep = internalAction({
 });
 
 // ---------------------------------------------------------------------------
-// Internal mutation: insert an emailEventLog entry for sequence step tracking.
-// Writes to Convex so sendTemplateEmail receives a valid Convex logId.
+// Internal action: insert an emailEventLog entry for sequence step tracking.
+// Writes directly to Supabase so the sequence path is fully Supabase-primary.
 // ---------------------------------------------------------------------------
 
-export const insertSequenceLog = internalMutation({
+export const insertSequenceLog = internalAction({
   args: {
     organizationId: v.id("organizations"),
     sequenceId: v.string(),
@@ -427,15 +426,16 @@ export const insertSequenceLog = internalMutation({
     recipientName: v.optional(v.string()),
     payload: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
     const now = Date.now();
-    const logId = await ctx.db.insert("emailEventLog", {
-      organizationId: args.organizationId,
+    const logId = await db.insert("emailEventLog", {
+      organizationId: String(args.organizationId),
       eventType: "sequence.step",
       templateId: args.templateId,
       recipientEmail: args.recipientEmail,
-      recipientName: args.recipientName,
-      payload: args.payload,
+      recipientName: args.recipientName ?? null,
+      payload: args.payload ?? null,
       status: "pending",
       createdAt: now,
     });

--- a/session_state.json
+++ b/session_state.json
@@ -1,18 +1,18 @@
 {
-  "session_id": "S0116",
-  "started_at": "2026-08-06T15:00:00Z",
-  "last_updated": "2026-08-06T15:20:00Z",
-  "status": "completed",
-  "focus": "Issue #3908: Add column-level RLS to org_sms_config to block api_token/api_secret",
+  "session_id": "S0117",
+  "started_at": "2026-08-06T20:00:00Z",
+  "last_updated": "2026-08-06T20:00:00Z",
+  "status": "active",
+  "focus": "Issue #3971: Migrate emailEventLog writes in insertSequenceLog to Supabase",
   "tasks_snapshot": {
     "total": 1,
     "not_started": 0,
-    "in_progress": 0,
-    "passing": 1,
+    "in_progress": 1,
+    "passing": 0,
     "failing": 0,
     "blocked": 0
   },
-  "active_task_ids": [],
+  "active_task_ids": [1],
   "blockers": [],
-  "notes": "S0116: Added column-level security for org_sms_config. Migration 00101 REVOKEs table-level SELECT and re-GRANTs safe columns only; creates security-barrier view org_sms_config_summary. Updated hook to query view. Updated gen-db-types.mjs to support CREATE VIEW. Regenerated database.types.ts and database.columns.ts."
+  "notes": "Migrating insertSequenceLog from Convex to Supabase. Plan: (1) insertSequenceLog becomes internalAction using createSupabaseDb; (2) processNextStep uses ctx.runAction; (3) sendTemplateEmail logId becomes v.string(); (4) updateLogStatus becomes internalAction using Supabase; (5) all callers of updateLogStatus switch from runMutation to runAction."
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3971.

Closes #3971

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a7cb08d fix(email): migrate emailEventLog writes in insertSequenceLog to Supabase (closes #3971)

### Files changed

```
 convex/emailEvents.ts    | 39 +++++++++++++++++++--------------------
 convex/emailSending.ts   | 10 +++++-----
 convex/emailSequences.ts | 20 ++++++++++----------
 session_state.json       | 18 +++++++++---------
 4 files changed, 43 insertions(+), 44 deletions(-)
```