### PR TITLE
Migrate `logAudit` helper off `ctx.db` for TABLE_MAP tables

### DIFF
--- a/convex/auditLog.ts
+++ b/convex/auditLog.ts
@@ -1,12 +1,9 @@
 import { MutationCtx } from "./_generated/server";
-import { internal } from "./_generated/api";
 import { Id } from "./_generated/dataModel";
-
-// @ts-ignore — TS2589
-const writeAuditLogRef = internal.supabase.auditLog.writeAuditLogToSupabase;
+import { createSupabaseDb } from "./_helpers/supabaseDb";
 
 export async function logAudit(
-  ctx: MutationCtx,
+  _ctx: MutationCtx,
   data: {
     organizationId: Id<"organizations">;
     userId: Id<"users">;
@@ -16,20 +13,9 @@ export async function logAudit(
     details?: string;
   }
 ) {
-  const auditLogId = await ctx.db.insert("auditLog", {
+  const db = createSupabaseDb();
+  await db.insert("auditLog", {
     ...data,
-    createdAt: Date.now(),
-  });
-
-  // Dual-write
-  await ctx.scheduler.runAfter(0, writeAuditLogRef, {
-    auditLogId: auditLogId as any,
-    organizationId: data.organizationId as any,
-    userId: data.userId as any,
-    action: data.action,
-    entityType: data.entityType,
-    entityId: data.entityId,
-    details: data.details,
     createdAt: Date.now(),
   });
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4371.

Closes #4371

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4321333 fix(auditLog): migrate logAudit off ctx.db to createSupabaseDb (closes #4371)

### Files changed

```
 convex/auditLog.ts | 22 ++++------------------
 1 file changed, 4 insertions(+), 18 deletions(-)
```