### PR TITLE
Extend GDPR export to include calls and emails linked to the contact

### DIFF
--- a/convex/contacts.ts
+++ b/convex/contacts.ts
@@ -503,6 +503,47 @@ export const gdprExport = action({
       .eq("entity_type", "contact")
       .eq("entity_id", args.contactId);
 
+    const { data: emailRows } = await client
+      .from("emails")
+      .select("direction, \"from\", \"to\", cc, subject, body_text, snippet, sent_at")
+      .eq("organization_id", orgStr)
+      .eq("contact_id", args.contactId)
+      .order("sent_at", { ascending: true });
+
+    // Calls are linked to contacts via the polymorphic object_relationships table.
+    // Check both directions: call→contact and contact→call.
+    const [{ data: callRelsForward }, { data: callRelsReverse }] = await Promise.all([
+      client
+        .from("object_relationships")
+        .select("source_id")
+        .eq("organization_id", orgStr)
+        .eq("source_type", "call")
+        .eq("target_type", "contact")
+        .eq("target_id", args.contactId),
+      client
+        .from("object_relationships")
+        .select("target_id")
+        .eq("organization_id", orgStr)
+        .eq("source_type", "contact")
+        .eq("source_id", args.contactId)
+        .eq("target_type", "call"),
+    ]);
+
+    const callIds = [
+      ...((callRelsForward ?? []).map((r: { source_id: string }) => r.source_id)),
+      ...((callRelsReverse ?? []).map((r: { target_id: string }) => r.target_id)),
+    ];
+
+    let calls: unknown[] = [];
+    if (callIds.length > 0) {
+      const { data: callRows } = await client
+        .from("calls")
+        .select("outcome, call_date, note, duration, created_at")
+        .in("id", callIds)
+        .order("call_date", { ascending: true });
+      calls = callRows ?? [];
+    }
+
     return {
       exportedAt: new Date().toISOString(),
       contact: {
@@ -520,6 +561,8 @@ export const gdprExport = action({
       activities: activities ?? [],
       notes: notes ?? [],
       customFieldValues: customFieldValues ?? [],
+      emails: emailRows ?? [],
+      calls,
     };
   },
 });

--- a/tests/convex/gdprExport.test.ts
+++ b/tests/convex/gdprExport.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import {
+  createTestCtx,
+  seedTestUser,
+} from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+async function seedContact(
+  organizationId: string,
+  userId: string,
+) {
+  const db = createSupabaseDb();
+  const now = Date.now();
+  const contactId = `contact-export-test-${now}`;
+  await db.insert("contacts", {
+    _id: contactId,
+    organizationId,
+    firstName: "Anna",
+    lastName: "Nowak",
+    email: "anna.nowak@example.com",
+    phone: "+48987654321",
+    title: "Manager",
+    notes: null,
+    source: null,
+    tags: null,
+    tagIds: null,
+    categoryId: null,
+    avatarUrl: null,
+    createdBy: userId,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return contactId;
+}
+
+describe("contacts.gdprExport — GDPR data export", () => {
+  test("includes emails linked to the contact", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const db = createSupabaseDb();
+    const orgStr = String(organizationId);
+    const userStr = String(userId);
+    const contactId = await seedContact(orgStr, userStr);
+    const now = Date.now();
+
+    await db.insert("emails", {
+      _id: `email-${now}`,
+      organizationId: orgStr,
+      threadId: `thread-${now}`,
+      messageId: `msg-${now}`,
+      inReplyTo: null,
+      direction: "outbound",
+      from: "test@example.com",
+      to: ["anna.nowak@example.com"],
+      cc: null,
+      bcc: null,
+      subject: "Oferta współpracy",
+      bodyHtml: null,
+      bodyText: "Dzień dobry, przesyłam ofertę...",
+      snippet: "Dzień dobry, przesyłam ofertę...",
+      isRead: true,
+      isStarred: false,
+      contactId,
+      companyId: null,
+      leadId: null,
+      provider: null,
+      mailProviderId: null,
+      gmailMessageId: null,
+      gmailThreadId: null,
+      sentBy: userStr,
+      templateId: null,
+      patientId: null,
+      appointmentId: null,
+      employeeId: null,
+      sentAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await t.withIdentity(identity).action(api.contacts.gdprExport, {
+      organizationId,
+      contactId,
+    });
+
+    expect(result.emails).toHaveLength(1);
+    const email = (result.emails as Array<Record<string, unknown>>)[0];
+    expect(email.subject).toBe("Oferta współpracy");
+    expect(email.body_text).toBe("Dzień dobry, przesyłam ofertę...");
+  });
+
+  test("does not include emails from a different contact", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const db = createSupabaseDb();
+    const orgStr = String(organizationId);
+    const userStr = String(userId);
+    const contactId = await seedContact(orgStr, userStr);
+    const now = Date.now();
+
+    await db.insert("emails", {
+      _id: `email-other-${now}`,
+      organizationId: orgStr,
+      threadId: `thread-other-${now}`,
+      messageId: `msg-other-${now}`,
+      inReplyTo: null,
+      direction: "inbound",
+      from: "other@example.com",
+      to: ["test@example.com"],
+      cc: null,
+      bcc: null,
+      subject: "Inny kontakt",
+      bodyHtml: null,
+      bodyText: "Treść dla innego kontaktu",
+      snippet: null,
+      isRead: false,
+      isStarred: false,
+      contactId: "different-contact-id",
+      companyId: null,
+      leadId: null,
+      provider: null,
+      mailProviderId: null,
+      gmailMessageId: null,
+      gmailThreadId: null,
+      sentBy: userStr,
+      templateId: null,
+      patientId: null,
+      appointmentId: null,
+      employeeId: null,
+      sentAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await t.withIdentity(identity).action(api.contacts.gdprExport, {
+      organizationId,
+      contactId,
+    });
+
+    expect(result.emails).toHaveLength(0);
+  });
+
+  test("includes calls linked to the contact via object_relationships (call as source)", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const db = createSupabaseDb();
+    const orgStr = String(organizationId);
+    const userStr = String(userId);
+    const contactId = await seedContact(orgStr, userStr);
+    const now = Date.now();
+
+    const callId = `call-${now}`;
+    await db.insert("calls", {
+      _id: callId,
+      organizationId: orgStr,
+      outcome: "connected",
+      callDate: now,
+      note: "Omówiono warunki umowy.",
+      duration: 300,
+      tagIds: null,
+      categoryId: null,
+      createdBy: userStr,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert("objectRelationships", {
+      _id: `rel-${now}`,
+      organizationId: orgStr,
+      sourceType: "call",
+      sourceId: callId,
+      targetType: "contact",
+      targetId: contactId,
+      relationshipType: null,
+      createdBy: userStr,
+      createdAt: now,
+    });
+
+    const result = await t.withIdentity(identity).action(api.contacts.gdprExport, {
+      organizationId,
+      contactId,
+    });
+
+    expect(result.calls).toHaveLength(1);
+    const call = (result.calls as Array<Record<string, unknown>>)[0];
+    expect(call.outcome).toBe("connected");
+    expect(call.note).toBe("Omówiono warunki umowy.");
+  });
+
+  test("includes calls linked to the contact via object_relationships (contact as source)", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const db = createSupabaseDb();
+    const orgStr = String(organizationId);
+    const userStr = String(userId);
+    const contactId = await seedContact(orgStr, userStr);
+    const now = Date.now();
+
+    const callId = `call-rev-${now}`;
+    await db.insert("calls", {
+      _id: callId,
+      organizationId: orgStr,
+      outcome: "no_answer",
+      callDate: now,
+      note: null,
+      duration: 0,
+      tagIds: null,
+      categoryId: null,
+      createdBy: userStr,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert("objectRelationships", {
+      _id: `rel-rev-${now}`,
+      organizationId: orgStr,
+      sourceType: "contact",
+      sourceId: contactId,
+      targetType: "call",
+      targetId: callId,
+      relationshipType: null,
+      createdBy: userStr,
+      createdAt: now,
+    });
+
+    const result = await t.withIdentity(identity).action(api.contacts.gdprExport, {
+      organizationId,
+      contactId,
+    });
+
+    expect(result.calls).toHaveLength(1);
+    const call = (result.calls as Array<Record<string, unknown>>)[0];
+    expect(call.outcome).toBe("no_answer");
+  });
+
+  test("returns empty calls and emails arrays when none are linked", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const orgStr = String(organizationId);
+    const userStr = String(userId);
+    const contactId = await seedContact(orgStr, userStr);
+
+    const result = await t.withIdentity(identity).action(api.contacts.gdprExport, {
+      organizationId,
+      contactId,
+    });
+
+    expect(result.calls).toEqual([]);
+    expect(result.emails).toEqual([]);
+  });
+
+  test("denies export for non-owner/admin users", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t, { role: "member" });
+    const orgStr = String(organizationId);
+    const userStr = String(userId);
+    const contactId = await seedContact(orgStr, userStr);
+    const memberIdentity = {
+      subject: `${userId}|fake-session-id`,
+      issuer: "test",
+      tokenIdentifier: `test|${userId}`,
+    };
+
+    await expect(
+      t.withIdentity(memberIdentity).action(api.contacts.gdprExport, {
+        organizationId,
+        contactId,
+      })
+    ).rejects.toThrow("Permission denied");
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4352.

Closes #4352

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a94a4a0 fix(gdpr): extend gdprExport to include calls and emails linked to contact (closes #4352)

### Files changed

```
 convex/contacts.ts              |  43 +++++++
 tests/convex/gdprExport.test.ts | 275 ++++++++++++++++++++++++++++++++++++++++
 2 files changed, 318 insertions(+)
```