### PR TITLE
4/1 — Pracownicy — ujednolić statusy konta pracownika

### DIFF
--- a/src/components/gabinet/employees/account-tab-content.tsx
+++ b/src/components/gabinet/employees/account-tab-content.tsx
@@ -83,9 +83,13 @@ export function AccountTabContent({
             </div>
             <div className="flex items-center justify-between px-4 py-3">
               <span className="text-sm text-muted-foreground">{t("gabinet.employees.accountStatus", "Status konta")}</span>
-              <Badge variant={employee.isActive ? "default" : "secondary"}>
-                {employee.isActive ? t("gabinet.employees.accountActive", "Aktywny") : t("gabinet.employees.accountInactive", "Nieaktywny")}
-              </Badge>
+              {employee.isActive ? (
+                <Badge variant="default">{t("gabinet.employees.statusActive", "Konto aktywne")}</Badge>
+              ) : employee.userId ? (
+                <Badge variant="destructive">{t("gabinet.employees.statusBlocked", "Konto zablokowane")}</Badge>
+              ) : (
+                <Badge variant="secondary">{t("gabinet.employees.statusInactive", "Konto nieaktywne")}</Badge>
+              )}
             </div>
           </div>
         </div>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -487,7 +487,9 @@ function EmployeeDetail() {
       </Badge>
       {!employee.isActive && (
         <Badge variant="outline" className="text-muted-foreground">
-          {t("common.inactive")}
+          {employee.userId
+            ? t("gabinet.employees.statusBlocked", "Konto zablokowane")
+            : t("gabinet.employees.statusInactive", "Konto nieaktywne")}
         </Badge>
       )}
     </div>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -245,7 +245,9 @@ function EmployeesIndex() {
             </div>
             {!item.isActive && (
               <Badge variant="outline" className="text-xs text-muted-foreground">
-                {t("common.inactive")}
+                {item.userId
+                  ? t("gabinet.employees.statusBlocked", "Konto zablokowane")
+                  : t("gabinet.employees.statusInactive", "Konto nieaktywne")}
               </Badge>
             )}
           </div>
@@ -620,8 +622,8 @@ function EmployeesIndex() {
                   )}
                   <Badge variant="outline" className="text-xs shrink-0">
                     {isExpired
-                      ? t("gabinet.employees.invitationExpired", "Wygasło")
-                      : t("gabinet.employees.pendingAcceptance", { defaultValue: "Oczekuje na akceptację" })}
+                      ? t("gabinet.employees.statusInvitationExpired", "Zaproszenie wygasło")
+                      : t("gabinet.employees.statusInvitationPending", "Zaproszenie wysłane — oczekuje na akceptację")}
                   </Badge>
                   <Button
                     size="sm"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4605.

Closes #4605

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d738f7b feat(gabinet): unify employee account status labels to 5-state model (closes #4605)

### Files changed

```
 src/components/gabinet/employees/account-tab-content.tsx       | 10 +++++++---
 .../_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx  |  4 +++-
 .../_app/_auth/dashboard/_layout.gabinet.employees.index.tsx   |  8 +++++---
 3 files changed, 15 insertions(+), 7 deletions(-)
```