### PR TITLE
Billing page "Manage" button is shown even when no `customerId` exists

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.billing.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.billing.tsx
@@ -319,7 +319,12 @@ export default function BillingSettings() {
           <p className="text-sm font-normal text-primary/60">
             {t("billing.stripeRedirect", "You will be redirected to the Stripe Customer Portal.")}
           </p>
-          <Button type="submit" size="sm" onClick={handleCreateCustomerPortal}>
+          <Button
+            type="submit"
+            size="sm"
+            onClick={handleCreateCustomerPortal}
+            disabled={!user?.customerId}
+          >
             {t("billing.manage", "Manage")}
           </Button>
         </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4192.

Closes #4192

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e20b22c fix(billing): disable Manage button when no customerId exists (closes #4192)

### Files changed

```
 src/routes/_app/_auth/dashboard/_layout.settings.billing.tsx | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)
```