### PR TITLE
1/3 — Gabinet — sprawdź wybór wariantu zabiegu podczas umawiania wizyty

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -476,7 +476,7 @@ export function AppointmentPreviewContent({
     setNotes(appt.notes ?? "");
     setInternalNotes(appt.internalNotes ?? "");
     setTreatmentId(detail.treatments?.[0]?.treatmentId ?? "");
-    setVariantId("");
+    setVariantId(detail.treatments?.[0]?.variantId ?? "");
     setTagIds((appt.tagIds ?? []).map((id) => id as Id<"tagDefinitions">));
   }, [detail, appointmentId]);
 
@@ -496,7 +496,7 @@ export function AppointmentPreviewContent({
   const junctionTreatments = detail.treatments ?? [];
   const isMultiTreatment = junctionTreatments.length > 1;
   const initialTreatmentId = detail.treatments?.[0]?.treatmentId ?? "";
-  const initialVariantId = "";
+  const initialVariantId = detail.treatments?.[0]?.variantId ?? "";
   const allTransitions = VALID_TRANSITIONS[initialStatus] ?? [];
   const availableTransitions = canDelete
     ? allTransitions
@@ -721,7 +721,13 @@ export function AppointmentPreviewContent({
           args.internalNotes = internalNotes || null;
         if (treatmentId && treatmentId !== initialTreatmentId)
           args.treatmentId = treatmentId;
-        if (variantId !== initialVariantId) args.variantId = variantId || null;
+        if (variantId !== initialVariantId) {
+          args.variantId = variantId || null;
+          // The backend updates junction rows only when treatmentId is present in
+          // the args. Include it even when unchanged so a variant-only change is
+          // persisted to the junction row (not silently dropped).
+          if (!args.treatmentId && treatmentId) args.treatmentId = treatmentId;
+        }
         if (tagsDirty) args.tagIds = tagIds.map((id) => String(id));
 
         await updateAppointment(args);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4477.

Closes #4477

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b96527d fix(gabinet): restore selected treatment variant in appointment preview popup (closes #4477)

### Files changed

```
 .../gabinet/calendar/appointment-preview-content.tsx         | 12 +++++++++---
 1 file changed, 9 insertions(+), 3 deletions(-)
```