### PR TITLE
Migrate `triggerEmailEvent` in `emailEventTrigger.ts` to write directly to Supab

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -1611,7 +1611,7 @@ export const processRun = internalAction({
             }
 
             if (!("mode" in action)) {
-              const logId = await ctx.runMutation(internal.emailEventTrigger.triggerEmailEvent, {
+              const logId = await ctx.runAction(internal.emailEventTrigger.triggerEmailEvent, {
                 organizationId: run.organizationId,
                 eventType: action.templateEventType,
                 recipientEmail,

--- a/convex/emailEventTrigger.ts
+++ b/convex/emailEventTrigger.ts
@@ -1,22 +1,20 @@
-import { internalMutation } from "./_generated/server";
+import { internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
-
-// @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
-const writeEventLogRef = internal.supabase.emailEventLog.writeEmailEventLogToSupabase;
+import { createSupabaseDb } from "./_helpers/supabaseDb";
 
 /**
  * Internal email event trigger.
  *
- * Call this from Convex mutations (appointments, documents, CRM) to fire
+ * Call this from Convex actions (or schedule from mutations) to fire
  * an email event without requiring public API authentication.
  *
- * The trigger inserts a pending log entry and schedules async processing.
- * The scheduler resolves bindings → template → sends via Resend.
+ * The trigger inserts a pending log entry directly to Supabase and schedules
+ * async processing. The scheduler resolves bindings → template → sends via Resend.
  *
  * @example
- * // Inside an appointment mutation:
- * await ctx.runMutation(internal.emailEventTrigger.triggerEmailEvent, {
+ * // Inside an action, or scheduled from a mutation:
+ * await ctx.scheduler.runAfter(0, internal.emailEventTrigger.triggerEmailEvent, {
  *   organizationId: args.organizationId,
  *   eventType: "appointment.created",
  *   recipientEmail: patient.email,
@@ -31,7 +29,7 @@ const writeEventLogRef = internal.supabase.emailEventLog.writeEmailEventLogToSup
  *   triggeredBy: userId,
  * });
  */
-export const triggerEmailEvent = internalMutation({
+export const triggerEmailEvent = internalAction({
   args: {
     organizationId: v.id("organizations"),
     /** Event type key, e.g. "appointment.created", "lead.status_changed" */
@@ -50,60 +48,41 @@ export const triggerEmailEvent = internalMutation({
     triggeredBy: v.optional(v.id("users")),
   },
   handler: async (ctx, args) => {
+    const db = createSupabaseDb();
+
     if (args.idempotencyKey) {
-      const existing = await ctx.db
+      const existing = await db
         .query("emailEventLog")
-        .withIndex("by_orgAndIdempotency", (q) =>
-          q
-            .eq("organizationId", args.organizationId)
-            .eq("idempotencyKey", args.idempotencyKey),
-        )
+        .eq("organizationId", String(args.organizationId))
+        .eq("idempotencyKey", args.idempotencyKey)
         .unique();
       if (existing) {
-        return existing._id;
+        return existing._id as string;
       }
     }
 
-    const logId = await ctx.db.insert("emailEventLog", {
-      organizationId: args.organizationId,
+    const logId = await db.insert("emailEventLog", {
+      organizationId: String(args.organizationId),
       eventType: args.eventType,
       status: "pending",
-      payload: args.payload,
-      source: args.source,
-      relatedEntityType: args.relatedEntityType,
-      relatedEntityId: args.relatedEntityId,
-      idempotencyKey: args.idempotencyKey,
+      payload: args.payload ?? null,
+      source: args.source ?? null,
+      relatedEntityType: args.relatedEntityType ?? null,
+      relatedEntityId: args.relatedEntityId ?? null,
+      idempotencyKey: args.idempotencyKey ?? null,
       recipientEmail: args.recipientEmail,
-      recipientName: args.recipientName,
-      triggeredBy: args.triggeredBy,
+      recipientName: args.recipientName ?? null,
+      triggeredBy: args.triggeredBy ? String(args.triggeredBy) : null,
       createdAt: Date.now(),
     });
 
-    // Sync to Supabase
-    await ctx.scheduler.runAfter(0, writeEventLogRef, {
-      emailEventLogId: logId as string,
-      organizationId: args.organizationId as string,
-      eventType: args.eventType,
-      status: "pending",
-      payload: args.payload,
-      source: args.source,
-      relatedEntityType: args.relatedEntityType,
-      relatedEntityId: args.relatedEntityId,
-      idempotencyKey: args.idempotencyKey,
-      recipientEmail: args.recipientEmail,
-      recipientName: args.recipientName,
-      triggeredBy: args.triggeredBy as string | undefined,
-      createdAt: Date.now(),
-    });
-
-    // Schedule async processing — non-blocking, so the calling mutation
+    // Schedule async processing — non-blocking, so the calling action
     // doesn't wait for email delivery.
     await ctx.scheduler.runAfter(0, internal.emailEvents.processEvent, {
       logId,
     });
 
     // Enroll in any active sequences triggered by this event type.
-    // Delegated to an action so the HTTP call to Supabase is allowed.
     // Silent no-op if no sequences match.
     await ctx.scheduler.runAfter(0, internal.emailSequences.enrollForEvent, {
       organizationId: args.organizationId,

--- a/convex/gabinet/appointmentReminders.ts
+++ b/convex/gabinet/appointmentReminders.ts
@@ -282,7 +282,7 @@ export const sendReminder = internalMutation({
               ? "gabinet.appointment.reminder_1h"
               : "gabinet.appointment.reminder_custom";
 
-      await ctx.runMutation(internal.emailEventTrigger.triggerEmailEvent, {
+      await ctx.scheduler.runAfter(0, internal.emailEventTrigger.triggerEmailEvent, {
         organizationId: reminder.organizationId as Id<"organizations">,
         eventType: reminderEventType,
         recipientEmail: patient.email as string,

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -194,7 +194,7 @@ async function applyAppointmentStatusChange(
         : "Patient";
       const treatmentName = treatment?.name ?? "Treatment";
       const employeeName = employee?.name ?? "Specjalista";
-      await ctx.runMutation(internal.emailEventTrigger.triggerEmailEvent, {
+      await ctx.scheduler.runAfter(0, internal.emailEventTrigger.triggerEmailEvent, {
         organizationId: args.organizationId,
         eventType: "appointment.cancelled",
         recipientEmail: patient.email,

--- a/tests/convex/emailEventTrigger.test.ts
+++ b/tests/convex/emailEventTrigger.test.ts
@@ -16,10 +16,10 @@ describe("emailEventTrigger", () => {
 
   test("triggerEmailEvent creates a pending log entry when no bindings exist", async () => {
     const t = createTestCtx();
-    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { organizationId, userId } = await seedTestUser(t);
 
     // Call triggerEmailEvent — no bindings configured for this org
-    await t.withIdentity(identity).mutation(
+    await t.action(
       internal.emailEventTrigger.triggerEmailEvent,
       {
         organizationId,
@@ -31,15 +31,17 @@ describe("emailEventTrigger", () => {
       },
     );
 
-    // A log entry must be created with status "pending"
-    const logs = await t.run(async (ctx) =>
-      ctx.db.query("emailEventLog").collect(),
-    );
+    // A log entry must be created in Supabase with status "pending"
+    const db = createSupabaseDb();
+    const logs = await db
+      .query("emailEventLog")
+      .eq("organizationId", String(organizationId))
+      .collect();
     expect(logs).toHaveLength(1);
     expect(logs[0].status).toBe("pending");
     expect(logs[0].eventType).toBe("appointment.created");
     expect(logs[0].recipientEmail).toBe("patient@example.com");
-    expect(logs[0].organizationId).toBe(organizationId);
+    expect(String(logs[0].organizationId)).toBe(String(organizationId));
   });
 
   // ─── listEnabledBindings: no bindings ─────────────────────────
@@ -146,10 +148,10 @@ describe("emailEventTrigger", () => {
 
   test("multiple triggerEmailEvent calls each create a separate log entry", async () => {
     const t = createTestCtx();
-    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { organizationId, userId } = await seedTestUser(t);
 
     for (const email of ["a@example.com", "b@example.com"]) {
-      await t.withIdentity(identity).mutation(
+      await t.action(
         internal.emailEventTrigger.triggerEmailEvent,
         {
           organizationId,
@@ -160,9 +162,11 @@ describe("emailEventTrigger", () => {
       );
     }
 
-    const logs = await t.run(async (ctx) =>
-      ctx.db.query("emailEventLog").collect(),
-    );
+    const db = createSupabaseDb();
+    const logs = await db
+      .query("emailEventLog")
+      .eq("organizationId", String(organizationId))
+      .collect();
     expect(logs).toHaveLength(2);
     const emails = logs.map((l) => l.recipientEmail).sort();
     expect(emails).toEqual(["a@example.com", "b@example.com"]);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3992.

Closes #3992

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- bee2a5d fix(emailEvents): migrate triggerEmailEvent to Supabase-primary internalAction (closes #3992)

### Files changed

```
 convex/automation.ts                   |   2 +-
 convex/emailEventTrigger.ts            | 215 +++++++++++++++------------------
 convex/gabinet/appointmentReminders.ts |   2 +-
 convex/gabinet/appointments.ts         |   2 +-
 tests/convex/emailEventTrigger.test.ts |  28 +++--
 5 files changed, 116 insertions(+), 133 deletions(-)
```