### PR TITLE
Show variant name in appointment-details-tab.tsx

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -3358,6 +3358,7 @@ export interface AppointmentFullDetailTreatment {
   id: string;
   treatmentId: string | null;
   variantId: string | null;
+  variantName: string | null;
   priceAtBooking: number | null;
   sortOrder: number;
 }
@@ -3516,7 +3517,7 @@ export const getFullDetail = action({
       : null;
     const documents = documentsRaw as unknown as FormDocumentRow[];
     const payments = paymentsRaw as unknown as PaymentRow[];
-    const appointmentTreatments: AppointmentFullDetailTreatment[] = (
+    const rawTreatmentRows = (
       (appointmentTreatmentsRaw as unknown as Array<Record<string, unknown>>) ?? []
     ).map((row) => ({
       id: String(row.id ?? row._id),
@@ -3524,6 +3525,24 @@ export const getFullDetail = action({
       variantId: row.variantId ? String(row.variantId) : null,
       priceAtBooking: row.priceAtBooking != null ? Number(row.priceAtBooking) : null,
       sortOrder: Number(row.sortOrder ?? 0),
+    }));
+    const uniqueVariantIds = Array.from(
+      new Set(rawTreatmentRows.map((t) => t.variantId).filter((id): id is string => id !== null)),
+    );
+    const variantRows = await Promise.all(
+      uniqueVariantIds.map((id) =>
+        db.get("gabinetTreatmentVariants", id).catch(() => null),
+      ),
+    );
+    const variantNameMap = new Map<string, string>(
+      (variantRows.filter((v) => v !== null) as Array<Record<string, unknown>>).map((v) => [
+        String(v._id ?? v.id),
+        String(v.name),
+      ]),
+    );
+    const appointmentTreatments: AppointmentFullDetailTreatment[] = rawTreatmentRows.map((t) => ({
+      ...t,
+      variantName: t.variantId ? (variantNameMap.get(t.variantId) ?? null) : null,
     }));
     const primaryTreatmentId = appointmentTreatments[0]?.treatmentId ?? null;
     const treatment = (primaryTreatmentId

--- a/src/components/gabinet/appointments/appointment-details-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-details-tab.tsx
@@ -41,6 +41,8 @@ type TreatmentListItem = {
 type JunctionTreatment = {
   id: string;
   treatmentId: string;
+  variantId?: string | null;
+  variantName?: string | null;
   priceAtBooking?: number | null;
 };
 
@@ -128,7 +130,12 @@ export function AppointmentDetailsTab({
                 >
                   <div className="flex items-center gap-2">
                     <Stethoscope className="h-4 w-4 shrink-0 text-primary" />
-                    <span className="text-sm font-medium">{name}</span>
+                    <div>
+                      <span className="text-sm font-medium">{name}</span>
+                      {jt.variantName && (
+                        <span className="block text-xs text-muted-foreground">{jt.variantName}</span>
+                      )}
+                    </div>
                   </div>
                   {price != null && (
                     <span className="text-sm text-muted-foreground">
@@ -182,17 +189,30 @@ export function AppointmentDetailsTab({
                   searchPlaceholder={t("gabinet.appointments.searchTreatment")}
                   emptyText={t("common.noResults")}
                   closeLabel={t("common.close")}
-                  selectedLabel={treatment?.name as string | undefined}
+                  selectedLabel={
+                    junctionTreatments[0]?.variantName
+                      ? `${(treatment?.name as string | undefined) ?? ""} — ${junctionTreatments[0].variantName}`
+                      : (treatment?.name as string | undefined)
+                  }
                   triggerIcon={
                     <Stethoscope className="size-4 shrink-0 text-primary" />
                   }
                   disabled={isSavingTreatment}
                 />
               ) : (
-                <span className="flex items-center gap-2 text-sm font-medium">
+                <div className="flex items-center gap-2">
                   <Stethoscope className="size-4 shrink-0 text-primary" />
-                  {(treatment?.name as string | undefined) ?? "-"}
-                </span>
+                  <div>
+                    <span className="text-sm font-medium">
+                      {(treatment?.name as string | undefined) ?? "-"}
+                    </span>
+                    {junctionTreatments[0]?.variantName && (
+                      <span className="block text-xs text-muted-foreground">
+                        {junctionTreatments[0].variantName}
+                      </span>
+                    )}
+                  </div>
+                </div>
               )}
             </div>
             <div className="flex items-center justify-between">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4522.

Closes #4522

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- ab8a612 fix(gabinet): show variant name in appointment details tab (closes #4522)

### Files changed

```
 convex/gabinet/appointments.ts                     | 21 ++++++++++++++-
 .../appointments/appointment-details-tab.tsx       | 30 ++++++++++++++++++----
 2 files changed, 45 insertions(+), 6 deletions(-)
```