### PR TITLE
Hardcoded fallback prices on pricing page don't match seeded plan prices

### DIFF
--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -13,8 +13,8 @@ export const Route = createFileRoute("/pricing")({
 
 function PricingPage() {
   const pricingPlans = useQuery(api.app.getPublicPricingPlans);
-  const crmProPrice = pricingPlans != null ? formatPln(pricingPlans.crm.monthPln) : "99 zł";
-  const gabinetProPrice = pricingPlans != null ? formatPln(pricingPlans.gabinet.monthPln) : "149 zł";
+  const crmProPrice = pricingPlans != null ? formatPln(pricingPlans.crm.monthPln) : "119 zł";
+  const gabinetProPrice = pricingPlans != null ? formatPln(pricingPlans.gabinet.monthPln) : "199 zł";
 
   return (
     <div className="min-h-dvh bg-background text-foreground">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4238.

Closes #4238

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 488679b fix(pricing): update fallback prices to match seeded plan prices (closes #4238)

### Files changed

```
 src/routes/pricing.tsx | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```