### PR TITLE
Extend `gabinetRbac.test.ts` for patient mutations

### DIFF
--- a/tests/convex/gabinetRbac.test.ts
+++ b/tests/convex/gabinetRbac.test.ts
@@ -132,6 +132,87 @@ describe("gabinet_appointments RBAC", () => {
   });
 });
 
+describe("gabinet_patients RBAC", () => {
+  test("viewer cannot create a patient", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { identity: viewerIdentity } = await seedSecondUser(
+      t,
+      organizationId,
+      { role: "viewer" },
+    );
+    await seedGabinetPrereqs(t, organizationId, userId);
+
+    await expect(
+      t.withIdentity(viewerIdentity).action(api.gabinet.patients.create, {
+        organizationId,
+        firstName: "Nowy",
+        lastName: "Pacjent",
+        email: "nowy@example.com",
+      }),
+    ).rejects.toThrow("Permission denied");
+  });
+
+  test("viewer cannot update a patient", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { identity: viewerIdentity } = await seedSecondUser(
+      t,
+      organizationId,
+      { role: "viewer" },
+    );
+    const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    await expect(
+      t.withIdentity(viewerIdentity).action(api.gabinet.patients.update, {
+        organizationId,
+        patientId: String(patientId),
+        firstName: "Zmieniony",
+      }),
+    ).rejects.toThrow("Permission denied");
+  });
+
+  test("viewer cannot remove a patient", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { identity: viewerIdentity } = await seedSecondUser(
+      t,
+      organizationId,
+      { role: "viewer" },
+    );
+    const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
+
+    await expect(
+      t.withIdentity(viewerIdentity).action(api.gabinet.patients.remove, {
+        organizationId,
+        patientId: String(patientId),
+      }),
+    ).rejects.toThrow("Permission denied");
+  });
+
+  test("member can create a patient (create:all by default)", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { identity: memberIdentity } = await seedSecondUser(
+      t,
+      organizationId,
+      { role: "member" },
+    );
+    await seedGabinetPrereqs(t, organizationId, userId);
+
+    const newPatientId = await t
+      .withIdentity(memberIdentity)
+      .action(api.gabinet.patients.create, {
+        organizationId,
+        firstName: "Nowy",
+        lastName: "Pacjent",
+        email: "nowy@example.com",
+      });
+
+    expect(newPatientId).toBeTruthy();
+  });
+});
+
 describe("gabinet_packages RBAC", () => {
   test("viewer cannot create a package", async () => {
     const t = createTestCtx();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4259.

Closes #4259

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 02fa9e5 test(gabinetRbac): add viewer-vs-member RBAC tests for patient mutations (closes #4259)

### Files changed

```
 tests/convex/gabinetRbac.test.ts | 81 ++++++++++++++++++++++++++++++++++++++++
 1 file changed, 81 insertions(+)
```