### PR TITLE
Rozszerzyć logAudit na operacje wrażliwe

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -894,6 +894,15 @@ export const _createSideEffects = internalMutation({
       actorLabel: args.actorLabel,
     });
 
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: createdByUserId,
+      action: "appointment_created",
+      entityType: "gabinetAppointment",
+      entityId: args.appointmentId,
+      details: `Created appointment for patient ${args.patientId} on ${args.date} at ${args.startTime}`,
+    });
+
     // --- 6. Schedule reminders (inline — avoid DB read since appointment is in Supabase) ---
     if (args.sendReminder) {
       try {
@@ -1960,6 +1969,15 @@ export const _updateSideEffects = internalMutation({
       },
       performedBy: actorUserId,
       actorLabel: args.actorLabel,
+    });
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: actorUserId,
+      action: "appointment_updated",
+      entityType: "gabinetAppointment",
+      entityId: args.appointmentId,
+      details: description,
     });
 
     // A "significant" reschedule is one where the patient's calendar changes:

--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { internal } from "../_generated/api";
 import { logActivity } from "../_helpers/activities";
+import { logAudit } from "../auditLog";
 import { logError } from "../_helpers/logged";
 import { gabinetEmployeeRoleValidator } from "../schema";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
@@ -582,6 +583,15 @@ export const _createSideEffects = internalMutation({
       performedBy: createdByUserId,
       actorLabel: args.actorLabel,
     });
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: createdByUserId,
+      action: "employee_created",
+      entityType: "gabinetEmployee",
+      entityId: args.employeeId,
+      details: `Created employee profile`,
+    });
   },
 });
 
@@ -781,6 +791,15 @@ export const _updateSideEffects = internalMutation({
       performedBy: updatedByUserId,
       actorLabel: args.actorLabel,
     });
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: updatedByUserId,
+      action: "employee_updated",
+      entityType: "gabinetEmployee",
+      entityId: args.employeeId,
+      details: `Updated employee profile`,
+    });
   },
 });
 
@@ -865,6 +884,15 @@ export const _removeSideEffects = internalMutation({
       description: `Deactivated employee profile`,
       performedBy: deletedByUserId,
       actorLabel: args.actorLabel,
+    });
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: deletedByUserId,
+      action: "employee_deleted",
+      entityType: "gabinetEmployee",
+      entityId: args.employeeId,
+      details: `Deactivated employee profile`,
     });
   },
 });

--- a/convex/gabinet/loyalty.ts
+++ b/convex/gabinet/loyalty.ts
@@ -5,6 +5,7 @@ import { v } from "convex/values";
 import { Id } from "../_generated/dataModel";
 import { calculateLoyaltyTier } from "./_helpers/loyaltyTier";
 import { logActivity } from "../_helpers/activities";
+import { logAudit } from "../auditLog";
 import type { GabinetLoyaltyTier } from "../schema";
 
 // Dual-write refs removed — Supabase is now primary for loyalty writes
@@ -413,6 +414,15 @@ export const _earnSideEffects = internalMutation({
       performedBy: args.performedBy as Id<"users">,
       actorLabel: args.actorLabel,
     });
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: args.performedBy as Id<"users">,
+      action: "loyalty_points_earned",
+      entityType: "gabinetPatient",
+      entityId: args.patientId,
+      details: `Earned ${args.points} loyalty points (new balance: ${args.newBalance})`,
+    });
   },
 });
 
@@ -437,6 +447,15 @@ export const _spendSideEffects = internalMutation({
       performedBy: args.performedBy as Id<"users">,
       actorLabel: args.actorLabel,
     });
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: args.performedBy as Id<"users">,
+      action: "loyalty_points_spent",
+      entityType: "gabinetPatient",
+      entityId: args.patientId,
+      details: `Spent ${args.points} loyalty points (new balance: ${args.newBalance})`,
+    });
   },
 });
 
