### PR TITLE
4/5 — Pracownicy — obsługa wygasłego zaproszenia

### DIFF
--- a/src/components/gabinet/employees/account-tab-content.tsx
+++ b/src/components/gabinet/employees/account-tab-content.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
-import { ChevronRight, Pencil, Power, Settings } from "@/lib/ez-icons";
+import { ChevronRight, Pencil, Power, Send, Settings } from "@/lib/ez-icons";
 import type { MappedGabinetEmployee } from "@/lib/supabase/mappers/gabinet/employees";
+import type { MappedInvitation } from "@/lib/supabase/mappers";
 import type { TFunction } from "i18next";
 import { ChangePasswordDialog } from "./change-password-dialog";
 import { toast } from "sonner";
@@ -15,6 +16,8 @@ export function AccountTabContent({
   onEditEmployee,
   onDeactivate,
   onActivate,
+  pendingInvitation,
+  onResendInvitation,
   t,
 }: {
   employee: MappedGabinetEmployee;
@@ -24,6 +27,8 @@ export function AccountTabContent({
   onEditEmployee: () => void;
   onDeactivate: () => void;
   onActivate?: () => Promise<void>;
+  pendingInvitation?: MappedInvitation | null;
+  onResendInvitation?: () => Promise<void>;
   t: TFunction;
 }) {
   const [changePasswordOpen, setChangePasswordOpen] = useState(false);
@@ -85,7 +90,13 @@ export function AccountTabContent({
             </div>
             <div className="flex items-center justify-between px-4 py-3">
               <span className="text-sm text-muted-foreground">{t("gabinet.employees.accountStatus", "Status konta")}</span>
-              {employee.isActive ? (
+              {pendingInvitation ? (
+                pendingInvitation.expiresAt <= Date.now() ? (
+                  <Badge variant="outline">{t("gabinet.employees.statusInvitationExpired", "Zaproszenie wygasło")}</Badge>
+                ) : (
+                  <Badge variant="secondary">{t("gabinet.employees.statusInvitationPending", "Zaproszenie wysłane — oczekuje na akceptację")}</Badge>
+                )
+              ) : employee.isActive ? (
                 <Badge variant="default">{t("gabinet.employees.statusActive", "Konto aktywne")}</Badge>
               ) : employee.userId ? (
                 <Badge variant="destructive">{t("gabinet.employees.statusBlocked", "Konto zablokowane")}</Badge>
@@ -126,6 +137,20 @@ export function AccountTabContent({
                 </div>
                 <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
               </button>
+              {pendingInvitation && pendingInvitation.expiresAt <= Date.now() && onResendInvitation && (
+                <button
+                  type="button"
+                  className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+                  onClick={onResendInvitation}
+                >
+                  <Send className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm">{t("gabinet.employees.resendInvitation", "Wyślij zaproszenie ponownie")}</p>
+                    <p className="text-xs text-muted-foreground">{t("gabinet.employees.resendInvitationDesc", "Ponów wysyłkę zaproszenia z nowym terminem ważności")}</p>
+                  </div>
+                  <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                </button>
+              )}
               {!employee.isActive && !employee.userId && onActivate ? (
                 <button
                   type="button"

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -19,6 +19,7 @@ import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
 import { useSupabaseScheduledActivitiesByEntity } from "@/hooks/use-supabase-scheduled-activities";
 import { useSupabaseNotesByEntity } from "@/hooks/use-supabase-notes";
 import { useSupabaseGabinetAppointmentsByEmployee } from "@/hooks/use-supabase-gabinet-appointments";
+import { useSupabasePendingInvitations } from "@/hooks/use-supabase-invitations";
 import {
   FlexibleScheduleEditor,
   groupSchedulesIntoPeriods,
@@ -92,6 +93,7 @@ function EmployeeDetail() {
   const trackView = useAction(api.recentlyViewed.track);
   const listDocumentsByEntity = useAction(api.documents.documents.listByEntity);
   const changeEmployeePassword = useAction(api.gabinet.employees.changeEmployeePassword);
+  const resendInvitation = useAction(api.invitations.resend);
 
   // Supabase cache invalidation helpers
   const invalidateEmployeeCache = () => {
@@ -180,6 +182,7 @@ function EmployeeDetail() {
   const { data: locations } = useSupabaseGabinetLocationsList(String(organizationId));
 
   const { data: members } = useSupabaseOrganizationMembers(organizationId);
+  const { data: pendingInvitations } = useSupabasePendingInvitations(organizationId);
 
   const { data: allEmployees } = useSupabaseGabinetEmployeesList(organizationId);
 
@@ -358,6 +361,16 @@ function EmployeeDetail() {
   // --- Derived data (used in both layout props and tab content) ---
 
   const user = employee?.userId ? userMap.get(employee.userId) : undefined;
+
+  // Match a pending invitation to this employee by email (employee.email or linked user email).
+  // Used to show "Zaproszenie wysłane/wygasło" status and the resend action.
+  const pendingInvitation = useMemo(() => {
+    const email = employee?.email || user?.email;
+    if (!email || !pendingInvitations) return null;
+    return pendingInvitations.find((inv) => inv.email === email) ?? null;
+  }, [pendingInvitations, employee?.email, user?.email]);
+
+  const isExpiredInvitation = pendingInvitation ? pendingInvitation.expiresAt <= Date.now() : false;
   const fullName = employee
     ? (employee.firstName || employee.lastName
         ? `${employee.firstName ?? ""} ${employee.lastName ?? ""}`.trim()
@@ -391,6 +404,22 @@ function EmployeeDetail() {
         formatActionError(e, t, {
           key: "gabinet.employees.errors.activateFailed",
           defaultValue: "Nie udało się aktywować konta.",
+        }),
+      );
+    }
+  };
+
+  const handleResendInvitation = async () => {
+    if (!pendingInvitation) return;
+    try {
+      await resendInvitation({ organizationId, invitationId: pendingInvitation._id });
+      toast.success(t("team.invitationResent", "Zaproszenie zostało wysłane ponownie."));
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(organizationId) });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "team.errors.resendFailed",
+          defaultValue: "Nie udało się wysłać zaproszenia ponownie.",
         }),
       );
     }
@@ -488,7 +517,7 @@ function EmployeeDetail() {
 
   const sidebarExtra = undefined;
 
-  // Header subtitle with color swatch, role badge, and inactive badge
+  // Header subtitle with color swatch, role badge, and account/invitation status badge
   const headerSubtitle = !employee ? undefined : (
     <div className="flex items-center gap-2">
       {employee.color && (
@@ -500,13 +529,19 @@ function EmployeeDetail() {
       <Badge variant={employee.isActive ? "default" : "secondary"}>
         {t(`gabinet.employees.roles.${employee.role}`)}
       </Badge>
-      {!employee.isActive && (
+      {pendingInvitation ? (
+        <Badge variant="outline" className="text-muted-foreground">
+          {isExpiredInvitation
+            ? t("gabinet.employees.statusInvitationExpired", "Zaproszenie wygasło")
+            : t("gabinet.employees.statusInvitationPending", "Zaproszenie wysłane — oczekuje na akceptację")}
+        </Badge>
+      ) : !employee.isActive ? (
         <Badge variant="outline" className="text-muted-foreground">
           {employee.userId
             ? t("gabinet.employees.statusBlocked", "Konto zablokowane")
             : t("gabinet.employees.statusInactive", "Konto nieaktywne")}
         </Badge>
-      )}
+      ) : null}
     </div>
   );
 
@@ -688,6 +723,8 @@ function EmployeeDetail() {
           onEditEmployee={() => setEditDrawerOpen(true)}
           onDeactivate={handleDeactivate}
           onActivate={handleActivate}
+          pendingInvitation={pendingInvitation}
+          onResendInvitation={isExpiredInvitation ? handleResendInvitation : undefined}
           t={t}
         />
       ),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4610.

Closes #4610

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4bb9ec5 feat(gabinet): show expired-invitation status and resend action in employee detail view (closes #4610)

### Files changed

```
 .../gabinet/employees/account-tab-content.tsx      | 29 ++++++++++++++-
 .../_layout.gabinet.employees.$employeeId.tsx      | 43 ++++++++++++++++++++--
 2 files changed, 67 insertions(+), 5 deletions(-)
```