### PR TITLE
Wire up `cancelRecurringSeries` to the UI

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3328,6 +3328,7 @@
       },
       "actions": {
         "cancel": "Cancel appointment",
+        "cancelSeries": "Cancel series",
         "complete": "Complete",
         "confirm": "Confirm",
         "noShow": "No show",
@@ -3337,8 +3338,14 @@
       "cancelDesc": "Provide a reason for cancelling the appointment",
       "cancelReasonPlaceholder": "Enter cancellation reason...",
       "cancelReasonRequired": "Cancellation reason is required",
+      "cancelScope": {
+        "single": "Only this appointment",
+        "series": "This and all following"
+      },
+      "cancelSeriesTitle": "Cancel appointment series",
       "cancelTitle": "Cancel appointment",
       "cancelled": "Appointment cancelled",
+      "seriesCancelled": "Appointment series cancelled",
       "details": "Appointment details",
       "internalNotes": "Staff notes",
       "internalNotesDesc": "Visible to staff only. The client cannot see this information.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3327,6 +3327,7 @@
       },
       "actions": {
         "cancel": "Anuluj wizytę",
+        "cancelSeries": "Anuluj serię",
         "complete": "Zakończ",
         "confirm": "Potwierdź",
         "noShow": "Nie pojawił się",
@@ -3336,8 +3337,14 @@
       "cancelDesc": "Podaj powód anulowania wizyty",
       "cancelReasonPlaceholder": "Wpisz powód anulowania...",
       "cancelReasonRequired": "Powód anulowania jest wymagany",
+      "cancelScope": {
+        "single": "Tylko ta wizyta",
+        "series": "Ta i wszystkie następne"
+      },
+      "cancelSeriesTitle": "Anuluj serię wizyt",
       "cancelTitle": "Anuluj wizytę",
       "cancelled": "Wizyta anulowana",
+      "seriesCancelled": "Seria wizyt anulowana",
       "details": "Szczegóły wizyty",
       "internalNotes": "Uwagi dla personelu",
       "internalNotesDesc": "Widoczne tylko dla personelu. Klient nie widzi tych informacji.",

--- a/src/components/gabinet/appointments/cancel-appointment-dialog.tsx
+++ b/src/components/gabinet/appointments/cancel-appointment-dialog.tsx
@@ -7,7 +7,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
+
+type CancelScope = "single" | "series";
 
 export function CancelAppointmentDialog({
   open,
@@ -16,6 +20,9 @@ export function CancelAppointmentDialog({
   isUpdating,
   onCancelReasonChange,
   onConfirm,
+  isRecurring,
+  cancelScope = "single",
+  onCancelScopeChange,
   t,
 }: {
   open: boolean;
@@ -24,18 +31,51 @@ export function CancelAppointmentDialog({
   isUpdating: boolean;
   onCancelReasonChange: (val: string) => void;
   onConfirm: () => void;
+  isRecurring?: boolean;
+  cancelScope?: CancelScope;
+  onCancelScopeChange?: (scope: CancelScope) => void;
   t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
+  const title =
+    isRecurring && cancelScope === "series"
+      ? t("gabinet.appointments.cancelSeriesTitle", "Anuluj serię wizyt")
+      : t("gabinet.appointments.cancelTitle");
+
+  const confirmLabel =
+    isRecurring && cancelScope === "series"
+      ? t("gabinet.appointments.actions.cancelSeries", "Anuluj serię")
+      : t("gabinet.appointments.actions.cancel");
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>{t("gabinet.appointments.cancelTitle")}</DialogTitle>
+          <DialogTitle>{title}</DialogTitle>
           <DialogDescription>
             {t("gabinet.appointments.cancelDesc")}
           </DialogDescription>
         </DialogHeader>
-        <div className="py-4">
+        <div className="space-y-4 py-4">
+          {isRecurring && onCancelScopeChange && (
+            <RadioGroup
+              value={cancelScope}
+              onValueChange={(v) => onCancelScopeChange(v as CancelScope)}
+              className="gap-2"
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="single" id="cancel-scope-single" />
+                <Label htmlFor="cancel-scope-single" className="cursor-pointer font-normal">
+                  {t("gabinet.appointments.cancelScope.single", "Tylko ta wizyta")}
+                </Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="series" id="cancel-scope-series" />
+                <Label htmlFor="cancel-scope-series" className="cursor-pointer font-normal">
+                  {t("gabinet.appointments.cancelScope.series", "Ta i wszystkie następne")}
+                </Label>
+              </div>
+            </RadioGroup>
+          )}
           <RichTextEditor
             placeholder={t("gabinet.appointments.cancelReasonPlaceholder")}
             value={cancelReason}
@@ -52,9 +92,7 @@ export function CancelAppointmentDialog({
             onClick={onConfirm}
             disabled={isUpdating}
           >
-            {isUpdating
-              ? t("common.processing")
-              : t("gabinet.appointments.actions.cancel")}
+            {isUpdating ? t("common.processing") : confirmLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -53,6 +53,7 @@ import { DocumentGateDialog } from "@/components/documents/document-gate-dialog"
 import { useAppointmentDocumentCounts } from "@/components/documents/appointment-document-checklist";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Checkbox } from "@/components/ui/checkbox";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Tooltip,
   TooltipContent,
@@ -227,6 +228,7 @@ export function AppointmentPreviewContent({
   const getFullDetail = useAction(api.gabinet.appointments.getFullDetail);
   const updateAppointment = useAction(api.gabinet.appointments.update);
   const updateStatus = useAction(api.gabinet.appointments.updateStatus);
+  const cancelRecurringSeries = useAction(api.gabinet.appointments.cancelRecurringSeries);
   const updatePatient = useAction(api.gabinet.patients.update);
   const getWarnings = useAction(api.gabinet.appointments.getWarnings);
   const listActiveTreatments = useAction(api.gabinet.treatments.listActive);
@@ -404,6 +406,7 @@ export function AppointmentPreviewContent({
   const [savingPhone, setSavingPhone] = useState(false);
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [cancelReason, setCancelReason] = useState("");
+  const [cancelScope, setCancelScope] = useState<"single" | "series">("single");
   const [gateDialogOpen, setGateDialogOpen] = useState(false);
   const [gateTiming, setGateTiming] = useState<"before_start" | "during_visit">(
     "before_start",
@@ -649,13 +652,23 @@ export function AppointmentPreviewContent({
     const previous = status;
     setSavingStatus(true);
     try {
-      await updateStatus({
-        organizationId,
-        appointmentId: appointment._id,
-        status: "cancelled",
-        cancellationReason: cancelReason.trim(),
-      });
-      setStatus("cancelled");
+      if (cancelScope === "series" && appointment.recurringGroupId) {
+        await cancelRecurringSeries({
+          organizationId,
+          recurringGroupId: String(appointment.recurringGroupId),
+          fromDate: appointment.date,
+        });
+        toast.success(t("gabinet.appointments.seriesCancelled", "Seria wizyt anulowana"));
+      } else {
+        await updateStatus({
+          organizationId,
+          appointmentId: appointment._id,
+          status: "cancelled",
+          cancellationReason: cancelReason.trim(),
+        });
+        setStatus("cancelled");
+        toast.success(t("gabinet.appointments.cancelled"));
+      }
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: supabaseKeys.gabinetAppointments.all,
@@ -667,7 +680,7 @@ export function AppointmentPreviewContent({
       await refetch();
       setCancelDialogOpen(false);
       setCancelReason("");
-      toast.success(t("gabinet.appointments.cancelled"));
+      setCancelScope("single");
     } catch (error) {
       setStatus(previous);
       console.error("[appointment-preview] cancel failed", error);
@@ -1617,7 +1630,7 @@ export function AppointmentPreviewContent({
         open={cancelDialogOpen}
         onOpenChange={(o) => {
           setCancelDialogOpen(o);
-          if (!o) setCancelReason("");
+          if (!o) { setCancelReason(""); setCancelScope("single"); }
         }}
       >
         <DialogContent
@@ -1629,12 +1642,36 @@ export function AppointmentPreviewContent({
           )}
         >
           <DialogHeader>
-            <DialogTitle>{t("gabinet.appointments.cancelTitle")}</DialogTitle>
+            <DialogTitle>
+              {appointment.isRecurring && appointment.recurringGroupId && cancelScope === "series"
+                ? t("gabinet.appointments.cancelSeriesTitle", "Anuluj serię wizyt")
+                : t("gabinet.appointments.cancelTitle")}
+            </DialogTitle>
             <DialogDescription>
               {t("gabinet.appointments.cancelDesc")}
             </DialogDescription>
           </DialogHeader>
-          <div className="py-4">
+          <div className="space-y-4 py-4">
+            {appointment.isRecurring && appointment.recurringGroupId && (
+              <RadioGroup
+                value={cancelScope}
+                onValueChange={(v) => setCancelScope(v as "single" | "series")}
+                className="gap-2"
+              >
+                <div className="flex items-center gap-2">
+                  <RadioGroupItem value="single" id="preview-cancel-scope-single" />
+                  <Label htmlFor="preview-cancel-scope-single" className="cursor-pointer font-normal">
+                    {t("gabinet.appointments.cancelScope.single", "Tylko ta wizyta")}
+                  </Label>
+                </div>
+                <div className="flex items-center gap-2">
+                  <RadioGroupItem value="series" id="preview-cancel-scope-series" />
+                  <Label htmlFor="preview-cancel-scope-series" className="cursor-pointer font-normal">
+                    {t("gabinet.appointments.cancelScope.series", "Ta i wszystkie następne")}
+                  </Label>
+                </div>
+              </RadioGroup>
+            )}
             <RichTextEditor
               placeholder={t("gabinet.appointments.cancelReasonPlaceholder")}
               value={cancelReason}
@@ -1648,6 +1685,7 @@ export function AppointmentPreviewContent({
               onClick={() => {
                 setCancelDialogOpen(false);
                 setCancelReason("");
+                setCancelScope("single");
               }}
             >
               {t("common.cancel")}
@@ -1659,7 +1697,9 @@ export function AppointmentPreviewContent({
             >
               {savingStatus
                 ? t("common.processing")
-                : t("gabinet.appointments.actions.cancel")}
+                : appointment.isRecurring && appointment.recurringGroupId && cancelScope === "series"
+                  ? t("gabinet.appointments.actions.cancelSeries", "Anuluj serię")
+                  : t("gabinet.appointments.actions.cancel")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -195,6 +195,7 @@ function AppointmentDetail() {
 
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [cancelReason, setCancelReason] = useState("");
+  const [cancelScope, setCancelScope] = useState<"single" | "series">("single");
   const [isUpdating, setIsUpdating] = useState(false);
   const [internalNotes, setInternalNotes] = useState("");
   const [isSavingNotes, setIsSavingNotes] = useState(false);
@@ -249,6 +250,7 @@ function AppointmentDetail() {
 
   const updateStatus = useAction(api.gabinet.appointments.updateStatus);
   const updateAppointment = useAction(api.gabinet.appointments.update);
+  const cancelRecurringSeries = useAction(api.gabinet.appointments.cancelRecurringSeries);
   const trackView = useAction(api.recentlyViewed.track);
   const sendReminderNow = useAction(api.gabinet.appointmentReminders.sendReminderNow);
   const [isSendingReminder, setIsSendingReminder] = useState(false);
@@ -699,15 +701,25 @@ function AppointmentDetail() {
 
     setIsUpdating(true);
     try {
-      await updateAppointment({
-        organizationId,
-        appointmentId: appointment._id,
-        status: "cancelled",
-        cancellationReason: cancelReason.trim(),
-      });
-      toast.success(t("gabinet.appointments.cancelled"));
+      if (cancelScope === "series" && appointment.recurringGroupId) {
+        await cancelRecurringSeries({
+          organizationId,
+          recurringGroupId: String(appointment.recurringGroupId),
+          fromDate: appointment.date as string,
+        });
+        toast.success(t("gabinet.appointments.seriesCancelled", "Seria wizyt anulowana"));
+      } else {
+        await updateAppointment({
+          organizationId,
+          appointmentId: appointment._id,
+          status: "cancelled",
+          cancellationReason: cancelReason.trim(),
+        });
+        toast.success(t("gabinet.appointments.cancelled"));
+      }
       setCancelDialogOpen(false);
       setCancelReason("");
+      setCancelScope("single");
       await invalidateAppointmentCaches();
       await refetch();
     } catch (error) {
@@ -1323,11 +1335,17 @@ function AppointmentDetail() {
       {/* Cancel Dialog */}
       <CancelAppointmentDialog
         open={cancelDialogOpen}
-        onOpenChange={setCancelDialogOpen}
+        onOpenChange={(o) => {
+          setCancelDialogOpen(o);
+          if (!o) { setCancelReason(""); setCancelScope("single"); }
+        }}
         cancelReason={cancelReason}
         isUpdating={isUpdating}
         onCancelReasonChange={setCancelReason}
         onConfirm={handleCancelConfirm}
+        isRecurring={!!(appointment.isRecurring && appointment.recurringGroupId)}
+        cancelScope={cancelScope}
+        onCancelScopeChange={setCancelScope}
         t={t}
       />
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4548.

Closes #4548

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 71a4a60 feat(gabinet): wire cancelRecurringSeries to cancel dialog UI (closes #4548)

### Files changed

```
 public/locales/en/translation.json                 |  7 +++
 public/locales/pl/translation.json                 |  7 +++
 .../appointments/cancel-appointment-dialog.tsx     | 48 ++++++++++++++--
 .../calendar/appointment-preview-content.tsx       | 64 ++++++++++++++++++----
 ...ut.gabinet.appointments.$appointmentId.lazy.tsx | 34 +++++++++---
 5 files changed, 135 insertions(+), 25 deletions(-)
```