### PR TITLE
Add Supabase Postgres index on `leads.created_at` for reports query performance

### DIFF
--- a/supabase/migrations/00115_leads_created_at_idx.sql
+++ b/supabase/migrations/00115_leads_created_at_idx.sql
@@ -1,0 +1,4 @@
+-- Index to support useSupabaseLeadsForReports date-range queries.
+-- The hook filters by (organization_id, created_at) range; without this index
+-- the query does a full org-scoped scan of leads which degrades at scale.
+CREATE INDEX leads_org_created_at_idx ON leads (organization_id, created_at);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4288.

Closes #4288

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8295cb8 perf(db): add composite index on leads(organization_id, created_at) (closes #4288)

### Files changed

```
 supabase/migrations/00115_leads_created_at_idx.sql | 4 ++++
 1 file changed, 4 insertions(+)
```