### PR TITLE
feat(a11y): add WCAG 1.1.1 chart text-alternative test and fix chart containers (closes #4335)

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -561,6 +561,65 @@ test.describe("Accessibility — WCAG 2.1 AA", () => {
   });
 });
 
+// ─── WCAG 1.1.1 Chart Text Alternatives ──────────────────────────────────────
+// Non-text content (charts) must have a text alternative (WCAG 1.1.1).
+// Recharts SVGs render inside a div[data-chart] container and do NOT trigger
+// axe-core's `image-alt` rule (which targets <img> elements), so a dedicated
+// aria-label presence check per chart container is required.
+
+test.describe("Chart text alternatives — WCAG 1.1.1", () => {
+  test.setTimeout(60_000);
+
+  test.beforeEach(async ({ page }) => {
+    await loginAndGoToDashboard(page);
+  });
+
+  test("all chart containers on /dashboard have aria-label (WCAG 1.1.1)", async ({
+    page,
+  }) => {
+    await navigateTo(page, "/dashboard");
+    await assertNoErrorBoundary(page);
+
+    // Wait up to 15 s for at least one chart to appear; skip if the org has no
+    // data yet (charts may be hidden behind empty-state UI).
+    const firstChart = page.locator("[data-chart]").first();
+    const rendered = await firstChart
+      .waitFor({ state: "visible", timeout: 15_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (!rendered) {
+      test.skip();
+      return;
+    }
+
+    const chartContainers = page.locator("[data-chart]");
+    const count = await chartContainers.count();
+
+    expect(
+      count,
+      "Expected at least one [data-chart] container on /dashboard"
+    ).toBeGreaterThan(0);
+
+    const missing: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const container = chartContainers.nth(i);
+      const ariaLabel = await container.getAttribute("aria-label");
+      if (!ariaLabel) {
+        const chartId =
+          (await container.getAttribute("data-chart")) ?? `chart[${i}]`;
+        missing.push(chartId);
+      }
+    }
+
+    expect(
+      missing,
+      "Chart containers missing aria-label (WCAG 1.1.1 Non-text Content):\n" +
+        missing.map((id) => `  • ${id}`).join("\n")
+    ).toHaveLength(0);
+  });
+});
+
 // ─── WCAG 1.4.10 Reflow ──────────────────────────────────────────────────────
 // Content must be presentable without loss of information and without requiring
 // horizontal scrolling at a viewport width of 320 CSS pixels.

--- a/src/components/dashboard/crm-pipeline-chart.tsx
+++ b/src/components/dashboard/crm-pipeline-chart.tsx
@@ -100,6 +100,8 @@ export function CrmPipelineChart({ data = defaultPipelineData, className, blurre
           config={pipelineChartConfig}
           className="w-full"
           style={{ height: Math.max(200, chartData.length * 48) }}
+          role="img"
+          aria-label={t("dashboard.dealsByStage")}
         >
           <BarChart
             accessibilityLayer

--- a/src/components/shadcn-studio/blocks/chart-conversion-rate.tsx
+++ b/src/components/shadcn-studio/blocks/chart-conversion-rate.tsx
@@ -100,7 +100,7 @@ const ConversionRateCard = ({
             </div>
           </div>
           <div className='relative'>
-            <ChartContainer config={conversionRateChartConfig} className='h-20 w-full'>
+            <ChartContainer config={conversionRateChartConfig} className='h-20 w-full' role='img' aria-label={title}>
               <AreaChart
                 data={chartData}
                 margin={{

--- a/src/components/shadcn-studio/blocks/chart-earning-report.tsx
+++ b/src/components/shadcn-studio/blocks/chart-earning-report.tsx
@@ -107,7 +107,7 @@ const EarningReportCard = ({ title, subTitle, statData, chartData = defaultEarni
           </div>
         ))}
         <div className='relative'>
-          <ChartContainer config={earningReportChartConfig} className='h-45 w-full'>
+          <ChartContainer config={earningReportChartConfig} className='h-45 w-full' role='img' aria-label={title}>
             <BarChart
               accessibilityLayer
               data={chartData}

--- a/src/components/shadcn-studio/blocks/chart-total-income.tsx
+++ b/src/components/shadcn-studio/blocks/chart-total-income.tsx
@@ -111,7 +111,7 @@ const TotalIncomeCard = ({
           </DropdownMenu>
         </CardHeader>
         <CardContent className='relative pb-0'>
-          <ChartContainer config={totalIncomeChartConfig} className='max-h-80 min-h-48 w-full max-[400px]:max-w-73'>
+          <ChartContainer config={totalIncomeChartConfig} className='max-h-80 min-h-48 w-full max-[400px]:max-w-73' role='img' aria-label={title}>
             <AreaChart
               data={chartData}
               margin={{

--- a/src/components/shadcn-studio/blocks/chart-total-orders.tsx
+++ b/src/components/shadcn-studio/blocks/chart-total-orders.tsx
@@ -129,7 +129,7 @@ const TotalOrdersCard = ({
             <span className='text-muted-foreground text-sm'>{totalLabel}</span>
           </div>
           <div>
-            <ChartContainer config={chartConfig} className='h-30 w-full'>
+            <ChartContainer config={chartConfig} className='h-30 w-full' role='img' aria-label={title}>
               <PieChart margin={{ top: 0, bottom: 0, left: 0, right: 0 }}>
                 {!blurred && <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />}
                 <Pie


### PR DESCRIPTION
## Summary

- Adds a new `test.describe("Chart text alternatives — WCAG 1.1.1")` block to `e2e/accessibility.spec.ts` that navigates to `/dashboard`, finds every `[data-chart]` container, and asserts each has an `aria-label` attribute
- Fixes the five dashboard chart components (`CrmPipelineChart`, `TotalIncomeCard`, `EarningReportCard`, `ConversionRateCard`, `TotalOrdersCard`) by adding `role="img"` and `aria-label` to their `ChartContainer` elements

**Why the dedicated test is needed:** axe-core's `image-alt` rule targets `<img>` HTML elements. Recharts renders charts as `<svg>` inside a `div[data-chart]` container, which the rule ignores. The existing `runAxeScan` also explicitly `.exclude(".recharts-wrapper")`. A manual `aria-label` presence check is the only way to catch this WCAG 1.1.1 violation in automated testing.

## Test plan

- [ ] `e2e/accessibility.spec.ts` — "Chart text alternatives — WCAG 1.1.1" test passes with at least one chart container on /dashboard
- [ ] Verify `[data-chart]` divs in browser DevTools have `role="img"` and `aria-label` set
- [ ] Existing axe-core tests still pass (no regressions from the new attributes)
- [ ] Reflow tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)