### PR TITLE
Qualifications tab should check `performsServices` before rendering in employee 

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -621,7 +621,7 @@ function EmployeeDetail() {
         />
       ),
     },
-    {
+    ...(employee.performsServices ? [{
       label: t("gabinet.employees.tabs.qualificationsAndTreatments"),
       content: (
         <DetailedDataTab
@@ -638,7 +638,7 @@ function EmployeeDetail() {
           qualificationsOnlyView={true}
         />
       ),
-    },
+    }] : []),
     {
       label: t("gabinet.employees.tabs.detailedData"),
       content: (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4635.

Closes #4635

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8e5f38d fix(gabinet): hide qualificationsAndTreatments tab when performsServices=false (closes #4635)

### Files changed

```
 .../_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx    | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```