### PR TITLE
Remove stale `getDocumentsKpis` Convex function

### DIFF
--- a/convex/sidebarWidgets.ts
+++ b/convex/sidebarWidgets.ts
@@ -95,16 +95,6 @@ export const getProductsKpis = query({
   },
 });
 
-// --- Documents (CRM) ---
-// Stub for legacy consumers; the CRM documents page uses a direct Supabase hook.
-export const getDocumentsKpis = query({
-  args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    return { total: 0, newThisMonth: 0, pendingSent: 0 };
-  },
-});
-
 // --- Calendar (CRM) ---
 // Stub to keep old frontend bundles working while a rolling deploy finishes.
 // The real widget logic now lives in useSupabaseCalendarKpis. Safe to delete


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3852.

Closes #3852

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 6672c27 fix(sidebarWidgets): remove stale getDocumentsKpis Convex function (closes #3852)

### Files changed

```
 convex/sidebarWidgets.ts | 10 ----------
 1 file changed, 10 deletions(-)
```