### PR TITLE
Wyegzekwować albo usunąć ustawienia powodu przegranej

### DIFF
--- a/convex/crm/leads.ts
+++ b/convex/crm/leads.ts
@@ -622,6 +622,7 @@ export const moveToStage = action({
     leadId: v.string(),
     pipelineStageId: v.string(),
     stageOrder: v.number(),
+    lostReason: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runAction(
@@ -666,8 +667,17 @@ export const moveToStage = action({
       updateData.status = "won";
       updateData.wonAt = now;
     } else if (stage.isLostStage) {
+      const settings = await ctx.runAction(internal.orgSettings._getSettings, {
+        organizationId: args.organizationId,
+      });
+      if (settings?.lostReasonRequired && !args.lostReason) {
+        throw new Error("A lost reason is required");
+      }
       updateData.status = "lost";
       updateData.lostAt = now;
+      if (args.lostReason) {
+        updateData.lostReason = args.lostReason;
+      }
     } else if (lead.status === "won" || lead.status === "lost") {
       updateData.status = "open";
     }

--- a/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
@@ -25,6 +25,7 @@ import {
   type MappedRelationship,
 } from "@/hooks/use-supabase-relationships";
 import { useSupabaseLostReasonsList } from "@/hooks/use-supabase-lost-reasons";
+import { useSupabaseOrgSettings } from "@/hooks/use-supabase-organizations";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
@@ -165,9 +166,14 @@ function LostReasonDialog({
   organizationId: string;
 }) {
   const { data: lostReasons } = useSupabaseLostReasonsList(organizationId);
+  const { data: orgSettings } = useSupabaseOrgSettings(organizationId);
   const { t } = useTranslation();
   const [selectedReason, setSelectedReason] = useState("");
   const [customReason, setCustomReason] = useState("");
+
+  // Hide freeform custom entry when org has disabled custom lost reasons.
+  // Defaults to allowed (fail-open) when settings are not yet loaded or not configured.
+  const allowCustom = orgSettings?.allowCustomLostReason !== false;
 
   const handleSubmit = () => {
     const reason = selectedReason === "__custom__" ? customReason : selectedReason;
@@ -195,10 +201,12 @@ function LostReasonDialog({
                   {r.label}
                 </SelectItem>
               ))}
-              <SelectItem value="__custom__">{t('detail.lostDialog.customReason')}</SelectItem>
+              {allowCustom && (
+                <SelectItem value="__custom__">{t('detail.lostDialog.customReason')}</SelectItem>
+              )}
             </SelectContent>
           </Select>
-          {selectedReason === "__custom__" && (
+          {selectedReason === "__custom__" && allowCustom && (
             <Input
               value={customReason}
               onChange={(e) => setCustomReason(e.target.value)}
@@ -345,6 +353,7 @@ function LeadDetail() {
   const [createContactDrawerOpen, setCreateContactDrawerOpen] = useState(false);
   const [createCompanyDrawerOpen, setCreateCompanyDrawerOpen] = useState(false);
   const [lostDialogOpen, setLostDialogOpen] = useState(false);
+  const [pendingLostStageId, setPendingLostStageId] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [activityDrawerOpen, setActivityDrawerOpen] = useState(false);
   const [showActivityForm, setShowActivityForm] = useState(false);
@@ -563,12 +572,23 @@ function LeadDetail() {
   };
 
   const handleMarkLost = async (reason: string) => {
-    await updateLead({
-      organizationId,
-      leadId: leadId as Id<"leads">,
-      status: "lost",
-      lostReason: reason,
-    });
+    if (pendingLostStageId) {
+      await moveToStage({
+        organizationId,
+        leadId: leadId as Id<"leads">,
+        pipelineStageId: pendingLostStageId as Id<"pipelineStages">,
+        stageOrder: 0,
+        lostReason: reason,
+      });
+      setPendingLostStageId(null);
+    } else {
+      await updateLead({
+        organizationId,
+        leadId: leadId as Id<"leads">,
+        status: "lost",
+        lostReason: reason,
+      });
+    }
     queryClient.invalidateQueries({ queryKey: supabaseKeys.leads.all });
     setLostDialogOpen(false);
   };
@@ -585,6 +605,12 @@ function LeadDetail() {
   };
 
   const handleStageClick = async (stageId: string) => {
+    const stage = allStages?.find((s) => s._id === stageId);
+    if (stage?.isLostStage) {
+      setPendingLostStageId(stageId);
+      setLostDialogOpen(true);
+      return;
+    }
     await moveToStage({
       organizationId,
       leadId: leadId as Id<"leads">,

--- a/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.index.tsx
@@ -497,7 +497,16 @@ function LeadsIndex() {
   };
 
   const handleMarkLost = async (lead: LeadRow) => {
-    await updateLead({ organizationId, leadId: lead._id, status: "lost" });
+    try {
+      await updateLead({ organizationId, leadId: lead._id, status: "lost" });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "leads.errors.updateFailed",
+          defaultValue: "Nie udało się oznaczyć szansy jako przegranej.",
+        }),
+      );
+    }
   };
 
   const handleDelete = async (lead: LeadRow) => {
@@ -518,11 +527,20 @@ function LeadsIndex() {
           break;
         case "markLost":
           for (const row of selectedRows) {
-            await updateLead({
-              organizationId,
-              leadId: row._id,
-              status: "lost",
-            });
+            try {
+              await updateLead({
+                organizationId,
+                leadId: row._id,
+                status: "lost",
+              });
+            } catch (e) {
+              toast.error(
+                formatActionError(e, t, {
+                  key: "leads.errors.updateFailed",
+                  defaultValue: "Nie udało się oznaczyć szansy jako przegranej.",
+                }),
+              );
+            }
           }
           break;
         case "delete":

--- a/src/routes/_app/_auth/dashboard/_layout.pipelines.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.pipelines.index.tsx
@@ -15,6 +15,8 @@ import { Kanban, TableIcon, KanbanIcon } from "@/lib/ez-icons";
 import { useState } from "react";
 import { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/pipelines/"
@@ -96,12 +98,21 @@ function PipelinesIndex() {
   };
 
   const handleMarkLost = async (leadId: Id<"leads">) => {
-    await updateLead({
-      organizationId,
-      leadId,
-      status: "lost",
-    });
-    queryClient.invalidateQueries({ queryKey: supabaseKeys.leads.all });
+    try {
+      await updateLead({
+        organizationId,
+        leadId,
+        status: "lost",
+      });
+      queryClient.invalidateQueries({ queryKey: supabaseKeys.leads.all });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "leads.errors.updateFailed",
+          defaultValue: "Nie udało się oznaczyć szansy jako przegranej.",
+        }),
+      );
+    }
   };
 
   const handleDelete = async (leadId: Id<"leads">) => {

--- a/tests/convex/orgSettingsEffect.test.ts
+++ b/tests/convex/orgSettingsEffect.test.ts
@@ -452,10 +452,10 @@ describe("allowCustomLostReason: controls whether lostReasons.create is permitte
     const t = createTestCtx();
     const { organizationId, identity } = await seedTestUser(t);
 
-    await seedConvexOrgSettings(t, organizationId, { allowCustomLostReason: true });
+    await seedSupabaseOrgSettings(String(organizationId), { allowCustomLostReason: true });
 
     await expect(
-      t.withIdentity(identity).action(api.lostReasons.create, {
+      t.withIdentity(identity).action(api.crm.lostReasons.create, {
         organizationId,
         label: "Custom reason",
       }),
@@ -466,10 +466,10 @@ describe("allowCustomLostReason: controls whether lostReasons.create is permitte
     const t = createTestCtx();
     const { organizationId, identity } = await seedTestUser(t);
 
-    await seedConvexOrgSettings(t, organizationId, { allowCustomLostReason: false });
+    await seedSupabaseOrgSettings(String(organizationId), { allowCustomLostReason: false });
 
     await expect(
-      t.withIdentity(identity).action(api.lostReasons.create, {
+      t.withIdentity(identity).action(api.crm.lostReasons.create, {
         organizationId,
         label: "Blocked reason",
       }),
@@ -483,7 +483,7 @@ describe("allowCustomLostReason: controls whether lostReasons.create is permitte
     // No orgSettings row — lostReasons.create should succeed (settings?.allowCustomLostReason === false is false when settings is null)
 
     await expect(
-      t.withIdentity(identity).action(api.lostReasons.create, {
+      t.withIdentity(identity).action(api.crm.lostReasons.create, {
         organizationId,
         label: "Default allow reason",
       }),
@@ -513,11 +513,11 @@ describe("lostReasonRequired: blocks leads.update to 'lost' status when no lostR
     const t = createTestCtx();
     const { organizationId, userId, identity } = await seedTestUser(t);
 
-    await seedConvexOrgSettings(t, organizationId, { lostReasonRequired: true });
+    await seedSupabaseOrgSettings(String(organizationId), { lostReasonRequired: true });
     const leadId = await seedLead(String(organizationId), String(userId));
 
     await expect(
-      t.withIdentity(identity).action(api.leads.update, {
+      t.withIdentity(identity).action(api.crm.leads.update, {
         organizationId,
         leadId,
         status: "lost",
@@ -529,11 +529,11 @@ describe("lostReasonRequired: blocks leads.update to 'lost' status when no lostR
     const t = createTestCtx();
     const { organizationId, userId, identity } = await seedTestUser(t);
 
-    await seedConvexOrgSettings(t, organizationId, { lostReasonRequired: true });
+    await seedSupabaseOrgSettings(String(organizationId), { lostReasonRequired: true });
     const leadId = await seedLead(String(organizationId), String(userId));
 
     await expect(
-      t.withIdentity(identity).action(api.leads.update, {
+      t.withIdentity(identity).action(api.crm.leads.update, {
         organizationId,
         leadId,
         status: "lost",
@@ -546,11 +546,11 @@ describe("lostReasonRequired: blocks leads.update to 'lost' status when no lostR
     const t = createTestCtx();
     const { organizationId, userId, identity } = await seedTestUser(t);
 
-    await seedConvexOrgSettings(t, organizationId, { lostReasonRequired: false });
+    await seedSupabaseOrgSettings(String(organizationId), { lostReasonRequired: false });
     const leadId = await seedLead(String(organizationId), String(userId));
 
     await expect(
-      t.withIdentity(identity).action(api.leads.update, {
+      t.withIdentity(identity).action(api.crm.leads.update, {
         organizationId,
         leadId,
         status: "lost",
@@ -566,7 +566,7 @@ describe("lostReasonRequired: blocks leads.update to 'lost' status when no lostR
     const leadId = await seedLead(String(organizationId), String(userId));
 
     await expect(
-      t.withIdentity(identity).action(api.leads.update, {
+      t.withIdentity(identity).action(api.crm.leads.update, {
         organizationId,
         leadId,
         status: "lost",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4444.

Closes #4444

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 30e67f2 fix(crm): enforce lostReasonRequired and allowCustomLostReason settings (closes #4444)

### Files changed

```
 convex/crm/leads.ts                                | 10 ++++++
 .../_auth/dashboard/_layout.leads.$leadId.lazy.tsx | 42 +++++++++++++++++-----
 .../_app/_auth/dashboard/_layout.leads.index.tsx   | 30 ++++++++++++----
 .../_auth/dashboard/_layout.pipelines.index.tsx    | 23 ++++++++----
 tests/convex/orgSettingsEffect.test.ts             | 24 ++++++-------
 5 files changed, 97 insertions(+), 32 deletions(-)
```