### PR TITLE
Podnieść pokrycie testami krytycznej logiki biznesowej

### DIFF
--- a/convex/_test_helpers.ts
+++ b/convex/_test_helpers.ts
@@ -30,7 +30,7 @@ export function createTestCtx() {
  */
 export async function seedTestUser(
   t: ReturnType<typeof convexTest>,
-  opts?: { role?: "owner" | "admin" | "member" },
+  opts?: { role?: "owner" | "admin" | "member" | "viewer" },
 ) {
   const role = opts?.role ?? "owner";
 
@@ -95,7 +95,7 @@ export async function seedTestUser(
 export async function seedSecondUser(
   t: ReturnType<typeof convexTest>,
   organizationId: Id<"organizations">,
-  opts?: { role?: "owner" | "admin" | "member" },
+  opts?: { role?: "owner" | "admin" | "member" | "viewer" },
 ) {
   const role = opts?.role ?? "member";
 
@@ -146,6 +146,16 @@ export async function seedGabinetPrereqs(
 ) {
   const ids = await t.run(async (ctx) => {
     const now = Date.now();
+
+    // Activate the gabinet product subscription so verifyProductAccess passes.
+    await ctx.db.insert("productSubscriptions", {
+      organizationId,
+      productId: "gabinet",
+      status: "active",
+      cancelAtPeriodEnd: false,
+      createdAt: now,
+      updatedAt: now,
+    });
 
     const patientId = await ctx.db.insert("gabinetPatients", {
       organizationId,

--- a/tests/convex/documentLifecycle.test.ts
+++ b/tests/convex/documentLifecycle.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Document lifecycle tests — status transition validation for documentInstances.
+ *
+ * documentInstances.updateStatus enforces a strict transition graph. These
+ * tests verify that valid transitions succeed and that invalid transitions are
+ * rejected with a clear error, ensuring the backend never allows a document to
+ * move to an incompatible state.
+ *
+ * Transition graph:
+ *   draft → pending_review, approved, pending_signature
+ *   pending_review → draft, approved
+ *   approved → pending_signature, archived
+ *   pending_signature → signed, archived
+ *   signed → archived
+ *   archived → approved, signed
+ */
+
+import { afterEach, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+async function seedDocumentInstance(
+  organizationId: any,
+  userId: any,
+  status:
+    | "draft"
+    | "pending_review"
+    | "approved"
+    | "pending_signature"
+    | "signed"
+    | "archived" = "draft",
+): Promise<string> {
+  const db = createSupabaseDb();
+  const now = Date.now();
+  return await db.insert("documentInstances", {
+    organizationId: String(organizationId),
+    type: "file",
+    title: "Test Document",
+    status,
+    module: "gabinet",
+    signatures: JSON.stringify([]),
+    createdBy: String(userId),
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+describe("documentInstances.updateStatus — valid transitions", () => {
+  test("draft → pending_review", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const docId = await seedDocumentInstance(organizationId, userId, "draft");
+
+    await t
+      .withIdentity(identity)
+      .action(api.documentInstances.updateStatus, {
+        id: docId,
+        status: "pending_review",
+      });
+
+    const db = createSupabaseDb();
+    const doc = await db.get<{ status: string }>("documentInstances", docId);
+    expect(doc?.status).toBe("pending_review");
+  });
+
+  test("draft → approved (skip review step)", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const docId = await seedDocumentInstance(organizationId, userId, "draft");
+
+    await t
+      .withIdentity(identity)
+      .action(api.documentInstances.updateStatus, {
+        id: docId,
+        status: "approved",
+      });
+
+    const db = createSupabaseDb();
+    const doc = await db.get<{ status: string; approvedBy: string }>(
+      "documentInstances",
+      docId,
+    );
+    expect(doc?.status).toBe("approved");
+    expect(doc?.approvedBy).toBe(String(userId));
+  });
+
+  test("pending_review → approved sets approvedBy", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const docId = await seedDocumentInstance(
+      organizationId,
+      userId,
+      "pending_review",
+    );
+
+    await t
+      .withIdentity(identity)
+      .action(api.documentInstances.updateStatus, {
+        id: docId,
+        status: "approved",
+      });
+
+    const db = createSupabaseDb();
+    const doc = await db.get<{ status: string; approvedBy: string }>(
+      "documentInstances",
+      docId,
+    );
+    expect(doc?.status).toBe("approved");
+    expect(doc?.approvedBy).toBe(String(userId));
+  });
+
+  test("approved → pending_signature", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const docId = await seedDocumentInstance(organizationId, userId, "approved");
+
+    await t
+      .withIdentity(identity)
+      .action(api.documentInstances.updateStatus, {
+        id: docId,
+        status: "pending_signature",
+      });
+
+    const db = createSupabaseDb();
+    const doc = await db.get<{ status: string }>("documentInstances", docId);
+    expect(doc?.status).toBe("pending_signature");
+  });
+
+  test("signed → archived", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const docId = await seedDocumentInstance(organizationId, userId, "signed");
+
+    await t
+      .withIdentity(identity)
+      .action(api.documentInstances.updateStatus, {
+        id: docId,
+        status: "archived",
+      });
+
+    const db = createSupabaseDb();
+    const doc = await db.get<{ status: string }>("documentInstances", docId);
+    expect(doc?.status).toBe("archived");
+  });
+
+  test("archived → approved (restoration path)", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const docId = await seedDocumentInstance(
+      organizationId,
+      userId,
+      "archived",
+    );
+
+    await t
+      .withIdentity(identity)
+      .action(api.documentInstances.updateStatus, {
+        id: docId,
+        status: "approved",
+      });
+
+    const db = createSupabaseDb();
+    const doc = await db.get<{ status: string }>("documentInstances", docId);
+    expect(doc?.status).toBe("approved");
+  });
+});
+
+describe("documentInstances.updateStatus — invalid transitions", () => {
+  test("signed → draft is rejected", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const docId = await seedDocumentInstance(organizationId, userId, "signed");
+
+    await expect(
+      t.withIdentity(identity).action(api.documentInstances.updateStatus, {
+        id: docId,
+        status: "draft",
+      }),
+    ).rejects.toThrow("Cannot transition from signed to draft");
+  });
+
+  test("signed → pending_review is rejected", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const docId = await seedDocumentInstance(organizationId, userId, "signed");
+
+    await expect(
+      t.withIdentity(identity).action(api.documentInstances.updateStatus, {
+        id: docId,
+        status: "pending_review",
+      }),
+    ).rejects.toThrow("Cannot transition from signed to pending_review");
+  });
+
+  test("approved → draft is rejected", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const docId = await seedDocumentInstance(organizationId, userId, "approved");
+
+    await expect(
+      t.withIdentity(identity).action(api.documentInstances.updateStatus, {
+        id: docId,
+        status: "draft",
+      }),
+    ).rejects.toThrow("Cannot transition from approved to draft");
+  });
+
+  test("pending_signature → draft is rejected", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const docId = await seedDocumentInstance(
+      organizationId,
+      userId,
+      "pending_signature",
+    );
+
+    await expect(
+      t.withIdentity(identity).action(api.documentInstances.updateStatus, {
+        id: docId,
+        status: "draft",
+      }),
+    ).rejects.toThrow("Cannot transition from pending_signature to draft");
+  });
+});
+
+describe("documentInstances.updateDraft — edit guard", () => {
+  test("cannot update a signed document", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const docId = await seedDocumentInstance(organizationId, userId, "signed");
+
+    await expect(
+      t.withIdentity(identity).action(api.documentInstances.updateDraft, {
+        id: docId,
+        title: "Modified Title",
+      }),
+    ).rejects.toThrow("Podpisanych i zarchiwizowanych dokumentów nie można edytować");
+  });
+
+  test("cannot update an archived document", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const docId = await seedDocumentInstance(
+      organizationId,
+      userId,
+      "archived",
+    );
+
+    await expect(
+      t.withIdentity(identity).action(api.documentInstances.updateDraft, {
+        id: docId,
+        title: "Modified Title",
+      }),
+    ).rejects.toThrow("Podpisanych i zarchiwizowanych dokumentów nie można edytować");
+  });
+
+  test("can update a draft document", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const docId = await seedDocumentInstance(organizationId, userId, "draft");
+
+    await t.withIdentity(identity).action(api.documentInstances.updateDraft, {
+      id: docId,
+      title: "Updated Title",
+    });
+
+    const db = createSupabaseDb();
+    const doc = await db.get<{ title: string }>("documentInstances", docId);
+    expect(doc?.title).toBe("Updated Title");
+  });
+});

