### PR TITLE
Token leakage via URL in SMS body

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -607,6 +607,18 @@ const devTables = {
   }).index("by_createdAt", ["createdAt"]),
 };
 
+// Single-use redirect stubs that shield signing tokens from SMS provider logs.
+// The SMS body contains the opaque stubId; the real token never leaves the server.
+const signingStubTables = {
+  signingLinkStubs: defineTable({
+    stubId: v.string(),
+    token: v.string(),
+    organizationId: v.id("organizations"),
+    expiresAt: v.number(),
+    usedAt: v.optional(v.number()),
+  }).index("by_stubId", ["stubId"]),
+};
+
 const schema = defineSchema({
   ...authTables,
   ...platformTables,
@@ -616,6 +628,7 @@ const schema = defineSchema({
   ...documentTables,
   ...tagAndCategoryTables,
   ...devTables,
+  ...signingStubTables,
 });
 
 export default schema;

--- a/convex/signingStubs.ts
+++ b/convex/signingStubs.ts
@@ -1,0 +1,66 @@
+import { action, internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
+
+const STUB_EXPIRY_MS = 48 * 60 * 60 * 1000; // 48 hours
+
+function generateStubId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// Creates a single-use stub that maps an opaque ID to the real signing token.
+// Called from sendSigningLinkSms so the raw token never appears in SMS logs.
+export const createStub = internalMutation({
+  args: {
+    token: v.string(),
+    organizationId: v.id("organizations"),
+    signingTokenExpiresAt: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const stubId = generateStubId();
+    const expiresAt = Math.min(
+      Date.now() + STUB_EXPIRY_MS,
+      args.signingTokenExpiresAt,
+    );
+    await ctx.db.insert("signingLinkStubs", {
+      stubId,
+      token: args.token,
+      organizationId: args.organizationId,
+      expiresAt,
+    });
+    return stubId;
+  },
+});
+
+// Public: browser calls this with the stubId from the SMS URL.
+// Returns the real signing token and burns the stub (single-use).
+export const resolveStub = action({
+  args: { stubId: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.runMutation(internal.signingStubs._consumeStub, {
+      stubId: args.stubId,
+    });
+  },
+});
+
+// Internal: atomically validates and consumes the stub in one transaction.
+export const _consumeStub = internalMutation({
+  args: { stubId: v.string() },
+  handler: async (ctx, args) => {
+    const stub = await ctx.db
+      .query("signingLinkStubs")
+      .withIndex("by_stubId", (q) => q.eq("stubId", args.stubId))
+      .first();
+
+    if (!stub) throw new Error("Link not found");
+    if (stub.usedAt) throw new Error("Link already used");
+    if (Date.now() > stub.expiresAt) throw new Error("Link expired");
+
+    await ctx.db.patch(stub._id, { usedAt: Date.now() });
+    return stub.token;
+  },
+});

--- a/convex/sms.ts
+++ b/convex/sms.ts
@@ -331,8 +331,16 @@ export const sendSigningLinkSms = internalAction({
       return { sent: false };
     }
 
+    // Create a single-use redirect stub so the raw signing token never appears
+    // in SMS provider logs. The stub burns on first visit (48 h max TTL).
+    const stubId = await ctx.runMutation(internal.signingStubs.createStub, {
+      token: args.token,
+      organizationId: args.organizationId,
+      signingTokenExpiresAt: args.expiresAt,
+    });
+
     const APP_URL = process.env.APP_URL ?? "https://app.example.com";
-    const signingUrl = `${APP_URL}/sign/${args.token}`;
+    const signingUrl = `${APP_URL}/sign-stub/${stubId}`;
     const expiryDate = new Date(args.expiresAt).toLocaleDateString("pl-PL");
     const message = `${args.organizationName} prosi o podpisanie dokumentu „${args.documentTitle}". Link: ${signingUrl} (ważny do: ${expiryDate})`;
 

--- a/src/routes/sign-stub.$stubId.tsx
+++ b/src/routes/sign-stub.$stubId.tsx
@@ -1,0 +1,60 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useAction } from "convex/react";
+import { useEffect, useRef, useState } from "react";
+import { api } from "@cvx/_generated/api";
+import { Card, CardContent } from "@/components/ui/card";
+import { AlertTriangle } from "@/lib/ez-icons";
+
+export const Route = createFileRoute("/sign-stub/$stubId")({
+  component: SigningStubPage,
+});
+
+function SigningStubPage() {
+  const { stubId } = Route.useParams();
+  const resolveStub = useAction(api.signingStubs.resolveStub);
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+  const called = useRef(false);
+
+  useEffect(() => {
+    // Guard against React StrictMode double-invoke in development.
+    if (called.current) return;
+    called.current = true;
+
+    resolveStub({ stubId })
+      .then((token) => {
+        void navigate({ to: "/sign/$token", params: { token } });
+      })
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : "";
+        if (/already used/i.test(msg)) {
+          setError("Ten link do podpisu został już wykorzystany.");
+        } else if (/expired/i.test(msg)) {
+          setError("Ten link do podpisu wygasł.");
+        } else {
+          setError("Nie znaleziono dokumentu lub link jest nieprawidłowy.");
+        }
+      });
+  }, [stubId, resolveStub, navigate]);
+
+  return (
+    <div className="h-dvh overflow-y-auto bg-muted/30">
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center gap-4 py-16">
+            {error ? (
+              <>
+                <AlertTriangle className="h-12 w-12 text-muted-foreground" />
+                <p className="text-center text-muted-foreground">{error}</p>
+              </>
+            ) : (
+              <p className="animate-pulse text-muted-foreground">
+                Ładowanie dokumentu...
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4214.

Closes #4214

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8bf2e6c security(sms): shield signing token from SMS provider logs via single-use redirect stub (closes #4214)

### Files changed

```
 convex/schema.ts                 | 13 ++++++++
 convex/signingStubs.ts           | 66 ++++++++++++++++++++++++++++++++++++++++
 convex/sms.ts                    | 10 +++++-
 src/routes/sign-stub.$stubId.tsx | 60 ++++++++++++++++++++++++++++++++++++
 4 files changed, 148 insertions(+), 1 deletion(-)
```