### PR TITLE
Add `JSONB[]`-array column type override support to `gen-db-types.mjs`

### DIFF
--- a/scripts/gen-db-types.mjs
+++ b/scripts/gen-db-types.mjs
@@ -25,6 +25,8 @@
  *   NUMERIC             → number
  *   BOOLEAN             → boolean
  *   JSONB               → unknown  (caller casts as needed)
+ *                          Override with inline annotation: -- type:<ts-type>
+ *                          e.g.  JSONB  -- type:string[]  emits string[] instead
  *   TSVECTOR            → (skipped — generated column)
  *   <enum_name>         → string   (union of literal values would be ideal but
  *                                    the enum definitions are complex; string is
@@ -107,6 +109,12 @@ function mapSqlType(rawType) {
  * @returns {Col | null}
  */
 function parseColumnLine(rawLine) {
+  // Extract per-column type override before stripping the comment.
+  // Syntax:  -- type:<ts-type>   e.g.  JSONB  -- type:string[]
+  let typeHint = null;
+  const hintMatch = rawLine.match(/--\s*type:(\S+)/);
+  if (hintMatch) typeHint = hintMatch[1];
+
   const line = rawLine.replace(/--.*$/, "").trim();
   if (!line) return null;
   // Skip table-level constraints
@@ -124,7 +132,7 @@ function parseColumnLine(rawLine) {
 
   if (rest.includes("GENERATED ALWAYS")) return null;
 
-  const tsType = mapSqlType(rawType);
+  const tsType = typeHint ?? mapSqlType(rawType);
   if (tsType === null) return null;
 
   const isPk = rest.includes("PRIMARY KEY");

--- a/src/components/gabinet/waitlist-view.tsx
+++ b/src/components/gabinet/waitlist-view.tsx
@@ -318,8 +318,8 @@ function WaitlistEntryRow({
 
   const isActionable = entry.status === "waiting";
   const isCancelled = entry.status === "cancelled" || entry.status === "expired";
-  const preferredDates = entry.preferred_dates as string[] | null;
-  const preferredTimes = entry.preferred_times as string[] | null;
+  const preferredDates = entry.preferred_dates;
+  const preferredTimes = entry.preferred_times;
 
   async function handleNotify() {
     setNotifying(true);

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -7761,8 +7761,8 @@ export interface Database {
           patient_id: string;
           treatment_id: string | null;
           employee_id: string | null;
-          preferred_dates: unknown | null;
-          preferred_times: unknown | null;
+          preferred_dates: string[] | null;
+          preferred_times: string[] | null;
           notes: string | null;
           status: string;
           notified_at: number | null;
@@ -7777,8 +7777,8 @@ export interface Database {
           patient_id: string;
           treatment_id?: string | null;
           employee_id?: string | null;
-          preferred_dates?: unknown | null;
-          preferred_times?: unknown | null;
+          preferred_dates?: string[] | null;
+          preferred_times?: string[] | null;
           notes?: string | null;
           status?: string;
           notified_at?: number | null;
@@ -7793,8 +7793,8 @@ export interface Database {
           patient_id?: string;
           treatment_id?: string | null;
           employee_id?: string | null;
-          preferred_dates?: unknown | null;
-          preferred_times?: unknown | null;
+          preferred_dates?: string[] | null;
+          preferred_times?: string[] | null;
           notes?: string | null;
           status?: string;
           notified_at?: number | null;
@@ -8089,6 +8089,3 @@ export type GabinetWaitlistUpdate = Database["public"]["Tables"]["gabinet_waitli
 export type LeadStageHistoryRow = Database["public"]["Tables"]["lead_stage_history"]["Row"];
 export type LeadStageHistoryInsert = Database["public"]["Tables"]["lead_stage_history"]["Insert"];
 export type LeadStageHistoryUpdate = Database["public"]["Tables"]["lead_stage_history"]["Update"];
-export type GoogleCalendarSyncConfigRow = Database["public"]["Tables"]["google_calendar_sync_configs"]["Row"];
-export type GoogleCalendarSyncConfigInsert = Database["public"]["Tables"]["google_calendar_sync_configs"]["Insert"];
-export type GoogleCalendarSyncConfigUpdate = Database["public"]["Tables"]["google_calendar_sync_configs"]["Update"];

--- a/supabase/migrations/00112_gabinet_waitlist.sql
+++ b/supabase/migrations/00112_gabinet_waitlist.sql
@@ -9,8 +9,8 @@ CREATE TABLE IF NOT EXISTS gabinet_waitlist (
   patient_id        TEXT NOT NULL REFERENCES gabinet_patients(id) ON DELETE CASCADE,
   treatment_id      TEXT REFERENCES gabinet_treatments(id) ON DELETE SET NULL,
   employee_id       TEXT REFERENCES gabinet_employees(id) ON DELETE SET NULL,
-  preferred_dates   JSONB,    -- array of YYYY-MM-DD strings
-  preferred_times   JSONB,    -- array of HH:MM strings
+  preferred_dates   JSONB,    -- type:string[] array of YYYY-MM-DD strings
+  preferred_times   JSONB,    -- type:string[] array of HH:MM strings
   notes             TEXT,
   status            TEXT NOT NULL DEFAULT 'waiting'
                     CHECK (status IN ('waiting', 'notified', 'booked', 'cancelled', 'expired')),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4435.

Closes #4435

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0e99f11 feat(gen-db-types): add -- type:<ts-type> annotation for JSONB column overrides (closes #4435)

### Files changed

```
 scripts/gen-db-types.mjs                       | 10 +++++++++-
 src/components/gabinet/waitlist-view.tsx       |  4 ++--
 src/lib/supabase/database.types.ts             | 15 ++++++---------
 supabase/migrations/00112_gabinet_waitlist.sql |  4 ++--
 4 files changed, 19 insertions(+), 14 deletions(-)
```