### PR TITLE
Backfill tier for existing gabinetLoyaltyPoints rows

### DIFF
--- a/supabase/migrations/00107_backfill_gabinet_loyalty_points_tier.sql
+++ b/supabase/migrations/00107_backfill_gabinet_loyalty_points_tier.sql
@@ -1,0 +1,23 @@
+-- Backfill tier for existing gabinet_loyalty_points rows (#4086).
+--
+-- Rows created before issue #4078 (which added tier calculation on every
+-- points change) have tier = NULL.  This migration sets tier based on
+-- lifetime_earned using the same hardcoded thresholds as calculateLoyaltyTier()
+-- in convex/gabinet/_helpers/loyaltyTier.ts:
+--   platinum: lifetime_earned >= 1000
+--   gold:     lifetime_earned >= 500
+--   silver:   lifetime_earned >= 200
+--   bronze:   lifetime_earned >= 0 (default)
+--
+-- Only touches rows where tier IS NULL; already-populated rows are untouched.
+-- Orgs that have since configured custom tiers will naturally get the correct
+-- tier recalculated on the patient's next earn/spend/adjust action.
+
+UPDATE gabinet_loyalty_points
+SET tier = CASE
+  WHEN lifetime_earned >= 1000 THEN 'platinum'::gabinet_loyalty_tier_enum
+  WHEN lifetime_earned >= 500  THEN 'gold'::gabinet_loyalty_tier_enum
+  WHEN lifetime_earned >= 200  THEN 'silver'::gabinet_loyalty_tier_enum
+  ELSE                              'bronze'::gabinet_loyalty_tier_enum
+END
+WHERE tier IS NULL;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4086.

Closes #4086

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 22efee7 feat(gabinet): backfill tier for existing gabinetLoyaltyPoints rows (closes #4086)

### Files changed

```
 .../00107_backfill_gabinet_loyalty_points_tier.sql | 23 ++++++++++++++++++++++
 1 file changed, 23 insertions(+)
```