### PR TITLE
1/1 — Gabinet — napraw dodawanie nowego zabiegu z menu „Dodaj zabieg”

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx
@@ -537,6 +537,9 @@ function TreatmentsIndex() {
         setEditingTreatment(null);
         setTagIds([]);
         setCategoryId(undefined);
+        void queryClient.invalidateQueries({
+          queryKey: supabaseKeys.gabinetTreatments.list(organizationId),
+        });
 
         // Auto-create package from inline form data (create case only).
         if (isNewTreatment && inlinePackageData && savedTreatmentId) {
@@ -637,7 +640,7 @@ function TreatmentsIndex() {
         setIsSubmitting(false);
       }
     },
-    [editingTreatment, createTreatment, updateTreatment, setTreatmentProductsAction, createPackage, organizationId, tagIds, categoryId, t],
+    [editingTreatment, createTreatment, updateTreatment, setTreatmentProductsAction, createPackage, organizationId, tagIds, categoryId, t, queryClient],
   );
 
   const handleBulkAction = useCallback(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4475.

Closes #4475

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- afddfea fix(gabinet): invalidate treatments list cache after create/update (closes #4475)

### Files changed

```
 src/routes/_app/_auth/dashboard/_layout.gabinet.treatments.index.tsx | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)
```