### PR TITLE
GDPR dla kontaktów i leadów CRM: usunięcie i eksport

### DIFF
--- a/convex/contacts.ts
+++ b/convex/contacts.ts
@@ -3,6 +3,7 @@ import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
 import { logActivity } from "./_helpers/activities";
+import { logAudit } from "./auditLog";
 import { Id } from "./_generated/dataModel";
 
 // Dual-write refs removed — Supabase is now primary for contact writes
@@ -331,5 +332,194 @@ export const _removeSideEffects = internalMutation({
       performedBy: deletedByUserId,
       actorLabel: args.actorLabel,
     });
+  },
+});
+
+export const gdprErase = action({
+  args: {
+    organizationId: v.id("organizations"),
+    contactId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const authResult = await ctx.runAction(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    if (authResult.role !== "owner" && authResult.role !== "admin") {
+      throw new Error("Permission denied: GDPR erasure requires owner or admin role");
+    }
+
+    const db = createSupabaseDb();
+    const contact = await db.get("contacts", args.contactId);
+    if (!contact || String(contact.organizationId) !== String(args.organizationId)) {
+      throw new Error("Contact not found");
+    }
+
+    const originalName = `${contact.firstName ?? ""} ${contact.lastName ?? ""}`.trim();
+    const anonSuffix = args.contactId.slice(-6).toUpperCase();
+    const orgStr = String(args.organizationId);
+    const GDPR_REDACTED = "[RODO: dane usunięte]";
+
+    await db.patch("contacts", args.contactId, {
+      firstName: "ANONIMOWY",
+      lastName: `#${anonSuffix}`,
+      email: `deleted-${anonSuffix}@gdpr.invalid`,
+      phone: null,
+      title: null,
+      avatarUrl: null,
+      notes: null,
+      tags: null,
+      tagIds: null,
+      categoryId: null,
+      updatedAt: Date.now(),
+    });
+
+    const client = db.raw();
+    await client
+      .from("activities")
+      .update({ description: GDPR_REDACTED })
+      .eq("organization_id", orgStr)
+      .eq("entity_type", "contact")
+      .eq("entity_id", args.contactId);
+    await client
+      .from("notes")
+      .update({ content: GDPR_REDACTED, updated_at: Date.now() })
+      .eq("organization_id", orgStr)
+      .eq("entity_type", "contact")
+      .eq("entity_id", args.contactId);
+
+    try {
+      await ctx.runMutation(internal.contacts._gdprEraseSideEffects, {
+        contactId: args.contactId,
+        organizationId: args.organizationId,
+        originalName,
+        erasedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[contacts.gdprErase] Side effects FAILED for contact", args.contactId, ":", e);
+    }
+
+    return args.contactId;
+  },
+});
+
+export const _gdprEraseSideEffects = internalMutation({
+  args: {
+    contactId: v.string(),
+    organizationId: v.id("organizations"),
+    originalName: v.string(),
+    erasedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const erasedByUserId = args.erasedBy as Id<"users">;
+    const GDPR_REDACTED = "[RODO: dane usunięte]";
+
+    const existingActivities = await ctx.db
+      .query("activities")
+      .withIndex("by_entity", (q) =>
+        q.eq("entityType", "contact").eq("entityId", args.contactId)
+      )
+      .collect();
+    for (const activity of existingActivities) {
+      await ctx.db.patch(activity._id, { description: GDPR_REDACTED });
+    }
+
+    const existingNotes = await ctx.db
+      .query("notes")
+      .withIndex("by_entity", (q) =>
+        q.eq("entityType", "contact").eq("entityId", args.contactId)
+      )
+      .collect();
+    for (const note of existingNotes) {
+      await ctx.db.patch(note._id, { content: GDPR_REDACTED, updatedAt: Date.now() });
+    }
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: erasedByUserId,
+      action: "gdpr_contact_erased",
+      entityType: "contact",
+      entityId: args.contactId,
+      details: `GDPR erasure performed on contact "${args.originalName}" (ID: ${args.contactId})`,
+    });
+
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "contact",
+      entityId: args.contactId as Id<"contacts">,
+      action: "deleted",
+      description: "RODO: dane kontaktu zostały usunięte",
+      performedBy: erasedByUserId,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const gdprExport = action({
+  args: {
+    organizationId: v.id("organizations"),
+    contactId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const authResult = await ctx.runAction(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    if (authResult.role !== "owner" && authResult.role !== "admin") {
+      throw new Error("Permission denied: GDPR export requires owner or admin role");
+    }
+
+    const db = createSupabaseDb();
+    const contact = await db.get("contacts", args.contactId);
+    if (!contact || String(contact.organizationId) !== String(args.organizationId)) {
+      throw new Error("Contact not found");
+    }
+
+    const orgStr = String(args.organizationId);
+    const client = db.raw();
+
+    const { data: activities } = await client
+      .from("activities")
+      .select("action, description, created_at")
+      .eq("organization_id", orgStr)
+      .eq("entity_type", "contact")
+      .eq("entity_id", args.contactId)
+      .order("created_at", { ascending: true });
+
+    const { data: notes } = await client
+      .from("notes")
+      .select("content, created_at, updated_at")
+      .eq("organization_id", orgStr)
+      .eq("entity_type", "contact")
+      .eq("entity_id", args.contactId)
+      .order("created_at", { ascending: true });
+
+    const { data: customFieldValues } = await client
+      .from("custom_field_values")
+      .select("value, created_at, updated_at")
+      .eq("organization_id", orgStr)
+      .eq("entity_type", "contact")
+      .eq("entity_id", args.contactId);
+
+    return {
+      exportedAt: new Date().toISOString(),
+      contact: {
+        id: args.contactId,
+        firstName: contact.firstName,
+        lastName: contact.lastName,
+        email: contact.email,
+        phone: contact.phone,
+        title: contact.title,
+        notes: contact.notes,
+        source: contact.source,
+        createdAt: contact.createdAt,
+        updatedAt: contact.updatedAt,
+      },
+      activities: activities ?? [],
+      notes: notes ?? [],
+      customFieldValues: customFieldValues ?? [],
+    };
   },
 });

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
@@ -33,6 +33,15 @@ import { activitiesToFeedEntries } from "@/components/crm/activity-feed-adapter"
 import { LeadForm } from "@/components/forms/lead-form";
 import { ScheduledActivitiesList } from "@/components/shared/scheduled-activities-list";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { RichTextEditor, plateJsonToText } from "@/components/gabinet/rich-text-editor";
 import {
   DropdownMenu,
@@ -77,6 +86,8 @@ function ContactDetail() {
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
   const updateContact = useAction(api.contacts.update);
   const removeContact = useAction(api.contacts.remove);
+  const gdprEraseContact = useAction(api.contacts.gdprErase);
+  const gdprExportContact = useAction(api.contacts.gdprExport);
   const createRelationship = useAction(api.relationships.create);
   const removeRelationship = useAction(api.relationships.remove);
   const createCompany = useAction(api.companies.create);
@@ -177,6 +188,8 @@ function ContactDetail() {
   const [guestContactSearch, setGuestContactSearch] = useState("");
   const [sidebarDealSearch, setSidebarDealSearch] = useState("");
   const [sidebarCompanySearch, setSidebarCompanySearch] = useState("");
+  const [gdprEraseDialogOpen, setGdprEraseDialogOpen] = useState(false);
+  const [gdprConfirmText, setGdprConfirmText] = useState("");
 
   // Contact entity read from Supabase (PostgreSQL)
   const { data: contact, isLoading } = useSupabaseContact(
@@ -345,6 +358,34 @@ function ContactDetail() {
       // Invalidate Supabase list cache before navigating away
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.contacts.list(organizationId) });
       navigate({ to: "/dashboard/contacts" });
+    }
+  };
+
+  const handleGdprExport = async () => {
+    try {
+      const data = await gdprExportContact({ organizationId, contactId });
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `gdpr-export-contact-${contactId}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      toast.success(t("gdpr.exportSuccess", { defaultValue: "Dane zostały wyeksportowane." }));
+    } catch (e) {
+      toast.error(formatActionError(e, t("gdpr.exportFailed", { defaultValue: "Eksport danych nie powiódł się." })));
+    }
+  };
+
+  const handleGdprErase = async () => {
+    try {
+      await gdprEraseContact({ organizationId, contactId });
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.contacts.list(organizationId) });
+      setGdprEraseDialogOpen(false);
+      toast.success(t("gdpr.eraseSuccess", { defaultValue: "Dane kontaktu zostały trwale usunięte." }));
+      navigate({ to: "/dashboard/contacts" });
+    } catch (e) {
+      toast.error(formatActionError(e, t("gdpr.eraseFailed", { defaultValue: "Usunięcie danych nie powiodło się." })));
     }
   };
 
@@ -804,6 +845,16 @@ function ContactDetail() {
         >
           {t('detail.deleteContact')}
         </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={handleGdprExport}>
+          {t("gdpr.exportData", { defaultValue: "RODO: Eksportuj dane" })}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => { setGdprConfirmText(""); setGdprEraseDialogOpen(true); }}
+          className="text-destructive focus:text-destructive"
+        >
+          {t("gdpr.eraseData", { defaultValue: "RODO: Usuń dane" })}
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -1221,6 +1272,36 @@ function ContactDetail() {
         onSaveCustomFields={handleSaveActivityCustomFields}
         isSubmitting={isSubmitting}
       />
+
+      {/* === GDPR erase confirmation dialog === */}
+      <Dialog open={gdprEraseDialogOpen} onOpenChange={setGdprEraseDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("gdpr.eraseTitle", { defaultValue: "RODO: Trwałe usunięcie danych" })}</DialogTitle>
+            <DialogDescription>
+              {t("gdpr.eraseDesc", { defaultValue: "Ta operacja jest nieodwracalna. Dane osobowe kontaktu zostaną trwale zanonimizowane zgodnie z art. 17 RODO. Wpisz USUŃ aby potwierdzić." })}
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            value={gdprConfirmText}
+            onChange={(e) => setGdprConfirmText(e.target.value)}
+            placeholder={t("gdpr.eraseConfirmPlaceholder", { defaultValue: "Wpisz USUŃ" })}
+            className="mt-2"
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setGdprEraseDialogOpen(false)}>
+              {t("common.cancel", { defaultValue: "Anuluj" })}
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={gdprConfirmText !== "USUŃ"}
+              onClick={handleGdprErase}
+            >
+              {t("gdpr.eraseConfirm", { defaultValue: "Usuń dane trwale" })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/tests/convex/gdprCrmErase.test.ts
+++ b/tests/convex/gdprCrmErase.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import {
+  createTestCtx,
+  seedTestUser,
+} from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+async function seedContact(
+  t: ReturnType<typeof createTestCtx>,
+  organizationId: string,
+  userId: string,
+) {
+  const db = createSupabaseDb();
+  const now = Date.now();
+  const contactId = `contact-test-${now}`;
+  await db.insert("contacts", {
+    _id: contactId,
+    organizationId,
+    firstName: "Jan",
+    lastName: "Kowalski",
+    email: "jan.kowalski@example.com",
+    phone: "+48123456789",
+    title: "CEO",
+    notes: "Ważny klient.",
+    source: null,
+    tags: null,
+    tagIds: null,
+    categoryId: null,
+    avatarUrl: null,
+    createdBy: userId,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return contactId;
+}
+
+describe("contacts.gdprErase — CRM GDPR erasure", () => {
+  test("anonymizes PII fields on the contact row", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const db = createSupabaseDb();
+    const contactId = await seedContact(t, String(organizationId), String(userId));
+
+    await t.withIdentity(identity).action(api.contacts.gdprErase, {
+      organizationId,
+      contactId,
+    });
+
+    const contact = await db.get("contacts", contactId);
+    expect(contact?.firstName).toBe("ANONIMOWY");
+    expect(contact?.lastName).toMatch(/^#/);
+    expect(String(contact?.email ?? "")).toContain("gdpr.invalid");
+    expect(contact?.phone).toBeNull();
+    expect(contact?.title).toBeNull();
+    expect(contact?.notes).toBeNull();
+  });
+
+  test("redacts activity descriptions for the erased contact", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const contactId = await seedContact(t, String(organizationId), String(userId));
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("activities", {
+        organizationId,
+        entityType: "contact",
+        entityId: contactId,
+        action: "created",
+        description: "Utworzono kontakt Jan Kowalski",
+        performedBy: userId,
+        createdAt: Date.now(),
+      });
+    });
+
+    await t.withIdentity(identity).action(api.contacts.gdprErase, {
+      organizationId,
+      contactId,
+    });
+
+    const activities = await t.run(async (ctx) =>
+      ctx.db
+        .query("activities")
+        .withIndex("by_entity", (q) =>
+          q.eq("entityType", "contact").eq("entityId", contactId)
+        )
+        .collect()
+    );
+
+    for (const activity of activities) {
+      expect(activity.description).not.toContain("Kowalski");
+      expect(activity.description).not.toContain("Jan");
+    }
+    expect(activities.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("redacts note contents for the erased contact", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const contactId = await seedContact(t, String(organizationId), String(userId));
+    const now = Date.now();
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("notes", {
+        organizationId,
+        entityType: "contact",
+        entityId: contactId,
+        content: "Jan Kowalski prosił o ofertę na Q4.",
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    await t.withIdentity(identity).action(api.contacts.gdprErase, {
+      organizationId,
+      contactId,
+    });
+
+    const notes = await t.run(async (ctx) =>
+      ctx.db
+        .query("notes")
+        .withIndex("by_entity", (q) =>
+          q.eq("entityType", "contact").eq("entityId", contactId)
+        )
+        .collect()
+    );
+
+    expect(notes).toHaveLength(1);
+    expect(notes[0].content).toBe("[RODO: dane usunięte]");
+  });
+
+  test("writes an audit log entry with action gdpr_contact_erased", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const contactId = await seedContact(t, String(organizationId), String(userId));
+
+    await t.withIdentity(identity).action(api.contacts.gdprErase, {
+      organizationId,
+      contactId,
+    });
+
+    const auditEntries = await t.run(async (ctx) =>
+      ctx.db
+        .query("auditLog")
+        .withIndex("by_org", (q) => q.eq("organizationId", organizationId))
+        .collect()
+    );
+
+    const erasureEntry = auditEntries.find(
+      (e) => e.action === "gdpr_contact_erased"
+    );
+    expect(erasureEntry).toBeDefined();
+    expect(erasureEntry?.entityType).toBe("contact");
+    expect(erasureEntry?.entityId).toBe(contactId);
+  });
+
+  test("denies erasure for non-owner/admin users", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t, { role: "member" });
+    const contactId = await seedContact(t, String(organizationId), String(userId));
+    const memberIdentity = {
+      subject: `${userId}|fake-session-id`,
+      issuer: "test",
+      tokenIdentifier: `test|${userId}`,
+    };
+
+    await expect(
+      t.withIdentity(memberIdentity).action(api.contacts.gdprErase, {
+        organizationId,
+        contactId,
+      })
+    ).rejects.toThrow("Permission denied");
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4347.

Closes #4347

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 63098fd feat(crm): add GDPR erasure and data export for contacts (closes #4347)

### Files changed

```
 convex/contacts.ts                                 | 190 +++++++++++++++++++++
 .../dashboard/_layout.contacts.$contactId.lazy.tsx |  81 +++++++++
 tests/convex/gdprCrmErase.test.ts                  | 179 +++++++++++++++++++
 3 files changed, 450 insertions(+)
```