### PR TITLE
Apply the same stub pattern to `signingEmails.ts` for email signing links

### DIFF
--- a/convex/documents/signing.ts
+++ b/convex/documents/signing.ts
@@ -163,7 +163,15 @@ export const sendSigningEmailInternal = internalAction({
       senderName: defaultAccount?.fromName as string | undefined,
     };
 
-    const signingUrl = `${getAppUrl()}/sign/form/${data.signingToken}`;
+    // Create a single-use redirect stub so the raw signing token never appears
+    // in email provider logs (Resend, Gmail) or browser history / Referer headers.
+    const stubId = await ctx.runMutation(internal.signingStubs.createStub, {
+      token: data.signingToken,
+      organizationId: data.organizationId as Id<"organizations">,
+      signingTokenExpiresAt: newExpiry,
+      destination: "sign_form",
+    });
+    const signingUrl = `${getAppUrl()}/sign-stub/${stubId}`;
 
     // Context-aware messaging
     const ctaText = data.needsFormFill

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -607,8 +607,9 @@ const devTables = {
   }).index("by_createdAt", ["createdAt"]),
 };
 
-// Single-use redirect stubs that shield signing tokens from SMS provider logs.
-// The SMS body contains the opaque stubId; the real token never leaves the server.
+// Single-use redirect stubs that shield signing tokens from provider logs.
+// The SMS/email body contains the opaque stubId; the real token never leaves the server.
+// destination: "sign" (default) → /sign/$token; "sign_form" → /sign/form/$token
 const signingStubTables = {
   signingLinkStubs: defineTable({
     stubId: v.string(),
@@ -616,6 +617,7 @@ const signingStubTables = {
     organizationId: v.id("organizations"),
     expiresAt: v.number(),
     usedAt: v.optional(v.number()),
+    destination: v.optional(v.string()),
   })
     .index("by_stubId", ["stubId"])
     .index("by_expiresAt", ["expiresAt"]),

--- a/convex/signatureRequests.ts
+++ b/convex/signatureRequests.ts
@@ -280,6 +280,7 @@ export const _sendSigningEmails = internalMutation({
           organizationName: orgName,
           token: ct.token,
           expiresAt: args.expiresAt,
+          organizationId: args.organizationId as Id<"organizations">,
         });
       }
       if (sig?.signerPhone && sig?.verificationMethod === "sms") {

--- a/convex/signingEmails.ts
+++ b/convex/signingEmails.ts
@@ -1,5 +1,6 @@
 import { internalAction } from "./_generated/server";
 import { v } from "convex/values";
+import { internal } from "./_generated/api";
 import { Resend } from "resend";
 import { RESEND_API_KEY, RESEND_FROM } from "@cvx/env";
 
@@ -17,15 +18,24 @@ export const sendSigningRequestEmail = internalAction({
     organizationName: v.string(),
     token: v.string(),
     expiresAt: v.number(),
+    organizationId: v.id("organizations"),
   },
-  handler: async (_ctx, args): Promise<{ sent: boolean }> => {
+  handler: async (ctx, args): Promise<{ sent: boolean }> => {
     if (!RESEND_API_KEY) {
       console.warn("RESEND_API_KEY not set — skipping email");
       return { sent: false };
     }
 
+    // Create a single-use redirect stub so the raw signing token never appears
+    // in email provider logs or browser history / Referer headers.
+    const stubId = await ctx.runMutation(internal.signingStubs.createStub, {
+      token: args.token,
+      organizationId: args.organizationId,
+      signingTokenExpiresAt: args.expiresAt,
+    });
+
     const resend = new Resend(RESEND_API_KEY);
-    const signingUrl = `${APP_URL}/sign/${args.token}`;
+    const signingUrl = `${APP_URL}/sign-stub/${stubId}`;
     const expiryDate = new Date(args.expiresAt).toLocaleDateString("pl-PL");
 
     await resend.emails.send({

--- a/convex/signingStubs.ts
+++ b/convex/signingStubs.ts
@@ -22,12 +22,15 @@ function generateStubId(): string {
 }
 
 // Creates a single-use stub that maps an opaque ID to the real signing token.
-// Called from sendSigningLinkSms so the raw token never appears in SMS logs.
+// Called from sendSigningLinkSms and signing email senders so the raw token
+// never appears in provider logs.
+// destination: "sign" (default) → /sign/$token; "sign_form" → /sign/form/$token
 export const createStub = internalMutation({
   args: {
     token: v.string(),
     organizationId: v.id("organizations"),
     signingTokenExpiresAt: v.number(),
+    destination: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const stubId = generateStubId();
@@ -40,6 +43,7 @@ export const createStub = internalMutation({
       token: args.token,
       organizationId: args.organizationId,
       expiresAt,
+      destination: args.destination,
     });
     return stubId;
   },
@@ -57,6 +61,7 @@ export const resolveStub = action({
 });
 
 // Internal: atomically validates and consumes the stub in one transaction.
+// Returns { token, destination } so the caller knows where to redirect.
 export const _consumeStub = internalMutation({
   args: { stubId: v.string() },
   handler: async (ctx, args) => {
@@ -70,7 +75,7 @@ export const _consumeStub = internalMutation({
     if (Date.now() > stub.expiresAt) throw new Error("Link expired");
 
     await ctx.db.patch(stub._id, { usedAt: Date.now() });
-    return stub.token;
+    return { token: stub.token, destination: stub.destination ?? "sign" };
   },
 });
 

--- a/src/routes/sign-stub.$stubId.tsx
+++ b/src/routes/sign-stub.$stubId.tsx
@@ -22,8 +22,12 @@ function SigningStubPage() {
     called.current = true;
 
     resolveStub({ stubId })
-      .then((token) => {
-        void navigate({ to: "/sign/$token", params: { token } });
+      .then(({ token, destination }) => {
+        if (destination === "sign_form") {
+          void navigate({ to: "/sign/form/$token", params: { token } });
+        } else {
+          void navigate({ to: "/sign/$token", params: { token } });
+        }
       })
       .catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : "";


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4228.

Closes #4228

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 34e97e7 security(signing): apply stub pattern to email signing links to shield token from provider logs (closes #4228)

### Files changed

```
 convex/documents/signing.ts      | 10 +++++++++-
 convex/schema.ts                 |  6 ++++--
 convex/signatureRequests.ts      |  1 +
 convex/signingEmails.ts          | 14 ++++++++++++--
 convex/signingStubs.ts           |  9 +++++++--
 src/routes/sign-stub.$stubId.tsx |  8 ++++++--
 6 files changed, 39 insertions(+), 9 deletions(-)
```