### PR TITLE
Remove redundant `isSystemGabinetRole` runtime guards after schema validation

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -238,14 +238,13 @@ export const create = action({
     });
 
     if (args.locationId) {
-      const locationRole = args.locationRole && isSystemGabinetRole(args.locationRole) ? args.locationRole : undefined;
       try {
         await db.insert("gabinetEmployeeLocations", {
           organizationId: String(args.organizationId),
           employeeId: String(employeeId),
           locationId: args.locationId,
           isPrimary: true,
-          role: locationRole,
+          role: args.locationRole,
           createdAt: now,
         });
       } catch (e) {
@@ -752,8 +751,7 @@ export const update = action({
         await db.delete("gabinetEmployeeLocations", String(loc._id));
       }
       if (locationId) {
-        const effectiveLocationRole =
-          locationRole != null && isSystemGabinetRole(locationRole) ? locationRole : undefined;
+        const effectiveLocationRole = locationRole != null ? locationRole : undefined;
         try {
           await db.insert("gabinetEmployeeLocations", {
             organizationId: String(organizationId),
@@ -775,8 +773,7 @@ export const update = action({
         .eq("isPrimary", true)
         .collect();
       for (const loc of existingLocs) {
-        const effectiveLocationRole =
-          locationRole != null && isSystemGabinetRole(locationRole) ? locationRole : null;
+        const effectiveLocationRole = locationRole ?? null;
         try {
           await db.patch("gabinetEmployeeLocations", String(loc._id), {
             role: effectiveLocationRole,
@@ -1323,17 +1320,13 @@ export const createWithPassword = action({
     });
 
     if (args.locationId) {
-      const locationRole =
-        args.locationRole && isSystemGabinetRole(args.locationRole)
-          ? args.locationRole
-          : undefined;
       try {
         await db.insert("gabinetEmployeeLocations", {
           organizationId: String(args.organizationId),
           employeeId: String(employeeId),
           locationId: args.locationId,
           isPrimary: true,
-          role: locationRole,
+          role: args.locationRole,
           createdAt: now,
         });
       } catch (e) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4593.

Closes #4593

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 332fa7e refactor(gabinet): remove redundant isSystemGabinetRole guards where schema validates locationRole (closes #4593)

### Files changed

```
 convex/gabinet/employees.ts | 15 ++++-----------
 1 file changed, 4 insertions(+), 11 deletions(-)
```