### PR TITLE
Migrate `emitEvent` in automation.ts from internalMutation to Convex action (Supabase reads)

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -3,7 +3,7 @@ import {
   internalMutation,
   action,
   query,
-  MutationCtx,
+  ActionCtx,
 } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
@@ -334,7 +334,7 @@ function resolveAutomationTargetId(
 }
 
 async function getAutomationEditPermission(
-  ctx: MutationCtx,
+  ctx: ActionCtx,
   organizationId: Id<"organizations">,
   actorUserId: Id<"users"> | undefined,
   feature: Feature,
@@ -348,17 +348,12 @@ async function getAutomationEditPermission(
     };
   }
 
-  // teamMemberships and orgPermissions are dual-written to Convex
-  // (_writeOrgPermissionsToConvex, ctx.db.insert in teams/invitations).
-  // ctx.db reads are the permanent pattern for mutation callers — identical
-  // to checkPermission in _helpers/permissions.ts. Do NOT replace with
-  // createSupabaseDb(): mutations cannot use fetch in the Convex runtime.
-  const membership = await ctx.db
+  const permDb = createSupabaseDb();
+  const membership = await permDb
     .query("teamMemberships")
-    .withIndex("by_orgAndUser", (q) =>
-      q.eq("organizationId", organizationId).eq("userId", actorUserId),
-    )
-    .unique();
+    .eq("organizationId", String(organizationId))
+    .eq("userId", String(actorUserId))
+    .first();
 
   if (!membership) {
     return {
@@ -382,13 +377,11 @@ async function getAutomationEditPermission(
     };
   }
 
-  // orgPermissions is kept in sync via dual-write; ctx.db is permanent here.
-  const override = await ctx.db
+  const override = await permDb
     .query("orgPermissions")
-    .withIndex("by_orgAndRole", (q) =>
-      q.eq("organizationId", organizationId).eq("role", role),
-    )
-    .unique();
+    .eq("organizationId", String(organizationId))
+    .eq("role", role)
+    .first();
 
   let orgScope: Scope;
   if (override) {
@@ -437,10 +430,10 @@ async function getAutomationEditPermission(
   };
 }
 
-// Thin internalMutation wrappers called via ctx.runMutation from processRun
-// (now an internalAction). These keep the mutation context for Convex writes.
+// Thin wrappers called from processRun (internalAction). These either need
+// Convex write access (internalMutation) or Supabase read access (internalAction).
 
-export const _getAutomationPermission = internalMutation({
+export const _getAutomationPermission = internalAction({
   args: {
     organizationId: v.id("organizations"),
     actorUserId: v.optional(v.id("users")),
@@ -1802,7 +1795,7 @@ export const processRun = internalAction({
               continue;
             }
 
-            const permission = await ctx.runMutation(
+            const permission = await ctx.runAction(
               internal.automation._getAutomationPermission,
               {
                 organizationId: run.organizationId,

--- a/scripts/check-convex-db-reads.mjs
+++ b/scripts/check-convex-db-reads.mjs
@@ -78,13 +78,10 @@ const WHITELIST_PATHS = new Set([
   // Auth/permissions helpers called from QueryCtx — Convex queries cannot
   // make HTTP calls, so createSupabaseDb() is unavailable. Many mutation
   // callers have been migrated to action-based variants (authAction.ts for
-  // auth/perms, seatLimits.checkSeatLimitAction for seat checks). Some
-  // mutation-context callers also legitimately read these tables via ctx.db
-  // for the same reason (mutations cannot use fetch in the Convex runtime);
-  // e.g. automation.ts:getAutomationEditPermission uses a fake actorCtx to
-  // read teamMemberships/orgPermissions — it is exempt via MULTILINE_PENDING
-  // rather than this whitelist. Primary query-context callers here:
-  // getSeatUsage, verifyOrgAccess in queries.
+  // auth/perms, seatLimits.checkSeatLimitAction for seat checks). Primary
+  // query-context callers here: getSeatUsage, verifyOrgAccess in queries.
+  // automation.ts:_getAutomationPermission was migrated to internalAction
+  // in issue #4353 and now reads teamMemberships/orgPermissions via Supabase.
   "_helpers/auth",
   "_helpers/permissions",
   "_helpers/seatLimits",
@@ -221,7 +218,6 @@ const GET_PENDING = new Set([
 const MULTILINE_PENDING = new Set([
   "activities",
   "app",
-  "automation",
   "calls",
   "customFields",
   "documentInstances",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4353.

Closes #4353

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d72f849 fix(automation): migrate _getAutomationPermission to internalAction + Supabase reads (closes #4353)

### Files changed

```
 convex/automation.ts              | 37 +++++++++++++++----------------------
 scripts/check-convex-db-reads.mjs | 12 ++++--------
 2 files changed, 19 insertions(+), 30 deletions(-)
```