### PR TITLE
Remove `_patchAdminInConvex` dual-write and clean up `isPlatformAdmin` from Convex schema

### DIFF
--- a/convex/_helpers/authAction.ts
+++ b/convex/_helpers/authAction.ts
@@ -3,6 +3,7 @@ import { internal } from "../_generated/api";
 import { v } from "convex/values";
 import { auth } from "@cvx/auth";
 import { createSupabaseDb } from "./supabaseDb";
+import type { UserRow } from "./supabaseRows";
 import type { Feature, Action, PermissionResult, Scope } from "./permissionTypes";
 import { DEFAULT_PERMISSIONS } from "./permissions";
 import { defaultGabinetScope, maxScope } from "./gabinetRolePermissions";
@@ -238,7 +239,7 @@ export const verifyPlatformAdmin = internalAction({
     const userId = await auth.getUserId(ctx);
     if (!userId) throw new Error("Not authenticated");
     const db = createSupabaseDb();
-    const user = await db.get("users", String(userId));
+    const user = (await db.get("users", String(userId))) as UserRow | null;
     if (!user) throw new Error("User not found");
     if (!user.isPlatformAdmin) throw new Error("Platform admin access required");
     return { userId: userId as Id<"users"> };

--- a/convex/_helpers/supabaseRows.ts
+++ b/convex/_helpers/supabaseRows.ts
@@ -6,6 +6,10 @@ import type { Doc, TableNames } from "../_generated/dataModel";
 // `undefined`; consumers that read those fields should coalesce with `??`.
 export type SupabaseRow<T extends TableNames> = Omit<Doc<T>, "_creationTime">;
 
+// Supabase users row extended with is_platform_admin (not in Convex schema;
+// Supabase is the sole authority for this flag after migration #4362).
+export type UserRow = SupabaseRow<"users"> & { isPlatformAdmin?: boolean | null };
+
 export type DocumentAnalysisJobRow = SupabaseRow<"documentAnalysisJobs">;
 export type FormDocumentRow = SupabaseRow<"formDocuments">;
 export type FormTemplateRow = SupabaseRow<"formTemplates">;

--- a/convex/app.ts
+++ b/convex/app.ts
@@ -6,6 +6,7 @@ import { asyncMap } from "convex-helpers";
 import { v } from "convex/values";
 import { User } from "~/types";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
+import type { UserRow } from "./_helpers/supabaseRows";
 
 export const getCurrentUser = query({
   args: {},
@@ -53,7 +54,7 @@ export const getIsPlatformAdmin = action({
     const userId = await auth.getUserId(ctx);
     if (!userId) return { isPlatformAdmin: false };
     const db = createSupabaseDb();
-    const user = await db.get("users", String(userId));
+    const user = (await db.get("users", String(userId))) as UserRow | null;
     return { isPlatformAdmin: Boolean(user?.isPlatformAdmin) };
   },
 });

--- a/convex/platformAdmins.ts
+++ b/convex/platformAdmins.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { action } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
+import type { UserRow } from "./_helpers/supabaseRows";
 
 // List all users with their platform-admin flag. Used by the /admin/users
 // page to render the toggle. Platform admin only — this exposes user emails
@@ -11,7 +12,7 @@ export const list = action({
   handler: async (ctx) => {
     await ctx.runAction(internal._helpers.authAction.verifyPlatformAdmin, {});
     const db = createSupabaseDb();
-    const users = await db.query("users").collect();
+    const users = (await db.query("users").collect()) as UserRow[];
     return users
       .map((u) => ({
         _id: u._id,
@@ -45,7 +46,7 @@ export const setRole = action({
     if (!args.isPlatformAdmin) {
       // About to demote someone — ensure at least one platform admin remains.
       const db = createSupabaseDb();
-      const allUsers = await db.query("users").collect();
+      const allUsers = (await db.query("users").collect()) as UserRow[];
       const remainingAdmins = allUsers.filter(
         (u) => u.isPlatformAdmin && String(u._id) !== String(args.userId),
       );

--- a/convex/schema/platform.ts
+++ b/convex/schema/platform.ts
@@ -36,8 +36,6 @@ export function createPlatformTables({
       v.union(v.literal("light"), v.literal("dark"), v.literal("system")),
     ),
     timezone: v.optional(v.string()),
-    // Stored in Supabase (is_platform_admin column); present here for SupabaseRow<"users"> type coverage.
-    isPlatformAdmin: v.optional(v.boolean()),
   })
     .index("email", ["email"])
     .index("customerId", ["customerId"]),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4362.

Closes #4362

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b8f0888 fix(platform): remove isPlatformAdmin from Convex schema, use UserRow type for Supabase reads (closes #4362)

### Files changed

```
 convex/_helpers/authAction.ts   | 3 ++-
 convex/_helpers/supabaseRows.ts | 4 ++++
 convex/app.ts                   | 3 ++-
 convex/platformAdmins.ts        | 5 +++--
 convex/schema/platform.ts       | 2 --
 5 files changed, 11 insertions(+), 6 deletions(-)
```