### PR TITLE
Migrate `resourceInvites` ctx.db.get off Convex to Supabase

### DIFF
--- a/convex/resourceInvites.ts
+++ b/convex/resourceInvites.ts
@@ -65,6 +65,7 @@ export const create = action({
 
     // Side effects (notifications, audit) via internal mutation
     try {
+      const org = await db.get("organizations", String(args.organizationId));
       await ctx.runMutation(internal.resourceInvites._createSideEffects, {
         organizationId: args.organizationId,
         userId: authResult.userId,
@@ -73,6 +74,7 @@ export const create = action({
         resourceType: args.resourceType,
         resourceId: args.resourceId,
         accessLevel: args.accessLevel,
+        orgOwnerId: (org?.ownerId as string | undefined) ?? undefined,
       });
     } catch {
       // side effects are best-effort
@@ -164,13 +166,13 @@ export const _createSideEffects = internalMutation({
     resourceType: v.string(),
     resourceId: v.string(),
     accessLevel: v.string(),
+    orgOwnerId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const org = await ctx.db.get(args.organizationId);
-    if (org) {
+    if (args.orgOwnerId) {
       await createNotificationDirect(ctx, {
         organizationId: args.organizationId,
-        userId: org.ownerId,
+        userId: args.orgOwnerId as any,
         type: "resource_invite",
         title: "Resource shared",
         message: `${args.userName} shared a ${args.resourceType} with ${args.email}`,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4042.

Closes #4042

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f00a1d6 fix(resourceInvites): migrate ctx.db.get off Convex to Supabase (closes #4042)

### Files changed

```
 convex/resourceInvites.ts | 8 +++++---
 1 file changed, 5 insertions(+), 3 deletions(-)
```