### PR TITLE
Add logAudit to employees.ts changeEmployeePassword

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -1308,5 +1308,37 @@ export const changeEmployeePassword = action({
       provider: "password",
       account: { id: email, secret: args.newPassword },
     });
+
+    try {
+      await ctx.runMutation(internal.gabinet.employees._changePasswordSideEffects, {
+        employeeId: args.employeeId,
+        organizationId: args.organizationId,
+        changedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[employees.changeEmployeePassword] side effects failed:", e);
+    }
+  },
+});
+
+export const _changePasswordSideEffects = internalMutation({
+  args: {
+    employeeId: v.string(),
+    organizationId: v.id("organizations"),
+    changedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const changedByUserId = args.changedBy as Id<"users">;
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: changedByUserId,
+      action: "employee_password_changed",
+      entityType: "gabinetEmployee",
+      entityId: args.employeeId,
+      details: `Changed employee account password`,
+    });
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4182.

Closes #4182

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 168d5f6 feat(gabinet): add logAudit to changeEmployeePassword (closes #4182)

### Files changed

```
 convex/gabinet/employees.ts | 32 ++++++++++++++++++++++++++++++++
 1 file changed, 32 insertions(+)
```