### PR TITLE
Fix `t` prop type across other gabinet components

### DIFF
--- a/src/components/gabinet/appointments/cancel-appointment-dialog.tsx
+++ b/src/components/gabinet/appointments/cancel-appointment-dialog.tsx
@@ -24,7 +24,7 @@ export function CancelAppointmentDialog({
   isUpdating: boolean;
   onCancelReasonChange: (val: string) => void;
   onConfirm: () => void;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/gabinet/appointments/package-usage-dialog.tsx
+++ b/src/components/gabinet/appointments/package-usage-dialog.tsx
@@ -32,7 +32,7 @@ export function PackageUsageDialog({
   isUsageSubmitting: boolean;
   onItemQtyChange: (idx: number, val: number) => void;
   onSubmit: () => void;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/gabinet/documentation-tab.tsx
+++ b/src/components/gabinet/documentation-tab.tsx
@@ -644,7 +644,7 @@ function PhotosSection({
   onRemove: (storageId: Id<"_storage">) => void;
   uploadFile: (file: File, type: "before" | "after") => void;
   uploadingFiles: UploadingFile[];
-  t: (key: string, fallback?: string) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   const orderedPhotos = useMemo(
     () => [...beforePhotos, ...afterPhotos],
@@ -744,7 +744,7 @@ function PhotoColumn({
   onPreview: (globalIndex: number) => void;
   uploadFile: (file: File, type: "before" | "after") => void;
   uploadingFiles: UploadingFile[];
-  t: (key: string, fallback?: string) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   const [isDragging, setIsDragging] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -949,7 +949,7 @@ function PhotoPreviewDialog({
   compareMode: boolean;
   onToggleCompare: (next: boolean) => void;
   onClose: () => void;
-  t: (key: string, fallback?: string) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   const open = index !== null;
   const photo = index !== null ? photos[index] : undefined;
@@ -1153,7 +1153,7 @@ function ComparePane({
   label: string;
   url: string | null | undefined;
   photo: Photo | undefined;
-  t: (key: string, fallback?: string) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <div className="flex flex-col gap-2">

--- a/src/components/gabinet/employees/appointments-tab-content.tsx
+++ b/src/components/gabinet/employees/appointments-tab-content.tsx
@@ -32,7 +32,7 @@ export function AppointmentsTabContent({
   setAppointmentsView: (v: "calendar" | "list") => void;
   treatmentMap: Map<string, string>;
   navigate: (opts: { to: string }) => void;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
   i18nLanguage: string;
 }) {
   return (

--- a/src/components/gabinet/employees/change-password-dialog.tsx
+++ b/src/components/gabinet/employees/change-password-dialog.tsx
@@ -33,7 +33,7 @@ export function ChangePasswordDialog({
   setChangePasswordError: (v: string | null) => void;
   changePasswordSubmitting: boolean;
   onSubmit: () => Promise<void>;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <Dialog

--- a/src/components/gabinet/employees/notes-tab-content.tsx
+++ b/src/components/gabinet/employees/notes-tab-content.tsx
@@ -18,7 +18,7 @@ export function NotesTabContent({
   isAddingNote: boolean;
   setIsAddingNote: (v: boolean) => void;
   handleAddNote: () => Promise<void>;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <div className="space-y-4">

--- a/src/components/gabinet/employees/patients-tab-content.tsx
+++ b/src/components/gabinet/employees/patients-tab-content.tsx
@@ -37,7 +37,7 @@ export function PatientsTabContent({
   setClientTreatmentFilter: (v: string) => void;
   treatments: Array<{ _id: string; name: string }> | undefined;
   navigate: (opts: { to: string }) => void;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
   i18nLanguage: string;
 }) {
   return (

--- a/src/components/gabinet/employees/upcoming-agenda.tsx
+++ b/src/components/gabinet/employees/upcoming-agenda.tsx
@@ -15,7 +15,7 @@ export function UpcomingAgenda({
   appointments: MappedGabinetAppointment[] | undefined;
   treatmentMap: Map<string, string>;
   navigate: (opts: { to: string }) => void;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
   i18nLanguage: string;
 }) {
   const today = new Date().toISOString().split("T")[0];

--- a/src/components/gabinet/patients/add-payment-dialog.tsx
+++ b/src/components/gabinet/patients/add-payment-dialog.tsx
@@ -68,7 +68,7 @@ export function AddPaymentDialog({
   patientPayments: Payment[] | undefined;
   getApptTreatmentDisplay: (apt?: MappedGabinetAppointment | null) => string | undefined;
   getApptPrice: (apt?: MappedGabinetAppointment | null) => number;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <Dialog

--- a/src/components/gabinet/patients/appointment-row.tsx
+++ b/src/components/gabinet/patients/appointment-row.tsx
@@ -16,7 +16,7 @@ export function AppointmentRow({
   treatmentDisplayName: string | undefined;
   onClick: () => void;
   isPast?: boolean;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <div

--- a/src/components/gabinet/patients/cancel-payment-dialog.tsx
+++ b/src/components/gabinet/patients/cancel-payment-dialog.tsx
@@ -25,7 +25,7 @@ export function CancelPaymentDialog({
   isCancelSubmitting: boolean;
   onClose: () => void;
   onSubmit: () => Promise<void>;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <Dialog

--- a/src/components/gabinet/patients/edit-payment-dialog.tsx
+++ b/src/components/gabinet/patients/edit-payment-dialog.tsx
@@ -55,7 +55,7 @@ export function EditPaymentDialog({
   onSubmit: () => Promise<void>;
   patientAppointments: MappedGabinetAppointment[] | undefined;
   getApptPrice: (apt?: MappedGabinetAppointment | null) => number;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <Dialog

--- a/src/components/gabinet/patients/gdpr-erase-dialog.tsx
+++ b/src/components/gabinet/patients/gdpr-erase-dialog.tsx
@@ -25,7 +25,7 @@ export function GdprEraseDialog({
   isGdprSubmitting: boolean;
   onClose: () => void;
   onSubmit: () => Promise<void>;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <Dialog

--- a/src/components/gabinet/patients/patient-appointments-tab.tsx
+++ b/src/components/gabinet/patients/patient-appointments-tab.tsx
@@ -14,7 +14,7 @@ export function PatientAppointmentsTab({
   getApptTreatmentDisplay: (apt?: MappedGabinetAppointment | null) => string | undefined;
   getVisitCountLabel: (apt: MappedGabinetAppointment) => { label: string; title: string } | null;
   navigate: (opts: { to: string; params?: Record<string, string> }) => void;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   const today = new Date().toISOString().split("T")[0];
 

--- a/src/components/gabinet/patients/patient-beauty-plan-tab.tsx
+++ b/src/components/gabinet/patients/patient-beauty-plan-tab.tsx
@@ -12,7 +12,7 @@ export function PatientBeautyPlanTab({
   beautyPlanEntries: MappedGabinetAppointment[];
   getApptTreatmentDisplay: (apt?: MappedGabinetAppointment | null) => string | undefined;
   navigate: (opts: { to: string; params?: Record<string, string>; search?: Record<string, string> }) => void;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <div className="space-y-4">

--- a/src/components/gabinet/patients/patient-billing-tab.tsx
+++ b/src/components/gabinet/patients/patient-billing-tab.tsx
@@ -24,7 +24,7 @@ export function PatientBillingTab({
   canGenerateReceipt: boolean;
   generatingReceiptFor: string | null;
   handleDownloadReceipt: (receiptId: string) => Promise<void>;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <div className="space-y-4">

--- a/src/components/gabinet/patients/patient-loyalty-tab.tsx
+++ b/src/components/gabinet/patients/patient-loyalty-tab.tsx
@@ -23,7 +23,7 @@ export function PatientLoyaltyTab({
 }: {
   loyaltyBalance: LoyaltyBalance;
   loyaltyTransactions: LoyaltyTransaction[] | undefined;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <div className="space-y-6">

--- a/src/components/gabinet/patients/patient-overview-tab.tsx
+++ b/src/components/gabinet/patients/patient-overview-tab.tsx
@@ -39,7 +39,7 @@ export function PatientOverviewTab({
   getApptTreatmentDisplay: (apt?: MappedGabinetAppointment | null) => string | undefined;
   getVisitCountLabel: (apt: MappedGabinetAppointment) => { label: string; title: string } | null;
   navigate: (opts: { to: string; params?: Record<string, string> }) => void;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <div className="flex flex-col space-y-6">

--- a/src/components/gabinet/patients/patient-payments-tab.tsx
+++ b/src/components/gabinet/patients/patient-payments-tab.tsx
@@ -113,7 +113,7 @@ export function PatientPaymentsTab({
   }) => void;
   openCancelDialog: (paymentId: string) => void;
   navigate: (opts: { to: string; params?: Record<string, string> }) => void;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   const completedPayments = (patientPayments ?? []).filter(
     (p) => p.status === "completed" && p.kind !== "credit_refund",

--- a/src/components/gabinet/patients/patient-sidebar-extra.tsx
+++ b/src/components/gabinet/patients/patient-sidebar-extra.tsx
@@ -29,7 +29,7 @@ export function PatientSidebarExtra({
   patientPayments: Payment[] | undefined;
   loyaltyBalance: LoyaltyBalance;
   latestIntake: LatestIntake;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <div className="space-y-4">

--- a/src/components/gabinet/patients/refund-credit-dialog.tsx
+++ b/src/components/gabinet/patients/refund-credit-dialog.tsx
@@ -47,7 +47,7 @@ export function RefundCreditDialog({
   onClose: () => void;
   onRefund: () => Promise<void>;
   onRequestAuthorization: () => Promise<void>;
-  t: (key: string, opts?: Record<string, unknown>) => string;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   return (
     <Dialog


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4526.

Closes #4526

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b37971e fix(gabinet): widen t prop type across all gabinet sub-components (closes #4526)

### Files changed

```
 src/components/gabinet/appointments/cancel-appointment-dialog.tsx | 2 +-
 src/components/gabinet/appointments/package-usage-dialog.tsx      | 2 +-
 src/components/gabinet/documentation-tab.tsx                      | 8 ++++----
 src/components/gabinet/employees/appointments-tab-content.tsx     | 2 +-
 src/components/gabinet/employees/change-password-dialog.tsx       | 2 +-
 src/components/gabinet/employees/notes-tab-content.tsx            | 2 +-
 src/components/gabinet/employees/patients-tab-content.tsx         | 2 +-
 src/components/gabinet/employees/upcoming-agenda.tsx              | 2 +-
 src/components/gabinet/patients/add-payment-dialog.tsx            | 2 +-
 src/components/gabinet/patients/appointment-row.tsx               | 2 +-
 src/components/gabinet/patients/cancel-payment-dialog.tsx         | 2 +-
 src/components/gabinet/patients/edit-payment-dialog.tsx           | 2 +-
 src/components/gabinet/patients/gdpr-erase-dialog.tsx             | 2 +-
 src/components/gabinet/patients/patient-appointments-tab.tsx      | 2 +-
 src/components/gabinet/patients/patient-beauty-plan-tab.tsx       | 2 +-
 src/components/gabinet/patients/patient-billing-tab.tsx           | 2 +-
 src/components/gabinet/patients/patient-loyalty-tab.tsx           | 2 +-
 src/components/gabinet/patients/patient-overview-tab.tsx          | 2 +-
 src/components/gabinet/patients/patient-payments-tab.tsx          | 2 +-
 src/components/gabinet/patients/patient-sidebar-extra.tsx         | 2 +-
 src/components/gabinet/patients/refund-credit-dialog.tsx          | 2 +-
 21 files changed, 24 insertions(+), 24 deletions(-)
```