### PR TITLE
Show `prepaymentStatus` dynamically in `appointment-details-tab.tsx

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3345,6 +3345,7 @@
       "internalNotesPlaceholder": "Add description",
       "prepayment": "Prepayment",
       "prepaymentAmount": "Prepayment amount",
+      "prepaymentPaid": "Prepayment paid",
       "prepaymentPending": "Prepayment pending",
       "prepaymentRequired": "Prepayment required",
       "scheduling": "Scheduling",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3344,6 +3344,7 @@
       "internalNotesPlaceholder": "Dodaj opis",
       "prepayment": "Przedpłata",
       "prepaymentAmount": "Kwota przedpłaty",
+      "prepaymentPaid": "Przedpłata opłacona",
       "prepaymentPending": "Oczekuje na przedpłatę",
       "prepaymentRequired": "Wymagana przedpłata",
       "scheduling": "Harmonogram",

--- a/src/components/gabinet/appointments/appointment-details-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-details-tab.tsx
@@ -414,8 +414,16 @@ export function AppointmentDetailsTab({
               <span className="text-muted-foreground">
                 {t("common.status")}
               </span>
-              <Badge variant="secondary">
-                {t("gabinet.appointments.prepaymentPending")}
+              <Badge
+                variant={
+                  appointment.prepaymentStatus === "paid"
+                    ? "default"
+                    : "secondary"
+                }
+              >
+                {appointment.prepaymentStatus === "paid"
+                  ? t("gabinet.appointments.prepaymentPaid")
+                  : t("gabinet.appointments.prepaymentPending")}
               </Badge>
             </div>
           </CardContent>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4495.

Closes #4495

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f13fa48 fix(gabinet): show prepaymentStatus dynamically in appointment-details-tab (closes #4495)

### Files changed

```
 public/locales/en/translation.json                           |  1 +
 public/locales/pl/translation.json                           |  1 +
 .../gabinet/appointments/appointment-details-tab.tsx         | 12 ++++++++++--
 3 files changed, 12 insertions(+), 2 deletions(-)
```