### PR TITLE
fix(gabinet/employees): migrate _getUserEmailById ctx.db.get off Convex to Supabase

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -1239,14 +1239,6 @@ export const createWithPassword = action({
   },
 });
 
-export const _getUserEmailById = internalQuery({
-  args: { userId: v.string() },
-  handler: async (ctx, args) => {
-    const user = await ctx.db.get(args.userId as Id<"users">);
-    return user?.email ?? null;
-  },
-});
-
 export const changeEmployeePassword = action({
   args: {
     organizationId: v.id("organizations"),
@@ -1268,9 +1260,8 @@ export const changeEmployeePassword = action({
     const employee = await db.get("gabinetEmployees", args.employeeId);
     if (!employee) throw new Error("Pracownik nie istnieje.");
     if (!employee.userId) throw new Error("Pracownik nie ma powiązanego konta użytkownika.");
-    const email = await ctx.runQuery(internal.gabinet.employees._getUserEmailById, {
-      userId: String(employee.userId),
-    });
+    const userRow = await db.get("users", String(employee.userId));
+    const email = userRow?.email ?? null;
     if (!email) throw new Error("Nie znaleziono adresu e-mail użytkownika.");
     await modifyAccountCredentials(ctx, {
       provider: "password",


### PR DESCRIPTION
## Summary

- Removes the `_getUserEmailById` `internalQuery` that was reading the `users` table via `ctx.db.get` on Convex (line 1245).
- `changeEmployeePassword` already had a `createSupabaseDb()` instance (`db`) in scope, so the email lookup is inlined as `db.get("users", userId)` — no new abstractions needed.

## What was NOT changed

`_getConvexUser` (line 971) is **intentionally** left as a Convex-side read. It is called by `_finalisePasswordUser` immediately after `createAccount`, at a point where the user exists only in the Convex auth store and has not yet been mirrored to Supabase. The existing comment documents this clearly.

## Test plan

- [ ] `changeEmployeePassword` action still resolves the employee's email for password resets
- [ ] No regression in employee creation flow (`createWithPassword` / `_finalisePasswordUser`)

Closes #4020

🤖 Generated with [Claude Code](https://claude.com/claude-code)