### PR TITLE
Fix pre-existing TS errors in src/components/gabinet/employees/account-tab-conte

### DIFF
--- a/src/components/gabinet/documentation-tab.tsx
+++ b/src/components/gabinet/documentation-tab.tsx
@@ -618,7 +618,7 @@ export function DocumentationTab({
         onRemove={handleRemovePhoto}
         uploadFile={uploadFile}
         uploadingFiles={uploadingFiles}
-        t={t as (key: string, fallback?: string) => string}
+        t={t as (key: string, opts?: Record<string, unknown> | string) => string}
       />
 
     </div>

--- a/src/components/gabinet/employees/account-tab-content.tsx
+++ b/src/components/gabinet/employees/account-tab-content.tsx
@@ -3,7 +3,6 @@ import { Badge } from "@/components/ui/badge";
 import { ChevronRight, Pencil, Power, Send, Settings } from "@/lib/ez-icons";
 import type { MappedGabinetEmployee } from "@/lib/supabase/mappers/gabinet/employees";
 import type { MappedInvitation } from "@/lib/supabase/mappers";
-import type { TFunction } from "i18next";
 import { ChangePasswordDialog } from "./change-password-dialog";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
@@ -29,7 +28,7 @@ export function AccountTabContent({
   onActivate?: () => Promise<void>;
   pendingInvitation?: MappedInvitation | null;
   onResendInvitation?: () => Promise<void>;
-  t: TFunction;
+  t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   const [changePasswordOpen, setChangePasswordOpen] = useState(false);
   const [newPassword, setNewPassword] = useState("");

--- a/src/lib/format-action-error.ts
+++ b/src/lib/format-action-error.ts
@@ -1,4 +1,4 @@
-import type { TFunction } from "i18next";
+type TFn = (key: string, opts?: Record<string, unknown> | string) => string;
 
 // Snake_case Postgres column name → Polish form label. Used to turn raw
 // backend errors like `null value in column "duration"` into something the
@@ -417,7 +417,7 @@ const APPOINTMENT_ERROR_MAP: Array<{
 // Falls back to a provided generic message when nothing matches.
 export function formatAppointmentError(
   err: unknown,
-  t: TFunction,
+  t: TFn,
   fallback: { key: string; defaultValue: string },
 ): string {
   console.error("[formatAppointmentError]", err);
@@ -490,7 +490,7 @@ const TREATMENT_ERROR_MAP: Array<{
 // users.
 export function formatTreatmentError(
   err: unknown,
-  t: TFunction,
+  t: TFn,
   fallback: { key: string; defaultValue: string },
 ): string {
   console.error("[formatTreatmentError]", err);
@@ -616,7 +616,7 @@ const GENERIC_ERROR_MAP: Array<{
 // backend output never leaks to end users.
 export function formatActionError(
   err: unknown,
-  t: TFunction,
+  t: TFn,
   fallback: { key: string; defaultValue: string },
 ): string {
   console.error("[formatActionError]", err);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4630.

Closes #4630

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 6818457 fix(gabinet): replace TFunction with simple callable type to fix TS errors (closes #4630)

### Files changed

```
 src/components/gabinet/documentation-tab.tsx             | 2 +-
 src/components/gabinet/employees/account-tab-content.tsx | 3 +--
 src/lib/format-action-error.ts                           | 8 ++++----
 3 files changed, 6 insertions(+), 7 deletions(-)
```