### PR TITLE
Merge-patients preserves wrong tier

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -8,6 +8,8 @@ import { logAudit } from "../auditLog";
 import { logError } from "../_helpers/logged";
 import type { GabinetPatientRow, SupabasePaginationResult } from "../_helpers/supabaseRows";
 import { Id } from "../_generated/dataModel";
+import { calculateLoyaltyTier } from "./_helpers/loyaltyTier";
+import type { GabinetLoyaltyTier } from "../schema";
 
 // Dual-write refs removed — Supabase is now primary for patient writes
 
@@ -929,6 +931,22 @@ export const merge = action({
         .first(),
     ]);
 
+    let tierDefs: { tier: GabinetLoyaltyTier; threshold: number }[] | undefined;
+    try {
+      const orgTiers = await db
+        .query("gabinetLoyaltyTiers")
+        .eq("organizationId", orgIdStr)
+        .collect();
+      if (orgTiers.length > 0) {
+        tierDefs = orgTiers.map((t) => ({
+          tier: t.tier as GabinetLoyaltyTier,
+          threshold: t.threshold as number,
+        }));
+      }
+    } catch {
+      // fall back to hardcoded defaults
+    }
+
     let consolidatedLoyaltyBalance = 0;
     if (sourceLoyalty) {
       const sBalance = Number(sourceLoyalty.balance ?? 0);
@@ -936,17 +954,23 @@ export const merge = action({
       const sSpent = Number(sourceLoyalty.lifetimeSpent ?? 0);
       if (targetLoyalty) {
         const newBalance = Number(targetLoyalty.balance ?? 0) + sBalance;
+        const newLifetimeEarned = Number(targetLoyalty.lifetimeEarned ?? 0) + sEarned;
         await db.patch("gabinetLoyaltyPoints", String(targetLoyalty._id), {
           balance: newBalance,
-          lifetimeEarned: Number(targetLoyalty.lifetimeEarned ?? 0) + sEarned,
+          lifetimeEarned: newLifetimeEarned,
           lifetimeSpent: Number(targetLoyalty.lifetimeSpent ?? 0) + sSpent,
+          tier: calculateLoyaltyTier(newLifetimeEarned, tierDefs),
           updatedAt: Date.now(),
         });
         await db.delete("gabinetLoyaltyPoints", String(sourceLoyalty._id));
         consolidatedLoyaltyBalance = newBalance;
       } else {
+        // No target loyalty row — reassign source row to target patient.
+        // The source's existing tier was calculated from sEarned alone, so
+        // recalculate in case org tier definitions changed since last earn.
         await db.patch("gabinetLoyaltyPoints", String(sourceLoyalty._id), {
           patientId: args.targetPatientId,
+          tier: calculateLoyaltyTier(sEarned, tierDefs),
           updatedAt: Date.now(),
         });
         consolidatedLoyaltyBalance = sBalance;

--- a/tests/convex/patientsMerge.test.ts
+++ b/tests/convex/patientsMerge.test.ts
@@ -249,6 +249,95 @@ describe("gabinet/patients.merge", () => {
       );
       expect(targetLoyalty?.balance).toBe(75);
     });
+
+    test("recalculates tier from combined lifetimeEarned after merge", async () => {
+      // Scenario: target has bronze tier (150 lifetime), source has bronze tier
+      // (200 lifetime). After merge lifetimeEarned = 350 → should be silver
+      // (default threshold 200). Without the fix the tier stays bronze.
+      const t = createTestCtx();
+      const { organizationId, userId, identity } = await seedTestUser(t);
+      const { patientId: targetId } = await seedGabinetPrereqs(
+        t,
+        organizationId,
+        userId,
+      );
+      const sourceId = "patient_tier_source";
+      await seedSecondPatient(String(organizationId), String(userId), sourceId);
+
+      const db = createSupabaseDb();
+      await db.insert("gabinetLoyaltyPoints", {
+        _id: "loyalty_tier_target",
+        organizationId: String(organizationId),
+        patientId: String(targetId),
+        balance: 150,
+        lifetimeEarned: 150,
+        lifetimeSpent: 0,
+        tier: "bronze",
+        updatedAt: Date.now(),
+      });
+      await db.insert("gabinetLoyaltyPoints", {
+        _id: "loyalty_tier_source",
+        organizationId: String(organizationId),
+        patientId: sourceId,
+        balance: 200,
+        lifetimeEarned: 200,
+        lifetimeSpent: 0,
+        tier: "silver",
+        updatedAt: Date.now(),
+      });
+
+      await t.withIdentity(identity).action(api.gabinet.patients.merge, {
+        organizationId,
+        targetPatientId: String(targetId),
+        sourcePatientId: sourceId,
+      });
+
+      const merged = await db.get<{
+        lifetimeEarned: number;
+        tier: string;
+      }>("gabinetLoyaltyPoints", "loyalty_tier_target");
+      expect(merged?.lifetimeEarned).toBe(350);
+      expect(merged?.tier).toBe("silver");
+    });
+
+    test("recalculates tier when source row is reassigned to target patient", async () => {
+      // Source has outdated 'bronze' tier but lifetimeEarned of 600 → gold.
+      // The merge reassigns the source row; tier should be recalculated.
+      const t = createTestCtx();
+      const { organizationId, userId, identity } = await seedTestUser(t);
+      const { patientId: targetId } = await seedGabinetPrereqs(
+        t,
+        organizationId,
+        userId,
+      );
+      const sourceId = "patient_stale_tier_source";
+      await seedSecondPatient(String(organizationId), String(userId), sourceId);
+
+      const db = createSupabaseDb();
+      await db.insert("gabinetLoyaltyPoints", {
+        _id: "loyalty_stale_tier",
+        organizationId: String(organizationId),
+        patientId: sourceId,
+        balance: 600,
+        lifetimeEarned: 600,
+        lifetimeSpent: 0,
+        tier: "bronze",
+        updatedAt: Date.now(),
+      });
+
+      await t.withIdentity(identity).action(api.gabinet.patients.merge, {
+        organizationId,
+        targetPatientId: String(targetId),
+        sourcePatientId: sourceId,
+      });
+
+      const reassigned = await db.get<{
+        patientId: string;
+        tier: string;
+      }>("gabinetLoyaltyPoints", "loyalty_stale_tier");
+      expect(reassigned?.patientId).toBe(String(targetId));
+      expect(reassigned?.tier).toBe("gold");
+    });
   });
 
   describe("polymorphic activities/notes reassignment", () => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4087.

Closes #4087

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 6348b03 fix(gabinet): recalculate loyalty tier after patient merge (closes #4087)

### Files changed

```
 convex/gabinet/patients.ts         | 26 ++++++++++-
 tests/convex/patientsMerge.test.ts | 89 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 114 insertions(+), 1 deletion(-)
```