### PR TITLE
Fix remaining unsafe indexed accesses beyond `[0]`

### DIFF
--- a/src/components/base/input/input-tags.tsx
+++ b/src/components/base/input/input-tags.tsx
@@ -177,7 +177,7 @@ export const InputTags = ({
     const focusLastTag = useCallback(() => {
         const tagEls = tagGroupRef.current?.querySelectorAll<HTMLElement>('[role="row"]');
         if (tagEls && tagEls.length > 0) {
-            tagEls[tagEls.length - 1].focus();
+            tagEls[tagEls.length - 1]!.focus();
         }
     }, []);
 

--- a/src/components/gabinet/warehouse-shopping-list-dialog.test.tsx
+++ b/src/components/gabinet/warehouse-shopping-list-dialog.test.tsx
@@ -86,7 +86,7 @@ describe("groupShoppingItems", () => {
       makeItem("Dostawca B"),
     ];
     const groups = groupShoppingItems(items);
-    expect(groups[groups.length - 1].supplier).toBeNull();
+    expect(groups[groups.length - 1]!.supplier).toBeNull();
   });
 
   it("handles items with no supplier (all null)", () => {

--- a/src/components/sidebar-widgets/smart-agenda.tsx
+++ b/src/components/sidebar-widgets/smart-agenda.tsx
@@ -94,7 +94,7 @@ export function SmartAgenda({ organizationId, userId }: SmartAgendaProps) {
         groups.push({ label, events: [] });
         currentLabel = label;
       }
-      groups[groups.length - 1].events.push(event);
+      groups[groups.length - 1]!.events.push(event);
     }
     return groups;
   }, [dayLabels, events, i18n.language]);

--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -35,8 +35,8 @@ export function getAvatarGradient(name?: string | null): string {
   const fromColors = ["from-red-400", "from-orange-400", "from-amber-400", "from-lime-400", "from-emerald-400", "from-cyan-400", "from-blue-400", "from-violet-400", "from-purple-400", "from-pink-400"];
   const toColors = ["to-orange-500", "to-amber-500", "to-yellow-500", "to-green-500", "to-teal-500", "to-sky-500", "to-indigo-500", "to-purple-500", "to-fuchsia-500", "to-rose-500"];
 
-  const from = fromColors[hash % fromColors.length];
-  const to = toColors[(hash >> 4) % toColors.length];
+  const from = fromColors[hash % fromColors.length]!;
+  const to = toColors[(hash >> 4) % toColors.length]!;
 
   return `${from} ${to}`;
 }

--- a/tests/convex/timezoneAvailability.test.ts
+++ b/tests/convex/timezoneAvailability.test.ts
@@ -64,7 +64,7 @@ describe("nowDate/nowTime filtering in getAvailableSlotsQuery (timezone contract
     const { slots } = result;
     expect(slots.length).toBeGreaterThan(0);
     expect(slots[0].start).toBe("08:00");
-    expect(slots[slots.length - 1].start).toBe("17:30");
+    expect(slots[slots.length - 1]!.start).toBe("17:30");
   });
 
   test("nowDate=date nowTime=14:00 excludes all slots at or before 14:00", async () => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4410.

Closes #4410

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 893e8e4 fix(types): add ! to remaining unsafe non-[0] indexed accesses (closes #4410)

### Files changed

```
 src/components/base/input/input-tags.tsx                       | 2 +-
 src/components/gabinet/warehouse-shopping-list-dialog.test.tsx | 2 +-
 src/components/sidebar-widgets/smart-agenda.tsx                | 2 +-
 src/lib/avatar.ts                                              | 4 ++--
 tests/convex/timezoneAvailability.test.ts                      | 2 +-
 5 files changed, 6 insertions(+), 6 deletions(-)
```