### PR TITLE
Zweryfikować pełny CRUD i dostępność akcji w UI dla encji Gabinetu

### DIFF
--- a/convex/gabinet/appointmentReminders.ts
+++ b/convex/gabinet/appointmentReminders.ts
@@ -466,6 +466,63 @@ export const scheduleReminderInternal = internalMutation({
 });
 
 /**
+ * Manually send a reminder for an appointment immediately, bypassing the
+ * scheduled-time check. Used from the appointment detail UI when staff want
+ * to trigger a reminder on demand (e.g. patient did not receive the automatic one).
+ */
+export const sendReminderNow = action({
+  args: {
+    organizationId: v.id("organizations"),
+    appointmentId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.runAction(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
+
+    const db = createSupabaseDb();
+
+    const appointment = await db.get("gabinetAppointments", args.appointmentId);
+    if (!appointment || String(appointment.organizationId) !== String(args.organizationId)) {
+      throw new Error("Appointment not found");
+    }
+
+    if (
+      appointment.status === "cancelled" ||
+      appointment.status === "completed" ||
+      appointment.status === "no_show"
+    ) {
+      throw new Error("Cannot send reminder for a cancelled, completed, or no-show appointment");
+    }
+
+    const now = Date.now();
+
+    const reminderId = await db.insert("appointmentReminders", {
+      organizationId: String(args.organizationId),
+      appointmentId: args.appointmentId,
+      type: "notification",
+      scheduledFor: now,
+      status: "pending",
+      createdAt: now,
+    });
+
+    await ctx.runMutation(
+      internal.gabinet.appointmentReminders._scheduleReminderSideEffects,
+      {
+        reminderId,
+        organizationId: args.organizationId,
+        appointmentId: args.appointmentId,
+        delayMs: 0,
+      },
+    );
+
+    return reminderId;
+  },
+});
+
+/**
  * Internal: cancel pending reminders without auth checks.
  * Used by appointment cancel mutations.
  */

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3268,6 +3268,7 @@
       "prepaymentRequired": "Prepayment required",
       "scheduling": "Scheduling",
       "sendReminder": "Send reminder",
+      "reminderSent": "Reminder sent",
       "reminderInfo": "Reminder: {{hours}}h before appointment",
       "statusUpdated": "Appointment status updated",
       "tabs": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3289,6 +3289,7 @@
       "prepaymentRequired": "Wymagana przedpłata",
       "scheduling": "Harmonogram",
       "sendReminder": "Wyślij przypomnienie",
+      "reminderSent": "Przypomnienie wysłane",
       "reminderInfo": "Przypomnienie: {{hours}}h przed wizytą",
       "statusUpdated": "Status wizyty zaktualizowany",
       "tabs": {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -306,6 +306,8 @@ function AppointmentDetail() {
   const updateStatus = useAction(api.gabinet.appointments.updateStatus);
   const updateAppointment = useAction(api.gabinet.appointments.update);
   const trackView = useAction(api.recentlyViewed.track);
+  const sendReminderNow = useAction(api.gabinet.appointmentReminders.sendReminderNow);
+  const [isSendingReminder, setIsSendingReminder] = useState(false);
   const queryClient = useQueryClient();
 
   // Refresh the Supabase-backed appointment lists (calendar, dashboards, etc.)
@@ -988,6 +990,22 @@ function AppointmentDetail() {
       toast.error(msg);
     } finally {
       setIsUpdating(false);
+    }
+  };
+
+  const handleSendReminder = async () => {
+    setIsSendingReminder(true);
+    try {
+      await sendReminderNow({
+        organizationId,
+        appointmentId: appointmentId as string,
+      });
+      toast.success(t("gabinet.appointments.reminderSent"));
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : t("common.error");
+      toast.error(msg);
+    } finally {
+      setIsSendingReminder(false);
     }
   };
 
@@ -2459,6 +2477,23 @@ function AppointmentDetail() {
             : "?"
         }
         actionsMenu={statusAction}
+        quickActionItems={
+          canEdit &&
+          appointment.status !== "cancelled" &&
+          appointment.status !== "completed" &&
+          appointment.status !== "no_show"
+            ? [
+                {
+                  key: "sendReminder",
+                  label: isSendingReminder
+                    ? t("common.processing")
+                    : t("gabinet.appointments.sendReminder"),
+                  icon: <Send size={14} variant="stroke" />,
+                  onClick: handleSendReminder,
+                },
+              ]
+            : undefined
+        }
         fields={detailFields}
         expandedFieldCount={5}
         sidebarExtra={sidebarExtra}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4076.

Closes #4076

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 6a34d89 feat(gabinet): add manual reminder send for appointments (closes #4076)

### Files changed

```
 convex/gabinet/appointmentReminders.ts             | 57 ++++++++++++++++++++++
 public/locales/en/translation.json                 |  1 +
 public/locales/pl/translation.json                 |  1 +
 ...ut.gabinet.appointments.$appointmentId.lazy.tsx | 35 +++++++++++++
 4 files changed, 94 insertions(+)
```