### PR TITLE
Migracja gabinetDocuments do documentInstances

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -603,7 +603,7 @@ function GabinetDocumentsPage() {
 
   // --- Column visibility ---
   const { allColumns, defaultHidden } = useAllColumns(columns, filterableFields);
-  const { hiddenColumnIds, toggleColumn, setHiddenColumns: _setHiddenColumns } = useColumnVisibility(defaultHidden, "gabinetDocuments");
+  const { hiddenColumnIds, toggleColumn, setHiddenColumns: _setHiddenColumns } = useColumnVisibility(defaultHidden, "gabinet-documents");
 
   // --- Handlers ---
   const handleResendSigningEmail = (docId: string) => {
@@ -778,7 +778,7 @@ function GabinetDocumentsPage() {
       {/* Statistics — below the list so the document list stays primary */}
       {!docsLoading && documents && documents.length > 0 && (
         <MiniChartsRow
-          storageKey="gabinetDocuments"
+          storageKey="gabinet-documents"
           leftChart={{
             title: t("gabinet.formDocuments.byDay", "Dokumenty w czasie"),
             data: documentsByDay,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4163.

Closes #4163

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e71d914 fix(gabinet): remove last gabinetDocuments references in documents page (closes #4163)

### Files changed

```
 src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```