### PR TITLE
Remove blank line left after `listEntityRuns` deletion in convex/automation.ts

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -1348,7 +1348,6 @@ export const listActionTypes = action({
   },
 });
 
-
 export const emitEvent = internalMutation({
   args: automationEventArgsValidator,
   handler: async (ctx, args) => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #3918.

Closes #3918

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d731d66 fix(automation): remove extra blank line between listActionTypes and emitEvent (closes #3918)

### Files changed

```
 convex/automation.ts | 1 -
 1 file changed, 1 deletion(-)
```