### PR TITLE
Audit other `getActive*` / `getEnabled*` queries for similar grace-period patter

### DIFF
--- a/convex/_helpers/products.ts
+++ b/convex/_helpers/products.ts
@@ -6,10 +6,6 @@ import { GABINET_MODULES, GABINET_PRODUCT_ID, type GabinetModule } from "../gabi
 /**
  * Verify that the organization has an active subscription for a specific product.
  * Throws if no active subscription exists.
- *
- * During development/MVP, if no productSubscriptions exist at all,
- * access is granted (grace period). Once the first productSubscription is created
- * for any org, enforcement begins.
  */
 export async function verifyProductAccess(
   ctx: QueryCtx,
@@ -24,12 +20,6 @@ export async function verifyProductAccess(
     .first();
 
   if (!subscription) {
-    // Grace period: if no subscriptions exist at all, allow access
-    const anySubscription = await ctx.db
-      .query("productSubscriptions")
-      .first();
-    if (!anySubscription) return; // no enforcement yet
-
     throw new Error(`No active subscription for product: ${productId}`);
   }
 

--- a/tests/convex/productAccess.test.ts
+++ b/tests/convex/productAccess.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, describe } from "vitest";
 import { api } from "../../convex/_generated/api";
 import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { verifyProductAccess } from "../../convex/_helpers/products";
 
 describe("getActiveProducts", () => {
   test("returns empty array when org has no subscriptions", async () => {
@@ -107,5 +108,118 @@ describe("getActiveProducts", () => {
     );
 
     expect(products).not.toContain("crm");
+  });
+});
+
+describe("verifyProductAccess", () => {
+  test("throws when org has no subscriptions at all (no grace period)", async () => {
+    const t = createTestCtx();
+    const { organizationId } = await seedTestUser(t);
+
+    await expect(
+      t.run(async (ctx) => {
+        await verifyProductAccess(ctx, organizationId, "gabinet");
+      }),
+    ).rejects.toThrow("No active subscription for product: gabinet");
+  });
+
+  test("throws when other orgs have subscriptions but this org does not", async () => {
+    const t = createTestCtx();
+    const { organizationId } = await seedTestUser(t);
+
+    // Seed a subscription for a different org
+    await t.run(async (ctx) => {
+      const otherUserId = await ctx.db.insert("users", {
+        name: "Other User",
+        email: "other@example.com",
+      });
+      const otherOrgId = await ctx.db.insert("organizations", {
+        name: "Other Org",
+        slug: "other-org",
+        ownerId: otherUserId,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      await ctx.db.insert("productSubscriptions", {
+        organizationId: otherOrgId,
+        productId: "gabinet",
+        status: "active",
+        cancelAtPeriodEnd: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    await expect(
+      t.run(async (ctx) => {
+        await verifyProductAccess(ctx, organizationId, "gabinet");
+      }),
+    ).rejects.toThrow("No active subscription for product: gabinet");
+  });
+
+  test("allows access for active subscription", async () => {
+    const t = createTestCtx();
+    const { organizationId } = await seedTestUser(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("productSubscriptions", {
+        organizationId,
+        productId: "gabinet",
+        status: "active",
+        cancelAtPeriodEnd: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    await expect(
+      t.run(async (ctx) => {
+        await verifyProductAccess(ctx, organizationId, "gabinet");
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("allows access for trialing subscription", async () => {
+    const t = createTestCtx();
+    const { organizationId } = await seedTestUser(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("productSubscriptions", {
+        organizationId,
+        productId: "gabinet",
+        status: "trialing",
+        cancelAtPeriodEnd: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    await expect(
+      t.run(async (ctx) => {
+        await verifyProductAccess(ctx, organizationId, "gabinet");
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("throws for canceled subscription", async () => {
+    const t = createTestCtx();
+    const { organizationId } = await seedTestUser(t);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("productSubscriptions", {
+        organizationId,
+        productId: "gabinet",
+        status: "canceled",
+        cancelAtPeriodEnd: false,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+    });
+
+    await expect(
+      t.run(async (ctx) => {
+        await verifyProductAccess(ctx, organizationId, "gabinet");
+      }),
+    ).rejects.toThrow("Subscription for gabinet is canceled");
   });
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4154.

Closes #4154

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0acd9cf fix(platform): remove grace period from verifyProductAccess (closes #4154)

### Files changed

```
 convex/_helpers/products.ts        |  10 ----
 tests/convex/productAccess.test.ts | 114 +++++++++++++++++++++++++++++++++++++
 2 files changed, 114 insertions(+), 10 deletions(-)
```