### PR TITLE
Migrate remaining `listLocations` Convex action callers to `useSupabaseGabinetLo

### DIFF
--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -6,6 +6,7 @@ import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseCustomFieldDefinitions } from "@/hooks/use-supabase-custom-fields";
+import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -98,12 +99,7 @@ export function EmployeeForm({
     enabled: !!organizationId,
   });
 
-  const listLocationsAction = useAction(api.gabinet.locations.listLocations);
-  const { data: locations } = useQuery({
-    queryKey: ["gabinet.locations.listLocations", organizationId],
-    queryFn: () => listLocationsAction({ organizationId }),
-    enabled: !!organizationId,
-  }) as { data: Array<{ _id: string; name: string; isActive: boolean }> | undefined };
+  const { data: locations } = useSupabaseGabinetLocationsList(String(organizationId));
 
   const { data: customFieldDefs } = useSupabaseCustomFieldDefinitions(
     organizationId,

--- a/src/components/forms/user-invitation-form.tsx
+++ b/src/components/forms/user-invitation-form.tsx
@@ -6,6 +6,7 @@ import { api } from "@cvx/_generated/api";
 import { useSupabasePendingInvitations } from "@/hooks/use-supabase-invitations";
 import { useSupabaseSeatUsage } from "@/hooks/use-supabase-organizations";
 import { useSupabaseCustomFieldDefinitions } from "@/hooks/use-supabase-custom-fields";
+import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
 import { Button } from "@/components/ui/button";
@@ -117,12 +118,9 @@ export function UserInvitationForm({
     enabled: !!organizationId && module === "gabinet",
   }) as { data: Array<{ _id: string; name: string; duration?: number }> | undefined };
 
-  const listLocationsAction = useAction(api.gabinet.locations.listLocations);
-  const { data: locations } = useQuery({
-    queryKey: ["gabinet.locations.listLocations", organizationId],
-    queryFn: () => listLocationsAction({ organizationId }),
-    enabled: !!organizationId && module === "gabinet",
-  }) as { data: Array<{ _id: string; name: string; isActive: boolean }> | undefined };
+  const { data: locations } = useSupabaseGabinetLocationsList(String(organizationId), {
+    enabled: module === "gabinet",
+  });
 
   const { tags: tagDefinitions } = useTagDefinitions(organizationId) as {
     tags: Array<{ _id: Id<"tagDefinitions">; name: string; color: string }>;

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -96,6 +96,7 @@ import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { useSupabaseGabinetAppointmentsByDateRange } from "@/hooks/use-supabase-gabinet-appointments";
 import { useSupabaseOrgSettings, useSupabaseOrganizationMembers } from "@/hooks/use-supabase-organizations";
+import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
 import { formatPhoneNumber } from "@/lib/phone";
 
 // ---------------------------------------------------------------------------
@@ -239,12 +240,7 @@ export function AppointmentDialog({
 
   const { data: members } = useSupabaseOrganizationMembers(String(organizationId));
 
-  const listLocationsAction = useAction(api.gabinet.locations.listLocations);
-  const { data: locations } = useQuery({
-    queryKey: ["gabinet.locations.listLocations", organizationId],
-    queryFn: () => listLocationsAction({ organizationId }),
-    enabled: !!organizationId,
-  });
+  const { data: locations } = useSupabaseGabinetLocationsList(String(organizationId));
 
   const { data: orgSettings } = useSupabaseOrgSettings(String(organizationId));
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4280.

Closes #4280

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d2b0ded feat(gabinet): migrate listLocations callers to useSupabaseGabinetLocationsList (closes #4280)

### Files changed

```
 src/components/forms/employee-form.tsx                 |  8 ++------
 src/components/forms/user-invitation-form.tsx          | 10 ++++------
 src/components/gabinet/calendar/appointment-dialog.tsx |  8 ++------
 3 files changed, 8 insertions(+), 18 deletions(-)
```