### PR TITLE
Add `gabinet_receipts` tab to appointment detail page's own receipt list

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -4121,7 +4121,19 @@
       "title": "Receipt",
       "receiptNumber": "Receipt number",
       "issuedAt": "Issued at",
-      "totalGross": "Total (gross)"
+      "totalGross": "Total (gross)",
+      "receiptHistory": "Receipts",
+      "receiptHistoryDesc": "All receipts linked to this appointment",
+      "noReceipts": "No receipts",
+      "noReceiptsDesc": "Receipts will appear here once a payment is made.",
+      "types": {
+        "original": "Original",
+        "correction": "Correction"
+      },
+      "statuses": {
+        "issued": "Issued",
+        "void": "Void"
+      }
     }
   },
   "customFields": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -4142,7 +4142,19 @@
       "title": "Paragon",
       "receiptNumber": "Nr paragonu",
       "issuedAt": "Data wystawienia",
-      "totalGross": "Kwota brutto"
+      "totalGross": "Kwota brutto",
+      "receiptHistory": "Paragony",
+      "receiptHistoryDesc": "Wszystkie paragony powiązane z tą wizytą",
+      "noReceipts": "Brak paragonów",
+      "noReceiptsDesc": "Paragony pojawią się tutaj po dokonaniu płatności.",
+      "types": {
+        "original": "Oryginalny",
+        "correction": "Korekta"
+      },
+      "statuses": {
+        "issued": "Wystawiony",
+        "void": "Anulowany"
+      }
     }
   },
   "customFields": {

--- a/src/hooks/use-supabase-gabinet-receipts.ts
+++ b/src/hooks/use-supabase-gabinet-receipts.ts
@@ -10,6 +10,37 @@ import {
   type MappedGabinetReceipt,
 } from "@/lib/supabase/mappers/gabinet/receipts";
 
+export function useSupabaseGabinetReceiptsByAppointment(
+  organizationId: string,
+  appointmentId: string | undefined,
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  return useQuery<MappedGabinetReceipt[], Error>({
+    queryKey: [
+      ...supabaseKeys.gabinetReceipts.list(organizationId),
+      "byAppointment",
+      appointmentId ?? "",
+    ],
+    queryFn: async (): Promise<MappedGabinetReceipt[]> => {
+      if (!client || !appointmentId) return [];
+
+      const { data, error } = await client
+        .from("gabinet_receipts")
+        .select("*")
+        .eq("organization_id", organizationId)
+        .eq("appointment_id", appointmentId)
+        .order("issued_at", { ascending: false });
+
+      if (error) throw error;
+      return (data ?? []).map(mapGabinetReceiptFromSupabase);
+    },
+    enabled: enabled && isReady && !!organizationId && !!appointmentId,
+  } satisfies UseQueryOptions<MappedGabinetReceipt[], Error>);
+}
+
 export function useSupabaseGabinetReceiptsByPatient(
   organizationId: string,
   patientId: string | undefined,

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -15,6 +15,7 @@ import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
 import { useSupabaseGabinetEquipmentList } from "@/hooks/use-supabase-gabinet-equipment";
 import { useSupabaseGabinetSameDayAppointments } from "@/hooks/use-supabase-gabinet-appointments";
 import { useSupabaseAutomationEntityRuns } from "@/hooks/use-supabase-automation";
+import { useSupabaseGabinetReceiptsByAppointment } from "@/hooks/use-supabase-gabinet-receipts";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -110,6 +111,7 @@ import {
   Send,
   Inbox,
   Stethoscope,
+  FileText,
 } from "@/lib/ez-icons";
 import { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
@@ -423,6 +425,11 @@ function AppointmentDetail() {
       detail?.appointment?.date,
       appointmentId,
     );
+
+  const { data: appointmentReceipts = [] } = useSupabaseGabinetReceiptsByAppointment(
+    organizationId,
+    appointmentId,
+  );
 
   // Which additional same-day appointments to include in the batch settlement.
   const [selectedAdditionalIds, setSelectedAdditionalIds] = useState<Set<string>>(
@@ -2461,6 +2468,140 @@ function AppointmentDetail() {
         />
       ),
     },
+    {
+      label: t("gabinet.receipts.receiptHistory", "Paragony"),
+      count: appointmentReceipts.length > 0 ? appointmentReceipts.length : undefined,
+      content: (
+        <div className="space-y-4">
+          <Card>
+            <CardHeader className="px-6 py-3 border-b">
+              <CardTitle className="text-sm flex items-center gap-2">
+                <FileText className="h-4 w-4" variant="stroke" />
+                {t("gabinet.receipts.receiptHistory", "Paragony")}
+              </CardTitle>
+              <CardDescription className="text-xs">
+                {t("gabinet.receipts.receiptHistoryDesc", "Wszystkie paragony powiązane z tą wizytą")}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="px-6 py-4">
+              {appointmentReceipts.length === 0 ? (
+                <EmptyState
+                  icon={FileText}
+                  title={t("gabinet.receipts.noReceipts", "Brak paragonów")}
+                  description={t(
+                    "gabinet.receipts.noReceiptsDesc",
+                    "Paragony pojawią się tutaj po dokonaniu płatności.",
+                  )}
+                />
+              ) : (
+                <div className="overflow-x-auto border rounded-lg">
+                  <table className="w-full">
+                    <thead>
+                      <tr className="border-b bg-muted/50">
+                        <th className="text-left p-3 text-sm font-medium">
+                          {t("gabinet.receipts.receiptNumber", "Nr paragonu")}
+                        </th>
+                        <th className="text-left p-3 text-sm font-medium">
+                          {t("gabinet.receipts.issuedAt", "Data wystawienia")}
+                        </th>
+                        <th className="text-left p-3 text-sm font-medium">
+                          {t("gabinet.receipts.totalGross", "Kwota brutto")}
+                        </th>
+                        <th className="text-left p-3 text-sm font-medium">
+                          {t("gabinet.payments.method", "Metoda")}
+                        </th>
+                        <th className="text-left p-3 text-sm font-medium">
+                          {t("common.type", "Typ")}
+                        </th>
+                        <th className="text-left p-3 text-sm font-medium">
+                          {t("common.status", "Status")}
+                        </th>
+                        <th className="p-3" />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {appointmentReceipts.map((receipt) => (
+                        <tr
+                          key={receipt._id}
+                          className="border-b last:border-0 hover:bg-muted/30"
+                        >
+                          <td className="p-3 font-mono text-sm font-medium">
+                            {receipt.receiptNumber}
+                          </td>
+                          <td className="p-3 text-sm text-muted-foreground">
+                            {new Date(receipt.issuedAt).toLocaleDateString(
+                              i18n.language,
+                            )}
+                          </td>
+                          <td className="p-3 font-medium">
+                            {receipt.totalGross != null
+                              ? formatCurrencyPLN(receipt.totalGross)
+                              : "—"}
+                          </td>
+                          <td className="p-3">
+                            <Badge variant="outline">
+                              {t(
+                                `gabinet.payments.methods.${receipt.paymentMethod.split("+")[0]}`,
+                                receipt.paymentMethod,
+                              )}
+                              {receipt.paymentMethod.includes("+") && (
+                                <span className="ml-1 text-muted-foreground">
+                                  +
+                                </span>
+                              )}
+                            </Badge>
+                          </td>
+                          <td className="p-3">
+                            <Badge
+                              variant="outline"
+                              className={
+                                receipt.receiptType === "correction"
+                                  ? "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-800 dark:bg-orange-950/40 dark:text-orange-400"
+                                  : ""
+                              }
+                            >
+                              {receipt.receiptType === "correction"
+                                ? t("gabinet.receipts.types.correction", "Korekta")
+                                : t("gabinet.receipts.types.original", "Oryginalny")}
+                            </Badge>
+                          </td>
+                          <td className="p-3">
+                            <Badge
+                              variant={
+                                receipt.status === "void"
+                                  ? "destructive"
+                                  : "secondary"
+                              }
+                            >
+                              {receipt.status === "void"
+                                ? t("gabinet.receipts.statuses.void", "Anulowany")
+                                : t("gabinet.receipts.statuses.issued", "Wystawiony")}
+                            </Badge>
+                          </td>
+                          <td className="p-3 text-right">
+                            {receipt.pdfUrl && (
+                              <a
+                                href={receipt.pdfUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                <Button size="sm" variant="outline">
+                                  {t("gabinet.receipts.download", "Pobierz paragon")}
+                                </Button>
+                              </a>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      ),
+    },
   ];
 
   return (
@@ -2503,7 +2644,9 @@ function AppointmentDetail() {
             ? t("gabinet.payments.payments")
             : tabSearch === "documentation"
               ? t("gabinet.appointments.tabs.documentation", "Notatki z wizyty")
-              : undefined
+              : tabSearch === "receipts"
+                ? t("gabinet.receipts.receiptHistory", "Paragony")
+                : undefined
         }
       />
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4104.

Closes #4104

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f116946 feat(gabinet): add Paragony (receipts) tab to appointment detail page (closes #4104)

### Files changed

```
 public/locales/en/translation.json                 |  14 +-
 public/locales/pl/translation.json                 |  14 +-
 src/hooks/use-supabase-gabinet-receipts.ts         |  31 +++++
 ...ut.gabinet.appointments.$appointmentId.lazy.tsx | 145 ++++++++++++++++++++-
 4 files changed, 201 insertions(+), 3 deletions(-)
```