### PR TITLE
Propagate `actorLabel` from action callers into `logActivity`

### DIFF
--- a/convex/calls.ts
+++ b/convex/calls.ts
@@ -136,6 +136,7 @@ export const create = action({
         organizationId: args.organizationId,
         outcome: args.outcome,
         createdBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[calls.create] Side effects FAILED for call", callId, ":", e);
@@ -151,6 +152,7 @@ export const _createSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     outcome: v.string(),
     createdBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -160,6 +162,7 @@ export const _createSideEffects = internalMutation({
       action: "created",
       description: `Logged a call with outcome "${args.outcome}"`,
       performedBy: args.createdBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -203,6 +206,7 @@ export const update = action({
         callId,
         organizationId,
         updatedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[calls.update] Side effects FAILED for call", callId, ":", e);
@@ -217,6 +221,7 @@ export const _updateSideEffects = internalMutation({
     callId: v.string(),
     organizationId: v.id("organizations"),
     updatedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -226,6 +231,7 @@ export const _updateSideEffects = internalMutation({
       action: "updated",
       description: `Updated call`,
       performedBy: args.updatedBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -269,6 +275,7 @@ export const remove = action({
         callId: args.callId,
         organizationId: args.organizationId,
         deletedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[calls.remove] Side effects FAILED for call", args.callId, ":", e);
@@ -298,6 +305,7 @@ export const _removeSideEffects = internalMutation({
     callId: v.string(),
     organizationId: v.id("organizations"),
     deletedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -307,6 +315,7 @@ export const _removeSideEffects = internalMutation({
       action: "deleted",
       description: `Deleted call`,
       performedBy: args.deletedBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });

--- a/convex/companies.ts
+++ b/convex/companies.ts
@@ -91,6 +91,7 @@ export const create = action({
         organizationId: args.organizationId,
         name: args.name,
         createdBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[companies.create] Side effects FAILED for company", companyId, ":", e);
@@ -106,6 +107,7 @@ export const _createSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     name: v.string(),
     createdBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const createdByUserId = args.createdBy as Id<"users">;
@@ -117,6 +119,7 @@ export const _createSideEffects = internalMutation({
       action: "created",
       description: `Created company "${args.name}"`,
       performedBy: createdByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -211,6 +214,7 @@ export const update = action({
         organizationId,
         name: (company.name as string) ?? "",
         updatedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[companies.update] Side effects FAILED for company", companyId, ":", e);
@@ -226,6 +230,7 @@ export const _updateSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     name: v.string(),
     updatedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const updatedByUserId = args.updatedBy as Id<"users">;
@@ -237,6 +242,7 @@ export const _updateSideEffects = internalMutation({
       action: "updated",
       description: `Updated company "${args.name}"`,
       performedBy: updatedByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -305,6 +311,7 @@ export const remove = action({
         organizationId: args.organizationId,
         name: (company.name as string) ?? "",
         deletedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[companies.remove] Side effects FAILED for company", args.companyId, ":", e);
@@ -320,6 +327,7 @@ export const _removeSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     name: v.string(),
     deletedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const deletedByUserId = args.deletedBy as Id<"users">;
@@ -331,6 +339,7 @@ export const _removeSideEffects = internalMutation({
       action: "deleted",
       description: `Deleted company "${args.name}"`,
       performedBy: deletedByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });

--- a/convex/contacts.ts
+++ b/convex/contacts.ts
@@ -86,6 +86,7 @@ export const create = action({
         firstName: args.firstName,
         lastName: args.lastName ?? undefined,
         createdBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[contacts.create] Side effects FAILED for contact", contactId, ":", e);
@@ -102,6 +103,7 @@ export const _createSideEffects = internalMutation({
     firstName: v.string(),
     lastName: v.optional(v.string()),
     createdBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const createdByUserId = args.createdBy as Id<"users">;
@@ -113,6 +115,7 @@ export const _createSideEffects = internalMutation({
       action: "created",
       description: `Created contact "${args.firstName}${args.lastName ? ` ${args.lastName}` : ""}"`,
       performedBy: createdByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -201,6 +204,7 @@ export const update = action({
         organizationId,
         firstName: (contact.firstName as string) ?? "",
         updatedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[contacts.update] Side effects FAILED for contact", contactId, ":", e);
@@ -216,6 +220,7 @@ export const _updateSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     firstName: v.string(),
     updatedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const updatedByUserId = args.updatedBy as Id<"users">;
@@ -227,6 +232,7 @@ export const _updateSideEffects = internalMutation({
       action: "updated",
       description: `Updated contact "${args.firstName}"`,
       performedBy: updatedByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -295,6 +301,7 @@ export const remove = action({
         organizationId: args.organizationId,
         firstName: (contact.firstName as string) ?? "",
         deletedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[contacts.remove] Side effects FAILED for contact", args.contactId, ":", e);
@@ -310,6 +317,7 @@ export const _removeSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     firstName: v.string(),
     deletedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const deletedByUserId = args.deletedBy as Id<"users">;
@@ -321,6 +329,7 @@ export const _removeSideEffects = internalMutation({
       action: "deleted",
       description: `Deleted contact "${args.firstName}"`,
       performedBy: deletedByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });

--- a/convex/documents.ts
+++ b/convex/documents.ts
@@ -65,6 +65,7 @@ export const create = action({
         documentId: docId,
         name: args.name,
         performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[documents.create] Side effects FAILED for document", docId, ":", e);
@@ -80,6 +81,7 @@ export const _createSideEffects = internalMutation({
     documentId: v.string(),
     name: v.string(),
     performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -89,6 +91,7 @@ export const _createSideEffects = internalMutation({
       action: "document_uploaded",
       description: `Uploaded document "${args.name}"`,
       performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -143,6 +146,7 @@ export const update = action({
         documentId,
         name: doc.name as string,
         performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[documents.update] Side effects FAILED for document", documentId, ":", e);
@@ -158,6 +162,7 @@ export const _updateSideEffects = internalMutation({
     documentId: v.string(),
     name: v.string(),
     performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -167,6 +172,7 @@ export const _updateSideEffects = internalMutation({
       action: "updated",
       description: `Updated document "${args.name}"`,
       performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -214,6 +220,7 @@ export const remove = action({
         documentId: args.documentId,
         name: doc.name as string,
         performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[documents.remove] Side effects FAILED for document", args.documentId, ":", e);
@@ -229,6 +236,7 @@ export const _removeSideEffects = internalMutation({
     documentId: v.string(),
     name: v.string(),
     performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -238,6 +246,7 @@ export const _removeSideEffects = internalMutation({
       action: "deleted",
       description: `Deleted document "${args.name}"`,
       performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -290,6 +299,7 @@ export const updateStatus = action({
         oldStatus: (doc.status as string) ?? null,
         newStatus: args.status,
         performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[documents.updateStatus] Side effects FAILED for document", args.documentId, ":", e);
@@ -307,6 +317,7 @@ export const _updateStatusSideEffects = internalMutation({
     oldStatus: v.union(v.string(), v.null()),
     newStatus: v.string(),
     performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -317,6 +328,7 @@ export const _updateStatusSideEffects = internalMutation({
       description: `Changed document "${args.name}" status to "${args.newStatus}"`,
       metadata: { oldStatus: args.oldStatus, newStatus: args.newStatus },
       performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -145,6 +145,7 @@ async function applyAppointmentStatusChange(
     treatmentId?: string | null;
     variantId?: string | null;
     priceAtBooking?: number | null;
+    actorLabel?: string;
   },
 ) {
   const now = Date.now();
@@ -261,6 +262,7 @@ async function applyAppointmentStatusChange(
       newStatus: args.nextStatus,
     },
     performedBy: args.actorUserId,
+    actorLabel: args.actorLabel,
   });
 
   await logAudit(ctx, {
@@ -836,6 +838,7 @@ export const _createSideEffects = internalMutation({
       appointmentId: v.string(),
       activityId: v.string(),
     })),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const now = args.createdAt;
@@ -907,6 +910,7 @@ export const _createSideEffects = internalMutation({
       action: "created",
       description: `Created appointment for ${args.date} at ${args.startTime}`,
       performedBy: createdByUserId,
+      actorLabel: args.actorLabel,
     });
 
     // --- 6. Schedule reminders (inline — avoid DB read since appointment is in Supabase) ---
@@ -1469,6 +1473,7 @@ export const create = action({
           packageUsageId: resolvedPackageUsageId ?? undefined,
           scheduledActivityId,
           recurActivityIds,
+          actorLabel: authResult.userName ?? authResult.userEmail,
         },
       );
     } catch (e) {
@@ -1880,6 +1885,7 @@ export const update = action({
           employeeChanged: !!args.employeeId,
           updatedFields: Object.keys(updates),
           updatedAt: now,
+          actorLabel: authResult.userName ?? authResult.userEmail,
         },
       );
     } catch (e) {
@@ -1931,6 +1937,7 @@ export const _updateSideEffects = internalMutation({
     employeeChanged: v.boolean(),
     updatedFields: v.array(v.string()),
     updatedAt: v.number(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const actorUserId = args.actorUserId as Id<"users">;
@@ -1971,6 +1978,7 @@ export const _updateSideEffects = internalMutation({
         updatedFields: args.updatedFields,
       },
       performedBy: actorUserId,
+      actorLabel: args.actorLabel,
     });
 
     // A "significant" reschedule is one where the patient's calendar changes:
@@ -2232,6 +2240,7 @@ export const updateStatus = action({
           packageUsageId: (appt.packageUsageId as string) ?? undefined,
           patientEmail: (appt as any).patientEmail ?? undefined,
           patientPhone: (appt as any).patientPhone ?? undefined,
+          actorLabel: authResult.userName ?? authResult.userEmail,
         },
       );
     } catch (e) {
@@ -2519,6 +2528,7 @@ export const _updateStatusSideEffects = internalMutation({
     packageUsageId: v.optional(v.string()),
     patientEmail: v.optional(v.string()),
     patientPhone: v.optional(v.string()),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const actorUserId = args.actorUserId as Id<"users">;
@@ -2566,6 +2576,7 @@ export const _updateStatusSideEffects = internalMutation({
       treatmentId: args.treatmentId ?? null,
       variantId: args.variantId ?? null,
       priceAtBooking: args.priceAtBooking ?? null,
+      actorLabel: args.actorLabel,
     });
 
     // After completing: auto-generate "after_completion" documents
@@ -2790,6 +2801,7 @@ export const cancel = action({
           startTime: appt.startTime as string,
           previousStatus: appt.status as string,
           packageUsageId: (appt.packageUsageId as string) ?? undefined,
+          actorLabel: authResult.userName ?? authResult.userEmail,
         },
       );
     } catch (e) {
@@ -2813,6 +2825,7 @@ export const _cancelSideEffects = internalMutation({
     startTime: v.string(),
     previousStatus: v.string(),
     packageUsageId: v.optional(v.string()),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const actorUserId = args.actorUserId as Id<"users">;
@@ -2834,6 +2847,7 @@ export const _cancelSideEffects = internalMutation({
       action: "status_changed",
       description: `Cancelled appointment${args.reason ? `: ${args.reason}` : ""}`,
       performedBy: actorUserId,
+      actorLabel: args.actorLabel,
     });
 
     await logAudit(ctx, {

--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -240,6 +240,7 @@ export const create = action({
         employeeId,
         organizationId: args.organizationId,
         createdBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[employees.create] Side effects FAILED for employee", employeeId, ":", e);
@@ -567,6 +568,7 @@ export const _createSideEffects = internalMutation({
     employeeId: v.string(),
     organizationId: v.id("organizations"),
     createdBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const createdByUserId = args.createdBy as Id<"users">;
@@ -578,6 +580,7 @@ export const _createSideEffects = internalMutation({
       action: "created",
       description: `Created employee profile`,
       performedBy: createdByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -715,6 +718,7 @@ export const update = action({
         employeeId,
         organizationId,
         updatedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[employees.update] Side effects FAILED for employee", employeeId, ":", e);
@@ -763,6 +767,7 @@ export const _updateSideEffects = internalMutation({
     employeeId: v.string(),
     organizationId: v.id("organizations"),
     updatedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const updatedByUserId = args.updatedBy as Id<"users">;
@@ -774,6 +779,7 @@ export const _updateSideEffects = internalMutation({
       action: "updated",
       description: `Updated employee profile`,
       performedBy: updatedByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -823,6 +829,7 @@ export const remove = action({
         employeeId: args.employeeId,
         organizationId: args.organizationId,
         deletedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[employees.remove] Side effects FAILED for employee", args.employeeId, ":", e);
@@ -845,6 +852,7 @@ export const _removeSideEffects = internalMutation({
     employeeId: v.string(),
     organizationId: v.id("organizations"),
     deletedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const deletedByUserId = args.deletedBy as Id<"users">;
@@ -856,6 +864,7 @@ export const _removeSideEffects = internalMutation({
       action: "deleted",
       description: `Deactivated employee profile`,
       performedBy: deletedByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -932,6 +941,7 @@ export const setQualifiedTreatments = action({
         organizationId: args.organizationId,
         treatmentCount: args.treatmentIds.length,
         updatedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[employees.setQualifiedTreatments] Side effects FAILED:", e);
@@ -945,6 +955,7 @@ export const _setQualifiedSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     treatmentCount: v.number(),
     updatedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const updatedByUserId = args.updatedBy as Id<"users">;
@@ -956,6 +967,7 @@ export const _setQualifiedSideEffects = internalMutation({
       action: "updated",
       description: `Updated treatment qualifications (${args.treatmentCount} treatments)`,
       performedBy: updatedByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -1223,6 +1235,7 @@ export const createWithPassword = action({
         employeeId: String(employeeId),
         organizationId: args.organizationId,
         createdBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[employees.createWithPassword] side effects failed:", e);

--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -233,6 +233,7 @@ export const create = action({
           organizationId: args.organizationId,
           name: args.name,
           createdBy: String(authResult.userId),
+          actorLabel: authResult.userName ?? authResult.userEmail,
         });
       } catch (e) {
         console.error(
@@ -271,6 +272,7 @@ export const _createSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     name: v.string(),
     createdBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -280,6 +282,7 @@ export const _createSideEffects = internalMutation({
       action: "created",
       description: `Created package ${args.name}`,
       performedBy: args.createdBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -1043,6 +1046,7 @@ export const usePackageTreatmentsBatch = action({
         packageId: String(usage.packageId),
         totalUsed: args.items.reduce((sum, i) => sum + i.quantity, 0),
         createdBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error(
@@ -1059,6 +1063,7 @@ export const _batchUsageSideEffects = internalMutation({
     packageId: v.string(),
     totalUsed: v.number(),
     createdBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const db = createSupabaseDb();
@@ -1070,6 +1075,7 @@ export const _batchUsageSideEffects = internalMutation({
       action: "updated",
       description: `Used ${args.totalUsed} treatment(s) from package ${pkg?.name ?? ""}`,
       performedBy: args.createdBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });

--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -417,6 +417,7 @@ export const create = action({
         referralSource: args.referralSource ?? undefined,
         createdBy: String(authResult.userId),
         createdAt: now,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[patients.create] Side effects FAILED for patient", patientId, ":", e);
@@ -461,6 +462,7 @@ export const _createSideEffects = internalMutation({
     referralSource: v.optional(v.string()),
     createdBy: v.string(),
     createdAt: v.number(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const createdByUserId = args.createdBy as Id<"users">;
@@ -472,6 +474,7 @@ export const _createSideEffects = internalMutation({
       action: "created",
       description: `Created patient ${args.firstName} ${args.lastName}`,
       performedBy: createdByUserId,
+      actorLabel: args.actorLabel,
     });
 
     await ctx.runMutation(internal.automation.emitEvent, {
@@ -580,6 +583,7 @@ export const update = action({
         firstName: (patient.firstName as string) ?? "",
         lastName: (patient.lastName as string) ?? "",
         updatedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[patients.update] Side effects FAILED for patient", patientId, ":", e);
@@ -613,6 +617,7 @@ export const _updateSideEffects = internalMutation({
     firstName: v.string(),
     lastName: v.string(),
     updatedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const updatedByUserId = args.updatedBy as Id<"users">;
@@ -624,6 +629,7 @@ export const _updateSideEffects = internalMutation({
       action: "updated",
       description: `Updated patient ${args.firstName} ${args.lastName}`,
       performedBy: updatedByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -681,6 +687,7 @@ export const remove = action({
         firstName: (patient.firstName as string) ?? "",
         lastName: (patient.lastName as string) ?? "",
         deletedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[patients.remove] Side effects FAILED for patient", args.patientId, ":", e);
@@ -697,6 +704,7 @@ export const _removeSideEffects = internalMutation({
     firstName: v.string(),
     lastName: v.string(),
     deletedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const deletedByUserId = args.deletedBy as Id<"users">;
@@ -708,6 +716,7 @@ export const _removeSideEffects = internalMutation({
       action: "deleted",
       description: `Deleted patient ${args.firstName} ${args.lastName}`,
       performedBy: deletedByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -973,6 +982,7 @@ export const merge = action({
         targetName: `${target.firstName ?? ""} ${target.lastName ?? ""}`.trim(),
         sourceName: `${source.firstName ?? ""} ${source.lastName ?? ""}`.trim(),
         performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error(
@@ -1010,6 +1020,7 @@ export const _mergeSideEffects = internalMutation({
     targetName: v.string(),
     sourceName: v.string(),
     performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const performedByUserId = args.performedBy as Id<"users">;
@@ -1024,6 +1035,7 @@ export const _mergeSideEffects = internalMutation({
         merge: { sourcePatientId: args.sourcePatientId },
       },
       performedBy: performedByUserId,
+      actorLabel: args.actorLabel,
     });
 
     await logActivity(ctx, {
@@ -1036,6 +1048,7 @@ export const _mergeSideEffects = internalMutation({
         merge: { targetPatientId: args.targetPatientId },
       },
       performedBy: performedByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -1134,6 +1147,7 @@ export const gdprErase = action({
         organizationId: args.organizationId,
         originalName,
         erasedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[patients.gdprErase] Side effects FAILED for patient", args.patientId, ":", e);
@@ -1149,6 +1163,7 @@ export const _gdprEraseSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     originalName: v.string(),
     erasedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const erasedByUserId = args.erasedBy as Id<"users">;
@@ -1212,6 +1227,7 @@ export const _gdprEraseSideEffects = internalMutation({
       action: "deleted",
       description: "RODO: dane klienta zostały usunięte",
       performedBy: erasedByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });

--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -266,6 +266,7 @@ export const create = action({
           organizationId: args.organizationId,
           name: args.name,
           createdBy: String(authResult.userId),
+          actorLabel: authResult.userName ?? authResult.userEmail,
         });
       } catch (e) {
         console.error("[treatments.create] Side effects FAILED for treatment", treatmentId, ":", e);
@@ -306,6 +307,7 @@ export const _createSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     name: v.string(),
     createdBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const createdByUserId = args.createdBy as Id<"users">;
@@ -317,6 +319,7 @@ export const _createSideEffects = internalMutation({
       action: "created",
       description: `Created treatment "${args.name}"`,
       performedBy: createdByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -425,6 +428,7 @@ export const update = action({
           organizationId,
           treatmentName: (treatment.name as string) ?? "",
           updatedBy: String(authResult.userId),
+          actorLabel: authResult.userName ?? authResult.userEmail,
         });
       } catch (e) {
         console.error("[treatments.update] Side effects FAILED for treatment", treatmentId, ":", e);
@@ -457,6 +461,7 @@ export const _updateSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     treatmentName: v.string(),
     updatedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const updatedByUserId = args.updatedBy as Id<"users">;
@@ -468,6 +473,7 @@ export const _updateSideEffects = internalMutation({
       action: "updated",
       description: `Updated treatment "${args.treatmentName}"`,
       performedBy: updatedByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -519,6 +525,7 @@ export const remove = action({
         organizationId: args.organizationId,
         treatmentName: (treatment.name as string) ?? "",
         deletedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[treatments.remove] Side effects FAILED for treatment", args.treatmentId, ":", e);
@@ -534,6 +541,7 @@ export const _removeSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     treatmentName: v.string(),
     deletedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const deletedByUserId = args.deletedBy as Id<"users">;
@@ -545,6 +553,7 @@ export const _removeSideEffects = internalMutation({
       action: "deleted",
       description: `Deleted treatment "${args.treatmentName}"`,
       performedBy: deletedByUserId,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -760,6 +769,7 @@ export const setTreatmentProducts = action({
           organizationId: args.organizationId,
           treatmentName: (treatment.name as string) ?? "",
           updatedBy: String(authResult.userId),
+          actorLabel: authResult.userName ?? authResult.userEmail,
         });
       } catch (e) {
         console.error("[treatments.setTreatmentProducts] Side effects FAILED:", e);
@@ -1352,6 +1362,7 @@ export const setRequiredFormTemplates = action({
         organizationId: args.organizationId,
         treatmentName: (treatment.name as string) ?? "",
         updatedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[treatments.setRequiredFormTemplates] Side effects FAILED:", e);
@@ -1419,6 +1430,7 @@ export const saveTreatmentParameters = action({
           organizationId: args.organizationId,
           treatmentName: (treatment.name as string) ?? "",
           updatedBy: String(authResult.userId),
+          actorLabel: authResult.userName ?? authResult.userEmail,
         });
       } catch (e) {
         console.error("[treatments.saveTreatmentParameters] Side effects FAILED:", e);
@@ -1652,6 +1664,7 @@ export const createVariant = action({
         organizationId: args.organizationId,
         name: `Added variant "${args.name}" to treatment "${(treatment.name as string) ?? ""}"`,
         createdBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[treatments.createVariant] Side effects FAILED:", e);
@@ -1752,6 +1765,7 @@ export const updateVariant = action({
         organizationId: args.organizationId,
         treatmentName: `Updated variant "${(variant.name as string) ?? ""}"`,
         updatedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[treatments.updateVariant] Side effects FAILED:", e);
@@ -1814,6 +1828,7 @@ export const deleteVariant = action({
         organizationId: args.organizationId,
         treatmentName: `Deleted variant "${(variant.name as string) ?? ""}"`,
         updatedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[treatments.deleteVariant] Side effects FAILED:", e);

--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -144,6 +144,7 @@ export const create = action({
         assignedTo: args.assignedTo ?? undefined,
         createdBy: String(authResult.userId),
         createdAt: now,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[leads.create] Side effects FAILED for lead", leadId, ":", e);
@@ -161,6 +162,7 @@ export const _createSideEffects = internalMutation({
     assignedTo: v.optional(v.string()),
     createdBy: v.string(),
     createdAt: v.number(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const createdByUserId = args.createdBy as Id<"users">;
@@ -172,6 +174,7 @@ export const _createSideEffects = internalMutation({
       action: "created",
       description: `Created lead "${args.title}"`,
       performedBy: createdByUserId,
+      actorLabel: args.actorLabel,
     });
 
     // Notify assigned user if different from creator
@@ -310,6 +313,7 @@ export const update = action({
         leadOwnerId: String(lead.assignedTo ?? lead.createdBy),
         updatedBy: String(authResult.userId),
         updatedAt: now,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[leads.update] Side effects FAILED for lead", leadId, ":", e);
@@ -331,6 +335,7 @@ export const _updateSideEffects = internalMutation({
     leadOwnerId: v.string(),
     updatedBy: v.string(),
     updatedAt: v.number(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const updatedByUserId = args.updatedBy as Id<"users">;
@@ -345,6 +350,7 @@ export const _updateSideEffects = internalMutation({
         description: `Changed lead status from "${args.oldStatus}" to "${args.newStatus}"`,
         metadata: { oldStatus: args.oldStatus, newStatus: args.newStatus },
         performedBy: updatedByUserId,
+        actorLabel: args.actorLabel,
       });
 
       // Audit log for status changes to won/lost
@@ -414,6 +420,7 @@ export const _updateSideEffects = internalMutation({
         action: "updated",
         description: `Updated lead "${args.title}"`,
         performedBy: updatedByUserId,
+        actorLabel: args.actorLabel,
       });
     }
 
@@ -505,6 +512,7 @@ export const remove = action({
         organizationId: args.organizationId,
         title: (lead.title as string) ?? "",
         deletedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[leads.remove] Side effects FAILED for lead", args.leadId, ":", e);
@@ -520,6 +528,7 @@ export const _removeSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     title: v.string(),
     deletedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const deletedByUserId = args.deletedBy as Id<"users">;
@@ -531,6 +540,7 @@ export const _removeSideEffects = internalMutation({
       action: "deleted",
       description: `Deleted lead "${args.title}"`,
       performedBy: deletedByUserId,
+      actorLabel: args.actorLabel,
     });
 
     await logAudit(ctx, {
@@ -720,6 +730,7 @@ export const moveToStage = action({
         leadAssignedTo: lead.assignedTo ? String(lead.assignedTo) : null,
         createdActivities,
         now,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch {
       // side effects are best-effort
@@ -747,6 +758,7 @@ export const _moveToStageSideEffects = internalMutation({
       title: v.string(),
     }))),
     now: v.number(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -760,6 +772,7 @@ export const _moveToStageSideEffects = internalMutation({
         toStageId: String(args.pipelineStageId),
       },
       performedBy: args.userId,
+      actorLabel: args.actorLabel,
     });
 
     // scheduledActivities for stage actions are inserted by the parent action in Supabase.

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -530,6 +530,7 @@ export const markPaid = action({
         amount: payment.amount as number,
         currency: payment.currency as string,
         appointmentId: (payment.appointmentId as string) ?? null,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch {
       // side effects are best-effort
@@ -633,6 +634,7 @@ export const splitMarkPaid = action({
         amount: args.firstAmount,
         currency: payment.currency as string,
         appointmentId: (payment.appointmentId as string) ?? null,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
       await ctx.runMutation(internal.payments._createPaymentSideEffects, {
         paymentId: newPaymentId,
@@ -851,6 +853,7 @@ export const _markPaidSideEffects = internalMutation({
     amount: v.number(),
     currency: v.string(),
     appointmentId: v.union(v.string(), v.null()),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -860,6 +863,7 @@ export const _markPaidSideEffects = internalMutation({
       action: "updated",
       description: `Payment of ${args.amount} ${args.currency} marked as paid`,
       performedBy: args.userId,
+      actorLabel: args.actorLabel,
     });
 
     await logAudit(ctx, {

--- a/convex/pipelines.ts
+++ b/convex/pipelines.ts
@@ -130,6 +130,7 @@ export const _sideEffects = internalMutation({
     migrateToStageId: v.optional(v.string()),
     stageId: v.optional(v.string()),
     leadIds: v.optional(v.array(v.string())),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const userId = args.userId as any;
@@ -142,6 +143,7 @@ export const _sideEffects = internalMutation({
         action: "created",
         description: `Created pipeline "${args.pipelineName}"`,
         performedBy: userId,
+        actorLabel: args.actorLabel,
       });
     } else if (args.type === "pipeline_updated" && args.pipelineId) {
       await logActivity(ctx, {
@@ -151,6 +153,7 @@ export const _sideEffects = internalMutation({
         action: "updated",
         description: `Updated pipeline "${args.pipelineName}"`,
         performedBy: userId,
+        actorLabel: args.actorLabel,
       });
     } else if (args.type === "pipeline_deleted" && args.pipelineId) {
       // Unlink leads from deleted stages
@@ -172,6 +175,7 @@ export const _sideEffects = internalMutation({
         action: "deleted",
         description: `Deleted pipeline "${args.pipelineName}"`,
         performedBy: userId,
+        actorLabel: args.actorLabel,
       });
     } else if (args.type === "stage_added" && args.pipelineId) {
       await logActivity(ctx, {
@@ -181,6 +185,7 @@ export const _sideEffects = internalMutation({
         action: "updated",
         description: `Added stage "${args.stageName}" to pipeline`,
         performedBy: userId,
+        actorLabel: args.actorLabel,
       });
     } else if (args.type === "stage_updated" && args.pipelineId) {
       await logActivity(ctx, {
@@ -190,6 +195,7 @@ export const _sideEffects = internalMutation({
         action: "updated",
         description: `Updated stage "${args.stageName}"`,
         performedBy: userId,
+        actorLabel: args.actorLabel,
       });
     } else if (args.type === "stage_removed" && args.pipelineId) {
       // Migrate or unlink leads
@@ -218,6 +224,7 @@ export const _sideEffects = internalMutation({
         action: "updated",
         description: `Removed stage "${args.stageName}"${args.migrateToStageId ? " (leads migrated)" : ""}`,
         performedBy: userId,
+        actorLabel: args.actorLabel,
       });
     } else if (args.type === "stages_reordered" && args.pipelineId) {
       await logActivity(ctx, {
@@ -227,6 +234,7 @@ export const _sideEffects = internalMutation({
         action: "updated",
         description: "Reordered pipeline stages",
         performedBy: userId,
+        actorLabel: args.actorLabel,
       });
     }
   },
@@ -359,6 +367,7 @@ export const create = action({
         userId: String(authResult.userId),
         pipelineId,
         pipelineName: args.name,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[pipelines.create] side effects error:", e);
@@ -413,6 +422,7 @@ export const update = action({
         userId: String(authResult.userId),
         pipelineId: args.pipelineId,
         pipelineName: (args.name ?? pipeline.name) as string,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[pipelines.update] side effects error:", e);
@@ -478,6 +488,7 @@ export const remove = action({
         pipelineId: args.pipelineId,
         pipelineName: pipeline.name as string,
         leadIds: allLeadIds,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[pipelines.remove] side effects error:", e);
@@ -537,6 +548,7 @@ export const addStage = action({
         userId: String(authResult.userId),
         pipelineId: args.pipelineId,
         stageName: args.name,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[pipelines.addStage] side effects error:", e);
@@ -590,6 +602,7 @@ export const updateStage = action({
         userId: String(authResult.userId),
         pipelineId: stage.pipelineId as string,
         stageName: (args.name ?? stage.name) as string,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[pipelines.updateStage] side effects error:", e);
@@ -655,6 +668,7 @@ export const removeStage = action({
         stageId: args.stageId,
         migrateToStageId: args.migrateToStageId,
         leadIds,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[pipelines.removeStage] side effects error:", e);
@@ -701,6 +715,7 @@ export const reorderStages = action({
         organizationId: args.organizationId,
         userId: String(authResult.userId),
         pipelineId: args.pipelineId,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[pipelines.reorderStages] side effects error:", e);

--- a/convex/products.ts
+++ b/convex/products.ts
@@ -116,6 +116,7 @@ export const create = action({
         organizationId: args.organizationId,
         name: args.name,
         createdBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[products.create] Side effects FAILED for product", productId, ":", e);
@@ -131,6 +132,7 @@ export const _createSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     name: v.string(),
     createdBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -140,6 +142,7 @@ export const _createSideEffects = internalMutation({
       action: "created",
       description: `Created product "${args.name}"`,
       performedBy: args.createdBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -223,6 +226,7 @@ export const update = action({
         organizationId,
         name: (product.name as string) ?? "",
         updatedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[products.update] Side effects FAILED for product", productId, ":", e);
@@ -238,6 +242,7 @@ export const _updateSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     name: v.string(),
     updatedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -247,6 +252,7 @@ export const _updateSideEffects = internalMutation({
       action: "updated",
       description: `Updated product "${args.name}"`,
       performedBy: args.updatedBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -293,6 +299,7 @@ export const remove = action({
         organizationId: args.organizationId,
         name: (product.name as string) ?? "",
         deletedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[products.remove] Side effects FAILED for product", args.productId, ":", e);
@@ -308,6 +315,7 @@ export const _removeSideEffects = internalMutation({
     organizationId: v.id("organizations"),
     name: v.string(),
     deletedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -317,6 +325,7 @@ export const _removeSideEffects = internalMutation({
       action: "deleted",
       description: `Deleted product "${args.name}"`,
       performedBy: args.deletedBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -360,6 +369,7 @@ export const toggleActive = action({
         name: (product.name as string) ?? "",
         wasActive: !!product.isActive,
         updatedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[products.toggleActive] Side effects FAILED for product", args.productId, ":", e);
@@ -376,6 +386,7 @@ export const _toggleActiveSideEffects = internalMutation({
     name: v.string(),
     wasActive: v.boolean(),
     updatedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -385,6 +396,7 @@ export const _toggleActiveSideEffects = internalMutation({
       action: "updated",
       description: `${args.wasActive ? "Deactivated" : "Activated"} product "${args.name}"`,
       performedBy: args.updatedBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -474,6 +486,7 @@ export const addToDeal = action({
         dealId: args.dealId,
         productName: (product.name as string) ?? "",
         addedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[products.addToDeal] Side effects FAILED:", e);
@@ -489,6 +502,7 @@ export const _addToDealSideEffects = internalMutation({
     dealId: v.string(),
     productName: v.string(),
     addedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -498,6 +512,7 @@ export const _addToDealSideEffects = internalMutation({
       action: "updated",
       description: `Added product "${args.productName}" to deal`,
       performedBy: args.addedBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -536,6 +551,7 @@ export const removeFromDeal = action({
         dealId: String(dealProduct.dealId),
         productName: (product?.name as string) ?? "unknown",
         removedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[products.removeFromDeal] Side effects FAILED:", e);
@@ -551,6 +567,7 @@ export const _removeFromDealSideEffects = internalMutation({
     dealId: v.string(),
     productName: v.string(),
     removedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -560,6 +577,7 @@ export const _removeFromDealSideEffects = internalMutation({
       action: "updated",
       description: `Removed product "${args.productName}" from deal`,
       performedBy: args.removedBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });

--- a/convex/relationships.ts
+++ b/convex/relationships.ts
@@ -151,6 +151,7 @@ export const create = action({
         targetType: args.targetType,
         targetId: args.targetId,
         createdBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[relationships.create] Side effects FAILED for relationship", relId, ":", e);
@@ -168,6 +169,7 @@ export const _createSideEffects = internalMutation({
     targetType: v.string(),
     targetId: v.string(),
     createdBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -178,6 +180,7 @@ export const _createSideEffects = internalMutation({
       description: `Added relationship to ${args.targetType} entity`,
       metadata: { targetType: args.targetType, targetId: args.targetId },
       performedBy: args.createdBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -211,6 +214,7 @@ export const remove = action({
         targetType: String(rel.targetType),
         targetId: String(rel.targetId),
         deletedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[relationships.remove] Side effects FAILED for relationship", args.relationshipId, ":", e);
@@ -228,6 +232,7 @@ export const _removeSideEffects = internalMutation({
     targetType: v.string(),
     targetId: v.string(),
     deletedBy: v.string(),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -238,6 +243,7 @@ export const _removeSideEffects = internalMutation({
       description: `Removed relationship to ${args.targetType} entity`,
       metadata: { targetType: args.targetType, targetId: args.targetId },
       performedBy: args.deletedBy as Id<"users">,
+      actorLabel: args.actorLabel,
     });
   },
 });

--- a/convex/scheduledActivities.ts
+++ b/convex/scheduledActivities.ts
@@ -26,6 +26,7 @@ export const _createSideEffects = internalMutation({
     userId: v.string(),
     ownerId: v.string(),
     description: v.optional(v.string()),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -35,6 +36,7 @@ export const _createSideEffects = internalMutation({
       action: "created",
       description: `Created ${args.activityType} "${args.title}"`,
       performedBy: args.userId as any,
+      actorLabel: args.actorLabel,
     });
 
     // Notify owner if different from creator
@@ -67,6 +69,7 @@ export const _updateSideEffects = internalMutation({
     oldOwnerId: v.optional(v.string()),
     googleEventId: v.optional(v.string()),
     description: v.optional(v.string()),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     await logActivity(ctx, {
@@ -76,6 +79,7 @@ export const _updateSideEffects = internalMutation({
       action: "updated",
       description: args.description ?? `Updated ${args.activityType} "${args.title}"`,
       performedBy: args.userId as any,
+      actorLabel: args.actorLabel,
     });
 
     // Notify new owner if changed and not the current user
@@ -107,6 +111,7 @@ export const _deleteSideEffects = internalMutation({
     title: v.string(),
     userId: v.string(),
     googleEventId: v.optional(v.string()),
+    actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     // Delete Google Calendar event before removing the activity
@@ -124,6 +129,7 @@ export const _deleteSideEffects = internalMutation({
       action: "deleted",
       description: `Deleted ${args.activityType} "${args.title}"`,
       performedBy: args.userId as any,
+      actorLabel: args.actorLabel,
     });
   },
 });
@@ -198,6 +204,7 @@ export const create = action({
         title: args.title,
         userId: String(authResult.userId),
         ownerId: args.ownerId,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[scheduledActivities.create] side effects error:", e);
@@ -270,6 +277,7 @@ export const update = action({
         newOwnerId: updates.ownerId,
         oldOwnerId: activity.ownerId as string | undefined,
         googleEventId: activity.googleEventId as string | undefined,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[scheduledActivities.update] side effects error:", e);
@@ -314,6 +322,7 @@ export const remove = action({
         title: activity.title as string,
         userId: String(authResult.userId),
         googleEventId: activity.googleEventId as string | undefined,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[scheduledActivities.remove] side effects error:", e);
@@ -364,6 +373,7 @@ export const markComplete = action({
         userId: String(authResult.userId),
         googleEventId: activity.googleEventId as string | undefined,
         description: `Completed ${activity.activityType} "${activity.title}"`,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[scheduledActivities.markComplete] side effects error:", e);
@@ -412,6 +422,7 @@ export const markIncomplete = action({
         title: activity.title as string,
         userId: String(authResult.userId),
         description: `Reopened ${activity.activityType} "${activity.title}"`,
+        actorLabel: authResult.userName ?? authResult.userEmail,
       });
     } catch (e) {
       console.error("[scheduledActivities.markIncomplete] side effects error:", e);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4046.

Closes #4046

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f45bbd5 fix(activities): propagate actorLabel from action callers into logActivity (closes #4046)

### Files changed

```
 convex/calls.ts                |  9 +++++++++
 convex/companies.ts            |  9 +++++++++
 convex/contacts.ts             |  9 +++++++++
 convex/documents.ts            | 12 ++++++++++++
 convex/gabinet/appointments.ts | 14 ++++++++++++++
 convex/gabinet/employees.ts    | 13 +++++++++++++
 convex/gabinet/packages.ts     |  6 ++++++
 convex/gabinet/patients.ts     | 16 ++++++++++++++++
 convex/gabinet/treatments.ts   | 15 +++++++++++++++
 convex/leads.ts                | 13 +++++++++++++
 convex/payments.ts             |  4 ++++
 convex/pipelines.ts            | 15 +++++++++++++++
 convex/products.ts             | 18 ++++++++++++++++++
 convex/relationships.ts        |  6 ++++++
 convex/scheduledActivities.ts  | 11 +++++++++++
 15 files changed, 170 insertions(+)
```