### PR TITLE
Otworzyć typ ModuleId na nowe moduły

### DIFF
--- a/docs/modules/module-onboarding.md
+++ b/docs/modules/module-onboarding.md
@@ -56,7 +56,7 @@ A good first deliverable is a short ownership statement similar to the existing 
 
 Every module needs a stable module id and a product key.
 
-Today, module ids are typed in `src/modules/types.ts` as `ModuleId = "crm" | "gabinet"`. Adding a new module currently requires extending that union. The module manifest then uses that id, and `productKey` is used for activation filtering.
+Module ids are typed in `src/modules/types.ts` as `ModuleId = string` — any string value is valid, no platform-core change required when adding a new module. The module manifest uses that id, and `productKey` is used for activation filtering.
 
 Recommendation: keep module id and product key the same unless there is a real billing/catalog reason to separate them. That makes activation, routing, settings, and automation ownership much easier to follow.
 
@@ -299,7 +299,6 @@ The repo is much better than the old hardcoded shell model, but it is not yet co
 
 The current manual touchpoints are:
 
-- `src/modules/types.ts` because `ModuleId` is still a fixed union
 - `src/modules/registry.ts` because manifests are still manually imported into `moduleRegistry`
 - `convex/productSubscriptions.ts` if activation defaults or product filtering need alignment (the no-subscription grace fallback was removed in #4291 and is no longer a manual touchpoint)
 - `convex/_helpers/permissionTypes.ts` because feature ids are centrally enumerated

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -2,7 +2,7 @@ import type { ComponentType, ElementType } from "react";
 import type { Id } from "@cvx/_generated/dataModel";
 import type { Feature } from "@/hooks/use-permission";
 
-export type ModuleId = "crm" | "gabinet";
+export type ModuleId = string;
 export type ProductKey = string;
 
 export interface ModuleRouteMatch {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4392.

Closes #4392

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8a337b0 feat(platform): widen ModuleId to string so new modules need no core changes (closes #4392)

### Files changed

```
 docs/modules/module-onboarding.md | 3 +--
 src/modules/types.ts              | 2 +-
 2 files changed, 2 insertions(+), 3 deletions(-)
```