### PR TITLE
Add `defaultGabinetScope` safe fallback for unknown features

### DIFF
--- a/convex/_helpers/gabinetRolePermissions.ts
+++ b/convex/_helpers/gabinetRolePermissions.ts
@@ -14,7 +14,7 @@
  */
 
 import { FEATURES } from "./permissionTypes";
-import type { Action, Scope, FeaturePermissions } from "./permissionTypes";
+import type { Action, Feature, Scope, FeaturePermissions } from "./permissionTypes";
 
 export type SystemGabinetRole =
   | "doctor"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4400.

Closes #4400

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 5904324 fix(rbac): add missing Feature import in gabinetRolePermissions (closes #4400)

### Files changed

```
 convex/_helpers/gabinetRolePermissions.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```