### PR TITLE
`PREAUTH_getUserByCustomerId` returns only one subscription with `.first()`

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -186,10 +186,9 @@ const handleCheckoutSessionCompleted = async (
     throw new Error(ERRORS.SOMETHING_WENT_WRONG);
   }
 
-  const freeSubscriptionStripeId =
-    user.subscription.planKey === PLANS.FREE
-      ? user.subscription.stripeId
-      : undefined;
+  const freeSubscriptionStripeId = user.subscriptions.find(
+    (sub) => sub.planKey === PLANS.FREE && sub.productKey === productKey,
+  )?.stripeId;
 
   const subscription = await stripe.subscriptions.retrieve(subscriptionId);
 

--- a/convex/stripe.ts
+++ b/convex/stripe.ts
@@ -121,24 +121,19 @@ export const PREAUTH_getUserByCustomerId = internalQuery({
     if (!user) {
       throw new Error(ERRORS.STRIPE_SOMETHING_WENT_WRONG);
     }
-    const subscription = await ctx.db
+    const subs = await ctx.db
       .query("subscriptions")
       .withIndex("userId", (q) => q.eq("userId", user._id))
-      .first();
-    if (!subscription) {
+      .collect();
+    if (subs.length === 0) {
       throw new Error(ERRORS.STRIPE_SOMETHING_WENT_WRONG);
     }
-    const plan = await ctx.db.get(subscription.planId);
-    if (!plan) {
-      throw new Error(ERRORS.STRIPE_SOMETHING_WENT_WRONG);
-    }
-    return {
-      ...user,
-      subscription: {
-        ...subscription,
-        planKey: plan.key,
-      },
-    };
+    const subscriptions = await asyncMap(subs, async (sub) => {
+      const plan = await ctx.db.get(sub.planId);
+      if (!plan) throw new Error(ERRORS.STRIPE_SOMETHING_WENT_WRONG);
+      return { ...sub, planKey: plan.key, productKey: plan.productKey };
+    });
+    return { ...user, subscriptions };
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4110.

Closes #4110

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 9271faa fix(billing): scope free-plan cancellation to productKey in handleCheckoutSessionCompleted (closes #4110)

### Files changed

```
 convex/http.ts   |  7 +++----
 convex/stripe.ts | 23 +++++++++--------------
 2 files changed, 12 insertions(+), 18 deletions(-)
```