### PR TITLE
MappedGabinetEmployee types userId as non-nullable string but DB allows null

### DIFF
--- a/src/components/gabinet/employees/edit-employee-drawer.tsx
+++ b/src/components/gabinet/employees/edit-employee-drawer.tsx
@@ -68,7 +68,7 @@ export function EditEmployeeDrawer({
     enabled: isReady && !!client,
   });
 
-  const [userId, setUserId] = useState<string>(employee.userId);
+  const [userId, setUserId] = useState<string | undefined>(employee.userId);
   const [firstName, setFirstName] = useState(employee.firstName ?? "");
   const [lastName, setLastName] = useState(employee.lastName ?? "");
   const [role, setRole] = useState<GabinetEmployeeRole>(employee.role as GabinetEmployeeRole);

--- a/src/lib/supabase/mappers/gabinet/employees.ts
+++ b/src/lib/supabase/mappers/gabinet/employees.ts
@@ -9,7 +9,7 @@ export interface MappedGabinetEmployee {
   _id: string;
   _creationTime: number;
   organizationId: string;
-  userId: string;
+  userId?: string;
   firstName?: string;
   lastName?: string;
   role: string;

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -1317,7 +1317,7 @@ function GabinetCalendarPage() {
     // Hide employees flagged as not visible in the calendar (issue #1859).
     // Older rows without the column default to true at the DB level, so
     // anything strictly === false is the only thing to exclude.
-    const list = (employees ?? []).filter((e) => e.showInCalendar !== false);
+    const list = (employees ?? []).filter((e) => e.showInCalendar !== false && e.userId);
     return list.map((emp) => {
       const name = getEmployeeName(emp);
       const initials = getEmployeeInitials(name);

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -334,7 +334,7 @@ function EmployeeDetail() {
 
   // --- Derived data (used in both layout props and tab content) ---
 
-  const user = employee ? userMap.get(employee.userId) : undefined;
+  const user = employee?.userId ? userMap.get(employee.userId) : undefined;
   const fullName = employee
     ? (employee.firstName || employee.lastName
         ? `${employee.firstName ?? ""} ${employee.lastName ?? ""}`.trim()


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4508.

Closes #4508

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e9d75a9 fix(gabinet): type userId as optional in MappedGabinetEmployee (closes #4508)

### Files changed

```
 src/components/gabinet/employees/edit-employee-drawer.tsx               | 2 +-
 src/lib/supabase/mappers/gabinet/employees.ts                           | 2 +-
 src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx | 2 +-
 .../_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx      | 2 +-
 4 files changed, 4 insertions(+), 4 deletions(-)
```