### PR TITLE
Add backend test for `moveToStage` enforcing `lostReasonRequired`

### DIFF
--- a/tests/convex/orgSettingsEffect.test.ts
+++ b/tests/convex/orgSettingsEffect.test.ts
@@ -574,3 +574,115 @@ describe("lostReasonRequired: blocks leads.update to 'lost' status when no lostR
     ).resolves.toBeDefined();
   });
 });
+
+// =============================================================================
+// lostReasonRequired (via moveToStage)
+// =============================================================================
+
+describe("lostReasonRequired: blocks moveToStage to a lost pipeline stage when no lostReason provided", () => {
+  async function seedLeadAndLostStage(
+    organizationId: string,
+    userId: string,
+  ): Promise<{ leadId: string; lostStageId: string }> {
+    const db = createSupabaseDb();
+    const now = Date.now();
+    const leadId = await db.insert("leads", {
+      organizationId,
+      title: "Test Lead",
+      status: "open",
+      createdBy: userId,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const lostStageId = await db.insert("pipelineStages", {
+      organizationId,
+      name: "Lost",
+      isLostStage: true,
+      order: 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+    return { leadId, lostStageId };
+  }
+
+  test("lostReasonRequired=true blocks moveToStage to a lost stage without a reason", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    await seedSupabaseOrgSettings(String(organizationId), { lostReasonRequired: true });
+    const { leadId, lostStageId } = await seedLeadAndLostStage(
+      String(organizationId),
+      String(userId),
+    );
+
+    await expect(
+      t.withIdentity(identity).action(api.crm.leads.moveToStage, {
+        organizationId,
+        leadId,
+        pipelineStageId: lostStageId,
+        stageOrder: 0,
+      }),
+    ).rejects.toThrow("A lost reason is required");
+  });
+
+  test("lostReasonRequired=true allows moveToStage to a lost stage when lostReason is provided", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    await seedSupabaseOrgSettings(String(organizationId), { lostReasonRequired: true });
+    const { leadId, lostStageId } = await seedLeadAndLostStage(
+      String(organizationId),
+      String(userId),
+    );
+
+    await expect(
+      t.withIdentity(identity).action(api.crm.leads.moveToStage, {
+        organizationId,
+        leadId,
+        pipelineStageId: lostStageId,
+        stageOrder: 0,
+        lostReason: "Price too high",
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  test("lostReasonRequired=false allows moveToStage to a lost stage without a reason", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    await seedSupabaseOrgSettings(String(organizationId), { lostReasonRequired: false });
+    const { leadId, lostStageId } = await seedLeadAndLostStage(
+      String(organizationId),
+      String(userId),
+    );
+
+    await expect(
+      t.withIdentity(identity).action(api.crm.leads.moveToStage, {
+        organizationId,
+        leadId,
+        pipelineStageId: lostStageId,
+        stageOrder: 0,
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  test("lostReasonRequired defaults to not required (fail-open) when orgSettings not configured", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    // No orgSettings row — moveToStage to a lost stage should succeed without a reason
+    const { leadId, lostStageId } = await seedLeadAndLostStage(
+      String(organizationId),
+      String(userId),
+    );
+
+    await expect(
+      t.withIdentity(identity).action(api.crm.leads.moveToStage, {
+        organizationId,
+        leadId,
+        pipelineStageId: lostStageId,
+        stageOrder: 0,
+      }),
+    ).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4448.

Closes #4448

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 409035a test(crm): add orgSettingsEffect tests for moveToStage lostReasonRequired enforcement (closes #4448)

### Files changed

```
 tests/convex/orgSettingsEffect.test.ts | 112 +++++++++++++++++++++++++++++++++
 1 file changed, 112 insertions(+)
```