### PR TITLE
feat(admin): Platform Admin SP1 — module access management + enforcement re-enable

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -146,6 +146,7 @@ import type * as mail_emailShell from "../mail/emailShell.js";
 import type * as mail_testConnectionNode from "../mail/testConnectionNode.js";
 import type * as mailProviders from "../mailProviders.js";
 import type * as microsoft_oauth from "../microsoft/oauth.js";
+import type * as migrations_backfillEntitlements from "../migrations/backfillEntitlements.js";
 import type * as migrations_backfillCreditEarned from "../migrations/backfillCreditEarned.js";
 import type * as migrations_backfillMailProviders from "../migrations/backfillMailProviders.js";
 import type * as migrations_backfillProductSubscriptions from "../migrations/backfillProductSubscriptions.js";
@@ -346,6 +347,7 @@ declare const fullApi: ApiFromModules<{
   "mail/testConnectionNode": typeof mail_testConnectionNode;
   mailProviders: typeof mailProviders;
   "microsoft/oauth": typeof microsoft_oauth;
+  "migrations/backfillEntitlements": typeof migrations_backfillEntitlements;
   "migrations/backfillCreditEarned": typeof migrations_backfillCreditEarned;
   "migrations/backfillMailProviders": typeof migrations_backfillMailProviders;
   "migrations/backfillProductSubscriptions": typeof migrations_backfillProductSubscriptions;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -34,6 +34,7 @@ import type * as _test from "../_test.js";
 import type * as _test_helpers from "../_test_helpers.js";
 import type * as activities from "../activities.js";
 import type * as activityTypes from "../activityTypes.js";
+import type * as admin_entitlements from "../admin/entitlements.js";
 import type * as app from "../app.js";
 import type * as auditLog from "../auditLog.js";
 import type * as auth from "../auth.js";
@@ -233,6 +234,7 @@ declare const fullApi: ApiFromModules<{
   _test_helpers: typeof _test_helpers;
   activities: typeof activities;
   activityTypes: typeof activityTypes;
+  "admin/entitlements": typeof admin_entitlements;
   app: typeof app;
   auditLog: typeof auditLog;
   auth: typeof auth;

--- a/convex/_helpers/products.ts
+++ b/convex/_helpers/products.ts
@@ -12,21 +12,17 @@ export async function verifyProductAccess(
   organizationId: Id<"organizations">,
   productId: string,
 ): Promise<void> {
-  // NOTE: productSubscriptions data moved to Supabase during the Convex→Supabase
-  // migration; the Convex `productSubscriptions` table is empty. This helper runs
-  // in a QueryCtx, which cannot read Supabase (no network in the V8 isolate), so
-  // it cannot enforce module entitlements here — reading the empty Convex table
-  // blocked EVERY org from the entire gabinet module. Fail open to restore access
-  // (matches pre-migration production behavior). Proper entitlement enforcement
-  // must be re-implemented against Supabase in an action context. See follow-up.
   const subscription = await ctx.db
     .query("productSubscriptions")
     .withIndex("by_orgAndProduct", (q) =>
-      q.eq("organizationId", organizationId).eq("productId", productId)
+      q.eq("organizationId", organizationId).eq("productId", productId),
     )
     .first();
 
-  if (subscription && subscription.status !== "active" && subscription.status !== "trialing") {
+  if (!subscription) {
+    throw new Error(`No active subscription for product: ${productId}`);
+  }
+  if (subscription.status !== "active" && subscription.status !== "trialing") {
     throw new Error(`Subscription for ${productId} is ${subscription.status}`);
   }
 }
@@ -55,6 +51,7 @@ export async function checkModuleAccess(
  */
 export const verifyGabinetAccess = internalQuery({
   args: { organizationId: v.id("organizations") },
+  returns: v.null(),
   handler: async (ctx, args) => {
     await verifyProductAccess(ctx, args.organizationId, GABINET_PRODUCT_ID);
   },

--- a/convex/admin/entitlements.ts
+++ b/convex/admin/entitlements.ts
@@ -1,7 +1,8 @@
 import { v } from "convex/values";
-import { action, internalMutation } from "../_generated/server";
+import { action, internalMutation, internalQuery } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { logAudit } from "../auditLog";
+import { createSupabaseDb } from "../_helpers/supabaseDb";
 
 const productIdValidator = v.union(v.literal("crm"), v.literal("gabinet"));
 
@@ -55,6 +56,91 @@ export const _upsertEntitlement = internalMutation({
     });
 
     return { status };
+  },
+});
+
+type EntStatus = "active" | "canceled" | "none";
+
+const entStatusValidator = v.union(
+  v.literal("active"),
+  v.literal("canceled"),
+  v.literal("none"),
+);
+
+const entitlementRowValidator = v.object({
+  organizationId: v.string(),
+  productId: v.string(),
+  status: v.string(),
+});
+
+const orgEntitlementRowValidator = v.object({
+  organizationId: v.string(),
+  name: v.string(),
+  memberCount: v.number(),
+  crm: entStatusValidator,
+  gabinet: entStatusValidator,
+});
+
+export const _listEntitlementsInternal = internalQuery({
+  args: {},
+  returns: v.array(entitlementRowValidator),
+  handler: async (
+    ctx,
+  ): Promise<Array<{ organizationId: string; productId: string; status: string }>> => {
+    const rows = await ctx.db.query("productSubscriptions").collect();
+    return rows.map((r) => ({
+      organizationId: String(r.organizationId),
+      productId: r.productId,
+      status: r.status,
+    }));
+  },
+});
+
+export const listOrgEntitlements = action({
+  args: {},
+  returns: v.array(orgEntitlementRowValidator),
+  handler: async (
+    ctx,
+  ): Promise<
+    Array<{
+      organizationId: string;
+      name: string;
+      memberCount: number;
+      crm: EntStatus;
+      gabinet: EntStatus;
+    }>
+  > => {
+    await ctx.runAction(internal._helpers.authAction.verifyPlatformAdmin, {});
+    const db = createSupabaseDb();
+    const orgs = await db.query("organizations").collect();
+    const memberships = await db.query("teamMemberships").collect();
+    const ents = await ctx.runQuery(
+      internal.admin.entitlements._listEntitlementsInternal,
+      {},
+    );
+
+    const statusFor = (orgId: string, productId: string): EntStatus => {
+      const e = ents.find(
+        (x) => x.organizationId === orgId && x.productId === productId,
+      );
+      if (!e) return "none";
+      return e.status === "active" || e.status === "trialing" ? "active" : "canceled";
+    };
+
+    return orgs
+      .map((o) => {
+        const orgId = String(o._id);
+        return {
+          organizationId: orgId,
+          name: (o.name as string) ?? "(no name)",
+          memberCount: memberships.filter(
+            (m) => String(m.organizationId) === orgId,
+          ).length,
+          crm: statusFor(orgId, "crm"),
+          gabinet: statusFor(orgId, "gabinet"),
+        };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
   },
 });
 

--- a/convex/admin/entitlements.ts
+++ b/convex/admin/entitlements.ts
@@ -1,0 +1,81 @@
+import { v } from "convex/values";
+import { action, internalMutation } from "../_generated/server";
+import { internal } from "../_generated/api";
+import { logAudit } from "../auditLog";
+
+const productIdValidator = v.union(v.literal("crm"), v.literal("gabinet"));
+
+// Convex-side upsert of a per-org product entitlement. Convex-only table.
+const statusValidator = v.union(v.literal("active"), v.literal("canceled"));
+
+export const _upsertEntitlement = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    productId: productIdValidator,
+    grant: v.boolean(),
+    grantedByUserId: v.id("users"),
+  },
+  returns: v.object({ status: statusValidator }),
+  handler: async (ctx, args): Promise<{ status: "active" | "canceled" }> => {
+    const status = args.grant ? "active" : "canceled";
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("productSubscriptions")
+      .withIndex("by_orgAndProduct", (q) =>
+        q.eq("organizationId", args.organizationId).eq("productId", args.productId),
+      )
+      .unique();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        status,
+        source: "manual",
+        grantedByUserId: args.grantedByUserId,
+        updatedAt: now,
+      });
+    } else {
+      await ctx.db.insert("productSubscriptions", {
+        organizationId: args.organizationId,
+        productId: args.productId,
+        status,
+        cancelAtPeriodEnd: false,
+        source: "manual",
+        grantedByUserId: args.grantedByUserId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: args.grantedByUserId,
+      action: args.grant ? "product_access_granted" : "product_access_revoked",
+      entityType: "productSubscription",
+      entityId: args.productId,
+    });
+
+    return { status };
+  },
+});
+
+// Platform-admin: grant or revoke a module for an org.
+export const setEntitlement = action({
+  args: {
+    organizationId: v.id("organizations"),
+    productId: productIdValidator,
+    grant: v.boolean(),
+  },
+  returns: v.object({ status: statusValidator }),
+  handler: async (ctx, args): Promise<{ status: "active" | "canceled" }> => {
+    const { userId } = await ctx.runAction(
+      internal._helpers.authAction.verifyPlatformAdmin,
+      {},
+    );
+    return await ctx.runMutation(internal.admin.entitlements._upsertEntitlement, {
+      organizationId: args.organizationId,
+      productId: args.productId,
+      grant: args.grant,
+      grantedByUserId: userId,
+    });
+  },
+});

--- a/convex/migrations/backfillEntitlements.ts
+++ b/convex/migrations/backfillEntitlements.ts
@@ -1,0 +1,72 @@
+import { v } from "convex/values";
+import { internalAction } from "../_generated/server";
+import { internal } from "../_generated/api";
+import { createSupabaseDb } from "../_helpers/supabaseDb";
+import type { Id } from "../_generated/dataModel";
+
+// One-off: ensure every org has a CRM entitlement, and every org with real
+// gabinet data has a Gabinet entitlement. Idempotent. Pass dryRun to count only.
+export const run = internalAction({
+  args: { dryRun: v.optional(v.boolean()) },
+  returns: v.object({
+    orgs: v.number(),
+    crmGranted: v.number(),
+    gabinetGranted: v.number(),
+    dryRun: v.boolean(),
+  }),
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ orgs: number; crmGranted: number; gabinetGranted: number; dryRun: boolean }> => {
+    const dryRun = args.dryRun ?? false;
+    const db = createSupabaseDb();
+    const orgs = await db.query("organizations").collect();
+    const existing = await ctx.runQuery(
+      internal.admin.entitlements._listEntitlementsInternal,
+      {},
+    );
+    const has = (orgId: string, productId: string) =>
+      existing.some(
+        (e) => e.organizationId === orgId && e.productId === productId,
+      );
+
+    // Any org appearing in these gabinet tables counts as "using gabinet".
+    const gabinetOrgIds = new Set<string>();
+    for (const table of ["gabinetPatients", "gabinetEmployees", "gabinetAppointments"] as const) {
+      const rows = await db.query(table).collect();
+      for (const r of rows) gabinetOrgIds.add(String((r as { organizationId: unknown }).organizationId));
+    }
+
+    // A system actor id for grantedByUserId: reuse the first org owner if present.
+    let crmGranted = 0;
+    let gabinetGranted = 0;
+    for (const o of orgs) {
+      const orgId = String(o._id);
+      const grantedBy = String((o as { ownerId?: unknown }).ownerId ?? o._id);
+      if (!has(orgId, "crm")) {
+        crmGranted++;
+        if (!dryRun) {
+          await ctx.runMutation(internal.admin.entitlements._upsertEntitlement, {
+            organizationId: orgId as unknown as Id<"organizations">,
+            productId: "crm",
+            grant: true,
+            grantedByUserId: grantedBy as unknown as Id<"users">,
+          });
+        }
+      }
+      if (gabinetOrgIds.has(orgId) && !has(orgId, "gabinet")) {
+        gabinetGranted++;
+        if (!dryRun) {
+          await ctx.runMutation(internal.admin.entitlements._upsertEntitlement, {
+            organizationId: orgId as unknown as Id<"organizations">,
+            productId: "gabinet",
+            grant: true,
+            grantedByUserId: grantedBy as unknown as Id<"users">,
+          });
+        }
+      }
+    }
+
+    return { orgs: orgs.length, crmGranted, gabinetGranted, dryRun };
+  },
+});

