### PR TITLE
Add waitlist notification trigger on new appointment slot creation

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -215,6 +215,20 @@ async function applyAppointmentStatusChange(
     );
   }
 
+  if (args.nextStatus === "cancelled") {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.gabinet.waitlist.notifyWaitlistOnSlotOpen,
+      {
+        organizationId: args.organizationId,
+        treatmentId: args.treatmentId ?? undefined,
+        employeeUserId: String(args.appointment.employeeId),
+        date: args.appointment.date,
+        startTime: args.appointment.startTime,
+      },
+    );
+  }
+
   if (args.nextStatus === "completed") {
     if (args.treatmentId) {
       await handleAppointmentCompletion(ctx, {
@@ -2011,6 +2025,18 @@ export const _updateSideEffects = internalMutation({
           previousStatus: args.previousStatus,
           createdBy: args.createdBy,
           updatedFields: args.updatedFields,
+        },
+      );
+      // The previous date/time/employee slot is now free — notify waitlist patients.
+      await ctx.scheduler.runAfter(
+        0,
+        internal.gabinet.waitlist.notifyWaitlistOnSlotOpen,
+        {
+          organizationId: args.organizationId,
+          treatmentId: args.treatmentId,
+          employeeUserId: args.previousEmployeeId,
+          date: args.previousDate,
+          startTime: args.previousStartTime,
         },
       );
     } else {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4173.

Closes #4173

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e041e0c feat(gabinet): trigger waitlist notification on cancellation via updateStatus and on appointment reschedule (closes #4173)

### Files changed

```
 convex/gabinet/appointments.ts | 26 ++++++++++++++++++++++++++
 1 file changed, 26 insertions(+)
```