### PR TITLE
Missing audit/activity logging for loyalty writes in appointments.ts and package

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -3082,7 +3082,7 @@ async function returnPackageEntry(
  * treatment price and deduct from linked package if applicable.
  */
 async function handleAppointmentCompletion(
-  _ctx: any,
+  ctx: MutationCtx,
   args: {
     organizationId: Id<"organizations">;
     appointmentId: Id<"gabinetAppointments">;
@@ -3165,6 +3165,21 @@ async function handleAppointmentCompletion(
         balanceAfter: newBalance,
         createdBy: userIdStr,
         createdAt: now,
+      });
+
+      await logAudit(ctx, {
+        organizationId: args.organizationId,
+        userId: args.userId,
+        action: "loyalty_points_earned",
+        entityType: "gabinetPatient",
+        entityId: patientIdStr,
+        details: JSON.stringify({
+          points,
+          balanceAfter: newBalance,
+          reason: `Appointment completed: ${treatment?.name ?? "Treatment"}`,
+          referenceType: "appointment",
+          referenceId: String(args.appointmentId),
+        }),
       });
     }
   }

--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -904,6 +904,22 @@ export const _purchaseSideEffects = internalMutation({
         isGift: !args.patientId,
       }),
     });
+
+    if (args.loyaltyPointsAwarded > 0 && args.patientId) {
+      await logAudit(ctx, {
+        organizationId: args.organizationId,
+        userId: args.createdBy as Id<"users">,
+        action: "loyalty_points_earned",
+        entityType: "gabinetPatient",
+        entityId: args.patientId,
+        details: JSON.stringify({
+          points: args.loyaltyPointsAwarded,
+          reason: `Package purchase: ${args.packageName}`,
+          referenceType: "packageUsage",
+          referenceId: args.usageId,
+        }),
+      });
+    }
   },
 });
 
@@ -1407,6 +1423,52 @@ export const assignGiftPackage = action({
         createdAt: now,
       });
     }
+
+    if (loyaltyPointsAwarded > 0) {
+      try {
+        await ctx.runMutation(internal.gabinet.packages._assignGiftSideEffects, {
+          usageId: args.usageId,
+          organizationId: args.organizationId,
+          patientId: args.patientId,
+          packageName: (pkg?.name as string) ?? "",
+          loyaltyPointsAwarded,
+          performedBy: String(authResult.userId),
+        });
+      } catch (e) {
+        console.error(
+          "[packages.assignGiftPackage] Side effects FAILED for usage",
+          args.usageId,
+          ":",
+          e,
+        );
+      }
+    }
+  },
+});
+
+export const _assignGiftSideEffects = internalMutation({
+  args: {
+    usageId: v.string(),
+    organizationId: v.id("organizations"),
+    patientId: v.string(),
+    packageName: v.string(),
+    loyaltyPointsAwarded: v.number(),
+    performedBy: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: args.performedBy as Id<"users">,
+      action: "loyalty_points_earned",
+      entityType: "gabinetPatient",
+      entityId: args.patientId,
+      details: JSON.stringify({
+        points: args.loyaltyPointsAwarded,
+        reason: `Gift package assigned: ${args.packageName}`,
+        referenceType: "packageUsage",
+        referenceId: args.usageId,
+      }),
+    });
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4274.

Closes #4274

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 317abaa fix(loyalty): add missing audit logging for loyalty point writes (closes #4274)

### Files changed

```
 convex/gabinet/appointments.ts | 17 +++++++++++-
 convex/gabinet/packages.ts     | 62 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 78 insertions(+), 1 deletion(-)
```