### PR TITLE
Fix `tsconfig.app.json` pre-existing TS5102 error

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,7 +24,6 @@
     "noFallthroughCasesInSwitch": true,
 
     /* Alias */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@cvx/*": ["./convex/*"],


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4641.

Closes #4641

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 7afa82f fix(tsconfig): remove baseUrl to resolve TS5102 with moduleResolution bundler (closes #4641)

### Files changed

```
 tsconfig.app.json | 1 -
 1 file changed, 1 deletion(-)
```