### PR TITLE
Migrate `crm/seed.ts` activity inserts off `ctx.db`

### DIFF
--- a/convex/crm/seed.ts
+++ b/convex/crm/seed.ts
@@ -15,6 +15,7 @@ import { mutation, internalMutation, query } from "../_generated/server";
 import { v } from "convex/values";
 import { requireOrgAdmin } from "../_helpers/auth";
 import { Id } from "../_generated/dataModel";
+import { createSupabaseDb } from "../_helpers/supabaseDb";
 
 // ---------------------------------------------------------------------------
 // Queries
@@ -267,12 +268,13 @@ async function doSeed(ctx: any, orgId: Id<"organizations">, userId: Id<"users">)
   // 5. ACTIVITIES (timeline entries)
   // ============================================================
   const actionTypes = ["created", "updated", "note_added", "email_sent", "email_received", "call", "stage_changed", "status_changed", "relationship_added", "assigned", "document_uploaded"] as const;
+  const supabaseDb = createSupabaseDb();
 
   // Activities for contacts
   for (let i = 0; i < Math.min(12, contactIds.length); i++) {
     const count = randomBetween(2, 5);
     for (let j = 0; j < count; j++) {
-      await ctx.db.insert("activities", {
+      await supabaseDb.insert("activities", {
         organizationId: orgId,
         entityType: "contact",
         entityId: contactIds[i],
@@ -298,7 +300,7 @@ async function doSeed(ctx: any, orgId: Id<"organizations">, userId: Id<"users">)
   for (let i = 0; i < Math.min(8, companyIds.length); i++) {
     const count = randomBetween(1, 4);
     for (let j = 0; j < count; j++) {
-      await ctx.db.insert("activities", {
+      await supabaseDb.insert("activities", {
         organizationId: orgId,
         entityType: "company",
         entityId: companyIds[i],
@@ -320,7 +322,7 @@ async function doSeed(ctx: any, orgId: Id<"organizations">, userId: Id<"users">)
   for (let i = 0; i < leadIds.length; i++) {
     const count = randomBetween(2, 6);
     for (let j = 0; j < count; j++) {
-      await ctx.db.insert("activities", {
+      await supabaseDb.insert("activities", {
         organizationId: orgId,
         entityType: "lead",
         entityId: leadIds[i],


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4377.

Closes #4377

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0d62a0f fix(seed): migrate activity inserts off ctx.db to createSupabaseDb (closes #4377)

### Files changed

```
 convex/crm/seed.ts | 8 +++++---
 1 file changed, 5 insertions(+), 3 deletions(-)
```