### PR TITLE
Add an index on `form_documents(entity_type, entity_id, timing, auto_generated)`

### DIFF
--- a/supabase/migrations/00105_form_documents_entity_timing_idx.sql
+++ b/supabase/migrations/00105_form_documents_entity_timing_idx.sql
@@ -1,0 +1,11 @@
+-- Add composite index on form_documents(entity_type, entity_id, timing, auto_generated).
+--
+-- The gate query that runs at appointment status transitions filters on all four
+-- columns. The existing form_documents_entity_idx covers only (entity_type, entity_id),
+-- so Postgres has to scan every document for the appointment and then filter by timing
+-- and auto_generated in a second pass. The new index lets the planner satisfy the
+-- entire predicate from the index, making the lookup O(1) instead of a filtered scan
+-- over all documents for that entity. Closes #3834.
+
+CREATE INDEX form_documents_entity_timing_idx
+  ON form_documents (entity_type, entity_id, timing, auto_generated);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3834.

Closes #3834

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f7c41d6 perf(form_documents): add composite index on (entity_type, entity_id, timing, auto_generated) (closes #3834)

### Files changed

```
 .../migrations/00105_form_documents_entity_timing_idx.sql     | 11 +++++++++++
 1 file changed, 11 insertions(+)
```