### PR TITLE
Migrate `organizations.getUsageStats` Convex query to Supabase hook

### DIFF
--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -442,57 +442,6 @@ export const _removeMemberInternal = internalMutation({
   },
 });
 
-export const getUsageStats = query({
-  args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
-    await requireOrgAdmin(ctx, args.organizationId);
-
-    const [members, contacts, companies, leads, documents, products, emails] =
-      await Promise.all([
-        ctx.db
-          .query("teamMemberships")
-          .withIndex("by_organizationId", (q) =>
-            q.eq("organizationId", args.organizationId)
-          )
-          .collect(),
-        ctx.db
-          .query("contacts")
-          .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-          .collect(),
-        ctx.db
-          .query("companies")
-          .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-          .collect(),
-        ctx.db
-          .query("leads")
-          .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-          .collect(),
-        ctx.db
-          .query("documents")
-          .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-          .collect(),
-        ctx.db
-          .query("products")
-          .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-          .collect(),
-        ctx.db
-          .query("emails")
-          .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-          .collect(),
-      ]);
-
-    return {
-      memberCount: members.length,
-      contactCount: contacts.length,
-      companyCount: companies.length,
-      leadCount: leads.length,
-      documentCount: documents.length,
-      productCount: products.length,
-      emailCount: emails.length,
-    };
-  },
-});
-
 export const getSeatUsage = query({
   args: { organizationId: v.id("organizations") },
   handler: async (ctx, args) => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3982.

Closes #3982

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8499296 fix(orgs): remove getUsageStats Convex query, Supabase hook already handles reads (closes #3982)

### Files changed

```
 convex/organizations.ts | 51 -------------------------------------------------
 1 file changed, 51 deletions(-)
```