### PR TITLE
`PREAUTH_getUserByCustomerId` reads `subscription` via `.first()` on the userId 

### DIFF
--- a/convex/stripe.ts
+++ b/convex/stripe.ts
@@ -402,13 +402,26 @@ export const getCurrentUserSubscription = internalQuery({
     if (!userId) {
       throw new Error(ERRORS.STRIPE_SOMETHING_WENT_WRONG);
     }
-    const [currentSubscription, newPlan] = await Promise.all([
-      ctx.db
+    const newPlan = await ctx.db.get(args.planId);
+
+    // Scope the lookup to the specific module's productKey so that a user with
+    // a paid CRM subscription and a free Gabinet subscription can still initiate
+    // a Gabinet checkout (multi-module billing correctness).
+    let currentSubscription = null;
+    if (newPlan?.productKey) {
+      currentSubscription = await ctx.db
+        .query("subscriptions")
+        .withIndex("by_userId_and_productKey", (q) =>
+          q.eq("userId", userId).eq("productKey", newPlan.productKey),
+        )
+        .first();
+    } else {
+      currentSubscription = await ctx.db
         .query("subscriptions")
         .withIndex("userId", (q) => q.eq("userId", userId))
-        .first(),
-      ctx.db.get(args.planId),
-    ]);
+        .first();
+    }
+
     if (!currentSubscription) {
       throw new Error(ERRORS.STRIPE_SOMETHING_WENT_WRONG);
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4115.

Closes #4115

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 9929d9a fix(billing): scope getCurrentUserSubscription to productKey (closes #4115)

### Files changed

```
 convex/stripe.ts | 23 ++++++++++++++++++-----
 1 file changed, 18 insertions(+), 5 deletions(-)
```