### PR TITLE
Remove stale `requirePlatformAdmin(` guard pattern from scripts/check-convex-aut

### DIFF
--- a/scripts/check-convex-auth.mjs
+++ b/scripts/check-convex-auth.mjs
@@ -36,7 +36,6 @@ const GUARD_PATTERNS = [
   "verifyOrgAccess(",
   "checkPermission(",
   "requireOrgAdmin(",
-  "requirePlatformAdmin(",
   // Patient-portal session token guard
   "validatePortalSessionSupabase(",
   // Basic user identity checks
@@ -46,6 +45,7 @@ const GUARD_PATTERNS = [
   // Action-context org-membership variants (internalQuery helpers)
   "authAction.verifyOrgAccess",
   "authAction.checkPermission",
+  "authAction.verifyPlatformAdmin",
   // Known project-level auth wrappers that themselves call a guard above.
   // getEffectivePermissions: calls verifyOrgAccess internally (_helpers/permissions.ts)
   "getEffectivePermissions(",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4366.

Closes #4366

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 062825a fix(ci): replace stale requirePlatformAdmin( guard with authAction.verifyPlatformAdmin in check-convex-auth.mjs (closes #4366)

### Files changed

```
 scripts/check-convex-auth.mjs | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```