### PR TITLE
batchImportEmployees contains dead `if (matchedUserId)` guard after the null-ski

### DIFF
--- a/convex/gabinet/csvImport.ts
+++ b/convex/gabinet/csvImport.ts
@@ -387,18 +387,16 @@ export const batchImportEmployees = action({
         });
 
         // Mirror gabinet role into Convex so permission checks work.
-        if (matchedUserId) {
-          existingUserIds.add(matchedUserId);
-          try {
-            await ctx.runMutation(internal.gabinet.employees._upsertMembership, {
-              organizationId: args.organizationId,
-              userId: matchedUserId,
-              gabinetRole: safeRole,
-              isActive: true,
-            });
-          } catch {
-            // Non-fatal: membership mirror failure doesn't block the import
-          }
+        existingUserIds.add(matchedUserId);
+        try {
+          await ctx.runMutation(internal.gabinet.employees._upsertMembership, {
+            organizationId: args.organizationId,
+            userId: matchedUserId,
+            gabinetRole: safeRole,
+            isActive: true,
+          });
+        } catch {
+          // Non-fatal: membership mirror failure doesn't block the import
         }
 
         void newEmployeeId;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4509.

Closes #4509

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 053c00c fix(gabinet): remove dead if (matchedUserId) guard in batchImportEmployees (closes #4509)

### Files changed

```
 convex/gabinet/csvImport.ts | 22 ++++++++++------------
 1 file changed, 10 insertions(+), 12 deletions(-)
```