### PR TITLE
Migrate direct `writeAuditLogToSupabase` calls in documents/signing path off dua

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -670,8 +670,7 @@ export const recordSignature = action({
     // When createdBy is null (auto-generated / system documents) we still
     // write the entry with userId omitted so all signing events are auditable.
     try {
-      await ctx.scheduler.runAfter(0, internal.supabase.auditLog.writeAuditLogToSupabase, {
-        auditLogId: crypto.randomUUID(),
+      await db.insert("auditLog", {
         organizationId: String(doc.organizationId),
         userId: doc.createdBy ? String(doc.createdBy) : undefined,
         action: "document.signed",

--- a/convex/signatureRequests.ts
+++ b/convex/signatureRequests.ts
@@ -386,8 +386,7 @@ export const signExternal = action({
     const createdBy = instance.createdBy ? String(instance.createdBy) : null;
     if (createdBy) {
       try {
-        await ctx.scheduler.runAfter(0, internal.supabase.auditLog.writeAuditLogToSupabase, {
-          auditLogId: crypto.randomUUID(),
+        await db.insert("auditLog", {
           organizationId: String(request.organizationId),
           userId: createdBy,
           action: "document.signed",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4374.

Closes #4374

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 9df40e3 fix(documents): migrate writeAuditLogToSupabase calls to createSupabaseDb (closes #4374)

### Files changed

```
 convex/documents/documents.ts | 3 +--
 convex/signatureRequests.ts   | 3 +--
 2 files changed, 2 insertions(+), 4 deletions(-)
```