### PR TITLE
Audit similar `as Id<>` casts in other route files

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.companies.$companyId.tsx
@@ -291,7 +291,7 @@ function CompanyDetail() {
     try {
       await updateCompany({
         organizationId,
-        companyId: companyId as Id<"companies">,
+        companyId,
         name: formData.name,
         domain: formData.domain,
         industry: formData.industry,
@@ -308,7 +308,7 @@ function CompanyDetail() {
         const fieldsToSave = companyCfDefs
           .filter((d) => customFieldRecord[d.fieldKey] !== undefined && customFieldRecord[d.fieldKey] !== "")
           .map((d) => ({
-            fieldDefinitionId: d._id as Id<"customFieldDefinitions">,
+            fieldDefinitionId: d._id,
             value: customFieldRecord[d.fieldKey],
           }));
         if (fieldsToSave.length > 0) {
@@ -338,7 +338,7 @@ function CompanyDetail() {
     if (window.confirm(t('detail.confirmDeleteCompany'))) {
       await removeCompany({
         organizationId,
-        companyId: companyId as Id<"companies">,
+        companyId,
       });
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.companies.all });
       navigate({ to: "/dashboard/companies" });
@@ -594,7 +594,7 @@ function CompanyDetail() {
       dueDate: data.dueDate,
       endDate: data.endDate,
       description: data.description,
-      ownerId: currentUser._id as Id<"users">,
+      ownerId: currentUser._id,
       linkedEntityType: "company",
       linkedEntityId: companyId,
     });
@@ -617,7 +617,7 @@ function CompanyDetail() {
       const fieldsToSave = activityCustomFieldDefs
         .filter((d) => data.customFieldValues![d.fieldKey] !== undefined && data.customFieldValues![d.fieldKey] !== "")
         .map((d) => ({
-          fieldDefinitionId: d._id as Id<"customFieldDefinitions">,
+          fieldDefinitionId: d._id,
           value: data.customFieldValues![d.fieldKey],
         }));
       if (fieldsToSave.length > 0) {
@@ -644,7 +644,7 @@ function CompanyDetail() {
   }) => {
     await updateScheduledActivity({
       organizationId,
-      activityId: data.activityId as Id<"scheduledActivities">,
+      activityId: data.activityId,
       title: data.title,
       activityType: data.activityType,
       dueDate: data.dueDate,
@@ -657,7 +657,7 @@ function CompanyDetail() {
   const handleDeleteActivity = async (activityId: string) => {
     await removeScheduledActivity({
       organizationId,
-      activityId: activityId as Id<"scheduledActivities">,
+      activityId,
     });
     void queryClient.invalidateQueries({ queryKey: supabaseKeys.scheduledActivities.list(organizationId) });
     setActivityDrawerOpen(false);
@@ -666,9 +666,9 @@ function CompanyDetail() {
 
   const handleToggleActivityComplete = async (activityId: string, isCompleted: boolean) => {
     if (isCompleted) {
-      await markActivityComplete({ organizationId, activityId: activityId as Id<"scheduledActivities"> });
+      await markActivityComplete({ organizationId, activityId });
     } else {
-      await markActivityIncomplete({ organizationId, activityId: activityId as Id<"scheduledActivities"> });
+      await markActivityIncomplete({ organizationId, activityId });
     }
     void queryClient.invalidateQueries({ queryKey: supabaseKeys.scheduledActivities.list(organizationId) });
   };
@@ -678,7 +678,7 @@ function CompanyDetail() {
     const fieldsToSave = activityCustomFieldDefs
       .filter((d) => values[d.fieldKey] !== undefined && values[d.fieldKey] !== "")
       .map((d) => ({
-        fieldDefinitionId: d._id as Id<"customFieldDefinitions">,
+        fieldDefinitionId: d._id,
         value: values[d.fieldKey],
       }));
     if (fieldsToSave.length > 0) {

--- a/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.leads.$leadId.lazy.tsx
@@ -413,7 +413,7 @@ function LeadDetail() {
     try {
       await updateLead({
         organizationId,
-        leadId: leadId as Id<"leads">,
+        leadId,
         title: formData.title,
         value: formData.value,
         status: formData.status as any,
@@ -426,8 +426,8 @@ function LeadDetail() {
       if (formData.pipelineStageId) {
         await moveToStage({
           organizationId,
-          leadId: leadId as Id<"leads">,
-          pipelineStageId: formData.pipelineStageId as Id<"pipelineStages">,
+          leadId,
+          pipelineStageId: formData.pipelineStageId,
           stageOrder: 0,
         });
       }
@@ -435,7 +435,7 @@ function LeadDetail() {
         const fieldsToSave = leadCfDefs
           .filter((d) => customFieldRecord[d.fieldKey] !== undefined && customFieldRecord[d.fieldKey] !== "")
           .map((d) => ({
-            fieldDefinitionId: d._id as Id<"customFieldDefinitions">,
+            fieldDefinitionId: d._id,
             value: customFieldRecord[d.fieldKey],
           }));
         if (fieldsToSave.length > 0) {
@@ -465,7 +465,7 @@ function LeadDetail() {
   const handleMarkWon = async () => {
     await updateLead({
       organizationId,
-      leadId: leadId as Id<"leads">,
+      leadId,
       status: "won",
     });
     queryClient.invalidateQueries({ queryKey: supabaseKeys.leads.all });
@@ -475,8 +475,8 @@ function LeadDetail() {
     if (pendingLostStageId) {
       await moveToStage({
         organizationId,
-        leadId: leadId as Id<"leads">,
-        pipelineStageId: pendingLostStageId as Id<"pipelineStages">,
+        leadId,
+        pipelineStageId: pendingLostStageId,
         stageOrder: 0,
         lostReason: reason,
       });
@@ -484,7 +484,7 @@ function LeadDetail() {
     } else {
       await updateLead({
         organizationId,
-        leadId: leadId as Id<"leads">,
+        leadId,
         status: "lost",
         lostReason: reason,
       });
@@ -497,7 +497,7 @@ function LeadDetail() {
     if (window.confirm(t('detail.confirmDeleteDeal'))) {
       await removeLead({
         organizationId,
-        leadId: leadId as Id<"leads">,
+        leadId,
       });
       queryClient.invalidateQueries({ queryKey: supabaseKeys.leads.all });
       navigate({ to: "/dashboard/leads" });
@@ -513,8 +513,8 @@ function LeadDetail() {
     }
     await moveToStage({
       organizationId,
-      leadId: leadId as Id<"leads">,
-      pipelineStageId: stageId as Id<"pipelineStages">,
+      leadId,
+      pipelineStageId: stageId,
       stageOrder: 0,
     });
     queryClient.invalidateQueries({ queryKey: supabaseKeys.leads.all });
@@ -570,7 +570,7 @@ function LeadDetail() {
       );
 
       try {
-        await removeRelationship({ organizationId, relationshipId: rel._id as Id<"objectRelationships"> });
+        await removeRelationship({ organizationId, relationshipId: rel._id });
       } catch (error) {
         void queryClient.invalidateQueries({ queryKey: relationshipsQueryKey });
         throw error;
@@ -630,7 +630,7 @@ function LeadDetail() {
       );
 
       try {
-        await removeRelationship({ organizationId, relationshipId: rel._id as Id<"objectRelationships"> });
+        await removeRelationship({ organizationId, relationshipId: rel._id });
       } catch (error) {
         void queryClient.invalidateQueries({ queryKey: relationshipsQueryKey });
         throw error;
@@ -821,7 +821,7 @@ function LeadDetail() {
       dueDate: data.dueDate,
       endDate: data.endDate,
       description: data.description,
-      ownerId: currentUser._id as Id<"users">,
+      ownerId: currentUser._id,
       linkedEntityType: "lead",
       linkedEntityId: leadId,
     });
@@ -840,7 +840,7 @@ function LeadDetail() {
       const fieldsToSave = activityCustomFieldDefs
         .filter((d) => data.customFieldValues![d.fieldKey] !== undefined && data.customFieldValues![d.fieldKey] !== "")
         .map((d) => ({
-          fieldDefinitionId: d._id as Id<"customFieldDefinitions">,
+          fieldDefinitionId: d._id,
           value: data.customFieldValues![d.fieldKey],
         }));
       if (fieldsToSave.length > 0) {
@@ -865,7 +865,7 @@ function LeadDetail() {
   }) => {
     await updateScheduledActivity({
       organizationId,
-      activityId: data.activityId as Id<"scheduledActivities">,
+      activityId: data.activityId,
       title: data.title,
       activityType: data.activityType,
       dueDate: data.dueDate,
@@ -877,7 +877,7 @@ function LeadDetail() {
   const handleDeleteActivity = async (activityId: string) => {
     await removeScheduledActivity({
       organizationId,
-      activityId: activityId as Id<"scheduledActivities">,
+      activityId,
     });
     setActivityDrawerOpen(false);
     setSelectedActivityId(null);
@@ -885,9 +885,9 @@ function LeadDetail() {
 
   const handleToggleActivityComplete = async (activityId: string, isCompleted: boolean) => {
     if (isCompleted) {
-      await markActivityComplete({ organizationId, activityId: activityId as Id<"scheduledActivities"> });
+      await markActivityComplete({ organizationId, activityId });
     } else {
-      await markActivityIncomplete({ organizationId, activityId: activityId as Id<"scheduledActivities"> });
+      await markActivityIncomplete({ organizationId, activityId });
     }
   };
 
@@ -896,7 +896,7 @@ function LeadDetail() {
     const fieldsToSave = activityCustomFieldDefs
       .filter((d) => values[d.fieldKey] !== undefined && values[d.fieldKey] !== "")
       .map((d) => ({
-        fieldDefinitionId: d._id as Id<"customFieldDefinitions">,
+        fieldDefinitionId: d._id,
         value: values[d.fieldKey],
       }));
     if (fieldsToSave.length > 0) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4517.

Closes #4517

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8580909 refactor(crm): remove unnecessary as Id<> casts in companies and leads routes (closes #4517)

### Files changed

```
 .../dashboard/_layout.companies.$companyId.tsx     | 20 +++++------
 .../_auth/dashboard/_layout.leads.$leadId.lazy.tsx | 40 +++++++++++-----------
 2 files changed, 30 insertions(+), 30 deletions(-)
```