### PR TITLE
Expose gabinetLeave activities on the employee timeline

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -652,6 +652,7 @@ export const approveLeave = action({
       await ctx.runMutation(internal.gabinet.scheduling._leaveSideEffects, {
         organizationId: args.organizationId,
         leaveId: args.leaveId,
+        userId: leave.userId as string,
         action: "status_changed",
         description: `Leave request approved`,
         performedBy: String(authResult.userId),
@@ -728,6 +729,7 @@ export const rejectLeave = action({
       await ctx.runMutation(internal.gabinet.scheduling._leaveSideEffects, {
         organizationId: args.organizationId,
         leaveId: args.leaveId,
+        userId: leave.userId as string,
         action: "status_changed",
         description: `Leave request rejected`,
         performedBy: String(authResult.userId),
@@ -797,6 +799,7 @@ export const deleteLeave = action({
       await ctx.runMutation(internal.gabinet.scheduling._leaveSideEffects, {
         organizationId: args.organizationId,
         leaveId: args.leaveId,
+        userId: leave.userId as string,
         action: "deleted",
         description: `Leave request deleted`,
         performedBy: String(authResult.userId),
@@ -1088,10 +1091,10 @@ export const _createLeaveSideEffects = internalMutation({
     await logActivity(ctx, {
       organizationId: args.organizationId,
       entityType: "gabinetLeave",
-      entityId: args.leaveId,
+      entityId: args.userId,
       action: "created",
       description: `Leave request created (${args.type}: ${args.startDate} – ${args.endDate})`,
-      metadata: { userId: args.userId, type: args.type, startDate: args.startDate, endDate: args.endDate },
+      metadata: { leaveId: args.leaveId, type: args.type, startDate: args.startDate, endDate: args.endDate },
       performedBy: args.performedBy as Id<"users">,
       actorLabel: args.actorLabel,
     });
@@ -1102,6 +1105,7 @@ export const _leaveSideEffects = internalMutation({
   args: {
     organizationId: v.id("organizations"),
     leaveId: v.string(),
+    userId: v.string(),
     action: v.union(v.literal("status_changed"), v.literal("deleted")),
     description: v.string(),
     performedBy: v.string(),
@@ -1111,9 +1115,10 @@ export const _leaveSideEffects = internalMutation({
     await logActivity(ctx, {
       organizationId: args.organizationId,
       entityType: "gabinetLeave",
-      entityId: args.leaveId,
+      entityId: args.userId,
       action: args.action,
       description: args.description,
+      metadata: { leaveId: args.leaveId },
       performedBy: args.performedBy as Id<"users">,
       actorLabel: args.actorLabel,
     });

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -232,6 +232,13 @@ function EmployeeDetail() {
     { enabled: !!employee?.userId },
   );
 
+  const { data: leaveActivities } = useSupabaseActivitiesByEntity(
+    organizationId,
+    "gabinetLeave",
+    employee?.userId ?? undefined,
+    { enabled: !!employee?.userId },
+  );
+
   const { data: scheduledActivitiesData } = useSupabaseScheduledActivitiesByEntity(
     organizationId,
     "gabinetEmployee",
@@ -542,6 +549,7 @@ function EmployeeDetail() {
   const mergedEmployeeActivities = [
     ...(activities ?? []),
     ...(scheduleActivities ?? []),
+    ...(leaveActivities ?? []),
   ].sort((a, b) => b.createdAt - a.createdAt);
 
   // Tabs definition


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4138.

Closes #4138

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d729352 feat(gabinet): expose gabinetLeave activities on employee timeline (closes #4138)

### Files changed

```
 convex/gabinet/scheduling.ts                                  | 11 ++++++++---
 .../_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx |  8 ++++++++
 2 files changed, 16 insertions(+), 3 deletions(-)
```