### PR TITLE
Fix pre-existing `contacts.ts` ctx.db violations

### DIFF
--- a/convex/contacts.ts
+++ b/convex/contacts.ts
@@ -416,24 +416,24 @@ export const _gdprEraseSideEffects = internalMutation({
     const erasedByUserId = args.erasedBy as Id<"users">;
     const GDPR_REDACTED = "[RODO: dane usunięte]";
 
-    const existingActivities = await ctx.db
+    const db = createSupabaseDb();
+
+    const existingActivities = await db
       .query("activities")
-      .withIndex("by_entity", (q) =>
-        q.eq("entityType", "contact").eq("entityId", args.contactId)
-      )
+      .eq("entityType", "contact")
+      .eq("entityId", args.contactId)
       .collect();
     for (const activity of existingActivities) {
-      await ctx.db.patch(activity._id, { description: GDPR_REDACTED });
+      await db.patch("activities", String(activity._id), { description: GDPR_REDACTED });
     }
 
-    const existingNotes = await ctx.db
+    const existingNotes = await db
       .query("notes")
-      .withIndex("by_entity", (q) =>
-        q.eq("entityType", "contact").eq("entityId", args.contactId)
-      )
+      .eq("entityType", "contact")
+      .eq("entityId", args.contactId)
       .collect();
     for (const note of existingNotes) {
-      await ctx.db.patch(note._id, { content: GDPR_REDACTED, updatedAt: Date.now() });
+      await db.patch("notes", String(note._id), { content: GDPR_REDACTED, updatedAt: Date.now() });
     }
 
     await logAudit(ctx, {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4364.

Closes #4364

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 1aa25a2 fix(contacts): migrate ctx.db reads for activities/notes to createSupabaseDb (closes #4364)

### Files changed

```
 convex/contacts.ts | 20 ++++++++++----------
 1 file changed, 10 insertions(+), 10 deletions(-)
```