### PR TITLE
Remove processRun `automationRuns` insert fallback path

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -1473,13 +1473,13 @@ export const processRun = internalAction({
     const processRunDb = createSupabaseDb();
 
     // Idempotency guard: emitEvent writes the row to Supabase (status "pending") before
-    // scheduling this action. If processRun somehow runs twice, the row will already have
-    // a terminal status — skip silently to avoid double-processing.
+    // scheduling this action. If the row is missing the event was never properly initiated;
+    // if it already has a terminal status, processRun ran a second time — either way, bail.
     const existingRun = await processRunDb
       .query("automationRuns")
       .eq("eventIdempotencyKey", args.eventIdempotencyKey)
       .first();
-    if (existingRun && existingRun.status !== "pending") return;
+    if (!existingRun || existingRun.status !== "pending") return;
 
     const rules = await processRunDb
       .query("automationRules")


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4356.

Closes #4356

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 9202770 fix(automation): guard processRun against missing automationRuns row (closes #4356)

### Files changed

```
 convex/automation.ts | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```