### PR TITLE
Replace `create` action's `locationRole

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -181,7 +181,7 @@ export const create = action({
     categoryId: v.optional(v.union(v.string(), v.null())),
     customFields: v.optional(v.array(v.any())),
     locationId: v.optional(v.string()),
-    locationRole: v.optional(v.string()),
+    locationRole: v.optional(gabinetEmployeeRoleValidator),
   },
   handler: async (ctx, args) => {
     try {
@@ -1218,7 +1218,7 @@ export const createWithPassword = action({
     categoryId: v.optional(v.string()),
     customFields: v.optional(v.array(v.any())),
     locationId: v.optional(v.string()),
-    locationRole: v.optional(v.string()),
+    locationRole: v.optional(gabinetEmployeeRoleValidator),
   },
   handler: async (ctx, args) => {
     if (args.password.length < 8) {
@@ -1473,7 +1473,7 @@ export const createForExistingMember = action({
     categoryId: v.optional(v.string()),
     customFields: v.optional(v.array(v.any())),
     locationId: v.optional(v.string()),
-    locationRole: v.optional(v.string()),
+    locationRole: v.optional(gabinetEmployeeRoleValidator),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runAction(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4483.

Closes #4483

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4da994a fix(gabinet): use gabinetEmployeeRoleValidator for locationRole in create actions (closes #4483)

### Files changed

```
 convex/gabinet/employees.ts | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```