### PR TITLE
Migrate `pipelineStages` read in `doSeed` to `createSupabaseDb()`

### DIFF
--- a/convex/crm/seed.ts
+++ b/convex/crm/seed.ts
@@ -97,12 +97,12 @@ async function doSeed(ctx: any, orgId: Id<"organizations">, userId: Id<"users">)
   }
 
   // Get pipeline stages for leads
-  const stages = await ctx.db
+  const stages = await supabaseDb
     .query("pipelineStages")
-    .withIndex("by_org", (q: any) => q.eq("organizationId", orgId))
+    .eq("organizationId", orgId)
     .collect();
   const stageMap: Record<string, Id<"pipelineStages">> = {};
-  for (const s of stages) stageMap[s.name] = s._id;
+  for (const s of stages) stageMap[s.name] = s._id as Id<"pipelineStages">;
 
   // ============================================================
   // 1. COMPANIES


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4385.

Closes #4385

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3c98c60 fix(seed): migrate pipelineStages read in doSeed to createSupabaseDb (closes #4385)

### Files changed

```
 convex/crm/seed.ts | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```