### PR TITLE
Monthly frequency `setMonth` overflow for end-of-month start dates

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -337,6 +337,7 @@ function generateRecurringDates(
 ): string[] {
   const dates: string[] = [];
   const d = new Date(startDate + "T00:00:00");
+  const origDay = d.getDate();
   const max = rule.count ?? 52;
   const untilDate = rule.until ? new Date(rule.until + "T23:59:59") : null;
 
@@ -351,9 +352,13 @@ function generateRecurringDates(
       case "biweekly":
         d.setDate(d.getDate() + 14);
         break;
-      case "monthly":
+      case "monthly": {
+        d.setDate(1);
         d.setMonth(d.getMonth() + 1);
+        const lastDay = new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
+        d.setDate(Math.min(origDay, lastDay));
         break;
+      }
       default:
         return dates;
     }

--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -163,6 +163,7 @@ function generateRecurringDates(
   }
   const dates: string[] = [];
   const d = new Date(startDate + "T00:00:00");
+  const origDay = d.getDate();
   for (let i = 1; i < count; i++) {
     switch (frequency) {
       case "daily":
@@ -174,9 +175,13 @@ function generateRecurringDates(
       case "biweekly":
         d.setDate(d.getDate() + 14);
         break;
-      case "monthly":
+      case "monthly": {
+        d.setDate(1);
         d.setMonth(d.getMonth() + 1);
+        const lastDay = new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
+        d.setDate(Math.min(origDay, lastDay));
         break;
+      }
       default:
         return dates;
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4549.

Closes #4549

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0de2906 fix(gabinet): clamp monthly recurrence to last day of month (closes #4549)

### Files changed

```
 convex/gabinet/appointments.ts                         | 7 ++++++-
 src/components/gabinet/calendar/appointment-dialog.tsx | 7 ++++++-
 2 files changed, 12 insertions(+), 2 deletions(-)
```