@@ -460,6 +479,15 @@ export const _adjustSideEffects = internalMutation({
       metadata: { type: "adjust", points: args.points, newBalance: args.newBalance, patientId: args.patientId },
       performedBy: args.performedBy as Id<"users">,
       actorLabel: args.actorLabel,
+    });
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: args.performedBy as Id<"users">,
+      action: "loyalty_points_adjusted",
+      entityType: "gabinetPatient",
+      entityId: args.patientId,
+      details: `Adjusted loyalty points by ${args.points > 0 ? "+" : ""}${args.points} (new balance: ${args.newBalance})`,
     });
   },
 });

--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -479,6 +479,15 @@ export const _createSideEffects = internalMutation({
       actorLabel: args.actorLabel,
     });
 
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: createdByUserId,
+      action: "patient_created",
+      entityType: "gabinetPatient",
+      entityId: args.patientId,
+      details: `Created patient ${args.firstName} ${args.lastName}`,
+    });
+
     await ctx.runMutation(internal.automation.emitEvent, {
       organizationId: args.organizationId,
       module: "gabinet",
@@ -633,6 +642,15 @@ export const _updateSideEffects = internalMutation({
       performedBy: updatedByUserId,
       actorLabel: args.actorLabel,
     });
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: updatedByUserId,
+      action: "patient_updated",
+      entityType: "gabinetPatient",
+      entityId: args.patientId,
+      details: `Updated patient ${args.firstName} ${args.lastName}`,
+    });
   },
 });
 
@@ -719,6 +737,15 @@ export const _removeSideEffects = internalMutation({
       description: `Deleted patient ${args.firstName} ${args.lastName}`,
       performedBy: deletedByUserId,
       actorLabel: args.actorLabel,
+    });
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: deletedByUserId,
+      action: "patient_deleted",
+      entityType: "gabinetPatient",
+      entityId: args.patientId,
+      details: `Deleted patient ${args.firstName} ${args.lastName}`,
     });
   },
 });

--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -4,6 +4,7 @@ import { paginationOptsValidator } from "convex/server";
 import { Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
 import { logActivity } from "../_helpers/activities";
+import { logAudit } from "../auditLog";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { logError } from "../_helpers/logged";
 import type {
@@ -321,6 +322,15 @@ export const _createSideEffects = internalMutation({
       performedBy: createdByUserId,
       actorLabel: args.actorLabel,
     });
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: createdByUserId,
+      action: "treatment_created",
+      entityType: "gabinetTreatment",
+      entityId: args.treatmentId,
+      details: `Created treatment "${args.name}"`,
+    });
   },
 });
 
@@ -475,6 +485,15 @@ export const _updateSideEffects = internalMutation({
       performedBy: updatedByUserId,
       actorLabel: args.actorLabel,
     });
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: updatedByUserId,
+      action: "treatment_updated",
+      entityType: "gabinetTreatment",
+      entityId: args.treatmentId,
+      details: `Updated treatment "${args.treatmentName}"`,
+    });
   },
 });
 
@@ -554,6 +573,15 @@ export const _removeSideEffects = internalMutation({
       description: `Deleted treatment "${args.treatmentName}"`,
       performedBy: deletedByUserId,
       actorLabel: args.actorLabel,
+    });
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: deletedByUserId,
+      action: "treatment_deleted",
+      entityType: "gabinetTreatment",
+      entityId: args.treatmentId,
+      details: `Deleted treatment "${args.treatmentName}"`,
     });
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4176.

Closes #4176

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 728d463 feat(gabinet): extend logAudit to sensitive operations (closes #4176)

### Files changed

```
 convex/gabinet/appointments.ts | 18 ++++++++++++++++++
 convex/gabinet/employees.ts    | 28 ++++++++++++++++++++++++++++
 convex/gabinet/loyalty.ts      | 28 ++++++++++++++++++++++++++++
 convex/gabinet/patients.ts     | 27 +++++++++++++++++++++++++++
 convex/gabinet/treatments.ts   | 28 ++++++++++++++++++++++++++++
 5 files changed, 129 insertions(+)
```