### PR TITLE
Update billing UI to use `trialEndDate` instead of `currentPeriodEnd` for trial 

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.billing.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.billing.tsx
@@ -243,7 +243,9 @@ export default function BillingSettings() {
                   {t("billing.trialBanner", "You are on a free trial.")}{" "}
                   {t("billing.trialEnds", "Trial ends")}:{" "}
                   <span className="font-medium">
-                    {new Date(user.subscription.currentPeriodEnd * 1000).toLocaleDateString()}
+                    {new Date(
+                      (user.subscription.trialEndDate ?? user.subscription.currentPeriodEnd) * 1000,
+                    ).toLocaleDateString()}
                   </span>
                   .
                 </p>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4198.

Closes #4198

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- ae84601 fix(billing): use trialEndDate instead of currentPeriodEnd for trial display (closes #4198)

### Files changed

```
 src/routes/_app/_auth/dashboard/_layout.settings.billing.tsx | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)
```