### PR TITLE
Add a Supabase hook for single-location-with-rooms fetch to replace `getLocation

### DIFF
--- a/convex/gabinet/locations.ts
+++ b/convex/gabinet/locations.ts
@@ -5,12 +5,7 @@ import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { logError } from "../_helpers/logged";
 import { logActivity } from "../_helpers/activities";
-import type {
-  GabinetLocationRow,
-  GabinetRoomRow,
-} from "../_helpers/supabaseRows";
-
-type GabinetLocationWithRooms = GabinetLocationRow & { rooms: GabinetRoomRow[] };
+import type { GabinetLocationRow } from "../_helpers/supabaseRows";
 
 // Dual-write refs removed — Supabase is now primary for location/room writes
 
@@ -30,28 +25,6 @@ export const listLocations = action({
   },
 });
 
-export const getLocation = action({
-  args: {
-    organizationId: v.id("organizations"),
-    locationId: v.string(),
-  },
-  handler: async (ctx, args): Promise<GabinetLocationWithRooms | null> => {
-    await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
-      organizationId: args.organizationId,
-    });
-    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
-    const db = createSupabaseDb();
-    const location = (await db.get("gabinetLocations", args.locationId)) as
-      | GabinetLocationRow
-      | null;
-    if (!location || String(location.organizationId) !== String(args.organizationId)) return null;
-    const rooms = (await db
-      .query("gabinetRooms")
-      .eq("locationId", args.locationId)
-      .collect()) as GabinetRoomRow[];
-    return { ...location, rooms };
-  },
-});
 
 export const createLocation = action({
   args: {

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -96,7 +96,7 @@ import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { useSupabaseGabinetAppointmentsByDateRange } from "@/hooks/use-supabase-gabinet-appointments";
 import { useSupabaseOrgSettings, useSupabaseOrganizationMembers } from "@/hooks/use-supabase-organizations";
-import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
+import { useSupabaseGabinetLocationsList, useSupabaseGabinetLocation } from "@/hooks/use-supabase-gabinet-locations";
 import { formatPhoneNumber } from "@/lib/phone";
 
 // ---------------------------------------------------------------------------
@@ -608,16 +608,11 @@ export function AppointmentDialog({
   }, [slotsErrored, slotsError]);
 
   // Rooms query — enabled only when a location is selected
-  const getLocationAction = useAction(api.gabinet.locations.getLocation);
-  const { data: locationWithRooms } = useQuery({
-    queryKey: ["gabinet.locations.getLocation", organizationId, locationId],
-    queryFn: () =>
-      getLocationAction({
-        organizationId,
-        locationId: locationId as string,
-      }),
-    enabled: !!locationId,
-  });
+  const { data: locationWithRooms } = useSupabaseGabinetLocation(
+    String(organizationId),
+    locationId as string,
+    { enabled: !!locationId },
+  );
   const activeRooms = locationWithRooms?.rooms?.filter((r) => r.isActive) ?? [];
 
   const activeLocations = locations?.filter((l) => l.isActive) ?? [];

--- a/src/hooks/use-supabase-gabinet-locations.ts
+++ b/src/hooks/use-supabase-gabinet-locations.ts
@@ -9,6 +9,14 @@ import {
   mapGabinetLocationFromSupabase,
   type MappedGabinetLocation,
 } from "@/lib/supabase/mappers/gabinet/locations";
+import {
+  mapGabinetRoomFromSupabase,
+  type MappedGabinetRoom,
+} from "@/lib/supabase/mappers/gabinet/rooms";
+
+export type MappedGabinetLocationWithRooms = MappedGabinetLocation & {
+  rooms: MappedGabinetRoom[];
+};
 
 // ---------------------------------------------------------------------------
 // Locations List
@@ -59,4 +67,56 @@ export function useSupabaseGabinetLocationsList(
     },
     enabled: enabled && isReady && !!organizationId,
   } satisfies UseQueryOptions<MappedGabinetLocation[], Error>);
+}
+
+// ---------------------------------------------------------------------------
+// Single Location with Rooms
+// ---------------------------------------------------------------------------
+
+interface UseSupabaseGabinetLocationOptions {
+  enabled?: boolean;
+}
+
+export function useSupabaseGabinetLocation(
+  organizationId: string,
+  locationId: string | null | undefined,
+  options: UseSupabaseGabinetLocationOptions = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  return useQuery<MappedGabinetLocationWithRooms | null, Error>({
+    queryKey: [
+      ...supabaseKeys.gabinetLocations.detail(organizationId, locationId ?? ""),
+      "with-rooms",
+    ],
+    queryFn: async (): Promise<MappedGabinetLocationWithRooms | null> => {
+      if (!client) throw new Error("Supabase client not ready");
+
+      const { data: locationData, error: locationError } = await client
+        .from("gabinet_locations")
+        .select("*")
+        .eq("organization_id", organizationId)
+        .eq("id", locationId!)
+        .maybeSingle();
+
+      if (locationError) throw locationError;
+      if (!locationData) return null;
+
+      const { data: roomsData, error: roomsError } = await client
+        .from("gabinet_rooms")
+        .select("*")
+        .eq("organization_id", organizationId)
+        .eq("location_id", locationId!)
+        .order("name", { ascending: true });
+
+      if (roomsError) throw roomsError;
+
+      return {
+        ...mapGabinetLocationFromSupabase(locationData),
+        rooms: (roomsData ?? []).map(mapGabinetRoomFromSupabase),
+      };
+    },
+    enabled: enabled && isReady && !!organizationId && !!locationId,
+  } satisfies UseQueryOptions<MappedGabinetLocationWithRooms | null, Error>);
 }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
@@ -4,7 +4,7 @@ import { useAction, useQuery as useConvexQuery } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { useSupabaseGabinetEquipmentList } from "@/hooks/use-supabase-gabinet-equipment";
-import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
+import { useSupabaseGabinetLocationsList, useSupabaseGabinetLocation } from "@/hooks/use-supabase-gabinet-locations";
 import type { MappedGabinetEquipment } from "@/lib/supabase/mappers/gabinet/equipment";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { SectionHeader } from "@untitled/app/section-headers/section-headers";
@@ -271,16 +271,11 @@ function EquipmentCard({
     { enabled: expanded && activityOpen },
   );
 
-  const getLocationAction = useAction(api.gabinet.locations.getLocation);
-  const { data: selectedLocationData } = useQuery({
-    queryKey: ["gabinet.locations.getLocation", organizationId, transferLocationId],
-    queryFn: () =>
-      getLocationAction({
-        organizationId,
-        locationId: transferLocationId as string,
-      }),
-    enabled: !!transferLocationId,
-  });
+  const { data: selectedLocationData } = useSupabaseGabinetLocation(
+    organizationId as string,
+    transferLocationId,
+    { enabled: !!transferLocationId },
+  );
 
   const currentLocation = locations.find(
     (l) => l._id === item.currentLocationId

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.locations.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
-import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
+import { useSupabaseGabinetLocationsList, useSupabaseGabinetLocation } from "@/hooks/use-supabase-gabinet-locations";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { SectionHeader } from "@untitled/app/section-headers/section-headers";
 import { UntitledAlert } from "@/components/ui/untitled-alert";
@@ -208,13 +208,11 @@ function LocationCard({
   const [saving, setSaving] = useState(false);
   const [addingRoom, setAddingRoom] = useState(false);
 
-  const getLocationAction = useAction(api.gabinet.locations.getLocation);
-  const { data: location } = useQuery({
-    queryKey: ["gabinet.locations.getLocation", organizationId, locationId],
-    queryFn: () =>
-      getLocationAction({ organizationId, locationId: locationId as string }),
-    enabled: expanded && !!organizationId && !!locationId,
-  }) as { data: LocationWithRooms | null | undefined };
+  const { data: location } = useSupabaseGabinetLocation(
+    organizationId as string,
+    locationId as string,
+    { enabled: expanded && !!organizationId && !!locationId },
+  ) as { data: LocationWithRooms | null | undefined };
 
   const updateLocation = useAction(api.gabinet.locations.updateLocation);
   const deleteLocation = useAction(api.gabinet.locations.deleteLocation);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4281.

Closes #4281

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e9ec2f1 feat(gabinet): add useSupabaseGabinetLocation hook and remove getLocation Convex action (closes #4281)

### Files changed

```
 convex/gabinet/locations.ts                        | 29 +----------
 .../gabinet/calendar/appointment-dialog.tsx        | 17 +++---
 src/hooks/use-supabase-gabinet-locations.ts        | 60 ++++++++++++++++++++++
 .../_layout.gabinet.settings.equipment.tsx         | 17 +++---
 .../_layout.gabinet.settings.locations.tsx         | 14 +++--
 5 files changed, 79 insertions(+), 58 deletions(-)
```