--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -107,6 +107,21 @@ export const _createOrgInternal = internalMutation({
       performedBy: user._id,
     });
 
+    // Grant the CRM baseline entitlement to every new org. getActiveProducts /
+    // verifyProductAccess read productSubscriptions; without this a new org
+    // would have no modules once enforcement is on. Direct insert (create path,
+    // no pre-existing row); mirrors _upsertEntitlement's shape.
+    await ctx.db.insert("productSubscriptions", {
+      organizationId: orgId,
+      productId: "crm",
+      status: "active",
+      cancelAtPeriodEnd: false,
+      source: "manual",
+      grantedByUserId: user._id,
+      createdAt: now,
+      updatedAt: now,
+    });
+
     // Seed default reference data
     await ctx.scheduler.runAfter(
       0,

--- a/convex/productSubscriptions.ts
+++ b/convex/productSubscriptions.ts
@@ -4,6 +4,7 @@ import { verifyOrgAccess } from "./_helpers/auth";
 
 export const getActiveProducts = query({
   args: { organizationId: v.id("organizations") },
+  returns: v.array(v.string()),
   handler: async (ctx, args) => {
     await verifyOrgAccess(ctx, args.organizationId);
     const subs = await ctx.db
@@ -11,18 +12,8 @@ export const getActiveProducts = query({
       .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
       .collect();
 
-    const active = subs
+    return subs
       .filter((s) => s.status === "active" || s.status === "trialing")
       .map((s) => s.productId);
-    if (active.length > 0) return active;
-
-    // Fallback: productSubscriptions data moved to Supabase during the migration
-    // and the Convex table is empty, so this query returned [] for EVERY org —
-    // which collapsed the left module navigation to nothing (getVisibleModules
-    // filters to zero when given an empty array). Until entitlements are re-read
-    // from Supabase, surface the full product catalog so navigation renders.
-    // Consistent with verifyProductAccess failing open (see _helpers/products.ts).
-    const products = await ctx.db.query("platformProducts").collect();
-    return products.map((p) => p.productId);
   },
 });

--- a/convex/schema/platform.ts
+++ b/convex/schema/platform.ts
@@ -107,6 +107,9 @@ export function createPlatformTables({
     currentPeriodEnd: v.optional(v.number()),
     cancelAtPeriodEnd: v.boolean(),
     trialEndDate: v.optional(v.number()),
+    source: v.optional(v.union(v.literal("manual"), v.literal("stripe"))),
+    grantedByUserId: v.optional(v.id("users")),
+    note: v.optional(v.string()),
     createdAt: v.number(),
     updatedAt: v.number(),
   })

--- a/docs/superpowers/plans/2026-08-08-platform-admin-sp1-module-access.md
+++ b/docs/superpowers/plans/2026-08-08-platform-admin-sp1-module-access.md
@@ -1,0 +1,969 @@
+# Platform Admin SP1 — Module Access & Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give platform admins a UI to grant/revoke module access (CRM, Gabinet) per organization, backfill existing orgs, and re-enable the module-access enforcement that is currently disabled by emergency stopgaps.
+
+**Architecture:** Entitlements are rows in the existing Convex `productSubscriptions` table (the table the enforcement already reads). Admin reads that need org data (in Supabase) are Convex **actions**; entitlement writes are Convex **internalMutations** (Convex-only table). A platform-admin-gated page under `/admin` renders the org×module grid. Enforcement (`getActiveProducts`, `verifyProductAccess`) is flipped back on only after existing orgs are backfilled.
+
+**Tech Stack:** Convex (actions/queries/mutations, convex-test + Vitest), React 19 + TanStack Router/Query, shadcn/ui, Playwright.
+
+## Global Constraints
+
+- Build on top of **PR #4345** (`fix/unblock-gabinet-and-pln-schema`) merged to `main` — it contains the stopgaps this plan reverts (`verifyProductAccess` fail-open, `getActiveProducts` catalog fallback). Do not start the enforcement flip until #4345 is merged and this branch is rebased on it.
+- The serving Convex deployment is **`helpful-mule-867`**; deploy with `npx convex dev --once` (NOT `convex deploy`, which targets the unused `pleasant-elephant-723`).
+- `organizations`, `teamMemberships`, `gabinet_*` are in Supabase (TABLE_MAP); a Convex **query** cannot read them — use **actions** + `createSupabaseDb()`. `productSubscriptions` is Convex-only — read/write it in query/mutation ctx.
+- Platform-admin gate: `await ctx.runAction(internal._helpers.authAction.verifyPlatformAdmin, {})` → returns `{ userId: Id<"users"> }`; throws for non-admins.
+- Entitlement product ids are exactly `"crm"` and `"gabinet"` (match `platformProducts.productId`). CRM is the baseline (auto-granted, never revoked in UI). Revoke = set `status: "canceled"` (never delete).
+- Run Convex tests with `npm run test:unit` (cwd is `convex/`). Test files live in `tests/convex/`.
+- No new npm dependencies. Reuse shadcn components in `src/components/ui/`.
+- Convex functions use the object form `{ args, handler }` (a lint hook enforces this).
+
+---
+
+## File Structure
+
+- Modify `convex/schema/platform.ts` — add `source`, `grantedByUserId`, `note` to `productSubscriptions`.
+- Create `convex/admin/entitlements.ts` — `setEntitlement` (action), `_upsertEntitlement` (internalMutation), `listOrgEntitlements` (action), `_listEntitlementsInternal` (internalQuery).
+- Modify `convex/organizations.ts` — auto-grant CRM in `create`.
+- Create `convex/migrations/backfillEntitlements.ts` — one-off backfill action.
+- Modify `convex/productSubscriptions.ts` — remove catalog fallback (enforcement flip).
+- Modify `convex/_helpers/products.ts` — restore `verifyProductAccess` throw (enforcement flip).
+- Create `src/routes/_app/_auth/admin.entitlements.tsx` — admin grid.
+- Modify `src/routes/_app/_auth/admin.index.tsx` — add card link.
+- Create tests: `tests/convex/entitlements.test.ts`, `tests/convex/backfillEntitlements.test.ts`, `tests/convex/enforcementFlip.test.ts`, `e2e/admin/entitlements.spec.ts`.
+
+---
+
+### Task 1: Entitlement write path (schema + upsert mutation + setEntitlement action)
+
+**Files:**
+- Modify: `convex/schema/platform.ts:95-115` (productSubscriptions table)
+- Create: `convex/admin/entitlements.ts`
+- Test: `tests/convex/entitlements.test.ts`
+
+**Interfaces:**
+- Consumes: `internal._helpers.authAction.verifyPlatformAdmin` → `{ userId: Id<"users"> }`; `logAudit(ctx, {...})` from `convex/auditLog.ts`.
+- Produces:
+  - `internal.admin.entitlements._upsertEntitlement` (internalMutation) args `{ organizationId: Id<"organizations">, productId: "crm"|"gabinet", grant: boolean, grantedByUserId: Id<"users"> }` → returns `{ status: "active"|"canceled" }`.
+  - `api.admin.entitlements.setEntitlement` (action) args `{ organizationId: Id<"organizations">, productId: "crm"|"gabinet", grant: boolean }` → returns `{ status: "active"|"canceled" }`.
+
+- [ ] **Step 1: Add schema fields**
+
+In `convex/schema/platform.ts`, inside the `productSubscriptions` `defineTable({...})` object (after `trialEndDate`, before `createdAt`), add:
+
+```ts
+    source: v.optional(v.union(v.literal("manual"), v.literal("stripe"))),
+    grantedByUserId: v.optional(v.id("users")),
+    note: v.optional(v.string()),
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/convex/entitlements.test.ts`:
+
+```ts
+import { afterEach, describe, expect, test } from "vitest";
+import { api, internal } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+// Make the seeded user a platform admin by inserting them into the in-memory
+// Supabase users table with is_platform_admin=true (verifyPlatformAdmin reads
+// the Supabase users row, which seedTestUser does not create).
+async function makePlatformAdmin(userId: string) {
+  await createSupabaseDb().insert("users", {
+    _id: userId,
+    name: "Admin",
+    email: `admin-${userId}@example.com`,
+    isPlatformAdmin: true,
+  });
+}
+
+describe("admin/entitlements.setEntitlement", () => {
+  test("grant creates an active manual entitlement with audit", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await makePlatformAdmin(String(userId));
+
+    const res = await t
+      .withIdentity(identity)
+      .action(api.admin.entitlements.setEntitlement, {
+        organizationId,
+        productId: "gabinet",
+        grant: true,
+      });
+    expect(res.status).toBe("active");
+
+    const row = await t.run(async (ctx) =>
+      ctx.db
+        .query("productSubscriptions")
+        .withIndex("by_orgAndProduct", (q) =>
+          q.eq("organizationId", organizationId).eq("productId", "gabinet"),
+        )
+        .unique(),
+    );
+    expect(row?.status).toBe("active");
+    expect(row?.source).toBe("manual");
+    expect(String(row?.grantedByUserId)).toBe(String(userId));
+
+    const audit = await t.run(async (ctx) =>
+      ctx.db.query("auditLog").collect(),
+    );
+    expect(audit.some((a) => a.action === "product_access_granted")).toBe(true);
+  });
+
+  test("revoke flips an existing entitlement to canceled", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await makePlatformAdmin(String(userId));
+
+    await t.withIdentity(identity).action(api.admin.entitlements.setEntitlement, {
+      organizationId, productId: "gabinet", grant: true,
+    });
+    const res = await t
+      .withIdentity(identity)
+      .action(api.admin.entitlements.setEntitlement, {
+        organizationId, productId: "gabinet", grant: false,
+      });
+    expect(res.status).toBe("canceled");
+
+    const row = await t.run(async (ctx) =>
+      ctx.db
+        .query("productSubscriptions")
+        .withIndex("by_orgAndProduct", (q) =>
+          q.eq("organizationId", organizationId).eq("productId", "gabinet"),
+        )
+        .unique(),
+    );
+    expect(row?.status).toBe("canceled");
+  });
+
+  test("rejects non-platform-admin callers", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    // Insert Supabase user WITHOUT platform admin.
+    await createSupabaseDb().insert("users", {
+      _id: String(userId), name: "Nobody", email: "nobody@example.com",
+      isPlatformAdmin: false,
+    });
+    await expect(
+      t.withIdentity(identity).action(api.admin.entitlements.setEntitlement, {
+        organizationId, productId: "gabinet", grant: true,
+      }),
+    ).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm run test:unit -- entitlements`
+Expected: FAIL — `api.admin.entitlements.setEntitlement` does not exist.
+
+- [ ] **Step 4: Implement the write path**
+
+Create `convex/admin/entitlements.ts`:
+
+```ts
+import { v } from "convex/values";
+import { action, internalMutation } from "../_generated/server";
+import { internal } from "../_generated/api";
+import { logAudit } from "../auditLog";
+
+const productIdValidator = v.union(v.literal("crm"), v.literal("gabinet"));
+
+// Convex-side upsert of a per-org product entitlement. Convex-only table.
+export const _upsertEntitlement = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    productId: productIdValidator,
+    grant: v.boolean(),
+    grantedByUserId: v.id("users"),
+  },
+  handler: async (ctx, args): Promise<{ status: "active" | "canceled" }> => {
+    const status = args.grant ? "active" : "canceled";
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("productSubscriptions")
+      .withIndex("by_orgAndProduct", (q) =>
+        q.eq("organizationId", args.organizationId).eq("productId", args.productId),
+      )
+      .unique();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        status,
+        source: "manual",
+        grantedByUserId: args.grantedByUserId,
+        updatedAt: now,
+      });
+    } else {
+      await ctx.db.insert("productSubscriptions", {
+        organizationId: args.organizationId,
+        productId: args.productId,
+        status,
+        cancelAtPeriodEnd: false,
+        source: "manual",
+        grantedByUserId: args.grantedByUserId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: args.grantedByUserId,
+      action: args.grant ? "product_access_granted" : "product_access_revoked",
+      entityType: "productSubscription",
+      entityId: args.productId,
+    });
+
+    return { status };
+  },
+});
+
+// Platform-admin: grant or revoke a module for an org.
+export const setEntitlement = action({
+  args: {
+    organizationId: v.id("organizations"),
+    productId: productIdValidator,
+    grant: v.boolean(),
+  },
+  handler: async (ctx, args): Promise<{ status: "active" | "canceled" }> => {
+    const { userId } = await ctx.runAction(
+      internal._helpers.authAction.verifyPlatformAdmin,
+      {},
+    );
+    return await ctx.runMutation(internal.admin.entitlements._upsertEntitlement, {
+      organizationId: args.organizationId,
+      productId: args.productId,
+      grant: args.grant,
+      grantedByUserId: userId,
+    });
+  },
+});
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm run test:unit -- entitlements`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npx tsc -p convex/tsconfig.json`
+Expected: exit 0, 0 errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add convex/schema/platform.ts convex/admin/entitlements.ts tests/convex/entitlements.test.ts
+git commit -m "feat(admin): entitlement write path — setEntitlement + upsert + audit"
+```
+
+---
+
+### Task 2: Entitlement listing (internalQuery + listOrgEntitlements action)
+
+**Files:**
+- Modify: `convex/admin/entitlements.ts`
+- Test: `tests/convex/entitlements.test.ts` (add a describe block)
+
+**Interfaces:**
+- Consumes: `createSupabaseDb()` (`convex/_helpers/supabaseDb.ts`) — `.query(table).collect()`, `.query(table).eq(field, value).collect()`.
+- Produces:
+  - `internal.admin.entitlements._listEntitlementsInternal` (internalQuery) args `{}` → `Array<{ organizationId: string; productId: string; status: string }>`.
+  - `api.admin.entitlements.listOrgEntitlements` (action) args `{}` → `Array<{ organizationId: string; name: string; memberCount: number; crm: "active"|"canceled"|"none"; gabinet: "active"|"canceled"|"none" }>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/convex/entitlements.test.ts`:
+
+```ts
+describe("admin/entitlements.listOrgEntitlements", () => {
+  test("merges orgs with their entitlement status", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await createSupabaseDb().insert("users", {
+      _id: String(userId), name: "Admin", email: "a@example.com",
+      isPlatformAdmin: true,
+    });
+    await t.withIdentity(identity).action(api.admin.entitlements.setEntitlement, {
+      organizationId, productId: "gabinet", grant: true,
+    });
+
+    const rows = await t
+      .withIdentity(identity)
+      .action(api.admin.entitlements.listOrgEntitlements, {});
+    const org = rows.find((r) => r.organizationId === String(organizationId));
+    expect(org).toBeTruthy();
+    expect(org?.name).toBe("Test Org");
+    expect(org?.gabinet).toBe("active");
+    expect(org?.crm).toBe("none");
+    expect(org?.memberCount).toBe(1);
+  });
+
+  test("rejects non-platform-admin callers", async () => {
+    const t = createTestCtx();
+    const { userId, identity } = await seedTestUser(t);
+    await createSupabaseDb().insert("users", {
+      _id: String(userId), name: "N", email: "n@example.com", isPlatformAdmin: false,
+    });
+    await expect(
+      t.withIdentity(identity).action(api.admin.entitlements.listOrgEntitlements, {}),
+    ).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- entitlements`
+Expected: FAIL — `listOrgEntitlements` does not exist.
+
+- [ ] **Step 3: Implement listing**
+
+Append to `convex/admin/entitlements.ts` (add `internalQuery` to the `_generated/server` import and `createSupabaseDb` from `../_helpers/supabaseDb`):
+
+```ts
+import { internalQuery } from "../_generated/server";
+import { createSupabaseDb } from "../_helpers/supabaseDb";
+
+type EntStatus = "active" | "canceled" | "none";
+
+export const _listEntitlementsInternal = internalQuery({
+  args: {},
+  handler: async (
+    ctx,
+  ): Promise<Array<{ organizationId: string; productId: string; status: string }>> => {
+    const rows = await ctx.db.query("productSubscriptions").collect();
+    return rows.map((r) => ({
+      organizationId: String(r.organizationId),
+      productId: r.productId,
+      status: r.status,
+    }));
+  },
+});
+
+export const listOrgEntitlements = action({
+  args: {},
+  handler: async (
+    ctx,
+  ): Promise<
+    Array<{
+      organizationId: string;
+      name: string;
+      memberCount: number;
+      crm: EntStatus;
+      gabinet: EntStatus;
+    }>
+  > => {
+    await ctx.runAction(internal._helpers.authAction.verifyPlatformAdmin, {});
+    const db = createSupabaseDb();
+    const orgs = await db.query("organizations").collect();
+    const memberships = await db.query("teamMemberships").collect();
+    const ents = await ctx.runQuery(
+      internal.admin.entitlements._listEntitlementsInternal,
+      {},
+    );
+
+    const statusFor = (orgId: string, productId: string): EntStatus => {
+      const e = ents.find(
+        (x) => x.organizationId === orgId && x.productId === productId,
+      );
+      if (!e) return "none";
+      return e.status === "active" || e.status === "trialing" ? "active" : "canceled";
+    };
+
+    return orgs
+      .map((o) => {
+        const orgId = String(o._id);
+        return {
+          organizationId: orgId,
+          name: (o.name as string) ?? "(no name)",
+          memberCount: memberships.filter(
+            (m) => String(m.organizationId) === orgId,
+          ).length,
+          crm: statusFor(orgId, "crm"),
+          gabinet: statusFor(orgId, "gabinet"),
+        };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+  },
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test:unit -- entitlements`
+Expected: PASS (5 tests total).
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `npx tsc -p convex/tsconfig.json` (expect 0 errors), then:
+
+```bash
+git add convex/admin/entitlements.ts tests/convex/entitlements.test.ts
+git commit -m "feat(admin): listOrgEntitlements — org x module grid backend"
+```
+
+---
+
+### Task 3: Auto-grant CRM on org creation
+
+**Files:**
+- Modify: `convex/organizations.ts:51-90` (the `_createOrgInternal` internalMutation)
+- Test: `tests/convex/entitlements.test.ts` (add a describe block)
+
+**Interfaces:**
+- Consumes: nothing new — inserts the CRM `productSubscriptions` row directly in the mutation ctx, mirroring `_upsertEntitlement`'s insert shape (Task 1). Placed in `_createOrgInternal` because it already has the creator `user` (from `requireUser`) and `ctx.db`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/convex/entitlements.test.ts`:
+
+```ts
+describe("organizations.create — CRM baseline grant", () => {
+  test("new org receives an active CRM entitlement", async () => {
+    const t = createTestCtx();
+    const { userId, identity } = await seedTestUser(t);
+    // seedTestUser already made an org named "test-org"; create a second.
+    const orgId = await t
+      .withIdentity(identity)
+      .action(api.organizations.create, {
+        name: "Second Org",
+        slug: "second-org",
+      });
+
+    const row = await t.run(async (ctx) =>
+      ctx.db
+        .query("productSubscriptions")
+        .withIndex("by_orgAndProduct", (q) =>
+          q.eq("organizationId", orgId as any).eq("productId", "crm"),
+        )
+        .unique(),
+    );
+    expect(row?.status).toBe("active");
+    expect(row?.source).toBe("manual");
+    expect(String(row?.grantedByUserId)).toBe(String(userId));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- entitlements`
+Expected: FAIL — no CRM `productSubscriptions` row after create.
+
+- [ ] **Step 3: Implement the CRM grant**
+
+In `convex/organizations.ts`, inside `_createOrgInternal`, after the owner `teamMemberships` insert (the `user`, `orgId`, and `now` variables are already in scope), add a direct CRM entitlement insert:
+
+```ts
+    // Grant the CRM baseline entitlement to every new org. getActiveProducts /
+    // verifyProductAccess read productSubscriptions; without this a new org
+    // would have no modules once enforcement is on. Direct insert (create path,
+    // no pre-existing row); mirrors _upsertEntitlement's shape.
+    await ctx.db.insert("productSubscriptions", {
+      organizationId: orgId,
+      productId: "crm",
+      status: "active",
+      cancelAtPeriodEnd: false,
+      source: "manual",
+      grantedByUserId: user._id,
+      createdAt: now,
+      updatedAt: now,
+    });
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test:unit -- entitlements`
+Expected: PASS (6 tests total).
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `npx tsc -p convex/tsconfig.json` (expect 0 errors), then:
+
+```bash
+git add convex/organizations.ts tests/convex/entitlements.test.ts
+git commit -m "feat(admin): auto-grant CRM baseline entitlement on org create"
+```
+
+---
+
+### Task 4: Backfill action (CRM to all, Gabinet to gabinet-data orgs)
+
+**Files:**
+- Create: `convex/migrations/backfillEntitlements.ts`
+- Test: `tests/convex/backfillEntitlements.test.ts`
+
+**Interfaces:**
+- Consumes: `createSupabaseDb()`; `internal.admin.entitlements._upsertEntitlement`; `internal.admin.entitlements._listEntitlementsInternal`.
+- Produces: `internal.migrations.backfillEntitlements.run` (internalAction) args `{ dryRun?: boolean }` → `{ orgs: number; crmGranted: number; gabinetGranted: number; dryRun: boolean }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/convex/backfillEntitlements.test.ts`:
+
+```ts
+import { afterEach, describe, expect, test } from "vitest";
+import { internal } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+describe("migrations/backfillEntitlements.run", () => {
+  test("grants CRM to all orgs and Gabinet only to orgs with gabinet data; idempotent", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    // Give this org gabinet data (a patient row in Supabase).
+    await createSupabaseDb().insert("gabinetPatients", {
+      _id: "pat_1",
+      organizationId: String(organizationId),
+      firstName: "Jan", lastName: "Kowalski",
+      createdBy: String(userId), createdAt: Date.now(), updatedAt: Date.now(),
+    });
+
+    const res = await t.run(async () => null).then(() =>
+      t.action(internal.migrations.backfillEntitlements.run, { dryRun: false }),
+    );
+    expect(res.crmGranted).toBeGreaterThanOrEqual(1);
+    expect(res.gabinetGranted).toBeGreaterThanOrEqual(1);
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("productSubscriptions").collect(),
+    );
+    const crm = rows.find(
+      (r) => String(r.organizationId) === String(organizationId) && r.productId === "crm",
+    );
+    const gab = rows.find(
+      (r) => String(r.organizationId) === String(organizationId) && r.productId === "gabinet",
+    );
+    expect(crm?.status).toBe("active");
+    expect(gab?.status).toBe("active");
+
+    // Idempotent: second run grants nothing new.
+    const res2 = await t.action(internal.migrations.backfillEntitlements.run, {
+      dryRun: false,
+    });
+    expect(res2.crmGranted).toBe(0);
+    expect(res2.gabinetGranted).toBe(0);
+  });
+
+  test("dryRun writes nothing", async () => {
+    const t = createTestCtx();
+    await seedTestUser(t);
+    const res = await t.action(internal.migrations.backfillEntitlements.run, {
+      dryRun: true,
+    });
+    expect(res.dryRun).toBe(true);
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("productSubscriptions").collect(),
+    );
+    expect(rows.length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- backfillEntitlements`
+Expected: FAIL — `internal.migrations.backfillEntitlements.run` does not exist.
+
+- [ ] **Step 3: Implement the backfill**
+
+Create `convex/migrations/backfillEntitlements.ts`:
+
+```ts
+import { v } from "convex/values";
+import { internalAction } from "../_generated/server";
+import { internal } from "../_generated/api";
+import { createSupabaseDb } from "../_helpers/supabaseDb";
+import type { Id } from "../_generated/dataModel";
+
+// One-off: ensure every org has a CRM entitlement, and every org with real
+// gabinet data has a Gabinet entitlement. Idempotent. Pass dryRun to count only.
+export const run = internalAction({
+  args: { dryRun: v.optional(v.boolean()) },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ orgs: number; crmGranted: number; gabinetGranted: number; dryRun: boolean }> => {
+    const dryRun = args.dryRun ?? false;
+    const db = createSupabaseDb();
+    const orgs = await db.query("organizations").collect();
+    const existing = await ctx.runQuery(
+      internal.admin.entitlements._listEntitlementsInternal,
+      {},
+    );
+    const has = (orgId: string, productId: string) =>
+      existing.some(
+        (e) => e.organizationId === orgId && e.productId === productId,
+      );
+
+    // Any org appearing in these gabinet tables counts as "using gabinet".
+    const gabinetOrgIds = new Set<string>();
+    for (const table of ["gabinetPatients", "gabinetEmployees", "gabinetAppointments"] as const) {
+      const rows = await db.query(table).collect();
+      for (const r of rows) gabinetOrgIds.add(String((r as { organizationId: unknown }).organizationId));
+    }
+
+    // A system actor id for grantedByUserId: reuse the first org owner if present.
+    let crmGranted = 0;
+    let gabinetGranted = 0;
+    for (const o of orgs) {
+      const orgId = String(o._id);
+      const grantedBy = String((o as { ownerId?: unknown }).ownerId ?? o._id);
+      if (!has(orgId, "crm")) {
+        crmGranted++;
+        if (!dryRun) {
+          await ctx.runMutation(internal.admin.entitlements._upsertEntitlement, {
+            organizationId: orgId as unknown as Id<"organizations">,
+            productId: "crm",
+            grant: true,
+            grantedByUserId: grantedBy as unknown as Id<"users">,
+          });
+        }
+      }
+      if (gabinetOrgIds.has(orgId) && !has(orgId, "gabinet")) {
+        gabinetGranted++;
+        if (!dryRun) {
+          await ctx.runMutation(internal.admin.entitlements._upsertEntitlement, {
+            organizationId: orgId as unknown as Id<"organizations">,
+            productId: "gabinet",
+            grant: true,
+            grantedByUserId: grantedBy as unknown as Id<"users">,
+          });
+        }
+      }
+    }
+
+    return { orgs: orgs.length, crmGranted, gabinetGranted, dryRun };
+  },
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test:unit -- backfillEntitlements`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `npx tsc -p convex/tsconfig.json` (expect 0 errors), then:
+
+```bash
+git add convex/migrations/backfillEntitlements.ts tests/convex/backfillEntitlements.test.ts
+git commit -m "feat(admin): backfillEntitlements one-off (CRM all, Gabinet by data)"
+```
+
+---
+
+### Task 5: Admin UI — entitlements grid + index card
+
+**Files:**
+- Create: `src/routes/_app/_auth/admin.entitlements.tsx`
+- Modify: `src/routes/_app/_auth/admin.index.tsx` (add a card)
+- Test: `e2e/admin/entitlements.spec.ts`
+
+**Interfaces:**
+- Consumes: `api.app.getIsPlatformAdmin` (action), `api.admin.entitlements.listOrgEntitlements` (action), `api.admin.entitlements.setEntitlement` (action).
+
+- [ ] **Step 1: Implement the route**
+
+Create `src/routes/_app/_auth/admin.entitlements.tsx` — mirror the gate + data-fetch pattern of `admin.users.tsx`:
+
+```tsx
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAction } from "convex/react";
+import { api } from "@cvx/_generated/api";
+import { toast } from "sonner";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import { formatActionError } from "@/lib/format-action-error";
+
+export const Route = createFileRoute("/_app/_auth/admin/entitlements")({
+  component: AdminEntitlements,
+});
+
+function AdminEntitlements() {
+  const queryClient = useQueryClient();
+  const getIsPlatformAdmin = useAction(api.app.getIsPlatformAdmin);
+  const { data: adminStatus, isLoading: adminLoading } = useQuery({
+    queryKey: ["isPlatformAdmin"],
+    queryFn: () => getIsPlatformAdmin({}),
+  });
+
+  const listAction = useAction(api.admin.entitlements.listOrgEntitlements);
+  const listQuery = useQuery({
+    queryKey: ["admin", "entitlements"],
+    queryFn: () => listAction({}),
+    enabled: Boolean(adminStatus?.isPlatformAdmin),
+  });
+
+  const setAction = useAction(api.admin.entitlements.setEntitlement);
+  const setMutation = useMutation({
+    mutationFn: setAction,
+    onSuccess: () => {
+      toast.success("Zaktualizowano dostęp");
+      queryClient.invalidateQueries({ queryKey: ["admin", "entitlements"] });
+    },
+    onError: (e) => toast.error(formatActionError(e)),
+  });
+
+  if (adminLoading) {
+    return <div className="p-8 text-sm text-muted-foreground">Loading…</div>;
+  }
+  if (!adminStatus?.isPlatformAdmin) {
+    return (
+      <div className="mx-auto max-w-2xl p-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>403 — Platform admin required</CardTitle>
+            <CardDescription>This page is only accessible to platform administrators.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Link to="/admin" className="text-sm underline">Back to admin</Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const rows = listQuery.data ?? [];
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-8">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Dostęp do modułów</h1>
+        <p className="text-sm text-muted-foreground">
+          Nadawaj i odbieraj moduły per organizacja. CRM jest bazowy (zawsze aktywny).
+        </p>
+      </div>
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Organizacja</TableHead>
+                <TableHead>Członkowie</TableHead>
+                <TableHead>CRM</TableHead>
+                <TableHead>Gabinet</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((org) => (
+                <TableRow key={org.organizationId}>
+                  <TableCell className="font-medium">{org.name}</TableCell>
+                  <TableCell>{org.memberCount}</TableCell>
+                  <TableCell><Badge variant="secondary">Bazowy</Badge></TableCell>
+                  <TableCell>
+                    <Switch
+                      checked={org.gabinet === "active"}
+                      disabled={setMutation.isPending}
+                      onCheckedChange={(checked) => {
+                        if (!checked && !window.confirm(`Odebrać Gabinet dla „${org.name}"? Odetnie to żywy moduł.`)) {
+                          return;
+                        }
+                        setMutation.mutate({
+                          organizationId: org.organizationId as never,
+                          productId: "gabinet",
+                          grant: checked,
+                        });
+                      }}
+                      aria-label={`Gabinet dla ${org.name}`}
+                    />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add the card to the admin index**
+
+In `src/routes/_app/_auth/admin.index.tsx`, add inside the `grid` div (alongside the existing cards):
+
+```tsx
+        <Link to="/admin/entitlements" className="block">
+          <Card className="h-full transition hover:border-foreground/20">
+            <CardHeader>
+              <CardTitle>Module access</CardTitle>
+              <CardDescription>
+                Grant or revoke module access (CRM, Gabinet) per organization.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </Link>
+```
+
+- [ ] **Step 3: App typecheck**
+
+Run: `npx tsc -p tsconfig.app.json`
+Expected: 0 new errors in the two touched files (pre-existing repo errors elsewhere are out of scope — confirm none reference `admin.entitlements.tsx`).
+
+- [ ] **Step 4: Write the E2E test**
+
+Create `e2e/admin/entitlements.spec.ts` following the existing `e2e/` login helper pattern (check an existing spec for the login fixture; log in as the platform-admin test account). Assert: navigating to `/admin/entitlements` shows the "Dostęp do modułów" heading and at least one org row; toggling the Gabinet switch shows the success toast and the switch stays in the new state after refetch. Add a second case: a non-admin session sees the "403 — Platform admin required" card.
+
+- [ ] **Step 5: Run E2E**
+
+Run: `npx playwright test e2e/admin/entitlements.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/routes/_app/_auth/admin.entitlements.tsx src/routes/_app/_auth/admin.index.tsx e2e/admin/entitlements.spec.ts
+git commit -m "feat(admin): module-access entitlements grid page"
+```
+
+---
+
+### Task 6: Enforcement flip (revert stopgaps) — DO LAST, AFTER BACKFILL IS RUN
+
+**Files:**
+- Modify: `convex/productSubscriptions.ts` (remove catalog fallback added by #4345)
+- Modify: `convex/_helpers/products.ts` (restore `verifyProductAccess` throw)
+- Test: `tests/convex/enforcementFlip.test.ts`
+
+**Interfaces:** none new — restores prior behavior.
+
+> DO NOT do this task until the Rollout section's backfill has been run and verified on the live deployment `helpful-mule-867`. Flipping before grants exist will re-break production.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/convex/enforcementFlip.test.ts`:
+
+```ts
+import { afterEach, describe, expect, test } from "vitest";
+import { api, internal } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+describe("enforcement after flip", () => {
+  test("getActiveProducts returns only granted products (no catalog fallback)", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    // Grant only CRM.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("productSubscriptions", {
+        organizationId, productId: "crm", status: "active",
+        cancelAtPeriodEnd: false, source: "manual", grantedByUserId: userId,
+        createdAt: Date.now(), updatedAt: Date.now(),
+      });
+    });
+    const products = await t
+      .withIdentity(identity)
+      .query(api.productSubscriptions.getActiveProducts, { organizationId });
+    expect(products).toEqual(["crm"]);
+  });
+
+  test("verifyGabinetAccess throws when gabinet not granted", async () => {
+    const t = createTestCtx();
+    const { organizationId } = await seedTestUser(t);
+    await expect(
+      t.run(async (ctx) =>
+        ctx.runQuery(internal._helpers.products.verifyGabinetAccess, {
+          organizationId,
+        }),
+      ),
+    ).rejects.toThrow(/No active subscription/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- enforcementFlip`
+Expected: FAIL — `getActiveProducts` returns the catalog fallback (`["crm","gabinet"]`) and `verifyGabinetAccess` does not throw (fail-open), because #4345's stopgaps are still in place.
+
+- [ ] **Step 3: Remove the catalog fallback**
+
+In `convex/productSubscriptions.ts`, `getActiveProducts` handler, delete the fallback block so it ends at the mapped active list:
+
+```ts
+  handler: async (ctx, args) => {
+    await verifyOrgAccess(ctx, args.organizationId);
+    const subs = await ctx.db
+      .query("productSubscriptions")
+      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+      .collect();
+
+    return subs
+      .filter((s) => s.status === "active" || s.status === "trialing")
+      .map((s) => s.productId);
+  },
+```
+
+- [ ] **Step 4: Restore verifyProductAccess throw**
+
+In `convex/_helpers/products.ts`, restore the missing-subscription throw:
+
+```ts
+  const subscription = await ctx.db
+    .query("productSubscriptions")
+    .withIndex("by_orgAndProduct", (q) =>
+      q.eq("organizationId", organizationId).eq("productId", productId),
+    )
+    .first();
+
+  if (!subscription) {
+    throw new Error(`No active subscription for product: ${productId}`);
+  }
+  if (subscription.status !== "active" && subscription.status !== "trialing") {
+    throw new Error(`Subscription for ${productId} is ${subscription.status}`);
+  }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm run test:unit -- enforcementFlip`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Full convex test suite + typecheck**
+
+Run: `npm run test:unit` (expect all green) and `npx tsc -p convex/tsconfig.json` (expect 0 errors).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add convex/productSubscriptions.ts convex/_helpers/products.ts tests/convex/enforcementFlip.test.ts
+git commit -m "feat(admin): re-enable module enforcement (revert #4345 stopgaps)"
+```
+
+---
+
+## Rollout (ordered live steps — enforcement is being turned on)
+
+Perform after Tasks 1–5 are merged and deployed, and before/around Task 6:
+
+1. Merge Tasks 1–5 to `main`; deploy to the live deployment: `npx convex dev --once` (targets `helpful-mule-867`). At this point the stopgaps are still active — no lock-out.
+2. Dry-run the backfill against the live deployment and review counts:
+   `npx convex run migrations/backfillEntitlements:run '{"dryRun":true}'`
+   Confirm `orgs`, `crmGranted`, `gabinetGranted` look right.
+3. Run it for real: `npx convex run migrations/backfillEntitlements:run '{"dryRun":false}'`.
+4. Verify grants: in the Convex dashboard (or a one-off query) confirm every org has a CRM `productSubscriptions` row and every gabinet-using org has a Gabinet row.
+5. Deploy Task 6 (the flip) with `npx convex dev --once`.
+6. Verify live in-browser on `www.quera-dev.helloalex.pl`: a granted org shows the module nav and Gabinet loads; use `/admin/entitlements` to revoke Gabinet for a disposable test org and confirm it disappears from that org's nav and its gabinet functions are blocked.
+```

--- a/docs/superpowers/specs/2026-08-08-platform-admin-sp1-module-access-design.md
+++ b/docs/superpowers/specs/2026-08-08-platform-admin-sp1-module-access-design.md
@@ -1,0 +1,118 @@
+# Platform Admin Console — SP1: Module Access & Enforcement — Design
+
+**Date:** 2026-08-08
+**Status:** Approved (design)
+**Author:** Alfred + Claude
+
+## Context
+
+The platform is a multi-tenant SaaS: a shared platform layer (orgs, auth, billing, RBAC) with pluggable vertical modules (CRM, Gabinet). Module access is gated by the Convex `productSubscriptions` table: `getActiveProducts` (drives the module navigation) and `verifyProductAccess` / `checkModuleAccess` (gate every gabinet backend function) both read it.
+
+During the 2026-08-07 production incident that table was found to be **empty** — no grants had ever been written (pre-launch, no Stripe). Enforcement therefore blocked every org from Gabinet and collapsed the module navigation. As an emergency stopgap (PR #4345) enforcement was disabled: `verifyProductAccess` was made **fail-open** and `getActiveProducts` was given a **catalog fallback**. Consequently there is currently **no module paywall** — every org sees and can use every module.
+
+SP1 restores real enforcement by giving the operator a way to grant/revoke module access per organization, backfilling existing orgs so nobody is locked out, and then reverting the stopgaps. See `~/.claude/.../memory/project_incident_2026-08-07_prod_convex.md` for the incident detail.
+
+### Where SP1 sits in the full console
+
+This is sub-project 1 of a full Platform Admin Console, decomposed as: **SP1 Module access & enforcement** (this doc) → SP2 Organizations console → SP4 Plans/products/pricing → SP3 Users & platform admins → SP5 Billing & Stripe → SP6 Platform settings & observability. Each gets its own spec → plan → build. SP1 is first because it is urgent and reverts the stopgaps.
+
+### Dependency / ordering note
+
+The stopgaps SP1 reverts live in **PR #4345** (branch `fix/unblock-gabinet-and-pln-schema`), which must be merged to `main` before SP1's enforcement-re-enable step, and SP1 should be built on top of it. The stopgaps are also already live on the serving deployment `helpful-mule-867`.
+
+## Goals
+
+- Platform admins can grant/revoke module access (CRM, Gabinet) per organization.
+- Existing orgs are backfilled so re-enabling enforcement locks nobody out.
+- Enforcement (`getActiveProducts`, `verifyProductAccess`) is restored to read real grants.
+- New orgs automatically receive the CRM baseline entitlement.
+
+## Non-goals (later sub-projects)
+
+- Stripe/self-serve billing, invoices, plan/pricing management (SP4/SP5).
+- Trials with expiry, time-limited grants (SP5).
+- Organizations console / user management beyond the entitlements table (SP2/SP3).
+- A "locked / upsell" screen for ungranted modules — ungranted modules stay hidden (SP5 may add upsell).
+
+## Deployment / architecture constraints (must respect)
+
+- The serving Convex deployment is **`helpful-mule-867`** (deploy with `npx convex dev --once`, not `convex deploy`). See memory `project_convex_deploy_pipeline`.
+- `organizations`, `teamMemberships`, and the `gabinet_*` tables live in **Supabase** (TABLE_MAP). A Convex **query** (V8 isolate) cannot read Supabase — only **actions** can. Therefore anything that reads org or gabinet data must be an action; `productSubscriptions` is a Convex-only table and is read/written directly in query/mutation ctx.
+- Platform-admin auth is `isPlatformAdmin` on the Supabase `users` row, checked via the existing `verifyPlatformAdmin` internal action (`convex/_helpers/authAction.ts`) or `getIsPlatformAdmin` (`convex/app.ts`).
+
+## Model
+
+Entitlements reuse the existing Convex `productSubscriptions` table (the table enforcement already reads). New optional fields (backward compatible) are added for provenance/audit:
+
+- `source: v.optional(v.union(v.literal("manual"), v.literal("stripe")))` — manual operator grant vs Stripe (SP5).
+- `grantedByUserId: v.optional(v.id("users"))` — who granted.
+- `note: v.optional(v.string())` — optional operator note.
+
+A manual grant is a row `{ organizationId, productId: "crm" | "gabinet", status: "active", cancelAtPeriodEnd: false, source: "manual", grantedByUserId, createdAt, updatedAt }`. There is exactly one row per `(organizationId, productId)` (upsert via the `by_orgAndProduct` index). **Revoke = set `status: "canceled"`** (row retained for history; `getActiveProducts`/`verifyProductAccess` already treat only `active`/`trialing` as access). Re-grant flips `status` back to `active`.
+
+CRM is the **baseline product**: auto-granted (`active`) to every org on creation and in the backfill; shown in the UI as an always-on badge, not a toggle. Gabinet (and future modules) are operator-granted add-ons.
+
+## Backend
+
+New module `convex/admin/entitlements.ts`, all platform-admin gated:
+
+- `listOrgEntitlements` (**action**): `verifyPlatformAdmin` → reads organizations from Supabase (`createSupabaseDb`) and their team-membership counts, reads `productSubscriptions` from Convex via an internalQuery, merges → returns `Array<{ organizationId: string; name: string; memberCount: number; crm: EntitlementStatus; gabinet: EntitlementStatus }>` where `EntitlementStatus = "active" | "canceled" | "none"`.
+- `setEntitlement` (**action**): args `{ organizationId: Id<"organizations">; productId: "crm" | "gabinet"; grant: boolean }` → `verifyPlatformAdmin` → calls the internal upsert mutation → writes an audit-log entry via the existing audit helper. Returns the new status.
+- `_upsertEntitlement` (**internalMutation**): upserts the `productSubscriptions` row for `(organizationId, productId)`: sets `status` to `active` (grant) or `canceled` (revoke), `source: "manual"`, `grantedByUserId`, timestamps.
+- `_listEntitlementsInternal` (**internalQuery**): returns all `productSubscriptions` rows (or by org) for the listing action to merge.
+
+Org-create hook: in `convex/organizations.ts` `create` (already an action), after the org is created, grant the CRM baseline entitlement by calling `_upsertEntitlement` (or a small dedicated internal) with `productId: "crm"`, `source: "manual"`, `status: "active"`.
+
+## Backfill
+
+A one-off internal action `convex/migrations/backfillEntitlements.ts`:
+
+1. List all organizations from Supabase.
+2. For each org: upsert a CRM entitlement (`active`) if none exists.
+3. For each org that has real gabinet data — at least one row in `gabinet_patients`, `gabinet_employees`, or `gabinet_appointments` (Supabase) — upsert a Gabinet entitlement (`active`) if none exists.
+4. Idempotent: skip orgs that already have the entitlement. Supports a `dryRun` arg that logs the counts (total orgs, orgs granted Gabinet) without writing, to verify before the enforcement flip.
+
+## Enforcement re-enablement (strict ordering)
+
+The stopgaps must not be reverted until grants exist, or prod breaks again. Order:
+
+1. Ship the entitlements schema fields, backend, org-create CRM grant, backfill action, and admin UI — **with the PR #4345 stopgaps still in place** (fail-open `verifyProductAccess`, catalog fallback in `getActiveProducts`). No lock-out risk yet.
+2. Run `backfillEntitlements` with `dryRun: true`, review counts, then run it for real.
+3. Verify every org has a CRM entitlement and every gabinet-using org has a Gabinet entitlement (query check).
+4. **Only then** revert the stopgaps: remove the catalog fallback from `getActiveProducts` (return only real active/trialing grants) and restore `verifyProductAccess` to throw when there is no active entitlement.
+5. Deploy to `helpful-mule-867` (`npx convex dev --once`) and verify live in-browser: for a granted org the nav shows the modules and gabinet loads; revoking Gabinet for a test org hides it and blocks its backend functions.
+
+## UI
+
+New route `src/routes/_app/_auth/admin.entitlements.tsx`, platform-admin gated with the same `getIsPlatformAdmin` guard pattern as `admin.index.tsx`; a card linking to it is added to `admin.index.tsx`.
+
+The page renders a table of organizations (name, member count) with:
+- a **CRM** column showing an always-on "Bazowy" badge (baseline; not toggleable),
+- a **Gabinet** column with a switch: "Nadany" (active) / "Brak" (none/canceled). Toggling on calls `setEntitlement({ grant: true })`; toggling off opens a confirmation dialog (revoking cuts off a live module) then calls `setEntitlement({ grant: false })`.
+
+After a successful mutation the list refetches and a toast confirms. Components come from the existing design system (`Card`, `Table`, `Switch`, `Badge`, `Dialog`, toast) — no new dependencies. Loading and empty states mirror existing admin pages.
+
+## Denied UX
+
+An ungranted module is **hidden from the navigation** (existing `getVisibleModules` behavior) and its backend functions throw via `verifyProductAccess`. This matches the operator-granted B2B model. A visible-but-locked upsell screen is out of scope (SP5).
+
+## Error handling
+
+- All admin backend entry points reject non-platform-admins (throw; UI shows the existing 403 card).
+- `setEntitlement` validates `productId` against the known set (`crm`, `gabinet`) and no-ops gracefully if the requested state already holds.
+- Revoking CRM is not offered in the UI; if attempted via the API it is allowed but discouraged (CRM is baseline) — the UI simply never exposes it.
+
+## Testing
+
+- **convex-test** (`convex/tests/`):
+  - `setEntitlement`: grant creates/flips an `active` row with `source:"manual"` + `grantedByUserId` + audit entry; revoke flips to `canceled`; non-platform-admin is rejected.
+  - `listOrgEntitlements`: merges Supabase orgs (in-memory stub) with Convex entitlements into the correct per-product status.
+  - `getActiveProducts` (post-revert): returns only active/trialing product ids, no catalog fallback.
+  - `verifyProductAccess` (post-revert): throws when no active entitlement, passes when granted.
+  - `backfillEntitlements`: idempotent; grants CRM to all orgs and Gabinet only to orgs with gabinet data; `dryRun` writes nothing.
+  - org `create`: new org receives a CRM entitlement.
+- **Playwright** (`e2e/`): a platform admin opens `/admin/entitlements`, toggles Gabinet for an org and sees the status update; a non-admin visiting `/admin/entitlements` sees the 403 card.
+
+## Rollout
+
+Because enforcement is being turned back on, the plan's last task is the flip (step 4–5 above) and it must be verified live on `helpful-mule-867` before closing SP1. The stopgap-revert commits should be isolated so they can be deployed in the correct order relative to the backfill.

--- a/e2e/admin/entitlements.spec.ts
+++ b/e2e/admin/entitlements.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from "@playwright/test";
+import { BASE_URL, loginAndGoToDashboard, waitForApp } from "../helpers/auth";
+import { navigateTo, assertNoErrorBoundary, getBodyText } from "../helpers/common";
+
+/**
+ * E2E tests for admin/entitlements — module-access entitlements grid.
+ *
+ * NOTE: These tests require:
+ *   1. A running dev/preview server at PLAYWRIGHT_BASE_URL (default: http://localhost:5173)
+ *   2. The default test account (PLAYWRIGHT_TEST_EMAIL / PLAYWRIGHT_TEST_PASSWORD) must
+ *      be a platform admin so it can reach the entitlements page.
+ *
+ * If the server is unavailable or the account lacks platform-admin status, the tests
+ * that assert page content will be marked as skipped rather than failed.
+ *
+ * Run command: npx playwright test e2e/admin/entitlements.spec.ts
+ */
+
+test.describe("Admin — Module-access entitlements", () => {
+  test.setTimeout(120_000);
+
+  test.beforeEach(async ({ page }) => {
+    await loginAndGoToDashboard(page);
+  });
+
+  // ─── Admin (platform-admin account) ─────────────────────────────────────
+
+  test("platform admin sees 'Dostęp do modułów' heading", async ({ page }) => {
+    await navigateTo(page, "/admin/entitlements");
+    await assertNoErrorBoundary(page);
+
+    const bodyText = await getBodyText(page);
+
+    // If the user is not a platform admin, the 403 card appears — skip the
+    // platform-admin-specific assertions rather than failing.
+    if (bodyText.includes("Platform admin required")) {
+      test.skip();
+      return;
+    }
+
+    expect(bodyText).toContain("Dostęp do modułów");
+  });
+
+  test("platform admin sees at least one org row in the table", async ({ page }) => {
+    await navigateTo(page, "/admin/entitlements");
+    await assertNoErrorBoundary(page);
+
+    const bodyText = await getBodyText(page);
+
+    if (bodyText.includes("Platform admin required")) {
+      test.skip();
+      return;
+    }
+
+    // The table has column headers Organizacja / Członkowie / CRM / Gabinet.
+    expect(bodyText).toContain("Organizacja");
+    expect(bodyText).toContain("CRM");
+    expect(bodyText).toContain("Gabinet");
+
+    // There should be at least one row with a "Bazowy" CRM badge.
+    const bazowy = page.locator('text="Bazowy"').first();
+    await expect(bazowy).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("platform admin can toggle Gabinet switch and sees success toast", async ({ page }) => {
+    await navigateTo(page, "/admin/entitlements");
+    await assertNoErrorBoundary(page);
+
+    const bodyText = await getBodyText(page);
+
+    if (bodyText.includes("Platform admin required")) {
+      test.skip();
+      return;
+    }
+
+    // Find the first Gabinet switch in the table.
+    const firstSwitch = page.locator('[role="switch"][aria-label*="Gabinet"]').first();
+    const switchVisible = await firstSwitch.isVisible({ timeout: 8_000 }).catch(() => false);
+
+    if (!switchVisible) {
+      // No orgs visible — skip rather than fail.
+      test.skip();
+      return;
+    }
+
+    // Read current state and toggle.
+    const isChecked = await firstSwitch.getAttribute("data-state");
+    const wasActive = isChecked === "checked";
+
+    // If revoking (turning off), the confirm dialog will appear — handle it.
+    page.on("dialog", async (dialog) => {
+      await dialog.accept();
+    });
+
+    await firstSwitch.click();
+
+    // Expect either a success toast or the switch to change state.
+    const toastAppeared = await page
+      .locator('text="Zaktualizowano dostęp"')
+      .waitFor({ timeout: 10_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (!toastAppeared) {
+      // Mutation may have toggled without toast (already in desired state) —
+      // still verify the switch changed.
+      const newState = await firstSwitch.getAttribute("data-state").catch(() => null);
+      const nowActive = newState === "checked";
+      expect(nowActive).not.toBe(wasActive);
+    } else {
+      expect(toastAppeared).toBe(true);
+    }
+
+    // Toggle back to restore state (best-effort, no assertion).
+    page.on("dialog", async (dialog) => {
+      await dialog.accept();
+    });
+    await firstSwitch.click().catch(() => {});
+  });
+
+  // ─── Non-admin (regular authenticated user) ─────────────────────────────
+
+  test("non-platform-admin user sees 403 card", async ({ page }) => {
+    await navigateTo(page, "/admin/entitlements");
+    await assertNoErrorBoundary(page);
+    await waitForApp(page);
+
+    const bodyText = await getBodyText(page);
+
+    // The test account (amiesak@gmail.com) IS a platform admin in the dev
+    // environment, so the 403 path cannot be exercised without a separate
+    // non-admin account. Guard with a conditional so CI doesn't fail if the
+    // account has been granted admin status.
+    if (bodyText.includes("Dostęp do modułów")) {
+      // Account is a platform admin — skip the 403 assertion.
+      test.skip();
+      return;
+    }
+
+    expect(bodyText).toContain("Platform admin required");
+
+    // "Back to admin" link must be visible.
+    const backLink = page.locator('a:has-text("Back to admin")').first();
+    await expect(backLink).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/session_state.json
+++ b/session_state.json
@@ -1,18 +1,18 @@
 {
   "session_id": "S0126",
   "started_at": "2026-08-07T14:30:00Z",
-  "last_updated": "2026-08-07T15:10:00Z",
-  "status": "active",
-  "focus": "Prod incident part 2: convex/ typecheck FIXED (0 errors, verified against regenerated _generated = what convex deploy sees). PR #4344 open. Awaiting user decision on the prod convex deploy (manual step).",
+  "last_updated": "2026-08-07T17:44:00Z",
+  "status": "completed",
+  "focus": "RESOLVED — Prod incident part 2: convex/ typecheck fixed (PR #4344 merged to main), user ran `npx convex deploy` in their own terminal, mintUserToken now on prod. App can mint Supabase JWT again.",
   "tasks_snapshot": {
     "total": 1,
     "not_started": 0,
-    "in_progress": 1,
-    "passing": 0,
+    "in_progress": 0,
+    "passing": 1,
     "failing": 0,
     "blocked": 0
   },
-  "active_task_ids": ["CVXFIX-01"],
-  "blockers": ["Prod convex deploy is a manual step needing user go-ahead + prod deploy access; not yet executed."],
-  "notes": "DONE: all convex/ TS errors fixed type-only (49 by convex-expert agent + 4 more surfaced by _generated regen: http/init callback params, signingStubs return type, backfillProductSubscriptions self-module ref cycle). `npx tsc -p convex/tsconfig.json` = 0 with regenerated _generated; check:convex-codegen in sync (191 modules). Commits bf8082c6 + 77eeaf38 on fix/convex-typecheck-prod-deploy; PR #4344. NEXT: after go-ahead run `npx convex deploy` to prod (pleasant-elephant-723) → verify mintUserToken in function-spec. convex deploy to prod is MANUAL (not auto on merge). No CONVEX_DEPLOY_KEY locally; device auth likely works. Autonomous worker loop STAYS stopped."
+  "active_task_ids": [],
+  "blockers": [],
+  "notes": "RESOLVED 17:43. PR #4344 merged (197d89b3). Netlify did NOT auto-deploy Convex in 14 min (auto-deploy broken — CONVEX_DEPLOY_KEY missing in Netlify prod ctx). User ran `npx convex deploy` manually in own terminal (Claude Bash/`!` are non-interactive, convex deploy needs a TTY). Verified: prod pleasant-elephant-723 now has mintUserToken + mintSupabaseToken; prod HTTP 200. FOLLOW-UP (not done): set prod CONVEX_DEPLOY_KEY in Netlify env (Production ctx) to restore auto-deploy — see memory project_convex_deploy_pipeline. Also still pending from earlier: harden auto-merge (never merge on red CI); autonomous worker loop STAYS stopped; convex/ app-typecheck (src/) + convex-auth-gate remain pre-existing red on main."
 }

--- a/session_state.json
+++ b/session_state.json
@@ -1,18 +1,18 @@
 {
-  "session_id": "S0126",
-  "started_at": "2026-08-07T14:30:00Z",
-  "last_updated": "2026-08-07T17:44:00Z",
+  "session_id": "S0127",
+  "started_at": "2026-08-08T00:00:00Z",
+  "last_updated": "2026-08-08T00:00:00Z",
   "status": "completed",
-  "focus": "RESOLVED — Prod incident part 2: convex/ typecheck fixed (PR #4344 merged to main), user ran `npx convex deploy` in their own terminal, mintUserToken now on prod. App can mint Supabase JWT again.",
+  "focus": "SP1 Task 2: listOrgEntitlements — internalQuery + action for org×module status grid",
   "tasks_snapshot": {
     "total": 1,
     "not_started": 0,
-    "in_progress": 0,
-    "passing": 1,
+    "in_progress": 1,
+    "passing": 0,
     "failing": 0,
     "blocked": 0
   },
-  "active_task_ids": [],
+  "active_task_ids": [1],
   "blockers": [],
-  "notes": "RESOLVED 17:43. PR #4344 merged (197d89b3). Netlify did NOT auto-deploy Convex in 14 min (auto-deploy broken — CONVEX_DEPLOY_KEY missing in Netlify prod ctx). User ran `npx convex deploy` manually in own terminal (Claude Bash/`!` are non-interactive, convex deploy needs a TTY). Verified: prod pleasant-elephant-723 now has mintUserToken + mintSupabaseToken; prod HTTP 200. FOLLOW-UP (not done): set prod CONVEX_DEPLOY_KEY in Netlify env (Production ctx) to restore auto-deploy — see memory project_convex_deploy_pipeline. Also still pending from earlier: harden auto-merge (never merge on red CI); autonomous worker loop STAYS stopped; convex/ app-typecheck (src/) + convex-auth-gate remain pre-existing red on main."
+  "notes": "TDD: append failing test first (listOrgEntitlements not yet defined), then implement in convex/admin/entitlements.ts. Do not touch Task 1 tests."
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as AppAuthDashboardLayoutRouteImport } from './routes/_app/_auth/
 import { Route as AppAuthAdminUsersRouteImport } from './routes/_app/_auth/admin.users'
 import { Route as AppAuthAdminErrorsRouteImport } from './routes/_app/_auth/admin.errors'
 import { Route as AppAuthAdminEmailConfigRouteImport } from './routes/_app/_auth/admin.email-config'
+import { Route as AppAuthAdminEntitlementsRouteImport } from './routes/_app/_auth/admin.entitlements'
 import { Route as AppAuthDashboardLayoutIndexRouteImport } from './routes/_app/_auth/dashboard/_layout.index'
 import { Route as AppAuthOnboardingLayoutUsernameRouteImport } from './routes/_app/_auth/onboarding/_layout.username'
 import { Route as AppAuthDashboardLayoutSetupRouteImport } from './routes/_app/_auth/dashboard/_layout.setup'
@@ -240,6 +241,11 @@ const AppAuthAdminErrorsRoute = AppAuthAdminErrorsRouteImport.update({
 const AppAuthAdminEmailConfigRoute = AppAuthAdminEmailConfigRouteImport.update({
   id: '/admin/email-config',
   path: '/admin/email-config',
+  getParentRoute: () => AppAuthRoute,
+} as any)
+const AppAuthAdminEntitlementsRoute = AppAuthAdminEntitlementsRouteImport.update({
+  id: '/admin/entitlements',
+  path: '/admin/entitlements',
   getParentRoute: () => AppAuthRoute,
 } as any)
 const AppAuthDashboardLayoutIndexRoute =
@@ -801,6 +807,7 @@ export interface FileRoutesByFullPath {
   '/admin/email-config': typeof AppAuthAdminEmailConfigRoute
   '/admin/errors': typeof AppAuthAdminErrorsRoute
   '/admin/users': typeof AppAuthAdminUsersRoute
+  '/admin/entitlements': typeof AppAuthAdminEntitlementsRoute
   '/dashboard': typeof AppAuthDashboardLayoutRouteWithChildren
   '/onboarding': typeof AppAuthOnboardingLayoutRouteWithChildren
   '/patient/appointments': typeof AppPatientLayoutAppointmentsRoute
@@ -910,6 +917,7 @@ export interface FileRoutesByTo {
   '/admin/email-config': typeof AppAuthAdminEmailConfigRoute
   '/admin/errors': typeof AppAuthAdminErrorsRoute
   '/admin/users': typeof AppAuthAdminUsersRoute
+  '/admin/entitlements': typeof AppAuthAdminEntitlementsRoute
   '/onboarding': typeof AppAuthOnboardingLayoutRouteWithChildren
   '/patient/appointments': typeof AppPatientLayoutAppointmentsRoute
   '/patient/book': typeof AppPatientLayoutBookRoute
@@ -1017,6 +1025,7 @@ export interface FileRoutesById {
   '/_app/_auth/admin/email-config': typeof AppAuthAdminEmailConfigRoute
   '/_app/_auth/admin/errors': typeof AppAuthAdminErrorsRoute
   '/_app/_auth/admin/users': typeof AppAuthAdminUsersRoute
+  '/_app/_auth/admin/entitlements': typeof AppAuthAdminEntitlementsRoute
   '/_app/_auth/dashboard/_layout': typeof AppAuthDashboardLayoutRouteWithChildren
   '/_app/_auth/onboarding/_layout': typeof AppAuthOnboardingLayoutRouteWithChildren
   '/_app/patient/_layout/appointments': typeof AppPatientLayoutAppointmentsRoute
@@ -1130,6 +1139,7 @@ export interface FileRouteTypes {
     | '/admin/email-config'
     | '/admin/errors'
     | '/admin/users'
+    | '/admin/entitlements'
     | '/dashboard'
     | '/onboarding'
     | '/patient/appointments'
@@ -1239,6 +1249,7 @@ export interface FileRouteTypes {
     | '/admin/email-config'
     | '/admin/errors'
     | '/admin/users'
+    | '/admin/entitlements'
     | '/onboarding'
     | '/patient/appointments'
     | '/patient/book'
@@ -1345,6 +1356,7 @@ export interface FileRouteTypes {
     | '/_app/_auth/admin/email-config'
     | '/_app/_auth/admin/errors'
     | '/_app/_auth/admin/users'
+    | '/_app/_auth/admin/entitlements'
     | '/_app/_auth/dashboard/_layout'
     | '/_app/_auth/onboarding/_layout'
     | '/_app/patient/_layout/appointments'
@@ -1621,6 +1633,13 @@ declare module '@tanstack/react-router' {
       path: '/admin/email-config'
       fullPath: '/admin/email-config'
       preLoaderRoute: typeof AppAuthAdminEmailConfigRouteImport
+      parentRoute: typeof AppAuthRoute
+    }
+    '/_app/_auth/admin/entitlements': {
+      id: '/_app/_auth/admin/entitlements'
+      path: '/admin/entitlements'
+      fullPath: '/admin/entitlements'
+      preLoaderRoute: typeof AppAuthAdminEntitlementsRouteImport
       parentRoute: typeof AppAuthRoute
     }
     '/_app/_auth/dashboard/_layout/': {
@@ -2603,6 +2622,7 @@ interface AppAuthRouteChildren {
   AppAuthAdminEmailConfigRoute: typeof AppAuthAdminEmailConfigRoute
   AppAuthAdminErrorsRoute: typeof AppAuthAdminErrorsRoute
   AppAuthAdminUsersRoute: typeof AppAuthAdminUsersRoute
+  AppAuthAdminEntitlementsRoute: typeof AppAuthAdminEntitlementsRoute
   AppAuthDashboardLayoutRoute: typeof AppAuthDashboardLayoutRouteWithChildren
   AppAuthOnboardingLayoutRoute: typeof AppAuthOnboardingLayoutRouteWithChildren
   AppAuthAdminIndexRoute: typeof AppAuthAdminIndexRoute
@@ -2612,6 +2632,7 @@ const AppAuthRouteChildren: AppAuthRouteChildren = {
   AppAuthAdminEmailConfigRoute: AppAuthAdminEmailConfigRoute,
   AppAuthAdminErrorsRoute: AppAuthAdminErrorsRoute,
   AppAuthAdminUsersRoute: AppAuthAdminUsersRoute,
+  AppAuthAdminEntitlementsRoute: AppAuthAdminEntitlementsRoute,
   AppAuthDashboardLayoutRoute: AppAuthDashboardLayoutRouteWithChildren,
   AppAuthOnboardingLayoutRoute: AppAuthOnboardingLayoutRouteWithChildren,
   AppAuthAdminIndexRoute: AppAuthAdminIndexRoute,

--- a/src/routes/_app/_auth/admin.entitlements.tsx
+++ b/src/routes/_app/_auth/admin.entitlements.tsx
@@ -1,0 +1,147 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAction } from "convex/react";
+import { api } from "@cvx/_generated/api";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import { formatActionError } from "@/lib/format-action-error";
+
+export const Route = createFileRoute("/_app/_auth/admin/entitlements")({
+  component: AdminEntitlements,
+});
+
+function AdminEntitlements() {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const getIsPlatformAdmin = useAction(api.app.getIsPlatformAdmin);
+  const { data: adminStatus, isLoading: adminLoading } = useQuery({
+    queryKey: ["isPlatformAdmin"],
+    queryFn: () => getIsPlatformAdmin({}),
+  });
+
+  const listAction = useAction(api.admin.entitlements.listOrgEntitlements);
+  const listQuery = useQuery({
+    queryKey: ["admin", "entitlements"],
+    queryFn: () => listAction({}),
+    enabled: Boolean(adminStatus?.isPlatformAdmin),
+  });
+
+  const setAction = useAction(api.admin.entitlements.setEntitlement);
+  const setMutation = useMutation({
+    mutationFn: setAction,
+    onSuccess: () => {
+      toast.success("Zaktualizowano dostęp");
+      queryClient.invalidateQueries({ queryKey: ["admin", "entitlements"] });
+    },
+    onError: (e) =>
+      toast.error(
+        formatActionError(e, t, {
+          key: "admin.entitlements.errors.setFailed",
+          defaultValue: "Nie udało się zaktualizować dostępu do modułu.",
+        }),
+      ),
+  });
+
+  if (adminLoading) {
+    return <div className="p-8 text-sm text-muted-foreground">Loading…</div>;
+  }
+  if (!adminStatus?.isPlatformAdmin) {
+    return (
+      <div className="mx-auto max-w-2xl p-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>403 — Platform admin required</CardTitle>
+            <CardDescription>
+              This page is only accessible to platform administrators.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Link to="/admin" className="text-sm underline">
+              Back to admin
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const rows = listQuery.data ?? [];
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-8">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Dostęp do modułów
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Nadawaj i odbieraj moduły per organizacja. CRM jest bazowy (zawsze
+          aktywny).
+        </p>
+      </div>
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Organizacja</TableHead>
+                <TableHead>Członkowie</TableHead>
+                <TableHead>CRM</TableHead>
+                <TableHead>Gabinet</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((org) => (
+                <TableRow key={org.organizationId}>
+                  <TableCell className="font-medium">{org.name}</TableCell>
+                  <TableCell>{org.memberCount}</TableCell>
+                  <TableCell>
+                    <Badge variant="secondary">Bazowy</Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Switch
+                      checked={org.gabinet === "active"}
+                      disabled={setMutation.isPending}
+                      onCheckedChange={(checked) => {
+                        if (
+                          !checked &&
+                          !window.confirm(
+                            `Odebrać Gabinet dla „${org.name}"? Odetnie to żywy moduł.`,
+                          )
+                        ) {
+                          return;
+                        }
+                        setMutation.mutate({
+                          organizationId: org.organizationId as never,
+                          productId: "gabinet",
+                          grant: checked,
+                        });
+                      }}
+                      aria-label={`Gabinet dla ${org.name}`}
+                    />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/routes/_app/_auth/admin.index.tsx
+++ b/src/routes/_app/_auth/admin.index.tsx
@@ -84,6 +84,17 @@ function AdminIndex() {
             </CardHeader>
           </Card>
         </Link>
+
+        <Link to="/admin/entitlements" className="block">
+          <Card className="h-full transition hover:border-foreground/20">
+            <CardHeader>
+              <CardTitle>Module access</CardTitle>
+              <CardDescription>
+                Grant or revoke module access (CRM, Gabinet) per organization.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </Link>
       </div>
     </div>
   );

--- a/tests/convex/automation.test.ts
+++ b/tests/convex/automation.test.ts
@@ -396,6 +396,12 @@ describe("automation lifecycle", () => {
   test("patient created event processes notification preset and records a processed run", async () => {
     const t = createManagedTestCtx();
     const { organizationId, userId, identity } = await seedTestUser(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("productSubscriptions", {
+        organizationId, productId: "gabinet", status: "active",
+        cancelAtPeriodEnd: false, createdAt: Date.now(), updatedAt: Date.now(),
+      });
+    });
 
     await t.withIdentity(identity).action(api.automation.createRule, {
       organizationId,

--- a/tests/convex/backfillEntitlements.test.ts
+++ b/tests/convex/backfillEntitlements.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { internal } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+describe("migrations/backfillEntitlements.run", () => {
+  test("grants CRM to all orgs and Gabinet only to orgs with gabinet data; idempotent", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    // Give this org gabinet data (a patient row in Supabase).
+    await createSupabaseDb().insert("gabinetPatients", {
+      _id: "pat_1",
+      organizationId: String(organizationId),
+      firstName: "Jan", lastName: "Kowalski",
+      createdBy: String(userId), createdAt: Date.now(), updatedAt: Date.now(),
+    });
+
+    const res = await t.run(async () => null).then(() =>
+      t.action(internal.migrations.backfillEntitlements.run, { dryRun: false }),
+    );
+    expect(res.crmGranted).toBeGreaterThanOrEqual(1);
+    expect(res.gabinetGranted).toBeGreaterThanOrEqual(1);
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("productSubscriptions").collect(),
+    );
+    const crm = rows.find(
+      (r) => String(r.organizationId) === String(organizationId) && r.productId === "crm",
+    );
+    const gab = rows.find(
+      (r) => String(r.organizationId) === String(organizationId) && r.productId === "gabinet",
+    );
+    expect(crm?.status).toBe("active");
+    expect(gab?.status).toBe("active");
+
+    // Idempotent: second run grants nothing new.
+    const res2 = await t.action(internal.migrations.backfillEntitlements.run, {
+      dryRun: false,
+    });
+    expect(res2.crmGranted).toBe(0);
+    expect(res2.gabinetGranted).toBe(0);
+  });
+
+  test("dryRun writes nothing", async () => {
+    const t = createTestCtx();
+    await seedTestUser(t);
+    const res = await t.action(internal.migrations.backfillEntitlements.run, {
+      dryRun: true,
+    });
+    expect(res.dryRun).toBe(true);
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("productSubscriptions").collect(),
+    );
+    expect(rows.length).toBe(0);
+  });
+});

--- a/tests/convex/enforcementFlip.test.ts
+++ b/tests/convex/enforcementFlip.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { api, internal } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+describe("enforcement after flip", () => {
+  test("getActiveProducts returns only granted products (no catalog fallback)", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    // Grant only CRM.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("productSubscriptions", {
+        organizationId, productId: "crm", status: "active",
+        cancelAtPeriodEnd: false, source: "manual", grantedByUserId: userId,
+        createdAt: Date.now(), updatedAt: Date.now(),
+      });
+    });
+    const products = await t
+      .withIdentity(identity)
+      .query(api.productSubscriptions.getActiveProducts, { organizationId });
+    expect(products).toEqual(["crm"]);
+  });
+
+  test("verifyGabinetAccess throws when gabinet not granted", async () => {
+    const t = createTestCtx();
+    const { organizationId } = await seedTestUser(t);
+    await expect(
+      t.run(async (ctx) =>
+        ctx.runQuery(internal._helpers.products.verifyGabinetAccess, {
+          organizationId,
+        }),
+      ),
+    ).rejects.toThrow(/No active subscription/);
+  });
+});

--- a/tests/convex/entitlements.test.ts
+++ b/tests/convex/entitlements.test.ts
@@ -128,3 +128,29 @@ describe("admin/entitlements.listOrgEntitlements", () => {
     ).rejects.toThrow();
   });
 });
+
+describe("organizations.create — CRM baseline grant", () => {
+  test("new org receives an active CRM entitlement", async () => {
+    const t = createTestCtx();
+    const { userId, identity } = await seedTestUser(t);
+    // seedTestUser already made an org named "test-org"; create a second.
+    const orgId = await t
+      .withIdentity(identity)
+      .action(api.organizations.create, {
+        name: "Second Org",
+        slug: "second-org",
+      });
+
+    const row = await t.run(async (ctx) =>
+      ctx.db
+        .query("productSubscriptions")
+        .withIndex("by_orgAndProduct", (q) =>
+          q.eq("organizationId", orgId as any).eq("productId", "crm"),
+        )
+        .unique(),
+    );
+    expect(row?.status).toBe("active");
+    expect(row?.source).toBe("manual");
+    expect(String(row?.grantedByUserId)).toBe(String(userId));
+  });
+});

--- a/tests/convex/entitlements.test.ts
+++ b/tests/convex/entitlements.test.ts
@@ -93,3 +93,38 @@ describe("admin/entitlements.setEntitlement", () => {
     ).rejects.toThrow();
   });
 });
+
+describe("admin/entitlements.listOrgEntitlements", () => {
+  test("merges orgs with their entitlement status", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await createSupabaseDb().insert("users", {
+      _id: String(userId), name: "Admin", email: "a@example.com",
+      isPlatformAdmin: true,
+    });
+    await t.withIdentity(identity).action(api.admin.entitlements.setEntitlement, {
+      organizationId, productId: "gabinet", grant: true,
+    });
+
+    const rows = await t
+      .withIdentity(identity)
+      .action(api.admin.entitlements.listOrgEntitlements, {});
+    const org = rows.find((r) => r.organizationId === String(organizationId));
+    expect(org).toBeTruthy();
+    expect(org?.name).toBe("Test Org");
+    expect(org?.gabinet).toBe("active");
+    expect(org?.crm).toBe("none");
+    expect(org?.memberCount).toBe(1);
+  });
+
+  test("rejects non-platform-admin callers", async () => {
+    const t = createTestCtx();
+    const { userId, identity } = await seedTestUser(t);
+    await createSupabaseDb().insert("users", {
+      _id: String(userId), name: "N", email: "n@example.com", isPlatformAdmin: false,
+    });
+    await expect(
+      t.withIdentity(identity).action(api.admin.entitlements.listOrgEntitlements, {}),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/convex/entitlements.test.ts
+++ b/tests/convex/entitlements.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { api, internal } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+// Make the seeded user a platform admin by inserting them into the in-memory
+// Supabase users table with is_platform_admin=true (verifyPlatformAdmin reads
+// the Supabase users row, which seedTestUser does not create).
+async function makePlatformAdmin(userId: string) {
+  await createSupabaseDb().insert("users", {
+    _id: userId,
+    name: "Admin",
+    email: `admin-${userId}@example.com`,
+    isPlatformAdmin: true,
+  });
+}
+
+describe("admin/entitlements.setEntitlement", () => {
+  test("grant creates an active manual entitlement with audit", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await makePlatformAdmin(String(userId));
+
+    const res = await t
+      .withIdentity(identity)
+      .action(api.admin.entitlements.setEntitlement, {
+        organizationId,
+        productId: "gabinet",
+        grant: true,
+      });
+    expect(res.status).toBe("active");
+
+    const row = await t.run(async (ctx) =>
+      ctx.db
+        .query("productSubscriptions")
+        .withIndex("by_orgAndProduct", (q) =>
+          q.eq("organizationId", organizationId).eq("productId", "gabinet"),
+        )
+        .unique(),
+    );
+    expect(row?.status).toBe("active");
+    expect(row?.source).toBe("manual");
+    expect(String(row?.grantedByUserId)).toBe(String(userId));
+
+    const audit = await t.run(async (ctx) =>
+      ctx.db.query("auditLog").collect(),
+    );
+    expect(audit.some((a) => a.action === "product_access_granted")).toBe(true);
+  });
+
+  test("revoke flips an existing entitlement to canceled", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    await makePlatformAdmin(String(userId));
+
+    await t.withIdentity(identity).action(api.admin.entitlements.setEntitlement, {
+      organizationId, productId: "gabinet", grant: true,
+    });
+    const res = await t
+      .withIdentity(identity)
+      .action(api.admin.entitlements.setEntitlement, {
+        organizationId, productId: "gabinet", grant: false,
+      });
+    expect(res.status).toBe("canceled");
+
+    const row = await t.run(async (ctx) =>
+      ctx.db
+        .query("productSubscriptions")
+        .withIndex("by_orgAndProduct", (q) =>
+          q.eq("organizationId", organizationId).eq("productId", "gabinet"),
+        )
+        .unique(),
+    );
+    expect(row?.status).toBe("canceled");
+  });
+
+  test("rejects non-platform-admin callers", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    // Insert Supabase user WITHOUT platform admin.
+    await createSupabaseDb().insert("users", {
+      _id: String(userId), name: "Nobody", email: "nobody@example.com",
+      isPlatformAdmin: false,
+    });
+    await expect(
+      t.withIdentity(identity).action(api.admin.entitlements.setEntitlement, {
+        organizationId, productId: "gabinet", grant: true,
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/convex/gabinetTreatmentsCreate.test.ts
+++ b/tests/convex/gabinetTreatmentsCreate.test.ts
@@ -14,6 +14,12 @@ describe("gabinet/treatments.create — happy path", () => {
   test("inserts a treatment with required fields and writes it to Supabase", async () => {
     const t = createTestCtx();
     const { organizationId, userId, identity } = await seedTestUser(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("productSubscriptions", {
+        organizationId, productId: "gabinet", status: "active",
+        cancelAtPeriodEnd: false, createdAt: Date.now(), updatedAt: Date.now(),
+      });
+    });
 
     const treatmentId = await t
       .withIdentity(identity)
@@ -44,6 +50,12 @@ describe("gabinet/treatments.create — happy path", () => {
   test("persists all optional columns when supplied", async () => {
     const t = createTestCtx();
     const { organizationId, identity } = await seedTestUser(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("productSubscriptions", {
+        organizationId, productId: "gabinet", status: "active",
+        cancelAtPeriodEnd: false, createdAt: Date.now(), updatedAt: Date.now(),
+      });
+    });
 
     const treatmentId = await t
       .withIdentity(identity)
@@ -92,6 +104,12 @@ describe("gabinet/treatments.create — happy path", () => {
   test("clears taxRate when taxExempt is true", async () => {
     const t = createTestCtx();
     const { organizationId, identity } = await seedTestUser(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("productSubscriptions", {
+        organizationId, productId: "gabinet", status: "active",
+        cancelAtPeriodEnd: false, createdAt: Date.now(), updatedAt: Date.now(),
+      });
+    });
 
     const treatmentId = await t
       .withIdentity(identity)


### PR DESCRIPTION
Sub-project 1 of the Platform Admin Console. Gives platform admins a UI to grant/revoke module access (CRM, Gabinet) per organization, auto-grants CRM to new orgs, backfills existing orgs, and re-enables the module-access enforcement that PR #4345 disabled via emergency stopgaps.

Spec: `docs/superpowers/specs/2026-08-08-platform-admin-sp1-module-access-design.md`
Plan: `docs/superpowers/plans/2026-08-08-platform-admin-sp1-module-access.md`

## What's in it (6 TDD tasks, each per-task reviewed + final whole-branch review, 0 Critical/0 Important)
1. Entitlement write path — `setEntitlement` action + `_upsertEntitlement` internalMutation (+ `source`/`grantedByUserId`/`note` schema fields) + audit. Revoke = status `canceled` (never delete).
2. `listOrgEntitlements` action — org × module grid (Supabase orgs/memberships merged with Convex `productSubscriptions`).
3. Auto-grant CRM baseline on org creation (`_createOrgInternal`).
4. `backfillEntitlements` one-off action — CRM to all orgs, Gabinet to orgs with real gabinet data; idempotent; `dryRun`.
5. `/admin/entitlements` grid page (platform-admin gated) + card on `/admin`.
6. Enforcement flip — remove `getActiveProducts` catalog fallback + restore `verifyProductAccess` throw (reverts #4345 stopgaps).

## Safety / rollout
The enforcement flip is code-complete but activates only via the **gated production Rollout** in the plan (deploy panel → dry-run backfill → run backfill on live → verify grants → deploy flip → verify in-browser). Merging does NOT auto-enable enforcement (Convex prod deploy to `helpful-mule-867` is a manual `npx convex dev --once` step). Order matters: backfill BEFORE the flip deploy, or orgs get locked out.

## Test status
New tests pass. The full convex suite shows 31 pre-existing failures (RBAC/tenant/portal-isolation "resolves instead of rejecting", migration-moved exports, harness stub gaps) — verified UNRELATED to this branch (0 flip-signature failures); documented for a future sub-project (enforcement broken app-wide from the Convex→Supabase migration).

## Non-blocking follow-ups
Revoke should preserve `source` (SP5); backfill `grantedByUserId` should use a system user; fix `as never` cast + unused test import; run E2E once a non-admin fixture exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)