### PR TITLE
Add duplicate employee-profile guard to `createWithPassword`

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -1276,6 +1276,15 @@ export const createWithPassword = action({
       userId = resolvedId;
     }
 
+    const existingProfile = await db
+      .query("gabinetEmployees")
+      .eq("organizationId", String(args.organizationId))
+      .eq("userId", userId)
+      .collect();
+    if (existingProfile.length > 0) {
+      throw new Error("Employee profile already exists for this user");
+    }
+
     const employeeId = await db.insert("gabinetEmployees", {
       organizationId: String(args.organizationId),
       userId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4567.

Closes #4567

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f16754f fix(gabinet): add duplicate employee-profile guard to createWithPassword (closes #4567)

### Files changed

```
 convex/gabinet/employees.ts | 9 +++++++++
 1 file changed, 9 insertions(+)
```