### PR TITLE
Uzupełnić ślad aktywności dla wszystkich encji Gabinetu

### DIFF
--- a/convex/gabinet/equipment.ts
+++ b/convex/gabinet/equipment.ts
@@ -6,6 +6,7 @@ import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { verifyOrgAccess } from "../_helpers/auth";
 import { checkModuleAccess } from "../_helpers/products";
 import { logError } from "../_helpers/logged";
+import { logActivity } from "../_helpers/activities";
 import type {
   GabinetEquipmentRow,
   GabinetLocationRow,
@@ -165,6 +166,18 @@ export const createEquipment = action({
       updatedAt: now,
     });
 
+    try {
+      await ctx.runMutation(internal.gabinet.equipment._createEquipmentSideEffects, {
+        organizationId: args.organizationId,
+        equipmentId,
+        name: args.name,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[equipment.createEquipment] Side effects FAILED:", e);
+    }
+
     return equipmentId;
     } catch (err) {
       await logError(ctx, err, {
@@ -198,7 +211,7 @@ export const updateEquipment = action({
   },
   handler: async (ctx, args) => {
     try {
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -223,6 +236,17 @@ export const updateEquipment = action({
       patch.parameterUnits = parameterUnits === null ? null : normalizeUnits(parameterUnits);
     }
     await db.patch("gabinetEquipment", equipmentId, patch);
+
+    try {
+      await ctx.runMutation(internal.gabinet.equipment._updateEquipmentSideEffects, {
+        organizationId,
+        equipmentId,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[equipment.updateEquipment] Side effects FAILED:", e);
+    }
 
     return equipmentId;
     } catch (err) {
@@ -296,7 +320,82 @@ export const transferEquipment = action({
       updatedAt: now,
     });
 
+    try {
+      await ctx.runMutation(internal.gabinet.equipment._transferEquipmentSideEffects, {
+        organizationId: args.organizationId,
+        equipmentId: args.equipmentId,
+        toLocationId: args.toLocationId,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[equipment.transferEquipment] Side effects FAILED:", e);
+    }
+
     return args.equipmentId;
+  },
+});
+
+export const _createEquipmentSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    equipmentId: v.string(),
+    name: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetEquipment",
+      entityId: args.equipmentId,
+      action: "created",
+      description: `Created equipment "${args.name}"`,
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _updateEquipmentSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    equipmentId: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetEquipment",
+      entityId: args.equipmentId,
+      action: "updated",
+      description: `Updated equipment`,
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _transferEquipmentSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    equipmentId: v.string(),
+    toLocationId: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetEquipment",
+      entityId: args.equipmentId,
+      action: "updated",
+      description: `Transferred equipment to location`,
+      metadata: { toLocationId: args.toLocationId },
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
   },
 });
 

--- a/convex/gabinet/leaveTypes.ts
+++ b/convex/gabinet/leaveTypes.ts
@@ -1,8 +1,10 @@
-import { action } from "../_generated/server";
+import { action, internalMutation } from "../_generated/server";
 import { v } from "convex/values";
+import { Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { logError } from "../_helpers/logged";
+import { logActivity } from "../_helpers/activities";
 import type { GabinetLeaveTypeRow } from "../_helpers/supabaseRows";
 
 // Dual-write refs removed — Supabase is now primary for leaveType writes
@@ -125,6 +127,18 @@ export const create = action({
       updatedAt: now,
     });
 
+    try {
+      await ctx.runMutation(internal.gabinet.leaveTypes._createSideEffects, {
+        organizationId: args.organizationId,
+        leaveTypeId,
+        name: args.name,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[leaveTypes.create] Side effects FAILED:", e);
+    }
+
     return leaveTypeId;
     } catch (err) {
       await logError(ctx, err, {
@@ -151,7 +165,7 @@ export const update = action({
   },
   handler: async (ctx, args) => {
     try {
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -182,6 +196,17 @@ export const update = action({
 
     await db.patch("gabinetLeaveTypes", leaveTypeId, patch);
 
+    try {
+      await ctx.runMutation(internal.gabinet.leaveTypes._updateSideEffects, {
+        organizationId,
+        leaveTypeId,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[leaveTypes.update] Side effects FAILED:", e);
+    }
+
     return leaveTypeId;
     } catch (err) {
       await logError(ctx, err, {
@@ -201,7 +226,7 @@ export const remove = action({
     leaveTypeId: v.string(),
   },
   handler: async (ctx, args) => {
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -223,6 +248,17 @@ export const remove = action({
       isActive: false,
       updatedAt: Date.now(),
     });
+
+    try {
+      await ctx.runMutation(internal.gabinet.leaveTypes._removeSideEffects, {
+        organizationId: args.organizationId,
+        leaveTypeId: args.leaveTypeId,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[leaveTypes.remove] Side effects FAILED:", e);
+    }
   },
 });
 
@@ -348,7 +384,7 @@ export const adjustBalance = action({
     usedDays: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -371,6 +407,98 @@ export const adjustBalance = action({
     if (args.usedDays !== undefined) updates.usedDays = args.usedDays;
 
     await db.patch("gabinetLeaveBalances", args.balanceId, updates);
+
+    try {
+      await ctx.runMutation(internal.gabinet.leaveTypes._adjustBalanceSideEffects, {
+        organizationId: args.organizationId,
+        balanceId: args.balanceId,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[leaveTypes.adjustBalance] Side effects FAILED:", e);
+    }
+  },
+});
+
+export const _createSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    leaveTypeId: v.string(),
+    name: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetLeaveType",
+      entityId: args.leaveTypeId,
+      action: "created",
+      description: `Created leave type "${args.name}"`,
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _updateSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    leaveTypeId: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetLeaveType",
+      entityId: args.leaveTypeId,
+      action: "updated",
+      description: `Updated leave type`,
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _removeSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    leaveTypeId: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetLeaveType",
+      entityId: args.leaveTypeId,
+      action: "deleted",
+      description: `Deactivated leave type`,
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _adjustBalanceSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    balanceId: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetLeaveBalance",
+      entityId: args.balanceId,
+      action: "updated",
+      description: `Adjusted leave balance`,
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
   },
 });
 

--- a/convex/gabinet/locations.ts
+++ b/convex/gabinet/locations.ts
@@ -1,8 +1,10 @@
-import { action } from "../_generated/server";
+import { action, internalMutation } from "../_generated/server";
 import { v } from "convex/values";
+import { Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { logError } from "../_helpers/logged";
+import { logActivity } from "../_helpers/activities";
 import type {
   GabinetLocationRow,
   GabinetRoomRow,
@@ -130,6 +132,18 @@ export const createLocation = action({
       updatedAt: now,
     });
 
+    try {
+      await ctx.runMutation(internal.gabinet.locations._createLocationSideEffects, {
+        organizationId: args.organizationId,
+        locationId,
+        name: args.name,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[locations.createLocation] Side effects FAILED:", e);
+    }
+
     return locationId;
     } catch (err) {
       await logError(ctx, err, {
@@ -171,7 +185,7 @@ export const updateLocation = action({
   },
   handler: async (ctx, args) => {
     try {
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -192,6 +206,17 @@ export const updateLocation = action({
     const { organizationId, locationId, ...updates } = args;
     const now = Date.now();
     await db.patch("gabinetLocations", locationId, { ...updates, updatedAt: now });
+
+    try {
+      await ctx.runMutation(internal.gabinet.locations._updateLocationSideEffects, {
+        organizationId,
+        locationId,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[locations.updateLocation] Side effects FAILED:", e);
+    }
 
     return locationId;
     } catch (err) {
@@ -218,7 +243,7 @@ export const deleteLocation = action({
     locationId: v.string(),
   },
   handler: async (ctx, args) => {
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -255,6 +280,17 @@ export const deleteLocation = action({
       updatedAt: Date.now(),
     });
 
+    try {
+      await ctx.runMutation(internal.gabinet.locations._deleteLocationSideEffects, {
+        organizationId: args.organizationId,
+        locationId: args.locationId,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[locations.deleteLocation] Side effects FAILED:", e);
+    }
+
     return args.locationId;
   },
 });
@@ -289,7 +325,7 @@ export const createRoom = action({
   },
   handler: async (ctx, args) => {
     try {
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -350,6 +386,19 @@ export const createRoom = action({
       createdAt: now,
     });
 
+    try {
+      await ctx.runMutation(internal.gabinet.locations._createRoomSideEffects, {
+        organizationId: args.organizationId,
+        roomId,
+        name: args.name,
+        locationId: args.locationId,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[locations.createRoom] Side effects FAILED:", e);
+    }
+
     return roomId;
     } catch (err) {
       await logError(ctx, err, {
@@ -379,7 +428,7 @@ export const updateRoom = action({
   },
   handler: async (ctx, args) => {
     try {
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -399,6 +448,17 @@ export const updateRoom = action({
 
     const { organizationId, roomId, ...updates } = args;
     await db.patch("gabinetRooms", roomId, updates);
+
+    try {
+      await ctx.runMutation(internal.gabinet.locations._updateRoomSideEffects, {
+        organizationId,
+        roomId,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[locations.updateRoom] Side effects FAILED:", e);
+    }
 
     return roomId;
     } catch (err) {
@@ -425,7 +485,7 @@ export const deleteRoom = action({
     roomId: v.string(),
   },
   handler: async (ctx, args) => {
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -459,6 +519,141 @@ export const deleteRoom = action({
     // Soft-delete
     await db.patch("gabinetRooms", args.roomId, { isActive: false });
 
+    try {
+      await ctx.runMutation(internal.gabinet.locations._deleteRoomSideEffects, {
+        organizationId: args.organizationId,
+        roomId: args.roomId,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[locations.deleteRoom] Side effects FAILED:", e);
+    }
+
     return args.roomId;
+  },
+});
+
+export const _createLocationSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    locationId: v.string(),
+    name: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetLocation",
+      entityId: args.locationId,
+      action: "created",
+      description: `Created location "${args.name}"`,
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _updateLocationSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    locationId: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetLocation",
+      entityId: args.locationId,
+      action: "updated",
+      description: `Updated location`,
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _deleteLocationSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    locationId: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetLocation",
+      entityId: args.locationId,
+      action: "deleted",
+      description: `Deactivated location`,
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _createRoomSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    roomId: v.string(),
+    name: v.string(),
+    locationId: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetRoom",
+      entityId: args.roomId,
+      action: "created",
+      description: `Created room "${args.name}"`,
+      metadata: { locationId: args.locationId },
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _updateRoomSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    roomId: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetRoom",
+      entityId: args.roomId,
+      action: "updated",
+      description: `Updated room`,
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _deleteRoomSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    roomId: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetRoom",
+      entityId: args.roomId,
+      action: "deleted",
+      description: `Deactivated room`,
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
   },
 });

--- a/convex/gabinet/loyalty.ts
+++ b/convex/gabinet/loyalty.ts
@@ -1,8 +1,10 @@
-import { action } from "../_generated/server";
+import { action, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
+import { Id } from "../_generated/dataModel";
 import { calculateLoyaltyTier } from "./_helpers/loyaltyTier";
+import { logActivity } from "../_helpers/activities";
 import type { GabinetLoyaltyTier } from "../schema";
 
 // Dual-write refs removed — Supabase is now primary for loyalty writes
@@ -160,6 +162,20 @@ export const earnPoints = action({
       createdAt: now,
     });
 
+    try {
+      await ctx.runMutation(internal.gabinet.loyalty._earnSideEffects, {
+        organizationId: args.organizationId,
+        loyaltyId: String(loyalty!._id),
+        patientId: args.patientId,
+        points: args.points,
+        newBalance,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[loyalty.earnPoints] Side effects FAILED:", e);
+    }
+
     return newBalance;
   },
 });
@@ -249,6 +265,20 @@ export const spendPoints = action({
       createdBy: String(authResult.userId),
       createdAt: now,
     });
+
+    try {
+      await ctx.runMutation(internal.gabinet.loyalty._spendSideEffects, {
+        organizationId: args.organizationId,
+        loyaltyId: String(loyalty!._id),
+        patientId: args.patientId,
+        points: args.points,
+        newBalance,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[loyalty.spendPoints] Side effects FAILED:", e);
+    }
 
     return newBalance;
   },
@@ -344,6 +374,92 @@ export const adjustPoints = action({
       createdAt: now,
     });
 
+    try {
+      await ctx.runMutation(internal.gabinet.loyalty._adjustSideEffects, {
+        organizationId: args.organizationId,
+        loyaltyId: String(loyalty!._id),
+        patientId: args.patientId,
+        points: args.points,
+        newBalance,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[loyalty.adjustPoints] Side effects FAILED:", e);
+    }
+
     return newBalance;
+  },
+});
+
+export const _earnSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    loyaltyId: v.string(),
+    patientId: v.string(),
+    points: v.number(),
+    newBalance: v.number(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetLoyalty",
+      entityId: args.loyaltyId,
+      action: "updated",
+      description: `Earned ${args.points} loyalty points (balance: ${args.newBalance})`,
+      metadata: { type: "earn", points: args.points, newBalance: args.newBalance, patientId: args.patientId },
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _spendSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    loyaltyId: v.string(),
+    patientId: v.string(),
+    points: v.number(),
+    newBalance: v.number(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetLoyalty",
+      entityId: args.loyaltyId,
+      action: "updated",
+      description: `Spent ${args.points} loyalty points (balance: ${args.newBalance})`,
+      metadata: { type: "spend", points: args.points, newBalance: args.newBalance, patientId: args.patientId },
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _adjustSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    loyaltyId: v.string(),
+    patientId: v.string(),
+    points: v.number(),
+    newBalance: v.number(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetLoyalty",
+      entityId: args.loyaltyId,
+      action: "updated",
+      description: `Adjusted loyalty points by ${args.points > 0 ? "+" : ""}${args.points} (balance: ${args.newBalance})`,
+      metadata: { type: "adjust", points: args.points, newBalance: args.newBalance, patientId: args.patientId },
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
   },
 });

--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -1,8 +1,10 @@
-import { action } from "../_generated/server";
+import { action, internalMutation } from "../_generated/server";
 import { v } from "convex/values";
+import { Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { logError } from "../_helpers/logged";
+import { logActivity } from "../_helpers/activities";
 import { gabinetLeaveTypeValidator, gabinetLeaveStatusValidator } from "../schema";
 import { getAvailableSlotsSupabase } from "./_availability_supabase";
 import type {
@@ -61,6 +63,7 @@ export const setWorkingHours = action({
       .eq("dayOfWeek", args.dayOfWeek)
       .first();
 
+    let whId: string;
     if (existing) {
       await db.patch("gabinetWorkingHours", existing._id as string, {
         startTime: args.startTime,
@@ -71,22 +74,34 @@ export const setWorkingHours = action({
         locationId: args.locationId ?? null,
         updatedAt: now,
       });
-      return existing._id as string;
+      whId = existing._id as string;
+    } else {
+      whId = await db.insert("gabinetWorkingHours", {
+        organizationId: String(args.organizationId),
+        dayOfWeek: args.dayOfWeek,
+        startTime: args.startTime,
+        endTime: args.endTime,
+        isOpen: args.isOpen,
+        breakStart: args.breakStart ?? null,
+        breakEnd: args.breakEnd ?? null,
+        locationId: args.locationId ?? null,
+        createdBy: authResult.userId,
+        createdAt: now,
+        updatedAt: now,
+      });
     }
 
-    const whId = await db.insert("gabinetWorkingHours", {
-      organizationId: String(args.organizationId),
-      dayOfWeek: args.dayOfWeek,
-      startTime: args.startTime,
-      endTime: args.endTime,
-      isOpen: args.isOpen,
-      breakStart: args.breakStart ?? null,
-      breakEnd: args.breakEnd ?? null,
-      locationId: args.locationId ?? null,
-      createdBy: authResult.userId,
-      createdAt: now,
-      updatedAt: now,
-    });
+    try {
+      await ctx.runMutation(internal.gabinet.scheduling._workingHoursSideEffects, {
+        organizationId: args.organizationId,
+        workingHoursId: whId,
+        dayOfWeek: args.dayOfWeek,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[scheduling.setWorkingHours] Side effects FAILED:", e);
+    }
 
     return whId;
   },
@@ -150,6 +165,16 @@ export const bulkSetWorkingHours = action({
           updatedAt: now,
         });
       }
+    }
+
+    try {
+      await ctx.runMutation(internal.gabinet.scheduling._bulkWorkingHoursSideEffects, {
+        organizationId: args.organizationId,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[scheduling.bulkSetWorkingHours] Side effects FAILED:", e);
     }
   },
 });
@@ -224,23 +249,36 @@ export const setEmployeeSchedule = action({
       locationId: args.locationId ?? null,
     };
 
+    let scheduleId: string;
     if (existing) {
       await db.patch("gabinetEmployeeSchedules", existing._id as string, {
         ...data,
         updatedAt: now,
       });
-      return existing._id as string;
+      scheduleId = existing._id as string;
+    } else {
+      scheduleId = await db.insert("gabinetEmployeeSchedules", {
+        organizationId: String(args.organizationId),
+        userId: args.userId,
+        dayOfWeek: args.dayOfWeek,
+        ...data,
+        createdBy: authResult.userId,
+        createdAt: now,
+        updatedAt: now,
+      });
     }
 
-    const scheduleId = await db.insert("gabinetEmployeeSchedules", {
-      organizationId: String(args.organizationId),
-      userId: args.userId,
-      dayOfWeek: args.dayOfWeek,
-      ...data,
-      createdBy: authResult.userId,
-      createdAt: now,
-      updatedAt: now,
-    });
+    try {
+      await ctx.runMutation(internal.gabinet.scheduling._employeeScheduleSideEffects, {
+        organizationId: args.organizationId,
+        scheduleId,
+        userId: args.userId,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[scheduling.setEmployeeSchedule] Side effects FAILED:", e);
+    }
 
     return scheduleId;
   },
@@ -313,6 +351,17 @@ export const bulkSetEmployeeSchedule = action({
           updatedAt: now,
         });
       }
+    }
+
+    try {
+      await ctx.runMutation(internal.gabinet.scheduling._bulkEmployeeScheduleSideEffects, {
+        organizationId: args.organizationId,
+        userId: args.userId,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[scheduling.bulkSetEmployeeSchedule] Side effects FAILED:", e);
     }
   },
 });
@@ -392,6 +441,18 @@ export const saveSchedulePeriod = action({
         });
       }
     }
+
+    try {
+      await ctx.runMutation(internal.gabinet.scheduling._saveSchedulePeriodSideEffects, {
+        organizationId: args.organizationId,
+        userId: args.userId,
+        effectiveFrom: args.effectiveFrom,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[scheduling.saveSchedulePeriod] Side effects FAILED:", e);
+    }
   },
 });
 
@@ -405,7 +466,7 @@ export const removeSchedulePeriod = action({
     effectiveFrom: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -428,6 +489,18 @@ export const removeSchedulePeriod = action({
 
     for (const s of toRemove) {
       await db.delete("gabinetEmployeeSchedules", s._id as string);
+    }
+
+    try {
+      await ctx.runMutation(internal.gabinet.scheduling._removeSchedulePeriodSideEffects, {
+        organizationId: args.organizationId,
+        userId: args.userId,
+        effectiveFrom: args.effectiveFrom,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[scheduling.removeSchedulePeriod] Side effects FAILED:", e);
     }
   },
 });
@@ -516,6 +589,21 @@ export const createLeave = action({
       updatedAt: now,
     });
 
+    try {
+      await ctx.runMutation(internal.gabinet.scheduling._createLeaveSideEffects, {
+        organizationId: args.organizationId,
+        leaveId,
+        userId: args.userId,
+        type: args.type,
+        startDate: args.startDate,
+        endDate: args.endDate,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[scheduling.createLeave] Side effects FAILED:", e);
+    }
+
     return leaveId;
     } catch (err) {
       await logError(ctx, err, {
@@ -559,6 +647,19 @@ export const approveLeave = action({
       approvedAt: now,
       updatedAt: now,
     });
+
+    try {
+      await ctx.runMutation(internal.gabinet.scheduling._leaveSideEffects, {
+        organizationId: args.organizationId,
+        leaveId: args.leaveId,
+        action: "status_changed",
+        description: `Leave request approved`,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[scheduling.approveLeave] Side effects FAILED:", e);
+    }
 
     // Update leave balance if leaveTypeId is set
     if (leave.leaveTypeId) {
@@ -622,6 +723,19 @@ export const rejectLeave = action({
       approvedAt: now,
       updatedAt: now,
     });
+
+    try {
+      await ctx.runMutation(internal.gabinet.scheduling._leaveSideEffects, {
+        organizationId: args.organizationId,
+        leaveId: args.leaveId,
+        action: "status_changed",
+        description: `Leave request rejected`,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[scheduling.rejectLeave] Side effects FAILED:", e);
+    }
   },
 });
 
@@ -631,7 +745,7 @@ export const deleteLeave = action({
     leaveId: v.string(),
   },
   handler: async (ctx, args) => {
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -678,6 +792,19 @@ export const deleteLeave = action({
     }
 
     await db.delete("gabinetLeaves", args.leaveId);
+
+    try {
+      await ctx.runMutation(internal.gabinet.scheduling._leaveSideEffects, {
+        organizationId: args.organizationId,
+        leaveId: args.leaveId,
+        action: "deleted",
+        description: `Leave request deleted`,
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[scheduling.deleteLeave] Side effects FAILED:", e);
+    }
   },
 });
 
@@ -717,7 +844,7 @@ export const removeEmployeeSchedule = action({
     scheduleId: v.string(),
   },
   handler: async (ctx, args) => {
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
@@ -735,6 +862,18 @@ export const removeEmployeeSchedule = action({
     }
 
     await db.delete("gabinetEmployeeSchedules", args.scheduleId);
+
+    try {
+      await ctx.runMutation(internal.gabinet.scheduling._employeeScheduleSideEffects, {
+        organizationId: args.organizationId,
+        scheduleId: args.scheduleId,
+        userId: String(schedule.userId),
+        performedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[scheduling.removeEmployeeSchedule] Side effects FAILED:", e);
+    }
   },
 });
 
@@ -798,5 +937,185 @@ export const findNextAvailableSlot = action({
     }
 
     return null;
+  },
+});
+
+export const _workingHoursSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    workingHoursId: v.string(),
+    dayOfWeek: v.number(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetWorkingHours",
+      entityId: args.workingHoursId,
+      action: "updated",
+      description: `Updated working hours for ${days[args.dayOfWeek] ?? `day ${args.dayOfWeek}`}`,
+      metadata: { dayOfWeek: args.dayOfWeek },
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _bulkWorkingHoursSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetWorkingHours",
+      entityId: String(args.organizationId),
+      action: "updated",
+      description: `Updated organization working hours`,
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _employeeScheduleSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    scheduleId: v.string(),
+    userId: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetEmployeeSchedule",
+      entityId: args.scheduleId,
+      action: "updated",
+      description: `Updated employee schedule`,
+      metadata: { userId: args.userId },
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _bulkEmployeeScheduleSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    userId: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetEmployeeSchedule",
+      entityId: args.userId,
+      action: "updated",
+      description: `Updated employee weekly schedule`,
+      metadata: { userId: args.userId },
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _saveSchedulePeriodSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    userId: v.string(),
+    effectiveFrom: v.optional(v.string()),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetEmployeeSchedule",
+      entityId: args.userId,
+      action: "updated",
+      description: args.effectiveFrom
+        ? `Saved schedule period from ${args.effectiveFrom}`
+        : `Saved default schedule period`,
+      metadata: { userId: args.userId, effectiveFrom: args.effectiveFrom },
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _removeSchedulePeriodSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    userId: v.string(),
+    effectiveFrom: v.optional(v.string()),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetEmployeeSchedule",
+      entityId: args.userId,
+      action: "deleted",
+      description: args.effectiveFrom
+        ? `Removed schedule period from ${args.effectiveFrom}`
+        : `Removed default schedule period`,
+      metadata: { userId: args.userId, effectiveFrom: args.effectiveFrom },
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _createLeaveSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    leaveId: v.string(),
+    userId: v.string(),
+    type: v.string(),
+    startDate: v.string(),
+    endDate: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetLeave",
+      entityId: args.leaveId,
+      action: "created",
+      description: `Leave request created (${args.type}: ${args.startDate} – ${args.endDate})`,
+      metadata: { userId: args.userId, type: args.type, startDate: args.startDate, endDate: args.endDate },
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const _leaveSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    leaveId: v.string(),
+    action: v.union(v.literal("status_changed"), v.literal("deleted")),
+    description: v.string(),
+    performedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "gabinetLeave",
+      entityId: args.leaveId,
+      action: args.action,
+      description: args.description,
+      performedBy: args.performedBy as Id<"users">,
+      actorLabel: args.actorLabel,
+    });
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4131.

Closes #4131

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a1de1b4 feat(gabinet): add activity trail for loyalty, scheduling, leave types, locations, and equipment (closes #4131)

### Files changed

```
 convex/gabinet/equipment.ts  | 101 +++++++++++-
 convex/gabinet/leaveTypes.ts | 136 +++++++++++++++-
 convex/gabinet/locations.ts  | 207 +++++++++++++++++++++++-
 convex/gabinet/loyalty.ts    | 118 +++++++++++++-
 convex/gabinet/scheduling.ts | 375 +++++++++++++++++++++++++++++++++++++++----
 5 files changed, 897 insertions(+), 40 deletions(-)
```