### PR TITLE
Migrate `list` queries in companies.ts / contacts.ts off `ctx.db`

### DIFF
--- a/convex/companies.ts
+++ b/convex/companies.ts
@@ -1,36 +1,12 @@
-import { query, action, internalMutation } from "./_generated/server";
+import { action, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
-import { paginationOptsValidator } from "convex/server";
-import { verifyOrgAccess } from "./_helpers/auth";
 import { logActivity } from "./_helpers/activities";
-import { checkPermission } from "./_helpers/permissions";
 import { Id } from "./_generated/dataModel";
 
 // Dual-write refs removed — Supabase is now primary for company writes
-
-export const list = query({
-  args: {
-    organizationId: v.id("organizations"),
-    paginationOpts: paginationOptsValidator,
-  },
-  handler: async (ctx, args) => {
-    const { user } = await verifyOrgAccess(ctx, args.organizationId);
-    const perm = await checkPermission(ctx, args.organizationId, "companies", "view");
-    if (!perm.allowed) throw new Error("Permission denied");
-
-    const result = await ctx.db
-      .query("companies")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .order("desc")
-      .paginate(args.paginationOpts);
-    if (perm.scope === "own") {
-      return { ...result, page: result.page.filter((r) => r.createdBy === user._id) };
-    }
-    return result;
-  },
-});
+// list query removed — browser reads companies directly from Supabase via use-supabase-companies.ts
 
 export const create = action({
   args: {

--- a/convex/contacts.ts
+++ b/convex/contacts.ts
@@ -1,36 +1,12 @@
-import { query, action, internalMutation } from "./_generated/server";
+import { action, internalMutation } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
-import { paginationOptsValidator } from "convex/server";
-import { verifyOrgAccess } from "./_helpers/auth";
 import { logActivity } from "./_helpers/activities";
-import { checkPermission } from "./_helpers/permissions";
 import { Id } from "./_generated/dataModel";
 
 // Dual-write refs removed — Supabase is now primary for contact writes
-
-export const list = query({
-  args: {
-    organizationId: v.id("organizations"),
-    paginationOpts: paginationOptsValidator,
-  },
-  handler: async (ctx, args) => {
-    const { user } = await verifyOrgAccess(ctx, args.organizationId);
-    const perm = await checkPermission(ctx, args.organizationId, "contacts", "view");
-    if (!perm.allowed) throw new Error("Permission denied");
-
-    const result = await ctx.db
-      .query("contacts")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .order("desc")
-      .paginate(args.paginationOpts);
-    if (perm.scope === "own") {
-      return { ...result, page: result.page.filter((r) => r.createdBy === user._id) };
-    }
-    return result;
-  },
-});
+// list query removed — browser reads contacts directly from Supabase via use-supabase-contacts.ts
 
 export const create = action({
   args: {

--- a/scripts/check-convex-db-reads.mjs
+++ b/scripts/check-convex-db-reads.mjs
@@ -155,8 +155,6 @@ const MULTILINE_PENDING = new Set([
   "app",
   "automation",
   "calls",
-  "companies",
-  "contacts",
   "customFields",
   "documentInstances",
   "documentTemplateFields",

--- a/src/components/documents/template-preview-sheet.tsx
+++ b/src/components/documents/template-preview-sheet.tsx
@@ -3,6 +3,8 @@ import { useQuery } from "@tanstack/react-query";
 import { convexQuery } from "@convex-dev/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
+import { useSupabaseContactsList } from "@/hooks/use-supabase-contacts";
+import { useSupabaseCompaniesList } from "@/hooks/use-supabase-companies";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
 import {
@@ -299,12 +301,9 @@ export function TemplatePreviewSheet({
     enabled: entityType === "patient" && !!organizationId,
   }) as { data: { page: any[] } | undefined };
 
-  const { data: contacts } = useQuery({
-    ...convexQuery(api.contacts.list, {
-      organizationId,
-      paginationOpts: { numItems: 50, cursor: null },
-    }),
+  const { data: contacts } = useSupabaseContactsList(organizationId, {
     enabled: entityType === "contact",
+    limit: 50,
   });
 
   const listAppointmentsAction = useAction(api.gabinet.appointments.list);
@@ -317,12 +316,9 @@ export function TemplatePreviewSheet({
     enabled: entityType === "appointment" && !!organizationId,
   }) as { data: { page: any[] } | undefined };
 
-  const { data: companies } = useQuery({
-    ...convexQuery(api.companies.list, {
-      organizationId,
-      paginationOpts: { numItems: 50, cursor: null },
-    }),
+  const { data: companies } = useSupabaseCompaniesList(organizationId, {
     enabled: entityType === "company",
+    limit: 50,
   });
 
   const { data: leads } = useQuery({
@@ -356,10 +352,10 @@ export function TemplatePreviewSheet({
   // Normalize entity lists to a common shape
   const entityList = useMemo((): Array<Record<string, unknown>> => {
     if (!entityType) return [];
-    // All queries use pagination, so extract .page
+    // Supabase hooks return arrays directly; Convex action queries return { page: [] }
     const raw = { patient: patients, contact: contacts, appointment: appointments, company: companies, lead: leads, employee: employees, treatment: treatments }[entityType];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const items: unknown[] = (raw as any)?.page ?? [];
+    const items: unknown[] = Array.isArray(raw) ? raw : ((raw as any)?.page ?? []);
     return (items as Record<string, unknown>[]).filter((item) => {
       if (!searchQuery.trim()) return true;
       const config = ENTITY_CONFIG[entityType];

--- a/tests/convex/tenantIsolation.test.ts
+++ b/tests/convex/tenantIsolation.test.ts
@@ -108,19 +108,6 @@ describe("tenant isolation — permissions", () => {
 // ─── Contacts ─────────────────────────────────────────────────────────────────
 
 describe("tenant isolation — contacts", () => {
-  test("list: org A user cannot list org B contacts", async () => {
-    const t = createTestCtx();
-    const { identity: identityA } = await seedTestUser(t);
-    const { organizationId: orgBId } = await seedOrgB(t);
-
-    await expect(
-      t.withIdentity(identityA).query(api.contacts.list, {
-        organizationId: orgBId,
-        paginationOpts: PAGINATION,
-      }),
-    ).rejects.toThrow("Not a member of this organization");
-  });
-
   test("getById: org A user cannot fetch an org B contact by ID", async () => {
     const t = createTestCtx();
     const { organizationId: orgAId, identity: identityA } = await seedTestUser(t);
@@ -152,19 +139,6 @@ describe("tenant isolation — contacts", () => {
 // ─── Companies ────────────────────────────────────────────────────────────────
 
 describe("tenant isolation — companies", () => {
-  test("list: org A user cannot list org B companies", async () => {
-    const t = createTestCtx();
-    const { identity: identityA } = await seedTestUser(t);
-    const { organizationId: orgBId } = await seedOrgB(t);
-
-    await expect(
-      t.withIdentity(identityA).query(api.companies.list, {
-        organizationId: orgBId,
-        paginationOpts: PAGINATION,
-      }),
-    ).rejects.toThrow("Not a member of this organization");
-  });
-
   test("getById: org A user cannot fetch an org B company by ID", async () => {
     const t = createTestCtx();
     const { organizationId: orgAId, identity: identityA } = await seedTestUser(t);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3974.

Closes #3974

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c6283ba fix(crm): migrate list queries in companies/contacts off ctx.db (closes #3974)

### Files changed

```
 convex/companies.ts                                | 28 ++--------------------
 convex/contacts.ts                                 | 28 ++--------------------
 scripts/check-convex-db-reads.mjs                  |  2 --
 .../documents/template-preview-sheet.tsx           | 20 +++++++---------
 tests/convex/tenantIsolation.test.ts               | 26 --------------------
 5 files changed, 12 insertions(+), 92 deletions(-)
```