### PR TITLE
Wire `useSupabaseInvitationByToken` to login page invite banner

### DIFF
--- a/src/hooks/use-supabase-invitations.ts
+++ b/src/hooks/use-supabase-invitations.ts
@@ -4,6 +4,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useSupabase } from "@/components/supabase-provider";
+import { createAnonSupabaseClient } from "@/lib/supabase/client";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { mapInvitationFromSupabase, type MappedInvitation } from "@/lib/supabase/mappers";
 
@@ -42,6 +43,48 @@ export interface InvitationByTokenResult {
   };
   orgName: string | null;
   inviterName: string | null;
+}
+
+// Module-level singleton — avoids creating a new client on every render.
+// No auth header; relies on SECURITY DEFINER functions granted to the anon role.
+const anonClient = createAnonSupabaseClient();
+
+/**
+ * Fetches invitation details by token without requiring SupabaseProvider.
+ *
+ * Uses an unauthenticated (anon-key-only) client and calls the
+ * `get_invitation_by_token` SECURITY DEFINER function. Intended for the
+ * login-page invite banner, which renders before the user has a JWT.
+ */
+export function useAnonSupabaseInvitationByToken(token: string, options?: { enabled?: boolean }) {
+  const { enabled = true } = options ?? {};
+
+  return useQuery<InvitationByTokenResult | null, Error>({
+    queryKey: ["supabase", "invitations", "byToken", "anon", token],
+    queryFn: async () => {
+      const { data, error } = await anonClient
+        .rpc("get_invitation_by_token", { p_token: token });
+
+      if (error) throw error;
+      const row = Array.isArray(data) ? data[0] : null;
+      if (!row) return null;
+
+      return {
+        invitation: {
+          _id: row.id,
+          email: row.email,
+          role: row.role,
+          status: row.status,
+          expiresAt: row.expires_at,
+          createdAt: row.created_at,
+          module: row.module ?? null,
+        },
+        orgName: row.org_name ?? null,
+        inviterName: row.inviter_name ?? null,
+      };
+    },
+    enabled: enabled && !!token,
+  });
 }
 
 export function useSupabaseInvitationByToken(token: string, options?: { enabled?: boolean }) {

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -67,3 +67,20 @@ export function createSupabaseClient(
     },
   });
 }
+
+/**
+ * Create an unauthenticated Supabase client using only the anon key.
+ *
+ * This client cannot access RLS-protected tables directly, but it can call
+ * SECURITY DEFINER Postgres functions that are granted to the `anon` role
+ * (e.g. `get_invitation_by_token`). Use this only outside SupabaseProvider
+ * where no Convex JWT is available.
+ */
+export function createAnonSupabaseClient(): SupabaseClient<Database> {
+  return createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+}

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -7551,6 +7551,20 @@ export interface Database {
         Args: Record<string, never>;
         Returns: string;
       };
+      get_invitation_by_token: {
+        Args: { p_token: string };
+        Returns: {
+          id: string;
+          email: string;
+          role: string;
+          status: string;
+          expires_at: number;
+          created_at: number;
+          module: string | null;
+          org_name: string | null;
+          inviter_name: string | null;
+        }[];
+      };
     };
     Enums: Record<string, never>;
     CompositeTypes: Record<string, never>;

--- a/src/routes/_app/login/_layout.index.tsx
+++ b/src/routes/_app/login/_layout.index.tsx
@@ -18,6 +18,7 @@ import { Route as GabinetRoute } from "@/routes/_app/_auth/dashboard/_layout.gab
 import { useQuery } from "@tanstack/react-query";
 import { convexQuery, useConvexAuth } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
+import { useAnonSupabaseInvitationByToken } from "@/hooks/use-supabase-invitations";
 import Logo from "@/assets/svg/logo";
 
 export const Route = createFileRoute("/_app/login/_layout/")({
@@ -57,8 +58,9 @@ function Login() {
   });
 
   // Fetch invitation context for the banner shown above the OTP form.
-  const { data: inviteData } = useQuery({
-    ...convexQuery(api.invitations.getByToken, { token: inviteToken ?? "" }),
+  // Uses the anon Supabase client (no JWT needed) via the get_invitation_by_token
+  // SECURITY DEFINER function, since this page renders outside SupabaseProvider.
+  const { data: inviteData } = useAnonSupabaseInvitationByToken(inviteToken ?? "", {
     enabled: Boolean(inviteToken),
   });
 

--- a/supabase/migrations/00103_invitation_by_token_rpc.sql
+++ b/supabase/migrations/00103_invitation_by_token_rpc.sql
@@ -1,0 +1,52 @@
+-- Expose invitation details by token to unauthenticated callers (issue #3977).
+--
+-- The login-page invite banner renders outside SupabaseProvider (no Convex JWT
+-- is available yet), so it cannot use the normal authenticated Supabase client.
+-- This SECURITY DEFINER function bypasses RLS in a controlled way: it only ever
+-- returns the single row matching the exact token supplied, which is already a
+-- secret random value known only to the invitee.
+
+CREATE OR REPLACE FUNCTION public.get_invitation_by_token(p_token text)
+RETURNS TABLE(
+  id          text,
+  email       text,
+  role        text,
+  status      text,
+  expires_at  bigint,
+  created_at  bigint,
+  module      text,
+  org_name    text,
+  inviter_name text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT
+    i.id,
+    i.email,
+    i.role::text,
+    i.status::text,
+    i.expires_at,
+    i.created_at,
+    i.module,
+    o.name  AS org_name,
+    u.name  AS inviter_name
+  FROM  invitations  i
+  LEFT JOIN organizations o ON o.id = i.organization_id
+  LEFT JOIN users         u ON u.id = i.invited_by
+  WHERE i.token = p_token
+  LIMIT 1;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_invitation_by_token(text) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.get_invitation_by_token(text)
+  TO anon, authenticated, service_role;
+
+COMMENT ON FUNCTION public.get_invitation_by_token(text) IS
+  'Returns invitation details (including org name and inviter name) for the '
+  'given token without requiring an authenticated JWT. Callable by the anon '
+  'role so the login-page invite banner can show context before the user logs '
+  'in. The token acts as the credential — only the exact matching row is '
+  'returned, and no other invitation data is exposed.';


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3977.

Closes #3977

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- da34a18 fix(login): wire invite banner to Supabase via anon SECURITY DEFINER RPC (closes #3977)

### Files changed

```
 src/hooks/use-supabase-invitations.ts              | 43 ++++++++++++++++++
 src/lib/supabase/client.ts                         | 17 +++++++
 src/lib/supabase/database.types.ts                 | 14 ++++++
 src/routes/_app/login/_layout.index.tsx            |  6 ++-
 .../migrations/00103_invitation_by_token_rpc.sql   | 52 ++++++++++++++++++++++
 5 files changed, 130 insertions(+), 2 deletions(-)
```