### PR TITLE
5/6 — Pracownicy — trzy sposoby aktywacji konta

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -174,6 +174,7 @@ export const create = action({
     qualifiedTreatmentIds: v.optional(v.array(v.string())),
     licenseNumber: v.optional(v.union(v.string(), v.null())),
     hireDate: v.optional(v.union(v.string(), v.null())),
+    isActive: v.optional(v.boolean()),
     color: v.optional(v.union(v.string(), v.null())),
     notes: v.optional(v.union(v.string(), v.null())),
     showInCalendar: v.optional(v.boolean()),
@@ -185,9 +186,6 @@ export const create = action({
   },
   handler: async (ctx, args) => {
     try {
-    if (!args.userId) {
-      throw new Error("Tworzenie pracownika bez konta użytkownika jest niedozwolone. Wyślij zaproszenie e-mail.");
-    }
 
     // --- Auth + permissions (via internal queries) ---
     const authResult = await ctx.runAction(
@@ -228,7 +226,7 @@ export const create = action({
       qualifiedTreatmentIds: args.qualifiedTreatmentIds ?? [],
       licenseNumber: args.licenseNumber ?? null,
       hireDate: args.hireDate ?? null,
-      isActive: true,
+      isActive: args.isActive ?? true,
       color: args.color ?? null,
       notes: args.notes ?? null,
       showInCalendar: args.showInCalendar ?? true,

--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -63,7 +63,7 @@ export interface EmployeeFormData {
   categoryId?: Id<"categoryDefinitions">;
   customFields?: Array<{ fieldDefinitionId: string; value: unknown }>;
   grantSystemAccess?: boolean;
-  accessMode?: "invite" | "password";
+  accessMode?: "invite" | "password" | "inactive";
   accessEmail?: string;
   accessRole?: "admin" | "member" | "viewer";
   password?: string;
@@ -122,7 +122,7 @@ export function EmployeeForm({
   const [treatmentSearch, setTreatmentSearch] = useState("");
   const [accessEmail, setAccessEmail] = useState("");
   const [accessRole, setAccessRole] = useState<"admin" | "member" | "viewer">("member");
-  const [accessMode, setAccessMode] = useState<"invite" | "password">("invite");
+  const [accessMode, setAccessMode] = useState<"invite" | "password" | "inactive">("invite");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [locationId, setLocationId] = useState<string | undefined>(undefined);
@@ -187,10 +187,10 @@ export function EmployeeForm({
       tagIds: tagIds.length > 0 ? tagIds : undefined,
       categoryId: categoryId || undefined,
       customFields: customFields.length > 0 ? customFields : undefined,
-      grantSystemAccess: true,
+      grantSystemAccess: accessMode !== "inactive",
       accessMode,
-      accessEmail: accessEmail.trim() || undefined,
-      accessRole: accessRole,
+      accessEmail: accessMode !== "inactive" ? accessEmail.trim() || undefined : undefined,
+      accessRole: accessMode !== "inactive" ? accessRole : undefined,
       password: accessMode === "password" ? password : undefined,
       locationId: locationId,
       locationRole: locationRole,
@@ -430,8 +430,8 @@ export function EmployeeForm({
             {/* Access mode toggle */}
             <div className="space-y-1.5">
               <Label>{t("gabinet.employees.accessMethod", { defaultValue: "Sposób aktywacji konta" })}</Label>
-              <div className="flex gap-2">
-                <label className="flex flex-1 cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-accent/40 has-[:checked]:border-primary has-[:checked]:bg-accent/60">
+              <div className="flex flex-col gap-1.5">
+                <label className="flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-accent/40 has-[:checked]:border-primary has-[:checked]:bg-accent/60">
                   <input
                     type="radio"
                     name="accessMode"
@@ -442,7 +442,7 @@ export function EmployeeForm({
                   />
                   {t("gabinet.employees.accessModeInvite", { defaultValue: "Wyślij zaproszenie e-mailem" })}
                 </label>
-                <label className="flex flex-1 cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-accent/40 has-[:checked]:border-primary has-[:checked]:bg-accent/60">
+                <label className="flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-accent/40 has-[:checked]:border-primary has-[:checked]:bg-accent/60">
                   <input
                     type="radio"
                     name="accessMode"
@@ -451,11 +451,23 @@ export function EmployeeForm({
                     onChange={() => setAccessMode("password")}
                     className="accent-primary"
                   />
-                  {t("gabinet.employees.accessModePassword", { defaultValue: "Ustaw hasło ręcznie" })}
+                  {t("gabinet.employees.accessModePassword", { defaultValue: "Utwórz hasło jednorazowe" })}
+                </label>
+                <label className="flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-accent/40 has-[:checked]:border-primary has-[:checked]:bg-accent/60">
+                  <input
+                    type="radio"
+                    name="accessMode"
+                    value="inactive"
+                    checked={accessMode === "inactive"}
+                    onChange={() => setAccessMode("inactive")}
+                    className="accent-primary"
+                  />
+                  {t("gabinet.employees.accessModeInactive", { defaultValue: "Utwórz konto jako nieaktywne" })}
                 </label>
               </div>
             </div>
 
+            {accessMode !== "inactive" && (
             <div className="space-y-1.5">
               <Label>
                 {t("gabinet.employees.accessEmail", { defaultValue: "Adres e-mail" })} <span className="text-destructive">*</span>
@@ -467,6 +479,8 @@ export function EmployeeForm({
                 placeholder={t("gabinet.employees.accessEmailPlaceholder", { defaultValue: "np. jan.kowalski@firma.pl" })}
               />
             </div>
+            )}
+            {accessMode !== "inactive" && (
             <div className="space-y-1.5">
               <Label>
                 {t("gabinet.employees.accessRole", { defaultValue: "Rola dostępu" })} <span className="text-destructive">*</span>
@@ -488,6 +502,7 @@ export function EmployeeForm({
                 </SelectContent>
               </Select>
             </div>
+            )}
 
             {/* Password fields — only shown in manual password mode */}
             {accessMode === "password" && (
@@ -618,7 +633,7 @@ export function EmployeeForm({
           type="submit"
           disabled={
             isSubmitting ||
-            !accessEmail.trim() ||
+            (accessMode !== "inactive" && !accessEmail.trim()) ||
             !isPasswordValid
           }
         >

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -697,7 +697,32 @@ function CreateEmployeeSheet({
             onSubmit={async (data) => {
               setSaving(true);
               try {
-                if (data.accessMode === "password" && data.accessEmail && data.password) {
+                if (data.accessMode === "inactive") {
+                  // Create employee record without any user account (no login access).
+                  // isActive is a new param added to the create action validator — types
+                  // will be in sync after the next `npx convex dev` codegen run.
+                  await (createEmployee as (args: Record<string, unknown>) => Promise<unknown>)({
+                    organizationId,
+                    firstName: data.firstName,
+                    lastName: data.lastName,
+                    role: data.role,
+                    specialization: data.specialization,
+                    licenseNumber: data.licenseNumber,
+                    color: data.color,
+                    showInCalendar: data.showInCalendar,
+                    qualifiedTreatmentIds: data.qualifiedTreatmentIds as string[],
+                    tagIds: data.tagIds as string[] | undefined,
+                    categoryId: data.categoryId as string | undefined,
+                    customFields: data.customFields,
+                    locationId: data.locationId,
+                    locationRole: data.locationRole,
+                    isActive: false,
+                  });
+                  toast.success(t("common.created"));
+                  void queryClient.invalidateQueries({
+                    queryKey: supabaseKeys.gabinetEmployees.list(organizationId),
+                  });
+                } else if (data.accessMode === "password" && data.accessEmail && data.password) {
                   await createWithPassword({
                     organizationId,
                     email: data.accessEmail,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4560.

Closes #4560

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0fdd02a feat(gabinet): add three account-activation options to Add Employee form (closes #4560)

### Files changed

```
 convex/gabinet/employees.ts                        |  6 ++--
 src/components/forms/employee-form.tsx             | 35 +++++++++++++++-------
 .../dashboard/_layout.gabinet.employees.index.tsx  | 27 ++++++++++++++++-
 3 files changed, 53 insertions(+), 15 deletions(-)
```