### PR TITLE
Fix `invitations.create` seat-limit enforcement not throwing

### DIFF
--- a/convex/_helpers/seatLimits.ts
+++ b/convex/_helpers/seatLimits.ts
@@ -108,7 +108,7 @@ export const _getSubscriptionAndPlanData = internalQuery({
       return { seatLimit: 20 };
     }
 
-    let maxSeatLimit = 20;
+    let maxSeatLimit: number | null = null;
     for (const sub of subscriptions) {
       const plan = await ctx.db.get(sub.planId);
       if (!plan) {
@@ -117,12 +117,13 @@ export const _getSubscriptionAndPlanData = internalQuery({
         );
         continue;
       }
-      if (plan.seatLimit > maxSeatLimit) {
+      if (maxSeatLimit === null || plan.seatLimit > maxSeatLimit) {
         maxSeatLimit = plan.seatLimit;
       }
     }
 
-    return { seatLimit: maxSeatLimit };
+    // Fall back to free tier only when every plan lookup failed (FK issue, etc.)
+    return { seatLimit: maxSeatLimit ?? 20 };
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4258.

Closes #4258

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 15b596b fix(seatLimits): enforce plan seatLimit when lower than default free tier

### Files changed

```
 convex/_helpers/seatLimits.ts | 7 ++++---
 1 file changed, 4 insertions(+), 3 deletions(-)
```