### PR TITLE
Add activity sections to settings pages for org-level entity types

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
@@ -38,6 +38,9 @@ import {
   Trash2,
 } from "@/lib/ez-icons";
 import { useState } from "react";
+import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
+import { ActivityTimeline } from "@/components/activity-timeline/activity-timeline";
+import type { ActivityWithMetadata } from "@/components/activity-timeline/presenter/activity-presenter";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
@@ -250,6 +253,7 @@ function EquipmentCard({
   const [saving, setSaving] = useState(false);
   const [transferOpen, setTransferOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [activityOpen, setActivityOpen] = useState(false);
   const [transferLocationId, setTransferLocationId] = useState<string>("");
   const [transferRoomId, setTransferRoomId] = useState<string>("");
   const [transferNotes, setTransferNotes] = useState("");
@@ -259,6 +263,13 @@ function EquipmentCard({
 
   const updateEquipment = useAction(api.gabinet.equipment.updateEquipment);
   const transferEquipment = useAction(api.gabinet.equipment.transferEquipment);
+
+  const { data: equipmentActivities } = useSupabaseActivitiesByEntity(
+    organizationId as string,
+    "gabinetEquipment",
+    item._id as string,
+    { enabled: expanded && activityOpen },
+  );
 
   const getLocationAction = useAction(api.gabinet.locations.getLocation);
   const { data: selectedLocationData } = useQuery({
@@ -476,20 +487,35 @@ function EquipmentCard({
             </div>
 
             <div className="flex items-center justify-between pt-2">
-              <Button
-                size="sm"
-                variant="ghost"
-                className="gap-1.5 text-muted-foreground"
-                onClick={() => setHistoryOpen((v) => !v)}
-              >
-                <History className="h-4 w-4" variant="stroke" />
-                {t("gabinet.equipment.transferHistory")}
-                {historyOpen ? (
-                  <ChevronDown className="h-3 w-3" variant="stroke" />
-                ) : (
-                  <ChevronRight className="h-3 w-3" variant="stroke" />
-                )}
-              </Button>
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="gap-1.5 text-muted-foreground"
+                  onClick={() => setHistoryOpen((v) => !v)}
+                >
+                  <History className="h-4 w-4" variant="stroke" />
+                  {t("gabinet.equipment.transferHistory")}
+                  {historyOpen ? (
+                    <ChevronDown className="h-3 w-3" variant="stroke" />
+                  ) : (
+                    <ChevronRight className="h-3 w-3" variant="stroke" />
+                  )}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="gap-1.5 text-muted-foreground"
+                  onClick={() => setActivityOpen((v) => !v)}
+                >
+                  {t("dashboard.recentActivity")}
+                  {activityOpen ? (
+                    <ChevronDown className="h-3 w-3" variant="stroke" />
+                  ) : (
+                    <ChevronRight className="h-3 w-3" variant="stroke" />
+                  )}
+                </Button>
+              </div>
               {canEdit && (
                 <Button
                   size="sm"
@@ -506,6 +532,13 @@ function EquipmentCard({
                 equipmentId={item._id as Id<"gabinetEquipment">}
                 organizationId={organizationId}
                 locations={locations}
+              />
+            )}
+
+            {activityOpen && (
+              <ActivityTimeline
+                activities={(equipmentActivities ?? []) as ActivityWithMetadata[]}
+                maxHeight="200px"
               />
             )}
           </div>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leave-types.tsx
@@ -18,6 +18,9 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { Plus, Pencil } from "@/lib/ez-icons";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
+import { ActivityTimeline } from "@/components/activity-timeline/activity-timeline";
+import type { ActivityWithMetadata } from "@/components/activity-timeline/presenter/activity-presenter";
 import { toast } from "sonner";
 import { Id } from "@cvx/_generated/dataModel";
 import { formatActionError } from "@/lib/format-action-error";
@@ -170,6 +173,8 @@ function LeaveTypesSettings() {
           open={!!editingId}
           onClose={() => setEditingId(null)}
           initial={editing}
+          leaveTypeId={editingId ?? undefined}
+          organizationId={organizationId as string}
           onSubmit={async (data) => {
             await updateLeaveType({ organizationId, leaveTypeId: editingId! as Id<"gabinetLeaveTypes">, ...data });
             toast.success(t("common.saved"));
@@ -215,6 +220,8 @@ function LeaveTypeDialog({
   open,
   onClose,
   initial,
+  leaveTypeId,
+  organizationId,
   onSubmit,
   onDelete,
   t,
@@ -229,6 +236,8 @@ function LeaveTypeDialog({
     requiresApproval: boolean;
     isActive: boolean;
   };
+  leaveTypeId?: string;
+  organizationId?: string;
   onSubmit: (data: {
     name: string;
     color?: string;
@@ -247,6 +256,13 @@ function LeaveTypeDialog({
   const [requiresApproval, setRequiresApproval] = useState(initial?.requiresApproval ?? true);
   const [isActive, setIsActive] = useState(initial?.isActive ?? true);
   const [saving, setSaving] = useState(false);
+
+  const { data: leaveTypeActivities } = useSupabaseActivitiesByEntity(
+    organizationId ?? "",
+    "gabinetLeaveType",
+    leaveTypeId,
+    { enabled: !!leaveTypeId && !!organizationId },
+  );
 
   const handleSubmit = async () => {
     if (!name.trim()) return;
@@ -335,6 +351,16 @@ function LeaveTypeDialog({
             </label>
           )}
         </div>
+
+        {leaveTypeId && leaveTypeActivities && leaveTypeActivities.length > 0 && (
+          <div className="space-y-1.5 border-t pt-3">
+            <p className="text-xs font-medium text-muted-foreground">{t("dashboard.recentActivity")}</p>
+            <ActivityTimeline
+              activities={leaveTypeActivities as ActivityWithMetadata[]}
+              maxHeight="180px"
+            />
+          </div>
+        )}
 
         <DialogFooter className="flex gap-2">
           {onDelete && (

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
@@ -29,9 +29,12 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Id } from "@cvx/_generated/dataModel";
-import { Plus, Trash2, ChevronDown, ChevronRight, MapPin, Phone } from "@/lib/ez-icons";
+import { Plus, Trash2, ChevronDown, ChevronRight, MapPin, Phone, History } from "@/lib/ez-icons";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
+import { ActivityTimeline } from "@/components/activity-timeline/activity-timeline";
+import type { ActivityWithMetadata } from "@/components/activity-timeline/presenter/activity-presenter";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
 import { PermissionGate, usePermission } from "@/hooks/use-permission";
@@ -79,6 +82,101 @@ type LocationWithRooms = {
   }>;
 };
 
+function RoomRow({
+  room,
+  organizationId,
+  canEdit,
+  canDelete,
+  onToggle,
+  onDelete,
+}: {
+  room: { _id: Id<"gabinetRooms">; name: string; floor?: string; isActive: boolean };
+  organizationId: Id<"organizations">;
+  canEdit: boolean;
+  canDelete: boolean;
+  onToggle: (roomId: Id<"gabinetRooms">, isActive: boolean) => void;
+  onDelete: (roomId: Id<"gabinetRooms">) => void;
+}) {
+  const { t } = useTranslation();
+  const [showActivity, setShowActivity] = useState(false);
+
+  const { data: roomActivities } = useSupabaseActivitiesByEntity(
+    organizationId as string,
+    "gabinetRoom",
+    room._id as string,
+    { enabled: showActivity },
+  );
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 px-3 py-2">
+        <span className="flex-1 text-sm">{room.name}</span>
+        {room.floor && (
+          <span className="text-xs text-muted-foreground">
+            {t("gabinet.locations.floor")}: {room.floor}
+          </span>
+        )}
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
+          onClick={() => setShowActivity((v) => !v)}
+          title={t("dashboard.recentActivity")}
+        >
+          <History className="h-3.5 w-3.5" variant="stroke" />
+        </Button>
+        {canEdit ? (
+          <button
+            type="button"
+            onClick={() => onToggle(room._id, room.isActive)}
+            className="text-xs"
+          >
+            {room.isActive ? (
+              <Badge variant="default" className="text-[10px] cursor-pointer">
+                {t("common.active")}
+              </Badge>
+            ) : (
+              <Badge variant="secondary" className="text-[10px] cursor-pointer">
+                {t("common.inactive")}
+              </Badge>
+            )}
+          </button>
+        ) : (
+          <span className="text-xs">
+            {room.isActive ? (
+              <Badge variant="default" className="text-[10px]">
+                {t("common.active")}
+              </Badge>
+            ) : (
+              <Badge variant="secondary" className="text-[10px]">
+                {t("common.inactive")}
+              </Badge>
+            )}
+          </span>
+        )}
+        {canDelete && (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+            onClick={() => onDelete(room._id)}
+          >
+            <Trash2 className="h-3.5 w-3.5" variant="stroke" />
+          </Button>
+        )}
+      </div>
+      {showActivity && (
+        <div className="px-3 pb-2">
+          <ActivityTimeline
+            activities={(roomActivities ?? []) as ActivityWithMetadata[]}
+            maxHeight="180px"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
 function LocationCard({
   locationId,
   organizationId,
@@ -123,6 +221,13 @@ function LocationCard({
   const createRoom = useAction(api.gabinet.locations.createRoom);
   const updateRoom = useAction(api.gabinet.locations.updateRoom);
   const deleteRoom = useAction(api.gabinet.locations.deleteRoom);
+
+  const { data: locationActivities } = useSupabaseActivitiesByEntity(
+    organizationId as string,
+    "gabinetLocation",
+    locationId as string,
+    { enabled: expanded },
+  );
 
   // Summary card always uses the list data (passed via parent), so we need the basic info
   // Use the fetched data when expanded, otherwise use the location prop from parent list
@@ -442,56 +547,29 @@ function LocationCard({
               ) : (
                 <div className="rounded-md border divide-y">
                   {location.rooms.map((room) => (
-                    <div key={room._id} className="flex items-center gap-3 px-3 py-2">
-                      <span className="flex-1 text-sm">{room.name}</span>
-                      {room.floor && (
-                        <span className="text-xs text-muted-foreground">
-                          {t("gabinet.locations.floor")}: {room.floor}
-                        </span>
-                      )}
-                      {canEdit ? (
-                        <button
-                          type="button"
-                          onClick={() => handleToggleRoom(room._id, room.isActive)}
-                          className="text-xs"
-                        >
-                          {room.isActive ? (
-                            <Badge variant="default" className="text-[10px] cursor-pointer">
-                              {t("common.active")}
-                            </Badge>
-                          ) : (
-                            <Badge variant="secondary" className="text-[10px] cursor-pointer">
-                              {t("common.inactive")}
-                            </Badge>
-                          )}
-                        </button>
-                      ) : (
-                        <span className="text-xs">
-                          {room.isActive ? (
-                            <Badge variant="default" className="text-[10px]">
-                              {t("common.active")}
-                            </Badge>
-                          ) : (
-                            <Badge variant="secondary" className="text-[10px]">
-                              {t("common.inactive")}
-                            </Badge>
-                          )}
-                        </span>
-                      )}
-                      {canDelete && (
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                          onClick={() => handleDeleteRoom(room._id)}
-                        >
-                          <Trash2 className="h-3.5 w-3.5" variant="stroke" />
-                        </Button>
-                      )}
-                    </div>
+                    <RoomRow
+                      key={room._id}
+                      room={room}
+                      organizationId={organizationId}
+                      canEdit={canEdit}
+                      canDelete={canDelete}
+                      onToggle={handleToggleRoom}
+                      onDelete={handleDeleteRoom}
+                    />
                   ))}
                 </div>
               )}
+            </div>
+
+            <Separator />
+
+            {/* Location activity section */}
+            <div className="space-y-2">
+              <h4 className="text-sm font-medium">{t("dashboard.recentActivity")}</h4>
+              <ActivityTimeline
+                activities={(locationActivities ?? []) as ActivityWithMetadata[]}
+                maxHeight="200px"
+              />
             </div>
           </div>
         </>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4139.

Closes #4139

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 22d8c62 feat(gabinet): add activity timeline sections to settings pages (closes #4139)

### Files changed

```
 .../_layout.gabinet.settings.equipment.tsx         |  61 ++++++--
 .../_layout.gabinet.settings.leave-types.tsx       |  26 +++
 .../_layout.gabinet.settings.locations.tsx         | 174 +++++++++++++++------
 3 files changed, 199 insertions(+), 62 deletions(-)
```