### PR TITLE
Replace `gabinetMemberships.gabinetRole

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -5,7 +5,7 @@ import { internal } from "../_generated/api";
 import { logActivity } from "../_helpers/activities";
 import { logAudit } from "../auditLog";
 import { logError } from "../_helpers/logged";
-import { gabinetEmployeeRoleValidator } from "../schema";
+import { gabinetEmployeeRoleValidator, GabinetEmployeeRole } from "../schema";
 import { isSystemGabinetRole } from "../_helpers/gabinetRolePermissions";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { createLogger } from "../_helpers/logger";
@@ -529,7 +529,7 @@ export const _backfillMemberships = internalAction({
         await ctx.runMutation(internal.gabinet.employees._upsertMembership, {
           organizationId: e.organizationId as Id<"organizations">,
           userId: e.userId,
-          gabinetRole: e.role,
+          gabinetRole: e.role as GabinetEmployeeRole,
           isActive: Boolean(e.isActive),
         });
         upserted += 1;
@@ -551,7 +551,7 @@ export const _upsertMembership = internalMutation({
   args: {
     organizationId: v.id("organizations"),
     userId: v.string(),
-    gabinetRole: v.string(),
+    gabinetRole: gabinetEmployeeRoleValidator,
     isActive: v.boolean(),
   },
   handler: async (ctx, args) => {
@@ -804,7 +804,7 @@ export const update = action({
     // Mirror role change (or isActive change) into Convex `gabinetMemberships`
     // so permission checks reflect the new role on the next call.
     if ((args.role !== undefined || args.isActive !== undefined) && emp.userId) {
-      const effectiveRole = args.role ?? (emp.role as string);
+      const effectiveRole = args.role ?? (emp.role as GabinetEmployeeRole);
       const effectiveActive = args.isActive ?? Boolean(emp.isActive);
       await ctx.runMutation(internal.gabinet.employees._upsertMembership, {
         organizationId: args.organizationId,
@@ -926,7 +926,7 @@ export const remove = action({
       await ctx.runMutation(internal.gabinet.employees._upsertMembership, {
         organizationId: args.organizationId,
         userId: String(emp.userId),
-        gabinetRole: emp.role as string,
+        gabinetRole: emp.role as GabinetEmployeeRole,
         isActive: false,
       });
     }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -531,6 +531,7 @@ const crmTables = createCrmTables({
   emailDirectionValidator,
   orgRoleValidator,
   invitationStatusValidator,
+  gabinetEmployeeRoleValidator,
 });
 
 const gabinetTables = createGabinetTables({

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -14,6 +14,7 @@ interface CrmSchemaDeps {
   emailDirectionValidator: typeof import("../schema").emailDirectionValidator;
   orgRoleValidator: typeof import("../schema").orgRoleValidator;
   invitationStatusValidator: typeof import("../schema").invitationStatusValidator;
+  gabinetEmployeeRoleValidator: typeof import("../schema").gabinetEmployeeRoleValidator;
 }
 
 export function createCrmTables({
@@ -29,6 +30,7 @@ export function createCrmTables({
   emailDirectionValidator,
   orgRoleValidator,
   invitationStatusValidator,
+  gabinetEmployeeRoleValidator,
 }: CrmSchemaDeps) {
   return {
   // --- CRM Tables ---
@@ -771,7 +773,7 @@ export function createCrmTables({
   gabinetMemberships: defineTable({
     organizationId: v.id("organizations"),
     userId: v.id("users"),
-    gabinetRole: v.string(),
+    gabinetRole: gabinetEmployeeRoleValidator,
     isActive: v.boolean(),
     updatedAt: v.number(),
   })


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4482.

Closes #4482

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- fa83e22 fix(gabinet): use gabinetEmployeeRoleValidator for gabinetMemberships.gabinetRole and _upsertMembership args (closes #4482)

### Files changed

```
 convex/gabinet/employees.ts | 10 +++++-----
 convex/schema.ts            |  1 +
 convex/schema/crm.ts        |  4 +++-
 3 files changed, 9 insertions(+), 6 deletions(-)
```