### PR TITLE
Add activity section to `gabinetWorkingHours` UI

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.scheduling.tsx
@@ -22,6 +22,9 @@ import { formatActionError } from "@/lib/format-action-error";
 import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
+import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
+import { ActivityTimeline } from "@/components/activity-timeline/activity-timeline";
+import type { ActivityWithMetadata } from "@/components/activity-timeline/presenter/activity-presenter";
 
 function SchedulingSettingsSkeleton() {
   return (
@@ -133,6 +136,12 @@ function SchedulingSettings() {
   const { allowed: canEdit } = usePermission("gabinet_settings", "edit");
   const bulkSet = useAction(api.gabinet.scheduling.bulkSetWorkingHours);
   const [saving, setSaving] = useState(false);
+
+  const { data: workingHoursActivities } = useSupabaseActivitiesByEntity(
+    organizationId,
+    "gabinetWorkingHours",
+    organizationId,
+  );
 
   const { data: existing } = useSupabaseGabinetWorkingHoursList(organizationId);
 
@@ -368,6 +377,16 @@ function SchedulingSettings() {
           <Button onClick={handleSave} disabled={saving || validationErrors.length > 0 || breakErrors.length > 0}>
             {saving ? t("common.saving") : t("common.save")}
           </Button>
+        </div>
+      )}
+
+      {workingHoursActivities && workingHoursActivities.length > 0 && (
+        <div className="space-y-1.5 border-t pt-4">
+          <p className="text-xs font-medium text-muted-foreground">{t("dashboard.recentActivity")}</p>
+          <ActivityTimeline
+            activities={workingHoursActivities as ActivityWithMetadata[]}
+            maxHeight="240px"
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4140.

Closes #4140

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- fc3569a feat(gabinet): add activity timeline to scheduling settings page (closes #4140)

### Files changed

```
 .../dashboard/_layout.gabinet.settings.scheduling.tsx | 19 +++++++++++++++++++
 1 file changed, 19 insertions(+)
```