### PR TITLE
Add Supabase migration for `productKey` column on plans

### DIFF
--- a/supabase/migrations/00109_plans_product_key.sql
+++ b/supabase/migrations/00109_plans_product_key.sql
@@ -1,0 +1,22 @@
+-- ============================================================
+-- Migration 00109: Add product_key to plans (closes #4096)
+-- ============================================================
+--
+-- Context:
+--   The plans table in Supabase was created without a product_key column.
+--   The Convex schema (convex/schema/platform.ts) defines productKey as an
+--   optional field on plans, supporting multi-module billing (crm, gabinet,
+--   magazyn). The subscriptions table already received product_key in migration
+--   00108; this migration keeps the plans table in sync.
+--
+--   The column is nullable to match the Convex optional field and to allow
+--   legacy plans (pre-multi-module) to coexist without a backfill.
+-- ============================================================
+
+ALTER TABLE plans
+  ADD COLUMN IF NOT EXISTS product_key TEXT;
+
+-- Support the by_productAndKey index pattern used in Convex
+-- (productKey + key lookup for plan discovery per module).
+CREATE INDEX IF NOT EXISTS plans_product_key_key_idx
+  ON plans (product_key, key);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4096.

Closes #4096

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 9222301 feat(billing): add product_key column to plans table in Supabase (closes #4096)

### Files changed

```
 supabase/migrations/00109_plans_product_key.sql | 22 ++++++++++++++++++++++
 1 file changed, 22 insertions(+)
```