### PR TITLE
Fix `employee.userId as Id<"users">` in patient booking flow

### DIFF
--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -355,7 +355,10 @@ export const getQualifiedEmployees = action({
 
     // Filter to those qualified for the treatment (empty list ⇒ qualified
     // for everything, matching the original Convex behaviour).
+    // Also exclude employees without a linked user account — slot lookup
+    // requires a userId and they cannot participate in the booking flow.
     const qualified = employees.filter((e) => {
+      if (!e.userId) return false;
       const qualifiedIds = (e.qualifiedTreatmentIds as string[] | undefined) ?? [];
       return qualifiedIds.length === 0 || qualifiedIds.includes(args.treatmentId);
     });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4512.

Closes #4512

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0e5e50a fix(gabinet): exclude employees without userId from patient booking picker (closes #4512)

### Files changed

```
 convex/gabinet/patientPortal.ts | 3 +++
 1 file changed, 3 insertions(+)
```