### PR TITLE
`PREAUTH_createSubscription` still throws if any subscription exists (`Subscript

### DIFF
--- a/convex/stripe.ts
+++ b/convex/stripe.ts
@@ -156,13 +156,23 @@ export const PREAUTH_createSubscription = internalMutation({
     cancelAtPeriodEnd: v.boolean(),
   },
   handler: async (ctx, args) => {
-    const subscription = await ctx.db
+    // Resolve the incoming plan's productKey so we can scope the uniqueness
+    // check to one subscription per user per productKey (multi-module billing).
+    const incomingPlan = await ctx.db.get(args.planId);
+    const incomingProductKey = incomingPlan?.productKey;
+
+    const userSubs = await ctx.db
       .query("subscriptions")
       .withIndex("userId", (q) => q.eq("userId", args.userId))
-      .unique();
-    if (subscription) {
-      throw new Error("Subscription already exists");
+      .collect();
+
+    for (const sub of userSubs) {
+      const subPlan = await ctx.db.get(sub.planId);
+      if (subPlan?.productKey === incomingProductKey) {
+        throw new Error("Subscription already exists");
+      }
     }
+
     const subId = await ctx.db.insert("subscriptions", {
       userId: args.userId,
       planId: args.planId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4109.

Closes #4109

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0d9e84e fix(billing): scope PREAUTH_createSubscription guard to one sub per productKey (closes #4109)

### Files changed

```
 convex/stripe.ts | 18 ++++++++++++++----
 1 file changed, 14 insertions(+), 4 deletions(-)
```