### PR TITLE
Dziennik audytu wysyłek SMS i e-mail do pacjenta

### DIFF
--- a/convex/gabinet/appointmentReminders.ts
+++ b/convex/gabinet/appointmentReminders.ts
@@ -3,6 +3,7 @@ import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
 import { createNotificationDirect } from "../notifications";
+import { logAudit } from "../auditLog";
 import { Id } from "../_generated/dataModel";
 import type { SupabaseRow } from "../_helpers/supabaseRows";
 
@@ -294,6 +295,22 @@ export const sendReminder = internalMutation({
           appointmentTime: appointment.startTime,
           treatmentName,
           employeeName,
+        }),
+      });
+
+      await logAudit(ctx, {
+        organizationId: reminder.organizationId as Id<"organizations">,
+        userId: appointment.employeeId as Id<"users">,
+        action: "gabinet:email:sent",
+        entityType: "gabinetAppointment",
+        entityId: String(appointment._id),
+        details: JSON.stringify({
+          recipientEmail: patient.email,
+          recipientName: patientName,
+          eventType: reminderEventType,
+          appointmentDate: appointment.date,
+          appointmentTime: appointment.startTime,
+          treatmentName,
         }),
       });
     }

--- a/convex/gabinet/appointmentSms.ts
+++ b/convex/gabinet/appointmentSms.ts
@@ -3,6 +3,7 @@ import { Doc, Id } from "../_generated/dataModel";
 import { action, internalMutation, MutationCtx } from "../_generated/server";
 import { publishActivityEnvelope } from "../_helpers/activityEnvelope";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
+import { logAudit } from "../auditLog";
 import { v } from "convex/values";
 
 const CONFIRM_REPLY_KEYWORDS = new Set(["TAK", "T", "YES", "Y"]);
@@ -69,6 +70,7 @@ async function logSmsSharedActivities(
     description: string;
     performedBy: Id<"users">;
     metadata?: Record<string, unknown>;
+    messageBody?: string;
   },
 ) {
   const entityTargets: Array<{ entityType: string; entityId: string }> = [];
@@ -135,6 +137,27 @@ async function logSmsSharedActivities(
     eventKey,
     targets: entityTargets,
     metadata: args.metadata,
+  });
+
+  await logAudit(ctx, {
+    organizationId: args.organizationId,
+    userId: args.performedBy,
+    action: args.action === "sms_sent" ? "gabinet:sms:sent" : "gabinet:sms:received",
+    entityType: args.appointmentId
+      ? "gabinetAppointment"
+      : args.patientId
+        ? "gabinetPatient"
+        : undefined,
+    entityId: args.appointmentId
+      ? String(args.appointmentId)
+      : args.patientId
+        ? String(args.patientId)
+        : undefined,
+    details: JSON.stringify({
+      description: args.description,
+      body: args.messageBody,
+      ...args.metadata,
+    }),
   });
 }
 
@@ -232,6 +255,7 @@ export const queueAutomationSms = internalMutation({
       action: "sms_sent",
       description: `Sent automated SMS for ${args.eventType}`,
       performedBy: employeeId,
+      messageBody: args.message,
       metadata: {
         appointmentSmsEventId: eventId,
         direction: "outbound",
@@ -346,6 +370,7 @@ export const queueConfirmationRequest = internalMutation({
       action: "sms_sent",
       description: `Sent appointment confirmation SMS for ${appointment.date} at ${appointment.startTime}`,
       performedBy: employeeId,
+      messageBody: message,
       metadata: {
         appointmentSmsEventId: eventId,
         direction: "outbound",
@@ -512,6 +537,7 @@ export const processIncomingMessage = internalMutation({
         action: "sms_received",
         description: `Received appointment confirmation reply: ${normalizedBody}`,
         performedBy: matchingAppointmentEmployeeId,
+        messageBody: args.body,
         metadata: {
           appointmentSmsEventId: eventId,
           direction: "inbound",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4208.

Closes #4208

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 801166c feat(gabinet): add audit log entries for SMS and email sends to patients (closes #4208)

### Files changed

```
 convex/gabinet/appointmentReminders.ts | 17 +++++++++++++++++
 convex/gabinet/appointmentSms.ts       | 26 ++++++++++++++++++++++++++
 2 files changed, 43 insertions(+)
```