### PR TITLE
Fix gen-db-types.mjs to also handle `NUMERIC(p, s)` in ALTER TABLE ... ALTER COL

### DIFF
--- a/scripts/gen-db-types.mjs
+++ b/scripts/gen-db-types.mjs
@@ -324,7 +324,7 @@ function applyMigration(sql) {
       if (col) col.nullable = true;
     }
 
-    const alterTypeRe = /ALTER\s+COLUMN\s+"?(\w+)"?\s+TYPE\s+([\w\s\[\]()]+?)(?:\s+USING\b.*?)?(?=,\s*(?:ADD|ALTER|DROP|RENAME|ENABLE|DISABLE)\b|$)/gi;
+    const alterTypeRe = /ALTER\s+COLUMN\s+"?(\w+)"?\s+TYPE\s+([\w\s\[\](,)]+?)(?:\s+USING\b.*?)?(?=,\s*(?:ADD|ALTER|DROP|RENAME|ENABLE|DISABLE)\b|$)/gi;
     for (const a of actions.matchAll(alterTypeRe)) {
       const colName = a[1];
       const rawType = a[2].trim().toUpperCase();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4103.

Closes #4103

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4e0be75 fix(gen-db-types): handle NUMERIC(p, s) in ALTER COLUMN ... TYPE regex (closes #4103)

### Files changed

```
 scripts/gen-db-types.mjs | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```