### PR TITLE
Add a scheduled cleanup job for expired `signingLinkStubs` rows

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -53,4 +53,13 @@ crons.daily(
   internal.gabinet.patients._purgeExpiredPatients,
 );
 
+// Delete signingLinkStubs rows that have been past their expiresAt for more
+// than 24 h (grace period for diagnostics). Prevents unbounded table growth;
+// rows are already invalid at expiry so deletion has no functional impact.
+crons.daily(
+  "cleanup-expired-signing-stubs",
+  { hourUTC: 4, minuteUTC: 0 },
+  internal.signingStubs._cleanupExpiredStubs,
+);
+
 export default crons;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -616,7 +616,9 @@ const signingStubTables = {
     organizationId: v.id("organizations"),
     expiresAt: v.number(),
     usedAt: v.optional(v.number()),
-  }).index("by_stubId", ["stubId"]),
+  })
+    .index("by_stubId", ["stubId"])
+    .index("by_expiresAt", ["expiresAt"]),
 };
 
 const schema = defineSchema({

--- a/convex/signingStubs.ts
+++ b/convex/signingStubs.ts
@@ -2,6 +2,15 @@ import { action, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
 
+// Stubs past their expiry are already rejected by _consumeStub, so they are
+// safe to delete. A 24 h grace period past expiresAt preserves rows for any
+// incident diagnostics before removal.
+const CLEANUP_GRACE_MS = 24 * 60 * 60 * 1000; // 24 hours
+// Batch cap: Convex mutations have an implicit write-unit budget; 500 deletes
+// per invocation stays well under it and the daily cadence keeps the table
+// from growing between runs.
+const CLEANUP_BATCH_SIZE = 500;
+
 const STUB_EXPIRY_MS = 48 * 60 * 60 * 1000; // 48 hours
 
 function generateStubId(): string {
@@ -62,5 +71,27 @@ export const _consumeStub = internalMutation({
 
     await ctx.db.patch(stub._id, { usedAt: Date.now() });
     return stub.token;
+  },
+});
+
+// Cron target: delete stubs whose expiresAt has passed the grace period.
+// Rows rejected by _consumeStub are already dead at expiry; the grace period
+// gives 24 h of diagnostic window before the row disappears.
+export const _cleanupExpiredStubs = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const cutoff = Date.now() - CLEANUP_GRACE_MS;
+    const expired = await ctx.db
+      .query("signingLinkStubs")
+      .withIndex("by_expiresAt", (q) => q.lt("expiresAt", cutoff))
+      .take(CLEANUP_BATCH_SIZE);
+
+    for (const stub of expired) {
+      await ctx.db.delete(stub._id);
+    }
+
+    if (expired.length > 0) {
+      console.info(`[cleanupExpiredStubs] Deleted ${expired.length} expired stub(s)`);
+    }
   },
 });

--- a/tests/convex/signingStubsCleanup.test.ts
+++ b/tests/convex/signingStubsCleanup.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "vitest";
+import { internal } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+// Must match CLEANUP_GRACE_MS in signingStubs.ts
+const GRACE_MS = DAY_MS;
+
+describe("signingStubs._cleanupExpiredStubs — daily cron", () => {
+  test("deletes stubs whose expiresAt is past the 24 h grace period", async () => {
+    const t = createTestCtx();
+    const { organizationId } = await seedTestUser(t);
+
+    // Insert one stub that expired 25 h ago (outside grace period — should be deleted)
+    const oldExpiredId = await t.run(async (ctx) => {
+      return await ctx.db.insert("signingLinkStubs", {
+        stubId: "stale-stub",
+        token: "tok-stale",
+        organizationId,
+        expiresAt: Date.now() - GRACE_MS - HOUR_MS,
+      });
+    });
+
+    await t.mutation(internal.signingStubs._cleanupExpiredStubs, {});
+
+    const deleted = await t.run(async (ctx) => ctx.db.get(oldExpiredId));
+    expect(deleted).toBeNull();
+  });
+
+  test("keeps stubs whose expiresAt is within the 24 h grace period", async () => {
+    const t = createTestCtx();
+    const { organizationId } = await seedTestUser(t);
+
+    // Expired 1 h ago — within the 24 h grace window, must survive
+    const recentlyExpiredId = await t.run(async (ctx) => {
+      return await ctx.db.insert("signingLinkStubs", {
+        stubId: "recent-stub",
+        token: "tok-recent",
+        organizationId,
+        expiresAt: Date.now() - HOUR_MS,
+      });
+    });
+
+    await t.mutation(internal.signingStubs._cleanupExpiredStubs, {});
+
+    const surviving = await t.run(async (ctx) => ctx.db.get(recentlyExpiredId));
+    expect(surviving).not.toBeNull();
+  });
+
+  test("keeps stubs that have not yet expired", async () => {
+    const t = createTestCtx();
+    const { organizationId } = await seedTestUser(t);
+
+    // Expires in 10 h — definitely still valid
+    const activeId = await t.run(async (ctx) => {
+      return await ctx.db.insert("signingLinkStubs", {
+        stubId: "active-stub",
+        token: "tok-active",
+        organizationId,
+        expiresAt: Date.now() + 10 * HOUR_MS,
+      });
+    });
+
+    await t.mutation(internal.signingStubs._cleanupExpiredStubs, {});
+
+    const surviving = await t.run(async (ctx) => ctx.db.get(activeId));
+    expect(surviving).not.toBeNull();
+  });
+
+  test("deletes used stubs past the grace period alongside unused expired ones", async () => {
+    const t = createTestCtx();
+    const { organizationId } = await seedTestUser(t);
+
+    // Used stub, expired 25 h ago
+    const usedExpiredId = await t.run(async (ctx) => {
+      return await ctx.db.insert("signingLinkStubs", {
+        stubId: "used-expired",
+        token: "tok-used",
+        organizationId,
+        expiresAt: Date.now() - GRACE_MS - HOUR_MS,
+        usedAt: Date.now() - 2 * DAY_MS,
+      });
+    });
+
+    await t.mutation(internal.signingStubs._cleanupExpiredStubs, {});
+
+    const deleted = await t.run(async (ctx) => ctx.db.get(usedExpiredId));
+    expect(deleted).toBeNull();
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4227.

Closes #4227

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a79b0a8 feat(signing): add scheduled cleanup job for expired signingLinkStubs rows (closes #4227)

### Files changed

```
 convex/crons.ts                          |  9 ++++
 convex/schema.ts                         |  4 +-
 convex/signingStubs.ts                   | 31 +++++++++++
 tests/convex/signingStubsCleanup.test.ts | 91 ++++++++++++++++++++++++++++++++
 4 files changed, 134 insertions(+), 1 deletion(-)
```