### PR TITLE
Fix `employee.userId as Id<"users">` unsafe casts in employee detail page

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -567,10 +567,10 @@ function EmployeeDetail() {
     },
     {
       label: t("gabinet.employees.tabs.grafikPracy"),
-      content: (
+      content: employee.userId ? (
         <FlexibleScheduleEditor
           organizationId={organizationId}
-          userId={employee.userId as Id<"users">}
+          userId={employee.userId}
           periods={schedulePeriods}
           clinicHours={clinicHours ?? []}
           onSavePeriod={async (a) => { await saveSchedulePeriod(a); invalidateScheduleCache(); }}
@@ -578,6 +578,8 @@ function EmployeeDetail() {
           onSaveLegacy={async (a) => { await bulkSetEmployeeSchedule(a); invalidateScheduleCache(); }}
           onManageLeaves={() => navigate({ to: "/dashboard/gabinet/settings/leaves" })}
         />
+      ) : (
+        <p className="text-muted-foreground text-sm">{t("gabinet.employees.noUserAccount", "Pracownik nie ma powiązanego konta użytkownika.")}</p>
       ),
     },
     {
@@ -646,13 +648,15 @@ function EmployeeDetail() {
       ? [
           {
             label: t("gabinet.employees.tabs.permissions", "Uprawnienia"),
-            content: (
+            content: employee.userId ? (
               <EmployeePermissionsTab
                 organizationId={organizationId}
-                userId={employee.userId as Id<"users">}
+                userId={employee.userId}
                 gabinetRole={employee.role}
                 t={t}
               />
+            ) : (
+              <p className="text-muted-foreground text-sm">{t("gabinet.employees.noUserAccount", "Pracownik nie ma powiązanego konta użytkownika.")}</p>
             ),
           },
         ]


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4511.

Closes #4511

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f2a5752 fix(gabinet): guard FlexibleScheduleEditor and EmployeePermissionsTab against undefined userId (closes #4511)

### Files changed

```
 .../dashboard/_layout.gabinet.employees.$employeeId.tsx      | 12 ++++++++----
 1 file changed, 8 insertions(+), 4 deletions(-)
```