### PR TITLE
Uzupełnić tłumaczenia angielskie

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -667,7 +667,8 @@
       "filterByType": "Filter by type",
       "showCompleted": "Show completed",
       "hideCompleted": "Hide completed"
-    }
+    },
+    "pageTitle": "Activities"
   },
   "documents": {
     "title": "Documents",
@@ -1255,6 +1256,8 @@
     "automationLastRunLabel": "Last run: {{status}}",
     "automationRunsSubtitle": "Module: {{module}}",
     "automationActionCount_one": "{{count}} action",
+    "automationActionCount_few": "{{count}} actions",
+    "automationActionCount_many": "{{count}} actions",
     "automationActionCount_other": "{{count}} actions",
     "automationRuleStates": {
       "enabled": "Enabled",
@@ -2067,10 +2070,16 @@
     "relative": {
       "justNow": "just now",
       "minutesAgo_one": "{{count}}m ago",
+      "minutesAgo_few": "{{count}}m ago",
+      "minutesAgo_many": "{{count}}m ago",
       "minutesAgo_other": "{{count}}m ago",
       "hoursAgo_one": "{{count}}h ago",
+      "hoursAgo_few": "{{count}}h ago",
+      "hoursAgo_many": "{{count}}h ago",
       "hoursAgo_other": "{{count}}h ago",
       "daysAgo_one": "{{count}}d ago",
+      "daysAgo_few": "{{count}}d ago",
+      "daysAgo_many": "{{count}}d ago",
       "daysAgo_other": "{{count}}d ago"
     },
     "entityLabels": {
@@ -2159,12 +2168,16 @@
       "updatedEmployeeProfile": "Updated employee profile",
       "deactivatedEmployeeProfile": "Deactivated employee profile",
       "updatedTreatmentQualifications_one": "Updated treatment qualifications ({{count}} treatment)",
+      "updatedTreatmentQualifications_few": "Updated treatment qualifications ({{count}} treatments)",
+      "updatedTreatmentQualifications_many": "Updated treatment qualifications ({{count}} treatments)",
       "updatedTreatmentQualifications_other": "Updated treatment qualifications ({{count}} treatments)",
       "createdPatient": "Created patient {{name}}",
       "updatedPatient": "Updated patient {{name}}",
       "deletedPatient": "Deleted patient {{name}}",
       "createdPackage": "Created package {{name}}",
       "usedPackageTreatments_one": "Used {{count}} treatment from package {{name}}",
+      "usedPackageTreatments_few": "Used {{count}} treatments from package {{name}}",
+      "usedPackageTreatments_many": "Used {{count}} treatments from package {{name}}",
       "usedPackageTreatments_other": "Used {{count}} treatments from package {{name}}",
       "sentAutomatedSms": "Sent automated SMS for {{eventType}}",
       "sentAppointmentConfirmationSms": "Sent appointment confirmation SMS for {{date}} at {{time}}",
@@ -2498,6 +2511,8 @@
       },
       "duplicatesBanner": {
         "count_one": "{{count}} client has a duplicate email or phone.",
+        "count_few": "{{count}} clients have a duplicate email or phone.",
+        "count_many": "{{count}} clients have a duplicate email or phone.",
         "count_other": "{{count}} clients have a duplicate email or phone.",
         "action": "Review duplicates"
       },
@@ -2705,6 +2720,8 @@
       },
       "groupByEquipment": "Group by equipment",
       "groupCount_one": "{{count}} treatment",
+      "groupCount_few": "{{count}} treatments",
+      "groupCount_many": "{{count}} treatments",
       "groupCount_other": "{{count}} treatments",
       "groups": {
         "noEquipment": "No equipment",
@@ -2854,6 +2871,8 @@
       "allEmployees": "All employees",
       "filterByEmployee": "Select employees",
       "employeesSelectedCount_one": "{{count}} employee",
+      "employeesSelectedCount_few": "{{count}} employees",
+      "employeesSelectedCount_many": "{{count}} employees",
       "employeesSelectedCount_other": "{{count}} employees",
       "clearEmployeeSelection": "Clear selection",
       "noEmployeesFound": "No employees found",
@@ -2861,6 +2880,8 @@
       "usingDefaults": "Default hours",
       "editTitle": "Edit employee schedule",
       "datedPeriodsCount_one": "{{count}} dated period",
+      "datedPeriodsCount_few": "{{count}} dated periods",
+      "datedPeriodsCount_many": "{{count}} dated periods",
       "datedPeriodsCount_other": "{{count}} dated periods",
       "datedPeriodsHint": "Manage dated schedule periods for this employee from the edit panel.",
       "activePeriodHint": "Currently active dated schedule period (shown columns reflect it).",
@@ -3242,6 +3263,7 @@
       "dragToMove": "Drag to move",
       "patient": "Client",
       "treatment": "Treatment",
+      "package": "Package",
       "employee": "Employee",
       "date": "Date",
       "startTime": "Start Time",
@@ -4391,6 +4413,8 @@
     },
     "warnings": {
       "existingAppointments_one": "Employee has {{count}} scheduled appointment during this period. Remember to cancel or reschedule it.",
+      "existingAppointments_few": "Employee has {{count}} scheduled appointments during this period. Remember to cancel or reschedule them.",
+      "existingAppointments_many": "Employee has {{count}} scheduled appointments during this period. Remember to cancel or reschedule them.",
       "existingAppointments_other": "Employee has {{count}} scheduled appointments during this period. Remember to cancel or reschedule them."
     }
   },

--- a/session_state.json
+++ b/session_state.json
@@ -1,9 +1,9 @@
 {
-  "session_id": "S0122",
-  "started_at": "2026-08-07T11:00:00Z",
-  "last_updated": "2026-08-07T11:05:00Z",
+  "session_id": "S0123",
+  "started_at": "2026-08-07T12:00:00Z",
+  "last_updated": "2026-08-07T12:15:00Z",
   "status": "completed",
-  "focus": "Issue #4256: Clarify read vs write security model in docs (RLS bypassed by service-role key on write path)",
+  "focus": "Issue #4290: Add missing English translations (24 keys)",
   "tasks_snapshot": {
     "total": 1,
     "not_started": 0,
@@ -14,5 +14,5 @@
   },
   "active_task_ids": [],
   "blockers": [],
-  "notes": "Updated CLAUDE.md, docs/modules/platform-core.md, and docs/SECURITY.md to explicitly state that RLS only protects the read path (browser JWT), while the write path uses the service-role key which bypasses RLS — making verifyOrgAccess() the sole tenant boundary for writes. The referenced crm_new-architecture.openflow file does not exist in the repo; the fix targets the in-repo documentation equivalents."
+  "notes": "Added 24 missing EN translation keys to public/locales/en/translation.json. Keys were _few/_many plural variants missing from EN (English only needs _one/_other but the i18n library may fall back to these) plus activities.pageTitle and gabinet.appointments.package. All keys verified present and JSON validated."
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4290.

Closes #4290

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 347c7b4 i18n(en): add 24 missing English translation keys (closes #4290)

### Files changed

```
 public/locales/en/translation.json | 28 ++++++++++++++++++++++++++--
 session_state.json                 | 10 +++++-----
 2 files changed, 31 insertions(+), 7 deletions(-)
```