### PR TITLE
Join junction table in calendar indicator lookup

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -591,7 +591,10 @@ function GabinetCalendarPage() {
       if (a.recurringGroupId) recurringGroupIds.add(a.recurringGroupId);
       // Only payable appointments contribute to the paid/unpaid indicator
       // lookup. Cancelled appointments can't be paid by definition.
-      if (a.status !== "cancelled" && a.treatmentId) appointmentIds.add(a._id);
+      // treatment_id was dropped from gabinet_appointments (migration 00076);
+      // all treatment data lives in the junction table — the old scalar guard
+      // was incorrectly excluding new appointments that have no scalar treatmentId.
+      if (a.status !== "cancelled") appointmentIds.add(a._id);
     }
     return {
       patientIds: Array.from(patientIds),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4538.

Closes #4538

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- acf0161 fix(gabinet): remove stale treatmentId guard from calendar indicator lookup (closes #4538)

### Files changed

```
 .../_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx     | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)
```