### PR TITLE
Null audit log for documents with missing `createdBy`

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -667,26 +667,25 @@ export const recordSignature = action({
 
     // Audit log: record the signing event. Best-effort — a log failure must
     // never roll back a successfully completed signature.
-    const createdBy = doc.createdBy ? String(doc.createdBy) : null;
-    if (createdBy) {
-      try {
-        await ctx.scheduler.runAfter(0, internal.supabase.auditLog.writeAuditLogToSupabase, {
-          auditLogId: crypto.randomUUID(),
-          organizationId: String(doc.organizationId),
-          userId: createdBy,
-          action: "document.signed",
-          entityType: "formDocument",
-          entityId: String(doc._id),
-          details: JSON.stringify({
-            signedByName: resolvedSignedByName || undefined,
-            signedByEmail: args.signedByEmail || undefined,
-            signedByIp: args.signedByIp || undefined,
-          }),
-          createdAt: now,
-        });
-      } catch (err) {
-        console.error("[recordSignature] audit log write failed", err);
-      }
+    // When createdBy is null (auto-generated / system documents) we still
+    // write the entry with userId omitted so all signing events are auditable.
+    try {
+      await ctx.scheduler.runAfter(0, internal.supabase.auditLog.writeAuditLogToSupabase, {
+        auditLogId: crypto.randomUUID(),
+        organizationId: String(doc.organizationId),
+        userId: doc.createdBy ? String(doc.createdBy) : undefined,
+        action: "document.signed",
+        entityType: "formDocument",
+        entityId: String(doc._id),
+        details: JSON.stringify({
+          signedByName: resolvedSignedByName || undefined,
+          signedByEmail: args.signedByEmail || undefined,
+          signedByIp: args.signedByIp || undefined,
+        }),
+        createdAt: now,
+      });
+    } catch (err) {
+      console.error("[recordSignature] audit log write failed", err);
     }
 
     return doc._id as string;

--- a/convex/supabase/auditLog.ts
+++ b/convex/supabase/auditLog.ts
@@ -10,7 +10,7 @@ export const writeAuditLogToSupabase = internalAction({
   args: {
     auditLogId: v.string(),
     organizationId: v.string(),
-    userId: v.string(),
+    userId: v.optional(v.string()),
     action: v.string(),
     entityType: v.optional(v.string()),
     entityId: v.optional(v.string()),
@@ -24,7 +24,7 @@ export const writeAuditLogToSupabase = internalAction({
     const row = {
       id: args.auditLogId,
       organization_id: args.organizationId,
-      user_id: args.userId,
+      user_id: args.userId ?? null,
       action: args.action,
       entity_type: args.entityType ?? null,
       entity_id: args.entityId ?? null,

--- a/supabase/migrations/00114_audit_log_nullable_user_id.sql
+++ b/supabase/migrations/00114_audit_log_nullable_user_id.sql
@@ -1,0 +1,5 @@
+-- Make audit_log.user_id nullable so system-originated events (e.g. document
+-- signing triggered by a patient via a signing token, where the document has
+-- no createdBy) can be recorded without a user FK target.
+-- Closes: #4213
+ALTER TABLE audit_log ALTER COLUMN user_id DROP NOT NULL;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4213.

Closes #4213

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4ef2aa6 fix(signing): always write audit log for document signing, even without createdBy (closes #4213)

### Files changed

```
 convex/documents/documents.ts                      | 39 +++++++++++-----------
 convex/supabase/auditLog.ts                        |  4 +--
 .../00114_audit_log_nullable_user_id.sql           |  5 +++
 3 files changed, 26 insertions(+), 22 deletions(-)
```