### PR TITLE
Extract `AccountTabContent` account inline JSX into its own tab shell in `accoun

### DIFF
--- a/src/components/gabinet/employees/account-tab-content.tsx
+++ b/src/components/gabinet/employees/account-tab-content.tsx
@@ -1,7 +1,11 @@
+import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { ChevronRight, Pencil, Power, Settings } from "@/lib/ez-icons";
 import type { MappedGabinetEmployee } from "@/lib/supabase/mappers/gabinet/employees";
 import type { TFunction } from "i18next";
+import { ChangePasswordDialog } from "./change-password-dialog";
+import { toast } from "sonner";
+import { formatActionError } from "@/lib/format-action-error";
 
 export function AccountTabContent({
   employee,
@@ -15,76 +19,137 @@ export function AccountTabContent({
   employee: MappedGabinetEmployee;
   userEmail?: string | null;
   role?: string | null;
-  onChangePassword: () => void;
+  onChangePassword: (newPassword: string) => Promise<void>;
   onEditEmployee: () => void;
   onDeactivate: () => void;
   t: TFunction;
 }) {
-  return (
-    <div className="space-y-6">
-      <div>
-        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
-          {t("gabinet.employees.tabs.account", "Konto")}
-        </p>
-        <div className="rounded-lg border divide-y">
-          <div className="flex items-center justify-between px-4 py-3">
-            <span className="text-sm text-muted-foreground">{t("gabinet.employees.loginEmail", "Adres e-mail do logowania")}</span>
-            <span className="text-sm font-medium">{employee.email || userEmail || "—"}</span>
-          </div>
-          <div className="flex items-center justify-between px-4 py-3">
-            <span className="text-sm text-muted-foreground">{t("gabinet.employees.accountStatus", "Status konta")}</span>
-            <Badge variant={employee.isActive ? "default" : "secondary"}>
-              {employee.isActive ? t("gabinet.employees.accountActive", "Aktywny") : t("gabinet.employees.accountInactive", "Nieaktywny")}
-            </Badge>
-          </div>
-        </div>
-      </div>
+  const [changePasswordOpen, setChangePasswordOpen] = useState(false);
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [changePasswordSubmitting, setChangePasswordSubmitting] = useState(false);
+  const [changePasswordError, setChangePasswordError] = useState<string | null>(null);
 
-      {(role === "admin" || role === "owner") && (
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      setNewPassword("");
+      setConfirmPassword("");
+      setChangePasswordError(null);
+    }
+    setChangePasswordOpen(open);
+  };
+
+  const validatePasswordForm = (): string | null => {
+    if (newPassword.length < 8) return t("gabinet.employees.passwordTooShort");
+    if (!/[A-Z]/.test(newPassword)) return t("gabinet.employees.passwordNeedsUppercase");
+    if (!/[0-9]/.test(newPassword)) return t("gabinet.employees.passwordNeedsDigit");
+    if (newPassword !== confirmPassword) return t("gabinet.employees.passwordMismatch");
+    return null;
+  };
+
+  const handleSubmitPasswordChange = async () => {
+    const validationError = validatePasswordForm();
+    if (validationError) {
+      setChangePasswordError(validationError);
+      return;
+    }
+    setChangePasswordSubmitting(true);
+    setChangePasswordError(null);
+    try {
+      await onChangePassword(newPassword);
+      toast.success(t("gabinet.employees.changePasswordSuccess"));
+      handleOpenChange(false);
+    } catch (e) {
+      setChangePasswordError(formatActionError(e, t, {
+        key: "gabinet.employees.errors.changePasswordFailed",
+        defaultValue: "Nie udało się zmienić hasła.",
+      }));
+    } finally {
+      setChangePasswordSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="space-y-6">
         <div>
           <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
-            {t("gabinet.employees.adminActions", "Akcje administracyjne")}
+            {t("gabinet.employees.tabs.account", "Konto")}
           </p>
           <div className="rounded-lg border divide-y">
-            <button
-              type="button"
-              className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
-              onClick={onChangePassword}
-            >
-              <Settings className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
-              <div className="flex-1 min-w-0">
-                <p className="text-sm">{t("gabinet.employees.changePassword")}</p>
-                <p className="text-xs text-muted-foreground">{t("gabinet.employees.changePasswordDesc", "Ustaw nowe hasło do logowania")}</p>
-              </div>
-              <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
-            </button>
-            <button
-              type="button"
-              className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
-              onClick={onEditEmployee}
-            >
-              <Pencil className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
-              <div className="flex-1 min-w-0">
-                <p className="text-sm">{t("gabinet.employees.editEmployee")}</p>
-                <p className="text-xs text-muted-foreground">{t("gabinet.employees.editEmployeeDesc", "Zmień dane i ustawienia pracownika")}</p>
-              </div>
-              <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
-            </button>
-            <button
-              type="button"
-              className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
-              onClick={onDeactivate}
-            >
-              <Power className="h-4 w-4 text-destructive shrink-0" variant="stroke" />
-              <div className="flex-1 min-w-0">
-                <p className="text-sm text-destructive">{t("gabinet.employees.deactivate")}</p>
-                <p className="text-xs text-muted-foreground">{t("gabinet.employees.deactivateDesc", "Wyłącz dostęp pracownika do systemu")}</p>
-              </div>
-              <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
-            </button>
+            <div className="flex items-center justify-between px-4 py-3">
+              <span className="text-sm text-muted-foreground">{t("gabinet.employees.loginEmail", "Adres e-mail do logowania")}</span>
+              <span className="text-sm font-medium">{employee.email || userEmail || "—"}</span>
+            </div>
+            <div className="flex items-center justify-between px-4 py-3">
+              <span className="text-sm text-muted-foreground">{t("gabinet.employees.accountStatus", "Status konta")}</span>
+              <Badge variant={employee.isActive ? "default" : "secondary"}>
+                {employee.isActive ? t("gabinet.employees.accountActive", "Aktywny") : t("gabinet.employees.accountInactive", "Nieaktywny")}
+              </Badge>
+            </div>
           </div>
         </div>
-      )}
-    </div>
+
+        {(role === "admin" || role === "owner") && (
+          <div>
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+              {t("gabinet.employees.adminActions", "Akcje administracyjne")}
+            </p>
+            <div className="rounded-lg border divide-y">
+              <button
+                type="button"
+                className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+                onClick={() => setChangePasswordOpen(true)}
+              >
+                <Settings className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm">{t("gabinet.employees.changePassword")}</p>
+                  <p className="text-xs text-muted-foreground">{t("gabinet.employees.changePasswordDesc", "Ustaw nowe hasło do logowania")}</p>
+                </div>
+                <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+              </button>
+              <button
+                type="button"
+                className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+                onClick={onEditEmployee}
+              >
+                <Pencil className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm">{t("gabinet.employees.editEmployee")}</p>
+                  <p className="text-xs text-muted-foreground">{t("gabinet.employees.editEmployeeDesc", "Zmień dane i ustawienia pracownika")}</p>
+                </div>
+                <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+              </button>
+              <button
+                type="button"
+                className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+                onClick={onDeactivate}
+              >
+                <Power className="h-4 w-4 text-destructive shrink-0" variant="stroke" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm text-destructive">{t("gabinet.employees.deactivate")}</p>
+                  <p className="text-xs text-muted-foreground">{t("gabinet.employees.deactivateDesc", "Wyłącz dostęp pracownika do systemu")}</p>
+                </div>
+                <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <ChangePasswordDialog
+        open={changePasswordOpen}
+        onOpenChange={handleOpenChange}
+        newPassword={newPassword}
+        setNewPassword={setNewPassword}
+        confirmPassword={confirmPassword}
+        setConfirmPassword={setConfirmPassword}
+        changePasswordError={changePasswordError}
+        setChangePasswordError={setChangePasswordError}
+        changePasswordSubmitting={changePasswordSubmitting}
+        onSubmit={handleSubmitPasswordChange}
+        t={t}
+      />
+    </>
   );
 }

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -48,7 +48,6 @@ import { DetailedDataTab } from "@/components/gabinet/employees/detailed-data-ta
 import { AssignedItemsTab } from "@/components/gabinet/employees/assigned-items-tab";
 import { EmployeePermissionsTab } from "@/components/gabinet/employees/employee-permissions-tab";
 import { AccountTabContent } from "@/components/gabinet/employees/account-tab-content";
-import { ChangePasswordDialog } from "@/components/gabinet/employees/change-password-dialog";
 
 function EmployeeDetailSkeleton() {
   return (
@@ -108,11 +107,6 @@ function EmployeeDetail() {
   const [activityDrawerOpen, setActivityDrawerOpen] = useState(false);
   const [selectedActivityId, setSelectedActivityId] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [changePasswordOpen, setChangePasswordOpen] = useState(false);
-  const [newPassword, setNewPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [changePasswordSubmitting, setChangePasswordSubmitting] = useState(false);
-  const [changePasswordError, setChangePasswordError] = useState<string | null>(null);
   const [newNote, setNewNote] = useState("");
   const [isAddingNote, setIsAddingNote] = useState(false);
 
@@ -364,42 +358,6 @@ function EmployeeDetail() {
     }
   };
 
-  const validatePasswordForm = (): string | null => {
-    if (newPassword.length < 8) return t("gabinet.employees.passwordTooShort");
-    if (!/[A-Z]/.test(newPassword)) return t("gabinet.employees.passwordNeedsUppercase");
-    if (!/[0-9]/.test(newPassword)) return t("gabinet.employees.passwordNeedsDigit");
-    if (newPassword !== confirmPassword) return t("gabinet.employees.passwordMismatch");
-    return null;
-  };
-
-  const handleChangePassword = async () => {
-    const validationError = validatePasswordForm();
-    if (validationError) {
-      setChangePasswordError(validationError);
-      return;
-    }
-    setChangePasswordSubmitting(true);
-    setChangePasswordError(null);
-    try {
-      await changeEmployeePassword({
-        organizationId,
-        employeeId,
-        newPassword,
-      });
-      toast.success(t("gabinet.employees.changePasswordSuccess"));
-      setChangePasswordOpen(false);
-      setNewPassword("");
-      setConfirmPassword("");
-    } catch (e) {
-      setChangePasswordError(formatActionError(e, t, {
-        key: "gabinet.employees.errors.changePasswordFailed",
-        defaultValue: "Nie udało się zmienić hasła.",
-      }));
-    } finally {
-      setChangePasswordSubmitting(false);
-    }
-  };
-
   const handleUpdateActivity = async (data: {
     activityId: string;
     title?: string;
@@ -564,12 +522,6 @@ function EmployeeDetail() {
           treatmentMap={treatmentMap}
           organizationId={organizationId}
           role={role}
-          onChangePassword={() => {
-            setNewPassword("");
-            setConfirmPassword("");
-            setChangePasswordError(null);
-            setChangePasswordOpen(true);
-          }}
           onUpdate={async (a) => { await updateEmployee(a); invalidateEmployeeCache(); }}
           onSetTreatments={async (a) => { await setQualifiedTreatments(a); invalidateEmployeeCache(); }}
           t={t}
@@ -606,12 +558,6 @@ function EmployeeDetail() {
           treatmentMap={treatmentMap}
           organizationId={organizationId}
           role={role}
-          onChangePassword={() => {
-            setNewPassword("");
-            setConfirmPassword("");
-            setChangePasswordError(null);
-            setChangePasswordOpen(true);
-          }}
           onUpdate={async (a) => { await updateEmployee(a); invalidateEmployeeCache(); }}
           onSetTreatments={async (a) => { await setQualifiedTreatments(a); invalidateEmployeeCache(); }}
           t={t}
@@ -678,11 +624,8 @@ function EmployeeDetail() {
           employee={employee}
           userEmail={user?.email}
           role={role}
-          onChangePassword={() => {
-            setNewPassword("");
-            setConfirmPassword("");
-            setChangePasswordError(null);
-            setChangePasswordOpen(true);
+          onChangePassword={async (newPassword) => {
+            await changeEmployeePassword({ organizationId, employeeId, newPassword });
           }}
           onEditEmployee={() => setEditDrawerOpen(true)}
           onDeactivate={handleDeactivate}
@@ -805,20 +748,6 @@ function EmployeeDetail() {
         isSubmitting={isSubmitting}
       />
 
-      {/* Change password dialog */}
-      <ChangePasswordDialog
-        open={changePasswordOpen}
-        onOpenChange={setChangePasswordOpen}
-        newPassword={newPassword}
-        setNewPassword={setNewPassword}
-        confirmPassword={confirmPassword}
-        setConfirmPassword={setConfirmPassword}
-        changePasswordError={changePasswordError}
-        setChangePasswordError={setChangePasswordError}
-        changePasswordSubmitting={changePasswordSubmitting}
-        onSubmit={handleChangePassword}
-        t={t}
-      />
     </>
   );
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4458.

Closes #4458

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 6cfa7e2 refactor(gabinet): co-locate ChangePasswordDialog state in AccountTabContent (closes #4458)

### Files changed

```
 .../gabinet/employees/account-tab-content.tsx      | 185 ++++++++++++++-------
 .../_layout.gabinet.employees.$employeeId.tsx      |  75 +--------
 2 files changed, 127 insertions(+), 133 deletions(-)
```