### PR TITLE
Consolidate cancellation paths in `appointment-preview-content.tsx`

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2126,6 +2126,7 @@ export const updateStatus = action({
     appointmentId: v.string(),
     status: gabinetAppointmentStatusValidator,
     forceSkipDocumentGate: v.optional(v.boolean()),
+    cancellationReason: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
     try {
@@ -2218,6 +2219,9 @@ export const updateStatus = action({
     if (args.status === "cancelled") {
       patch.cancelledAt = now;
       patch.cancelledBy = String(authResult.userId);
+      if (args.cancellationReason !== undefined) {
+        patch.cancellationReason = args.cancellationReason;
+      }
     }
     console.info("[updateStatus] patching status in Supabase:", args.appointmentId, "->", args.status);
     await db.patch("gabinetAppointments", args.appointmentId, patch);

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -649,9 +649,9 @@ export function AppointmentPreviewContent({
     const previous = status;
     setSavingStatus(true);
     try {
-      await updateAppointment({
+      await updateStatus({
         organizationId,
-        appointmentId: appointment._id as Id<"gabinetAppointments">,
+        appointmentId: appointment._id,
         status: "cancelled",
         cancellationReason: cancelReason.trim(),
       });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4546.

Closes #4546

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 9999074 fix(gabinet): consolidate cancel paths — use updateStatus in cancel dialog (closes #4546)

### Files changed

```
 convex/gabinet/appointments.ts                                  | 4 ++++
 src/components/gabinet/calendar/appointment-preview-content.tsx | 4 ++--
 2 files changed, 6 insertions(+), 2 deletions(-)
```