### PR TITLE
Migrate shadcn-studio block imports from lucide-react to ez-icons

### DIFF
--- a/src/components/shadcn-studio/blocks/login-page-03/login-form.tsx
+++ b/src/components/shadcn-studio/blocks/login-page-03/login-form.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-import { EyeIcon, EyeOffIcon } from 'lucide-react'
+import { EyeIcon, EyeOffIcon } from '@/lib/ez-icons'
 
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'

--- a/src/components/shadcn-studio/blocks/register-03/register-form.tsx
+++ b/src/components/shadcn-studio/blocks/register-03/register-form.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-import { EyeIcon, EyeOffIcon } from 'lucide-react'
+import { EyeIcon, EyeOffIcon } from '@/lib/ez-icons'
 
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'

--- a/src/components/shadcn-studio/blocks/reset-password-03/reset-password-form.tsx
+++ b/src/components/shadcn-studio/blocks/reset-password-03/reset-password-form.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 
-import { EyeIcon, EyeOffIcon } from 'lucide-react'
+import { EyeIcon, EyeOffIcon } from '@/lib/ez-icons'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4596.

Closes #4596

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 52c0d64 fix(shadcn-studio): migrate EyeIcon/EyeOffIcon imports from lucide-react to ez-icons (closes #4596)

### Files changed

```
 src/components/shadcn-studio/blocks/login-page-03/login-form.tsx        | 2 +-
 src/components/shadcn-studio/blocks/register-03/register-form.tsx       | 2 +-
 .../shadcn-studio/blocks/reset-password-03/reset-password-form.tsx      | 2 +-
 3 files changed, 3 insertions(+), 3 deletions(-)
```