--- a/tests/convex/gabinetRbac.test.ts
+++ b/tests/convex/gabinetRbac.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Runtime RBAC enforcement for the Gabinet module.
+ *
+ * The permissionAlignment.test.ts only verifies statically that every backend
+ * checkPermission() call has a corresponding UI gate. These tests verify that
+ * the checks actually fire at runtime and block the right roles from mutating
+ * data they're not allowed to touch.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { api } from "../../convex/_generated/api";
+import {
+  createTestCtx,
+  seedGabinetPrereqs,
+  seedSecondUser,
+  seedTestUser,
+} from "../../convex/_test_helpers";
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      text: async () => JSON.stringify({ sid: "SM_TEST_123" }),
+    })) as unknown as typeof fetch,
+  );
+});
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  vi.unstubAllGlobals();
+});
+
+describe("gabinet_appointments RBAC", () => {
+  test("viewer cannot create an appointment", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity: ownerIdentity } =
+      await seedTestUser(t);
+    const { identity: viewerIdentity } = await seedSecondUser(
+      t,
+      organizationId,
+      { role: "viewer" },
+    );
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    await expect(
+      t.withIdentity(viewerIdentity).action(api.gabinet.appointments.create, {
+        organizationId,
+        patientId: String(patientId),
+        treatmentId: String(treatmentId),
+        employeeId: String(userId),
+        date: "2026-03-16",
+        startTime: "09:00",
+        endTime: "09:30",
+        allowPast: true,
+      }),
+    ).rejects.toThrow("Permission denied");
+  });
+
+  test("viewer cannot update appointment status (edit permission)", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity: ownerIdentity } =
+      await seedTestUser(t);
+    const { identity: viewerIdentity } = await seedSecondUser(
+      t,
+      organizationId,
+      { role: "viewer" },
+    );
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    const apptId = await t
+      .withIdentity(ownerIdentity)
+      .action(api.gabinet.appointments.create, {
+        organizationId,
+        patientId: String(patientId),
+        treatmentId: String(treatmentId),
+        employeeId: String(userId),
+        date: "2026-03-16",
+        startTime: "09:00",
+        endTime: "09:30",
+        allowPast: true,
+      });
+
+    await expect(
+      t.withIdentity(viewerIdentity).action(
+        api.gabinet.appointments.updateStatus,
+        {
+          organizationId,
+          appointmentId: apptId,
+          status: "confirmed",
+        },
+      ),
+    ).rejects.toThrow("Permission denied");
+  });
+
+  test("member can create an appointment (create:all by default)", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { identity: memberIdentity } = await seedSecondUser(
+      t,
+      organizationId,
+      { role: "member" },
+    );
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    const apptId = await t
+      .withIdentity(memberIdentity)
+      .action(api.gabinet.appointments.create, {
+        organizationId,
+        patientId: String(patientId),
+        treatmentId: String(treatmentId),
+        employeeId: String(userId),
+        date: "2026-03-16",
+        startTime: "09:00",
+        endTime: "09:30",
+        allowPast: true,
+      });
+
+    expect(apptId).toBeTruthy();
+  });
+});
+
+describe("gabinet_packages RBAC", () => {
+  test("viewer cannot create a package", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { identity: viewerIdentity } = await seedSecondUser(
+      t,
+      organizationId,
+      { role: "viewer" },
+    );
+    const { treatmentId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    await expect(
+      t.withIdentity(viewerIdentity).action(api.gabinet.packages.create, {
+        organizationId,
+        name: "Test Package",
+        treatments: [{ treatmentId: String(treatmentId), quantity: 4 }],
+        totalPrice: 400,
+      }),
+    ).rejects.toThrow("Permission denied");
+  });
+
+  test("viewer cannot purchase a package for a patient", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity: ownerIdentity } =
+      await seedTestUser(t);
+    const { identity: viewerIdentity } = await seedSecondUser(
+      t,
+      organizationId,
+      { role: "viewer" },
+    );
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    const packageId = await t
+      .withIdentity(ownerIdentity)
+      .action(api.gabinet.packages.create, {
+        organizationId,
+        name: "Test Package",
+        treatments: [{ treatmentId: String(treatmentId), quantity: 4 }],
+        totalPrice: 400,
+      });
+
+    await expect(
+      t
+        .withIdentity(viewerIdentity)
+        .action(api.gabinet.packages.purchasePackage, {
+          organizationId,
+          patientId: String(patientId),
+          packageId,
+          paidAmount: 400,
+          paymentMethod: "cash",
+        }),
+    ).rejects.toThrow("Permission denied");
+  });
+
+  test("viewer cannot use a package treatment session", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity: ownerIdentity } =
+      await seedTestUser(t);
+    const { identity: viewerIdentity } = await seedSecondUser(
+      t,
+      organizationId,
+      { role: "viewer" },
+    );
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    const packageId = await t
+      .withIdentity(ownerIdentity)
+      .action(api.gabinet.packages.create, {
+        organizationId,
+        name: "Test Package",
+        treatments: [{ treatmentId: String(treatmentId), quantity: 4 }],
+        totalPrice: 400,
+      });
+
+    const usageId = await t
+      .withIdentity(ownerIdentity)
+      .action(api.gabinet.packages.purchasePackage, {
+        organizationId,
+        patientId: String(patientId),
+        packageId,
+        paidAmount: 400,
+        paymentMethod: "cash",
+      });
+
+    await expect(
+      t
+        .withIdentity(viewerIdentity)
+        .action(api.gabinet.packages.usePackageTreatment, {
+          organizationId,
+          usageId,
+          treatmentId: String(treatmentId),
+        }),
+    ).rejects.toThrow("Permission denied");
+  });
+
+  test("member can create a package (create:all by default)", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { identity: memberIdentity } = await seedSecondUser(
+      t,
+      organizationId,
+      { role: "member" },
+    );
+    const { treatmentId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    const packageId = await t
+      .withIdentity(memberIdentity)
+      .action(api.gabinet.packages.create, {
+        organizationId,
+        name: "Member Package",
+        treatments: [{ treatmentId: String(treatmentId), quantity: 2 }],
+        totalPrice: 200,
+      });
+
+    expect(packageId).toBeTruthy();
+  });
+});

