### PR TITLE
Fix remaining `as Id<"...">` casts in `_layout.gabinet.employees.$employeeId.tsx

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -32,7 +32,6 @@ import { ActivityFeed } from "@/components/crm/activity-feed";
 import { activitiesToFeedEntries } from "@/components/crm/activity-feed-adapter";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
-import { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
@@ -351,7 +350,7 @@ function EmployeeDetail() {
     if (window.confirm(t("gabinet.employees.confirmDeactivate"))) {
       await removeEmployee({
         organizationId,
-        employeeId: employeeId as Id<"gabinetEmployees">,
+        employeeId: employeeId,
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetEmployees.list(organizationId) });
       navigate({ to: "/dashboard/gabinet/employees" });
@@ -368,7 +367,7 @@ function EmployeeDetail() {
   }) => {
     await updateScheduledActivity({
       organizationId,
-      activityId: data.activityId as Id<"scheduledActivities">,
+      activityId: data.activityId,
       title: data.title,
       activityType: data.activityType,
       dueDate: data.dueDate,
@@ -380,7 +379,7 @@ function EmployeeDetail() {
   const handleDeleteActivity = async (activityId: string) => {
     await removeScheduledActivity({
       organizationId,
-      activityId: activityId as Id<"scheduledActivities">,
+      activityId: activityId,
     });
     setActivityDrawerOpen(false);
     setSelectedActivityId(null);
@@ -388,9 +387,9 @@ function EmployeeDetail() {
 
   const handleToggleActivityComplete = async (activityId: string, isCompleted: boolean) => {
     if (isCompleted) {
-      await markActivityComplete({ organizationId, activityId: activityId as Id<"scheduledActivities"> });
+      await markActivityComplete({ organizationId, activityId: activityId });
     } else {
-      await markActivityIncomplete({ organizationId, activityId: activityId as Id<"scheduledActivities"> });
+      await markActivityIncomplete({ organizationId, activityId: activityId });
     }
   };
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4514.

Closes #4514

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b70b98a fix(gabinet): remove unnecessary as Id<> casts in employee detail route (closes #4514)

### Files changed

```
 .../_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx | 11 +++++------
 1 file changed, 5 insertions(+), 6 deletions(-)
```