### PR TITLE
`createOtp` returns `organizationId` and `signerPhone`/`signerEmail` to `request

### DIFF
--- a/convex/signatureRequests.ts
+++ b/convex/signatureRequests.ts
@@ -433,7 +433,7 @@ export const _notifyAuthor = internalMutation({
   },
 });
 
-export const createOtp = action({
+export const createOtp = internalAction({
   args: { token: v.string() },
   handler: async (_ctx, args) => {
     const db = createSupabaseDb();

--- a/convex/sms.ts
+++ b/convex/sms.ts
@@ -417,7 +417,7 @@ export const requestOtp = action({
   args: { token: v.string() },
   handler: async (ctx, args): Promise<{ sent: boolean; method: string }> => {
     // Create OTP (this validates the token and returns code + delivery info)
-    const result = await ctx.runAction(api.signatureRequests.createOtp, {
+    const result = await ctx.runAction(internal.signatureRequests.createOtp, {
       token: args.token,
     });
 

--- a/scripts/check-convex-auth.mjs
+++ b/scripts/check-convex-auth.mjs
@@ -67,10 +67,6 @@ const WHITELIST = new Set([
   //   token + OTP verification state are the auth mechanism.
   "signatureRequests:signExternal",
 
-  // createOtp: generates an OTP for a signing token. Auth is the possession
-  //   of the signing link sent to the signer.
-  "signatureRequests:createOtp",
-
   // verifyOtp: verifies the OTP a signer received. Auth is signing token +
   //   the correct OTP code.
   "signatureRequests:verifyOtp",
@@ -89,7 +85,7 @@ const WHITELIST = new Set([
 
   // ── Signing email notifications ───────────────────────────────────────────
   // These three are invoked only from authenticated actions (sendForSigning,
-  // createOtp) that have already validated org membership. They are thin
+  // requestOtp) that have already validated org membership. They are thin
   // notification helpers that should ideally be internalAction but changing
   // their visibility would break existing callers in this release cycle.
   // They write only to outbound email queues, never to org data tables.


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4215.

Closes #4215

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 5dcaf98 security(signing): make createOtp an internalAction to prevent client enumeration (closes #4215)

### Files changed

```
 convex/signatureRequests.ts   | 2 +-
 convex/sms.ts                 | 2 +-
 scripts/check-convex-auth.mjs | 6 +-----
 3 files changed, 3 insertions(+), 7 deletions(-)
```