### PR TITLE
Expose avg-time-per-stage in the CRM reports page

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -5015,7 +5015,9 @@
       "exportCsv": "Export CSV",
       "exportPdf": "Print / PDF",
       "exportSuccess": "Report exported successfully",
-      "funnelSpeed": "Funnel Speed"
+      "funnelSpeed": "Funnel Speed",
+      "funnelVelocity": "Funnel Velocity",
+      "avgDaysPerStage": "Avg. days per stage"
     }
   }
 }

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -5016,7 +5016,9 @@
       "exportCsv": "Eksportuj CSV",
       "exportPdf": "Drukuj / PDF",
       "exportSuccess": "Raport wyeksportowany",
-      "funnelSpeed": "Prędkość lejka"
+      "funnelSpeed": "Prędkość lejka",
+      "funnelVelocity": "Prędkość lejka",
+      "avgDaysPerStage": "Śr. dni na etap"
     }
   }
 }

--- a/src/hooks/use-supabase-leads.ts
+++ b/src/hooks/use-supabase-leads.ts
@@ -17,6 +17,60 @@ type LeadRow = Database["public"]["Tables"]["leads"]["Row"];
 type PipelineStageRow = Database["public"]["Tables"]["pipeline_stages"]["Row"];
 
 // ---------------------------------------------------------------------------
