### PR TITLE
Make `signingEmails

### DIFF
--- a/convex/signatureRequests.ts
+++ b/convex/signatureRequests.ts
@@ -273,7 +273,7 @@ export const _sendSigningEmails = internalMutation({
     for (const ct of tokens) {
       const sig = sigs.find((s: any) => s.slotId === ct.slotId);
       if (sig?.signerEmail) {
-        await ctx.scheduler.runAfter(0, api.signingEmails.sendSigningRequestEmail, {
+        await ctx.scheduler.runAfter(0, internal.signingEmails.sendSigningRequestEmail, {
           signerName: sig.signerName ?? sig.signerEmail,
           signerEmail: sig.signerEmail,
           documentTitle: args.instanceTitle,
@@ -422,7 +422,7 @@ export const _notifyAuthor = internalMutation({
   },
   handler: async (ctx, args) => {
     if (!args.authorEmail) return;
-    await ctx.scheduler.runAfter(0, api.signingEmails.sendSlotSignedNotification, {
+    await ctx.scheduler.runAfter(0, internal.signingEmails.sendSlotSignedNotification, {
       authorEmail: args.authorEmail,
       authorName: args.authorName ?? args.authorEmail,
       documentTitle: args.documentTitle,

--- a/convex/signingEmails.ts
+++ b/convex/signingEmails.ts
@@ -1,4 +1,4 @@
-import { action } from "./_generated/server";
+import { internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { Resend } from "resend";
 import { RESEND_API_KEY, RESEND_FROM } from "@cvx/env";
@@ -9,7 +9,7 @@ const APP_URL = process.env.APP_URL ?? "https://app.example.com";
 // Send signing request email
 // ---------------------------------------------------------------------------
 
-export const sendSigningRequestEmail = action({
+export const sendSigningRequestEmail = internalAction({
   args: {
     signerName: v.string(),
     signerEmail: v.string(),
@@ -63,7 +63,7 @@ export const sendSigningRequestEmail = action({
 // Send OTP code via email for email_otp verification
 // ---------------------------------------------------------------------------
 
-export const sendOtpEmail = action({
+export const sendOtpEmail = internalAction({
   args: {
     signerEmail: v.string(),
     code: v.string(),
@@ -98,7 +98,7 @@ export const sendOtpEmail = action({
 // Notify document author when a slot is signed
 // ---------------------------------------------------------------------------
 
-export const sendSlotSignedNotification = action({
+export const sendSlotSignedNotification = internalAction({
   args: {
     authorEmail: v.string(),
     authorName: v.string(),

--- a/convex/sms.ts
+++ b/convex/sms.ts
@@ -437,7 +437,7 @@ export const requestOtp = action({
       });
     } else if (verificationMethod === "email_otp") {
       if (!signerEmail) throw new Error("No email address for OTP delivery");
-      await ctx.runAction(api.signingEmails.sendOtpEmail, {
+      await ctx.runAction(internal.signingEmails.sendOtpEmail, {
         signerEmail,
         code: result.code,
       });

--- a/scripts/check-convex-auth.mjs
+++ b/scripts/check-convex-auth.mjs
@@ -83,16 +83,6 @@ const WHITELIST = new Set([
   //   Auth is the signing token (pre-validated by signatureRequests.verifyOtp).
   "documents/documents:recordSignature",
 
-  // ── Signing email notifications ───────────────────────────────────────────
-  // These three are invoked only from authenticated actions (sendForSigning,
-  // requestOtp) that have already validated org membership. They are thin
-  // notification helpers that should ideally be internalAction but changing
-  // their visibility would break existing callers in this release cycle.
-  // They write only to outbound email queues, never to org data tables.
-  "signingEmails:sendSigningRequestEmail",
-  "signingEmails:sendOtpEmail",
-  "signingEmails:sendSlotSignedNotification",
-
   // ── SMS OTP orchestration ─────────────────────────────────────────────────
   // requestOtp (sms module): orchestrates createOtp + SMS/email delivery for
   //   the document signing flow. The underlying createOtp validates the


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4217.

Closes #4217

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 578452a security(signing): make signingEmails helpers internalAction to close unauthenticated-call surface (closes #4217)

### Files changed

```
 convex/signatureRequests.ts   |  4 ++--
 convex/signingEmails.ts       |  8 ++++----
 convex/sms.ts                 |  2 +-
 scripts/check-convex-auth.mjs | 10 ----------
 4 files changed, 7 insertions(+), 17 deletions(-)
```