### PR TITLE
1/4 — Gabinet — sprawdź cenę wariantu zabiegu w wizycie

### DIFF
--- a/src/components/gabinet/appointments/appointment-details-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-details-tab.tsx
@@ -201,15 +201,15 @@ export function AppointmentDetailsTab({
               </span>
               <span className="font-medium">{calculateDuration()} min</span>
             </div>
-            {treatment?.price !== undefined && (
+            {(junctionTreatments[0]?.priceAtBooking ?? treatment?.price) != null && (
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">
                   {t("common.price")}
                 </span>
                 <span className="font-medium">
                   {formatCurrencyPLN(
-                    treatment.price as number,
-                    (treatment.currency as string | undefined) ?? "PLN",
+                    (junctionTreatments[0]?.priceAtBooking ?? treatment?.price) as number,
+                    (treatment?.currency as string | undefined) ?? "PLN",
                   )}
                 </span>
               </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4478.

Closes #4478

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- dd4170a fix(gabinet): show priceAtBooking (variant price) in single-treatment appointment details (closes #4478)

### Files changed

```
 src/components/gabinet/appointments/appointment-details-tab.tsx | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```