--- a/tests/convex/packageDeduction.test.ts
+++ b/tests/convex/packageDeduction.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Package deduction guard tests for the Gabinet module.
+ *
+ * The appointmentBillingFlow.test.ts covers the happy-path auto-deduction via
+ * appointment completion. These tests cover edge cases in the manual deduction
+ * path (usePackageTreatment) that the billing flow test cannot reach:
+ * exhausted sessions, expired packages, treatment-not-in-package, and the
+ * auto-complete transition when the last session is used.
+ */
+
+import { afterEach, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import {
+  createTestCtx,
+  seedGabinetPrereqs,
+  seedTestUser,
+} from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+async function setupPackage(
+  t: ReturnType<typeof import("convex-test").convexTest>,
+  identity: { subject: string; issuer: string; tokenIdentifier: string },
+  args: {
+    organizationId: any;
+    patientId: any;
+    treatmentId: any;
+    quantity?: number;
+    totalPrice?: number;
+    validityDays?: number;
+  },
+) {
+  const packageId = await t.withIdentity(identity).action(
+    api.gabinet.packages.create,
+    {
+      organizationId: args.organizationId,
+      name: "Test Package",
+      treatments: [
+        {
+          treatmentId: String(args.treatmentId),
+          quantity: args.quantity ?? 2,
+        },
+      ],
+      totalPrice: args.totalPrice ?? 200,
+      validityDays: args.validityDays,
+    },
+  );
+
+  const usageId = await t.withIdentity(identity).action(
+    api.gabinet.packages.purchasePackage,
+    {
+      organizationId: args.organizationId,
+      patientId: String(args.patientId),
+      packageId,
+      paidAmount: args.totalPrice ?? 200,
+      paymentMethod: "cash",
+    },
+  );
+
+  return { packageId, usageId };
+}
+
+describe("package session deduction guards", () => {
+  test("usePackageTreatment deducts one session from the package", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    const { usageId } = await setupPackage(t, identity, {
+      organizationId,
+      patientId,
+      treatmentId,
+      quantity: 4,
+    });
+
+    const db = createSupabaseDb();
+    const usageBefore = await db.get<{
+      treatmentsUsed: Array<{ usedCount: number; totalCount: number }>;
+      status: string;
+    }>("gabinetPackageUsage", usageId);
+    expect(usageBefore?.treatmentsUsed[0].usedCount).toBe(0);
+    expect(usageBefore?.status).toBe("active");
+
+    await t.withIdentity(identity).action(
+      api.gabinet.packages.usePackageTreatment,
+      {
+        organizationId,
+        usageId,
+        treatmentId: String(treatmentId),
+      },
+    );
+
+    const usageAfter = await db.get<{
+      treatmentsUsed: Array<{ usedCount: number; totalCount: number }>;
+      status: string;
+    }>("gabinetPackageUsage", usageId);
+    expect(usageAfter?.treatmentsUsed[0].usedCount).toBe(1);
+    expect(usageAfter?.status).toBe("active");
+  });
+
+  test("using the last session auto-completes the package", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    const { usageId } = await setupPackage(t, identity, {
+      organizationId,
+      patientId,
+      treatmentId,
+      quantity: 1,
+    });
+
+    await t.withIdentity(identity).action(
+      api.gabinet.packages.usePackageTreatment,
+      {
+        organizationId,
+        usageId,
+        treatmentId: String(treatmentId),
+      },
+    );
+
+    const db = createSupabaseDb();
+    const usage = await db.get<{
+      treatmentsUsed: Array<{ usedCount: number; totalCount: number }>;
+      status: string;
+    }>("gabinetPackageUsage", usageId);
+    expect(usage?.treatmentsUsed[0].usedCount).toBe(1);
+    expect(usage?.status).toBe("completed");
+  });
+
+  test("completed package cannot be used (all sessions exhausted)", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    const { usageId } = await setupPackage(t, identity, {
+      organizationId,
+      patientId,
+      treatmentId,
+      quantity: 1,
+    });
+
+    // Use the single session — package auto-completes after this call
+    await t.withIdentity(identity).action(
+      api.gabinet.packages.usePackageTreatment,
+      {
+        organizationId,
+        usageId,
+        treatmentId: String(treatmentId),
+      },
+    );
+
+    const db = createSupabaseDb();
+    const completed = await db.get<{ status: string }>(
+      "gabinetPackageUsage",
+      usageId,
+    );
+    expect(completed?.status).toBe("completed");
+
+    // Second use is rejected: package is no longer active
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.packages.usePackageTreatment, {
+        organizationId,
+        usageId,
+        treatmentId: String(treatmentId),
+      }),
+    ).rejects.toThrow("Package is not active");
+  });
+
+  test("usePackageTreatment fails when package has expired", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    // Purchase a package with 30-day validity
+    const { usageId } = await setupPackage(t, identity, {
+      organizationId,
+      patientId,
+      treatmentId,
+      quantity: 4,
+      validityDays: 30,
+    });
+
+    // Manually patch expiresAt to the past to simulate expiry
+    const db = createSupabaseDb();
+    await db.patch("gabinetPackageUsage", usageId, {
+      expiresAt: Date.now() - 1,
+      updatedAt: Date.now(),
+    });
+
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.packages.usePackageTreatment, {
+        organizationId,
+        usageId,
+        treatmentId: String(treatmentId),
+      }),
+    ).rejects.toThrow("Package has expired");
+  });
+
+  test("usePackageTreatment fails for a treatment not in the package", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    const { usageId } = await setupPackage(t, identity, {
+      organizationId,
+      patientId,
+      treatmentId,
+      quantity: 4,
+    });
+
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.packages.usePackageTreatment, {
+        organizationId,
+        usageId,
+        treatmentId: "non-existent-treatment-id",
+      }),
+    ).rejects.toThrow("Treatment not in package");
+  });
+
+  test("usePackageTreatment fails when package is cancelled", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    const { usageId } = await setupPackage(t, identity, {
+      organizationId,
+      patientId,
+      treatmentId,
+      quantity: 4,
+    });
+
+    // Cancel the usage
+    await t.withIdentity(identity).action(
+      api.gabinet.packages.updatePackageUsage,
+      {
+        organizationId,
+        usageId,
+        status: "cancelled",
+      },
+    );
+
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.packages.usePackageTreatment, {
+        organizationId,
+        usageId,
+        treatmentId: String(treatmentId),
+      }),
+    ).rejects.toThrow("Package is not active");
+  });
+
+  test("cannot delete a package that has been purchased by a patient", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    const { packageId } = await setupPackage(t, identity, {
+      organizationId,
+      patientId,
+      treatmentId,
+    });
+
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.packages.remove, {
+        organizationId,
+        packageId,
+      }),
+    ).rejects.toThrow(
+      "Cannot delete a package that has been purchased by patients",
+    );
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4254.

Closes #4254

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- eb916d1 test(gabinet): add RBAC, document lifecycle and package deduction tests (closes #4254)

### Files changed

```
 convex/_test_helpers.ts                |  14 +-
 tests/convex/documentLifecycle.test.ts | 276 ++++++++++++++++++++++++++++++
 tests/convex/gabinetRbac.test.ts       | 259 ++++++++++++++++++++++++++++
 tests/convex/packageDeduction.test.ts  | 303 +++++++++++++++++++++++++++++++++
 4 files changed, 850 insertions(+), 2 deletions(-)
```