### PR TITLE
Convert `emitEvent` to internal action with Supabase-primary write for `automationRuns`

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -1385,12 +1385,43 @@ export const listActionTypes = action({
   },
 });
 
-export const emitEvent = internalMutation({
+export const emitEvent = internalAction({
   args: automationEventArgsValidator,
   handler: async (ctx, args) => {
     const now = Date.now();
     const runId = crypto.randomUUID();
     const occurredAt = args.occurredAt ?? now;
+
+    const db = createSupabaseDb();
+
+    // Idempotency guard: if another emitEvent with the same key already ran
+    // (e.g. a retry or duplicate call), return the existing run ID without
+    // scheduling a second processRun.
+    const existing = await db
+      .query("automationRuns")
+      .eq("eventIdempotencyKey", args.eventIdempotencyKey)
+      .first();
+    if (existing) return existing._id as string;
+
+    await db.insert("automationRuns", {
+      _id: runId,
+      organizationId: args.organizationId as string,
+      ruleId: null,
+      module: args.module,
+      eventType: args.eventType,
+      entityType: args.entityType ?? null,
+      entityId: args.entityId ?? null,
+      eventIdempotencyKey: args.eventIdempotencyKey,
+      correlationKey: args.correlationKey ?? null,
+      payloadSnapshot: args.payload,
+      actorUserId: (args.actorUserId as string | undefined) ?? null,
+      status: "pending",
+      errorMessage: null,
+      occurredAt,
+      processedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    });
 
     // @ts-ignore -- TS2589: type instantiation depth in generated Convex API types
     const processRunRef = internal.automation.processRun;
@@ -1448,37 +1479,14 @@ export const processRun = internalAction({
     const payload = JSON.parse(run.payloadSnapshot) as Record<string, unknown>;
     const processRunDb = createSupabaseDb();
 
-    // Idempotency guard: if another processRun already claimed this eventIdempotencyKey
-    // (e.g. emitEvent was called twice due to a Convex mutation retry), skip silently.
-    // The Supabase UNIQUE constraint on event_idempotency_key is the last-line defence,
-    // but relying on it alone means the second action throws a 23505 error rather than
-    // returning cleanly. This explicit check restores the graceful early-exit behaviour
-    // that the old ctx.db dedup provided.
+    // Idempotency guard: emitEvent writes the row to Supabase (status "pending") before
+    // scheduling this action. If processRun somehow runs twice, the row will already have
+    // a terminal status — skip silently to avoid double-processing.
     const existingRun = await processRunDb
       .query("automationRuns")
       .eq("eventIdempotencyKey", args.eventIdempotencyKey)
       .first();
-    if (existingRun) return;
-
-    await processRunDb.insert("automationRuns", {
-      _id: args.runId,
-      organizationId: args.organizationId as string,
-      ruleId: null,
-      module: args.module,
-      eventType: args.eventType,
-      entityType: args.entityType ?? null,
-      entityId: args.entityId ?? null,
-      eventIdempotencyKey: args.eventIdempotencyKey,
-      correlationKey: args.correlationKey ?? null,
-      payloadSnapshot: args.payloadSnapshot,
-      actorUserId: (args.actorUserId as string | undefined) ?? null,
-      status: "pending",
-      errorMessage: null,
-      occurredAt: args.occurredAt,
-      processedAt: null,
-      createdAt: args.createdAt,
-      updatedAt: args.createdAt,
-    });
+    if (existingRun && existingRun.status !== "pending") return;
 
     const rules = await processRunDb
       .query("automationRules")

--- a/convex/gabinet/appointmentReminders.ts
+++ b/convex/gabinet/appointmentReminders.ts
@@ -329,7 +329,7 @@ export const sendReminder = internalMutation({
       treatmentName,
     };
 
-    await ctx.runMutation(internal.automation.emitEvent, {
+    await ctx.scheduler.runAfter(0, internal.automation.emitEvent, {
       organizationId: reminder.organizationId as Id<"organizations">,
       module: "gabinet",
       eventType: "gabinet.appointment.reminder_due",

--- a/convex/gabinet/appointmentSms.ts
+++ b/convex/gabinet/appointmentSms.ts
@@ -551,7 +551,7 @@ export const processIncomingMessage = internalMutation({
       });
     }
 
-    await ctx.runMutation(internal.automation.emitEvent, {
+    await ctx.scheduler.runAfter(0, internal.automation.emitEvent, {
       organizationId: args.organizationId as Id<"organizations">,
       module: "gabinet",
       eventType: "gabinet.appointment.sms_reply_received",

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -115,7 +115,7 @@ async function emitAutomationEvent(
   },
 ) {
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
-  await ctx.runMutation(internal.automation.emitEvent, {
+  await ctx.scheduler.runAfter(0, internal.automation.emitEvent, {
     organizationId: args.organizationId,
     module: args.module,
     eventType: args.eventType,

--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -488,7 +488,7 @@ export const _createSideEffects = internalMutation({
       details: `Created patient ${args.firstName} ${args.lastName}`,
     });
 
-    await ctx.runMutation(internal.automation.emitEvent, {
+    await ctx.scheduler.runAfter(0, internal.automation.emitEvent, {
       organizationId: args.organizationId,
       module: "gabinet",
       eventType: "gabinet.patient.created",

--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -391,7 +391,7 @@ export const _updateSideEffects = internalMutation({
         });
       }
 
-      await ctx.runMutation(internal.automation.emitEvent, {
+      await ctx.scheduler.runAfter(0, internal.automation.emitEvent, {
         organizationId: args.organizationId,
         module: "crm",
         eventType: "crm.lead.status_changed",
@@ -846,7 +846,7 @@ export const _moveToStageSideEffects = internalMutation({
         }
       }
 
-      await ctx.runMutation(internal.automation.emitEvent, {
+      await ctx.scheduler.runAfter(0, internal.automation.emitEvent, {
         organizationId: args.organizationId,
         module: "crm",
         eventType: "crm.lead.stage_changed",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4348.

Closes #4348

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 541728c feat(automation): convert emitEvent to internalAction with Supabase-primary write (#4348)

### Files changed

```
 convex/automation.ts                   | 64 +++++++++++++++++++---------------
 convex/gabinet/appointmentReminders.ts |  2 +-
 convex/gabinet/appointmentSms.ts       |  2 +-
 convex/gabinet/appointments.ts         |  2 +-
 convex/gabinet/patients.ts             |  2 +-
 convex/leads.ts                        |  4 +--
 6 files changed, 42 insertions(+), 34 deletions(-)
```