### PR TITLE
Catalog-driven subscription fallback

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -44,12 +44,10 @@ export const PRODUCT_KEYS = {
   GABINET: "gabinet",
   MAGAZYN: "magazyn",
 } as const;
-export const productKeyValidator = v.union(
-  v.literal(PRODUCT_KEYS.CRM),
-  v.literal(PRODUCT_KEYS.GABINET),
-  v.literal(PRODUCT_KEYS.MAGAZYN),
-);
-export type ProductKey = Infer<typeof productKeyValidator>;
+// Open string so new modules can be introduced without a schema migration.
+// PRODUCT_KEYS above serves as the developer reference for known modules.
+export const productKeyValidator = v.string();
+export type ProductKey = string;
 
 const priceValidator = v.object({
   stripeId: v.string(),

--- a/src/hooks/use-module-access.ts
+++ b/src/hooks/use-module-access.ts
@@ -10,8 +10,8 @@ export type { GabinetModule };
  * a given gabinet sub-module (or any product key string).
  *
  * Mirrors the server-side `checkModuleAccess` / `verifyProductAccess` logic:
- * - During grace period (no subscriptions at all) access is granted.
- * - Once subscriptions exist, the product must be present and active/trialing.
+ * access is granted only when an active or trialing productSubscription row
+ * exists for the requested product.
  */
 export function useModuleAccess(module: GabinetModule | (string & {})): {
   hasAccess: boolean;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4291.

Closes #4291

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 134b109 fix(platform): make productKeyValidator catalog-driven (closes #4291)

### Files changed

```
 convex/schema.ts               | 10 ++++------
 src/hooks/use-module-access.ts |  4 ++--
 2 files changed, 6 insertions(+), 8 deletions(-)
```