### PR TITLE
Poziomy lojalnościowe: wyliczać albo usunąć z interfejsu

### DIFF
--- a/convex/gabinet/_helpers/loyaltyTier.ts
+++ b/convex/gabinet/_helpers/loyaltyTier.ts
@@ -1,0 +1,10 @@
+import type { GabinetLoyaltyTier } from "../../schema";
+
+// Tier thresholds based on lifetime earned points:
+// bronze: 0–199, silver: 200–499, gold: 500–999, platinum: 1000+
+export function calculateLoyaltyTier(lifetimeEarned: number): GabinetLoyaltyTier {
+  if (lifetimeEarned >= 1000) return "platinum";
+  if (lifetimeEarned >= 500) return "gold";
+  if (lifetimeEarned >= 200) return "silver";
+  return "bronze";
+}

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -34,6 +34,7 @@ import { checkDocumentGate } from "./_helpers/documentGate";
 import { getJunctionTreatmentIds } from "./_helpers/junctionTreatments";
 import { logError } from "../_helpers/logged";
 import { applyMovementInternal, selectFefoLotsForProduct } from "../inventory";
+import { calculateLoyaltyTier } from "./_helpers/loyaltyTier";
 
 // Dual-write refs removed — Supabase is now primary for appointment writes
 
@@ -3079,6 +3080,7 @@ async function handleAppointmentCompletion(
           {
             balance: newBalance,
             lifetimeEarned: newLifetimeEarned,
+            tier: calculateLoyaltyTier(newLifetimeEarned),
             updatedAt: now,
           },
         );
@@ -3089,6 +3091,7 @@ async function handleAppointmentCompletion(
           balance: newBalance,
           lifetimeEarned: newLifetimeEarned,
           lifetimeSpent: 0,
+          tier: calculateLoyaltyTier(newLifetimeEarned),
           createdAt: now,
           updatedAt: now,
         });

--- a/convex/gabinet/loyalty.ts
+++ b/convex/gabinet/loyalty.ts
@@ -2,6 +2,7 @@ import { action } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
+import { calculateLoyaltyTier } from "./_helpers/loyaltyTier";
 
 // Dual-write refs removed — Supabase is now primary for loyalty writes
 
@@ -125,6 +126,7 @@ export const earnPoints = action({
     await db.patch("gabinetLoyaltyPoints", String(loyalty!._id), {
       balance: newBalance,
       lifetimeEarned: newLifetimeEarned,
+      tier: calculateLoyaltyTier(newLifetimeEarned),
       updatedAt: now,
     });
 
@@ -200,6 +202,7 @@ export const spendPoints = action({
     await db.patch("gabinetLoyaltyPoints", String(loyalty!._id), {
       balance: newBalance,
       lifetimeSpent: newLifetimeSpent,
+      tier: calculateLoyaltyTier(loyalty!.lifetimeEarned as number),
       updatedAt: now,
     });
 
@@ -277,6 +280,7 @@ export const adjustPoints = action({
       balance: newBalance,
       lifetimeEarned: newLifetimeEarned,
       lifetimeSpent: newLifetimeSpent,
+      tier: calculateLoyaltyTier(newLifetimeEarned),
       updatedAt: now,
     });
 

--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -6,6 +6,7 @@ import { paginationOptsValidator } from "convex/server";
 import { logActivity } from "../_helpers/activities";
 import { logError } from "../_helpers/logged";
 import { publishActivityEnvelope } from "../_helpers/activityEnvelope";
+import { calculateLoyaltyTier } from "./_helpers/loyaltyTier";
 import { Id } from "../_generated/dataModel";
 import type {
   GabinetPackageUsageRow,
@@ -791,6 +792,7 @@ export const purchasePackage = action({
         await db.patch("gabinetLoyaltyPoints", String(loyalty._id), {
           balance: newBalance,
           lifetimeEarned: newLifetimeEarned,
+          tier: calculateLoyaltyTier(newLifetimeEarned),
           updatedAt: now,
         });
       } else {
@@ -800,6 +802,7 @@ export const purchasePackage = action({
           balance: newBalance,
           lifetimeEarned: newLifetimeEarned,
           lifetimeSpent: 0,
+          tier: calculateLoyaltyTier(newLifetimeEarned),
           createdAt: now,
           updatedAt: now,
         });
@@ -1290,6 +1293,7 @@ export const assignGiftPackage = action({
         await db.patch("gabinetLoyaltyPoints", String(loyalty._id), {
           balance: newBalance,
           lifetimeEarned: newLifetimeEarned,
+          tier: calculateLoyaltyTier(newLifetimeEarned),
           updatedAt: now,
         });
       } else {
@@ -1299,6 +1303,7 @@ export const assignGiftPackage = action({
           balance: newBalance,
           lifetimeEarned: newLifetimeEarned,
           lifetimeSpent: 0,
+          tier: calculateLoyaltyTier(newLifetimeEarned),
           createdAt: now,
           updatedAt: now,
         });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4078.

Closes #4078

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f935202 feat(gabinet): calculate loyalty tier on every points change (closes #4078)

### Files changed

```
 convex/gabinet/_helpers/loyaltyTier.ts | 10 ++++++++++
 convex/gabinet/appointments.ts         |  3 +++
 convex/gabinet/loyalty.ts              |  4 ++++
 convex/gabinet/packages.ts             |  5 +++++
 4 files changed, 22 insertions(+)
```