### PR TITLE
Track async email action run status as "failed"

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -511,6 +511,7 @@ export const _logActivityForRun = internalMutation({
 export const _sendAutomationEmail = internalAction({
   args: {
     organizationId: v.id("organizations"),
+    runId: v.optional(v.string()),
     stepId: v.string(),
     recipient: v.string(),
     recipientName: v.optional(v.string()),
@@ -547,6 +548,7 @@ export const _sendAutomationEmail = internalAction({
       });
       await ctx.runMutation(internal.automation._recordAutomationEmailResult, {
         organizationId: args.organizationId,
+        runId: args.runId,
         stepId: args.stepId,
         success: false,
         errorMessage: "No default email account configured",
@@ -602,6 +604,7 @@ export const _sendAutomationEmail = internalAction({
       });
       await ctx.runMutation(internal.automation._recordAutomationEmailResult, {
         organizationId: args.organizationId,
+        runId: args.runId,
         stepId: args.stepId,
         success: true,
         fromEmail: defaultAccount.fromEmail,
@@ -624,6 +627,7 @@ export const _sendAutomationEmail = internalAction({
       });
       await ctx.runMutation(internal.automation._recordAutomationEmailResult, {
         organizationId: args.organizationId,
+        runId: args.runId,
         stepId: args.stepId,
         success: false,
         errorMessage,
@@ -690,6 +694,7 @@ export const _patchAutomationRunStep = internalAction({
 export const _recordAutomationEmailResult = internalMutation({
   args: {
     organizationId: v.id("organizations"),
+    runId: v.optional(v.string()),
     stepId: v.string(),
     success: v.boolean(),
     errorMessage: v.optional(v.string()),
@@ -716,6 +721,13 @@ export const _recordAutomationEmailResult = internalMutation({
         processedAt: now,
         updatedAt: now,
       });
+      if (args.runId) {
+        await ctx.scheduler.runAfter(0, internal.automation._patchAutomationRun, {
+          runId: args.runId,
+          status: "failed",
+          updatedAt: now,
+        });
+      }
       await ctx.scheduler.runAfter(0, patchLegacyRef, {
         organizationId: args.organizationId,
         appointmentId: args.appointmentId,
@@ -1638,6 +1650,7 @@ export const processRun = internalAction({
               internal.automation._sendAutomationEmail,
               {
                 organizationId: run.organizationId,
+                runId: run._id,
                 stepId,
                 recipient: recipientEmail,
                 recipientName,

--- a/tests/convex/automation.test.ts
+++ b/tests/convex/automation.test.ts
@@ -910,6 +910,22 @@ describe("automation lifecycle", () => {
         updatedAt: now,
       });
     });
+    // processRun reads emailTemplates from Supabase (the Supabase-primary source);
+    // seed the in-memory stub so the template lookup succeeds.
+    {
+      const now = Date.now();
+      await createSupabaseDb().insert("emailTemplates", {
+        _id: String(templateId),
+        organizationId: String(organizationId),
+        name: "Appointment follow-up",
+        subject: "Szablon {{patient.fullName}}",
+        body: "<p>{{patient.email}}</p>",
+        createdBy: String(userId),
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
 
     await t.withIdentity(identity).action(api.automation.createRule, {
       organizationId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4066.

Closes #4066

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a7b0582 fix(automation): track async email action run status as failed (closes #4066)

### Files changed

```
 convex/automation.ts            | 13 +++++++++++++
 tests/convex/automation.test.ts | 16 ++++++++++++++++
 2 files changed, 29 insertions(+)
```