### PR TITLE
Audit `leads.list` for Convex-only reads

### DIFF
--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -13,51 +13,44 @@ import { Id } from "./_generated/dataModel";
 
 // Dual-write refs removed — Supabase is now primary for lead writes
 
-export const list = query({
+export const list = action({
   args: {
     organizationId: v.id("organizations"),
     paginationOpts: paginationOptsValidator,
     status: v.optional(leadStatusValidator),
   },
   handler: async (ctx, args) => {
-    const { user } = await verifyOrgAccess(ctx, args.organizationId);
-    const perm = await checkPermission(
-      ctx,
-      args.organizationId,
-      "leads",
-      "view",
+    const authResult = await ctx.runAction(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
     );
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "leads", action: "view" },
+    ) as { allowed: boolean; scope: string };
     if (!perm.allowed) throw new Error("Permission denied");
 
-    const isOwn = perm.scope === "own";
-    const ownFilter = (r: any) =>
-      r.createdBy === user._id || r.assignedTo === user._id;
+    const db = createSupabaseDb();
+    let q = db
+      .query<{ createdBy: string; assignedTo: string | null }>("leads")
+      .eq("organizationId", String(args.organizationId));
+    if (args.status) q = q.eq("status", args.status);
 
-    if (args.status) {
-      const result = await ctx.db
-        .query("leads")
-        .withIndex("by_orgAndStatus", (q) =>
-          q
-            .eq("organizationId", args.organizationId)
-            .eq("status", args.status!),
-        )
-        .order("desc")
-        .paginate(args.paginationOpts);
-      if (isOwn) {
-        return { ...result, page: result.page.filter(ownFilter) };
-      }
-      return result;
-    }
+    const rows = await q
+      .order("createdAt", false)
+      .take(args.paginationOpts.numItems)
+      .collect();
 
-    const result = await ctx.db
-      .query("leads")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .order("desc")
-      .paginate(args.paginationOpts);
-    if (isOwn) {
-      return { ...result, page: result.page.filter(ownFilter) };
-    }
-    return result;
+    const page =
+      perm.scope === "own"
+        ? rows.filter(
+            (r) =>
+              r.createdBy === String(authResult.userId) ||
+              r.assignedTo === String(authResult.userId),
+          )
+        : rows;
+
+    return { page, isDone: true, continueCursor: "" };
   },
 });
 

--- a/tests/convex/tenantIsolation.test.ts
+++ b/tests/convex/tenantIsolation.test.ts
@@ -172,7 +172,7 @@ describe("tenant isolation — leads", () => {
     const { organizationId: orgBId } = await seedOrgB(t);
 
     await expect(
-      t.withIdentity(identityA).query(api.leads.list, {
+      t.withIdentity(identityA).action(api.leads.list, {
         organizationId: orgBId,
         paginationOpts: PAGINATION,
       }),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4010.

Closes #4010

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 68e7638 fix(leads): migrate leads.list off ctx.db to Supabase-primary action (closes #4010)

### Files changed

```
 convex/leads.ts                      | 63 ++++++++++++++++--------------------
 tests/convex/tenantIsolation.test.ts |  2 +-
 2 files changed, 29 insertions(+), 36 deletions(-)
```