### PR TITLE
`update` action has no way to change `locationRole` independently of `locationId

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -769,6 +769,24 @@ export const update = action({
           console.error("[employees.update] location insert failed:", e);
         }
       }
+    } else if (locationRole !== undefined) {
+      // locationId not provided — patch the role on the existing primary location in-place
+      const existingLocs = await db.query("gabinetEmployeeLocations")
+        .eq("organizationId", String(organizationId))
+        .eq("employeeId", employeeId)
+        .eq("isPrimary", true)
+        .collect();
+      for (const loc of existingLocs) {
+        const effectiveLocationRole =
+          locationRole != null && isSystemGabinetRole(locationRole) ? locationRole : null;
+        try {
+          await db.patch("gabinetEmployeeLocations", String(loc._id), {
+            role: effectiveLocationRole,
+          });
+        } catch (e) {
+          console.error("[employees.update] location role patch failed:", e);
+        }
+      }
     }
 
     // --- Delegate post-write side effects ---


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4577.

Closes #4577

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 588658d fix(gabinet): allow locationRole-only update without requiring locationId (closes #4577)

### Files changed

```
 convex/gabinet/employees.ts | 18 ++++++++++++++++++
 1 file changed, 18 insertions(+)
```