### PR TITLE
Add gdprErase custom field value redaction for contacts

### DIFF
--- a/convex/contacts.ts
+++ b/convex/contacts.ts
@@ -375,6 +375,14 @@ export const gdprErase = action({
     });
 
     const client = db.raw();
+
+    await client
+      .from("custom_field_values")
+      .delete()
+      .eq("organization_id", orgStr)
+      .eq("entity_type", "contact")
+      .eq("entity_id", args.contactId);
+
     await client
       .from("activities")
       .update({ description: GDPR_REDACTED })

--- a/tests/convex/gdprCrmErase.test.ts
+++ b/tests/convex/gdprCrmErase.test.ts
@@ -159,6 +159,38 @@ describe("contacts.gdprErase — CRM GDPR erasure", () => {
     expect(erasureEntry?.entityId).toBe(contactId);
   });
 
+  test("deletes custom field values linked to the contact", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const db = createSupabaseDb();
+    const orgStr = String(organizationId);
+    const contactId = await seedContact(t, orgStr, String(userId));
+    const now = Date.now();
+
+    await db.insert("customFieldValues", {
+      _id: `cfv-${now}`,
+      organizationId: orgStr,
+      fieldDefinitionId: `field-def-${now}`,
+      entityType: "contact",
+      entityId: contactId,
+      value: "Jan Kowalski",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await t.withIdentity(identity).action(api.contacts.gdprErase, {
+      organizationId,
+      contactId,
+    });
+
+    const remaining = await db
+      .query("customFieldValues")
+      .eq("entityType", "contact")
+      .eq("entityId", contactId)
+      .collect();
+    expect(remaining).toHaveLength(0);
+  });
+
   test("denies erasure for non-owner/admin users", async () => {
     const t = createTestCtx();
     const { organizationId, userId } = await seedTestUser(t, { role: "member" });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4390.

Closes #4390

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 04e97a4 fix(gdpr): delete customFieldValues in contacts.gdprErase (closes #4390)

### Files changed

```
 convex/contacts.ts                |  8 ++++++++
 tests/convex/gdprCrmErase.test.ts | 32 ++++++++++++++++++++++++++++++++
 2 files changed, 40 insertions(+)
```