### PR TITLE
Automate database.types.ts sync with migrations

### DIFF
--- a/scripts/gen-db-types.mjs
+++ b/scripts/gen-db-types.mjs
@@ -595,6 +595,12 @@ const entityAliases = [
   { table: "gabinet_loyalty_transactions", singular: "GabinetLoyaltyTransaction" },
   { table: "gabinet_loyalty_tiers", singular: "GabinetLoyaltyTier" },
   { table: "gabinet_receipts", singular: "GabinetReceipt" },
+  { table: "gabinet_cash_transactions", singular: "GabinetCashTransaction" },
+  { table: "gabinet_day_closes", singular: "GabinetDayClose" },
+  { table: "gabinet_waitlist", singular: "GabinetWaitlist" },
+
+  // CRM extras
+  { table: "lead_stage_history", singular: "LeadStageHistory" },
 ];
 
 for (const { table, singular } of entityAliases) {

--- a/src/lib/supabase/database.columns.ts
+++ b/src/lib/supabase/database.columns.ts
@@ -112,6 +112,15 @@
  *   • 00105_form_documents_entity_timing_idx.sql
  *   • 00106_gabinet_loyalty_tiers.sql
  *   • 00107_backfill_gabinet_loyalty_points_tier.sql
+ *   • 00108_subscriptions_product_key.sql
+ *   • 00109_plans_product_key.sql
+ *   • 00110_gabinet_cash_transactions.sql
+ *   • 00111_gabinet_day_closes.sql
+ *   • 00112_gabinet_waitlist.sql
+ *   • 00113_subscriptions_trial_end_date.sql
+ *   • 00114_audit_log_nullable_user_id.sql
+ *   • 00115_leads_created_at_idx.sql
+ *   • 00116_lead_stage_history.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  */
@@ -221,7 +230,11 @@ export type TableName =
   | "gabinet_appointment_treatments"
   | "gabinet_receipts"
   | "gabinet_receipt_sequences"
-  | "gabinet_loyalty_tiers";
+  | "gabinet_loyalty_tiers"
+  | "gabinet_cash_transactions"
+  | "gabinet_day_closes"
+  | "gabinet_waitlist"
+  | "lead_stage_history";
 
 /**
  * Column names per table, as a runtime-checkable Set.
@@ -233,11 +246,11 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   auth_verification_codes: new Set(["id", "account_id", "email", "phone", "code", "method", "expires_at", "used_at", "created_at"]),
   auth_rate_limits: new Set(["id", "identifier", "action", "attempts", "window_start", "created_at"]),
   users: new Set(["id", "name", "username", "image_storage_id", "image", "email", "email_verification_time", "phone", "phone_verification_time", "is_anonymous", "customer_id", "language", "theme", "timezone", "created_at", "updated_at", "is_platform_admin"]),
-  plans: new Set(["id", "key", "stripe_id", "name", "description", "seat_limit", "prices"]),
-  subscriptions: new Set(["id", "user_id", "plan_id", "price_stripe_id", "stripe_id", "currency", "interval", "status", "current_period_start", "current_period_end", "cancel_at_period_end", "trial_end_date"]),
+  plans: new Set(["id", "key", "stripe_id", "name", "description", "seat_limit", "prices", "product_key"]),
+  subscriptions: new Set(["id", "user_id", "plan_id", "price_stripe_id", "stripe_id", "currency", "interval", "status", "current_period_start", "current_period_end", "cancel_at_period_end", "product_key", "trial_end_date"]),
   platform_products: new Set(["id", "product_id", "name", "description", "is_active", "prices", "stripe_product_id", "created_at", "updated_at"]),
   organizations: new Set(["id", "name", "slug", "owner_id", "logo", "website", "created_at", "updated_at", "onboarding_completed"]),
-  product_subscriptions: new Set(["id", "organization_id", "product_id", "stripe_subscription_id", "status", "current_period_start", "current_period_end", "cancel_at_period_end", "trial_end_date", "created_at", "updated_at"]),
+  product_subscriptions: new Set(["id", "organization_id", "product_id", "stripe_subscription_id", "status", "current_period_start", "current_period_end", "cancel_at_period_end", "created_at", "updated_at", "trial_end_date"]),
   team_memberships: new Set(["id", "user_id", "organization_id", "role", "invited_by", "joined_at"]),
   org_settings: new Set(["id", "organization_id", "allow_custom_lost_reason", "lost_reason_required", "default_currency", "timezone", "resource_sharing_enabled", "reminder_enabled", "reminder_hours_before", "appointment_workflow_config", "created_at", "updated_at", "reminder_sms_48h", "reminder_sms_24h", "reminder_email_48h", "reminder_email_24h", "patient_retention_months"]),
   org_permissions: new Set(["id", "organization_id", "role", "permissions", "updated_by", "updated_at"]),
@@ -332,4 +345,8 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   gabinet_receipts: new Set(["id", "organization_id", "payment_id", "appointment_id", "patient_id", "receipt_number", "issued_at", "organization_name", "organization_nip", "organization_address", "total_net", "total_vat", "total_gross", "payment_method", "items_json", "fiscal_receipt_id", "pdf_storage_id", "pdf_url", "created_by", "created_at", "updated_at", "location_id", "status", "receipt_type"]),
   gabinet_receipt_sequences: new Set(["id", "organization_id", "location_id", "year", "last_number", "updated_at"]),
   gabinet_loyalty_tiers: new Set(["id", "organization_id", "tier", "name", "threshold", "color", "is_active", "created_at", "updated_at"]),
+  gabinet_cash_transactions: new Set(["id", "organization_id", "location_id", "date", "type", "amount", "reason", "created_by", "created_at", "updated_at"]),
+  gabinet_day_closes: new Set(["id", "organization_id", "location_id", "date", "payment_summary", "total_collected", "cash_from_payments", "cash_opening_balance", "cash_deposits", "cash_withdrawals", "cash_expected", "cash_counted", "cash_discrepancy", "notes", "closed_by", "closed_at", "created_at", "updated_at"]),
+  gabinet_waitlist: new Set(["id", "organization_id", "patient_id", "treatment_id", "employee_id", "preferred_dates", "preferred_times", "notes", "status", "notified_at", "priority", "created_by", "created_at", "updated_at"]),
+  lead_stage_history: new Set(["id", "organization_id", "lead_id", "stage_id", "entered_at", "exited_at"]),
 };

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -347,6 +347,7 @@ export interface Database {
           description: string;
           seat_limit: number;
           prices: unknown;
+          product_key: string | null;
         };
         Insert: {
           id?: string;
@@ -356,6 +357,7 @@ export interface Database {
           description: string;
           seat_limit: number;
           prices: unknown;
+          product_key?: string | null;
         };
         Update: {
           id?: string;
@@ -365,6 +367,7 @@ export interface Database {
           description?: string;
           seat_limit?: number;
           prices?: unknown;
+          product_key?: string | null;
         };
         Relationships: [];
       };
@@ -381,6 +384,7 @@ export interface Database {
           current_period_start: number;
           current_period_end: number;
           cancel_at_period_end: boolean;
+          product_key: string | null;
           trial_end_date: number | null;
         };
         Insert: {
@@ -395,6 +399,7 @@ export interface Database {
           current_period_start: number;
           current_period_end: number;
           cancel_at_period_end: boolean;
+          product_key?: string | null;
           trial_end_date?: number | null;
         };
         Update: {
@@ -409,6 +414,7 @@ export interface Database {
           current_period_start?: number;
           current_period_end?: number;
           cancel_at_period_end?: boolean;
+          product_key?: string | null;
           trial_end_date?: number | null;
         };
         Relationships: [
@@ -518,9 +524,9 @@ export interface Database {
           current_period_start: number | null;
           current_period_end: number | null;
           cancel_at_period_end: boolean;
-          trial_end_date: number | null;
           created_at: number;
           updated_at: number;
+          trial_end_date: number | null;
         };
         Insert: {
           id?: string;
@@ -531,9 +537,9 @@ export interface Database {
           current_period_start?: number | null;
           current_period_end?: number | null;
           cancel_at_period_end: boolean;
-          trial_end_date?: number | null;
           created_at: number;
           updated_at: number;
+          trial_end_date?: number | null;
         };
         Update: {
           id?: string;
@@ -544,9 +550,9 @@ export interface Database {
           current_period_start?: number | null;
           current_period_end?: number | null;
           cancel_at_period_end?: boolean;
-          trial_end_date?: number | null;
           created_at?: number;
           updated_at?: number;
+          trial_end_date?: number | null;
         };
         Relationships: [
           {
@@ -905,7 +911,7 @@ export interface Database {
         Row: {
           id: string;
           organization_id: string;
-          user_id: string;
+          user_id: string | null;
           action: string;
           entity_type: string | null;
           entity_id: string | null;
@@ -916,7 +922,7 @@ export interface Database {
         Insert: {
           id?: string;
           organization_id: string;
-          user_id: string;
+          user_id?: string | null;
           action: string;
           entity_type?: string | null;
           entity_id?: string | null;
@@ -927,7 +933,7 @@ export interface Database {
         Update: {
           id?: string;
           organization_id?: string;
-          user_id?: string;
+          user_id?: string | null;
           action?: string;
           entity_type?: string | null;
           entity_id?: string | null;
@@ -1520,55 +1526,6 @@ export interface Database {
             columns: ["created_by"];
             isOneToOne: false;
             referencedRelation: "users";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
-      lead_stage_history: {
-        Row: {
-          id: string;
-          organization_id: string;
-          lead_id: string;
-          stage_id: string;
-          entered_at: number;
-          exited_at: number | null;
-        };
-        Insert: {
-          id?: string;
-          organization_id: string;
-          lead_id: string;
-          stage_id: string;
-          entered_at: number;
-          exited_at?: number | null;
-        };
-        Update: {
-          id?: string;
-          organization_id?: string;
-          lead_id?: string;
-          stage_id?: string;
-          entered_at?: number;
-          exited_at?: number | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "lead_stage_history_organization_id_fkey";
-            columns: ["organization_id"];
-            isOneToOne: false;
-            referencedRelation: "organizations";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "lead_stage_history_lead_id_fkey";
-            columns: ["lead_id"];
-            isOneToOne: false;
-            referencedRelation: "leads";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "lead_stage_history_stage_id_fkey";
-            columns: ["stage_id"];
-            isOneToOne: false;
-            referencedRelation: "pipeline_stages";
             referencedColumns: ["id"];
           },
         ];
@@ -7651,86 +7608,6 @@ export interface Database {
           },
         ];
       };
-      gabinet_waitlist: {
-        Row: {
-          id: string;
-          organization_id: string;
-          patient_id: string;
-          treatment_id: string | null;
-          employee_id: string | null;
-          preferred_dates: string[] | null;
-          preferred_times: string[] | null;
-          notes: string | null;
-          status: string;
-          notified_at: number | null;
-          priority: number;
-          created_by: string;
-          created_at: number;
-          updated_at: number;
-        };
-        Insert: {
-          id?: string;
-          organization_id: string;
-          patient_id: string;
-          treatment_id?: string | null;
-          employee_id?: string | null;
-          preferred_dates?: string[] | null;
-          preferred_times?: string[] | null;
-          notes?: string | null;
-          status?: string;
-          notified_at?: number | null;
-          priority?: number;
-          created_by: string;
-          created_at: number;
-          updated_at: number;
-        };
-        Update: {
-          id?: string;
-          organization_id?: string;
-          patient_id?: string;
-          treatment_id?: string | null;
-          employee_id?: string | null;
-          preferred_dates?: string[] | null;
-          preferred_times?: string[] | null;
-          notes?: string | null;
-          status?: string;
-          notified_at?: number | null;
-          priority?: number;
-          created_by?: string;
-          created_at?: number;
-          updated_at?: number;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "gabinet_waitlist_organization_id_fkey";
-            columns: ["organization_id"];
-            isOneToOne: false;
-            referencedRelation: "organizations";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "gabinet_waitlist_patient_id_fkey";
-            columns: ["patient_id"];
-            isOneToOne: false;
-            referencedRelation: "gabinet_patients";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "gabinet_waitlist_treatment_id_fkey";
-            columns: ["treatment_id"];
-            isOneToOne: false;
-            referencedRelation: "gabinet_treatments";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "gabinet_waitlist_employee_id_fkey";
-            columns: ["employee_id"];
-            isOneToOne: false;
-            referencedRelation: "gabinet_employees";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
       gabinet_cash_transactions: {
         Row: {
           id: string;
@@ -7873,6 +7750,142 @@ export interface Database {
             columns: ["closed_by"];
             isOneToOne: false;
             referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      gabinet_waitlist: {
+        Row: {
+          id: string;
+          organization_id: string;
+          patient_id: string;
+          treatment_id: string | null;
+          employee_id: string | null;
+          preferred_dates: unknown | null;
+          preferred_times: unknown | null;
+          notes: string | null;
+          status: string;
+          notified_at: number | null;
+          priority: number;
+          created_by: string;
+          created_at: number;
+          updated_at: number;
+        };
+        Insert: {
+          id?: string;
+          organization_id: string;
+          patient_id: string;
+          treatment_id?: string | null;
+          employee_id?: string | null;
+          preferred_dates?: unknown | null;
+          preferred_times?: unknown | null;
+          notes?: string | null;
+          status?: string;
+          notified_at?: number | null;
+          priority?: number;
+          created_by: string;
+          created_at: number;
+          updated_at: number;
+        };
+        Update: {
+          id?: string;
+          organization_id?: string;
+          patient_id?: string;
+          treatment_id?: string | null;
+          employee_id?: string | null;
+          preferred_dates?: unknown | null;
+          preferred_times?: unknown | null;
+          notes?: string | null;
+          status?: string;
+          notified_at?: number | null;
+          priority?: number;
+          created_by?: string;
+          created_at?: number;
+          updated_at?: number;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "gabinet_waitlist_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organizations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gabinet_waitlist_patient_id_fkey";
+            columns: ["patient_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_patients";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gabinet_waitlist_treatment_id_fkey";
+            columns: ["treatment_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_treatments";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gabinet_waitlist_employee_id_fkey";
+            columns: ["employee_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_employees";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gabinet_waitlist_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      lead_stage_history: {
+        Row: {
+          id: string;
+          organization_id: string;
+          lead_id: string;
+          stage_id: string;
+          entered_at: number;
+          exited_at: number | null;
+        };
+        Insert: {
+          id?: string;
+          organization_id: string;
+          lead_id: string;
+          stage_id: string;
+          entered_at: number;
+          exited_at?: number | null;
+        };
+        Update: {
+          id?: string;
+          organization_id?: string;
+          lead_id?: string;
+          stage_id?: string;
+          entered_at?: number;
+          exited_at?: number | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "lead_stage_history_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organizations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "lead_stage_history_lead_id_fkey";
+            columns: ["lead_id"];
+            isOneToOne: false;
+            referencedRelation: "leads";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "lead_stage_history_stage_id_fkey";
+            columns: ["stage_id"];
+            isOneToOne: false;
+            referencedRelation: "pipeline_stages";
             referencedColumns: ["id"];
           },
         ];
@@ -8064,12 +8077,15 @@ export type GabinetLoyaltyTierUpdate = Database["public"]["Tables"]["gabinet_loy
 export type GabinetReceiptRow = Database["public"]["Tables"]["gabinet_receipts"]["Row"];
 export type GabinetReceiptInsert = Database["public"]["Tables"]["gabinet_receipts"]["Insert"];
 export type GabinetReceiptUpdate = Database["public"]["Tables"]["gabinet_receipts"]["Update"];
-export type GabinetWaitlistRow = Database["public"]["Tables"]["gabinet_waitlist"]["Row"];
-export type GabinetWaitlistInsert = Database["public"]["Tables"]["gabinet_waitlist"]["Insert"];
-export type GabinetWaitlistUpdate = Database["public"]["Tables"]["gabinet_waitlist"]["Update"];
 export type GabinetCashTransactionRow = Database["public"]["Tables"]["gabinet_cash_transactions"]["Row"];
 export type GabinetCashTransactionInsert = Database["public"]["Tables"]["gabinet_cash_transactions"]["Insert"];
 export type GabinetCashTransactionUpdate = Database["public"]["Tables"]["gabinet_cash_transactions"]["Update"];
 export type GabinetDayCloseRow = Database["public"]["Tables"]["gabinet_day_closes"]["Row"];
 export type GabinetDayCloseInsert = Database["public"]["Tables"]["gabinet_day_closes"]["Insert"];
 export type GabinetDayCloseUpdate = Database["public"]["Tables"]["gabinet_day_closes"]["Update"];
+export type GabinetWaitlistRow = Database["public"]["Tables"]["gabinet_waitlist"]["Row"];
+export type GabinetWaitlistInsert = Database["public"]["Tables"]["gabinet_waitlist"]["Insert"];
+export type GabinetWaitlistUpdate = Database["public"]["Tables"]["gabinet_waitlist"]["Update"];
+export type LeadStageHistoryRow = Database["public"]["Tables"]["lead_stage_history"]["Row"];
+export type LeadStageHistoryInsert = Database["public"]["Tables"]["lead_stage_history"]["Insert"];
+export type LeadStageHistoryUpdate = Database["public"]["Tables"]["lead_stage_history"]["Update"];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4312.

Closes #4312

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b2c93d0 fix(types): regenerate database.types.ts and database.columns.ts from migrations 00108–00116 (closes #4312)

### Files changed

```
 scripts/gen-db-types.mjs             |   6 +
 src/lib/supabase/database.columns.ts |  25 ++-
 src/lib/supabase/database.types.ts   | 292 ++++++++++++++++++-----------------
 3 files changed, 181 insertions(+), 142 deletions(-)
```