### PR TITLE
Compute `durationMinutes` as a named variable outside JSX

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1243,6 +1243,11 @@ function AppointmentDetail() {
     },
   ];
 
+  const [apptStartH, apptStartM] = detail.appointment.startTime.split(":").map(Number);
+  const [apptEndH, apptEndM] = detail.appointment.endTime.split(":").map(Number);
+  const apptComputedDuration = apptEndH * 60 + apptEndM - (apptStartH * 60 + apptStartM);
+  const appointmentDurationMinutes = apptComputedDuration > 0 ? apptComputedDuration : (detail.treatment?.duration ?? 30);
+
   return (
     <>
       <EntityDetailLayout
@@ -1311,12 +1316,7 @@ function AppointmentDetail() {
           appointmentDate={detail.appointment.date}
           startTime={detail.appointment.startTime}
           endTime={detail.appointment.endTime}
-          durationMinutes={(() => {
-              const [sh, sm] = detail.appointment.startTime.split(":").map(Number);
-              const [eh, em] = detail.appointment.endTime.split(":").map(Number);
-              const computed = eh * 60 + em - (sh * 60 + sm);
-              return computed > 0 ? computed : (detail.treatment?.duration ?? 30);
-            })()}
+          durationMinutes={appointmentDurationMinutes}
         />
       )}
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4503.

Closes #4503

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8cd60a6 refactor(gabinet): compute appointmentDurationMinutes as named const before return (closes #4503)

### Files changed

```
 .../_layout.gabinet.appointments.$appointmentId.lazy.tsx     | 12 ++++++------
 1 file changed, 6 insertions(+), 6 deletions(-)
```