### PR TITLE
5/5 — Pracownicy — uporządkować sekcję kalendarza

### DIFF
--- a/src/components/gabinet/employees/edit-employee-drawer.tsx
+++ b/src/components/gabinet/employees/edit-employee-drawer.tsx
@@ -17,6 +17,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { RichTextEditor } from "@/components/gabinet/rich-text-editor";
+import { Separator } from "@/components/ui/separator";
 import type { TFunction } from "i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
@@ -262,6 +263,13 @@ export function EditEmployeeDrawer({
             value={hireDate}
             onChange={(e) => setHireDate(e.target.value)}
           />
+        </div>
+
+        <div className="space-y-1.5">
+          <Separator />
+          <p className="text-sm font-medium text-muted-foreground pt-1">
+            {t("gabinet.employees.calendarSettings", { defaultValue: "Ustawienia kalendarza" })}
+          </p>
         </div>
 
         <div className="space-y-1.5">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4624.

Closes #4624

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- ddda088 fix(gabinet): add calendar settings section header in edit employee drawer (closes #4624)

### Files changed

```
 src/components/gabinet/employees/edit-employee-drawer.tsx | 8 ++++++++
 1 file changed, 8 insertions(+)
```