### PR TITLE
Update `convex/gabinet/appointments.ts` comment on line 162 ("Convex record may 

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -149,26 +149,6 @@ async function applyAppointmentStatusChange(
   },
 ) {
   const now = Date.now();
-  const patch: Record<string, unknown> = {
-    status: args.nextStatus,
-    updatedAt: now,
-  };
-
-  if (args.nextStatus === "cancelled") {
-    patch.cancelledAt = now;
-    patch.cancelledBy = args.actorUserId;
-    patch.cancellationReason = args.cancellationReason;
-  }
-
-  // Patch Convex record if it exists (Supabase is primary, Convex may lag)
-  try {
-    const convexRecord = await ctx.db.get(args.appointment._id);
-    if (convexRecord) {
-      await ctx.db.patch(args.appointment._id, patch);
-    }
-  } catch {
-    // Convex record may not exist during Supabase-primary migration
-  }
 
   if (args.nextStatus === "cancelled" && args.sendCancellationNotifications !== false) {
     // Patient/treatment live in Supabase (UUIDs) — ctx.db.get fails with
@@ -2556,9 +2536,7 @@ export const _updateStatusSideEffects = internalMutation({
     } as unknown as Doc<"gabinetAppointments">;
 
     // The status patch was already written to Supabase by the action.
-    // applyAppointmentStatusChange will try to ctx.db.patch the Convex record —
-    // since we're doing Supabase-primary, that patch may be a no-op on
-    // a missing Convex row. We still call it for the side effects (activity log,
+    // Call applyAppointmentStatusChange for side effects only (activity log,
     // audit, notification, automation event, calendar sync, completion handlers).
     await applyAppointmentStatusChange(ctx, {
       appointment: appointmentProxy,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4007.

Closes #4007

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a61be44 fix(gabinet/appointments): remove stale Convex dual-write from applyAppointmentStatusChange (closes #4007)

### Files changed

```
 convex/gabinet/appointments.ts | 24 +-----------------------
 1 file changed, 1 insertion(+), 23 deletions(-)
```