### PR TITLE
Fix `isPlatformAdmin` missing from `SupabaseRow<"users">` type

### DIFF
--- a/convex/schema/platform.ts
+++ b/convex/schema/platform.ts
@@ -36,6 +36,8 @@ export function createPlatformTables({
       v.union(v.literal("light"), v.literal("dark"), v.literal("system")),
     ),
     timezone: v.optional(v.string()),
+    // Stored in Supabase (is_platform_admin column); present here for SupabaseRow<"users"> type coverage.
+    isPlatformAdmin: v.optional(v.boolean()),
   })
     .index("email", ["email"])
     .index("customerId", ["customerId"]),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4310.

Closes #4310

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0bc004d fix(types): add isPlatformAdmin to users schema for SupabaseRow type coverage (closes #4310)

### Files changed

```
 convex/schema/platform.ts | 2 ++
 1 file changed, 2 insertions(+)
```