### PR TITLE
Fix unused `ctx` parameter in `convex/crm/seed.ts

### DIFF
--- a/convex/crm/seed.ts
+++ b/convex/crm/seed.ts
@@ -84,7 +84,7 @@ function randomBetween(min: number, max: number): number {
 // Seed implementation
 // ---------------------------------------------------------------------------
 
-async function doSeed(ctx: any, orgId: Id<"organizations">, userId: Id<"users">) {
+async function doSeed(_ctx: unknown, orgId: Id<"organizations">, userId: Id<"users">) {
   const supabaseDb = createSupabaseDb();
 
   // --- Guard ---


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4427.

Closes #4427

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 522fca2 fix(seed): rename unused ctx to _ctx in doSeed, tighten to unknown (closes #4427)

### Files changed

```
 convex/crm/seed.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```