### PR TITLE
Wyłączyć okres łaski w getActiveProducts

### DIFF
--- a/convex/productSubscriptions.ts
+++ b/convex/productSubscriptions.ts
@@ -11,11 +11,6 @@ export const getActiveProducts = query({
       .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
       .collect();
 
-    // If no subscriptions exist at all, return all products (grace period)
-    if (subs.length === 0) {
-      return ["crm", "gabinet"];
-    }
-
     return subs
       .filter((s) => s.status === "active" || s.status === "trialing")
       .map((s) => s.productId);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4150.

Closes #4150

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f9894e9 fix(platform): remove grace period in getActiveProducts (closes #4150)

### Files changed

```
 convex/productSubscriptions.ts | 5 -----
 1 file changed, 5 deletions(-)
```