### PR TITLE
hotfix(db): idempotent migration 00092 — restore migrations + prod

### DIFF
--- a/supabase/migrations/00092_gabinet_treatment_products_rls.sql
+++ b/supabase/migrations/00092_gabinet_treatment_products_rls.sql
@@ -8,6 +8,13 @@
 -- in line with every other table in the project (closes #3801).
 
 DROP POLICY IF EXISTS org_isolation ON gabinet_treatment_products;
+-- Idempotent: 00026 already created these per-command policies (#2332); this
+-- migration (#3801) re-established the same set. Drop-then-create so re-running
+-- against a DB that already has them cannot fail with 42710 (already exists).
+DROP POLICY IF EXISTS gabinet_treatment_products_select ON gabinet_treatment_products;
+DROP POLICY IF EXISTS gabinet_treatment_products_insert ON gabinet_treatment_products;
+DROP POLICY IF EXISTS gabinet_treatment_products_update ON gabinet_treatment_products;
+DROP POLICY IF EXISTS gabinet_treatment_products_delete ON gabinet_treatment_products;
 
 CREATE POLICY gabinet_treatment_products_select ON gabinet_treatment_products
   FOR SELECT USING (current_org_id() = organization_id);


### PR DESCRIPTION
Production is down (HTTP 500): a duplicate non-idempotent migration (00092 re-creates 00026's RLS policies) breaks the Supabase Migrations pipeline, which gates the Netlify prod build (#942). Fix makes 00092 idempotent (DROP POLICY IF EXISTS before CREATE, as 00099 already does). Recovers migrations + prod. Root cause: autonomous worker generated a duplicate RLS migration and it was merged despite red CI.