### PR TITLE
2/3 — Kalendarz / Wizyty — sprawdź statusy wizyty

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -635,7 +635,7 @@ function AppointmentDetail() {
         toast.warning(t("gabinet.stock.negativeWarning"));
       }
       await invalidateAppointmentCaches();
-      refetch();
+      await refetch();
 
       // When completing: the backend auto-generates after_completion docs.
       // Open dialog so the employee can fill them before they're sent to client.
@@ -694,7 +694,7 @@ function AppointmentDetail() {
       setCancelDialogOpen(false);
       setCancelReason("");
       await invalidateAppointmentCaches();
-      refetch();
+      await refetch();
     } catch (error) {
       const msg = error instanceof Error ? error.message : t("common.error");
       toast.error(msg);
@@ -1299,6 +1299,7 @@ function AppointmentDetail() {
             toast.warning(t("gabinet.stock.negativeWarning"));
           }
           await invalidateAppointmentCaches();
+          await refetch();
           setTimeout(() => setAfterCompletionDialogOpen(true), 500);
         }}
         onSuccess={() => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4486.

Closes #4486

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d3026d2 fix(gabinet): await refetch after status change so detail view shows new status immediately (closes #4486)

### Files changed

```
 .../dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx   | 5 +++--
 1 file changed, 3 insertions(+), 2 deletions(-)
```