### PR TITLE
Centrally-enumerated feature IDs block zero-touch modules

### DIFF
--- a/convex/_helpers/gabinetRolePermissions.ts
+++ b/convex/_helpers/gabinetRolePermissions.ts
@@ -13,7 +13,8 @@
  * used by `authAction.checkPermission` and the settings UI.
  */
 
-import type { Feature, Action, Scope, FeaturePermissions } from "./permissionTypes";
+import { FEATURES } from "./permissionTypes";
+import type { Action, Scope, FeaturePermissions } from "./permissionTypes";
 
 export type SystemGabinetRole =
   | "doctor"
@@ -39,8 +40,11 @@ export const SYSTEM_GABINET_ROLES: readonly SystemGabinetRole[] = [
 // Build a partial feature-permission record covering only gabinet_* features.
 // Non-gabinet features intentionally stay "none" — gabinet-role doesn't grant
 // anything outside its module; org-role still owns those.
+//
+// Parameter uses `gabinet_${string}` (not Extract<Feature, ...>) because Feature
+// is now `string` — Extract<string, `gabinet_${string}`> would yield `never`.
 function buildGabinet(
-  perms: Partial<Record<Extract<Feature, `gabinet_${string}`>, Partial<Record<Action, Scope>>>>,
+  perms: Partial<Record<`gabinet_${string}`, Partial<Record<Action, Scope>>>>,
 ): FeaturePermissions {
   const empty: Record<Action, Scope> = {
     view: "none",
@@ -52,44 +56,14 @@ function buildGabinet(
     refund: "none",
   };
   const result = {} as FeaturePermissions;
-  // Every feature defaults to all-none, so MAX-merge with org-role is a no-op
-  // for features this role doesn't speak to.
-  for (const f of [
-    "leads",
-    "contacts",
-    "companies",
-    "documents",
-    "activities",
-    "calls",
-    "email",
-    "products",
-    "pipelines",
-    "gabinet_dashboard",
-    "gabinet_patients",
-    "gabinet_appointments",
-    "gabinet_treatments",
-    "gabinet_packages",
-    "gabinet_employees",
-    "gabinet_payments",
-    "gabinet_receipts",
-    "gabinet_reports",
-    "gabinet_financial_reports",
-    "gabinet_purchase_prices",
-    "gabinet_photos",
-    "gabinet_online_booking",
-    "gabinet_inventory",
-    "gabinet_settings",
-    "settings",
-    "team",
-    "document_templates",
-    "document_instances",
-    "tagDefinitions",
-    "categoryDefinitions",
-  ] as const) {
-    result[f as Feature] = { ...empty };
+  // Seed every known feature to all-none so MAX-merge with org-role is a no-op
+  // for features this role doesn't speak to. Uses the canonical FEATURES registry
+  // (permissionTypes.ts) — no duplicate list needed here.
+  for (const f of FEATURES) {
+    result[f] = { ...empty };
   }
   for (const [feature, actions] of Object.entries(perms)) {
-    result[feature as Feature] = { ...empty, ...(actions ?? {}) };
+    result[feature] = { ...empty, ...(actions ?? {}) };
   }
   return result;
 }

--- a/convex/_helpers/permissionTypes.ts
+++ b/convex/_helpers/permissionTypes.ts
@@ -40,7 +40,10 @@ export const ACTIONS = ["view", "create", "edit", "delete", "approve", "sign", "
 
 export const SCOPES = ["none", "own", "all"] as const;
 
-export type Feature = (typeof FEATURES)[number];
+// Widened to string so new modules can introduce feature IDs without editing
+// this file (same pattern as ModuleId in platformProducts, see #4392 / #4397).
+// FEATURES above remains the runtime registry for buildDefaults() iteration.
+export type Feature = string;
 export type Action = (typeof ACTIONS)[number];
 export type Scope = (typeof SCOPES)[number];
 

--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -191,11 +191,17 @@ export async function checkPermission(
     .unique();
 
   let orgScope: Scope;
+  // Use optional chaining + "none" fallback so features not in the FEATURES
+  // registry (e.g. from a new zero-touch module) default to deny rather than
+  // throwing TypeError. Mirrors authAction.checkPermission (#4397).
   if (override) {
     const perms = override.permissions as FeaturePermissions;
-    orgScope = perms?.[feature]?.[action] ?? DEFAULT_PERMISSIONS[role][feature][action];
+    orgScope = (perms?.[feature]?.[action]
+      ?? (DEFAULT_PERMISSIONS[role] as Record<string, Record<Action, Scope> | undefined>)[feature]?.[action]
+      ?? "none") as Scope;
   } else {
-    orgScope = DEFAULT_PERMISSIONS[role][feature][action];
+    orgScope = ((DEFAULT_PERMISSIONS[role] as Record<string, Record<Action, Scope> | undefined>)[feature]?.[action]
+      ?? "none") as Scope;
   }
 
   // MAX-merge gabinet-role permissions for gabinet_* features, mirroring


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4397.

Closes #4397

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a8d9f96 feat(rbac): widen Feature to string so new modules need no core changes (closes #4397)

### Files changed

```
 convex/_helpers/gabinetRolePermissions.ts | 50 ++++++++-----------------------
 convex/_helpers/permissionTypes.ts        |  5 +++-
 convex/_helpers/permissions.ts            | 10 +++++--
 3 files changed, 24 insertions(+), 41 deletions(-)
```