### PR TITLE
Add `organizationId` filter to the employee locations query in `update`

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -366,6 +366,7 @@ export const _createFromInvitation = internalAction({
         try {
           const existingLocation = await db
             .query("gabinetEmployeeLocations")
+            .eq("organizationId", String(args.organizationId))
             .eq("employeeId", existingEmployeeId)
             .eq("locationId", locationId2)
             .collect();
@@ -744,6 +745,7 @@ export const update = action({
     // --- Upsert primary location ---
     if (locationId !== undefined) {
       const existingLocs = await db.query("gabinetEmployeeLocations")
+        .eq("organizationId", String(organizationId))
         .eq("employeeId", employeeId)
         .eq("isPrimary", true)
         .collect();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4473.

Closes #4473

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 44952e3 fix(gabinet): add organizationId filter to employee locations queries (closes #4473)

### Files changed

```
 convex/gabinet/employees.ts | 2 ++
 1 file changed, 2 insertions(+)
```