### PR TITLE
Fix `setWorkingHours` upsert to scope by `locationId`

### DIFF
--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -422,6 +422,11 @@ class SupabaseQueryBuilder<T = Record<string, unknown>> {
     return this;
   }
 
+  isNull(field: string) {
+    this.filters.push((q) => q.is(toSnakeCase(field), null));
+    return this;
+  }
+
   /**
    * JSONB containment filter (`@>` operator). Checks whether the column value
    * contains all key-value pairs in `value` (for objects) or all elements in

--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -58,11 +58,16 @@ export const setWorkingHours = action({
     const now = Date.now();
     const db = createSupabaseDb();
 
-    // Check if entry already exists for this org+day
-    const existing = await db.query("gabinetWorkingHours")
+    // Check if entry already exists for this org+day+locationId
+    const whQuery = db.query("gabinetWorkingHours")
       .eq("organizationId", String(args.organizationId))
-      .eq("dayOfWeek", args.dayOfWeek)
-      .first();
+      .eq("dayOfWeek", args.dayOfWeek);
+    if (args.locationId) {
+      whQuery.eq("locationId", args.locationId);
+    } else {
+      whQuery.isNull("locationId");
+    }
+    const existing = await whQuery.first();
 
     let whId: string;
     if (existing) {
@@ -136,10 +141,15 @@ export const bulkSetWorkingHours = action({
     const db = createSupabaseDb();
 
     for (const h of args.hours) {
-      const existing = await db.query("gabinetWorkingHours")
+      const hQuery = db.query("gabinetWorkingHours")
         .eq("organizationId", String(args.organizationId))
-        .eq("dayOfWeek", h.dayOfWeek)
-        .first();
+        .eq("dayOfWeek", h.dayOfWeek);
+      if (h.locationId) {
+        hQuery.eq("locationId", h.locationId);
+      } else {
+        hQuery.isNull("locationId");
+      }
+      const existing = await hQuery.first();
 
       if (existing) {
         await db.patch("gabinetWorkingHours", existing._id as string, {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4585.

Closes #4585

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 1d9a574 fix(gabinet): scope setWorkingHours upsert lookup by locationId (closes #4585)

### Files changed

```
 convex/_helpers/supabaseDb.ts |  5 +++++
 convex/gabinet/scheduling.ts  | 24 +++++++++++++++++-------
 2 files changed, 22 insertions(+), 7 deletions(-)
```