### PR TITLE
Add `customer.subscription.trial_will_end` webhook handler

### DIFF
--- a/convex/email/templates/subscriptionEmail.tsx
+++ b/convex/email/templates/subscriptionEmail.tsx
@@ -62,6 +62,78 @@ export function SubscriptionSuccessEmail({ email }: SubscriptionEmailOptions) {
   );
 }
 
+type TrialWillEndEmailOptions = {
+  email: string;
+  trialEndDate: Date;
+};
+
+export function TrialWillEndEmail({ email, trialEndDate }: TrialWillEndEmailOptions) {
+  const formattedDate = trialEndDate.toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+  return (
+    <Html>
+      <Head />
+      <Preview>Your free trial ends in 3 days</Preview>
+      <Body
+        style={{
+          backgroundColor: "#ffffff",
+          fontFamily:
+            '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif',
+        }}
+      >
+        <Container style={{ margin: "0 auto", padding: "20px 0 48px" }}>
+          <Img
+            src={`${SITE_URL}/images/convex-logo-email.jpg`}
+            width="40"
+            height="37"
+            alt=""
+          />
+          <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
+            Hello {email}!
+          </Text>
+          <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
+            Your free trial ends on <strong>{formattedDate}</strong>.
+            <br />
+            To keep access to all PRO features, make sure your billing information is up to date.
+          </Text>
+          <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
+            <Link href={`${SITE_URL}/dashboard/settings/billing`}>
+              Manage your subscription
+            </Link>
+          </Text>
+          <Text style={{ fontSize: "16px", lineHeight: "26px" }}>
+            The <Link href={SITE_URL}>Unify</Link> team.
+          </Text>
+          <Hr style={{ borderColor: "#cccccc", margin: "20px 0" }} />
+          <Text style={{ color: "#8898aa", fontSize: "12px" }}>
+            200 domain-name.com
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+export function renderTrialWillEndEmail(args: TrialWillEndEmailOptions) {
+  return render(<TrialWillEndEmail {...args} />);
+}
+
+export async function sendTrialWillEndEmail({
+  email,
+  trialEndDate,
+}: TrialWillEndEmailOptions) {
+  const html = renderTrialWillEndEmail({ email, trialEndDate });
+  await sendEmail({
+    to: email,
+    subject: "Your free trial ends in 3 days",
+    html,
+  });
+}
+
 export function SubscriptionErrorEmail({ email }: SubscriptionEmailOptions) {
   return (
     <Html>

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -10,6 +10,7 @@ import { Currency, Interval, PLANS } from "@cvx/schema";
 import {
   sendSubscriptionErrorEmail,
   sendSubscriptionSuccessEmail,
+  sendTrialWillEndEmail,
 } from "@cvx/email/templates/subscriptionEmail";
 import Stripe from "stripe";
 import { Doc, Id } from "@cvx/_generated/dataModel";
@@ -374,6 +375,28 @@ const handleCustomerSubscriptionDeleted = async (
   return new Response(null);
 };
 
+const handleCustomerSubscriptionTrialWillEnd = async (
+  ctx: ActionCtx,
+  event: Stripe.CustomerSubscriptionTrialWillEndEvent,
+) => {
+  const subscription = event.data.object;
+  const { customer: customerId } = z
+    .object({ customer: z.string() })
+    .parse(subscription);
+
+  const user = await ctx.runQuery(internal.stripe.PREAUTH_getUserByCustomerId, {
+    customerId,
+  });
+  if (!user?.email) throw new Error(ERRORS.SOMETHING_WENT_WRONG);
+
+  const trialEnd = subscription.trial_end;
+  const trialEndDate = trialEnd ? new Date(trialEnd * 1000) : new Date();
+
+  await sendTrialWillEndEmail({ email: user.email, trialEndDate });
+
+  return new Response(null);
+};
+
 const handleInvoiceFinalized = async (
   _ctx: ActionCtx,
   event: Stripe.InvoiceFinalizedEvent,
@@ -465,6 +488,14 @@ http.route({
          */
         case "customer.subscription.deleted": {
           return handleCustomerSubscriptionDeleted(ctx, event);
+        }
+
+        /**
+         * Occurs 3 days before a trial subscription ends.
+         * Sends a pre-expiry reminder email to the user.
+         */
+        case "customer.subscription.trial_will_end": {
+          return handleCustomerSubscriptionTrialWillEnd(ctx, event);
         }
 
         /**


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4191.

Closes #4191

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 498216e feat(billing): add customer.subscription.trial_will_end webhook handler (closes #4191)

### Files changed

```
 convex/email/templates/subscriptionEmail.tsx | 72 ++++++++++++++++++++++++++++
 convex/http.ts                               | 31 ++++++++++++
 2 files changed, 103 insertions(+)
```