### PR TITLE
Expose employee/patient activity timelines to cover new entity types

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -225,6 +225,13 @@ function EmployeeDetail() {
     employeeId,
   );
 
+  const { data: scheduleActivities } = useSupabaseActivitiesByEntity(
+    organizationId,
+    "gabinetEmployeeSchedule",
+    employee?.userId ?? undefined,
+    { enabled: !!employee?.userId },
+  );
+
   const { data: scheduledActivitiesData } = useSupabaseScheduledActivitiesByEntity(
     organizationId,
     "gabinetEmployee",
@@ -532,6 +539,11 @@ function EmployeeDetail() {
     </div>
   );
 
+  const mergedEmployeeActivities = [
+    ...(activities ?? []),
+    ...(scheduleActivities ?? []),
+  ].sort((a, b) => b.createdAt - a.createdAt);
+
   // Tabs definition
   const tabs = !employee ? [] : [
     {
@@ -780,7 +792,7 @@ function EmployeeDetail() {
       label: t("gabinet.employees.activity"),
       content: (
         <ActivityFeed
-          entries={activitiesToFeedEntries(activities ?? [], t)}
+          entries={activitiesToFeedEntries(mergedEmployeeActivities, t)}
           maxHeight="600px"
         />
       ),

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -321,6 +321,13 @@ function PatientDetail() {
     patientId,
   );
 
+  const { data: loyaltyActivities } = useSupabaseActivitiesByEntity(
+    organizationId,
+    "gabinetLoyalty",
+    loyaltyBalance?._id,
+    { enabled: !!loyaltyBalance?._id },
+  );
+
   const { data: loyaltyTransactions } = useSupabaseGabinetLoyaltyTransactions(
     organizationId,
     patientId,
@@ -1238,6 +1245,11 @@ function PatientDetail() {
       </div>
     );
   };
+
+  const mergedPatientActivities = [
+    ...(activities ?? []),
+    ...(loyaltyActivities ?? []),
+  ].sort((a, b) => b.createdAt - a.createdAt);
 
   const tabs = [
     {
@@ -2229,7 +2241,7 @@ function PatientDetail() {
       label: t("gabinet.patients.tabs.activity"),
       content: (
         <ActivityFeed
-          entries={activitiesToFeedEntries((activities ?? []) as any[], t)}
+          entries={activitiesToFeedEntries(mergedPatientActivities as any[], t)}
           maxHeight="600px"
         />
       ),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4135.

Closes #4135

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f87468a feat(gabinet): expose loyalty and schedule activities in patient/employee timelines (closes #4135)

### Files changed

```
 .../dashboard/_layout.gabinet.employees.$employeeId.tsx    | 14 +++++++++++++-
 .../dashboard/_layout.gabinet.patients.$patientId.tsx      | 14 +++++++++++++-
 2 files changed, 26 insertions(+), 2 deletions(-)
```