### PR TITLE
Wire pricing page prices to live Stripe plan data

### DIFF
--- a/convex/app.ts
+++ b/convex/app.ts
@@ -244,6 +244,41 @@ export const removeUserImage = mutation({
   },
 });
 
+// Public query — no auth required. Returns PLN monthly/yearly prices for the
+// CRM Pro and Gabinet Pro plans so the public pricing page can display live
+// prices instead of hardcoded placeholders. Returns null when plans have not
+// been seeded yet (Stripe not configured).
+export const getPublicPricingPlans = query({
+  args: {},
+  handler: async (ctx) => {
+    const [crmPro, gabinetPro] = await Promise.all([
+      ctx.db
+        .query("plans")
+        .withIndex("by_productAndKey", (q) =>
+          q.eq("productKey", PRODUCT_KEYS.CRM).eq("key", PLANS.PRO),
+        )
+        .unique(),
+      ctx.db
+        .query("plans")
+        .withIndex("by_productAndKey", (q) =>
+          q.eq("productKey", PRODUCT_KEYS.GABINET).eq("key", PLANS.PRO),
+        )
+        .unique(),
+    ]);
+    if (!crmPro || !gabinetPro) return null;
+    return {
+      crm: {
+        monthPln: crmPro.prices.month.pln.amount,
+        yearPln: crmPro.prices.year.pln.amount,
+      },
+      gabinet: {
+        monthPln: gabinetPro.prices.month.pln.amount,
+        yearPln: gabinetPro.prices.year.pln.amount,
+      },
+    };
+  },
+});
+
 export const getActivePlans = query({
   args: { productKey: v.optional(productKeyValidator) },
   handler: async (ctx, args) => {

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -1,11 +1,21 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
+import { useQuery } from "convex/react";
+import { api } from "@cvx/_generated/api";
 import Logo from "@/assets/svg/logo";
+
+function formatPln(amount: number): string {
+  return `${Math.round(amount / 100)} zł`;
+}
 
 export const Route = createFileRoute("/pricing")({
   component: PricingPage,
 });
 
 function PricingPage() {
+  const pricingPlans = useQuery(api.app.getPublicPricingPlans);
+  const crmProPrice = pricingPlans != null ? formatPln(pricingPlans.crm.monthPln) : "99 zł";
+  const gabinetProPrice = pricingPlans != null ? formatPln(pricingPlans.gabinet.monthPln) : "149 zł";
+
   return (
     <div className="min-h-dvh bg-background text-foreground">
       {/* Nav */}
@@ -78,7 +88,7 @@ function PricingPage() {
                 },
                 {
                   name: "Pro",
-                  price: "99 zł",
+                  price: crmProPrice,
                   interval: "/ miesiąc",
                   description: "Pełen CRM dla całego zespołu",
                   features: [
@@ -117,7 +127,7 @@ function PricingPage() {
                 },
                 {
                   name: "Pro",
-                  price: "149 zł",
+                  price: gabinetProPrice,
                   interval: "/ miesiąc",
                   description: "Kompletny system dla gabinetu",
                   features: [


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4232.

Closes #4232

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 504379c feat(pricing): wire pricing page prices to live Stripe plan data (closes #4232)

### Files changed

```
 convex/app.ts          | 35 +++++++++++++++++++++++++++++++++++
 src/routes/pricing.tsx | 14 ++++++++++++--
 2 files changed, 47 insertions(+), 2 deletions(-)
```