### PR TITLE
`_finalisePasswordUser` reads user from Convex (`_getConvexUser`) and assumes it

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -1108,7 +1108,12 @@ export const _finalisePasswordUser = internalAction({
     const user = await ctx.runQuery(internal.gabinet.employees._getConvexUser, {
       userId: args.userId,
     });
-    if (!user) throw new Error("User not found after account creation");
+    if (!user)
+      throw new Error(
+        `Convex user record missing for userId=${args.userId} (email=${args.email}). ` +
+          "The account may have been provisioned outside the Convex auth flow " +
+          "(e.g. direct Supabase insert). Use the employee-linking path for existing org members.",
+      );
 
     let effectiveUsername = user.username ?? undefined;
     if (!user.username) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4568.

Closes #4568

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 767342a fix(gabinet): improve error message when Convex user record is absent in _finalisePasswordUser (closes #4568)

### Files changed

```
 convex/gabinet/employees.ts | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)
```