### PR TITLE
Fix unused `ctx` parameter in `convex/documents/documents.ts

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -574,7 +574,7 @@ export const recordSignature = action({
     signedByIp: v.optional(v.string()),
     resolvedHtml: v.optional(v.string()),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     const db = createSupabaseDb();
 
     const doc = await db.query("formDocuments")


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4428.

Closes #4428

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 67c0b49 fix(documents): rename unused ctx to _ctx in recordSignature (closes #4428)

### Files changed

```
 convex/documents/documents.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```