+// Stage Velocity (avg days per stage, for Funnel Velocity report card)
+// ---------------------------------------------------------------------------
+
+export interface StageVelocityItem {
+  stageId: string;
+  avgDays: number;
+  sampleCount: number;
+}
+
+export function useSupabaseStageVelocity(
+  organizationId: string,
+  options: { startDate: string; endDate: string; enabled?: boolean },
+) {
+  const { client, isReady } = useSupabase();
+  const { startDate, endDate, enabled = true } = options;
+
+  return useQuery<StageVelocityItem[], Error>({
+    queryKey: [...supabaseKeys.leadStageHistory.list(organizationId), "velocity", startDate, endDate],
+    queryFn: async (): Promise<StageVelocityItem[]> => {
+      if (!client) throw new Error("Supabase client not ready");
+
+      const startMs = new Date(startDate).getTime();
+      const endMs = new Date(endDate + "T23:59:59.999Z").getTime();
+
+      const { data, error } = await client
+        .from("lead_stage_history")
+        .select("stage_id,entered_at,exited_at")
+        .eq("organization_id", organizationId)
+        .gte("entered_at", startMs)
+        .lte("entered_at", endMs)
+        .not("exited_at", "is", null);
+
+      if (error) throw error;
+
+      const stageMap = new Map<string, { total: number; count: number }>();
+      for (const row of data ?? []) {
+        if (row.exited_at == null) continue;
+        const days = (row.exited_at - row.entered_at) / (1000 * 60 * 60 * 24);
+        if (days < 0) continue;
+        const existing = stageMap.get(row.stage_id) ?? { total: 0, count: 0 };
+        stageMap.set(row.stage_id, { total: existing.total + days, count: existing.count + 1 });
+      }
+
+      return [...stageMap.entries()].map(([stageId, { total, count }]) => ({
+        stageId,
+        avgDays: total / count,
+        sampleCount: count,
+      }));
+    },
+    enabled: enabled && isReady && !!organizationId && !!startDate && !!endDate,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Leads for Reports (date range, no pagination)
 // ---------------------------------------------------------------------------
 

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -1515,6 +1515,55 @@ export interface Database {
           },
         ];
       };
+      lead_stage_history: {
+        Row: {
+          id: string;
+          organization_id: string;
+          lead_id: string;
+          stage_id: string;
+          entered_at: number;
+          exited_at: number | null;
+        };
+        Insert: {
+          id?: string;
+          organization_id: string;
+          lead_id: string;
+          stage_id: string;
+          entered_at: number;
+          exited_at?: number | null;
+        };
+        Update: {
+          id?: string;
+          organization_id?: string;
+          lead_id?: string;
+          stage_id?: string;
+          entered_at?: number;
+          exited_at?: number | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "lead_stage_history_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organizations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "lead_stage_history_lead_id_fkey";
+            columns: ["lead_id"];
+            isOneToOne: false;
+            referencedRelation: "leads";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "lead_stage_history_stage_id_fkey";
+            columns: ["stage_id"];
+            isOneToOne: false;
+            referencedRelation: "pipeline_stages";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       documents: {
         Row: {
           id: string;

--- a/src/lib/supabase/query-keys.ts
+++ b/src/lib/supabase/query-keys.ts
@@ -45,6 +45,7 @@ export const supabaseKeys = {
   pipelineStages: entityKeys("pipelineStages"),
   pipelineStageActions: entityKeys("pipelineStageActions"),
   dealProducts: entityKeys("dealProducts"),
+  leadStageHistory: entityKeys("leadStageHistory"),
   productStockLevels: entityKeys("productStockLevels"),
   productStockMovements: entityKeys("productStockMovements"),
   scheduledActivities: entityKeys("scheduledActivities"),

--- a/src/routes/_app/_auth/dashboard/_layout.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.reports.lazy.tsx
@@ -1,7 +1,7 @@
 import { createLazyFileRoute } from "@tanstack/react-router";
 import Papa from "papaparse";
 import { toast } from "sonner";
-import { useSupabaseLeadsForReports } from "@/hooks/use-supabase-leads";
+import { useSupabaseLeadsForReports, useSupabaseStageVelocity } from "@/hooks/use-supabase-leads";
 import { useSupabaseSourcesList } from "@/hooks/use-supabase-sources";
 import { useSupabaseAllPipelineStages } from "@/hooks/use-supabase-pipelines";
 import { useOrganization } from "@/components/org-context";
@@ -354,6 +354,55 @@ function MonthlyTrendChart({
   );
 }
 
+// ── Funnel Velocity Chart ──────────────────────────────────────────────────────
+
+const funnelVelocityConfig = {
+  avgDays: { label: "Avg days", color: "var(--chart-3)" },
+} satisfies ChartConfig;
+
+function FunnelVelocityChart({
+  data,
+}: {
+  data: { stage: string; avgDays: number; sampleCount: number }[];
+}) {
+  const { t } = useTranslation();
+
+  if (data.length === 0) {
+    return (
+      <div className="flex h-40 items-center justify-center text-muted-foreground text-sm">
+        {t("crm.reports.noData")}
+      </div>
+    );
+  }
+
+  return (
+    <ChartContainer config={funnelVelocityConfig} className="h-52 w-full">
+      <BarChart data={data} layout="vertical" margin={{ left: 8, right: 8 }}>
+        <CartesianGrid horizontal={false} />
+        <XAxis
+          type="number"
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={(v: number) => formatDays(v)}
+        />
+        <YAxis
+          type="category"
+          dataKey="stage"
+          tickLine={false}
+          axisLine={false}
+          width={110}
+          tick={{ fontSize: 12 }}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent formatter={(v) => [`${formatDays(Number(v))}`, ""]} />}
+        />
+        <Bar dataKey="avgDays" fill="var(--chart-3)" radius={4} />
+      </BarChart>
+    </ChartContainer>
+  );
+}
+
 // ── Main Component ─────────────────────────────────────────────────────────────
 
 function CrmReports() {
@@ -407,6 +456,11 @@ function CrmReports() {
 
   const { data: sources } = useSupabaseSourcesList(organizationId);
   const { data: stages } = useSupabaseAllPipelineStages(organizationId);
+
+  const { data: stageVelocityRaw, isLoading: loadingVelocity } = useSupabaseStageVelocity(
+    organizationId,
+    { startDate, endDate, enabled: !!organizationId },
+  );
 
   const sourceNameMap = useMemo(() => {
     const map = new Map<string, string>();
@@ -521,6 +575,16 @@ function CrmReports() {
         return { month: `${parseInt(month)}/${year.slice(2)}`, won, created };
       });
   }, [leads]);
+
+  const funnelVelocity = useMemo(() => {
+    return (stageVelocityRaw ?? [])
+      .map(({ stageId, avgDays, sampleCount }) => ({
+        stage: stageNameMap.get(stageId) ?? stageId,
+        avgDays,
+        sampleCount,
+      }))
+      .sort((a, b) => b.avgDays - a.avgDays);
+  }, [stageVelocityRaw, stageNameMap]);
 
   // ── KPI Sparklines ──────────────────────────────────────────────────────────
 
@@ -765,6 +829,24 @@ function CrmReports() {
           </CardContent>
         </Card>
       </div>
+
+      {/* Funnel Velocity */}
+      <Card>
+        <CardHeader className="flex justify-between border-b">
+          <div>
+            <span className="text-lg font-semibold">{t("crm.reports.funnelVelocity")}</span>
+            <p className="text-sm text-muted-foreground">{t("crm.reports.avgDaysPerStage")}</p>
+          </div>
+          <CardMenu />
+        </CardHeader>
+        <CardContent className="pt-4">
+          {loadingVelocity ? (
+            <Skeleton className="h-52 w-full" />
+          ) : (
+            <FunnelVelocityChart data={funnelVelocity} />
+          )}
+        </CardContent>
+      </Card>
 
       {/* Custom Date Range Panel */}
       <SidePanel


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4299.

Closes #4299

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 052b4b6 feat(crm): add Funnel Velocity card to CRM reports page (closes #4299)

### Files changed

```
 public/locales/en/translation.json                 |  6 +-
 public/locales/pl/translation.json                 |  4 +-
 src/hooks/use-supabase-leads.ts                    | 54 ++++++++++++++
 src/lib/supabase/database.types.ts                 | 49 +++++++++++++
 src/lib/supabase/query-keys.ts                     |  1 +
 .../_app/_auth/dashboard/_layout.reports.lazy.tsx  | 84 +++++++++++++++++++++-
 6 files changed, 194 insertions(+), 4 deletions(-)
```