### PR TITLE
Rozbić trasę appointments.$appointmentId.lazy.tsx (2927 linii) na komponenty

### DIFF
--- a/src/components/gabinet/appointments/appointment-details-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-details-tab.tsx
@@ -1,0 +1,457 @@
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+  CheckCircle,
+  DollarSign,
+  Heart,
+  Inbox,
+  MessageSquare,
+  Send,
+  ShieldAlert,
+  Sparkles,
+  StickyNote,
+  Stethoscope,
+  UserCircle,
+} from "@/lib/ez-icons";
+import { formatCurrencyPLN } from "@/lib/format-currency";
+import {
+  plateJsonToText,
+  RichTextEditor,
+} from "@/components/gabinet/rich-text-editor";
+import { TreatmentPicker } from "@/components/gabinet/appointment-shared/treatment-picker";
+import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
+
+type TreatmentListItem = {
+  _id: string;
+  name: string;
+  duration: number;
+  price?: number;
+  currency?: string;
+};
+
+type JunctionTreatment = {
+  id: string;
+  treatmentId: string;
+  priceAtBooking?: number | null;
+};
+
+type SmsSummary = {
+  labelKey: string;
+  tone: "default" | "destructive" | "secondary" | "outline";
+};
+
+type SmsEvent = Record<string, unknown>;
+
+export function AppointmentDetailsTab({
+  appointment,
+  treatment,
+  employee,
+  junctionTreatments,
+  treatmentsList,
+  smsSummary,
+  latestOutboundSms,
+  latestInboundSms,
+  internalNotes,
+  isSavingNotes,
+  canEdit,
+  isSavingTreatment,
+  editTreatmentId,
+  treatmentPickerOpen,
+  treatmentSearch,
+  onTreatmentPickerOpenChange,
+  onTreatmentSearchChange,
+  onTreatmentSelect,
+  onInternalNotesChange,
+  onSaveInternalNotes,
+  onMarkContraindicationReviewed,
+  calculateDuration,
+  getEmployeeName,
+  getEmployeeInitials,
+  language,
+  t,
+}: {
+  appointment: Record<string, unknown>;
+  treatment: Record<string, unknown> | null | undefined;
+  employee: Record<string, unknown> | null | undefined;
+  junctionTreatments: JunctionTreatment[];
+  treatmentsList: TreatmentListItem[] | undefined;
+  smsSummary: SmsSummary;
+  latestOutboundSms: SmsEvent | undefined;
+  latestInboundSms: SmsEvent | undefined;
+  internalNotes: string;
+  isSavingNotes: boolean;
+  canEdit: boolean;
+  isSavingTreatment: boolean;
+  editTreatmentId: string;
+  treatmentPickerOpen: boolean;
+  treatmentSearch: string;
+  onTreatmentPickerOpenChange: (open: boolean) => void;
+  onTreatmentSearchChange: (search: string) => void;
+  onTreatmentSelect: (id: string) => void;
+  onInternalNotesChange: (val: string) => void;
+  onSaveInternalNotes: () => void;
+  onMarkContraindicationReviewed: () => void;
+  calculateDuration: () => number;
+  getEmployeeName: () => string;
+  getEmployeeInitials: () => string;
+  language: string;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  return (
+    <div className="space-y-4">
+      {/* Treatment Info Card */}
+      <Card>
+        <CardHeader className="px-6 py-3 border-b">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Sparkles className="h-4 w-4" variant="stroke" />
+            {t("gabinet.treatments.treatment")}
+          </CardTitle>
+        </CardHeader>
+        {junctionTreatments.length > 1 ? (
+          /* Multi-treatment: one row per junction entry, totals at bottom */
+          <CardContent className="space-y-0 divide-y divide-border px-6 py-0">
+            {junctionTreatments.map((jt) => {
+              const tr = treatmentsList?.find((t) => t._id === jt.treatmentId);
+              const name = tr?.name ?? (treatment?.name as string | undefined) ?? "-";
+              const price = jt.priceAtBooking ?? tr?.price ?? null;
+              return (
+                <div
+                  key={jt.id}
+                  className="flex items-center justify-between py-3"
+                >
+                  <div className="flex items-center gap-2">
+                    <Stethoscope className="h-4 w-4 shrink-0 text-primary" />
+                    <span className="text-sm font-medium">{name}</span>
+                  </div>
+                  {price != null && (
+                    <span className="text-sm text-muted-foreground">
+                      {formatCurrencyPLN(price)}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+            <div className="flex items-center justify-between py-3 font-semibold">
+              <span className="text-sm">
+                {t("gabinet.appointments.totalDuration", "Łącznie")} ·{" "}
+                {calculateDuration()} min
+              </span>
+              <span className="text-sm">
+                {formatCurrencyPLN(
+                  junctionTreatments.reduce((sum, jt) => {
+                    const tr = treatmentsList?.find(
+                      (t) => t._id === jt.treatmentId,
+                    );
+                    return sum + (jt.priceAtBooking ?? tr?.price ?? 0);
+                  }, 0),
+                )}
+              </span>
+            </div>
+          </CardContent>
+        ) : (
+          /* Single / legacy treatment */
+          <CardContent className="space-y-3 px-6 py-4">
+            <div className="space-y-1.5">
+              <Label className="text-xs uppercase tracking-wide text-muted-foreground">
+                {t("common.name")}
+              </Label>
+              {canEdit ? (
+                <TreatmentPicker
+                  treatments={treatmentsList}
+                  value={editTreatmentId}
+                  onSelect={(id) => {
+                    onTreatmentSelect(id);
+                    onTreatmentPickerOpenChange(false);
+                    onTreatmentSearchChange("");
+                  }}
+                  open={treatmentPickerOpen}
+                  onOpenChange={onTreatmentPickerOpenChange}
+                  search={treatmentSearch}
+                  onSearchChange={onTreatmentSearchChange}
+                  formatPrice={(price, currency) =>
+                    formatCurrencyPLN(price ?? 0, currency ?? "PLN")
+                  }
+                  placeholder={t("gabinet.appointments.selectTreatment")}
+                  searchPlaceholder={t("gabinet.appointments.searchTreatment")}
+                  emptyText={t("common.noResults")}
+                  closeLabel={t("common.close")}
+                  selectedLabel={treatment?.name as string | undefined}
+                  triggerIcon={
+                    <Stethoscope className="size-4 shrink-0 text-primary" />
+                  }
+                  disabled={isSavingTreatment}
+                />
+              ) : (
+                <span className="flex items-center gap-2 text-sm font-medium">
+                  <Stethoscope className="size-4 shrink-0 text-primary" />
+                  {(treatment?.name as string | undefined) ?? "-"}
+                </span>
+              )}
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">
+                {t("gabinet.treatments.duration")}
+              </span>
+              <span className="font-medium">{calculateDuration()} min</span>
+            </div>
+            {treatment?.price !== undefined && (
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">
+                  {t("common.price")}
+                </span>
+                <span className="font-medium">
+                  {formatCurrencyPLN(
+                    treatment.price as number,
+                    (treatment.currency as string | undefined) ?? "PLN",
+                  )}
+                </span>
+              </div>
+            )}
+            {treatment?.description && (
+              <div className="pt-2">
+                <span className="text-sm text-muted-foreground">
+                  {t("common.description")}
+                </span>
+                <p className="text-sm mt-1">
+                  {plateJsonToText(treatment.description as string)}
+                </p>
+              </div>
+            )}
+            {treatment?.contraindications && (
+              <div className="pt-2 p-3 bg-destructive/10 rounded-lg">
+                <div className="flex items-center justify-between gap-2 mb-1">
+                  <div className="flex items-center gap-2 text-destructive">
+                    <ShieldAlert className="h-4 w-4" variant="stroke" />
+                    <span className="text-sm font-medium">
+                      {t("gabinet.treatments.contraindications")}
+                    </span>
+                  </div>
+                  {(appointment.contraindicationAlertsReviewed as boolean | undefined) ? (
+                    <div className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+                      <CheckCircle className="h-3.5 w-3.5" variant="stroke" />
+                      <span>
+                        {t(
+                          "gabinet.appointmentDetail.contraindicationDiscussed",
+                          "Omówiono",
+                        )}
+                      </span>
+                    </div>
+                  ) : canEdit ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 px-2 text-xs text-destructive hover:text-destructive"
+                      onClick={onMarkContraindicationReviewed}
+                    >
+                      {t(
+                        "gabinet.appointmentDetail.markContraindicationAsDiscussed",
+                        "Oznacz jako omówione",
+                      )}
+                    </Button>
+                  ) : null}
+                </div>
+                <p className="text-sm">
+                  {plateJsonToText(treatment.contraindications as string)}
+                </p>
+              </div>
+            )}
+            {!!(treatment as Record<string, unknown>)?.aftercare && (
+              <div className="pt-2 p-3 bg-primary/10 rounded-lg">
+                <div className="flex items-center gap-2 text-primary mb-1">
+                  <Heart className="h-4 w-4" variant="stroke" />
+                  <span className="text-sm font-medium">
+                    {t("gabinet.treatments.aftercare")}
+                  </span>
+                </div>
+                <p className="text-sm">
+                  {plateJsonToText(
+                    (treatment as Record<string, unknown>).aftercare as string,
+                  )}
+                </p>
+              </div>
+            )}
+          </CardContent>
+        )}
+      </Card>
+
+      {/* Employee Info Card */}
+      <Card>
+        <CardHeader className="px-6 py-3 border-b">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <UserCircle className="h-4 w-4" variant="stroke" />
+            {t("gabinet.employees.employee")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="px-6 py-4">
+          <div className="flex items-center gap-4">
+            <Avatar className="h-12 w-12">
+              <AvatarFallback>{getEmployeeInitials()}</AvatarFallback>
+            </Avatar>
+            <div>
+              <p className="font-medium">{getEmployeeName()}</p>
+              <p className="text-sm text-muted-foreground">
+                {employee?.email as string | undefined}
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* SMS Confirmation Card */}
+      <Card>
+        <CardHeader className="px-6 py-3 border-b">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <MessageSquare className="h-4 w-4" variant="stroke" />
+            {t("gabinet.appointmentDetail.sms.title")}
+          </CardTitle>
+          <CardDescription className="text-xs">
+            {t("gabinet.appointmentDetail.sms.description")}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 px-6 py-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant={smsSummary.tone}>{t(smsSummary.labelKey)}</Badge>
+            <Badge
+              variant="outline"
+              className={appointmentStatusBadgeClass(appointment.status as string)}
+            >
+              {t(`gabinet.appointments.statuses.${appointment.status}`)}
+            </Badge>
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            <div className="rounded-lg border p-3 space-y-2">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <Send className="h-4 w-4" variant="stroke" />
+                {t("gabinet.appointmentDetail.sms.lastOutbound")}
+              </div>
+              {latestOutboundSms ? (
+                <>
+                  <p className="text-sm">
+                    {latestOutboundSms.rawBody as string}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {t("gabinet.appointmentDetail.sms.processingStatus")}:{" "}
+                    {t(
+                      `gabinet.appointmentDetail.sms.processingStatuses.${latestOutboundSms.processingStatus}`,
+                    )}
+                  </p>
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  {t("gabinet.appointmentDetail.sms.noOutbound")}
+                </p>
+              )}
+            </div>
+
+            <div className="rounded-lg border p-3 space-y-2">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <Inbox className="h-4 w-4" variant="stroke" />
+                {t("gabinet.appointmentDetail.sms.lastInbound")}
+              </div>
+              {latestInboundSms ? (
+                <>
+                  <p className="text-sm">
+                    {latestInboundSms.rawBody as string}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {t("gabinet.appointmentDetail.sms.parsedIntent")}:{" "}
+                    {t(
+                      `gabinet.appointmentDetail.sms.intents.${latestInboundSms.parsedIntent ?? "unknown"}`,
+                    )}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {t("gabinet.appointmentDetail.sms.processingStatus")}:{" "}
+                    {t(
+                      `gabinet.appointmentDetail.sms.processingStatuses.${latestInboundSms.processingStatus}`,
+                    )}
+                  </p>
+                  {latestInboundSms.processingError && (
+                    <p className="text-xs text-muted-foreground">
+                      {t("gabinet.appointmentDetail.sms.processingReason")}:{" "}
+                      {latestInboundSms.processingError as string}
+                    </p>
+                  )}
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  {t("gabinet.appointmentDetail.sms.noInbound")}
+                </p>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Prepayment Status Card */}
+      {(appointment.prepaymentRequired as boolean | undefined) && (
+        <Card>
+          <CardHeader className="px-6 py-3 border-b">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <DollarSign className="h-4 w-4" variant="stroke" />
+              {t("gabinet.appointments.prepayment")}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 px-6 py-4">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">
+                {t("gabinet.appointments.prepaymentAmount")}
+              </span>
+              <span className="font-medium">
+                {formatCurrencyPLN((appointment.prepaymentAmount as number | undefined) ?? 0)}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">
+                {t("common.status")}
+              </span>
+              <Badge variant="secondary">
+                {t("gabinet.appointments.prepaymentPending")}
+              </Badge>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Internal Notes Card */}
+      <Card>
+        <CardHeader className="px-6 py-3 border-b">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <StickyNote className="h-4 w-4" variant="stroke" />
+            {t("gabinet.appointments.internalNotes")}
+          </CardTitle>
+          <CardDescription className="text-xs">
+            {t("gabinet.appointments.internalNotesDesc")}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3 px-6 py-4">
+          <RichTextEditor
+            placeholder={t("gabinet.appointments.internalNotesPlaceholder")}
+            value={internalNotes}
+            onChange={(val) => onInternalNotesChange(val ?? "")}
+          />
+          {canEdit && (
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                onClick={onSaveInternalNotes}
+                disabled={isSavingNotes}
+              >
+                {isSavingNotes ? t("common.saving") : t("common.save")}
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/gabinet/appointments/appointment-history-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-history-tab.tsx
@@ -1,0 +1,517 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Activity,
+  Calendar,
+  CreditCard,
+  History,
+  Package,
+  Plus,
+  Star,
+} from "@/lib/ez-icons";
+import { formatCurrencyPLN } from "@/lib/format-currency";
+import { EmptyState } from "@/components/layout/empty-state";
+import { ActivityFeed } from "@/components/crm/activity-feed";
+import { activitiesToFeedEntries } from "@/components/crm/activity-feed-adapter";
+import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
+import { Link } from "@tanstack/react-router";
+
+type HistoryAppointment = {
+  _id: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  status: string;
+  treatment?: { name?: string | null } | null;
+};
+
+type PackageUsageEntry = {
+  _id: string;
+  packageName?: string | null;
+  status: string;
+  totalUsed: number;
+  totalCount: number;
+  expiresAt?: number | null;
+  treatmentsUsed: Array<{
+    treatmentId: string;
+    treatmentName?: string | null;
+    usedCount?: number;
+    totalCount?: number;
+    variantId?: string;
+  }>;
+};
+
+export function AppointmentHistoryTab({
+  mergedTimeline,
+  patientHistory,
+  patientPackageUsage,
+  loyaltyBalance,
+  loyaltyTier,
+  loyaltyTransactions,
+  allPatientPayments,
+  canEdit,
+  onUseMultiple,
+  formatDate,
+  formatTime,
+  language,
+  t,
+}: {
+  mergedTimeline: unknown[];
+  patientHistory: HistoryAppointment[];
+  patientPackageUsage: PackageUsageEntry[];
+  loyaltyBalance: number;
+  loyaltyTier: string | null | undefined;
+  loyaltyTransactions: Record<string, unknown>[] | null | undefined;
+  allPatientPayments: Record<string, unknown>[] | null | undefined;
+  canEdit: boolean;
+  onUseMultiple: (pkg: PackageUsageEntry) => void;
+  formatDate: (dateStr: string) => string;
+  formatTime: (time: string) => string;
+  language: string;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="px-6 py-3 border-b">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Activity className="h-4 w-4" variant="stroke" />
+            {t("detail.tabs.timeline", "Timeline")}
+          </CardTitle>
+          <CardDescription className="text-xs">
+            {t(
+              "gabinet.appointmentDetail.history.unifiedDescription",
+              "Unified operational history for this appointment, including messages and workflow events.",
+            )}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="px-6 py-4">
+          <ActivityFeed
+            entries={activitiesToFeedEntries(mergedTimeline as any[], t)}
+            maxHeight="400px"
+          />
+        </CardContent>
+      </Card>
+
+      {/* Past Appointments Timeline */}
+      <Card>
+        <CardHeader className="px-6 py-3 border-b">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <History className="h-4 w-4" variant="stroke" />
+            {t("gabinet.patients.appointmentHistory")}
+          </CardTitle>
+          <CardDescription className="text-xs">
+            {t("gabinet.patients.lastAppointments", { count: 20 })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="px-6 py-4">
+          {patientHistory.length === 0 ? (
+            <EmptyState
+              icon={Calendar}
+              title={t("gabinet.patients.noHistory")}
+              description={t("gabinet.patients.noHistoryDesc")}
+            />
+          ) : (
+            <div className="relative">
+              <div className="absolute left-3 top-0 bottom-0 w-px bg-border" />
+              <div className="space-y-4">
+                {patientHistory.map((appt, index) => (
+                  <div key={appt._id} className="relative flex gap-4">
+                    <div className="relative z-10 flex items-center justify-center w-6 h-6 rounded-full bg-background border-2">
+                      {index === 0 && (
+                        <div className="w-2 h-2 rounded-full bg-primary" />
+                      )}
+                    </div>
+                    <Link
+                      to="/dashboard/gabinet/appointments/$appointmentId"
+                      params={{ appointmentId: appt._id }}
+                      className="flex-1 flex items-center justify-between p-3 border rounded-lg hover:bg-muted/50 transition-colors"
+                    >
+                      <div>
+                        <p className="font-medium">
+                          {appt.treatment?.name ?? "-"}
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                          {formatDate(appt.date)} &bull;{" "}
+                          {formatTime(appt.startTime)} -{" "}
+                          {formatTime(appt.endTime)}
+                        </p>
+                      </div>
+                      <Badge
+                        variant="outline"
+                        className={appointmentStatusBadgeClass(appt.status)}
+                      >
+                        {t(`gabinet.appointments.statuses.${appt.status}`)}
+                      </Badge>
+                    </Link>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Active Packages */}
+      <Card>
+        <CardHeader className="px-6 py-3 border-b">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Package className="h-4 w-4" variant="stroke" />
+            {t("gabinet.packages.activePackages")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="px-6 py-4">
+          {patientPackageUsage.length === 0 ? (
+            <EmptyState
+              icon={Package}
+              title={t("gabinet.packages.noActivePackages")}
+              description={t("gabinet.packages.noActivePackagesDesc")}
+            />
+          ) : (
+            <div className="space-y-3">
+              {patientPackageUsage.map((pkg) => {
+                const totals = {
+                  used: pkg.totalUsed,
+                  total: pkg.totalCount,
+                };
+                const progressPercent =
+                  totals.total > 0
+                    ? Math.min((totals.used / totals.total) * 100, 100)
+                    : 0;
+                const overallRemainingRatio =
+                  totals.total > 0
+                    ? (totals.total - totals.used) / totals.total
+                    : 1;
+                let overallBarColor = "bg-emerald-500";
+                if (overallRemainingRatio <= 0)
+                  overallBarColor = "bg-red-500";
+                else if (overallRemainingRatio < 0.1)
+                  overallBarColor = "bg-red-500";
+                else if (overallRemainingRatio < 0.3)
+                  overallBarColor = "bg-amber-500";
+
+                return (
+                  <div
+                    key={pkg._id}
+                    className="p-4 border rounded-lg space-y-3"
+                  >
+                    <div className="flex items-center justify-between">
+                      <p className="font-medium">
+                        {pkg.packageName ?? t("gabinet.packages.package")}
+                      </p>
+                      <div className="flex items-center gap-2">
+                        {pkg.status === "active" && canEdit && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => onUseMultiple(pkg)}
+                          >
+                            <Plus
+                              className="mr-1 h-3.5 w-3.5"
+                              variant="stroke"
+                            />
+                            {t("gabinet.packages.useMultiple")}
+                          </Button>
+                        )}
+                        <Badge
+                          variant="outline"
+                          className={
+                            pkg.status === "active"
+                              ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-400"
+                              : ""
+                          }
+                        >
+                          {t(`gabinet.packages.status.${pkg.status}`)}
+                        </Badge>
+                      </div>
+                    </div>
+
+                    {/* Overall progress */}
+                    <div className="space-y-1">
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="text-muted-foreground">
+                          {t("gabinet.packages.overallProgress")}
+                        </span>
+                        <span className="tabular-nums">
+                          {t("gabinet.packages.completionPercent", {
+                            percent: Math.round(progressPercent),
+                          })}
+                        </span>
+                      </div>
+                      <div className="h-2 bg-muted rounded-full overflow-hidden">
+                        <div
+                          className={`h-full transition-all rounded-full ${overallBarColor}`}
+                          style={{ width: `${progressPercent}%` }}
+                        />
+                      </div>
+                    </div>
+
+                    {/* Per-treatment progress bars */}
+                    {pkg.treatmentsUsed.length > 0 && (
+                      <div className="space-y-2">
+                        <p className="text-xs font-medium text-muted-foreground">
+                          {t("gabinet.packages.perTreatmentProgress")}
+                        </p>
+                        {pkg.treatmentsUsed.map((entry, index) => {
+                          const usedCount = entry.usedCount ?? 0;
+                          const totalCount = entry.totalCount ?? 0;
+                          const remaining = totalCount - usedCount;
+                          const pct =
+                            totalCount > 0
+                              ? Math.round((usedCount / totalCount) * 100)
+                              : 0;
+                          const remainingRatio =
+                            totalCount > 0 ? remaining / totalCount : 1;
+                          let barColor = "bg-emerald-500";
+                          let statusLabel = t(
+                            "gabinet.packages.plentyRemaining",
+                          );
+                          if (remainingRatio <= 0) {
+                            barColor = "bg-red-500";
+                            statusLabel = t("gabinet.packages.fullyUsed");
+                          } else if (remainingRatio < 0.1) {
+                            barColor = "bg-red-500";
+                            statusLabel = t("gabinet.packages.almostExhausted");
+                          } else if (remainingRatio < 0.3) {
+                            barColor = "bg-amber-500";
+                            statusLabel = t("gabinet.packages.runningLow");
+                          }
+
+                          return (
+                            <div
+                              key={`${pkg._id}-${entry.treatmentId ?? index}`}
+                              className="space-y-1"
+                            >
+                              <div className="flex items-center justify-between text-xs">
+                                <span className="truncate max-w-[50%]">
+                                  {entry.treatmentName ??
+                                    t("gabinet.treatments.treatment")}
+                                </span>
+                                <span className="text-muted-foreground tabular-nums">
+                                  {usedCount} / {totalCount}
+                                  <span className="ml-1.5 text-[10px]">
+                                    ({statusLabel})
+                                  </span>
+                                </span>
+                              </div>
+                              <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+                                <div
+                                  className={`h-full transition-all rounded-full ${barColor}`}
+                                  style={{ width: `${pct}%` }}
+                                />
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+
+                    {!!pkg.expiresAt && (
+                      <p className="text-xs text-muted-foreground">
+                        {t("gabinet.packages.expires")}:{" "}
+                        {new Date(pkg.expiresAt).toLocaleDateString(language)}
+                      </p>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Loyalty Summary */}
+      <Card>
+        <CardHeader className="px-6 py-3 border-b">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Star className="h-4 w-4" variant="stroke" />
+            {t("gabinet.loyalty.loyaltyProgram")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="px-6 py-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="text-center p-4 bg-muted/50 rounded-lg">
+              <p className="text-sm text-muted-foreground">
+                {t("gabinet.loyalty.pointsBalance")}
+              </p>
+              <p className="text-3xl font-bold text-primary">
+                {loyaltyBalance}
+              </p>
+            </div>
+            <div className="text-center p-4 bg-muted/50 rounded-lg">
+              <p className="text-sm text-muted-foreground">
+                {t("gabinet.loyalty.currentTier")}
+              </p>
+              <Badge variant="outline" className="text-lg mt-2">
+                {loyaltyTier
+                  ? t(`gabinet.loyalty.tiers.${loyaltyTier}`)
+                  : t("gabinet.loyalty.tiers.bronze")}
+              </Badge>
+            </div>
+          </div>
+          {loyaltyTransactions && loyaltyTransactions.length > 0 && (
+            <div className="mt-4">
+              <h4 className="text-sm font-medium mb-2">
+                {t("gabinet.loyalty.recentTransactions")}
+              </h4>
+              <div className="space-y-2">
+                {loyaltyTransactions
+                  .slice(0, 5)
+                  .map((tx) => (
+                    <div
+                      key={tx._id as string}
+                      className="flex items-center justify-between p-2 border rounded"
+                    >
+                      <div>
+                        <p className="text-sm">
+                          {t(`gabinet.loyalty.txTypes.${tx.type}`)}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {new Date(tx.createdAt as number).toLocaleDateString(
+                            "pl-PL",
+                          )}
+                        </p>
+                      </div>
+                      <span
+                        className={
+                          (tx.points as number) > 0
+                            ? "text-green-600 font-medium"
+                            : "text-destructive font-medium"
+                        }
+                      >
+                        {(tx.points as number) > 0 ? "+" : ""}
+                        {tx.points as number}
+                      </span>
+                    </div>
+                  ))}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Payment History */}
+      <Card>
+        <CardHeader className="px-6 py-3 border-b">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <CreditCard className="h-4 w-4" variant="stroke" />
+            {t("gabinet.payments.paymentHistory")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="px-6 py-4">
+          {allPatientPayments && allPatientPayments.length > 0 ? (
+            <>
+              <div className="grid grid-cols-2 gap-4 mb-4">
+                <div className="text-center p-4 bg-green-50 dark:bg-green-950/20 rounded-lg">
+                  <p className="text-sm text-muted-foreground">
+                    {t("gabinet.payments.totalSpent")}
+                  </p>
+                  <p className="text-2xl font-bold text-green-600">
+                    {formatCurrencyPLN(
+                      allPatientPayments
+                        .filter((p) => p.status === "completed")
+                        .reduce(
+                          (sum, p) => sum + (p.amount as number),
+                          0,
+                        ),
+                    )}
+                  </p>
+                </div>
+                <div className="text-center p-4 bg-muted/50 rounded-lg">
+                  <p className="text-sm text-muted-foreground">
+                    {t("gabinet.payments.lastPayment")}
+                  </p>
+                  <p className="text-sm font-medium">
+                    {allPatientPayments[0]
+                      ? new Date(
+                          (allPatientPayments[0] as Record<string, unknown>)
+                            .createdAt as number,
+                        ).toLocaleDateString(language)
+                      : "-"}
+                  </p>
+                </div>
+              </div>
+              <div className="overflow-x-auto border rounded-lg">
+                <table className="w-full">
+                  <thead>
+                    <tr className="border-b bg-muted/50">
+                      <th className="text-left p-3 text-sm font-medium">
+                        {t("gabinet.payments.amount")}
+                      </th>
+                      <th className="text-left p-3 text-sm font-medium">
+                        {t("gabinet.payments.method")}
+                      </th>
+                      <th className="text-left p-3 text-sm font-medium">
+                        {t("common.date")}
+                      </th>
+                      <th className="text-left p-3 text-sm font-medium">
+                        {t("common.status")}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {allPatientPayments
+                      .slice(0, 10)
+                      .map((payment) => (
+                        <tr
+                          key={payment._id as string}
+                          className="border-b last:border-0 hover:bg-muted/30"
+                        >
+                          <td className="p-3 font-medium">
+                            {formatCurrencyPLN(
+                              payment.amount as number,
+                              (payment.currency as string) ?? "PLN",
+                            )}
+                          </td>
+                          <td className="p-3">
+                            <Badge variant="outline">
+                              {t(
+                                `gabinet.payments.methods.${payment.paymentMethod}`,
+                              )}
+                            </Badge>
+                          </td>
+                          <td className="p-3 text-sm text-muted-foreground">
+                            {new Date(
+                              payment.createdAt as number,
+                            ).toLocaleDateString(language)}
+                          </td>
+                          <td className="p-3">
+                            <Badge
+                              variant={
+                                payment.status === "completed"
+                                  ? "default"
+                                  : payment.status === "refunded"
+                                    ? "destructive"
+                                    : "secondary"
+                              }
+                            >
+                              {t(
+                                `gabinet.payments.status.${payment.status}`,
+                              )}
+                            </Badge>
+                          </td>
+                        </tr>
+                      ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          ) : (
+            <EmptyState
+              icon={CreditCard}
+              title={t("gabinet.payments.noPayments")}
+              description={t("gabinet.payments.noPaymentsDesc")}
+            />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/gabinet/appointments/appointment-payments-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-payments-tab.tsx
@@ -1,0 +1,350 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { CreditCard, DollarSign, Info, Package, Plus } from "@/lib/ez-icons";
+import { formatCurrencyPLN } from "@/lib/format-currency";
+import { EmptyState } from "@/components/layout/empty-state";
+
+type JunctionTreatment = {
+  id: string;
+  treatmentId: string;
+  priceAtBooking?: number | null;
+};
+
+type PackageUsageEntry = {
+  _id: string;
+  packageName?: string | null;
+};
+
+export function AppointmentPaymentsTab({
+  appointment,
+  payments,
+  junctionTreatments,
+  treatmentPrice,
+  totalPaid,
+  outstanding,
+  linkedPackageUsage,
+  canCreatePayment,
+  canEditPayment,
+  canRefundPayment,
+  canGenerateReceipt,
+  generatingReceiptFor,
+  onAddPayment,
+  onMarkPaid,
+  onRefundPayment,
+  onDownloadReceipt,
+  language,
+  t,
+}: {
+  appointment: Record<string, unknown>;
+  payments: Record<string, unknown>[];
+  junctionTreatments: JunctionTreatment[];
+  treatmentPrice: number;
+  totalPaid: number;
+  outstanding: number;
+  linkedPackageUsage: PackageUsageEntry | null;
+  canCreatePayment: boolean;
+  canEditPayment: boolean;
+  canRefundPayment: boolean;
+  canGenerateReceipt: boolean;
+  generatingReceiptFor: string | null;
+  onAddPayment: () => void;
+  onMarkPaid: (paymentId: string) => void;
+  onRefundPayment: (paymentId: string) => void;
+  onDownloadReceipt: (paymentId: string) => void;
+  language: string;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  return (
+    <div className="space-y-4">
+      {/* Payment Summary Card */}
+      <Card>
+        <CardHeader className="px-6 py-3 border-b">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <DollarSign className="h-4 w-4" variant="stroke" />
+            {t("gabinet.payments.summary")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="px-6 py-4">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div className="text-center p-4 bg-muted/50 rounded-lg">
+              <p className="text-sm text-muted-foreground">
+                {t("gabinet.payments.treatmentPrice")}
+              </p>
+              <p className="text-2xl font-bold">
+                {formatCurrencyPLN(treatmentPrice)}
+              </p>
+            </div>
+            <div className="text-center p-4 bg-green-50 dark:bg-green-950/20 rounded-lg">
+              <p className="text-sm text-muted-foreground">
+                {t("gabinet.payments.totalPaid")}
+              </p>
+              <p className="text-2xl font-bold text-green-600">
+                {formatCurrencyPLN(totalPaid)}
+              </p>
+            </div>
+            <div
+              className={`text-center p-4 rounded-lg ${outstanding > 0 ? "bg-orange-50 dark:bg-orange-950/20" : "bg-muted/50"}`}
+            >
+              <p className="text-sm text-muted-foreground">
+                {t("gabinet.payments.outstanding")}
+              </p>
+              <p
+                className={`text-2xl font-bold ${outstanding > 0 ? "text-orange-600" : "text-green-600"}`}
+              >
+                {formatCurrencyPLN(outstanding)}
+              </p>
+            </div>
+          </div>
+          {(appointment.prepaymentRequired as boolean | undefined) &&
+            (appointment.prepaymentAmount as number | undefined) && (
+              <div className="mt-4 p-3 border rounded-lg bg-blue-50 dark:bg-blue-950/20">
+                <div className="flex items-center gap-2 text-blue-600">
+                  <Info className="h-4 w-4" variant="stroke" />
+                  <span className="font-medium">
+                    {t("gabinet.appointments.prepaymentRequired")}
+                  </span>
+                </div>
+                <p className="text-sm mt-1">
+                  {t("gabinet.appointments.prepaymentAmount")}:{" "}
+                  {formatCurrencyPLN(appointment.prepaymentAmount as number)}
+                </p>
+              </div>
+            )}
+        </CardContent>
+      </Card>
+
+      {/* Payments Table */}
+      <Card>
+        <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2 px-6 py-3 border-b">
+          <div>
+            <CardTitle className="text-sm flex items-center gap-2">
+              <CreditCard className="h-4 w-4" variant="stroke" />
+              {t("gabinet.payments.payments")}
+            </CardTitle>
+            <CardDescription className="text-xs">
+              {t("gabinet.payments.linkedToAppointment")}
+            </CardDescription>
+          </div>
+          {canCreatePayment && (
+            <Button size="sm" variant="outline" onClick={onAddPayment}>
+              <Plus className="mr-2 h-4 w-4" variant="stroke" />
+              {t("gabinet.payments.addPayment")}
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent className="px-6 py-4">
+          {payments.length === 0 ? (
+            <EmptyState
+              icon={CreditCard}
+              title={t("gabinet.payments.noPayments")}
+              description={t("gabinet.payments.noPaymentsDesc")}
+              action={
+                canCreatePayment ? (
+                  <Button onClick={onAddPayment}>
+                    <Plus className="mr-2 h-4 w-4" variant="stroke" />
+                    {t("gabinet.payments.addFirst")}
+                  </Button>
+                ) : undefined
+              }
+            />
+          ) : (
+            <div className="overflow-x-auto border rounded-lg">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b bg-muted/50">
+                    <th className="text-left p-3 text-sm font-medium">
+                      {t("gabinet.payments.amount")}
+                    </th>
+                    <th className="text-left p-3 text-sm font-medium">
+                      {t("gabinet.payments.method")}
+                    </th>
+                    <th className="text-left p-3 text-sm font-medium">
+                      {t("common.date")}
+                    </th>
+                    <th className="text-left p-3 text-sm font-medium">
+                      {t("common.status")}
+                    </th>
+                    <th className="text-right p-3 text-sm font-medium">
+                      {t("common.actions")}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {payments.map((payment) => {
+                    const creditEarned =
+                      (payment.creditEarned as number | null | undefined) ?? 0;
+                    const creditApplied =
+                      (payment.creditApplied as number | null | undefined) ?? 0;
+                    const isCreditRefund =
+                      (payment.kind as string | null | undefined) ===
+                      "credit_refund";
+                    const currency = (payment.currency as string) ?? "PLN";
+                    const creditBadges: Array<{
+                      key: string;
+                      label: string;
+                      className: string;
+                    }> = [];
+                    if (isCreditRefund) {
+                      creditBadges.push({
+                        key: "refund",
+                        label: t("gabinet.payments.credit.refund"),
+                        className:
+                          "border-red-200 bg-red-50 text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300",
+                      });
+                    } else {
+                      if (creditEarned > 0) {
+                        creditBadges.push({
+                          key: "earned",
+                          label: `${t("gabinet.payments.credit.earned")}: +${formatCurrencyPLN(creditEarned, currency)}`,
+                          className:
+                            "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-300",
+                        });
+                      }
+                      if (creditApplied > 0) {
+                        creditBadges.push({
+                          key: "applied",
+                          label: `${t("gabinet.payments.credit.applied")}: −${formatCurrencyPLN(creditApplied, currency)}`,
+                          className:
+                            "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-300",
+                        });
+                      }
+                    }
+                    return (
+                      <tr
+                        key={payment._id as string}
+                        className="border-b last:border-0 hover:bg-muted/30"
+                      >
+                        <td className="p-3">
+                          <p className="font-medium">
+                            {formatCurrencyPLN(
+                              payment.amount as number,
+                              currency,
+                            )}
+                          </p>
+                          {creditBadges.length > 0 && (
+                            <div className="mt-1 flex flex-wrap gap-1">
+                              {creditBadges.map((badge) => (
+                                <Badge
+                                  key={badge.key}
+                                  variant="outline"
+                                  className={`text-[10px] font-normal ${badge.className}`}
+                                >
+                                  {badge.label}
+                                </Badge>
+                              ))}
+                            </div>
+                          )}
+                        </td>
+                        <td className="p-3">
+                          <Badge variant="outline">
+                            {t(
+                              `gabinet.payments.methods.${payment.paymentMethod}`,
+                            )}
+                          </Badge>
+                        </td>
+                        <td className="p-3 text-sm text-muted-foreground">
+                          {new Date(
+                            payment.createdAt as number,
+                          ).toLocaleDateString(language)}
+                        </td>
+                        <td className="p-3">
+                          <Badge
+                            variant={
+                              payment.status === "completed"
+                                ? "default"
+                                : payment.status === "refunded"
+                                  ? "destructive"
+                                  : "secondary"
+                            }
+                          >
+                            {t(
+                              `gabinet.payments.status.${payment.status}`,
+                            )}
+                          </Badge>
+                        </td>
+                        <td className="p-3 text-right">
+                          {payment.status === "pending" && canEditPayment && (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() =>
+                                onMarkPaid(payment._id as string)
+                              }
+                            >
+                              {t("gabinet.payments.markPaid")}
+                            </Button>
+                          )}
+                          {payment.status === "completed" &&
+                            canRefundPayment && (
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                className="text-destructive"
+                                onClick={() =>
+                                  onRefundPayment(payment._id as string)
+                                }
+                              >
+                                {t("gabinet.payments.refund")}
+                              </Button>
+                            )}
+                          {payment.status === "completed" &&
+                            canGenerateReceipt && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={
+                                  generatingReceiptFor ===
+                                  (payment._id as string)
+                                }
+                                onClick={() =>
+                                  onDownloadReceipt(payment._id as string)
+                                }
+                              >
+                                {generatingReceiptFor ===
+                                (payment._id as string)
+                                  ? t("gabinet.receipts.generating")
+                                  : t("gabinet.receipts.download")}
+                              </Button>
+                            )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Package Usage Card (if applicable) */}
+      {(appointment.packageUsageId as string | undefined) && (
+        <Card>
+          <CardHeader className="px-6 py-3 border-b">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Package className="h-4 w-4" variant="stroke" />
+              {t("gabinet.packages.packageUsage")}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="px-6 py-4 space-y-1">
+            {linkedPackageUsage?.packageName && (
+              <p className="text-sm font-medium">
+                {linkedPackageUsage.packageName}
+              </p>
+            )}
+            <p className="text-sm text-muted-foreground">
+              {t("gabinet.packages.usedInThisAppointment")}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/gabinet/appointments/appointment-receipts-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-receipts-tab.tsx
@@ -1,0 +1,180 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { FileText } from "@/lib/ez-icons";
+import { formatCurrencyPLN } from "@/lib/format-currency";
+import { EmptyState } from "@/components/layout/empty-state";
+
+type Receipt = {
+  _id: string;
+  receiptNumber: string;
+  issuedAt: number;
+  totalGross?: number | null;
+  paymentMethod: string;
+  receiptType: string;
+  status: string;
+  pdfUrl?: string | null;
+};
+
+export function AppointmentReceiptsTab({
+  appointmentReceipts,
+  language,
+  t,
+}: {
+  appointmentReceipts: Receipt[];
+  language: string;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="px-6 py-3 border-b">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <FileText className="h-4 w-4" variant="stroke" />
+            {t("gabinet.receipts.receiptHistory", "Paragony")}
+          </CardTitle>
+          <CardDescription className="text-xs">
+            {t(
+              "gabinet.receipts.receiptHistoryDesc",
+              "Wszystkie paragony powiązane z tą wizytą",
+            )}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="px-6 py-4">
+          {appointmentReceipts.length === 0 ? (
+            <EmptyState
+              icon={FileText}
+              title={t("gabinet.receipts.noReceipts", "Brak paragonów")}
+              description={t(
+                "gabinet.receipts.noReceiptsDesc",
+                "Paragony pojawią się tutaj po dokonaniu płatności.",
+              )}
+            />
+          ) : (
+            <div className="overflow-x-auto border rounded-lg">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b bg-muted/50">
+                    <th className="text-left p-3 text-sm font-medium">
+                      {t("gabinet.receipts.receiptNumber", "Nr paragonu")}
+                    </th>
+                    <th className="text-left p-3 text-sm font-medium">
+                      {t("gabinet.receipts.issuedAt", "Data wystawienia")}
+                    </th>
+                    <th className="text-left p-3 text-sm font-medium">
+                      {t("gabinet.receipts.totalGross", "Kwota brutto")}
+                    </th>
+                    <th className="text-left p-3 text-sm font-medium">
+                      {t("gabinet.payments.method", "Metoda")}
+                    </th>
+                    <th className="text-left p-3 text-sm font-medium">
+                      {t("common.type", "Typ")}
+                    </th>
+                    <th className="text-left p-3 text-sm font-medium">
+                      {t("common.status", "Status")}
+                    </th>
+                    <th className="p-3" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {appointmentReceipts.map((receipt) => (
+                    <tr
+                      key={receipt._id}
+                      className="border-b last:border-0 hover:bg-muted/30"
+                    >
+                      <td className="p-3 font-mono text-sm font-medium">
+                        {receipt.receiptNumber}
+                      </td>
+                      <td className="p-3 text-sm text-muted-foreground">
+                        {new Date(receipt.issuedAt).toLocaleDateString(
+                          language,
+                        )}
+                      </td>
+                      <td className="p-3 font-medium">
+                        {receipt.totalGross != null
+                          ? formatCurrencyPLN(receipt.totalGross)
+                          : "—"}
+                      </td>
+                      <td className="p-3">
+                        <Badge variant="outline">
+                          {t(
+                            `gabinet.payments.methods.${receipt.paymentMethod.split("+")[0]}`,
+                            receipt.paymentMethod,
+                          )}
+                          {receipt.paymentMethod.includes("+") && (
+                            <span className="ml-1 text-muted-foreground">+</span>
+                          )}
+                        </Badge>
+                      </td>
+                      <td className="p-3">
+                        <Badge
+                          variant="outline"
+                          className={
+                            receipt.receiptType === "correction"
+                              ? "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-800 dark:bg-orange-950/40 dark:text-orange-400"
+                              : ""
+                          }
+                        >
+                          {receipt.receiptType === "correction"
+                            ? t(
+                                "gabinet.receipts.types.correction",
+                                "Korekta",
+                              )
+                            : t(
+                                "gabinet.receipts.types.original",
+                                "Oryginalny",
+                              )}
+                        </Badge>
+                      </td>
+                      <td className="p-3">
+                        <Badge
+                          variant={
+                            receipt.status === "void"
+                              ? "destructive"
+                              : "secondary"
+                          }
+                        >
+                          {receipt.status === "void"
+                            ? t(
+                                "gabinet.receipts.statuses.void",
+                                "Anulowany",
+                              )
+                            : t(
+                                "gabinet.receipts.statuses.issued",
+                                "Wystawiony",
+                              )}
+                        </Badge>
+                      </td>
+                      <td className="p-3 text-right">
+                        {receipt.pdfUrl && (
+                          <a
+                            href={receipt.pdfUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            <Button size="sm" variant="outline">
+                              {t(
+                                "gabinet.receipts.download",
+                                "Pobierz paragon",
+                              )}
+                            </Button>
+                          </a>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/gabinet/appointments/appointment-sidebar-extra.tsx
+++ b/src/components/gabinet/appointments/appointment-sidebar-extra.tsx
@@ -1,0 +1,289 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+} from "@/components/ui/item";
+import { TagsPicker } from "@/components/categories-tags/tags-picker";
+import {
+  Eye,
+  Mail,
+  MoreVerticalCircle02,
+  Phone,
+  RefreshCcw,
+  Star,
+} from "@/lib/ez-icons";
+import { formatPhoneNumber } from "@/lib/phone";
+import { Link } from "@tanstack/react-router";
+import { Id } from "@cvx/_generated/dataModel";
+
+type TagDefinition = { _id: Id<"tagDefinitions">; name: string; color?: string };
+
+type PatientData = {
+  _id: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  phone?: string | null;
+  email?: string | null;
+};
+
+type EmployeeData = {
+  _id?: string;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+};
+
+type TreatmentUsedEntry = {
+  treatmentId: string;
+  treatmentName?: string | null;
+  usedCount?: number;
+  totalCount?: number;
+};
+
+type PackageUsageEntry = {
+  _id: string;
+  packageName?: string | null;
+  status: string;
+  treatmentsUsed: TreatmentUsedEntry[];
+};
+
+export function AppointmentSidebarExtra({
+  patient,
+  employee,
+  relevantPkgs,
+  loyaltyBalance,
+  tagDefinitions,
+  tagIds,
+  isSavingTags,
+  canEdit,
+  onChangeEmployee,
+  onTagsChange,
+  t,
+}: {
+  patient: PatientData;
+  employee: EmployeeData | null | undefined;
+  relevantPkgs: PackageUsageEntry[];
+  loyaltyBalance: number;
+  tagDefinitions: TagDefinition[] | undefined;
+  tagIds: Id<"tagDefinitions">[];
+  isSavingTags: boolean;
+  canEdit: boolean;
+  onChangeEmployee: () => void;
+  onTagsChange: (newTagIds: Id<"tagDefinitions">[]) => void;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  const empName = employee ? (employee.name ?? employee.email ?? "-") : "-";
+
+  return (
+    <div className="space-y-3">
+      {/* Patient card */}
+      <Item variant="outline" size="sm" className="relative">
+        <ItemMedia>
+          <Avatar className="h-9 w-9 bg-purple-100 dark:bg-purple-900/50">
+            <AvatarFallback className="text-xs font-medium bg-purple-100 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300">
+              {patient.firstName && patient.lastName
+                ? `${patient.firstName[0]}${patient.lastName[0]}`
+                : "?"}
+            </AvatarFallback>
+          </Avatar>
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>
+            {patient.firstName} {patient.lastName}
+          </ItemTitle>
+          <ItemDescription className="text-xs">
+            {[
+              patient.phone ? formatPhoneNumber(patient.phone) : undefined,
+              patient.email,
+            ]
+              .filter(Boolean)
+              .join(" · ")}
+          </ItemDescription>
+          {loyaltyBalance > 0 && (
+            <Badge variant="outline" className="mt-0.5 w-fit text-[10px]">
+              <Star size={10} variant="stroke" className="mr-1" />
+              {loyaltyBalance} {t("gabinet.loyalty.points")}
+            </Badge>
+          )}
+        </ItemContent>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="absolute right-1 top-1 size-7"
+            >
+              <MoreVerticalCircle02 size={16} variant="stroke" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuItem asChild>
+              <Link
+                to="/dashboard/gabinet/patients/$patientId"
+                params={{ patientId: patient._id }}
+              >
+                <Eye size={14} variant="stroke" className="mr-2" />
+                {t("gabinet.patients.viewProfile", "Profil klienta")}
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            {patient.phone && (
+              <DropdownMenuItem asChild>
+                <a href={`tel:${patient.phone}`}>
+                  <Phone size={14} variant="stroke" className="mr-2" />
+                  {t("common.call", "Zadzwoń")}
+                </a>
+              </DropdownMenuItem>
+            )}
+            {patient.email && (
+              <DropdownMenuItem asChild>
+                <a href={`mailto:${patient.email}`}>
+                  <Mail size={14} variant="stroke" className="mr-2" />
+                  {t("common.sendEmail", "Wyślij e-mail")}
+                </a>
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </Item>
+
+      {/* Employee card */}
+      {employee && (
+        <Item variant="outline" size="sm" className="relative">
+          <ItemMedia>
+            <Avatar className="h-9 w-9 bg-cyan-100 dark:bg-cyan-900/50">
+              {employee.image && <AvatarImage src={employee.image} alt={empName} />}
+              <AvatarFallback className="text-xs font-medium bg-cyan-100 text-cyan-700 dark:bg-cyan-900/50 dark:text-cyan-300">
+                {empName
+                  .split(" ")
+                  .map((w: string) => w[0])
+                  .join("")
+                  .slice(0, 2)
+                  .toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+          </ItemMedia>
+          <ItemContent>
+            <ItemTitle>{empName}</ItemTitle>
+            <ItemDescription className="text-xs">
+              {employee.email ?? t("gabinet.employees.employee")}
+            </ItemDescription>
+          </ItemContent>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="absolute right-1 top-1 size-7"
+              >
+                <MoreVerticalCircle02 size={16} variant="stroke" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              {employee.email && (
+                <DropdownMenuItem asChild>
+                  <a href={`mailto:${employee.email}`}>
+                    <Mail size={14} variant="stroke" className="mr-2" />
+                    {t("common.sendEmail", "Wyślij e-mail")}
+                  </a>
+                </DropdownMenuItem>
+              )}
+              {canEdit && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={onChangeEmployee}>
+                    <RefreshCcw size={14} variant="stroke" className="mr-2" />
+                    {t("gabinet.appointments.changeEmployee", "Zmień pracownika")}
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </Item>
+      )}
+
+      {/* Packages */}
+      {relevantPkgs.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+            {t("gabinet.packages.activePackages", "Aktywne pakiety")}
+          </p>
+          {relevantPkgs.map((pkg) => (
+            <div
+              key={pkg._id}
+              className="rounded-md border p-2.5 space-y-1.5"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs font-medium truncate">{pkg.packageName}</p>
+                <Badge
+                  variant="outline"
+                  className={`text-[10px] shrink-0 ${pkg.status === "active" ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-400" : ""}`}
+                >
+                  {t(`gabinet.packages.status.${pkg.status}`)}
+                </Badge>
+              </div>
+              {pkg.treatmentsUsed.map((tu) => {
+                const used = tu.usedCount ?? 0;
+                const total = tu.totalCount ?? 0;
+                const remaining = Math.max(total - used, 0);
+                const pct = total > 0 ? Math.min((used / total) * 100, 100) : 0;
+                let barColor = "bg-emerald-500";
+                if (remaining <= 0) barColor = "bg-red-500";
+                else if (remaining / total < 0.3) barColor = "bg-amber-500";
+                return (
+                  <div key={tu.treatmentId} className="space-y-1">
+                    <div className="flex items-center justify-between text-[11px]">
+                      <span className="text-muted-foreground truncate">
+                        {tu.treatmentName ?? "-"}
+                      </span>
+                      <span className="tabular-nums text-muted-foreground shrink-0">
+                        {used} / {total}
+                      </span>
+                    </div>
+                    <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+                      <div
+                        className={`h-full rounded-full transition-all ${barColor}`}
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Tags */}
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+            {t("common.tags")}
+          </p>
+          {isSavingTags && (
+            <span className="text-[10px] text-muted-foreground">
+              {t("common.saving")}
+            </span>
+          )}
+        </div>
+        <TagsPicker
+          tags={tagDefinitions}
+          selectedIds={tagIds}
+          onChange={canEdit ? onTagsChange : () => {}}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/gabinet/appointments/cancel-appointment-dialog.tsx
+++ b/src/components/gabinet/appointments/cancel-appointment-dialog.tsx
@@ -1,0 +1,63 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
+
+export function CancelAppointmentDialog({
+  open,
+  onOpenChange,
+  cancelReason,
+  isUpdating,
+  onCancelReasonChange,
+  onConfirm,
+  t,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  cancelReason: string;
+  isUpdating: boolean;
+  onCancelReasonChange: (val: string) => void;
+  onConfirm: () => void;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("gabinet.appointments.cancelTitle")}</DialogTitle>
+          <DialogDescription>
+            {t("gabinet.appointments.cancelDesc")}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4">
+          <RichTextEditor
+            placeholder={t("gabinet.appointments.cancelReasonPlaceholder")}
+            value={cancelReason}
+            onChange={(val) => onCancelReasonChange(val ?? "")}
+            minHeight="80px"
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={isUpdating}
+          >
+            {isUpdating
+              ? t("common.processing")
+              : t("gabinet.appointments.actions.cancel")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/gabinet/appointments/package-usage-dialog.tsx
+++ b/src/components/gabinet/appointments/package-usage-dialog.tsx
@@ -1,0 +1,104 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+type UsageDialogItem = {
+  treatmentId: string;
+  variantId?: string;
+  treatmentName: string;
+  remaining: number;
+  qty: number;
+};
+
+export function PackageUsageDialog({
+  open,
+  onOpenChange,
+  usageDialogItems,
+  isUsageSubmitting,
+  onItemQtyChange,
+  onSubmit,
+  t,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  usageDialogItems: UsageDialogItem[];
+  isUsageSubmitting: boolean;
+  onItemQtyChange: (idx: number, val: number) => void;
+  onSubmit: () => void;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("gabinet.packages.useMultiple")}</DialogTitle>
+          <DialogDescription>
+            {t("gabinet.packages.useMultipleDesc")}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 py-2">
+          {usageDialogItems.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-4">
+              {t("gabinet.packages.allTreatmentsExhausted")}
+            </p>
+          ) : (
+            usageDialogItems.map((item, idx) => (
+              <div key={item.treatmentId} className="flex items-center gap-3">
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate">
+                    {item.treatmentName}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {t("gabinet.packages.availableRemaining", {
+                      remaining: item.remaining,
+                    })}
+                  </p>
+                </div>
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  className="w-20"
+                  min={0}
+                  max={item.remaining}
+                  value={item.qty}
+                  onChange={(e) => {
+                    const val = Math.max(
+                      0,
+                      Math.min(
+                        item.remaining,
+                        parseInt(e.target.value) || 0,
+                      ),
+                    );
+                    onItemQtyChange(idx, val);
+                  }}
+                />
+              </div>
+            ))
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            disabled={
+              isUsageSubmitting || usageDialogItems.every((it) => it.qty === 0)
+            }
+            onClick={onSubmit}
+          >
+            {isUsageSubmitting
+              ? t("common.saving")
+              : t("gabinet.packages.recordUsage")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/gabinet/appointments/payment-appointment-dialog.tsx
+++ b/src/components/gabinet/appointments/payment-appointment-dialog.tsx
@@ -1,0 +1,172 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { SettlementForm } from "@/components/gabinet/appointment-shared/settlement-form";
+import { formatCurrencyPLN } from "@/lib/format-currency";
+
+type JunctionTreatment = {
+  id: string;
+  treatmentId: string;
+  priceAtBooking?: number | null;
+};
+
+type TreatmentListItem = {
+  _id: string;
+  name: string;
+  duration: number;
+  price?: number;
+  currency?: string;
+};
+
+type PackageUsageEntry = {
+  _id: string;
+  packageName?: string | null;
+  status: string;
+  totalUsed: number;
+  totalCount: number;
+  treatmentsUsed: Array<{
+    treatmentId: string;
+    treatmentName?: string | null;
+    usedCount?: number;
+    totalCount?: number;
+  }>;
+};
+
+type SameDayAppointment = {
+  id: string;
+  startTime: string;
+  endTime: string;
+  treatmentNames: string[];
+  totalPrice: number;
+};
+
+export function PaymentAppointmentDialog({
+  open,
+  onOpenChange,
+  organizationId,
+  appointmentId,
+  patientId,
+  junctionTreatments,
+  legacyTreatmentPrice,
+  treatmentsList,
+  payments,
+  patientPackageUsage,
+  linkedPackageUsageId,
+  sameDayOtherAppointments,
+  selectedAdditionalIds,
+  availableTransitions,
+  onToggleAdditional,
+  onMarkCompleted,
+  onSuccess,
+  onCancel,
+  t,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationId: string;
+  appointmentId: string;
+  patientId: string;
+  junctionTreatments: JunctionTreatment[];
+  legacyTreatmentPrice: number | undefined;
+  treatmentsList: TreatmentListItem[] | undefined;
+  payments: Record<string, unknown>[];
+  patientPackageUsage: PackageUsageEntry[];
+  linkedPackageUsageId: string | null;
+  sameDayOtherAppointments: SameDayAppointment[] | undefined;
+  selectedAdditionalIds: Set<string>;
+  availableTransitions: string[];
+  onToggleAdditional: (id: string, checked: boolean) => void;
+  onMarkCompleted: () => Promise<void>;
+  onSuccess: () => void;
+  onCancel: () => void;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{t("gabinet.payments.addPayment")}</DialogTitle>
+          <DialogDescription>
+            {t("gabinet.payments.addPaymentDesc")}
+          </DialogDescription>
+        </DialogHeader>
+        {sameDayOtherAppointments && sameDayOtherAppointments.length > 0 && (
+          <div className="rounded-md border bg-muted/20 p-3 space-y-2 text-sm">
+            <p className="font-medium text-muted-foreground">
+              {t(
+                "gabinet.appointments.batchSettleTitle",
+                "Inne wizyty tego pacjenta w tym dniu — uwzględnij w rozliczeniu:",
+              )}
+            </p>
+            {sameDayOtherAppointments.map((appt) => (
+              <div key={appt.id} className="flex items-start gap-2">
+                <Checkbox
+                  id={`batch-detail-${appt.id}`}
+                  checked={selectedAdditionalIds.has(appt.id)}
+                  onCheckedChange={(checked) =>
+                    onToggleAdditional(appt.id, Boolean(checked))
+                  }
+                  className="mt-0.5"
+                />
+                <label
+                  htmlFor={`batch-detail-${appt.id}`}
+                  className="cursor-pointer leading-snug"
+                >
+                  <span className="font-medium">
+                    {appt.startTime.slice(0, 5)}–{appt.endTime.slice(0, 5)}
+                  </span>
+                  {appt.treatmentNames.length > 0 && (
+                    <span className="text-muted-foreground ml-1">
+                      · {appt.treatmentNames.join(", ")}
+                    </span>
+                  )}
+                  {appt.totalPrice > 0 && (
+                    <span className="text-muted-foreground ml-1">
+                      · {formatCurrencyPLN(appt.totalPrice)}
+                    </span>
+                  )}
+                </label>
+              </div>
+            ))}
+          </div>
+        )}
+        {open && (
+          <SettlementForm
+            organizationId={organizationId}
+            appointmentId={appointmentId}
+            patientId={patientId}
+            junctionTreatments={junctionTreatments}
+            legacyTreatmentPrice={legacyTreatmentPrice}
+            treatmentsList={treatmentsList}
+            payments={payments}
+            patientPackageUsage={patientPackageUsage}
+            linkedPackageUsageId={linkedPackageUsageId}
+            additionalAppointments={
+              (sameDayOtherAppointments ?? [])
+                .filter((a) => selectedAdditionalIds.has(a.id))
+                .map((a) => ({
+                  id: a.id,
+                  totalPrice: a.totalPrice,
+                  label: [
+                    `${a.startTime.slice(0, 5)}–${a.endTime.slice(0, 5)}`,
+                    ...(a.treatmentNames.length > 0
+                      ? [a.treatmentNames.join(", ")]
+                      : []),
+                  ].join(" · "),
+                }))
+            }
+            showMarkCompleted={availableTransitions.includes("completed")}
+            onMarkCompleted={onMarkCompleted}
+            onSuccess={onSuccess}
+            onCancel={onCancel}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -9,7 +9,6 @@ import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
-import { formatPhoneNumber } from "@/lib/phone";
 import { formatCurrencyPLN } from "@/lib/format-currency";
 import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
 import { useSupabaseGabinetEquipmentList } from "@/hooks/use-supabase-gabinet-equipment";
@@ -18,48 +17,7 @@ import { useSupabaseAutomationEntityRuns } from "@/hooks/use-supabase-automation
 import { useSupabaseGabinetReceiptsByAppointment } from "@/hooks/use-supabase-gabinet-receipts";
 
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import {
-  Item,
-  ItemContent,
-  ItemDescription,
-  ItemMedia,
-  ItemTitle,
-} from "@/components/ui/item";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { ChangeEmployeeModal } from "@/components/gabinet/change-employee-modal";
-import { DocumentationTab } from "@/components/gabinet/documentation-tab";
-import { TreatmentPicker } from "@/components/gabinet/appointment-shared/treatment-picker";
-import { SettlementForm } from "@/components/gabinet/appointment-shared/settlement-form";
-import {
-  RichTextEditor,
-  plateJsonToText,
-} from "@/components/gabinet/rich-text-editor";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import {
   Select,
   SelectContent,
@@ -71,8 +29,6 @@ import {
   type DetailField,
 } from "@/components/crm/entity-detail-layout";
 import { useSidebarSlot } from "@/components/layout/sidebar-slot-context";
-import { ActivityFeed } from "@/components/crm/activity-feed";
-import { activitiesToFeedEntries } from "@/components/crm/activity-feed-adapter";
 import { mergeTimelineSources } from "@/components/activity-timeline/merge-timeline-sources";
 import type {
   SmsEventEntry,
@@ -85,43 +41,25 @@ import {
 } from "@/components/documents/appointment-document-checklist";
 import { DocumentGateDialog } from "@/components/documents/document-gate-dialog";
 import { AfterCompletionDocumentsDialog } from "@/components/documents/after-completion-documents-dialog";
-import { EmptyState } from "@/components/layout/empty-state";
-import {
-  Calendar,
-  Mail,
-  Phone,
-  CreditCard,
-  Package,
-  History,
-  StickyNote,
-  Activity,
-  UserCircle,
-  DollarSign,
-  RefreshCcw,
-  Info,
-  Sparkles,
-  ShieldAlert,
-  CheckCircle,
-  Heart,
-  Plus,
-  Eye,
-  Star,
-  MoreVerticalCircle02,
-  MessageSquare,
-  Send,
-  Inbox,
-  Stethoscope,
-  FileText,
-} from "@/lib/ez-icons";
+import { Package, Send } from "@/lib/ez-icons";
 import { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
-import { Link } from "@tanstack/react-router";
 import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
-import { TagsPicker } from "@/components/categories-tags/tags-picker";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
+import { ChangeEmployeeModal } from "@/components/gabinet/change-employee-modal";
+import { DocumentationTab } from "@/components/gabinet/documentation-tab";
+
+import { AppointmentSidebarExtra } from "@/components/gabinet/appointments/appointment-sidebar-extra";
+import { AppointmentDetailsTab } from "@/components/gabinet/appointments/appointment-details-tab";
+import { AppointmentPaymentsTab } from "@/components/gabinet/appointments/appointment-payments-tab";
+import { AppointmentHistoryTab } from "@/components/gabinet/appointments/appointment-history-tab";
+import { AppointmentReceiptsTab } from "@/components/gabinet/appointments/appointment-receipts-tab";
+import { CancelAppointmentDialog } from "@/components/gabinet/appointments/cancel-appointment-dialog";
+import { PaymentAppointmentDialog } from "@/components/gabinet/appointments/payment-appointment-dialog";
+import { PackageUsageDialog } from "@/components/gabinet/appointments/package-usage-dialog";
 
 function AppointmentDetailSkeleton() {
   return (
@@ -271,8 +209,6 @@ function AppointmentDetail() {
 
   // Payment management state
   const [paymentDialogOpen, setPaymentDialogOpen] = useState(false);
-
-  // Body chart state
 
   // Package usage dialog state
   const [usageDialogOpen, setUsageDialogOpen] = useState(false);
@@ -594,239 +530,6 @@ function AppointmentDetail() {
       });
     }
     return fields;
-  })();
-
-  // Sidebar extra: patient card, employee card, packages
-  const sidebarExtra = (() => {
-    if (!detail) return null;
-    const {
-      appointment: _appt,
-      patient: pat,
-      treatment: _treat,
-      employee: emp,
-      patientPackageUsage: pkgUsage,
-      loyaltyBalance: loyBal,
-    } = detail;
-    const empName = emp ? (emp.name ?? emp.email ?? "-") : "-";
-    // Post-#3399 the appointment row has no scalar treatmentId — match
-    // package usage against every treatment of the visit (junction rows).
-    const apptTreatmentIds = new Set(
-      (detail.treatments ?? [])
-        .map((jt) => jt.treatmentId)
-        .filter((id): id is string => Boolean(id)),
-    );
-    const relevantPkgs = (pkgUsage ?? []).filter((pkg) =>
-      pkg.treatmentsUsed.some((tu) => apptTreatmentIds.has(tu.treatmentId)),
-    );
-
-    return (
-      <div className="space-y-3">
-        {/* Patient card */}
-        <Item variant="outline" size="sm" className="relative">
-          <ItemMedia>
-            <Avatar className="h-9 w-9 bg-purple-100 dark:bg-purple-900/50">
-              <AvatarFallback className="text-xs font-medium bg-purple-100 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300">
-                {pat?.firstName && pat?.lastName
-                  ? `${pat.firstName[0]}${pat.lastName[0]}`
-                  : "?"}
-              </AvatarFallback>
-            </Avatar>
-          </ItemMedia>
-          <ItemContent>
-            <ItemTitle>
-              {pat?.firstName} {pat?.lastName}
-            </ItemTitle>
-            <ItemDescription className="text-xs">
-              {[
-                pat?.phone ? formatPhoneNumber(pat.phone) : undefined,
-                pat?.email,
-              ]
-                .filter(Boolean)
-                .join(" · ")}
-            </ItemDescription>
-            {loyBal > 0 && (
-              <Badge variant="outline" className="mt-0.5 w-fit text-[10px]">
-                <Star size={10} variant="stroke" className="mr-1" />
-                {loyBal} {t("gabinet.loyalty.points")}
-              </Badge>
-            )}
-          </ItemContent>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="absolute right-1 top-1 size-7"
-              >
-                <MoreVerticalCircle02 size={16} variant="stroke" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-48">
-              <DropdownMenuItem asChild>
-                <Link
-                  to="/dashboard/gabinet/patients/$patientId"
-                  params={{ patientId: pat?._id ?? "" }}
-                >
-                  <Eye size={14} variant="stroke" className="mr-2" />
-                  {t("gabinet.patients.viewProfile", "Profil klienta")}
-                </Link>
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              {pat?.phone && (
-                <DropdownMenuItem asChild>
-                  <a href={`tel:${pat.phone}`}>
-                    <Phone size={14} variant="stroke" className="mr-2" />
-                    {t("common.call", "Zadzwoń")}
-                  </a>
-                </DropdownMenuItem>
-              )}
-              {pat?.email && (
-                <DropdownMenuItem asChild>
-                  <a href={`mailto:${pat.email}`}>
-                    <Mail size={14} variant="stroke" className="mr-2" />
-                    {t("common.sendEmail", "Wyślij e-mail")}
-                  </a>
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </Item>
-
-        {/* Employee card */}
-        {emp && (
-          <Item variant="outline" size="sm" className="relative">
-            <ItemMedia>
-              <Avatar className="h-9 w-9 bg-cyan-100 dark:bg-cyan-900/50">
-                {emp.image && <AvatarImage src={emp.image} alt={empName} />}
-                <AvatarFallback className="text-xs font-medium bg-cyan-100 text-cyan-700 dark:bg-cyan-900/50 dark:text-cyan-300">
-                  {empName
-                    .split(" ")
-                    .map((w: string) => w[0])
-                    .join("")
-                    .slice(0, 2)
-                    .toUpperCase()}
-                </AvatarFallback>
-              </Avatar>
-            </ItemMedia>
-            <ItemContent>
-              <ItemTitle>{empName}</ItemTitle>
-              <ItemDescription className="text-xs">
-                {emp.email ?? t("gabinet.employees.employee")}
-              </ItemDescription>
-            </ItemContent>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="absolute right-1 top-1 size-7"
-                >
-                  <MoreVerticalCircle02 size={16} variant="stroke" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
-                {emp.email && (
-                  <DropdownMenuItem asChild>
-                    <a href={`mailto:${emp.email}`}>
-                      <Mail size={14} variant="stroke" className="mr-2" />
-                      {t("common.sendEmail", "Wyślij e-mail")}
-                    </a>
-                  </DropdownMenuItem>
-                )}
-                {canEdit && (
-                  <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem onClick={() => setChangeEmployeeOpen(true)}>
-                      <RefreshCcw size={14} variant="stroke" className="mr-2" />
-                      {t("gabinet.appointments.changeEmployee", "Zmień pracownika")}
-                    </DropdownMenuItem>
-                  </>
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </Item>
-        )}
-
-        {/* Packages */}
-        {relevantPkgs.length > 0 && (
-          <div className="space-y-2">
-            <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
-              {t("gabinet.packages.activePackages", "Aktywne pakiety")}
-            </p>
-            {relevantPkgs.map((pkg) => {
-              const matchedTreatments = pkg.treatmentsUsed.filter((tu) =>
-                apptTreatmentIds.has(tu.treatmentId),
-              );
-              return (
-                <div
-                  key={pkg._id}
-                  className="rounded-md border p-2.5 space-y-1.5"
-                >
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="text-xs font-medium truncate">
-                      {pkg.packageName}
-                    </p>
-                    <Badge
-                      variant="outline"
-                      className={`text-[10px] shrink-0 ${pkg.status === "active" ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-400" : ""}`}
-                    >
-                      {t(`gabinet.packages.status.${pkg.status}`)}
-                    </Badge>
-                  </div>
-                  {matchedTreatments.map((tu) => {
-                    const used = tu.usedCount;
-                    const total = tu.totalCount;
-                    const remaining = Math.max(total - used, 0);
-                    const pct =
-                      total > 0 ? Math.min((used / total) * 100, 100) : 0;
-                    let barColor = "bg-emerald-500";
-                    if (remaining <= 0) barColor = "bg-red-500";
-                    else if (remaining / total < 0.3) barColor = "bg-amber-500";
-                    return (
-                      <div key={tu.treatmentId} className="space-y-1">
-                        <div className="flex items-center justify-between text-[11px]">
-                          <span className="text-muted-foreground truncate">
-                            {tu.treatmentName ?? "-"}
-                          </span>
-                          <span className="tabular-nums text-muted-foreground shrink-0">
-                            {used} / {total}
-                          </span>
-                        </div>
-                        <div className="h-1.5 bg-muted rounded-full overflow-hidden">
-                          <div
-                            className={`h-full rounded-full transition-all ${barColor}`}
-                            style={{ width: `${pct}%` }}
-                          />
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              );
-            })}
-          </div>
-        )}
-
-        {/* Tags */}
-        <div className="space-y-1.5">
-          <div className="flex items-center justify-between">
-            <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
-              {t("common.tags")}
-            </p>
-            {isSavingTags && (
-              <span className="text-[10px] text-muted-foreground">
-                {t("common.saving")}
-              </span>
-            )}
-          </div>
-          <TagsPicker
-            tags={tagDefinitions}
-            selectedIds={tagIds}
-            onChange={canEdit ? handleTagsChange : () => {}}
-          />
-        </div>
-      </div>
-    );
   })();
 
   if (!detail && !isLoading) {
@@ -1280,1166 +983,148 @@ function AppointmentDetail() {
       </span>
     );
 
+  // Sidebar extra: patient card, employee card, packages/loyalty/tags
+  const apptTreatmentIds = new Set(
+    (detail.treatments ?? [])
+      .map((jt) => jt.treatmentId)
+      .filter((id): id is string => Boolean(id)),
+  );
+  const relevantPkgs = (patientPackageUsage ?? []).filter((pkg) =>
+    pkg.treatmentsUsed.some((tu) => apptTreatmentIds.has(tu.treatmentId)),
+  );
+
+  const sidebarExtra = patient ? (
+    <AppointmentSidebarExtra
+      patient={patient}
+      employee={employee}
+      relevantPkgs={relevantPkgs}
+      loyaltyBalance={loyaltyBalance}
+      tagDefinitions={tagDefinitions}
+      tagIds={tagIds}
+      isSavingTags={isSavingTags}
+      canEdit={canEdit}
+      onChangeEmployee={() => setChangeEmployeeOpen(true)}
+      onTagsChange={handleTagsChange}
+      t={t}
+    />
+  ) : null;
+
   // Build tabs array
   const tabs = [
     {
       label: t("gabinet.appointments.tabs.details"),
       content: (
-        <div className="space-y-4">
-          {/* Treatment Info Card */}
-          <Card>
-            <CardHeader className="px-6 py-3 border-b">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <Sparkles className="h-4 w-4" variant="stroke" />
-                {t("gabinet.treatments.treatment")}
-              </CardTitle>
-            </CardHeader>
-            {detail.treatments.length > 1 ? (
-              /* Multi-treatment: one row per junction entry, totals at bottom */
-              <CardContent className="space-y-0 divide-y divide-border px-6 py-0">
-                {detail.treatments.map((jt) => {
-                  const tr = treatmentsList?.find(
-                    (t) => t._id === jt.treatmentId,
-                  );
-                  const name = tr?.name ?? treatment?.name ?? "-";
-                  const price = jt.priceAtBooking ?? tr?.price ?? null;
-                  return (
-                    <div
-                      key={jt.id}
-                      className="flex items-center justify-between py-3"
-                    >
-                      <div className="flex items-center gap-2">
-                        <Stethoscope className="h-4 w-4 shrink-0 text-primary" />
-                        <span className="text-sm font-medium">{name}</span>
-                      </div>
-                      {price != null && (
-                        <span className="text-sm text-muted-foreground">
-                          {formatCurrencyPLN(price)}
-                        </span>
-                      )}
-                    </div>
-                  );
-                })}
-                <div className="flex items-center justify-between py-3 font-semibold">
-                  <span className="text-sm">
-                    {t("gabinet.appointments.totalDuration", "Łącznie")} ·{" "}
-                    {calculateDuration()} min
-                  </span>
-                  <span className="text-sm">
-                    {formatCurrencyPLN(
-                      detail.treatments.reduce((sum, jt) => {
-                        const tr = treatmentsList?.find(
-                          (t) => t._id === jt.treatmentId,
-                        );
-                        return sum + (jt.priceAtBooking ?? tr?.price ?? 0);
-                      }, 0),
-                    )}
-                  </span>
-                </div>
-              </CardContent>
-            ) : (
-              /* Single / legacy treatment */
-              <CardContent className="space-y-3 px-6 py-4">
-                <div className="space-y-1.5">
-                  <Label className="text-xs uppercase tracking-wide text-muted-foreground">
-                    {t("common.name")}
-                  </Label>
-                  {canEdit ? (
-                    <TreatmentPicker
-                      treatments={treatmentsList}
-                      value={editTreatmentId}
-                      onSelect={(id) => {
-                        setEditTreatmentId(id);
-                        setTreatmentPickerOpen(false);
-                        setTreatmentSearch("");
-                        void handleSaveTreatment(id);
-                      }}
-                      open={treatmentPickerOpen}
-                      onOpenChange={setTreatmentPickerOpen}
-                      search={treatmentSearch}
-                      onSearchChange={setTreatmentSearch}
-                      formatPrice={(price, currency) =>
-                        formatCurrencyPLN(price ?? 0, currency ?? "PLN")
-                      }
-                      placeholder={t("gabinet.appointments.selectTreatment")}
-                      searchPlaceholder={t(
-                        "gabinet.appointments.searchTreatment",
-                      )}
-                      emptyText={t("common.noResults")}
-                      closeLabel={t("common.close")}
-                      selectedLabel={treatment?.name}
-                      triggerIcon={
-                        <Stethoscope className="size-4 shrink-0 text-primary" />
-                      }
-                      disabled={isSavingTreatment}
-                    />
-                  ) : (
-                    <span className="flex items-center gap-2 text-sm font-medium">
-                      <Stethoscope className="size-4 shrink-0 text-primary" />
-                      {treatment?.name ?? "-"}
-                    </span>
-                  )}
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">
-                    {t("gabinet.treatments.duration")}
-                  </span>
-                  <span className="font-medium">{calculateDuration()} min</span>
-                </div>
-                {treatment?.price !== undefined && (
-                  <div className="flex items-center justify-between">
-                    <span className="text-muted-foreground">
-                      {t("common.price")}
-                    </span>
-                    <span className="font-medium">
-                      {formatCurrencyPLN(
-                        treatment.price,
-                        treatment.currency ?? "PLN",
-                      )}
-                    </span>
-                  </div>
-                )}
-                {treatment?.description && (
-                  <div className="pt-2">
-                    <span className="text-sm text-muted-foreground">
-                      {t("common.description")}
-                    </span>
-                    <p className="text-sm mt-1">
-                      {plateJsonToText(treatment.description)}
-                    </p>
-                  </div>
-                )}
-                {treatment?.contraindications && (
-                  <div className="pt-2 p-3 bg-destructive/10 rounded-lg">
-                    <div className="flex items-center justify-between gap-2 mb-1">
-                      <div className="flex items-center gap-2 text-destructive">
-                        <ShieldAlert className="h-4 w-4" variant="stroke" />
-                        <span className="text-sm font-medium">
-                          {t("gabinet.treatments.contraindications")}
-                        </span>
-                      </div>
-                      {appointment.contraindicationAlertsReviewed ? (
-                        <div className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
-                          <CheckCircle
-                            className="h-3.5 w-3.5"
-                            variant="stroke"
-                          />
-                          <span>
-                            {t(
-                              "gabinet.appointmentDetail.contraindicationDiscussed",
-                              "Omówiono",
-                            )}
-                          </span>
-                        </div>
-                      ) : canEdit ? (
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="h-6 px-2 text-xs text-destructive hover:text-destructive"
-                          onClick={async () => {
-                            try {
-                              await updateAppointment({
-                                organizationId,
-                                appointmentId: appointment._id,
-                                contraindicationAlertsReviewed: true,
-                              });
-                              await refetch();
-                              toast.success(
-                                t(
-                                  "gabinet.appointmentDetail.contraindicationMarked",
-                                  "Oznaczono jako omówione",
-                                ),
-                              );
-                            } catch {
-                              toast.error(
-                                t("common.errorOccurred", "Wystąpił błąd"),
-                              );
-                            }
-                          }}
-                        >
-                          {t(
-                            "gabinet.appointmentDetail.markContraindicationAsDiscussed",
-                            "Oznacz jako omówione",
-                          )}
-                        </Button>
-                      ) : null}
-                    </div>
-                    <p className="text-sm">
-                      {plateJsonToText(treatment.contraindications)}
-                    </p>
-                  </div>
-                )}
-                {!!(treatment as Record<string, unknown>)?.aftercare && (
-                  <div className="pt-2 p-3 bg-primary/10 rounded-lg">
-                    <div className="flex items-center gap-2 text-primary mb-1">
-                      <Heart className="h-4 w-4" variant="stroke" />
-                      <span className="text-sm font-medium">
-                        {t("gabinet.treatments.aftercare")}
-                      </span>
-                    </div>
-                    <p className="text-sm">
-                      {plateJsonToText(
-                        (treatment as Record<string, unknown>)
-                          .aftercare as string,
-                      )}
-                    </p>
-                  </div>
-                )}
-              </CardContent>
-            )}
-          </Card>
-
-          {/* Employee Info Card */}
-          <Card>
-            <CardHeader className="px-6 py-3 border-b">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <UserCircle className="h-4 w-4" variant="stroke" />
-                {t("gabinet.employees.employee")}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="px-6 py-4">
-              <div className="flex items-center gap-4">
-                <Avatar className="h-12 w-12">
-                  <AvatarFallback>{getEmployeeInitials()}</AvatarFallback>
-                </Avatar>
-                <div>
-                  <p className="font-medium">{getEmployeeName()}</p>
-                  <p className="text-sm text-muted-foreground">
-                    {employee?.email}
-                  </p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* SMS Confirmation Card */}
-          <Card>
-            <CardHeader className="px-6 py-3 border-b">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <MessageSquare className="h-4 w-4" variant="stroke" />
-                {t("gabinet.appointmentDetail.sms.title")}
-              </CardTitle>
-              <CardDescription className="text-xs">
-                {t("gabinet.appointmentDetail.sms.description")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4 px-6 py-4">
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge variant={smsSummary.tone}>
-                  {t(smsSummary.labelKey)}
-                </Badge>
-                <Badge
-                  variant="outline"
-                  className={appointmentStatusBadgeClass(appointment.status)}
-                >
-                  {t(`gabinet.appointments.statuses.${appointment.status}`)}
-                </Badge>
-              </div>
-
-              <div className="grid gap-4 lg:grid-cols-2">
-                <div className="rounded-lg border p-3 space-y-2">
-                  <div className="flex items-center gap-2 text-sm font-medium">
-                    <Send className="h-4 w-4" variant="stroke" />
-                    {t("gabinet.appointmentDetail.sms.lastOutbound")}
-                  </div>
-                  {latestOutboundSms ? (
-                    <>
-                      <p className="text-sm">
-                        {
-                          (latestOutboundSms as Record<string, unknown>)
-                            .rawBody as string
-                        }
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {t("gabinet.appointmentDetail.sms.processingStatus")}:{" "}
-                        {t(
-                          `gabinet.appointmentDetail.sms.processingStatuses.${(latestOutboundSms as Record<string, unknown>).processingStatus}`,
-                        )}
-                      </p>
-                    </>
-                  ) : (
-                    <p className="text-sm text-muted-foreground">
-                      {t("gabinet.appointmentDetail.sms.noOutbound")}
-                    </p>
-                  )}
-                </div>
-
-                <div className="rounded-lg border p-3 space-y-2">
-                  <div className="flex items-center gap-2 text-sm font-medium">
-                    <Inbox className="h-4 w-4" variant="stroke" />
-                    {t("gabinet.appointmentDetail.sms.lastInbound")}
-                  </div>
-                  {latestInboundSms ? (
-                    <>
-                      <p className="text-sm">
-                        {
-                          (latestInboundSms as Record<string, unknown>)
-                            .rawBody as string
-                        }
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {t("gabinet.appointmentDetail.sms.parsedIntent")}:{" "}
-                        {t(
-                          `gabinet.appointmentDetail.sms.intents.${(latestInboundSms as Record<string, unknown>).parsedIntent ?? "unknown"}`,
-                        )}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {t("gabinet.appointmentDetail.sms.processingStatus")}:{" "}
-                        {t(
-                          `gabinet.appointmentDetail.sms.processingStatuses.${(latestInboundSms as Record<string, unknown>).processingStatus}`,
-                        )}
-                      </p>
-                      {(latestInboundSms as Record<string, unknown>)
-                        .processingError && (
-                        <p className="text-xs text-muted-foreground">
-                          {t("gabinet.appointmentDetail.sms.processingReason")}:{" "}
-                          {
-                            (latestInboundSms as Record<string, unknown>)
-                              .processingError as string
-                          }
-                        </p>
-                      )}
-                    </>
-                  ) : (
-                    <p className="text-sm text-muted-foreground">
-                      {t("gabinet.appointmentDetail.sms.noInbound")}
-                    </p>
-                  )}
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Prepayment Status Card */}
-          {appointment.prepaymentRequired && (
-            <Card>
-              <CardHeader className="px-6 py-3 border-b">
-                <CardTitle className="text-sm flex items-center gap-2">
-                  <DollarSign className="h-4 w-4" variant="stroke" />
-                  {t("gabinet.appointments.prepayment")}
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3 px-6 py-4">
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">
-                    {t("gabinet.appointments.prepaymentAmount")}
-                  </span>
-                  <span className="font-medium">
-                    {formatCurrencyPLN(appointment.prepaymentAmount ?? 0)}
-                  </span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">
-                    {t("common.status")}
-                  </span>
-                  <Badge variant="secondary">
-                    {t("gabinet.appointments.prepaymentPending")}
-                  </Badge>
-                </div>
-              </CardContent>
-            </Card>
-          )}
-
-          {/* Internal Notes Card */}
-          <Card>
-            <CardHeader className="px-6 py-3 border-b">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <StickyNote className="h-4 w-4" variant="stroke" />
-                {t("gabinet.appointments.internalNotes")}
-              </CardTitle>
-              <CardDescription className="text-xs">
-                {t("gabinet.appointments.internalNotesDesc")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 px-6 py-4">
-              <RichTextEditor
-                placeholder={t("gabinet.appointments.internalNotesPlaceholder")}
-                value={internalNotes}
-                onChange={(val) => setInternalNotes(val ?? "")}
-              />
-              {canEdit && (
-                <div className="flex justify-end">
-                  <Button
-                    size="sm"
-                    onClick={handleSaveInternalNotes}
-                    disabled={isSavingNotes}
-                  >
-                    {isSavingNotes ? t("common.saving") : t("common.save")}
-                  </Button>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </div>
+        <AppointmentDetailsTab
+          appointment={appointment}
+          treatment={treatment}
+          employee={employee}
+          junctionTreatments={junctionTreatments}
+          treatmentsList={treatmentsList}
+          smsSummary={smsSummary}
+          latestOutboundSms={latestOutboundSms as Record<string, unknown> | undefined}
+          latestInboundSms={latestInboundSms as Record<string, unknown> | undefined}
+          internalNotes={internalNotes}
+          isSavingNotes={isSavingNotes}
+          canEdit={canEdit}
+          isSavingTreatment={isSavingTreatment}
+          editTreatmentId={editTreatmentId}
+          treatmentPickerOpen={treatmentPickerOpen}
+          treatmentSearch={treatmentSearch}
+          onTreatmentPickerOpenChange={setTreatmentPickerOpen}
+          onTreatmentSearchChange={setTreatmentSearch}
+          onTreatmentSelect={(id) => {
+            setEditTreatmentId(id);
+            void handleSaveTreatment(id);
+          }}
+          onInternalNotesChange={setInternalNotes}
+          onSaveInternalNotes={handleSaveInternalNotes}
+          onMarkContraindicationReviewed={async () => {
+            try {
+              await updateAppointment({
+                organizationId,
+                appointmentId: appointment._id,
+                contraindicationAlertsReviewed: true,
+              });
+              await refetch();
+              toast.success(
+                t(
+                  "gabinet.appointmentDetail.contraindicationMarked",
+                  "Oznaczono jako omówione",
+                ),
+              );
+            } catch {
+              toast.error(t("common.errorOccurred", "Wystąpił błąd"));
+            }
+          }}
+          calculateDuration={calculateDuration}
+          getEmployeeName={getEmployeeName}
+          getEmployeeInitials={getEmployeeInitials}
+          language={i18n.language}
+          t={t}
+        />
       ),
     },
     {
       label: t("gabinet.payments.payments"),
       count: payments.length,
       content: (
-        <div className="space-y-4">
-          {/* Payment Summary Card */}
-          <Card>
-            <CardHeader className="px-6 py-3 border-b">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <DollarSign className="h-4 w-4" variant="stroke" />
-                {t("gabinet.payments.summary")}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="px-6 py-4">
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                <div className="text-center p-4 bg-muted/50 rounded-lg">
-                  <p className="text-sm text-muted-foreground">
-                    {t("gabinet.payments.treatmentPrice")}
-                  </p>
-                  <p className="text-2xl font-bold">
-                    {formatCurrencyPLN(treatmentPrice)}
-                  </p>
-                </div>
-                <div className="text-center p-4 bg-green-50 dark:bg-green-950/20 rounded-lg">
-                  <p className="text-sm text-muted-foreground">
-                    {t("gabinet.payments.totalPaid")}
-                  </p>
-                  <p className="text-2xl font-bold text-green-600">
-                    {formatCurrencyPLN(totalPaid)}
-                  </p>
-                </div>
-                <div
-                  className={`text-center p-4 rounded-lg ${outstanding > 0 ? "bg-orange-50 dark:bg-orange-950/20" : "bg-muted/50"}`}
-                >
-                  <p className="text-sm text-muted-foreground">
-                    {t("gabinet.payments.outstanding")}
-                  </p>
-                  <p
-                    className={`text-2xl font-bold ${outstanding > 0 ? "text-orange-600" : "text-green-600"}`}
-                  >
-                    {formatCurrencyPLN(outstanding)}
-                  </p>
-                </div>
-              </div>
-              {appointment.prepaymentRequired &&
-                appointment.prepaymentAmount && (
-                  <div className="mt-4 p-3 border rounded-lg bg-blue-50 dark:bg-blue-950/20">
-                    <div className="flex items-center gap-2 text-blue-600">
-                      <Info className="h-4 w-4" variant="stroke" />
-                      <span className="font-medium">
-                        {t("gabinet.appointments.prepaymentRequired")}
-                      </span>
-                    </div>
-                    <p className="text-sm mt-1">
-                      {t("gabinet.appointments.prepaymentAmount")}:{" "}
-                      {formatCurrencyPLN(appointment.prepaymentAmount)}
-                    </p>
-                  </div>
-                )}
-            </CardContent>
-          </Card>
-
-          {/* Payments Table */}
-          <Card>
-            <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2 px-6 py-3 border-b">
-              <div>
-                <CardTitle className="text-sm flex items-center gap-2">
-                  <CreditCard className="h-4 w-4" variant="stroke" />
-                  {t("gabinet.payments.payments")}
-                </CardTitle>
-                <CardDescription className="text-xs">
-                  {t("gabinet.payments.linkedToAppointment")}
-                </CardDescription>
-              </div>
-              {canCreatePayment && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => setPaymentDialogOpen(true)}
-                >
-                  <Plus className="mr-2 h-4 w-4" variant="stroke" />
-                  {t("gabinet.payments.addPayment")}
-                </Button>
-              )}
-            </CardHeader>
-            <CardContent className="px-6 py-4">
-              {payments.length === 0 ? (
-                <EmptyState
-                  icon={CreditCard}
-                  title={t("gabinet.payments.noPayments")}
-                  description={t("gabinet.payments.noPaymentsDesc")}
-                  action={
-                    canCreatePayment ? (
-                      <Button onClick={() => setPaymentDialogOpen(true)}>
-                        <Plus className="mr-2 h-4 w-4" variant="stroke" />
-                        {t("gabinet.payments.addFirst")}
-                      </Button>
-                    ) : undefined
-                  }
-                />
-              ) : (
-                <div className="overflow-x-auto border rounded-lg">
-                  <table className="w-full">
-                    <thead>
-                      <tr className="border-b bg-muted/50">
-                        <th className="text-left p-3 text-sm font-medium">
-                          {t("gabinet.payments.amount")}
-                        </th>
-                        <th className="text-left p-3 text-sm font-medium">
-                          {t("gabinet.payments.method")}
-                        </th>
-                        <th className="text-left p-3 text-sm font-medium">
-                          {t("common.date")}
-                        </th>
-                        <th className="text-left p-3 text-sm font-medium">
-                          {t("common.status")}
-                        </th>
-                        <th className="text-right p-3 text-sm font-medium">
-                          {t("common.actions")}
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {payments.map((payment: Record<string, unknown>) => {
-                        const creditEarned =
-                          (payment.creditEarned as number | null | undefined) ??
-                          0;
-                        const creditApplied =
-                          (payment.creditApplied as
-                            | number
-                            | null
-                            | undefined) ?? 0;
-                        const isCreditRefund =
-                          (payment.kind as string | null | undefined) ===
-                          "credit_refund";
-                        const currency = (payment.currency as string) ?? "PLN";
-                        const creditBadges: Array<{
-                          key: string;
-                          label: string;
-                          className: string;
-                        }> = [];
-                        if (isCreditRefund) {
-                          creditBadges.push({
-                            key: "refund",
-                            label: t("gabinet.payments.credit.refund"),
-                            className:
-                              "border-red-200 bg-red-50 text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300",
-                          });
-                        } else {
-                          if (creditEarned > 0) {
-                            creditBadges.push({
-                              key: "earned",
-                              label: `${t("gabinet.payments.credit.earned")}: +${formatCurrencyPLN(
-                                creditEarned,
-                                currency,
-                              )}`,
-                              className:
-                                "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-300",
-                            });
-                          }
-                          if (creditApplied > 0) {
-                            creditBadges.push({
-                              key: "applied",
-                              label: `${t("gabinet.payments.credit.applied")}: −${formatCurrencyPLN(
-                                creditApplied,
-                                currency,
-                              )}`,
-                              className:
-                                "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-300",
-                            });
-                          }
-                        }
-                        return (
-                          <tr
-                            key={payment._id as string}
-                            className="border-b last:border-0 hover:bg-muted/30"
-                          >
-                            <td className="p-3">
-                              <p className="font-medium">
-                                {formatCurrencyPLN(
-                                  payment.amount as number,
-                                  currency,
-                                )}
-                              </p>
-                              {creditBadges.length > 0 && (
-                                <div className="mt-1 flex flex-wrap gap-1">
-                                  {creditBadges.map((badge) => (
-                                    <Badge
-                                      key={badge.key}
-                                      variant="outline"
-                                      className={`text-[10px] font-normal ${badge.className}`}
-                                    >
-                                      {badge.label}
-                                    </Badge>
-                                  ))}
-                                </div>
-                              )}
-                            </td>
-                            <td className="p-3">
-                              <Badge variant="outline">
-                                {t(
-                                  `gabinet.payments.methods.${payment.paymentMethod}`,
-                                )}
-                              </Badge>
-                            </td>
-                            <td className="p-3 text-sm text-muted-foreground">
-                              {new Date(
-                                payment.createdAt as number,
-                              ).toLocaleDateString(i18n.language)}
-                            </td>
-                            <td className="p-3">
-                              <Badge
-                                variant={
-                                  payment.status === "completed"
-                                    ? "default"
-                                    : payment.status === "refunded"
-                                      ? "destructive"
-                                      : "secondary"
-                                }
-                              >
-                                {t(`gabinet.payments.status.${payment.status}`)}
-                              </Badge>
-                            </td>
-                            <td className="p-3 text-right">
-                              {payment.status === "pending" && canEditPayment && (
-                                <Button
-                                  size="sm"
-                                  variant="outline"
-                                  onClick={() =>
-                                    handleMarkPaid(payment._id as string)
-                                  }
-                                >
-                                  {t("gabinet.payments.markPaid")}
-                                </Button>
-                              )}
-                              {payment.status === "completed" && canRefundPayment && (
-                                <Button
-                                  size="sm"
-                                  variant="ghost"
-                                  className="text-destructive"
-                                  onClick={() =>
-                                    handleRefundPayment(payment._id as string)
-                                  }
-                                >
-                                  {t("gabinet.payments.refund")}
-                                </Button>
-                              )}
-                              {payment.status === "completed" && canGenerateReceipt && (
-                                <Button
-                                  size="sm"
-                                  variant="outline"
-                                  disabled={generatingReceiptFor === (payment._id as string)}
-                                  onClick={() =>
-                                    handleDownloadReceipt(payment._id as string)
-                                  }
-                                >
-                                  {generatingReceiptFor === (payment._id as string)
-                                    ? t("gabinet.receipts.generating")
-                                    : t("gabinet.receipts.download")}
-                                </Button>
-                              )}
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Package Usage Card (if applicable) */}
-          {appointment.packageUsageId && (
-            <Card>
-              <CardHeader className="px-6 py-3 border-b">
-                <CardTitle className="text-sm flex items-center gap-2">
-                  <Package className="h-4 w-4" variant="stroke" />
-                  {t("gabinet.packages.packageUsage")}
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="px-6 py-4 space-y-1">
-                {linkedPackageUsage?.packageName && (
-                  <p className="text-sm font-medium">
-                    {linkedPackageUsage.packageName}
-                  </p>
-                )}
-                <p className="text-sm text-muted-foreground">
-                  {t("gabinet.packages.usedInThisAppointment")}
-                </p>
-              </CardContent>
-            </Card>
-          )}
-        </div>
+        <AppointmentPaymentsTab
+          appointment={appointment}
+          payments={payments as Record<string, unknown>[]}
+          junctionTreatments={junctionTreatments}
+          treatmentPrice={treatmentPrice}
+          totalPaid={totalPaid}
+          outstanding={outstanding}
+          linkedPackageUsage={linkedPackageUsage}
+          canCreatePayment={canCreatePayment}
+          canEditPayment={canEditPayment}
+          canRefundPayment={canRefundPayment}
+          canGenerateReceipt={canGenerateReceipt}
+          generatingReceiptFor={generatingReceiptFor}
+          onAddPayment={() => setPaymentDialogOpen(true)}
+          onMarkPaid={handleMarkPaid}
+          onRefundPayment={handleRefundPayment}
+          onDownloadReceipt={handleDownloadReceipt}
+          language={i18n.language}
+          t={t}
+        />
       ),
     },
     {
       label: t("gabinet.patients.history"),
       content: (
-        <div className="space-y-4">
-          <Card>
-            <CardHeader className="px-6 py-3 border-b">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <Activity className="h-4 w-4" variant="stroke" />
-                {t("detail.tabs.timeline", "Timeline")}
-              </CardTitle>
-              <CardDescription className="text-xs">
-                {t(
-                  "gabinet.appointmentDetail.history.unifiedDescription",
-                  "Unified operational history for this appointment, including messages and workflow events.",
-                )}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="px-6 py-4">
-              <ActivityFeed
-                entries={activitiesToFeedEntries(mergedTimeline as any[], t)}
-                maxHeight="400px"
-              />
-            </CardContent>
-          </Card>
-
-          {/* Past Appointments Timeline */}
-          <Card>
-            <CardHeader className="px-6 py-3 border-b">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <History className="h-4 w-4" variant="stroke" />
-                {t("gabinet.patients.appointmentHistory")}
-              </CardTitle>
-              <CardDescription className="text-xs">
-                {t("gabinet.patients.lastAppointments", { count: 20 })}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="px-6 py-4">
-              {patientHistory.length === 0 ? (
-                <EmptyState
-                  icon={Calendar}
-                  title={t("gabinet.patients.noHistory")}
-                  description={t("gabinet.patients.noHistoryDesc")}
-                />
-              ) : (
-                <div className="relative">
-                  <div className="absolute left-3 top-0 bottom-0 w-px bg-border" />
-                  <div className="space-y-4">
-                    {patientHistory.map((appt, index) => (
-                      <div key={appt._id} className="relative flex gap-4">
-                        <div className="relative z-10 flex items-center justify-center w-6 h-6 rounded-full bg-background border-2">
-                          {index === 0 && (
-                            <div className="w-2 h-2 rounded-full bg-primary" />
-                          )}
-                        </div>
-                        <Link
-                          to="/dashboard/gabinet/appointments/$appointmentId"
-                          params={{ appointmentId: appt._id }}
-                          className="flex-1 flex items-center justify-between p-3 border rounded-lg hover:bg-muted/50 transition-colors"
-                        >
-                          <div>
-                            <p className="font-medium">
-                              {appt.treatment?.name ?? "-"}
-                            </p>
-                            <p className="text-sm text-muted-foreground">
-                              {formatDate(appt.date)} &bull;{" "}
-                              {formatTime(appt.startTime)} -{" "}
-                              {formatTime(appt.endTime)}
-                            </p>
-                          </div>
-                          <Badge
-                            variant="outline"
-                            className={appointmentStatusBadgeClass(appt.status)}
-                          >
-                            {t(`gabinet.appointments.statuses.${appt.status}`)}
-                          </Badge>
-                        </Link>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Active Packages */}
-          <Card>
-            <CardHeader className="px-6 py-3 border-b">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <Package className="h-4 w-4" variant="stroke" />
-                {t("gabinet.packages.activePackages")}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="px-6 py-4">
-              {patientPackageUsage.length === 0 ? (
-                <EmptyState
-                  icon={Package}
-                  title={t("gabinet.packages.noActivePackages")}
-                  description={t("gabinet.packages.noActivePackagesDesc")}
-                />
-              ) : (
-                <div className="space-y-3">
-                  {patientPackageUsage.map((pkg) => {
-                    const totals = {
-                      used: pkg.totalUsed,
-                      total: pkg.totalCount,
-                    };
-                    const progressPercent =
-                      totals.total > 0
-                        ? Math.min((totals.used / totals.total) * 100, 100)
-                        : 0;
-                    const overallRemainingRatio =
-                      totals.total > 0
-                        ? (totals.total - totals.used) / totals.total
-                        : 1;
-                    let overallBarColor = "bg-emerald-500";
-                    if (overallRemainingRatio <= 0)
-                      overallBarColor = "bg-red-500";
-                    else if (overallRemainingRatio < 0.1)
-                      overallBarColor = "bg-red-500";
-                    else if (overallRemainingRatio < 0.3)
-                      overallBarColor = "bg-amber-500";
-
-                    return (
-                      <div
-                        key={pkg._id}
-                        className="p-4 border rounded-lg space-y-3"
-                      >
-                        <div className="flex items-center justify-between">
-                          <p className="font-medium">
-                            {pkg.packageName ?? t("gabinet.packages.package")}
-                          </p>
-                          <div className="flex items-center gap-2">
-                            {pkg.status === "active" && canEdit && (
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => {
-                                  setUsageDialogPkgId(pkg._id);
-                                  setUsageDialogItems(
-                                    pkg.treatmentsUsed
-                                      .filter(
-                                        (e) =>
-                                          (e.usedCount ?? 0) <
-                                          (e.totalCount ?? 0),
-                                      )
-                                      .map((e) => ({
-                                        treatmentId: e.treatmentId,
-                                        variantId:
-                                          (e as any).variantId ?? undefined,
-                                        treatmentName:
-                                          e.treatmentName ??
-                                          t("gabinet.packages.treatment"),
-                                        remaining:
-                                          (e.totalCount ?? 0) -
-                                          (e.usedCount ?? 0),
-                                        qty: 0,
-                                      })),
-                                  );
-                                  setUsageDialogOpen(true);
-                                }}
-                              >
-                                <Plus
-                                  className="mr-1 h-3.5 w-3.5"
-                                  variant="stroke"
-                                />
-                                {t("gabinet.packages.useMultiple")}
-                              </Button>
-                            )}
-                            <Badge
-                              variant="outline"
-                              className={
-                                pkg.status === "active"
-                                  ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-400"
-                                  : ""
-                              }
-                            >
-                              {t(`gabinet.packages.status.${pkg.status}`)}
-                            </Badge>
-                          </div>
-                        </div>
-
-                        {/* Overall progress */}
-                        <div className="space-y-1">
-                          <div className="flex items-center justify-between text-sm">
-                            <span className="text-muted-foreground">
-                              {t("gabinet.packages.overallProgress")}
-                            </span>
-                            <span className="tabular-nums">
-                              {t("gabinet.packages.completionPercent", {
-                                percent: Math.round(progressPercent),
-                              })}
-                            </span>
-                          </div>
-                          <div className="h-2 bg-muted rounded-full overflow-hidden">
-                            <div
-                              className={`h-full transition-all rounded-full ${overallBarColor}`}
-                              style={{
-                                width: `${progressPercent}%`,
-                              }}
-                            />
-                          </div>
-                        </div>
-
-                        {/* Per-treatment progress bars */}
-                        {pkg.treatmentsUsed.length > 0 && (
-                          <div className="space-y-2">
-                            <p className="text-xs font-medium text-muted-foreground">
-                              {t("gabinet.packages.perTreatmentProgress")}
-                            </p>
-                            {pkg.treatmentsUsed.map((entry, index) => {
-                              const usedCount = entry.usedCount ?? 0;
-                              const totalCount = entry.totalCount ?? 0;
-                              const remaining = totalCount - usedCount;
-                              const pct =
-                                totalCount > 0
-                                  ? Math.round((usedCount / totalCount) * 100)
-                                  : 0;
-                              const remainingRatio =
-                                totalCount > 0 ? remaining / totalCount : 1;
-                              let barColor = "bg-emerald-500";
-                              let statusLabel = t(
-                                "gabinet.packages.plentyRemaining",
-                              );
-                              if (remainingRatio <= 0) {
-                                barColor = "bg-red-500";
-                                statusLabel = t("gabinet.packages.fullyUsed");
-                              } else if (remainingRatio < 0.1) {
-                                barColor = "bg-red-500";
-                                statusLabel = t(
-                                  "gabinet.packages.almostExhausted",
-                                );
-                              } else if (remainingRatio < 0.3) {
-                                barColor = "bg-amber-500";
-                                statusLabel = t("gabinet.packages.runningLow");
-                              }
-
-                              return (
-                                <div
-                                  key={`${pkg._id}-${entry.treatmentId ?? index}`}
-                                  className="space-y-1"
-                                >
-                                  <div className="flex items-center justify-between text-xs">
-                                    <span className="truncate max-w-[50%]">
-                                      {entry.treatmentName ??
-                                        t("gabinet.treatments.treatment")}
-                                    </span>
-                                    <span className="text-muted-foreground tabular-nums">
-                                      {usedCount} / {totalCount}
-                                      <span className="ml-1.5 text-[10px]">
-                                        ({statusLabel})
-                                      </span>
-                                    </span>
-                                  </div>
-                                  <div className="h-1.5 bg-muted rounded-full overflow-hidden">
-                                    <div
-                                      className={`h-full transition-all rounded-full ${barColor}`}
-                                      style={{ width: `${pct}%` }}
-                                    />
-                                  </div>
-                                </div>
-                              );
-                            })}
-                          </div>
-                        )}
-
-                        {!!pkg.expiresAt && (
-                          <p className="text-xs text-muted-foreground">
-                            {t("gabinet.packages.expires")}:{" "}
-                            {new Date(pkg.expiresAt).toLocaleDateString(
-                              i18n.language,
-                            )}
-                          </p>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Loyalty Summary */}
-          <Card>
-            <CardHeader className="px-6 py-3 border-b">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <Star className="h-4 w-4" variant="stroke" />
-                {t("gabinet.loyalty.loyaltyProgram")}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="px-6 py-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div className="text-center p-4 bg-muted/50 rounded-lg">
-                  <p className="text-sm text-muted-foreground">
-                    {t("gabinet.loyalty.pointsBalance")}
-                  </p>
-                  <p className="text-3xl font-bold text-primary">
-                    {loyaltyBalance}
-                  </p>
-                </div>
-                <div className="text-center p-4 bg-muted/50 rounded-lg">
-                  <p className="text-sm text-muted-foreground">
-                    {t("gabinet.loyalty.currentTier")}
-                  </p>
-                  <Badge variant="outline" className="text-lg mt-2">
-                    {loyaltyTier
-                      ? t(`gabinet.loyalty.tiers.${loyaltyTier}`)
-                      : t("gabinet.loyalty.tiers.bronze")}
-                  </Badge>
-                </div>
-              </div>
-              {loyaltyTransactions && loyaltyTransactions.length > 0 && (
-                <div className="mt-4">
-                  <h4 className="text-sm font-medium mb-2">
-                    {t("gabinet.loyalty.recentTransactions")}
-                  </h4>
-                  <div className="space-y-2">
-                    {loyaltyTransactions
-                      .slice(0, 5)
-                      .map((tx: Record<string, unknown>) => (
-                        <div
-                          key={tx._id as string}
-                          className="flex items-center justify-between p-2 border rounded"
-                        >
-                          <div>
-                            <p className="text-sm">
-                              {t(`gabinet.loyalty.txTypes.${tx.type}`)}
-                            </p>
-                            <p className="text-xs text-muted-foreground">
-                              {new Date(
-                                tx.createdAt as number,
-                              ).toLocaleDateString("pl-PL")}
-                            </p>
-                          </div>
-                          <span
-                            className={
-                              (tx.points as number) > 0
-                                ? "text-green-600 font-medium"
-                                : "text-destructive font-medium"
-                            }
-                          >
-                            {(tx.points as number) > 0 ? "+" : ""}
-                            {tx.points as number}
-                          </span>
-                        </div>
-                      ))}
-                  </div>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Payment History */}
-          <Card>
-            <CardHeader className="px-6 py-3 border-b">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <CreditCard className="h-4 w-4" variant="stroke" />
-                {t("gabinet.payments.paymentHistory")}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="px-6 py-4">
-              {allPatientPayments && allPatientPayments.length > 0 ? (
-                <>
-                  <div className="grid grid-cols-2 gap-4 mb-4">
-                    <div className="text-center p-4 bg-green-50 dark:bg-green-950/20 rounded-lg">
-                      <p className="text-sm text-muted-foreground">
-                        {t("gabinet.payments.totalSpent")}
-                      </p>
-                      <p className="text-2xl font-bold text-green-600">
-                        {formatCurrencyPLN(
-                          allPatientPayments
-                            .filter(
-                              (p: Record<string, unknown>) =>
-                                p.status === "completed",
-                            )
-                            .reduce(
-                              (sum: number, p: Record<string, unknown>) =>
-                                sum + (p.amount as number),
-                              0,
-                            ),
-                        )}
-                      </p>
-                    </div>
-                    <div className="text-center p-4 bg-muted/50 rounded-lg">
-                      <p className="text-sm text-muted-foreground">
-                        {t("gabinet.payments.lastPayment")}
-                      </p>
-                      <p className="text-sm font-medium">
-                        {allPatientPayments[0]
-                          ? new Date(
-                              (allPatientPayments[0] as Record<string, unknown>)
-                                .createdAt as number,
-                            ).toLocaleDateString(i18n.language)
-                          : "-"}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="overflow-x-auto border rounded-lg">
-                    <table className="w-full">
-                      <thead>
-                        <tr className="border-b bg-muted/50">
-                          <th className="text-left p-3 text-sm font-medium">
-                            {t("gabinet.payments.amount")}
-                          </th>
-                          <th className="text-left p-3 text-sm font-medium">
-                            {t("gabinet.payments.method")}
-                          </th>
-                          <th className="text-left p-3 text-sm font-medium">
-                            {t("common.date")}
-                          </th>
-                          <th className="text-left p-3 text-sm font-medium">
-                            {t("common.status")}
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {allPatientPayments
-                          .slice(0, 10)
-                          .map((payment: Record<string, unknown>) => (
-                            <tr
-                              key={payment._id as string}
-                              className="border-b last:border-0 hover:bg-muted/30"
-                            >
-                              <td className="p-3 font-medium">
-                                {formatCurrencyPLN(
-                                  payment.amount as number,
-                                  (payment.currency as string) ?? "PLN",
-                                )}
-                              </td>
-                              <td className="p-3">
-                                <Badge variant="outline">
-                                  {t(
-                                    `gabinet.payments.methods.${payment.paymentMethod}`,
-                                  )}
-                                </Badge>
-                              </td>
-                              <td className="p-3 text-sm text-muted-foreground">
-                                {new Date(
-                                  payment.createdAt as number,
-                                ).toLocaleDateString(i18n.language)}
-                              </td>
-                              <td className="p-3">
-                                <Badge
-                                  variant={
-                                    payment.status === "completed"
-                                      ? "default"
-                                      : payment.status === "refunded"
-                                        ? "destructive"
-                                        : "secondary"
-                                  }
-                                >
-                                  {t(
-                                    `gabinet.payments.status.${payment.status}`,
-                                  )}
-                                </Badge>
-                              </td>
-                            </tr>
-                          ))}
-                      </tbody>
-                    </table>
-                  </div>
-                </>
-              ) : (
-                <EmptyState
-                  icon={CreditCard}
-                  title={t("gabinet.payments.noPayments")}
-                  description={t("gabinet.payments.noPaymentsDesc")}
-                />
-              )}
-            </CardContent>
-          </Card>
-        </div>
+        <AppointmentHistoryTab
+          mergedTimeline={mergedTimeline}
+          patientHistory={patientHistory}
+          patientPackageUsage={patientPackageUsage}
+          loyaltyBalance={loyaltyBalance}
+          loyaltyTier={loyaltyTier as string | null | undefined}
+          loyaltyTransactions={loyaltyTransactions as Record<string, unknown>[] | null | undefined}
+          allPatientPayments={allPatientPayments as Record<string, unknown>[] | null | undefined}
+          canEdit={canEdit}
+          onUseMultiple={(pkg) => {
+            setUsageDialogPkgId(pkg._id);
+            setUsageDialogItems(
+              pkg.treatmentsUsed
+                .filter(
+                  (e) => (e.usedCount ?? 0) < (e.totalCount ?? 0),
+                )
+                .map((e) => ({
+                  treatmentId: e.treatmentId,
+                  variantId: (e as any).variantId ?? undefined,
+                  treatmentName:
+                    e.treatmentName ?? t("gabinet.packages.treatment"),
+                  remaining: (e.totalCount ?? 0) - (e.usedCount ?? 0),
+                  qty: 0,
+                })),
+            );
+            setUsageDialogOpen(true);
+          }}
+          formatDate={formatDate}
+          formatTime={formatTime}
+          language={i18n.language}
+          t={t}
+        />
       ),
     },
     {
@@ -2472,134 +1157,11 @@ function AppointmentDetail() {
       label: t("gabinet.receipts.receiptHistory", "Paragony"),
       count: appointmentReceipts.length > 0 ? appointmentReceipts.length : undefined,
       content: (
-        <div className="space-y-4">
-          <Card>
-            <CardHeader className="px-6 py-3 border-b">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <FileText className="h-4 w-4" variant="stroke" />
-                {t("gabinet.receipts.receiptHistory", "Paragony")}
-              </CardTitle>
-              <CardDescription className="text-xs">
-                {t("gabinet.receipts.receiptHistoryDesc", "Wszystkie paragony powiązane z tą wizytą")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="px-6 py-4">
-              {appointmentReceipts.length === 0 ? (
-                <EmptyState
-                  icon={FileText}
-                  title={t("gabinet.receipts.noReceipts", "Brak paragonów")}
-                  description={t(
-                    "gabinet.receipts.noReceiptsDesc",
-                    "Paragony pojawią się tutaj po dokonaniu płatności.",
-                  )}
-                />
-              ) : (
-                <div className="overflow-x-auto border rounded-lg">
-                  <table className="w-full">
-                    <thead>
-                      <tr className="border-b bg-muted/50">
-                        <th className="text-left p-3 text-sm font-medium">
-                          {t("gabinet.receipts.receiptNumber", "Nr paragonu")}
-                        </th>
-                        <th className="text-left p-3 text-sm font-medium">
-                          {t("gabinet.receipts.issuedAt", "Data wystawienia")}
-                        </th>
-                        <th className="text-left p-3 text-sm font-medium">
-                          {t("gabinet.receipts.totalGross", "Kwota brutto")}
-                        </th>
-                        <th className="text-left p-3 text-sm font-medium">
-                          {t("gabinet.payments.method", "Metoda")}
-                        </th>
-                        <th className="text-left p-3 text-sm font-medium">
-                          {t("common.type", "Typ")}
-                        </th>
-                        <th className="text-left p-3 text-sm font-medium">
-                          {t("common.status", "Status")}
-                        </th>
-                        <th className="p-3" />
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {appointmentReceipts.map((receipt) => (
-                        <tr
-                          key={receipt._id}
-                          className="border-b last:border-0 hover:bg-muted/30"
-                        >
-                          <td className="p-3 font-mono text-sm font-medium">
-                            {receipt.receiptNumber}
-                          </td>
-                          <td className="p-3 text-sm text-muted-foreground">
-                            {new Date(receipt.issuedAt).toLocaleDateString(
-                              i18n.language,
-                            )}
-                          </td>
-                          <td className="p-3 font-medium">
-                            {receipt.totalGross != null
-                              ? formatCurrencyPLN(receipt.totalGross)
-                              : "—"}
-                          </td>
-                          <td className="p-3">
-                            <Badge variant="outline">
-                              {t(
-                                `gabinet.payments.methods.${receipt.paymentMethod.split("+")[0]}`,
-                                receipt.paymentMethod,
-                              )}
-                              {receipt.paymentMethod.includes("+") && (
-                                <span className="ml-1 text-muted-foreground">
-                                  +
-                                </span>
-                              )}
-                            </Badge>
-                          </td>
-                          <td className="p-3">
-                            <Badge
-                              variant="outline"
-                              className={
-                                receipt.receiptType === "correction"
-                                  ? "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-800 dark:bg-orange-950/40 dark:text-orange-400"
-                                  : ""
-                              }
-                            >
-                              {receipt.receiptType === "correction"
-                                ? t("gabinet.receipts.types.correction", "Korekta")
-                                : t("gabinet.receipts.types.original", "Oryginalny")}
-                            </Badge>
-                          </td>
-                          <td className="p-3">
-                            <Badge
-                              variant={
-                                receipt.status === "void"
-                                  ? "destructive"
-                                  : "secondary"
-                              }
-                            >
-                              {receipt.status === "void"
-                                ? t("gabinet.receipts.statuses.void", "Anulowany")
-                                : t("gabinet.receipts.statuses.issued", "Wystawiony")}
-                            </Badge>
-                          </td>
-                          <td className="p-3 text-right">
-                            {receipt.pdfUrl && (
-                              <a
-                                href={receipt.pdfUrl}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                              >
-                                <Button size="sm" variant="outline">
-                                  {t("gabinet.receipts.download", "Pobierz paragon")}
-                                </Button>
-                              </a>
-                            )}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </div>
+        <AppointmentReceiptsTab
+          appointmentReceipts={appointmentReceipts}
+          language={i18n.language}
+          t={t}
+        />
       ),
     },
   ];
@@ -2670,41 +1232,15 @@ function AppointmentDetail() {
       )}
 
       {/* Cancel Dialog */}
-      <Dialog open={cancelDialogOpen} onOpenChange={setCancelDialogOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t("gabinet.appointments.cancelTitle")}</DialogTitle>
-            <DialogDescription>
-              {t("gabinet.appointments.cancelDesc")}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="py-4">
-            <RichTextEditor
-              placeholder={t("gabinet.appointments.cancelReasonPlaceholder")}
-              value={cancelReason}
-              onChange={(val) => setCancelReason(val ?? "")}
-              minHeight="80px"
-            />
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setCancelDialogOpen(false)}
-            >
-              {t("common.cancel")}
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleCancelConfirm}
-              disabled={isUpdating}
-            >
-              {isUpdating
-                ? t("common.processing")
-                : t("gabinet.appointments.actions.cancel")}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <CancelAppointmentDialog
+        open={cancelDialogOpen}
+        onOpenChange={setCancelDialogOpen}
+        cancelReason={cancelReason}
+        isUpdating={isUpdating}
+        onCancelReasonChange={setCancelReason}
+        onConfirm={handleCancelConfirm}
+        t={t}
+      />
 
       {/* Document Gate Dialog */}
       <DocumentGateDialog
@@ -2731,197 +1267,83 @@ function AppointmentDetail() {
       />
 
       {/* Payment Dialog */}
-      <Dialog open={paymentDialogOpen} onOpenChange={setPaymentDialogOpen}>
-        <DialogContent className="sm:max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>{t("gabinet.payments.addPayment")}</DialogTitle>
-            <DialogDescription>
-              {t("gabinet.payments.addPaymentDesc")}
-            </DialogDescription>
-          </DialogHeader>
-          {sameDayOtherAppointments && sameDayOtherAppointments.length > 0 && (
-            <div className="rounded-md border bg-muted/20 p-3 space-y-2 text-sm">
-              <p className="font-medium text-muted-foreground">
-                {t(
-                  "gabinet.appointments.batchSettleTitle",
-                  "Inne wizyty tego pacjenta w tym dniu — uwzględnij w rozliczeniu:",
-                )}
-              </p>
-              {sameDayOtherAppointments.map((appt) => (
-                <div key={appt.id} className="flex items-start gap-2">
-                  <Checkbox
-                    id={`batch-detail-${appt.id}`}
-                    checked={selectedAdditionalIds.has(appt.id)}
-                    onCheckedChange={(checked) =>
-                      toggleAdditional(appt.id, Boolean(checked))
-                    }
-                    className="mt-0.5"
-                  />
-                  <label
-                    htmlFor={`batch-detail-${appt.id}`}
-                    className="cursor-pointer leading-snug"
-                  >
-                    <span className="font-medium">
-                      {appt.startTime.slice(0, 5)}–{appt.endTime.slice(0, 5)}
-                    </span>
-                    {appt.treatmentNames.length > 0 && (
-                      <span className="text-muted-foreground ml-1">
-                        · {appt.treatmentNames.join(", ")}
-                      </span>
-                    )}
-                    {appt.totalPrice > 0 && (
-                      <span className="text-muted-foreground ml-1">
-                        · {formatCurrencyPLN(appt.totalPrice)}
-                      </span>
-                    )}
-                  </label>
-                </div>
-              ))}
-            </div>
-          )}
-          {paymentDialogOpen && (
-            <SettlementForm
-              organizationId={organizationId}
-              appointmentId={appointment._id}
-              patientId={patient!._id}
-              junctionTreatments={junctionTreatments}
-              legacyTreatmentPrice={treatment?.price}
-              treatmentsList={treatmentsList}
-              payments={payments as Array<Record<string, unknown>>}
-              patientPackageUsage={patientPackageUsage}
-              linkedPackageUsageId={appointment.packageUsageId ?? null}
-              additionalAppointments={
-                (sameDayOtherAppointments ?? [])
-                  .filter((a) => selectedAdditionalIds.has(a.id))
-                  .map((a) => ({
-                    id: a.id,
-                    totalPrice: a.totalPrice,
-                    label: [
-                      `${a.startTime.slice(0, 5)}–${a.endTime.slice(0, 5)}`,
-                      ...(a.treatmentNames.length > 0
-                        ? [a.treatmentNames.join(", ")]
-                        : []),
-                    ].join(" · "),
-                  }))
-              }
-              showMarkCompleted={availableTransitions.includes("completed")}
-              onMarkCompleted={async () => {
-                const result = await updateStatus({
-                  organizationId,
-                  appointmentId: appointment._id,
-                  status: "completed",
-                });
-                if (result?.warnings?.length) {
-                  toast.warning(t("gabinet.stock.negativeWarning"));
-                }
-                await invalidateAppointmentCaches();
-                setTimeout(() => setAfterCompletionDialogOpen(true), 500);
-              }}
-              onSuccess={() => {
-                setPaymentDialogOpen(false);
-                refetch();
-              }}
-              onCancel={() => setPaymentDialogOpen(false)}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
+      <PaymentAppointmentDialog
+        open={paymentDialogOpen}
+        onOpenChange={setPaymentDialogOpen}
+        organizationId={organizationId}
+        appointmentId={appointment._id}
+        patientId={patient!._id}
+        junctionTreatments={junctionTreatments}
+        legacyTreatmentPrice={treatment?.price}
+        treatmentsList={treatmentsList}
+        payments={payments as Array<Record<string, unknown>>}
+        patientPackageUsage={patientPackageUsage}
+        linkedPackageUsageId={appointment.packageUsageId ?? null}
+        sameDayOtherAppointments={sameDayOtherAppointments}
+        selectedAdditionalIds={selectedAdditionalIds}
+        availableTransitions={availableTransitions}
+        onToggleAdditional={toggleAdditional}
+        onMarkCompleted={async () => {
+          const result = await updateStatus({
+            organizationId,
+            appointmentId: appointment._id,
+            status: "completed",
+          });
+          if (result?.warnings?.length) {
+            toast.warning(t("gabinet.stock.negativeWarning"));
+          }
+          await invalidateAppointmentCaches();
+          setTimeout(() => setAfterCompletionDialogOpen(true), 500);
+        }}
+        onSuccess={() => {
+          setPaymentDialogOpen(false);
+          refetch();
+        }}
+        onCancel={() => setPaymentDialogOpen(false)}
+        t={t}
+      />
 
       {/* Multi-treatment package usage dialog */}
-      <Dialog open={usageDialogOpen} onOpenChange={setUsageDialogOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t("gabinet.packages.useMultiple")}</DialogTitle>
-            <DialogDescription>
-              {t("gabinet.packages.useMultipleDesc")}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-3 py-2">
-            {usageDialogItems.length === 0 ? (
-              <p className="text-sm text-muted-foreground text-center py-4">
-                {t("gabinet.packages.allTreatmentsExhausted")}
-              </p>
-            ) : (
-              usageDialogItems.map((item, idx) => (
-                <div key={item.treatmentId} className="flex items-center gap-3">
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium truncate">
-                      {item.treatmentName}
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      {t("gabinet.packages.availableRemaining", {
-                        remaining: item.remaining,
-                      })}
-                    </p>
-                  </div>
-                  <Input
-                    type="number"
-                    inputMode="numeric"
-                    className="w-20"
-                    min={0}
-                    max={item.remaining}
-                    value={item.qty}
-                    onChange={(e) => {
-                      const val = Math.max(
-                        0,
-                        Math.min(item.remaining, parseInt(e.target.value) || 0),
-                      );
-                      setUsageDialogItems((prev) =>
-                        prev.map((it, i) =>
-                          i === idx ? { ...it, qty: val } : it,
-                        ),
-                      );
-                    }}
-                  />
-                </div>
-              ))
-            )}
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setUsageDialogOpen(false)}>
-              {t("common.cancel")}
-            </Button>
-            <Button
-              disabled={
-                isUsageSubmitting ||
-                usageDialogItems.every((it) => it.qty === 0)
-              }
-              onClick={async () => {
-                if (!usageDialogPkgId) return;
-                const items = usageDialogItems
-                  .filter((it) => it.qty > 0)
-                  .map((it) => ({
-                    treatmentId: it.treatmentId,
-                    ...(it.variantId ? { variantId: it.variantId } : {}),
-                    quantity: it.qty,
-                  }));
-                if (items.length === 0) return;
-                setIsUsageSubmitting(true);
-                try {
-                  await usePackageTreatmentsBatch({
-                    organizationId,
-                    usageId: usageDialogPkgId,
-                    items,
-                    appointmentId,
-                  });
-                  toast.success(t("gabinet.packages.usageRecorded"));
-                  setUsageDialogOpen(false);
-                  refetch();
-                } catch (e) {
-                  const msg = e instanceof Error ? e.message : String(e);
-                  toast.error(msg);
-                } finally {
-                  setIsUsageSubmitting(false);
-                }
-              }}
-            >
-              {isUsageSubmitting
-                ? t("common.saving")
-                : t("gabinet.packages.recordUsage")}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <PackageUsageDialog
+        open={usageDialogOpen}
+        onOpenChange={setUsageDialogOpen}
+        usageDialogItems={usageDialogItems}
+        isUsageSubmitting={isUsageSubmitting}
+        onItemQtyChange={(idx, val) =>
+          setUsageDialogItems((prev) =>
+            prev.map((it, i) => (i === idx ? { ...it, qty: val } : it)),
+          )
+        }
+        onSubmit={async () => {
+          if (!usageDialogPkgId) return;
+          const items = usageDialogItems
+            .filter((it) => it.qty > 0)
+            .map((it) => ({
+              treatmentId: it.treatmentId,
+              ...(it.variantId ? { variantId: it.variantId } : {}),
+              quantity: it.qty,
+            }));
+          if (items.length === 0) return;
+          setIsUsageSubmitting(true);
+          try {
+            await usePackageTreatmentsBatch({
+              organizationId,
+              usageId: usageDialogPkgId,
+              items,
+              appointmentId,
+            });
+            toast.success(t("gabinet.packages.usageRecorded"));
+            setUsageDialogOpen(false);
+            refetch();
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            toast.error(msg);
+          } finally {
+            setIsUsageSubmitting(false);
+          }
+        }}
+        t={t}
+      />
     </>
   );
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4453.

Closes #4453

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 288704d refactor(gabinet): extract appointments.\$appointmentId route components (closes #4453)

### Files changed

```
 .../appointments/appointment-details-tab.tsx       |  457 +++++
 .../appointments/appointment-history-tab.tsx       |  517 +++++
 .../appointments/appointment-payments-tab.tsx      |  350 ++++
 .../appointments/appointment-receipts-tab.tsx      |  180 ++
 .../appointments/appointment-sidebar-extra.tsx     |  289 +++
 .../appointments/cancel-appointment-dialog.tsx     |   63 +
 .../gabinet/appointments/package-usage-dialog.tsx  |  104 +
 .../appointments/payment-appointment-dialog.tsx    |  172 ++
 ...ut.gabinet.appointments.$appointmentId.lazy.tsx | 2032 +++-----------------
 9 files changed, 2359 insertions(+), 1805 deletions(-)
```