### PR TITLE
Pass `locationId` from appointment dialog to `getAvailableSlotsQuery`

### DIFF
--- a/src/components/gabinet/calendar/appointment-dialog.tsx
+++ b/src/components/gabinet/calendar/appointment-dialog.tsx
@@ -604,6 +604,7 @@ export function AppointmentDialog({
       employeeId,
       dateStr,
       effectiveDuration,
+      locationId || null,
       // Bucket by the hour so the query is cached but still refreshes as the
       // clock advances past past-slot boundaries. Walk-in mode disables the
       // filter so it must also key the cache.
@@ -616,6 +617,7 @@ export function AppointmentDialog({
         userId: employeeId as string,
         date: dateStr,
         duration: effectiveDuration,
+        locationId: locationId || undefined,
         nowDate: recordWalkIn ? undefined : nowDate,
         nowTime: recordWalkIn ? undefined : nowTime,
       }),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4586.

Closes #4586

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b4abf11 fix(gabinet): forward locationId from appointment dialog to getAvailableSlotsQuery (closes #4586)

### Files changed

```
 src/components/gabinet/calendar/appointment-dialog.tsx | 2 ++
 1 file changed, 2 insertions(+)
```