### PR TITLE
The same "max wins" logic flaw exists in `checkSeatLimit` (the QueryCtx version)

### DIFF
--- a/convex/_helpers/seatLimits.ts
+++ b/convex/_helpers/seatLimits.ts
@@ -47,8 +47,10 @@ export async function checkSeatLimit(
   const org = await ctx.db.get(args.organizationId);
   if (!org) throw new Error("Organization not found");
 
-  // Find active or trialing subscription for org owner
-  const subscription = await ctx.db
+  // Find all active or trialing subscriptions for org owner and take the
+  // highest seatLimit ("max wins") so that orgs with multiple per-module
+  // plans get the most generous limit. Matches _getSubscriptionAndPlanData.
+  const subscriptions = await ctx.db
     .query("subscriptions")
     .withIndex("userId", (q) => q.eq("userId", org.ownerId))
     .filter((q) =>
@@ -57,23 +59,32 @@ export async function checkSeatLimit(
         q.eq(q.field("status"), "trialing")
       )
     )
-    .first();
+    .collect();
 
   // Fail open: default to free tier limit if subscription data is unavailable.
   let seatLimit = 20; // Default free tier
-  if (subscription) {
-    const plan = await ctx.db.get(subscription.planId);
-    if (plan) {
-      seatLimit = plan.seatLimit;
-    } else {
-      console.warn(
-        `[seatLimits] Plan ${subscription.planId} not found for subscription ${subscription._id}. Using default seat limit.`
-      );
-    }
-  } else {
+  if (subscriptions.length === 0) {
     console.warn(
       `[seatLimits] No active subscription found for org owner ${org.ownerId} (org: ${args.organizationId}). Using default free tier limit.`
     );
+  } else {
+    let maxSeatLimit: number | null = null;
+    for (const sub of subscriptions) {
+      const plan = await ctx.db.get(sub.planId);
+      if (!plan) {
+        console.warn(
+          `[seatLimits] Plan ${sub.planId} not found for subscription ${sub._id}. Skipping.`
+        );
+        continue;
+      }
+      if (maxSeatLimit === null || plan.seatLimit > maxSeatLimit) {
+        maxSeatLimit = plan.seatLimit;
+      }
+    }
+    // Fall back to free tier only when every plan lookup failed (FK issue, etc.)
+    if (maxSeatLimit !== null) {
+      seatLimit = maxSeatLimit;
+    }
   }
 
   return {

--- a/tests/convex/seatLimits.test.ts
+++ b/tests/convex/seatLimits.test.ts
@@ -190,6 +190,84 @@ describe("checkSeatLimit via getSeatUsage", () => {
     expect(usage.canAddMore).toBe(false);
   });
 
+  test("uses max seatLimit when owner has multiple active subscriptions", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    await t.run(async (ctx) => {
+      const planA = await ctx.db.insert("plans", {
+        key: "free",
+        stripeId: "price_free_multi",
+        name: "Free",
+        description: "Free plan (lower limit)",
+        seatLimit: 10,
+        prices: {
+          month: {
+            usd: { stripeId: "price_a_m_usd", amount: 0 },
+            eur: { stripeId: "price_a_m_eur", amount: 0 },
+            pln: { stripeId: "price_a_m_pln", amount: 0 },
+          },
+          year: {
+            usd: { stripeId: "price_a_y_usd", amount: 0 },
+            eur: { stripeId: "price_a_y_eur", amount: 0 },
+            pln: { stripeId: "price_a_y_pln", amount: 0 },
+          },
+        },
+      });
+      const planB = await ctx.db.insert("plans", {
+        key: "pro",
+        stripeId: "price_pro_multi",
+        name: "Pro",
+        description: "Pro plan (higher limit)",
+        seatLimit: 50,
+        prices: {
+          month: {
+            usd: { stripeId: "price_b_m_usd", amount: 2900 },
+            eur: { stripeId: "price_b_m_eur", amount: 2900 },
+            pln: { stripeId: "price_b_m_pln", amount: 12900 },
+          },
+          year: {
+            usd: { stripeId: "price_b_y_usd", amount: 29000 },
+            eur: { stripeId: "price_b_y_eur", amount: 29000 },
+            pln: { stripeId: "price_b_y_pln", amount: 129000 },
+          },
+        },
+      });
+
+      await ctx.db.insert("subscriptions", {
+        userId,
+        planId: planA,
+        priceStripeId: "price_a_m_usd",
+        stripeId: "sub_a",
+        currency: "usd",
+        interval: "month",
+        status: "active",
+        currentPeriodStart: Date.now(),
+        currentPeriodEnd: Date.now() + 30 * 24 * 60 * 60 * 1000,
+        cancelAtPeriodEnd: false,
+      });
+      await ctx.db.insert("subscriptions", {
+        userId,
+        planId: planB,
+        priceStripeId: "price_b_m_usd",
+        stripeId: "sub_b",
+        currency: "usd",
+        interval: "month",
+        status: "active",
+        currentPeriodStart: Date.now(),
+        currentPeriodEnd: Date.now() + 30 * 24 * 60 * 60 * 1000,
+        cancelAtPeriodEnd: false,
+      });
+    });
+
+    const usage = await t
+      .withIdentity(identity)
+      .query(api.organizations.getSeatUsage, { organizationId });
+
+    // Should use the higher of the two plan limits
+    expect(usage.seatLimit).toBe(50);
+  });
+
   test("seat limits are per-organization", async () => {
     const t = createTestCtx();
     const { organizationId: org1Id, identity } = await seedTestUser(t);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4263.

Closes #4263

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a7245f4 fix(seatLimits): align checkSeatLimit to use max-wins logic like _getSubscriptionAndPlanData (closes #4263)

### Files changed

```
 convex/_helpers/seatLimits.ts   | 37 ++++++++++++-------
 tests/convex/seatLimits.test.ts | 78 +++++++++++++++++++++++++++++++++++++++++
 2 files changed, 102 insertions(+), 13 deletions(-)
```