### PR TITLE
Migrate `gabinet/packages` multiline ctx.db.get off Convex to Supabase

### DIFF
--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -1061,9 +1061,8 @@ export const _batchUsageSideEffects = internalMutation({
     createdBy: v.string(),
   },
   handler: async (ctx, args) => {
-    const pkg = await ctx.db.get(
-      args.packageId as Id<"gabinetTreatmentPackages">,
-    );
+    const db = createSupabaseDb();
+    const pkg = await db.get("gabinetTreatmentPackages", args.packageId);
     await logActivity(ctx, {
       organizationId: args.organizationId,
       entityType: "gabinetPackage",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4043.

Closes #4043

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 66a27e3 fix(packages): migrate _batchUsageSideEffects ctx.db.get off Convex to Supabase (closes #4043)

### Files changed

```
 convex/gabinet/packages.ts | 5 ++---
 1 file changed, 2 insertions(+), 3 deletions(-)
```