### PR TITLE
Enforce lostReasonRequired on Kanban drag-to-lost-stage

### DIFF
--- a/src/components/crm/lost-reason-dialog.tsx
+++ b/src/components/crm/lost-reason-dialog.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useSupabaseLostReasonsList } from "@/hooks/use-supabase-lost-reasons";
+import { useSupabaseOrgSettings } from "@/hooks/use-supabase-organizations";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface LostReasonDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (reason: string) => void;
+  organizationId: string;
+}
+
+export function LostReasonDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  organizationId,
+}: LostReasonDialogProps) {
+  const { data: lostReasons } = useSupabaseLostReasonsList(organizationId);
+  const { data: orgSettings } = useSupabaseOrgSettings(organizationId);
+  const { t } = useTranslation();
+  const [selectedReason, setSelectedReason] = useState("");
+  const [customReason, setCustomReason] = useState("");
+
+  // Hide freeform custom entry when org has disabled custom lost reasons.
+  // Defaults to allowed (fail-open) when settings are not yet loaded or not configured.
+  const allowCustom = orgSettings?.allowCustomLostReason !== false;
+
+  const handleSubmit = () => {
+    const reason = selectedReason === "__custom__" ? customReason : selectedReason;
+    if (reason.trim()) {
+      onConfirm(reason.trim());
+      setSelectedReason("");
+      setCustomReason("");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle>{t("detail.lostDialog.title")}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <Select value={selectedReason} onValueChange={setSelectedReason}>
+            <SelectTrigger>
+              <SelectValue placeholder={t("detail.lostDialog.selectReason")} />
+            </SelectTrigger>
+            <SelectContent>
+              {lostReasons?.map((r) => (
+                <SelectItem key={r._id} value={r.label}>
+                  {r.label}
+                </SelectItem>
+              ))}
+              {allowCustom && (
+                <SelectItem value="__custom__">
+                  {t("detail.lostDialog.customReason")}
+                </SelectItem>
+              )}
+            </SelectContent>
+          </Select>
+          {selectedReason === "__custom__" && allowCustom && (
+            <Input
+              value={customReason}
+              onChange={(e) => setCustomReason(e.target.value)}
+              placeholder={t("detail.lostDialog.customPlaceholder")}
+              autoFocus
+            />
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            disabled={
+              !selectedReason ||
+              (selectedReason === "__custom__" && !customReason.trim())
+            }
+            onClick={handleSubmit}
+          >
+            {t("detail.lostDialog.confirm")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
@@ -24,8 +24,7 @@ import {
   useSupabaseRelationshipsByEntity,
   type MappedRelationship,
 } from "@/hooks/use-supabase-relationships";
-import { useSupabaseLostReasonsList } from "@/hooks/use-supabase-lost-reasons";
-import { useSupabaseOrgSettings } from "@/hooks/use-supabase-organizations";
+import { LostReasonDialog } from "@/components/crm/lost-reason-dialog";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
@@ -50,7 +49,6 @@ import { activitiesToFeedEntries } from "@/components/crm/activity-feed-adapter"
 import { ScheduledActivitiesList } from "@/components/shared/scheduled-activities-list";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   Dialog,
   DialogContent,
@@ -58,13 +56,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { RichTextEditor, plateJsonToText } from "@/components/gabinet/rich-text-editor";
 import {
   DropdownMenu,
@@ -149,90 +140,6 @@ function PipelineProgressBar({
         );
       })}
     </div>
-  );
-}
-
-// --- LostReasonDialog ---
-
-function LostReasonDialog({
-  open,
-  onOpenChange,
-  onConfirm,
-  organizationId,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onConfirm: (reason: string) => void;
-  organizationId: string;
-}) {
-  const { data: lostReasons } = useSupabaseLostReasonsList(organizationId);
-  const { data: orgSettings } = useSupabaseOrgSettings(organizationId);
-  const { t } = useTranslation();
-  const [selectedReason, setSelectedReason] = useState("");
-  const [customReason, setCustomReason] = useState("");
-
-  // Hide freeform custom entry when org has disabled custom lost reasons.
-  // Defaults to allowed (fail-open) when settings are not yet loaded or not configured.
-  const allowCustom = orgSettings?.allowCustomLostReason !== false;
-
-  const handleSubmit = () => {
-    const reason = selectedReason === "__custom__" ? customReason : selectedReason;
-    if (reason.trim()) {
-      onConfirm(reason.trim());
-      setSelectedReason("");
-      setCustomReason("");
-    }
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[400px]">
-        <DialogHeader>
-          <DialogTitle>{t('detail.lostDialog.title')}</DialogTitle>
-        </DialogHeader>
-        <div className="space-y-3">
-          <Select value={selectedReason} onValueChange={setSelectedReason}>
-            <SelectTrigger>
-              <SelectValue placeholder={t('detail.lostDialog.selectReason')} />
-            </SelectTrigger>
-            <SelectContent>
-              {lostReasons?.map((r) => (
-                <SelectItem key={r._id} value={r.label}>
-                  {r.label}
-                </SelectItem>
-              ))}
-              {allowCustom && (
-                <SelectItem value="__custom__">{t('detail.lostDialog.customReason')}</SelectItem>
-              )}
-            </SelectContent>
-          </Select>
-          {selectedReason === "__custom__" && allowCustom && (
-            <Input
-              value={customReason}
-              onChange={(e) => setCustomReason(e.target.value)}
-              placeholder={t('detail.lostDialog.customPlaceholder')}
-              autoFocus
-            />
-          )}
-        </div>
-        <DialogFooter>
-          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
-            {t('common.cancel')}
-          </Button>
-          <Button
-            size="sm"
-            variant="destructive"
-            disabled={
-              !selectedReason ||
-              (selectedReason === "__custom__" && !customReason.trim())
-            }
-            onClick={handleSubmit}
-          >
-            {t('detail.lostDialog.confirm')}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   );
 }
 

--- a/src/routes/_app/_auth/dashboard/_layout.pipelines.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.pipelines.index.tsx
@@ -9,6 +9,7 @@ import { PageHeader } from "@/components/layout/page-header";
 import { EmptyState } from "@/components/layout/empty-state";
 import { KanbanBoard, KanbanLead } from "@/components/kanban/kanban-board";
 import { KanbanCardDetailSheet } from "@/components/kanban/kanban-card-detail-sheet";
+import { LostReasonDialog } from "@/components/crm/lost-reason-dialog";
 import { api } from "@cvx/_generated/api";
 import { Button } from "@/components/ui/button";
 import { Kanban, TableIcon, KanbanIcon } from "@/lib/ez-icons";
@@ -41,6 +42,10 @@ function PipelinesIndex() {
   );
   const [selectedLead, setSelectedLead] = useState<KanbanLead | null>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
+  const [lostDialogOpen, setLostDialogOpen] = useState(false);
+  type PendingMove = { leadId: Id<"leads">; stageId: Id<"pipelineStages">; order: number };
+  const [pendingMove, setPendingMove] = useState<PendingMove | null>(null);
+  const [pendingMarkLostId, setPendingMarkLostId] = useState<Id<"leads"> | null>(null);
 
   const activePipeline =
     pipelines?.find((p) => p._id === selectedPipelineId) ??
@@ -78,6 +83,12 @@ function PipelinesIndex() {
     stageId: Id<"pipelineStages">,
     order: number
   ) => {
+    const targetStage = stagesWithLeads?.find((s) => s._id === stageId);
+    if (targetStage?.isLostStage) {
+      setPendingMove({ leadId, stageId, order });
+      setLostDialogOpen(true);
+      return;
+    }
     await moveToStage({
       organizationId,
       leadId,
@@ -97,14 +108,32 @@ function PipelinesIndex() {
     queryClient.invalidateQueries({ queryKey: supabaseKeys.leads.all });
   };
 
-  const handleMarkLost = async (leadId: Id<"leads">) => {
+  const handleMarkLost = (leadId: Id<"leads">) => {
+    setPendingMarkLostId(leadId);
+    setLostDialogOpen(true);
+  };
+
+  const handleLostConfirm = async (reason: string) => {
     try {
-      await updateLead({
-        organizationId,
-        leadId,
-        status: "lost",
-      });
-      queryClient.invalidateQueries({ queryKey: supabaseKeys.leads.all });
+      if (pendingMove) {
+        await moveToStage({
+          organizationId,
+          leadId: pendingMove.leadId,
+          pipelineStageId: pendingMove.stageId,
+          stageOrder: pendingMove.order,
+          lostReason: reason,
+        });
+        queryClient.invalidateQueries({ queryKey: supabaseKeys.leads.all });
+        queryClient.invalidateQueries({ queryKey: supabaseKeys.pipelineStages.all });
+      } else if (pendingMarkLostId) {
+        await updateLead({
+          organizationId,
+          leadId: pendingMarkLostId,
+          status: "lost",
+          lostReason: reason,
+        });
+        queryClient.invalidateQueries({ queryKey: supabaseKeys.leads.all });
+      }
     } catch (e) {
       toast.error(
         formatActionError(e, t, {
@@ -112,6 +141,10 @@ function PipelinesIndex() {
           defaultValue: "Nie udało się oznaczyć szansy jako przegranej.",
         }),
       );
+    } finally {
+      setLostDialogOpen(false);
+      setPendingMove(null);
+      setPendingMarkLostId(null);
     }
   };
 
@@ -194,6 +227,19 @@ function PipelinesIndex() {
         lead={selectedLead}
         open={sheetOpen}
         onOpenChange={setSheetOpen}
+      />
+
+      <LostReasonDialog
+        open={lostDialogOpen}
+        onOpenChange={(open) => {
+          setLostDialogOpen(open);
+          if (!open) {
+            setPendingMove(null);
+            setPendingMarkLostId(null);
+          }
+        }}
+        onConfirm={handleLostConfirm}
+        organizationId={organizationId}
       />
     </div>
   );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4447.

Closes #4447

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a1fef75 fix(kanban): enforce lostReasonRequired on drag-to-lost-stage (closes #4447)

### Files changed

```
 src/components/crm/lost-reason-dialog.tsx          | 106 +++++++++++++++++++++
 .../_auth/dashboard/_layout.leads.$leadId.lazy.tsx |  95 +-----------------
 .../_auth/dashboard/_layout.pipelines.index.tsx    |  60 ++++++++++--
 3 files changed, 160 insertions(+), 101 deletions(-)
```