### PR TITLE
Update CLAUDE.md Seat Limits section to say 20 seats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -629,7 +629,7 @@ Only output `GATE2_APPROVED` after ALL checks pass.
 
 ## Seat Limits
 
-Organizations have subscription-based seat limits enforced when inviting team members. The flow is: `checkSeatLimit()` helper in `convex/_helpers/seatLimits.ts` counts active `teamMemberships` and compares against the plan's `seatLimit` field. The `invitations.create` mutation calls this helper and throws if the limit is reached. The `getSeatUsage` query in `convex/organizations.ts` exposes seat usage to the frontend. The team settings page (`_layout.settings.team.tsx`) shows a progress bar, warning at 80%, and upgrade CTA at limit. Fail-open behavior: if subscription lookup fails, defaults to free tier limit (5 seats). See `docs/seat-limits.md` for user-facing documentation.
+Organizations have subscription-based seat limits enforced when inviting team members. The flow is: `checkSeatLimit()` helper in `convex/_helpers/seatLimits.ts` counts active `teamMemberships` and compares against the plan's `seatLimit` field. The `invitations.create` mutation calls this helper and throws if the limit is reached. The `getSeatUsage` query in `convex/organizations.ts` exposes seat usage to the frontend. The team settings page (`_layout.settings.team.tsx`) shows a progress bar, warning at 80%, and upgrade CTA at limit. Fail-open behavior: if subscription lookup fails, defaults to free tier limit (20 seats). See `docs/seat-limits.md` for user-facing documentation.
 
 ## UTUI Component Rules (MANDATORY)
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4266.

Closes #4266

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e650119 docs: update Seat Limits section in CLAUDE.md to reflect 20-seat free tier default (closes #4266)

### Files changed

```
 CLAUDE.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```