### PR TITLE
Wire `productKey` through Stripe webhook handler

### DIFF
--- a/convex/_helpers/seatLimits.ts
+++ b/convex/_helpers/seatLimits.ts
@@ -85,10 +85,12 @@ export async function checkSeatLimit(
 
 // Internal query for Convex-only tables (subscriptions + plans are NOT in
 // TABLE_MAP and must be read from ctx.db). Called by checkSeatLimitAction.
+// Returns the highest seatLimit across all active/trialing subscriptions so
+// that orgs with multiple per-module plans get the most generous limit.
 export const _getSubscriptionAndPlanData = internalQuery({
   args: { ownerId: v.id("users") },
   handler: async (ctx, args): Promise<{ seatLimit: number }> => {
-    const subscription = await ctx.db
+    const subscriptions = await ctx.db
       .query("subscriptions")
       .withIndex("userId", (q) => q.eq("userId", args.ownerId))
       .filter((q) =>
@@ -97,24 +99,30 @@ export const _getSubscriptionAndPlanData = internalQuery({
           q.eq(q.field("status"), "trialing"),
         ),
       )
-      .first();
+      .collect();
 
-    if (!subscription) {
+    if (subscriptions.length === 0) {
       console.warn(
         `[seatLimits] No active subscription found for org owner ${args.ownerId}. Using default free tier limit.`,
       );
       return { seatLimit: 20 };
     }
 
-    const plan = await ctx.db.get(subscription.planId);
-    if (!plan) {
-      console.warn(
-        `[seatLimits] Plan ${subscription.planId} not found for subscription ${subscription._id}. Using default seat limit.`,
-      );
-      return { seatLimit: 20 };
+    let maxSeatLimit = 20;
+    for (const sub of subscriptions) {
+      const plan = await ctx.db.get(sub.planId);
+      if (!plan) {
+        console.warn(
+          `[seatLimits] Plan ${sub.planId} not found for subscription ${sub._id}. Skipping.`,
+        );
+        continue;
+      }
+      if (plan.seatLimit > maxSeatLimit) {
+        maxSeatLimit = plan.seatLimit;
+      }
     }
 
-    return { seatLimit: plan.seatLimit };
+    return { seatLimit: maxSeatLimit };
   },
 });
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -12,7 +12,7 @@ import {
   sendSubscriptionSuccessEmail,
 } from "@cvx/email/templates/subscriptionEmail";
 import Stripe from "stripe";
-import { Doc } from "@cvx/_generated/dataModel";
+import { Doc, Id } from "@cvx/_generated/dataModel";
 import { createLogger } from "@cvx/_helpers/logger";
 
 function normalizeWebhookValue(value: FormDataEntryValue | unknown): string | undefined {
@@ -105,6 +105,18 @@ async function verifyTwilioRequest(
 
 const http = httpRouter();
 
+const PRODUCT_SUBSCRIPTION_STATUSES = new Set([
+  "active", "trialing", "past_due", "canceled", "incomplete",
+]);
+
+function toProductSubscriptionStatus(
+  stripeStatus: string,
+): "active" | "trialing" | "past_due" | "canceled" | "incomplete" {
+  return PRODUCT_SUBSCRIPTION_STATUSES.has(stripeStatus)
+    ? (stripeStatus as "active" | "trialing" | "past_due" | "canceled" | "incomplete")
+    : "incomplete";
+}
+
 /**
  * Gets and constructs a Stripe event signature.
  *
@@ -164,6 +176,9 @@ const handleCheckoutSessionCompleted = async (
     .object({ customer: z.string(), subscription: z.string() })
     .parse(session);
 
+  const productKey = session.metadata?.productKey;
+  const organizationId = session.metadata?.organizationId;
+
   const user = await ctx.runQuery(internal.stripe.PREAUTH_getUserByCustomerId, {
     customerId,
   });
@@ -179,6 +194,21 @@ const handleCheckoutSessionCompleted = async (
   const subscription = await stripe.subscriptions.retrieve(subscriptionId);
 
   await handleUpdateSubscription(ctx, user, subscription);
+
+  // Sync per-org per-module entitlement table so getActiveProducts() reflects
+  // the newly purchased module without requiring manual backfill.
+  if (organizationId && productKey) {
+    const normalizedStatus = toProductSubscriptionStatus(subscription.status);
+    await ctx.runMutation(internal.stripe.PREAUTH_upsertProductSubscription, {
+      organizationId: organizationId as Id<"organizations">,
+      productId: productKey,
+      stripeSubscriptionId: subscription.id,
+      status: normalizedStatus,
+      currentPeriodStart: subscription.current_period_start,
+      currentPeriodEnd: subscription.current_period_end,
+      cancelAtPeriodEnd: subscription.cancel_at_period_end,
+    });
+  }
 
   await sendSubscriptionSuccessEmail({
     email: user.email,
@@ -243,6 +273,21 @@ const handleCustomerSubscriptionUpdated = async (
 
   await handleUpdateSubscription(ctx, user, subscription);
 
+  const productKey = subscription.metadata?.productKey;
+  const organizationId = subscription.metadata?.organizationId;
+  if (organizationId && productKey) {
+    const normalizedStatus = toProductSubscriptionStatus(subscription.status);
+    await ctx.runMutation(internal.stripe.PREAUTH_upsertProductSubscription, {
+      organizationId: organizationId as Id<"organizations">,
+      productId: productKey,
+      stripeSubscriptionId: subscription.id,
+      status: normalizedStatus,
+      currentPeriodStart: subscription.current_period_start,
+      currentPeriodEnd: subscription.current_period_end,
+      cancelAtPeriodEnd: subscription.cancel_at_period_end,
+    });
+  }
+
   return new Response(null);
 };
 
@@ -284,6 +329,21 @@ const handleCustomerSubscriptionCreated = async (
 
   await handleUpdateSubscription(ctx, user, subscription);
 
+  const productKey = subscription.metadata?.productKey;
+  const organizationId = subscription.metadata?.organizationId;
+  if (organizationId && productKey) {
+    const normalizedStatus = toProductSubscriptionStatus(subscription.status);
+    await ctx.runMutation(internal.stripe.PREAUTH_upsertProductSubscription, {
+      organizationId: organizationId as Id<"organizations">,
+      productId: productKey,
+      stripeSubscriptionId: subscription.id,
+      status: normalizedStatus,
+      currentPeriodStart: subscription.current_period_start,
+      currentPeriodEnd: subscription.current_period_end,
+      cancelAtPeriodEnd: subscription.cancel_at_period_end,
+    });
+  }
+
   return new Response(null);
 };
 
@@ -295,6 +355,19 @@ const handleCustomerSubscriptionDeleted = async (
   await ctx.runMutation(internal.stripe.PREAUTH_deleteSubscription, {
     subscriptionStripeId: subscription.id,
   });
+
+  const productKey = subscription.metadata?.productKey;
+  const organizationId = subscription.metadata?.organizationId;
+  if (organizationId && productKey) {
+    await ctx.runMutation(internal.stripe.PREAUTH_upsertProductSubscription, {
+      organizationId: organizationId as Id<"organizations">,
+      productId: productKey,
+      stripeSubscriptionId: subscription.id,
+      status: "canceled",
+      cancelAtPeriodEnd: false,
+    });
+  }
+
   return new Response(null);
 };
 

--- a/convex/stripe.ts
+++ b/convex/stripe.ts
@@ -10,7 +10,7 @@ import type { Doc } from "@cvx/_generated/dataModel";
 import { v } from "convex/values";
 import { ERRORS } from "~/errors";
 import { auth } from "@cvx/auth";
-import { currencyValidator, intervalValidator, PLANS } from "@cvx/schema";
+import { currencyValidator, intervalValidator, PLANS, PRODUCT_KEYS } from "@cvx/schema";
 import { api, internal } from "~/convex/_generated/api";
 import { SITE_URL, STRIPE_SECRET_KEY } from "@cvx/env";
 import { asyncMap } from "convex-helpers";
@@ -124,7 +124,7 @@ export const PREAUTH_getUserByCustomerId = internalQuery({
     const subscription = await ctx.db
       .query("subscriptions")
       .withIndex("userId", (q) => q.eq("userId", user._id))
-      .unique();
+      .first();
     if (!subscription) {
       throw new Error(ERRORS.STRIPE_SOMETHING_WENT_WRONG);
     }
@@ -209,14 +209,7 @@ export const PREAUTH_replaceSubscription = internalMutation({
     }),
   },
   handler: async (ctx, args) => {
-    const subscription = await ctx.db
-      .query("subscriptions")
-      .withIndex("userId", (q) => q.eq("userId", args.userId))
-      .unique();
-    if (!subscription) {
-      throw new Error(ERRORS.STRIPE_SOMETHING_WENT_WRONG);
-    }
-    await ctx.db.delete(subscription._id);
+    // Look up the new plan first to get its productKey for targeted replacement
     const plan = await ctx.db
       .query("plans")
       .withIndex("stripeId", (q) => q.eq("stripeId", args.input.planStripeId))
@@ -224,6 +217,33 @@ export const PREAUTH_replaceSubscription = internalMutation({
     if (!plan) {
       throw new Error(ERRORS.STRIPE_SOMETHING_WENT_WRONG);
     }
+
+    // Find the subscription to replace: when productKey is known, only replace
+    // the subscription for that module so other modules are not disturbed.
+    let existingSubscription = null;
+    if (plan.productKey) {
+      const userSubs = await ctx.db
+        .query("subscriptions")
+        .withIndex("userId", (q) => q.eq("userId", args.userId))
+        .collect();
+      for (const sub of userSubs) {
+        const subPlan = await ctx.db.get(sub.planId);
+        if (subPlan?.productKey === plan.productKey) {
+          existingSubscription = sub;
+          break;
+        }
+      }
+    } else {
+      existingSubscription = await ctx.db
+        .query("subscriptions")
+        .withIndex("userId", (q) => q.eq("userId", args.userId))
+        .first();
+    }
+
+    if (existingSubscription) {
+      await ctx.db.delete(existingSubscription._id);
+    }
+
     const newSubId = await ctx.db.insert("subscriptions", {
       userId: args.userId,
       planId: plan._id,
@@ -267,6 +287,61 @@ export const PREAUTH_deleteSubscription = internalMutation({
       throw new Error(ERRORS.STRIPE_SOMETHING_WENT_WRONG);
     }
     await ctx.db.delete(subscription._id);
+  },
+});
+
+/**
+ * Upserts a per-organization per-product subscription record.
+ * Called from Stripe webhook handlers to keep the productSubscriptions table
+ * in sync with actual Stripe subscription state.
+ */
+export const PREAUTH_upsertProductSubscription = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    productId: v.string(),
+    stripeSubscriptionId: v.string(),
+    status: v.union(
+      v.literal("active"),
+      v.literal("trialing"),
+      v.literal("past_due"),
+      v.literal("canceled"),
+      v.literal("incomplete"),
+    ),
+    currentPeriodStart: v.optional(v.number()),
+    currentPeriodEnd: v.optional(v.number()),
+    cancelAtPeriodEnd: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("productSubscriptions")
+      .withIndex("by_orgAndProduct", (q) =>
+        q.eq("organizationId", args.organizationId).eq("productId", args.productId)
+      )
+      .first();
+
+    const now = Date.now();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        stripeSubscriptionId: args.stripeSubscriptionId,
+        status: args.status,
+        currentPeriodStart: args.currentPeriodStart,
+        currentPeriodEnd: args.currentPeriodEnd,
+        cancelAtPeriodEnd: args.cancelAtPeriodEnd,
+        updatedAt: now,
+      });
+    } else {
+      await ctx.db.insert("productSubscriptions", {
+        organizationId: args.organizationId,
+        productId: args.productId,
+        stripeSubscriptionId: args.stripeSubscriptionId,
+        status: args.status,
+        currentPeriodStart: args.currentPeriodStart,
+        currentPeriodEnd: args.currentPeriodEnd,
+        cancelAtPeriodEnd: args.cancelAtPeriodEnd,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
   },
 });
 
@@ -327,7 +402,7 @@ export const getCurrentUserSubscription = internalQuery({
       ctx.db
         .query("subscriptions")
         .withIndex("userId", (q) => q.eq("userId", userId))
-        .unique(),
+        .first(),
       ctx.db.get(args.planId),
     ]);
     if (!currentSubscription) {
@@ -350,6 +425,7 @@ export const getCurrentUserSubscription = internalQuery({
 export const createSubscriptionCheckout = action({
   args: {
     userId: v.id("users"),
+    organizationId: v.id("organizations"),
     planId: v.id("plans"),
     planInterval: intervalValidator,
     currency: currencyValidator,
@@ -374,6 +450,7 @@ export const createSubscriptionCheckout = action({
     }
 
     const price = newPlan?.prices[args.planInterval][args.currency];
+    const productKey = newPlan?.productKey ?? PRODUCT_KEYS.CRM;
 
     const checkout = await stripe.checkout.sessions.create({
       customer: user.customerId,
@@ -382,6 +459,16 @@ export const createSubscriptionCheckout = action({
       payment_method_types: ["card"],
       success_url: `${SITE_URL}/dashboard/checkout`,
       cancel_url: `${SITE_URL}/dashboard/settings/billing`,
+      metadata: {
+        productKey,
+        organizationId: args.organizationId,
+      },
+      subscription_data: {
+        metadata: {
+          productKey,
+          organizationId: args.organizationId,
+        },
+      },
     });
     if (!checkout) {
       throw new Error(ERRORS.STRIPE_SOMETHING_WENT_WRONG);

--- a/src/routes/_app/_auth/dashboard/_layout.settings.billing.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.billing.tsx
@@ -85,6 +85,7 @@ export default function BillingSettings() {
     }
     const checkoutUrl = await createSubscriptionCheckout({
       userId: user._id,
+      organizationId,
       planId: selectedPlanId,
       planInterval: selectedPlanInterval,
       currency,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4097.

Closes #4097

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 5604e73 feat(billing): wire productKey through Stripe webhook handler (closes #4097)

### Files changed

```
 convex/_helpers/seatLimits.ts                      |  28 ++++--
 convex/http.ts                                     |  75 +++++++++++++-
 convex/stripe.ts                                   | 109 ++++++++++++++++++---
 .../_auth/dashboard/_layout.settings.billing.tsx   |   1 +
 4 files changed, 191 insertions(+), 22 deletions(-)
```