### PR TITLE
fix(crm): update stale internal.* references after convex/crm migration (closes #4406)

### DIFF
--- a/convex/crm/calls.ts
+++ b/convex/crm/calls.ts
@@ -87,7 +87,7 @@ export const getById = action({
     }
 
     const relationships = await ctx.runQuery(
-      internal.calls._getRelationshipsBySource,
+      internal.crm.calls._getRelationshipsBySource,
       { callId: args.callId },
     );
 
@@ -131,7 +131,7 @@ export const create = action({
     });
 
     try {
-      await ctx.runMutation(internal.calls._createSideEffects, {
+      await ctx.runMutation(internal.crm.calls._createSideEffects, {
         callId,
         organizationId: args.organizationId,
         outcome: args.outcome,
@@ -202,7 +202,7 @@ export const update = action({
     await db.patch("calls", callId, { ...updates, updatedAt: Date.now() });
 
     try {
-      await ctx.runMutation(internal.calls._updateSideEffects, {
+      await ctx.runMutation(internal.crm.calls._updateSideEffects, {
         callId,
         organizationId,
         updatedBy: String(authResult.userId),
@@ -263,7 +263,7 @@ export const remove = action({
     }
 
     // Clean up relationships via internalMutation (needs ctx.db)
-    await ctx.runMutation(internal.calls._removeRelationships, {
+    await ctx.runMutation(internal.crm.calls._removeRelationships, {
       callId: args.callId,
     });
 
@@ -271,7 +271,7 @@ export const remove = action({
     await db.delete("calls", args.callId);
 
     try {
-      await ctx.runMutation(internal.calls._removeSideEffects, {
+      await ctx.runMutation(internal.crm.calls._removeSideEffects, {
         callId: args.callId,
         organizationId: args.organizationId,
         deletedBy: String(authResult.userId),

--- a/convex/crm/companies.ts
+++ b/convex/crm/companies.ts
@@ -86,7 +86,7 @@ export const create = action({
 
     // --- Delegate post-write side effects ---
     try {
-      await ctx.runMutation(internal.companies._createSideEffects, {
+      await ctx.runMutation(internal.crm.companies._createSideEffects, {
         companyId,
         organizationId: args.organizationId,
         name: args.name,
@@ -209,7 +209,7 @@ export const update = action({
 
     // --- Delegate post-write side effects ---
     try {
-      await ctx.runMutation(internal.companies._updateSideEffects, {
+      await ctx.runMutation(internal.crm.companies._updateSideEffects, {
         companyId,
         organizationId,
         name: (company.name as string) ?? "",
@@ -306,7 +306,7 @@ export const remove = action({
         await db.delete("objectRelationships", rel._id as string);
       }
 
-      await ctx.runMutation(internal.companies._removeSideEffects, {
+      await ctx.runMutation(internal.crm.companies._removeSideEffects, {
         companyId: args.companyId,
         organizationId: args.organizationId,
         name: (company.name as string) ?? "",

--- a/convex/crm/contacts.ts
+++ b/convex/crm/contacts.ts
@@ -81,7 +81,7 @@ export const create = action({
 
     // --- Delegate post-write side effects ---
     try {
-      await ctx.runMutation(internal.contacts._createSideEffects, {
+      await ctx.runMutation(internal.crm.contacts._createSideEffects, {
         contactId,
         organizationId: args.organizationId,
         firstName: args.firstName,
@@ -200,7 +200,7 @@ export const update = action({
 
     // --- Delegate post-write side effects ---
     try {
-      await ctx.runMutation(internal.contacts._updateSideEffects, {
+      await ctx.runMutation(internal.crm.contacts._updateSideEffects, {
         contactId,
         organizationId,
         firstName: (contact.firstName as string) ?? "",
@@ -297,7 +297,7 @@ export const remove = action({
         await db.delete("objectRelationships", rel._id as string);
       }
 
-      await ctx.runMutation(internal.contacts._removeSideEffects, {
+      await ctx.runMutation(internal.crm.contacts._removeSideEffects, {
         contactId: args.contactId,
         organizationId: args.organizationId,
         firstName: (contact.firstName as string) ?? "",
@@ -397,7 +397,7 @@ export const gdprErase = action({
       .eq("entity_id", args.contactId);
 
     try {
-      await ctx.runMutation(internal.contacts._gdprEraseSideEffects, {
+      await ctx.runMutation(internal.crm.contacts._gdprEraseSideEffects, {
         contactId: args.contactId,
         organizationId: args.organizationId,
         originalName,

--- a/convex/crm/documents.ts
+++ b/convex/crm/documents.ts
@@ -60,7 +60,7 @@ export const create = action({
     });
 
     try {
-      await ctx.runMutation(internal.documents._createSideEffects, {
+      await ctx.runMutation(internal.crm.documents._createSideEffects, {
         organizationId: args.organizationId,
         documentId: docId,
         name: args.name,
@@ -141,7 +141,7 @@ export const update = action({
     await db.patch("documents", documentId, cleanUpdates);
 
     try {
-      await ctx.runMutation(internal.documents._updateSideEffects, {
+      await ctx.runMutation(internal.crm.documents._updateSideEffects, {
         organizationId,
         documentId,
         name: doc.name as string,
@@ -215,7 +215,7 @@ export const remove = action({
     await db.delete("documents", args.documentId);
 
     try {
-      await ctx.runMutation(internal.documents._removeSideEffects, {
+      await ctx.runMutation(internal.crm.documents._removeSideEffects, {
         organizationId: args.organizationId,
         documentId: args.documentId,
         name: doc.name as string,
@@ -292,7 +292,7 @@ export const updateStatus = action({
     await db.patch("documents", args.documentId, updateData);
 
     try {
-      await ctx.runMutation(internal.documents._updateStatusSideEffects, {
+      await ctx.runMutation(internal.crm.documents._updateStatusSideEffects, {
         organizationId: args.organizationId,
         documentId: args.documentId,
         name: doc.name as string,

--- a/convex/crm/emails.ts
+++ b/convex/crm/emails.ts
@@ -243,7 +243,7 @@ export const send = action({
 
     // --- Delegate post-write side effects ---
     try {
-      await ctx.runMutation(internal.emails._sendSideEffects, {
+      await ctx.runMutation(internal.crm.emails._sendSideEffects, {
         emailId,
         organizationId: args.organizationId,
         to: args.to,

--- a/convex/crm/leads.ts
+++ b/convex/crm/leads.ts
@@ -137,7 +137,7 @@ export const create = action({
 
     // --- Delegate post-write side effects ---
     try {
-      await ctx.runMutation(internal.leads._createSideEffects, {
+      await ctx.runMutation(internal.crm.leads._createSideEffects, {
         leadId,
         organizationId: args.organizationId,
         title: args.title,
@@ -302,7 +302,7 @@ export const update = action({
 
     // --- Delegate post-write side effects ---
     try {
-      await ctx.runMutation(internal.leads._updateSideEffects, {
+      await ctx.runMutation(internal.crm.leads._updateSideEffects, {
         leadId,
         organizationId,
         title: (lead.title as string) ?? "",
@@ -507,7 +507,7 @@ export const remove = action({
         await db.delete("objectRelationships", rel._id as string);
       }
 
-      await ctx.runMutation(internal.leads._removeSideEffects, {
+      await ctx.runMutation(internal.crm.leads._removeSideEffects, {
         leadId: args.leadId,
         organizationId: args.organizationId,
         title: (lead.title as string) ?? "",
@@ -733,7 +733,7 @@ export const moveToStage = action({
 
     // Side effects via internalMutation (activity log, notifications for stage actions, audit)
     try {
-      await ctx.runMutation(internal.leads._moveToStageSideEffects, {
+      await ctx.runMutation(internal.crm.leads._moveToStageSideEffects, {
         organizationId: args.organizationId,
         leadId: args.leadId as any,
         pipelineStageId: args.pipelineStageId as any,
@@ -810,7 +810,7 @@ export const gdprErase = action({
       .eq("entity_id", args.leadId);
 
     try {
-      await ctx.runMutation(internal.leads._gdprEraseSideEffects, {
+      await ctx.runMutation(internal.crm.leads._gdprEraseSideEffects, {
         leadId: args.leadId,
         organizationId: args.organizationId,
         originalTitle,

--- a/convex/crm/notes.ts
+++ b/convex/crm/notes.ts
@@ -36,7 +36,7 @@ export const create = action({
     });
 
     try {
-      await ctx.runMutation(internal.notes._createSideEffects, {
+      await ctx.runMutation(internal.crm.notes._createSideEffects, {
         noteId,
         organizationId: args.organizationId,
         entityType: args.entityType,
@@ -116,7 +116,7 @@ export const update = action({
     });
 
     try {
-      await ctx.runMutation(internal.notes._updateSideEffects, {
+      await ctx.runMutation(internal.crm.notes._updateSideEffects, {
         noteId: args.noteId,
         organizationId: args.organizationId,
         entityType: String(note.entityType),
@@ -189,7 +189,7 @@ export const remove = action({
     }
 
     // Delete child notes (replies) via internalMutation
-    await ctx.runMutation(internal.notes._removeChildNotes, {
+    await ctx.runMutation(internal.crm.notes._removeChildNotes, {
       organizationId: args.organizationId,
       parentNoteId: args.noteId,
     });
@@ -198,7 +198,7 @@ export const remove = action({
     await db.delete("notes", args.noteId);
 
     try {
-      await ctx.runMutation(internal.notes._removeSideEffects, {
+      await ctx.runMutation(internal.crm.notes._removeSideEffects, {
         noteId: args.noteId,
         organizationId: args.organizationId,
         entityType: String(note.entityType),

--- a/convex/crm/pipelines.ts
+++ b/convex/crm/pipelines.ts
@@ -361,7 +361,7 @@ export const create = action({
 
     // Side effects (activity log)
     try {
-      await ctx.runMutation(internal.pipelines._sideEffects, {
+      await ctx.runMutation(internal.crm.pipelines._sideEffects, {
         type: "pipeline_created",
         organizationId: args.organizationId,
         userId: String(authResult.userId),
@@ -416,7 +416,7 @@ export const update = action({
     await db.patch("pipelines", args.pipelineId, updates);
 
     try {
-      await ctx.runMutation(internal.pipelines._sideEffects, {
+      await ctx.runMutation(internal.crm.pipelines._sideEffects, {
         type: "pipeline_updated",
         organizationId: args.organizationId,
         userId: String(authResult.userId),
@@ -481,7 +481,7 @@ export const remove = action({
     await db.delete("pipelines", args.pipelineId);
 
     try {
-      await ctx.runMutation(internal.pipelines._sideEffects, {
+      await ctx.runMutation(internal.crm.pipelines._sideEffects, {
         type: "pipeline_deleted",
         organizationId: args.organizationId,
         userId: String(authResult.userId),
@@ -542,7 +542,7 @@ export const addStage = action({
     });
 
     try {
-      await ctx.runMutation(internal.pipelines._sideEffects, {
+      await ctx.runMutation(internal.crm.pipelines._sideEffects, {
         type: "stage_added",
         organizationId: args.organizationId,
         userId: String(authResult.userId),
@@ -596,7 +596,7 @@ export const updateStage = action({
     await db.patch("pipelineStages", args.stageId, updates);
 
     try {
-      await ctx.runMutation(internal.pipelines._sideEffects, {
+      await ctx.runMutation(internal.crm.pipelines._sideEffects, {
         type: "stage_updated",
         organizationId: args.organizationId,
         userId: String(authResult.userId),
@@ -659,7 +659,7 @@ export const removeStage = action({
     await db.delete("pipelineStages", args.stageId);
 
     try {
-      await ctx.runMutation(internal.pipelines._sideEffects, {
+      await ctx.runMutation(internal.crm.pipelines._sideEffects, {
         type: "stage_removed",
         organizationId: args.organizationId,
         userId: String(authResult.userId),
@@ -710,7 +710,7 @@ export const reorderStages = action({
     }
 
     try {
-      await ctx.runMutation(internal.pipelines._sideEffects, {
+      await ctx.runMutation(internal.crm.pipelines._sideEffects, {
         type: "stages_reordered",
         organizationId: args.organizationId,
         userId: String(authResult.userId),

--- a/convex/crm/products.ts
+++ b/convex/crm/products.ts
@@ -111,7 +111,7 @@ export const create = action({
     }
 
     try {
-      await ctx.runMutation(internal.products._createSideEffects, {
+      await ctx.runMutation(internal.crm.products._createSideEffects, {
         productId,
         organizationId: args.organizationId,
         name: args.name,
@@ -221,7 +221,7 @@ export const update = action({
     await db.patch("products", productId, patchPayload);
 
     try {
-      await ctx.runMutation(internal.products._updateSideEffects, {
+      await ctx.runMutation(internal.crm.products._updateSideEffects, {
         productId,
         organizationId,
         name: (product.name as string) ?? "",
@@ -294,7 +294,7 @@ export const remove = action({
     await db.delete("products", args.productId);
 
     try {
-      await ctx.runMutation(internal.products._removeSideEffects, {
+      await ctx.runMutation(internal.crm.products._removeSideEffects, {
         productId: args.productId,
         organizationId: args.organizationId,
         name: (product.name as string) ?? "",
@@ -363,7 +363,7 @@ export const toggleActive = action({
     });
 
     try {
-      await ctx.runMutation(internal.products._toggleActiveSideEffects, {
+      await ctx.runMutation(internal.crm.products._toggleActiveSideEffects, {
         productId: args.productId,
         organizationId: args.organizationId,
         name: (product.name as string) ?? "",
@@ -481,7 +481,7 @@ export const addToDeal = action({
     });
 
     try {
-      await ctx.runMutation(internal.products._addToDealSideEffects, {
+      await ctx.runMutation(internal.crm.products._addToDealSideEffects, {
         organizationId: args.organizationId,
         dealId: args.dealId,
         productName: (product.name as string) ?? "",
@@ -546,7 +546,7 @@ export const removeFromDeal = action({
     await db.delete("dealProducts", args.dealProductId);
 
     try {
-      await ctx.runMutation(internal.products._removeFromDealSideEffects, {
+      await ctx.runMutation(internal.crm.products._removeFromDealSideEffects, {
         organizationId: args.organizationId,
         dealId: String(dealProduct.dealId),
         productName: (product?.name as string) ?? "unknown",

--- a/convex/google/gmail.ts
+++ b/convex/google/gmail.ts
@@ -68,7 +68,7 @@ export const sendViaGmail = action({
     const result = await response.json();
 
     // Store email record
-    await ctx.runMutation(internal.emails_internal.insertOutboundGmail, {
+    await ctx.runMutation(internal.crm.emails_internal.insertOutboundGmail, {
       organizationId: args.organizationId,
       to: args.to,
       cc: args.cc,
@@ -154,7 +154,7 @@ export const syncInbox = action({
         })
         .filter(Boolean);
 
-      await ctx.runMutation(internal.emails_internal.insertInboundGmail, {
+      await ctx.runMutation(internal.crm.emails_internal.insertInboundGmail, {
         organizationId: args.organizationId,
         gmailMessageId: msg.id,
         gmailThreadId: msg.threadId,

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -566,7 +566,7 @@ http.route({
       // Match to address to an email account to find the org.
       // emailAccounts is Supabase-primary, so this runs as an action.
       const emailAccount = await ctx.runAction(
-        internal.emails_internal.findEmailAccountByAddress,
+        internal.crm.emails_internal.findEmailAccountByAddress,
         { addresses: toAddresses }
       );
 
@@ -582,7 +582,7 @@ http.route({
       let threadId: string | undefined;
       if (inReplyTo) {
         const existingEmail = await ctx.runQuery(
-          internal.emails_internal.findByMessageId,
+          internal.crm.emails_internal.findByMessageId,
           { messageId: inReplyTo }
         );
         if (existingEmail) {
@@ -592,7 +592,7 @@ http.route({
 
       // Auto-link to contact by from email
       const contact = await ctx.runQuery(
-        internal.emails_internal.findContactByEmail,
+        internal.crm.emails_internal.findContactByEmail,
         { organizationId, email: fromEmail }
       );
 
@@ -604,7 +604,7 @@ http.route({
 
       const snippet = text ? text.slice(0, 200) : html ? html.replace(/<[^>]*>/g, "").slice(0, 200) : undefined;
 
-      await ctx.runMutation(internal.emails_internal.insertInbound, {
+      await ctx.runMutation(internal.crm.emails_internal.insertInbound, {
         organizationId,
         threadId: finalThreadId,
         messageId,


### PR DESCRIPTION
## Summary

- PR #4414 moved 17 CRM files from convex/ root to convex/crm/ via git mv, but did not update internal.* references within those files
- In Convex, the internal object mirrors the file path: files moved to convex/crm/ must be referenced as internal.crm.<module> instead of internal.<module>
- Without this fix, every CRM mutation/action that calls an internal helper would fail at runtime with a function-not-found error

## Changes

- 9 convex/crm/ files: updated self-referencing internal.* calls for contacts, leads, companies, calls, products, notes, pipelines, emails, documents
- convex/http.ts and convex/google/gmail.ts: updated references to the moved emails_internal module

## Verification

- convex/crm/ contains exactly 20 files (17 migrated + 3 pre-existing)
- No stale internal.* CRM references remain in any convex file
- No leftover CRM files in convex/ root
- Barrel convex/crm/index.ts not needed (only 1 external import from root aggregator)

## Test plan

- [ ] Run convex dev and confirm no runtime errors
- [ ] Test a CRM create/update/delete operation end-to-end
- [ ] Test email send and inbound email webhook
- [ ] Verify Gmail sync still works

Generated with Claude Code