### PR TITLE
Pre-existing TS errors in appointment-details-tab.tsx and siblings

### DIFF
--- a/src/components/gabinet/appointments/appointment-details-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-details-tab.tsx
@@ -76,7 +76,6 @@ export function AppointmentDetailsTab({
   calculateDuration,
   getEmployeeName,
   getEmployeeInitials,
-  language,
   t,
 }: {
   appointment: Record<string, unknown>;
@@ -103,8 +102,7 @@ export function AppointmentDetailsTab({
   calculateDuration: () => number;
   getEmployeeName: () => string;
   getEmployeeInitials: () => string;
-  language: string;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <div className="space-y-4">

--- a/src/components/gabinet/appointments/appointment-history-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-history-tab.tsx
@@ -75,7 +75,7 @@ export function AppointmentHistoryTab({
   formatDate: (dateStr: string) => string;
   formatTime: (time: string) => string;
   language: string;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <div className="space-y-4">

--- a/src/components/gabinet/appointments/appointment-payments-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-payments-tab.tsx
@@ -11,12 +11,6 @@ import { CreditCard, DollarSign, Info, Package, Plus } from "@/lib/ez-icons";
 import { formatCurrencyPLN } from "@/lib/format-currency";
 import { EmptyState } from "@/components/layout/empty-state";
 
-type JunctionTreatment = {
-  id: string;
-  treatmentId: string;
-  priceAtBooking?: number | null;
-};
-
 type PackageUsageEntry = {
   _id: string;
   packageName?: string | null;
@@ -25,7 +19,6 @@ type PackageUsageEntry = {
 export function AppointmentPaymentsTab({
   appointment,
   payments,
-  junctionTreatments,
   treatmentPrice,
   totalPaid,
   outstanding,
@@ -44,7 +37,6 @@ export function AppointmentPaymentsTab({
 }: {
   appointment: Record<string, unknown>;
   payments: Record<string, unknown>[];
-  junctionTreatments: JunctionTreatment[];
   treatmentPrice: number;
   totalPaid: number;
   outstanding: number;
@@ -59,7 +51,7 @@ export function AppointmentPaymentsTab({
   onRefundPayment: (paymentId: string) => void;
   onDownloadReceipt: (paymentId: string) => void;
   language: string;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <div className="space-y-4">

--- a/src/components/gabinet/appointments/appointment-receipts-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-receipts-tab.tsx
@@ -29,7 +29,7 @@ export function AppointmentReceiptsTab({
 }: {
   appointmentReceipts: Receipt[];
   language: string;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <div className="space-y-4">

--- a/src/components/gabinet/appointments/appointment-sidebar-extra.tsx
+++ b/src/components/gabinet/appointments/appointment-sidebar-extra.tsx
@@ -82,7 +82,7 @@ export function AppointmentSidebarExtra({
   canEdit: boolean;
   onChangeEmployee: () => void;
   onTagsChange: (newTagIds: Id<"tagDefinitions">[]) => void;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   const empName = employee ? (employee.name ?? employee.email ?? "-") : "-";
 

--- a/src/components/gabinet/appointments/payment-appointment-dialog.tsx
+++ b/src/components/gabinet/appointments/payment-appointment-dialog.tsx
@@ -84,7 +84,7 @@ export function PaymentAppointmentDialog({
   onMarkCompleted: () => Promise<void>;
   onSuccess: () => void;
   onCancel: () => void;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1059,7 +1059,6 @@ function AppointmentDetail() {
           calculateDuration={calculateDuration}
           getEmployeeName={getEmployeeName}
           getEmployeeInitials={getEmployeeInitials}
-          language={i18n.language}
           t={t}
         />
       ),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4524.

Closes #4524

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 17a8789 fix(gabinet): resolve pre-existing TS6133/TS2345 errors in appointment components (closes #4524)

### Files changed

```
 .../gabinet/appointments/appointment-details-tab.tsx           |  4 +---
 .../gabinet/appointments/appointment-history-tab.tsx           |  2 +-
 .../gabinet/appointments/appointment-payments-tab.tsx          | 10 +---------
 .../gabinet/appointments/appointment-receipts-tab.tsx          |  2 +-
 .../gabinet/appointments/appointment-sidebar-extra.tsx         |  2 +-
 .../gabinet/appointments/payment-appointment-dialog.tsx        |  2 +-
 .../_layout.gabinet.appointments.$appointmentId.lazy.tsx       |  1 -
 7 files changed, 6 insertions(+), 17 deletions(-)
```