### PR TITLE
No direct date/time editor on appointment detail

### DIFF
--- a/src/components/gabinet/appointments/reschedule-appointment-dialog.tsx
+++ b/src/components/gabinet/appointments/reschedule-appointment-dialog.tsx
@@ -1,0 +1,157 @@
+import { useState, useEffect, type ChangeEvent } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
+import { Loader2 } from "@/lib/ez-icons";
+import { cn } from "@/lib/utils";
+
+interface RescheduleAppointmentDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentDate: string; // YYYY-MM-DD
+  currentStartTime: string; // HH:MM
+  currentEndTime: string; // HH:MM
+  isSaving: boolean;
+  onSave: (date: string, startTime: string, endTime: string) => void;
+  t: (key: string, fallback?: string) => string;
+}
+
+export function RescheduleAppointmentDialog({
+  open,
+  onOpenChange,
+  currentDate,
+  currentStartTime,
+  currentEndTime,
+  isSaving,
+  onSave,
+  t,
+}: RescheduleAppointmentDialogProps) {
+  const [date, setDate] = useState(currentDate);
+  const [startTime, setStartTime] = useState(currentStartTime);
+  const [endTime, setEndTime] = useState(currentEndTime);
+
+  // Reset to current values when the dialog opens
+  useEffect(() => {
+    if (open) {
+      setDate(currentDate);
+      setStartTime(currentStartTime);
+      setEndTime(currentEndTime);
+    }
+  }, [open, currentDate, currentStartTime, currentEndTime]);
+
+  const isTimeValid = startTime < endTime;
+  const isUnchanged =
+    date === currentDate &&
+    startTime === currentStartTime &&
+    endTime === currentEndTime;
+
+  const handleSubmit = () => {
+    if (!isTimeValid || isUnchanged) return;
+    onSave(date, startTime, endTime);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>
+            {t("gabinet.appointments.reschedule", "Przenieś wizytę")}
+          </DialogTitle>
+          <DialogDescription>
+            {t(
+              "gabinet.appointments.rescheduleDesc",
+              "Zmień datę lub godzinę wizyty bez zmiany pracownika.",
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="reschedule-date">
+              {t("common.date", "Data")}
+            </Label>
+            <input
+              id="reschedule-date"
+              type="date"
+              value={date}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setDate(e.target.value)}
+              disabled={isSaving}
+              className={cn(
+                "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm",
+                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+              )}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="reschedule-start">
+                {t("gabinet.appointments.startTime", "Godzina od")}
+              </Label>
+              <TimePicker5Min
+                id="reschedule-start"
+                value={startTime}
+                onChange={(val) => setStartTime(val)}
+                disabled={isSaving}
+                allowTyping
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="reschedule-end">
+                {t("gabinet.appointments.endTime", "Godzina do")}
+              </Label>
+              <TimePicker5Min
+                id="reschedule-end"
+                value={endTime}
+                onChange={(val) => setEndTime(val)}
+                disabled={isSaving}
+                allowTyping
+              />
+            </div>
+          </div>
+
+          {!isTimeValid && startTime && endTime && (
+            <p className="text-xs text-destructive">
+              {t(
+                "gabinet.appointments.endTimeBeforeStart",
+                "Godzina zakończenia musi być późniejsza niż godzina rozpoczęcia.",
+              )}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSaving}
+          >
+            {t("common.cancel", "Anuluj")}
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={isSaving || !isTimeValid || isUnchanged || !date}
+          >
+            {isSaving ? (
+              <>
+                <Loader2 size={14} variant="stroke" className="mr-2 animate-spin" />
+                {t("common.saving", "Zapisywanie...")}
+              </>
+            ) : (
+              t("gabinet.appointments.confirmReschedule", "Zapisz termin")
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -41,7 +41,7 @@ import {
 } from "@/components/documents/appointment-document-checklist";
 import { DocumentGateDialog } from "@/components/documents/document-gate-dialog";
 import { AfterCompletionDocumentsDialog } from "@/components/documents/after-completion-documents-dialog";
-import { Package, Send } from "@/lib/ez-icons";
+import { Calendar, Package, Send } from "@/lib/ez-icons";
 import { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
 import { PermissionGate, usePermission } from "@/hooks/use-permission";
@@ -60,6 +60,7 @@ import { AppointmentReceiptsTab } from "@/components/gabinet/appointments/appoin
 import { CancelAppointmentDialog } from "@/components/gabinet/appointments/cancel-appointment-dialog";
 import { PaymentAppointmentDialog } from "@/components/gabinet/appointments/payment-appointment-dialog";
 import { PackageUsageDialog } from "@/components/gabinet/appointments/package-usage-dialog";
+import { RescheduleAppointmentDialog } from "@/components/gabinet/appointments/reschedule-appointment-dialog";
 
 function AppointmentDetailSkeleton() {
   return (
@@ -227,6 +228,10 @@ function AppointmentDetail() {
 
   // Change employee modal state
   const [changeEmployeeOpen, setChangeEmployeeOpen] = useState(false);
+
+  // Reschedule dialog state
+  const [rescheduleOpen, setRescheduleOpen] = useState(false);
+  const [isRescheduling, setIsRescheduling] = useState(false);
 
   // Document gate state
   const [gateDialogOpen, setGateDialogOpen] = useState(false);
@@ -710,6 +715,28 @@ function AppointmentDetail() {
       toast.error(msg);
     } finally {
       setIsUpdating(false);
+    }
+  };
+
+  const handleReschedule = async (date: string, startTime: string, endTime: string) => {
+    setIsRescheduling(true);
+    try {
+      await updateAppointment({
+        organizationId,
+        appointmentId: appointment._id,
+        date,
+        startTime,
+        endTime,
+      });
+      toast.success(t("gabinet.appointments.rescheduled", "Wizyta przeniesiona"));
+      setRescheduleOpen(false);
+      await invalidateAppointmentCaches();
+      await refetch();
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : t("common.error");
+      toast.error(msg);
+    } finally {
+      setIsRescheduling(false);
     }
   };
 
@@ -1225,6 +1252,12 @@ function AppointmentDetail() {
           appointment.status !== "no_show"
             ? [
                 {
+                  key: "reschedule",
+                  label: t("gabinet.appointments.reschedule", "Przenieś wizytę"),
+                  icon: <Calendar size={14} variant="stroke" />,
+                  onClick: () => setRescheduleOpen(true),
+                },
+                {
                   key: "sendReminder",
                   label: isSendingReminder
                     ? t("common.processing")
@@ -1274,6 +1307,18 @@ function AppointmentDetail() {
             })()}
         />
       )}
+
+      {/* Reschedule Dialog */}
+      <RescheduleAppointmentDialog
+        open={rescheduleOpen}
+        onOpenChange={setRescheduleOpen}
+        currentDate={appointment.date as string}
+        currentStartTime={appointment.startTime as string}
+        currentEndTime={appointment.endTime as string}
+        isSaving={isRescheduling}
+        onSave={handleReschedule}
+        t={t}
+      />
 
       {/* Cancel Dialog */}
       <CancelAppointmentDialog


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4542.

Closes #4542

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 2e463fd feat(gabinet): add standalone reschedule dialog on appointment detail (closes #4542)

### Files changed

```
 .../appointments/reschedule-appointment-dialog.tsx | 157 +++++++++++++++++++++
 ...ut.gabinet.appointments.$appointmentId.lazy.tsx |  47 +++++-
 2 files changed, 203 insertions(+), 1 deletion(-)
```