### PR TITLE
No variant editing on appointment detail page

### DIFF
--- a/src/components/gabinet/appointments/appointment-details-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-details-tab.tsx
@@ -10,6 +10,13 @@ import {
 } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   CheckCircle,
   DollarSign,
   Heart,
@@ -46,6 +53,13 @@ type JunctionTreatment = {
   priceAtBooking?: number | null;
 };
 
+type TreatmentVariant = {
+  _id: string;
+  name: string;
+  resolvedPrice: number | null;
+  resolvedDuration: number | null;
+};
+
 type SmsSummary = {
   labelKey: string;
   tone: "default" | "destructive" | "secondary" | "outline";
@@ -67,11 +81,14 @@ export function AppointmentDetailsTab({
   canEdit,
   isSavingTreatment,
   editTreatmentId,
+  editVariantId,
+  editTreatmentVariants,
   treatmentPickerOpen,
   treatmentSearch,
   onTreatmentPickerOpenChange,
   onTreatmentSearchChange,
   onTreatmentSelect,
+  onVariantSelect,
   onInternalNotesChange,
   onSaveInternalNotes,
   onMarkContraindicationReviewed,
@@ -93,11 +110,14 @@ export function AppointmentDetailsTab({
   canEdit: boolean;
   isSavingTreatment: boolean;
   editTreatmentId: string;
+  editVariantId: string;
+  editTreatmentVariants: TreatmentVariant[] | undefined;
   treatmentPickerOpen: boolean;
   treatmentSearch: string;
   onTreatmentPickerOpenChange: (open: boolean) => void;
   onTreatmentSearchChange: (search: string) => void;
   onTreatmentSelect: (id: string) => void;
+  onVariantSelect: (id: string) => void;
   onInternalNotesChange: (val: string) => void;
   onSaveInternalNotes: () => void;
   onMarkContraindicationReviewed: () => void;
@@ -170,35 +190,70 @@ export function AppointmentDetailsTab({
                 {t("common.name")}
               </Label>
               {canEdit ? (
-                <TreatmentPicker
-                  treatments={treatmentsList}
-                  value={editTreatmentId}
-                  onSelect={(id) => {
-                    onTreatmentSelect(id);
-                    onTreatmentPickerOpenChange(false);
-                    onTreatmentSearchChange("");
-                  }}
-                  open={treatmentPickerOpen}
-                  onOpenChange={onTreatmentPickerOpenChange}
-                  search={treatmentSearch}
-                  onSearchChange={onTreatmentSearchChange}
-                  formatPrice={(price, currency) =>
-                    formatCurrencyPLN(price ?? 0, currency ?? "PLN")
-                  }
-                  placeholder={t("gabinet.appointments.selectTreatment")}
-                  searchPlaceholder={t("gabinet.appointments.searchTreatment")}
-                  emptyText={t("common.noResults")}
-                  closeLabel={t("common.close")}
-                  selectedLabel={
-                    junctionTreatments[0]?.variantName
-                      ? `${(treatment?.name as string | undefined) ?? ""} — ${junctionTreatments[0].variantName}`
-                      : (treatment?.name as string | undefined)
-                  }
-                  triggerIcon={
-                    <Stethoscope className="size-4 shrink-0 text-primary" />
-                  }
-                  disabled={isSavingTreatment}
-                />
+                <>
+                  <TreatmentPicker
+                    treatments={treatmentsList}
+                    value={editTreatmentId}
+                    onSelect={(id) => {
+                      onTreatmentSelect(id);
+                      onTreatmentPickerOpenChange(false);
+                      onTreatmentSearchChange("");
+                    }}
+                    open={treatmentPickerOpen}
+                    onOpenChange={onTreatmentPickerOpenChange}
+                    search={treatmentSearch}
+                    onSearchChange={onTreatmentSearchChange}
+                    formatPrice={(price, currency) =>
+                      formatCurrencyPLN(price ?? 0, currency ?? "PLN")
+                    }
+                    placeholder={t("gabinet.appointments.selectTreatment")}
+                    searchPlaceholder={t("gabinet.appointments.searchTreatment")}
+                    emptyText={t("common.noResults")}
+                    closeLabel={t("common.close")}
+                    selectedLabel={
+                      junctionTreatments[0]?.variantName
+                        ? `${(treatment?.name as string | undefined) ?? ""} — ${junctionTreatments[0].variantName}`
+                        : (treatment?.name as string | undefined)
+                    }
+                    triggerIcon={
+                      <Stethoscope className="size-4 shrink-0 text-primary" />
+                    }
+                    disabled={isSavingTreatment}
+                  />
+                  {editTreatmentVariants && editTreatmentVariants.length > 0 && (
+                    <div className="space-y-1.5 mt-2">
+                      <Label className="text-xs uppercase tracking-wide text-muted-foreground">
+                        {t("gabinet.treatments.variant", "Wariant")}
+                      </Label>
+                      <Select
+                        value={editVariantId || "__none__"}
+                        onValueChange={(v) => onVariantSelect(v === "__none__" ? "" : v)}
+                        disabled={isSavingTreatment}
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="__none__">
+                            {t("gabinet.appointments.noVariant", "Bez wariantu")}
+                          </SelectItem>
+                          {editTreatmentVariants.map((v) => (
+                            <SelectItem key={v._id} value={v._id}>
+                              <div className="flex flex-col">
+                                <span>{v.name}</span>
+                                {v.resolvedPrice != null && (
+                                  <span className="text-xs text-muted-foreground">
+                                    {formatCurrencyPLN(v.resolvedPrice)}
+                                  </span>
+                                )}
+                              </div>
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+                </>
               ) : (
                 <div className="flex items-center gap-2">
                   <Stethoscope className="size-4 shrink-0 text-primary" />

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -201,6 +201,7 @@ function AppointmentDetail() {
   const [isSavingTags, setIsSavingTags] = useState(false);
 
   const [editTreatmentId, setEditTreatmentId] = useState("");
+  const [editVariantId, setEditVariantId] = useState("");
   const [treatmentPickerOpen, setTreatmentPickerOpen] = useState(false);
   const [treatmentSearch, setTreatmentSearch] = useState("");
   const [isSavingTreatment, setIsSavingTreatment] = useState(false);
@@ -309,6 +310,14 @@ function AppointmentDetail() {
         }>
       | undefined;
   };
+
+  // Variants for the currently-selected treatment on the Details tab
+  const listVariantsAction = useAction(api.gabinet.treatments.listVariants);
+  const { data: editTreatmentVariants } = useQuery({
+    queryKey: ["gabinet.treatments.listVariants", organizationId, editTreatmentId],
+    queryFn: () => listVariantsAction({ organizationId, treatmentId: editTreatmentId }),
+    enabled: !!organizationId && !!editTreatmentId,
+  }) as { data: Array<{ _id: string; name: string; resolvedPrice: number | null; resolvedDuration: number | null }> | undefined };
 
   const listSmsEventsAction = useAction(
     api.gabinet.appointmentSms.listByAppointment,
@@ -435,6 +444,7 @@ function AppointmentDetail() {
           ? String(appt.treatmentId)
           : "",
     );
+    setEditVariantId(detail.treatments?.[0]?.variantId ?? "");
   }, [detail]);
 
   // Initialize tagIds from appointment data
@@ -740,11 +750,33 @@ function AppointmentDetail() {
   const handleSaveTreatment = async (newTreatmentId: string) => {
     if (!newTreatmentId) return;
     setIsSavingTreatment(true);
+    setEditVariantId("");
     try {
       await updateAppointment({
         organizationId,
         appointmentId: appointment._id,
         treatmentId: newTreatmentId,
+        variantId: null,
+      });
+      toast.success(t("common.saved"));
+      await invalidateAppointmentCaches();
+      refetch();
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : t("common.error");
+      toast.error(msg);
+    } finally {
+      setIsSavingTreatment(false);
+    }
+  };
+
+  const handleSaveVariant = async (newVariantId: string) => {
+    setIsSavingTreatment(true);
+    try {
+      await updateAppointment({
+        organizationId,
+        appointmentId: appointment._id,
+        treatmentId: editTreatmentId,
+        variantId: newVariantId || null,
       });
       toast.success(t("common.saved"));
       await invalidateAppointmentCaches();
@@ -1029,6 +1061,8 @@ function AppointmentDetail() {
           canEdit={canEdit}
           isSavingTreatment={isSavingTreatment}
           editTreatmentId={editTreatmentId}
+          editVariantId={editVariantId}
+          editTreatmentVariants={editTreatmentVariants}
           treatmentPickerOpen={treatmentPickerOpen}
           treatmentSearch={treatmentSearch}
           onTreatmentPickerOpenChange={setTreatmentPickerOpen}
@@ -1036,6 +1070,10 @@ function AppointmentDetail() {
           onTreatmentSelect={(id) => {
             setEditTreatmentId(id);
             void handleSaveTreatment(id);
+          }}
+          onVariantSelect={(vid) => {
+            setEditVariantId(vid);
+            void handleSaveVariant(vid);
           }}
           onInternalNotesChange={setInternalNotes}
           onSaveInternalNotes={handleSaveInternalNotes}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4523.

Closes #4523

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3a51e68 fix(gabinet): add variant picker to appointment detail page (closes #4523)

### Files changed

```
 .../appointments/appointment-details-tab.tsx       | 113 +++++++++++++++------
 ...ut.gabinet.appointments.$appointmentId.lazy.tsx |  38 +++++++
 2 files changed, 122 insertions(+), 29 deletions(-)
```