### PR TITLE
Fix `checkSeatLimit` docstring claiming default is "5 seats" when code uses 20

### DIFF
--- a/convex/_helpers/seatLimits.ts
+++ b/convex/_helpers/seatLimits.ts
@@ -13,7 +13,7 @@ import { createSupabaseDb } from "./supabaseDb";
  * Pass skipPendingInvitations=true at acceptance time (pending→member is a no-op
  * on the total count, so only members are checked then).
  *
- * If subscription lookup fails, defaults to free tier limit (5 seats).
+ * If subscription lookup fails, defaults to free tier limit (20 seats).
  */
 export async function checkSeatLimit(
   ctx: QueryCtx,

--- a/docs/seat-limits.md
+++ b/docs/seat-limits.md
@@ -10,7 +10,7 @@ Pending invitations do not count toward the seat limit. Only active team members
 
 ## Free Tier
 
-Organizations on the free tier have a default limit of 5 seats. This includes the owner, so up to 4 additional members can be invited.
+Organizations on the free tier have a default limit of 20 seats. This includes the owner, so up to 19 additional members can be invited.
 
 ## Paid Plans
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4262.

Closes #4262

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 05e0baa fix(seatLimits): align docstring and user docs with actual default of 20 seats (closes #4262)

### Files changed

```
 convex/_helpers/seatLimits.ts | 2 +-
 docs/seat-limits.md           | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```