### PR TITLE
1/5 — Gabinet — sprawdź czas trwania wariantu w dostępności kalendarza

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1227,7 +1227,12 @@ function AppointmentDetail() {
           appointmentDate={detail.appointment.date}
           startTime={detail.appointment.startTime}
           endTime={detail.appointment.endTime}
-          durationMinutes={detail.treatment?.duration ?? 30}
+          durationMinutes={(() => {
+              const [sh, sm] = detail.appointment.startTime.split(":").map(Number);
+              const [eh, em] = detail.appointment.endTime.split(":").map(Number);
+              const computed = eh * 60 + em - (sh * 60 + sm);
+              return computed > 0 ? computed : (detail.treatment?.duration ?? 30);
+            })()}
         />
       )}
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4479.

Closes #4479

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 793a068 fix(gabinet): use actual appointment duration in change-employee modal (closes #4479)

### Files changed

```
 .../dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)
```