### PR TITLE
Add email-already-a-member check with employee-linking path

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -1405,3 +1405,80 @@ export const _changePasswordSideEffects = internalMutation({
     });
   },
 });
+
+// Creates a Gabinet employee profile for an existing org member (no invitation needed).
+// Used when createInvitation fails with "User is already a member" — the admin can
+// still link that member directly as an employee without re-inviting them.
+export const createForExistingMember = action({
+  args: {
+    organizationId: v.id("organizations"),
+    email: v.string(),
+    firstName: v.optional(v.string()),
+    lastName: v.optional(v.string()),
+    role: gabinetEmployeeRoleValidator,
+    specialization: v.optional(v.string()),
+    licenseNumber: v.optional(v.string()),
+    color: v.optional(v.string()),
+    showInCalendar: v.optional(v.boolean()),
+    qualifiedTreatmentIds: v.optional(v.array(v.string())),
+    tagIds: v.optional(v.array(v.string())),
+    categoryId: v.optional(v.string()),
+    customFields: v.optional(v.array(v.any())),
+    locationId: v.optional(v.string()),
+    locationRole: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const authResult = await ctx.runAction(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, {
+      organizationId: args.organizationId,
+    });
+    await ctx.runAction(internal._helpers.authAction.checkPermission, {
+      organizationId: args.organizationId,
+      feature: "gabinet_employees",
+      action: "create",
+    }).then((perm: { allowed: boolean; scope: string }) => {
+      if (!perm.allowed) throw new Error("Permission denied");
+    });
+
+    const db = createSupabaseDb();
+    const orgIdStr = String(args.organizationId);
+
+    const user = await db.query("users").eq("email", args.email).first();
+    if (!user) {
+      throw new Error("No user account found for this email address.");
+    }
+
+    const membership = await db
+      .query("teamMemberships")
+      .eq("organizationId", orgIdStr)
+      .eq("userId", String(user._id))
+      .first();
+    if (!membership) {
+      throw new Error("This user is not a member of this organization.");
+    }
+
+    await ctx.runAction(internal.gabinet.employees._createFromInvitation, {
+      organizationId: args.organizationId,
+      userId: String(user._id),
+      invitedBy: String(authResult.userId),
+      data: {
+        firstName: args.firstName,
+        lastName: args.lastName,
+        role: args.role,
+        specialization: args.specialization,
+        licenseNumber: args.licenseNumber,
+        color: args.color,
+        showInCalendar: args.showInCalendar,
+        qualifiedTreatmentIds: args.qualifiedTreatmentIds,
+        tagIds: args.tagIds,
+        categoryId: args.categoryId,
+        customFields: args.customFields,
+        locationId: args.locationId,
+        locationRole: args.locationRole,
+      },
+    });
+  },
+});

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3217,6 +3217,7 @@
       "active": "Active",
       "confirmDelete": "Are you sure you want to delete this employee?",
       "searchPlaceholder": "Search employees...",
+      "linkedAsMember": "Employee profile created and linked to existing account.",
       "errors": {
         "createFailed": "Could not add the employee.",
         "saveFailed": "Could not save employee changes.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3216,6 +3216,7 @@
       "active": "Aktywny",
       "confirmDelete": "Czy na pewno chcesz usunąć tego pracownika?",
       "searchPlaceholder": "Szukaj pracowników...",
+      "linkedAsMember": "Profil pracownika utworzony i powiązany z istniejącym kontem.",
       "errors": {
         "createFailed": "Nie udało się dodać pracownika.",
         "saveFailed": "Nie udało się zapisać zmian pracownika.",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -677,6 +677,7 @@ function CreateEmployeeSheet({
   const createEmployee = useAction(api.gabinet.employees.create);
   const createInvitation = useAction(api.invitations.create);
   const createWithPassword = useAction(api.gabinet.employees.createWithPassword);
+  const createForExistingMember = useAction(api.gabinet.employees.createForExistingMember);
   const [saving, setSaving] = useState(false);
 
   return (
@@ -721,30 +722,59 @@ function CreateEmployeeSheet({
                     queryKey: supabaseKeys.gabinetEmployees.list(organizationId),
                   });
                 } else if (data.grantSystemAccess && data.accessEmail) {
-                  await createInvitation({
-                    organizationId,
-                    email: data.accessEmail,
-                    role: data.accessRole ?? "member",
-                    module: "gabinet",
-                    moduleData: {
-                      firstName: data.firstName,
-                      lastName: data.lastName,
-                      role: data.role,
-                      specialization: data.specialization,
-                      color: data.color,
-                      showInCalendar: data.showInCalendar,
-                      qualifiedTreatmentIds: data.qualifiedTreatmentIds,
-                      tagIds: data.tagIds,
-                      categoryId: data.categoryId,
-                      customFields: data.customFields,
-                      locationId: data.locationId,
-                      locationRole: data.locationRole,
-                    },
-                  });
-                  toast.success(t("team.invitationSent"));
-                  void queryClient.invalidateQueries({
-                    queryKey: supabaseKeys.invitations.list(organizationId),
-                  });
+                  try {
+                    await createInvitation({
+                      organizationId,
+                      email: data.accessEmail,
+                      role: data.accessRole ?? "member",
+                      module: "gabinet",
+                      moduleData: {
+                        firstName: data.firstName,
+                        lastName: data.lastName,
+                        role: data.role,
+                        specialization: data.specialization,
+                        color: data.color,
+                        showInCalendar: data.showInCalendar,
+                        qualifiedTreatmentIds: data.qualifiedTreatmentIds,
+                        tagIds: data.tagIds,
+                        categoryId: data.categoryId,
+                        customFields: data.customFields,
+                        locationId: data.locationId,
+                        locationRole: data.locationRole,
+                      },
+                    });
+                    toast.success(t("team.invitationSent"));
+                    void queryClient.invalidateQueries({
+                      queryKey: supabaseKeys.invitations.list(organizationId),
+                    });
+                  } catch (inviteErr) {
+                    const msg = inviteErr instanceof Error ? inviteErr.message : String(inviteErr);
+                    if (msg.includes("already a member")) {
+                      // User already belongs to this org — link them directly as an employee
+                      await createForExistingMember({
+                        organizationId,
+                        email: data.accessEmail,
+                        firstName: data.firstName,
+                        lastName: data.lastName,
+                        role: data.role,
+                        specialization: data.specialization,
+                        color: data.color,
+                        showInCalendar: data.showInCalendar,
+                        qualifiedTreatmentIds: data.qualifiedTreatmentIds as string[] | undefined,
+                        tagIds: data.tagIds as string[] | undefined,
+                        categoryId: data.categoryId as string | undefined,
+                        customFields: data.customFields,
+                        locationId: data.locationId,
+                        locationRole: data.locationRole,
+                      });
+                      toast.success(t("gabinet.employees.linkedAsMember"));
+                      void queryClient.invalidateQueries({
+                        queryKey: supabaseKeys.gabinetEmployees.list(organizationId),
+                      });
+                    } else {
+                      throw inviteErr;
+                    }
+                  }
                 } else {
                   await createEmployee({
                     organizationId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4565.

Closes #4565

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 1f00a95 feat(gabinet): add employee-linking path for existing org members (closes #4565)

### Files changed

```
 convex/gabinet/employees.ts                        | 77 +++++++++++++++++++++
 public/locales/en/translation.json                 |  1 +
 public/locales/pl/translation.json                 |  1 +
 .../dashboard/_layout.gabinet.employees.index.tsx  | 78 +++++++++++++++-------
 4 files changed, 133 insertions(+), 24 deletions(-)
```