### PR TITLE
Add GDPR export/erase for leads when they contain direct PII

### DIFF
--- a/convex/leads.ts
+++ b/convex/leads.ts
@@ -757,6 +757,195 @@ export const moveToStage = action({
   },
 });
 
+export const gdprErase = action({
+  args: {
+    organizationId: v.id("organizations"),
+    leadId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const authResult = await ctx.runAction(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    if (authResult.role !== "owner" && authResult.role !== "admin") {
+      throw new Error("Permission denied: GDPR erasure requires owner or admin role");
+    }
+
+    const db = createSupabaseDb();
+    const lead = await db.get("leads", args.leadId);
+    if (!lead || String(lead.organizationId) !== String(args.organizationId)) {
+      throw new Error("Lead not found");
+    }
+
+    const originalTitle = (lead.title as string) ?? "";
+    const orgStr = String(args.organizationId);
+    const GDPR_REDACTED = "[RODO: dane usunięte]";
+
+    await db.patch("leads", args.leadId, {
+      notes: null,
+      updatedAt: Date.now(),
+    });
+
+    const client = db.raw();
+
+    await client
+      .from("custom_field_values")
+      .delete()
+      .eq("organization_id", orgStr)
+      .eq("entity_type", "lead")
+      .eq("entity_id", args.leadId);
+
+    await client
+      .from("activities")
+      .update({ description: GDPR_REDACTED })
+      .eq("organization_id", orgStr)
+      .eq("entity_type", "lead")
+      .eq("entity_id", args.leadId);
+
+    await client
+      .from("notes")
+      .update({ content: GDPR_REDACTED, updated_at: Date.now() })
+      .eq("organization_id", orgStr)
+      .eq("entity_type", "lead")
+      .eq("entity_id", args.leadId);
+
+    try {
+      await ctx.runMutation(internal.leads._gdprEraseSideEffects, {
+        leadId: args.leadId,
+        organizationId: args.organizationId,
+        originalTitle,
+        erasedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[leads.gdprErase] Side effects FAILED for lead", args.leadId, ":", e);
+    }
+
+    return args.leadId;
+  },
+});
+
+export const _gdprEraseSideEffects = internalMutation({
+  args: {
+    leadId: v.string(),
+    organizationId: v.id("organizations"),
+    originalTitle: v.string(),
+    erasedBy: v.string(),
+    actorLabel: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const erasedByUserId = args.erasedBy as Id<"users">;
+    const GDPR_REDACTED = "[RODO: dane usunięte]";
+
+    const db = createSupabaseDb();
+
+    const existingActivities = await db
+      .query("activities")
+      .eq("entityType", "lead")
+      .eq("entityId", args.leadId)
+      .collect();
+    for (const activity of existingActivities) {
+      await db.patch("activities", String(activity._id), { description: GDPR_REDACTED });
+    }
+
+    const existingNotes = await db
+      .query("notes")
+      .eq("entityType", "lead")
+      .eq("entityId", args.leadId)
+      .collect();
+    for (const note of existingNotes) {
+      await db.patch("notes", String(note._id), { content: GDPR_REDACTED, updatedAt: Date.now() });
+    }
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: erasedByUserId,
+      action: "gdpr_lead_erased",
+      entityType: "lead",
+      entityId: args.leadId,
+      details: `GDPR erasure performed on lead "${args.originalTitle}" (ID: ${args.leadId})`,
+    });
+
+    await logActivity(ctx, {
+      organizationId: args.organizationId,
+      entityType: "lead",
+      entityId: args.leadId as Id<"leads">,
+      action: "deleted",
+      description: "RODO: dane leadu zostały usunięte",
+      performedBy: erasedByUserId,
+      actorLabel: args.actorLabel,
+    });
+  },
+});
+
+export const gdprExport = action({
+  args: {
+    organizationId: v.id("organizations"),
+    leadId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const authResult = await ctx.runAction(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    if (authResult.role !== "owner" && authResult.role !== "admin") {
+      throw new Error("Permission denied: GDPR export requires owner or admin role");
+    }
+
+    const db = createSupabaseDb();
+    const lead = await db.get("leads", args.leadId);
+    if (!lead || String(lead.organizationId) !== String(args.organizationId)) {
+      throw new Error("Lead not found");
+    }
+
+    const orgStr = String(args.organizationId);
+    const client = db.raw();
+
+    const { data: activities } = await client
+      .from("activities")
+      .select("action, description, created_at")
+      .eq("organization_id", orgStr)
+      .eq("entity_type", "lead")
+      .eq("entity_id", args.leadId)
+      .order("created_at", { ascending: true });
+
+    const { data: notes } = await client
+      .from("notes")
+      .select("content, created_at, updated_at")
+      .eq("organization_id", orgStr)
+      .eq("entity_type", "lead")
+      .eq("entity_id", args.leadId)
+      .order("created_at", { ascending: true });
+
+    const { data: customFieldValues } = await client
+      .from("custom_field_values")
+      .select("value, created_at, updated_at")
+      .eq("organization_id", orgStr)
+      .eq("entity_type", "lead")
+      .eq("entity_id", args.leadId);
+
+    return {
+      exportedAt: new Date().toISOString(),
+      lead: {
+        id: args.leadId,
+        title: lead.title,
+        notes: lead.notes,
+        value: lead.value,
+        currency: lead.currency,
+        status: lead.status,
+        priority: lead.priority,
+        source: lead.source,
+        expectedCloseDate: lead.expectedCloseDate,
+        createdAt: lead.createdAt,
+        updatedAt: lead.updatedAt,
+      },
+      activities: activities ?? [],
+      notes: notes ?? [],
+      customFieldValues: customFieldValues ?? [],
+    };
+  },
+});
+
 export const _moveToStageSideEffects = internalMutation({
   args: {
     organizationId: v.id("organizations"),

--- a/tests/convex/gdprLeadErase.test.ts
+++ b/tests/convex/gdprLeadErase.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import {
+  createTestCtx,
+  seedTestUser,
+} from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+async function seedLead(
+  organizationId: string,
+  userId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  const db = createSupabaseDb();
+  const now = Date.now();
+  const leadId = `lead-gdpr-test-${now}`;
+  await db.insert("leads", {
+    _id: leadId,
+    organizationId,
+    title: "Potencjalny klient - Jan Kowalski",
+    value: 5000,
+    currency: "PLN",
+    status: "open",
+    priority: null,
+    expectedCloseDate: null,
+    source: null,
+    companyId: null,
+    assignedTo: null,
+    pipelineStageId: null,
+    stageOrder: null,
+    notes: "Jan Kowalski, tel. +48 123 456 789, prosi o wycenę.",
+    tags: null,
+    tagIds: null,
+    categoryId: null,
+    wonAt: null,
+    lostAt: null,
+    lostReason: null,
+    createdBy: userId,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  });
+  return leadId;
+}
+
+describe("leads.gdprErase — GDPR erasure for leads", () => {
+  test("redacts notes field on the lead row", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const db = createSupabaseDb();
+    const leadId = await seedLead(String(organizationId), String(userId));
+
+    await t.withIdentity(identity).action(api.leads.gdprErase, {
+      organizationId,
+      leadId,
+    });
+
+    const lead = await db.get("leads", leadId);
+    expect(lead?.notes).toBeNull();
+  });
+
+  test("deletes custom field values linked to the lead", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const db = createSupabaseDb();
+    const orgStr = String(organizationId);
+    const leadId = await seedLead(orgStr, String(userId));
+    const now = Date.now();
+
+    await db.insert("customFieldValues", {
+      _id: `cfv-${now}`,
+      organizationId: orgStr,
+      fieldDefinitionId: `field-def-${now}`,
+      entityType: "lead",
+      entityId: leadId,
+      value: "Jan Kowalski",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await t.withIdentity(identity).action(api.leads.gdprErase, {
+      organizationId,
+      leadId,
+    });
+
+    const remaining = await db
+      .query("customFieldValues")
+      .eq("entityType", "lead")
+      .eq("entityId", leadId)
+      .collect();
+    expect(remaining).toHaveLength(0);
+  });
+
+  test("redacts activity descriptions linked to the lead", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const leadId = await seedLead(String(organizationId), String(userId));
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("activities", {
+        organizationId,
+        entityType: "lead",
+        entityId: leadId,
+        action: "created",
+        description: "Utworzono lead Jan Kowalski",
+        performedBy: userId,
+        createdAt: Date.now(),
+      });
+    });
+
+    await t.withIdentity(identity).action(api.leads.gdprErase, {
+      organizationId,
+      leadId,
+    });
+
+    const activities = await t.run(async (ctx) =>
+      ctx.db
+        .query("activities")
+        .withIndex("by_entity", (q) =>
+          q.eq("entityType", "lead").eq("entityId", leadId)
+        )
+        .collect()
+    );
+
+    const nonGdprActivities = activities.filter(
+      (a) => a.description !== "[RODO: dane usunięte]"
+    );
+    expect(nonGdprActivities).toHaveLength(0);
+    expect(activities.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("redacts note contents linked to the lead", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const leadId = await seedLead(String(organizationId), String(userId));
+    const now = Date.now();
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("notes", {
+        organizationId,
+        entityType: "lead",
+        entityId: leadId,
+        content: "Jan Kowalski prosił o ofertę na Q4.",
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    await t.withIdentity(identity).action(api.leads.gdprErase, {
+      organizationId,
+      leadId,
+    });
+
+    const notes = await t.run(async (ctx) =>
+      ctx.db
+        .query("notes")
+        .withIndex("by_entity", (q) =>
+          q.eq("entityType", "lead").eq("entityId", leadId)
+        )
+        .collect()
+    );
+
+    expect(notes).toHaveLength(1);
+    expect(notes[0].content).toBe("[RODO: dane usunięte]");
+  });
+
+  test("writes an audit log entry with action gdpr_lead_erased", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const leadId = await seedLead(String(organizationId), String(userId));
+
+    await t.withIdentity(identity).action(api.leads.gdprErase, {
+      organizationId,
+      leadId,
+    });
+
+    const auditEntries = await t.run(async (ctx) =>
+      ctx.db
+        .query("auditLog")
+        .withIndex("by_org", (q) => q.eq("organizationId", organizationId))
+        .collect()
+    );
+
+    const erasureEntry = auditEntries.find(
+      (e) => e.action === "gdpr_lead_erased"
+    );
+    expect(erasureEntry).toBeDefined();
+    expect(erasureEntry?.entityType).toBe("lead");
+    expect(erasureEntry?.entityId).toBe(leadId);
+  });
+
+  test("denies erasure for non-owner/admin users", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t, { role: "member" });
+    const leadId = await seedLead(String(organizationId), String(userId));
+    const memberIdentity = {
+      subject: `${userId}|fake-session-id`,
+      issuer: "test",
+      tokenIdentifier: `test|${userId}`,
+    };
+
+    await expect(
+      t.withIdentity(memberIdentity).action(api.leads.gdprErase, {
+        organizationId,
+        leadId,
+      })
+    ).rejects.toThrow("Permission denied");
+  });
+});
+
+describe("leads.gdprExport — GDPR data export for leads", () => {
+  test("returns lead core data", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const leadId = await seedLead(String(organizationId), String(userId));
+
+    const result = await t.withIdentity(identity).action(api.leads.gdprExport, {
+      organizationId,
+      leadId,
+    });
+
+    expect(result.lead.id).toBe(leadId);
+    expect(result.lead.title).toBe("Potencjalny klient - Jan Kowalski");
+    expect(result.lead.notes).toBe("Jan Kowalski, tel. +48 123 456 789, prosi o wycenę.");
+    expect(result.exportedAt).toBeDefined();
+  });
+
+  test("includes custom field values linked to the lead", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const db = createSupabaseDb();
+    const orgStr = String(organizationId);
+    const leadId = await seedLead(orgStr, String(userId));
+    const now = Date.now();
+
+    await db.insert("customFieldValues", {
+      _id: `cfv-export-${now}`,
+      organizationId: orgStr,
+      fieldDefinitionId: `field-def-export-${now}`,
+      entityType: "lead",
+      entityId: leadId,
+      value: "Jan Kowalski",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await t.withIdentity(identity).action(api.leads.gdprExport, {
+      organizationId,
+      leadId,
+    });
+
+    expect(result.customFieldValues).toHaveLength(1);
+    const cfv = (result.customFieldValues as Array<Record<string, unknown>>)[0];
+    expect(cfv.value).toBe("Jan Kowalski");
+  });
+
+  test("returns empty arrays when no related data exists", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const leadId = await seedLead(String(organizationId), String(userId));
+
+    const result = await t.withIdentity(identity).action(api.leads.gdprExport, {
+      organizationId,
+      leadId,
+    });
+
+    expect(result.activities).toEqual([]);
+    expect(result.notes).toEqual([]);
+    expect(result.customFieldValues).toEqual([]);
+  });
+
+  test("denies export for non-owner/admin users", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t, { role: "member" });
+    const leadId = await seedLead(String(organizationId), String(userId));
+    const memberIdentity = {
+      subject: `${userId}|fake-session-id`,
+      issuer: "test",
+      tokenIdentifier: `test|${userId}`,
+    };
+
+    await expect(
+      t.withIdentity(memberIdentity).action(api.leads.gdprExport, {
+        organizationId,
+        leadId,
+      })
+    ).rejects.toThrow("Permission denied");
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4351.

Closes #4351

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4896ef8 feat(gdpr): add gdprErase and gdprExport for leads (closes #4351)

### Files changed

```
 convex/leads.ts                    | 189 ++++++++++++++++++++++++
 tests/convex/gdprLeadErase.test.ts | 294 +++++++++++++++++++++++++++++++++++++
 2 files changed, 483 insertions(+)
```