### PR TITLE
docs(security): add secret set dates table for Convex/Netlify secrets (closes #4246)

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -158,6 +158,46 @@ Add a calendar reminder for each tier on the day you first set the secrets. A co
 
 ---
 
+## Secret set dates
+
+GitHub Actions secrets are automatically age-checked by `secret-rotation-age.yml`, which reads `updated_at` from the GitHub API. **Convex and Netlify secrets have no equivalent API** — their rotation anchor must be recorded here. Update this table whenever you first set a secret or rotate it.
+
+### Convex environment variables (90-day rotation)
+
+| Secret | Last set date | Next due |
+|--------|--------------|----------|
+| `SUPABASE_DB_URL` (Convex copy) | _YYYY-MM-DD_ | _YYYY-MM-DD_ |
+| `SUPABASE_ANON_KEY` | _YYYY-MM-DD_ | _YYYY-MM-DD_ |
+| `SUPABASE_SERVICE_ROLE_KEY` | _YYYY-MM-DD_ | _YYYY-MM-DD_ |
+| `SUPABASE_JWT_SECRET` | _YYYY-MM-DD_ | _YYYY-MM-DD_ |
+| `CONVEX_DEPLOY_KEY` | _YYYY-MM-DD_ | _YYYY-MM-DD_ |
+
+### Convex environment variables (180-day rotation)
+
+| Secret | Last set date | Next due |
+|--------|--------------|----------|
+| `AUTH_RESEND_KEY` | _YYYY-MM-DD_ | _YYYY-MM-DD_ |
+| `RESEND_API_KEY` | _YYYY-MM-DD_ | _YYYY-MM-DD_ |
+| `STRIPE_SECRET_KEY` | _YYYY-MM-DD_ | _YYYY-MM-DD_ |
+| `STRIPE_WEBHOOK_SECRET` | _YYYY-MM-DD_ | _YYYY-MM-DD_ |
+| `GOOGLE_CLIENT_SECRET` | _YYYY-MM-DD_ | _YYYY-MM-DD_ |
+
+### Netlify environment variables (90-day rotation)
+
+| Secret | Last set date | Next due |
+|--------|--------------|----------|
+| `NETLIFY_AUTH_TOKEN` (Netlify copy) | _YYYY-MM-DD_ | _YYYY-MM-DD_ |
+
+### Netlify environment variables (180-day rotation)
+
+| Secret | Last set date | Next due |
+|--------|--------------|----------|
+| `SENTRY_AUTH_TOKEN` | _YYYY-MM-DD_ | _YYYY-MM-DD_ |
+
+> GitHub Actions secrets (`BACKUP_AWS_ACCESS_KEY_ID`, `BACKUP_AWS_SECRET_ACCESS_KEY`, `SUPABASE_DB_URL` (GH copy), `SUPABASE_SERVICE_ROLE_KEY` (GH copy), `NETLIFY_AUTH_TOKEN` (GH copy)) are tracked automatically by `secret-rotation-age.yml` and do not need a manual entry here.
+
+---
+
 ## Automated checks
 
 Three automated layers guard against leaked secrets:

--- a/session_state.json
+++ b/session_state.json
@@ -1,9 +1,9 @@
 {
-  "session_id": "S0120",
-  "started_at": "2026-08-07T10:00:00Z",
-  "last_updated": "2026-08-07T10:15:00Z",
+  "session_id": "S0121",
+  "started_at": "2026-08-07T10:30:00Z",
+  "last_updated": "2026-08-07T10:35:00Z",
   "status": "completed",
-  "focus": "Issue #4245: Secret rotation age check workflow",
+  "focus": "Issue #4246: Record initial secret-set dates in docs/secrets.md",
   "tasks_snapshot": {
     "total": 1,
     "not_started": 0,
@@ -14,5 +14,5 @@
   },
   "active_task_ids": [],
   "blockers": [],
-  "notes": "Added .github/workflows/secret-rotation-age.yml to check 90-day secret rotation age via GitHub API updated_at metadata. Updated docs/secrets.md to document the new workflow. Closes #4245."
+  "notes": "Added 'Secret set dates' section to docs/secrets.md with fillable tables for Convex and Netlify secrets. GitHub Actions secrets are auto-tracked by secret-rotation-age.yml; only Convex/Netlify secrets need the manual table. Closes #4246."
 }


### PR DESCRIPTION
## Summary

- Adds a **Secret set dates** section to `docs/secrets.md` with fillable tables for all Convex and Netlify secrets that carry a 90-day or 180-day rotation schedule.
- Explains clearly that GitHub Actions secrets are already auto-tracked by `secret-rotation-age.yml` via the GitHub API `updated_at` field — only Convex/Netlify secrets need a manual record because those platforms have no equivalent metadata API.
- Closes #4246.

## Test plan

- [ ] `docs/secrets.md` renders correctly in GitHub (Markdown table formatting).
- [ ] The new section appears between "Rotation schedule" and "Automated checks" and does not disrupt the existing content.
- [ ] Fill in the `_YYYY-MM-DD_` placeholders with real dates when secrets are initially set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)