### PR TITLE
2/2 — Kalendarz / Wizyty — sprawdź edycję istniejącej wizyty

### DIFF
--- a/src/components/gabinet/change-employee-modal.tsx
+++ b/src/components/gabinet/change-employee-modal.tsx
@@ -55,6 +55,7 @@ interface ChangeEmployeeModalProps {
   startTime: string; // HH:MM
   endTime: string; // HH:MM
   durationMinutes: number;
+  onSuccess?: () => void;
 }
 
 interface EmployeeRow {
@@ -128,6 +129,7 @@ export function ChangeEmployeeModal({
   startTime,
   endTime,
   durationMinutes,
+  onSuccess,
 }: ChangeEmployeeModalProps) {
   const { t } = useTranslation();
   const [selectedId, setSelectedId] = useState<Id<"users"> | null>(null);
@@ -265,6 +267,7 @@ export function ChangeEmployeeModal({
         queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetAppointments.all }),
         queryClient.invalidateQueries({ queryKey: supabaseKeys.scheduledActivities.all }),
       ]);
+      onSuccess?.();
       onOpenChange(false);
       setSelectedId(null);
       setUseNewSlot(false);

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -747,6 +747,7 @@ function AppointmentDetail() {
         treatmentId: newTreatmentId,
       });
       toast.success(t("common.saved"));
+      await invalidateAppointmentCaches();
       refetch();
     } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
@@ -1216,6 +1217,7 @@ function AppointmentDetail() {
         <ChangeEmployeeModal
           open={changeEmployeeOpen}
           onOpenChange={setChangeEmployeeOpen}
+          onSuccess={() => refetch()}
           organizationId={organizationId}
           appointmentId={appointmentId as Id<"gabinetAppointments">}
           treatmentIds={


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4485.

Closes #4485

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8b424d6 fix(gabinet): refresh calendar and detail after treatment/employee edit (closes #4485)

### Files changed

```
 src/components/gabinet/change-employee-modal.tsx                       | 3 +++
 .../dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx     | 2 ++
 2 files changed, 5 insertions(+)
```