### PR TITLE
Fix stale `api.*` references in frontend after CRM migration

### DIFF
--- a/src/components/csv/csv-export-button.tsx
+++ b/src/components/csv/csv-export-button.tsx
@@ -19,11 +19,11 @@ export function useCsvExport(
   const { t } = useTranslation();
   const [isExporting, setIsExporting] = useState(false);
 
-  const runContactsExport = useAction(api.csvExport.exportContacts);
-  const runCompaniesExport = useAction(api.csvExport.exportCompanies);
-  const runLeadsExport = useAction(api.csvExport.exportLeads);
-  const runPatientsExport = useAction(api.csvExport.exportPatients);
-  const runProductsExport = useAction(api.csvExport.exportProducts);
+  const runContactsExport = useAction(api.crm.csvExport.exportContacts);
+  const runCompaniesExport = useAction(api.crm.csvExport.exportCompanies);
+  const runLeadsExport = useAction(api.crm.csvExport.exportLeads);
+  const runPatientsExport = useAction(api.crm.csvExport.exportPatients);
+  const runProductsExport = useAction(api.crm.csvExport.exportProducts);
 
   const handleExport = useCallback(async () => {
     setIsExporting(true);

--- a/src/components/csv/csv-import-dialog.tsx
+++ b/src/components/csv/csv-import-dialog.tsx
@@ -68,10 +68,10 @@ export function CsvImportDialog({
 }: CsvImportDialogProps) {
   const { t } = useTranslation();
 
-  const batchCreateContacts = useAction(api.csvImport.batchCreateContacts);
-  const batchCreateCompanies = useAction(api.csvImport.batchCreateCompanies);
-  const batchCreateLeads = useAction(api.csvImport.batchCreateLeads);
-  const batchCreateProducts = useAction(api.csvImport.batchCreateProducts);
+  const batchCreateContacts = useAction(api.crm.csvImport.batchCreateContacts);
+  const batchCreateCompanies = useAction(api.crm.csvImport.batchCreateCompanies);
+  const batchCreateLeads = useAction(api.crm.csvImport.batchCreateLeads);
+  const batchCreateProducts = useAction(api.crm.csvImport.batchCreateProducts);
 
   const [step, setStep] = useState<Step>("upload");
   const [csvHeaders, setCsvHeaders] = useState<string[]>([]);

--- a/src/components/custom-fields/custom-field-renderer.tsx
+++ b/src/components/custom-fields/custom-field-renderer.tsx
@@ -219,14 +219,14 @@ function FileFieldRenderer({
   readonly: boolean;
 }) {
   const { organizationId } = useOrganization();
-  const generateUploadUrl = useMutation(api.documents.generateUploadUrl);
+  const generateUploadUrl = useMutation(api.crm.documents.generateUploadUrl);
   const [isUploading, setIsUploading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const fileVal = isFileValue(value) ? value : null;
 
   const { data: fileUrl } = useQuery({
-    ...convexQuery(api.documents.getFileUrl, {
+    ...convexQuery(api.crm.documents.getFileUrl, {
       organizationId,
       storageId: (fileVal?.storageId ?? "") as Id<"_storage">,
     }),

--- a/src/components/data-table/editable-examples.tsx
+++ b/src/components/data-table/editable-examples.tsx
@@ -151,7 +151,7 @@ export function getPatientColumnsWithInlineEdit(
  * import { api } from "@cvx/_generated/api";
  *
  * function ContactsPage() {
- *   const updateContact = useMutation(api.contacts.update);
+ *   const updateContact = useMutation(api.crm.contacts.update);
  *
  *   const handleInlineUpdate = async (contactId: string, field: keyof Contact, value: any) => {
  *     await updateContact({ id: contactId, [field]: value });

--- a/src/components/email/compose-dialog.tsx
+++ b/src/components/email/compose-dialog.tsx
@@ -57,7 +57,7 @@ export function ComposeDialog({
   defaultTo,
 }: ComposeDialogProps) {
   const { t } = useTranslation();
-  const sendEmail = useAction(api.emails.send);
+  const sendEmail = useAction(api.crm.emails.send);
   const sendViaGmail = useAction(api.google.gmail.sendViaGmail);
 
   const { data: googleConnection } = useQuery(

--- a/src/components/email/email-entity-tab.tsx
+++ b/src/components/email/email-entity-tab.tsx
@@ -39,7 +39,7 @@ export function EmailEntityTab({
     }
   }, [autoCompose]);
 
-  const listEmailsByEntity = useAction(api.emails.listByEntity);
+  const listEmailsByEntity = useAction(api.crm.emails.listByEntity);
   const { data: emailsData } = useQuery({
     queryKey: ["emails.listByEntity", organizationId, entityType, entityId],
     queryFn: () =>

--- a/src/components/email/inbox-list.tsx
+++ b/src/components/email/inbox-list.tsx
@@ -33,7 +33,7 @@ export function InboxList({
 
   // @ts-ignore — TS2589: Convex mutation type instantiation depth exceeded
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const toggleStar: any = useAction(api.emails.toggleStar);
+  const toggleStar: any = useAction(api.crm.emails.toggleStar);
 
   const { data: emailsData } = useSupabaseEmailsList(organizationId, {
     search: search.trim() || undefined,

--- a/src/components/email/thread-view.tsx
+++ b/src/components/email/thread-view.tsx
@@ -24,7 +24,7 @@ export function ThreadView({
 }: ThreadViewProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const markRead = useAction(api.emails.markRead);
+  const markRead = useAction(api.crm.emails.markRead);
 
   const { data: thread } = useSupabaseEmailThread(
     organizationId,

--- a/src/hooks/use-saved-views.ts
+++ b/src/hooks/use-saved-views.ts
@@ -97,9 +97,9 @@ export function useSavedViews({
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
 
   // @ts-ignore — Convex useMutation hits TS2589 deep instantiation limit; runtime works fine
-  const createViewMut = useAction(api.savedViews.create);
-  const updateViewMut = useAction(api.savedViews.update);
-  const removeViewMut = useAction(api.savedViews.remove);
+  const createViewMut = useAction(api.crm.savedViews.create);
+  const updateViewMut = useAction(api.crm.savedViews.update);
+  const removeViewMut = useAction(api.crm.savedViews.remove);
   const queryClient = useQueryClient();
 
   const { data: convexViews } = useSupabaseSavedViewsList(

--- a/src/routes/_app/_auth/dashboard/_layout.calls.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.calls.index.tsx
@@ -166,9 +166,9 @@ function CallsPage() {
     return filtered.filter((c: any) => c.note?.toLowerCase().includes(q));
   }, [allCalls, activeFilters, applyFilters, searchValue, nudgeFilter]);
 
-  const createCall = useAction(api.calls.create);
-  const updateCall = useAction(api.calls.update);
-  const removeCall = useAction(api.calls.remove);
+  const createCall = useAction(api.crm.calls.create);
+  const updateCall = useAction(api.crm.calls.update);
+  const removeCall = useAction(api.crm.calls.remove);
 
   const resetForm = () => {
     setOutcome("noAnswer");

--- a/src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx
@@ -76,13 +76,13 @@ function CompanyDetail() {
   const queryClient = useQueryClient();
   const { setShellSidebarMode } = useSidebarSlot();
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
-  const updateCompany = useAction(api.companies.update);
-  const removeCompany = useAction(api.companies.remove);
+  const updateCompany = useAction(api.crm.companies.update);
+  const removeCompany = useAction(api.crm.companies.remove);
   const createRelationship = useAction(api.relationships.create);
   const removeRelationship = useAction(api.relationships.remove);
-  const createContact = useAction(api.contacts.create);
-  const createNote = useAction(api.notes.create);
-  const createLead = useAction(api.leads.create);
+  const createContact = useAction(api.crm.contacts.create);
+  const createNote = useAction(api.crm.notes.create);
+  const createLead = useAction(api.crm.leads.create);
   const createScheduledActivity = useAction(api.scheduledActivities.create);
   const markActivityComplete = useAction(api.scheduledActivities.markComplete);
   const markActivityIncomplete = useAction(api.scheduledActivities.markIncomplete);

--- a/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.index.tsx
@@ -61,8 +61,8 @@ function CompaniesIndex() {
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
   const { nudge: nudgeFilter } = useSearch({ from: Route.id });
-  const createCompany = useAction(api.companies.create);
-  const removeCompany = useAction(api.companies.remove);
+  const createCompany = useAction(api.crm.companies.create);
+  const removeCompany = useAction(api.crm.companies.remove);
   const setCustomFieldValues = useAction(api.customFields.setValues);
 
   const [panelOpen, setPanelOpen] = useState(false);

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.$contactId.lazy.tsx
@@ -84,15 +84,15 @@ function ContactDetail() {
   const queryClient = useQueryClient();
   const { setShellSidebarMode } = useSidebarSlot();
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
-  const updateContact = useAction(api.contacts.update);
-  const removeContact = useAction(api.contacts.remove);
-  const gdprEraseContact = useAction(api.contacts.gdprErase);
-  const gdprExportContact = useAction(api.contacts.gdprExport);
+  const updateContact = useAction(api.crm.contacts.update);
+  const removeContact = useAction(api.crm.contacts.remove);
+  const gdprEraseContact = useAction(api.crm.contacts.gdprErase);
+  const gdprExportContact = useAction(api.crm.contacts.gdprExport);
   const createRelationship = useAction(api.relationships.create);
   const removeRelationship = useAction(api.relationships.remove);
-  const createCompany = useAction(api.companies.create);
-  const createLead = useAction(api.leads.create);
-  const createNote = useAction(api.notes.create);
+  const createCompany = useAction(api.crm.companies.create);
+  const createLead = useAction(api.crm.leads.create);
+  const createNote = useAction(api.crm.notes.create);
   const createScheduledActivity = useAction(api.scheduledActivities.create);
   const markActivityComplete = useAction(api.scheduledActivities.markComplete);
   const markActivityIncomplete = useAction(api.scheduledActivities.markIncomplete);

--- a/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.contacts.index.tsx
@@ -54,8 +54,8 @@ function ContactsIndex() {
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
   const { nudge: nudgeFilter } = useSearch({ from: Route.id });
-  const createContact = useAction(api.contacts.create);
-  const removeContact = useAction(api.contacts.remove);
+  const createContact = useAction(api.crm.contacts.create);
+  const removeContact = useAction(api.crm.contacts.remove);
   const setCustomFieldValues = useAction(api.customFields.setValues);
 
   const [panelOpen, setPanelOpen] = useState(false);

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -130,7 +130,7 @@ function EmployeeDetail() {
   const updateEmployee = useAction(api.gabinet.employees.update);
   const removeEmployee = useAction(api.gabinet.employees.remove);
   const setQualifiedTreatments = useAction(api.gabinet.employees.setQualifiedTreatments);
-  const createNote = useAction(api.notes.create);
+  const createNote = useAction(api.crm.notes.create);
   const markActivityComplete = useAction(api.scheduledActivities.markComplete);
   const markActivityIncomplete = useAction(api.scheduledActivities.markIncomplete);
   const updateScheduledActivity = useAction(api.scheduledActivities.update);

--- a/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
@@ -238,23 +238,23 @@ function LeadDetail() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   // @ts-ignore — TS2589 excessive depth in useMutation type instantiation (pre-existing)
-  const updateLead = useAction(api.leads.update);
-  const removeLead = useAction(api.leads.remove);
-  const moveToStage = useAction(api.leads.moveToStage);
+  const updateLead = useAction(api.crm.leads.update);
+  const removeLead = useAction(api.crm.leads.remove);
+  const moveToStage = useAction(api.crm.leads.moveToStage);
   const createRelationship = useAction(api.relationships.create);
   const removeRelationship = useAction(api.relationships.remove);
-  const createContactMutation = useAction(api.contacts.create);
-  const createCompanyMutation = useAction(api.companies.create);
+  const createContactMutation = useAction(api.crm.contacts.create);
+  const createCompanyMutation = useAction(api.crm.companies.create);
   const setCustomFields = useAction(api.customFields.setValues);
   const trackView = useAction(api.recentlyViewed.track);
-  const createNote = useAction(api.notes.create);
+  const createNote = useAction(api.crm.notes.create);
   const createScheduledActivity = useAction(api.scheduledActivities.create);
   const markActivityComplete = useAction(api.scheduledActivities.markComplete);
   const markActivityIncomplete = useAction(api.scheduledActivities.markIncomplete);
   const updateScheduledActivity = useAction(api.scheduledActivities.update);
   const removeScheduledActivity = useAction(api.scheduledActivities.remove);
-  const addProductToDeal = useAction(api.products.addToDeal);
-  const removeProductFromDeal = useAction(api.products.removeFromDeal);
+  const addProductToDeal = useAction(api.crm.products.addToDeal);
+  const removeProductFromDeal = useAction(api.crm.products.removeFromDeal);
   const listDocumentsByEntity = useAction(api.documents.documents.listByEntity);
 
   const { data: leadDocuments } = useQuery({
@@ -412,7 +412,7 @@ function LeadDetail() {
   );
   const relationships = relationshipsQuery.data;
 
-  const listProductsByDeal = useAction(api.products.listByDeal);
+  const listProductsByDeal = useAction(api.crm.products.listByDeal);
   const dealProductsQueryKey = useMemo(
     () => ["products.listByDeal", organizationId, leadId] as const,
     [organizationId, leadId],

--- a/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
@@ -101,9 +101,9 @@ function LeadsIndex() {
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
   const { nudge: nudgeFilter } = useSearch({ from: Route.id });
-  const updateLead = useAction(api.leads.update);
-  const removeLead = useAction(api.leads.remove);
-  const createLead = useAction(api.leads.create);
+  const updateLead = useAction(api.crm.leads.update);
+  const removeLead = useAction(api.crm.leads.remove);
+  const createLead = useAction(api.crm.leads.create);
 
   const [createOpen, setCreateOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);

--- a/src/routes/_app/_auth/dashboard/_layout.pipelines.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.pipelines.index.tsx
@@ -27,9 +27,9 @@ function PipelinesIndex() {
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
   // @ts-ignore — Convex type instantiation too deep (pre-existing)
-  const moveToStage = useAction(api.leads.moveToStage);
-  const updateLead = useAction(api.leads.update);
-  const removeLead = useAction(api.leads.remove);
+  const moveToStage = useAction(api.crm.leads.moveToStage);
+  const updateLead = useAction(api.crm.leads.update);
+  const removeLead = useAction(api.crm.leads.remove);
   const queryClient = useQueryClient();
 
   const { data: pipelines } = useSupabasePipelinesList(organizationId);

--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -681,10 +681,10 @@ function ProductsPage() {
     return data;
   }, [activeViewId, allProducts, applyFilters, activeFilters, simpleFilters, simpleFilterConditions, searchValue, nudgeFilter, usedProductIds, productStockStatus, totalsByProductId]);
 
-  const createProduct = useAction(api.products.create);
-  const updateProduct = useAction(api.products.update);
-  const removeProduct = useAction(api.products.remove);
-  const toggleActive = useAction(api.products.toggleActive);
+  const createProduct = useAction(api.crm.products.create);
+  const updateProduct = useAction(api.crm.products.update);
+  const removeProduct = useAction(api.crm.products.remove);
+  const toggleActive = useAction(api.crm.products.toggleActive);
 
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen
   const getPlannedUsage = useAction(api.gabinet.inventory.getPlannedUsage);

--- a/src/routes/_app/_auth/dashboard/_layout.settings.lost-reasons.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.lost-reasons.tsx
@@ -38,9 +38,9 @@ function LostReasonsSettings() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; label: string } | null>(null);
 
-  const createReason = useAction(api.lostReasons.create);
-  const updateReason = useAction(api.lostReasons.update);
-  const removeReason = useAction(api.lostReasons.remove);
+  const createReason = useAction(api.crm.lostReasons.create);
+  const updateReason = useAction(api.crm.lostReasons.update);
+  const removeReason = useAction(api.crm.lostReasons.remove);
   const upsertSettings = useAction(api.orgSettings.upsert);
 
   const { data: reasons } = useSupabaseLostReasonsList(organizationId);

--- a/src/routes/_app/_auth/dashboard/_layout.settings.pipelines.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.pipelines.tsx
@@ -52,10 +52,10 @@ function PipelinesSettings() {
   const { allowed: canCreate } = usePermission("pipelines", "create");
 
   // @ts-ignore — TS2589 excessive depth in useAction type instantiation (pre-existing)
-  const createPipeline = useAction(api.pipelines.create);
-  const removePipeline = useAction(api.pipelines.remove);
-  const addStage = useAction(api.pipelines.addStage);
-  const removeStage = useAction(api.pipelines.removeStage);
+  const createPipeline = useAction(api.crm.pipelines.create);
+  const removePipeline = useAction(api.crm.pipelines.remove);
+  const addStage = useAction(api.crm.pipelines.addStage);
+  const removeStage = useAction(api.crm.pipelines.removeStage);
 
   const { data: pipelines } = useSupabasePipelinesList(organizationId);
 
@@ -320,8 +320,8 @@ function StageActions({
   const { allowed: canEdit } = usePermission("pipelines", "edit");
   const { allowed: canDelete } = usePermission("pipelines", "delete");
 
-  const createAction = useAction(api.pipelineStageActions.create);
-  const removeAction = useAction(api.pipelineStageActions.remove);
+  const createAction = useAction(api.crm.pipelineStageActions.create);
+  const removeAction = useAction(api.crm.pipelineStageActions.remove);
 
   const { data: actions } = useSupabasePipelineStageActions(
     organizationId,

--- a/src/routes/_app/_auth/dashboard/_layout.settings.sources.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.sources.tsx
@@ -36,9 +36,9 @@ function SourcesSettings() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
 
-  const createSource = useAction(api.sources.create);
-  const updateSource = useAction(api.sources.update);
-  const removeSource = useAction(api.sources.remove);
+  const createSource = useAction(api.crm.sources.create);
+  const updateSource = useAction(api.crm.sources.update);
+  const removeSource = useAction(api.crm.sources.remove);
 
   const { data: sources } = useSupabaseSourcesList(organizationId);
 

--- a/src/routes/_app/_auth/dashboard/_layout.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.tsx
@@ -229,9 +229,9 @@ function DashboardLayoutInner({ user, orgs }: DashboardLayoutInnerProps) {
   const [searchOpen, setSearchOpen] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
 
-  const createContact = useAction(api.contacts.create);
-  const createCompany = useAction(api.companies.create);
-  const createLead = useAction(api.leads.create);
+  const createContact = useAction(api.crm.contacts.create);
+  const createCompany = useAction(api.crm.companies.create);
+  const createLead = useAction(api.crm.leads.create);
   const createPatient = useAction(api.gabinet.patients.create);
   const createTreatment = useAction(api.gabinet.treatments.create);
   const setTreatmentProducts = useAction(api.gabinet.treatments.setTreatmentProducts);
@@ -239,8 +239,8 @@ function DashboardLayoutInner({ user, orgs }: DashboardLayoutInnerProps) {
   const createEmployee = useAction(api.gabinet.employees.create);
   const createActivity = useAction(api.scheduledActivities.create);
   const createLeave = useAction(api.gabinet.scheduling.createLeave);
-  const createProduct = useAction(api.products.create);
-  const createCall = useAction(api.calls.create);
+  const createProduct = useAction(api.crm.products.create);
+  const createCall = useAction(api.crm.calls.create);
   const createInvitation = useAction(api.invitations.create);
   const updateActivity = useAction(api.scheduledActivities.update);
   const removeActivity = useAction(api.scheduledActivities.remove);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4417.

Closes #4417

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 37fdd0a fix(crm): update stale api.* references in frontend after convex/crm migration (closes #4417)

### Files changed

```
 src/components/csv/csv-export-button.tsx               | 10 +++++-----
 src/components/csv/csv-import-dialog.tsx               |  8 ++++----
 src/components/custom-fields/custom-field-renderer.tsx |  4 ++--
 src/components/data-table/editable-examples.tsx        |  2 +-
 src/components/email/compose-dialog.tsx                |  2 +-
 src/components/email/email-entity-tab.tsx              |  2 +-
 src/components/email/inbox-list.tsx                    |  2 +-
 src/components/email/thread-view.tsx                   |  2 +-
 src/hooks/use-saved-views.ts                           |  6 +++---
 .../_app/_auth/dashboard/_layout.calls.index.tsx       |  6 +++---
 .../_auth/dashboard/_layout.companies.$companyId.tsx   | 10 +++++-----
 .../_app/_auth/dashboard/_layout.companies.index.tsx   |  4 ++--
 .../dashboard/_layout.contacts.$contactId.lazy.tsx     | 14 +++++++-------
 .../_app/_auth/dashboard/_layout.contacts.index.tsx    |  4 ++--
 .../_layout.gabinet.employees.$employeeId.tsx          |  2 +-
 .../_auth/dashboard/_layout.leads.$leadId.lazy.tsx     | 18 +++++++++---------
 .../_app/_auth/dashboard/_layout.leads.index.tsx       |  6 +++---
 .../_app/_auth/dashboard/_layout.pipelines.index.tsx   |  6 +++---
 .../_app/_auth/dashboard/_layout.products.index.tsx    |  8 ++++----
 .../_auth/dashboard/_layout.settings.lost-reasons.tsx  |  6 +++---
 .../_auth/dashboard/_layout.settings.pipelines.tsx     | 12 ++++++------
 .../_app/_auth/dashboard/_layout.settings.sources.tsx  |  6 +++---
 src/routes/_app/_auth/dashboard/_layout.tsx            | 10 +++++-----
 23 files changed, 75 insertions(+), 75 deletions(-)
```