### PR TITLE
Track stage-entry timestamps to enable true funnel speed

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -30,6 +30,7 @@ const TABLE_MAP: Record<string, string> = {
   pipelines: "pipelines",
   pipelineStages: "pipeline_stages",
   pipelineStageActions: "pipeline_stage_actions",
+  leadStageHistory: "lead_stage_history",
   scheduledActivities: "scheduled_activities",
   savedViews: "saved_views",
   auditLog: "audit_log",

--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -674,6 +674,23 @@ export const moveToStage = action({
 
     await db.patch("leads", args.leadId, updateData);
 
+    // --- Record stage entry in lead_stage_history ---
+    try {
+      await db.raw()
+        .from("lead_stage_history")
+        .update({ exited_at: now })
+        .eq("lead_id", args.leadId)
+        .is("exited_at", null);
+      await db.insert("leadStageHistory", {
+        organizationId: args.organizationId,
+        leadId: args.leadId,
+        stageId: args.pipelineStageId,
+        enteredAt: now,
+      });
+    } catch (e) {
+      console.warn("[moveToStage] stage history write failed:", e);
+    }
+
     // --- Execute pipeline stage auto-actions (create_activity → scheduledActivities) in Supabase ---
     const createdActivities: Array<{ ownerId: string; title: string }> = [];
     try {

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -201,6 +201,16 @@ export function createCrmTables({
     .index("by_stage", ["stageId"])
     .index("by_org", ["organizationId"]),
 
+  leadStageHistory: defineTable({
+    organizationId: v.id("organizations"),
+    leadId: v.id("leads"),
+    stageId: v.id("pipelineStages"),
+    enteredAt: v.number(),
+    exitedAt: v.optional(v.number()),
+  })
+    .index("by_lead", ["leadId", "enteredAt"])
+    .index("by_org_stage", ["organizationId", "stageId"]),
+
   customFieldDefinitions: defineTable({
     organizationId: v.id("organizations"),
     entityType: entityTypeValidator,

--- a/supabase/migrations/00116_lead_stage_history.sql
+++ b/supabase/migrations/00116_lead_stage_history.sql
@@ -1,0 +1,32 @@
+-- Migration 00116: Lead Stage History (closes #4289)
+-- Tracks when a lead enters and exits each pipeline stage,
+-- enabling "avg time per stage" funnel velocity reporting.
+
+CREATE TABLE IF NOT EXISTS lead_stage_history (
+  id              TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  lead_id         TEXT NOT NULL REFERENCES leads(id) ON DELETE CASCADE,
+  stage_id        TEXT NOT NULL REFERENCES pipeline_stages(id),
+  entered_at      BIGINT NOT NULL,
+  exited_at       BIGINT
+);
+
+-- Fast lookup: all stage entries for a lead in chronological order
+CREATE INDEX IF NOT EXISTS lead_stage_history_lead_idx
+  ON lead_stage_history (lead_id, entered_at);
+
+-- Aggregate queries: avg time per stage across all leads in an org
+CREATE INDEX IF NOT EXISTS lead_stage_history_org_stage_idx
+  ON lead_stage_history (organization_id, stage_id);
+
+ALTER TABLE lead_stage_history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY lead_stage_history_select ON lead_stage_history
+  FOR SELECT USING (current_org_id() = organization_id);
+CREATE POLICY lead_stage_history_insert ON lead_stage_history
+  FOR INSERT WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY lead_stage_history_update ON lead_stage_history
+  FOR UPDATE USING (current_org_id() = organization_id)
+  WITH CHECK (current_org_id() = organization_id);
+CREATE POLICY lead_stage_history_delete ON lead_stage_history
+  FOR DELETE USING (current_org_id() = organization_id);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4289.

Closes #4289

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 7b56847 feat(crm): add lead_stage_history table and record stage transitions (closes #4289)

### Files changed

```
 convex/_helpers/supabaseDb.ts                    |  1 +
 convex/leads.ts                                  | 17 +++++++++++++
 convex/schema/crm.ts                             | 10 ++++++++
 supabase/migrations/00116_lead_stage_history.sql | 32 ++++++++++++++++++++++++
 4 files changed, 60 insertions(+)
```