### PR TITLE
ChangeEmployeeModal does not call `refetch()` on the Convex appointment detail q

### DIFF
--- a/src/components/gabinet/change-employee-modal.tsx
+++ b/src/components/gabinet/change-employee-modal.tsx
@@ -55,7 +55,7 @@ interface ChangeEmployeeModalProps {
   startTime: string; // HH:MM
   endTime: string; // HH:MM
   durationMinutes: number;
-  onSuccess?: () => void;
+  onSuccess?: () => Promise<void> | void;
 }
 
 interface EmployeeRow {
@@ -267,7 +267,7 @@ export function ChangeEmployeeModal({
         queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetAppointments.all }),
         queryClient.invalidateQueries({ queryKey: supabaseKeys.scheduledActivities.all }),
       ]);
-      onSuccess?.();
+      await onSuccess?.();
       onOpenChange(false);
       setSelectedId(null);
       setUseNewSlot(false);

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1305,7 +1305,7 @@ function AppointmentDetail() {
         <ChangeEmployeeModal
           open={changeEmployeeOpen}
           onOpenChange={setChangeEmployeeOpen}
-          onSuccess={() => refetch()}
+          onSuccess={async () => { await refetch(); }}
           organizationId={organizationId}
           appointmentId={appointmentId as Id<"gabinetAppointments">}
           treatmentIds={


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4543.

Closes #4543

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 5044a03 fix(gabinet): await refetch() on Convex fullDetail query before closing ChangeEmployeeModal (closes #4543)

### Files changed

```
 src/components/gabinet/change-employee-modal.tsx                      | 4 ++--
 .../dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx    | 2 +-
 2 files changed, 3 insertions(+), 3 deletions(-)
```