### PR TITLE
Tagged-PDF or accessible fallback for gabinet document viewer

### DIFF
--- a/src/components/documents/document-viewer.tsx
+++ b/src/components/documents/document-viewer.tsx
@@ -57,6 +57,8 @@ export function DocumentViewer({
 
       {/* Document content */}
       <div
+        role="region"
+        aria-label={title}
         className={cn(
           "mx-auto w-full max-w-[210mm] rounded-lg border bg-white p-8 shadow-sm",
           "prose prose-sm max-w-none text-gray-900",

--- a/src/routes/_app/patient/_layout.documents.tsx
+++ b/src/routes/_app/patient/_layout.documents.tsx
@@ -112,6 +112,7 @@ function PatientDocuments() {
                     variant="ghost"
                     size="sm"
                     onClick={() => setViewDocId(doc._id)}
+                    aria-label={t("patientPortal.documents.viewDocument", "Wyświetl dokument: {{title}}", { title: doc.title })}
                   >
                     <Eye className="h-4 w-4" variant="stroke" />
                   </Button>
@@ -120,6 +121,7 @@ function PatientDocuments() {
                       variant="ghost"
                       size="sm"
                       onClick={() => setSignDocId(doc._id)}
+                      aria-label={t("patientPortal.documents.signDocument", "Podpisz dokument: {{title}}", { title: doc.title })}
                     >
                       <PenTool
                         className="h-4 w-4 text-primary"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4325.

Closes #4325

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 72d2dcf fix(a11y): add accessible labels to document viewer and patient portal icon buttons (closes #4325)

### Files changed

```
 src/components/documents/document-viewer.tsx  | 2 ++
 src/routes/_app/patient/_layout.documents.tsx | 2 ++
 2 files changed, 4 insertions(+)
```