### PR TITLE
1/2 — Gabinet — sprawdź edycję istniejącego zabiegu

### DIFF
--- a/src/components/gabinet/treatment-form.tsx
+++ b/src/components/gabinet/treatment-form.tsx
@@ -287,7 +287,7 @@ export function TreatmentForm({
       price: parseFloat(price.replace(",", ".")) || 0,
       currency: currency || undefined,
       taxRate: numericTaxRate,
-      taxExempt: isExempt ? true : undefined,
+      taxExempt: isExempt ? true : false,
       requiredEquipmentIds: selectedEquipmentIds.length > 0 ? selectedEquipmentIds : undefined,
       contraindications: initialData?.contraindications ?? null,
       preparationInstructions: initialData?.preparationInstructions ?? null,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4476.

Closes #4476

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b7b944b fix(gabinet): clear taxExempt flag when switching away from ZW rate (closes #4476)

### Files changed

```
 src/components/gabinet/treatment-form.tsx | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```