### PR TITLE
Expose `trialEndDate` from Stripe's `trial_end` field on subscription sync

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -162,6 +162,7 @@ const handleUpdateSubscription = async (
       currentPeriodStart: subscription.current_period_start,
       currentPeriodEnd: subscription.current_period_end,
       cancelAtPeriodEnd: subscription.cancel_at_period_end,
+      trialEndDate: subscription.trial_end ?? undefined,
     },
   });
 };
@@ -206,6 +207,7 @@ const handleCheckoutSessionCompleted = async (
       currentPeriodStart: subscription.current_period_start,
       currentPeriodEnd: subscription.current_period_end,
       cancelAtPeriodEnd: subscription.cancel_at_period_end,
+      trialEndDate: subscription.trial_end ?? undefined,
     });
   }
 
@@ -284,6 +286,7 @@ const handleCustomerSubscriptionUpdated = async (
       currentPeriodStart: subscription.current_period_start,
       currentPeriodEnd: subscription.current_period_end,
       cancelAtPeriodEnd: subscription.cancel_at_period_end,
+      trialEndDate: subscription.trial_end ?? undefined,
     });
   }
 
@@ -340,6 +343,7 @@ const handleCustomerSubscriptionCreated = async (
       currentPeriodStart: subscription.current_period_start,
       currentPeriodEnd: subscription.current_period_end,
       cancelAtPeriodEnd: subscription.cancel_at_period_end,
+      trialEndDate: subscription.trial_end ?? undefined,
     });
   }
 

--- a/convex/schema/platform.ts
+++ b/convex/schema/platform.ts
@@ -66,6 +66,7 @@ export function createPlatformTables({
     currentPeriodStart: v.number(),
     currentPeriodEnd: v.number(),
     cancelAtPeriodEnd: v.boolean(),
+    trialEndDate: v.optional(v.number()),
   })
     .index("userId", ["userId"])
     .index("stripeId", ["stripeId"])
@@ -103,6 +104,7 @@ export function createPlatformTables({
     currentPeriodStart: v.optional(v.number()),
     currentPeriodEnd: v.optional(v.number()),
     cancelAtPeriodEnd: v.boolean(),
+    trialEndDate: v.optional(v.number()),
     createdAt: v.number(),
     updatedAt: v.number(),
   })

--- a/convex/stripe.ts
+++ b/convex/stripe.ts
@@ -151,6 +151,7 @@ export const PREAUTH_createSubscription = internalMutation({
     currentPeriodStart: v.number(),
     currentPeriodEnd: v.number(),
     cancelAtPeriodEnd: v.boolean(),
+    trialEndDate: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     // Resolve the incoming plan's productKey so we can scope the uniqueness
@@ -182,6 +183,7 @@ export const PREAUTH_createSubscription = internalMutation({
       currentPeriodStart: args.currentPeriodStart,
       currentPeriodEnd: args.currentPeriodEnd,
       cancelAtPeriodEnd: args.cancelAtPeriodEnd,
+      trialEndDate: args.trialEndDate,
     });
 
     // Dual-write: replicate to Supabase
@@ -198,6 +200,7 @@ export const PREAUTH_createSubscription = internalMutation({
       currentPeriodStart: args.currentPeriodStart,
       currentPeriodEnd: args.currentPeriodEnd,
       cancelAtPeriodEnd: args.cancelAtPeriodEnd,
+      trialEndDate: args.trialEndDate,
     });
   },
 });
@@ -215,6 +218,7 @@ export const PREAUTH_replaceSubscription = internalMutation({
       currentPeriodStart: v.number(),
       currentPeriodEnd: v.number(),
       cancelAtPeriodEnd: v.boolean(),
+      trialEndDate: v.optional(v.number()),
     }),
   },
   handler: async (ctx, args) => {
@@ -260,6 +264,7 @@ export const PREAUTH_replaceSubscription = internalMutation({
       currentPeriodStart: args.input.currentPeriodStart,
       currentPeriodEnd: args.input.currentPeriodEnd,
       cancelAtPeriodEnd: args.input.cancelAtPeriodEnd,
+      trialEndDate: args.input.trialEndDate,
     });
 
     // Dual-write: replicate to Supabase
@@ -276,6 +281,7 @@ export const PREAUTH_replaceSubscription = internalMutation({
       currentPeriodStart: args.input.currentPeriodStart,
       currentPeriodEnd: args.input.currentPeriodEnd,
       cancelAtPeriodEnd: args.input.cancelAtPeriodEnd,
+      trialEndDate: args.input.trialEndDate,
     });
   },
 });
