### PR TITLE
Guard `e.userId` null in `bookFromPortal` "any employee" fallback loop

### DIFF
--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -477,6 +477,7 @@ export const bookFromPortal = action({
 
       let foundEmployee: string | null = null;
       for (const emp of qualifiedEmployees) {
+        if (!emp.userId) continue;
         const { slots } = await getAvailableSlotsSupabase(db, {
           organizationId: String(organizationId),
           userId: String(emp.userId),

--- a/tests/convex/bookFromPortal.test.ts
+++ b/tests/convex/bookFromPortal.test.ts
@@ -32,6 +32,47 @@ async function seedActivePortalSession(
   return { tokenHash };
 }
 
+describe("bookFromPortal null userId guard (issue #4583)", () => {
+  test("skips employees with null userId instead of querying with string 'null'", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+    const { tokenHash } = await seedActivePortalSession(
+      String(patientId),
+      String(organizationId),
+    );
+
+    // Add an employee with no userId — should be silently skipped
+    const db = createSupabaseDb();
+    await db.insert("gabinetEmployees", {
+      organizationId: String(organizationId),
+      userId: null,
+      role: "doctor",
+      qualifiedTreatmentIds: [String(treatmentId)],
+      isActive: true,
+      createdBy: String(userId),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    // A past date triggers the past-time guard but not a crash from the null userId loop.
+    // The important thing is that the error is the expected business error, not a
+    // crash caused by passing "null" as a userId to getAvailableSlotsSupabase.
+    await expect(
+      t.action(api.gabinet.patientPortal.bookFromPortal, {
+        tokenHash,
+        treatmentId: String(treatmentId),
+        preferredDate: "2020-01-01",
+        preferredTime: "09:00",
+      }),
+    ).rejects.toThrow(/start time is in the past/i);
+  });
+});
+
 describe("bookFromPortal past-time guard (issue #1415)", () => {
   test("rejects bookings whose start time is already in the past", async () => {
     const t = createTestCtx();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4583.

Closes #4583

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 09cefdc fix(gabinet): guard emp.userId null in bookFromPortal any-employee loop (closes #4583)

### Files changed

```
 convex/gabinet/patientPortal.ts     |  1 +
 tests/convex/bookFromPortal.test.ts | 41 +++++++++++++++++++++++++++++++++++++
 2 files changed, 42 insertions(+)
```