### PR TITLE
`gabinet_employee_locations` has no entry in `supabaseKeys` query-key registry

### DIFF
--- a/src/components/gabinet/employees/edit-employee-drawer.tsx
+++ b/src/components/gabinet/employees/edit-employee-drawer.tsx
@@ -22,6 +22,7 @@ import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
 import { useSupabase } from "@/components/supabase-provider";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { EMPLOYEE_ROLES } from "@/lib/options";
 
 export { EMPLOYEE_ROLES as ROLES };
@@ -53,7 +54,7 @@ export function EditEmployeeDrawer({
   const { data: locations } = useSupabaseGabinetLocationsList(String(organizationId));
 
   const { data: currentPrimaryLocation } = useQuery({
-    queryKey: ["gabinet_employee_locations_primary", String(organizationId), employee._id],
+    queryKey: supabaseKeys.gabinetEmployeeLocations.detail(String(organizationId), employee._id),
     queryFn: async () => {
       if (!client) return null;
       const { data } = await client

--- a/src/lib/supabase/query-keys.ts
+++ b/src/lib/supabase/query-keys.ts
@@ -75,6 +75,7 @@ export const supabaseKeys = {
   gabinetTreatments: entityKeys("gabinetTreatments"),
   gabinetTreatmentVariants: entityKeys("gabinetTreatmentVariants"),
   gabinetEmployees: entityKeys("gabinetEmployees"),
+  gabinetEmployeeLocations: entityKeys("gabinetEmployeeLocations"),
   gabinetLocations: entityKeys("gabinetLocations"),
   gabinetRooms: entityKeys("gabinetRooms"),
   gabinetEquipment: entityKeys("gabinetEquipment"),

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -98,7 +98,7 @@ function EmployeeDetail() {
     void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetEmployees.list(organizationId) });
     void queryClient.invalidateQueries({ queryKey: supabaseKeys.gabinetEmployees.detail(organizationId, employeeId) });
     void queryClient.invalidateQueries({
-      queryKey: ["gabinet_employee_locations_primary", String(organizationId), employeeId],
+      queryKey: supabaseKeys.gabinetEmployeeLocations.detail(organizationId, employeeId),
     });
   };
   const invalidateScheduleCache = () => {
@@ -162,7 +162,7 @@ function EmployeeDetail() {
 
   const { client: supabaseClient, isReady: supabaseReady } = useSupabase();
   const { data: primaryLocationData } = useQuery({
-    queryKey: ["gabinet_employee_locations_primary", String(organizationId), employeeId],
+    queryKey: supabaseKeys.gabinetEmployeeLocations.detail(organizationId, employeeId),
     queryFn: async () => {
       if (!supabaseClient) return null;
       const { data } = await supabaseClient


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4579.

Closes #4579

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d678af7 fix(gabinet): centralise gabinet_employee_locations_primary key in supabaseKeys registry (closes #4579)

### Files changed

```
 src/components/gabinet/employees/edit-employee-drawer.tsx             | 3 ++-
 src/lib/supabase/query-keys.ts                                        | 1 +
 .../_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx    | 4 ++--
 3 files changed, 5 insertions(+), 3 deletions(-)
```