### PR TITLE
Remove `any` cast in `appointment-history-tab.tsx

### DIFF
--- a/src/components/crm/activity-feed-adapter.ts
+++ b/src/components/crm/activity-feed-adapter.ts
@@ -29,7 +29,7 @@ function looksLikeOpaqueId(value: string | undefined): boolean {
 }
 
 /** Shape returned by useSupabaseActivitiesByEntity */
-interface MappedActivityLike {
+export interface MappedActivityLike {
   _id: string;
   action: string;
   description: string;

--- a/src/components/gabinet/appointments/appointment-history-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-history-tab.tsx
@@ -19,7 +19,10 @@ import {
 import { formatCurrencyPLN } from "@/lib/format-currency";
 import { EmptyState } from "@/components/layout/empty-state";
 import { ActivityFeed } from "@/components/crm/activity-feed";
-import { activitiesToFeedEntries } from "@/components/crm/activity-feed-adapter";
+import {
+  activitiesToFeedEntries,
+  type MappedActivityLike,
+} from "@/components/crm/activity-feed-adapter";
 import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
 import { Link } from "@tanstack/react-router";
 
@@ -63,7 +66,7 @@ export function AppointmentHistoryTab({
   language,
   t,
 }: {
-  mergedTimeline: unknown[];
+  mergedTimeline: MappedActivityLike[];
   patientHistory: HistoryAppointment[];
   patientPackageUsage: PackageUsageEntry[];
   loyaltyBalance: number;
@@ -94,7 +97,7 @@ export function AppointmentHistoryTab({
         </CardHeader>
         <CardContent className="px-6 py-4">
           <ActivityFeed
-            entries={activitiesToFeedEntries(mergedTimeline as any[], t)}
+            entries={activitiesToFeedEntries(mergedTimeline, t)}
             maxHeight="400px"
           />
         </CardContent>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4527.

Closes #4527

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c5a8b7e fix(gabinet): remove any cast in appointment-history-tab by typing mergedTimeline (closes #4527)

### Files changed

```
 src/components/crm/activity-feed-adapter.ts                     | 2 +-
 src/components/gabinet/appointments/appointment-history-tab.tsx | 9 ++++++---
 2 files changed, 7 insertions(+), 4 deletions(-)
```