### PR TITLE
Migrate `documentInstances.ts` ctx.db.get off Convex

### DIFF
--- a/convex/documentInstances.ts
+++ b/convex/documentInstances.ts
@@ -336,9 +336,10 @@ export const updateStatus = action({
 
 export const _resolveReviewerName = internalMutation({
   args: { reviewerId: v.string() },
-  handler: async (ctx, args) => {
-    const reviewer = await ctx.db.get(args.reviewerId as Id<"users">);
-    return reviewer?.name ?? "";
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
+    const reviewer = await db.get("users", args.reviewerId);
+    return (reviewer?.name as string) ?? "";
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4019.

Closes #4019

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 89b7b5c fix(documentInstances): migrate _resolveReviewerName ctx.db.get off Convex to Supabase (closes #4019)

### Files changed

```
 convex/documentInstances.ts | 7 ++++---
 1 file changed, 4 insertions(+), 3 deletions(-)
```