@@ -316,6 +322,7 @@ export const PREAUTH_upsertProductSubscription = internalMutation({
     currentPeriodStart: v.optional(v.number()),
     currentPeriodEnd: v.optional(v.number()),
     cancelAtPeriodEnd: v.boolean(),
+    trialEndDate: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const existing = await ctx.db
@@ -333,6 +340,7 @@ export const PREAUTH_upsertProductSubscription = internalMutation({
         currentPeriodStart: args.currentPeriodStart,
         currentPeriodEnd: args.currentPeriodEnd,
         cancelAtPeriodEnd: args.cancelAtPeriodEnd,
+        trialEndDate: args.trialEndDate,
         updatedAt: now,
       });
     } else {
@@ -344,6 +352,7 @@ export const PREAUTH_upsertProductSubscription = internalMutation({
         currentPeriodStart: args.currentPeriodStart,
         currentPeriodEnd: args.currentPeriodEnd,
         cancelAtPeriodEnd: args.cancelAtPeriodEnd,
+        trialEndDate: args.trialEndDate,
         createdAt: now,
         updatedAt: now,
       });

--- a/convex/supabase/subscriptions.ts
+++ b/convex/supabase/subscriptions.ts
@@ -20,6 +20,7 @@ export const writeSubscriptionToSupabase = internalAction({
     currentPeriodStart: v.number(),
     currentPeriodEnd: v.number(),
     cancelAtPeriodEnd: v.boolean(),
+    trialEndDate: v.optional(v.number()),
   },
   returns: v.object({ success: v.boolean(), id: v.string() }),
   handler: async (_ctx, args) => {
@@ -38,6 +39,7 @@ export const writeSubscriptionToSupabase = internalAction({
       current_period_start: args.currentPeriodStart,
       current_period_end: args.currentPeriodEnd,
       cancel_at_period_end: args.cancelAtPeriodEnd,
+      trial_end_date: args.trialEndDate ?? null,
     };
 
     const data = await upsertWithFkRetry(client, "subscriptions", row)

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -372,6 +372,7 @@ export interface Database {
           current_period_start: number;
           current_period_end: number;
           cancel_at_period_end: boolean;
+          trial_end_date: number | null;
         };
         Insert: {
           id?: string;
@@ -385,6 +386,7 @@ export interface Database {
           current_period_start: number;
           current_period_end: number;
           cancel_at_period_end: boolean;
+          trial_end_date?: number | null;
         };
         Update: {
           id?: string;
@@ -398,6 +400,7 @@ export interface Database {
           current_period_start?: number;
           current_period_end?: number;
           cancel_at_period_end?: boolean;
+          trial_end_date?: number | null;
         };
         Relationships: [
           {
@@ -506,6 +509,7 @@ export interface Database {
           current_period_start: number | null;
           current_period_end: number | null;
           cancel_at_period_end: boolean;
+          trial_end_date: number | null;
           created_at: number;
           updated_at: number;
         };
@@ -518,6 +522,7 @@ export interface Database {
           current_period_start?: number | null;
           current_period_end?: number | null;
           cancel_at_period_end: boolean;
+          trial_end_date?: number | null;
           created_at: number;
           updated_at: number;
         };
@@ -530,6 +535,7 @@ export interface Database {
           current_period_start?: number | null;
           current_period_end?: number | null;
           cancel_at_period_end?: boolean;
+          trial_end_date?: number | null;
           created_at?: number;
           updated_at?: number;
         };

--- a/supabase/migrations/00113_subscriptions_trial_end_date.sql
+++ b/supabase/migrations/00113_subscriptions_trial_end_date.sql
@@ -1,0 +1,21 @@
+-- ============================================================
+-- Migration 00113: Add trial_end_date to subscriptions and
+--   product_subscriptions (closes #4190)
+-- ============================================================
+--
+-- Context:
+--   Stripe sends a trial_end unix timestamp on every subscription object
+--   (customer.subscription.created/updated, checkout.session.completed).
+--   The webhook handlers previously only captured current_period_end, which
+--   equals trial_end during a trial period but diverges if the trial is
+--   manually extended in the Stripe dashboard. A dedicated column makes the
+--   trial boundary explicit and survivable across period renewals.
+--
+--   The column is nullable: non-trial subscriptions have no trial_end.
+-- ============================================================
+
+ALTER TABLE subscriptions
+  ADD COLUMN IF NOT EXISTS trial_end_date BIGINT;
+
+ALTER TABLE product_subscriptions
+  ADD COLUMN IF NOT EXISTS trial_end_date BIGINT;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4190.

Closes #4190

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 1f9c2f0 feat(billing): capture trial_end as trialEndDate on subscription sync (closes #4190)

### Files changed

```
 convex/http.ts                                      |  4 ++++
 convex/schema/platform.ts                           |  2 ++
 convex/stripe.ts                                    |  9 +++++++++
 convex/supabase/subscriptions.ts                    |  2 ++
 src/lib/supabase/database.types.ts                  |  6 ++++++
 .../00113_subscriptions_trial_end_date.sql          | 21 +++++++++++++++++++++
 6 files changed, 44 insertions(+)
```