### PR TITLE
5/6 — Pracownicy — uporządkować sekcję aktywacji konta

### DIFF
--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -564,38 +564,53 @@ export function EmployeeForm({
         <div className="space-y-1.5">
           <Label>{t("gabinet.employees.accessMethod", { defaultValue: "Sposób aktywacji konta" })}</Label>
           <div className="flex flex-col gap-1.5">
-            <label className="flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-accent/40 has-[:checked]:border-primary has-[:checked]:bg-accent/60">
+            <label className="flex cursor-pointer items-start gap-2 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-accent/40 has-[:checked]:border-primary has-[:checked]:bg-accent/60">
               <input
                 type="radio"
                 name="accessMode"
                 value="invite"
                 checked={accessMode === "invite"}
                 onChange={() => setAccessMode("invite")}
-                className="accent-primary"
+                className="accent-primary mt-0.5"
               />
-              {t("gabinet.employees.accessModeInvite", { defaultValue: "Wyślij zaproszenie e-mailem" })}
+              <span className="flex flex-col gap-0.5">
+                <span>{t("gabinet.employees.accessModeInvite", { defaultValue: "Wyślij zaproszenie e-mailem" })}</span>
+                <span className="text-xs text-muted-foreground">
+                  {t("gabinet.employees.accessModeInviteDesc", { defaultValue: "Pracownik otrzyma link aktywacyjny na wskazany adres e-mail." })}
+                </span>
+              </span>
             </label>
-            <label className="flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-accent/40 has-[:checked]:border-primary has-[:checked]:bg-accent/60">
+            <label className="flex cursor-pointer items-start gap-2 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-accent/40 has-[:checked]:border-primary has-[:checked]:bg-accent/60">
               <input
                 type="radio"
                 name="accessMode"
                 value="password"
                 checked={accessMode === "password"}
                 onChange={() => setAccessMode("password")}
-                className="accent-primary"
+                className="accent-primary mt-0.5"
               />
-              {t("gabinet.employees.accessModePassword", { defaultValue: "Utwórz hasło jednorazowe" })}
+              <span className="flex flex-col gap-0.5">
+                <span>{t("gabinet.employees.accessModePassword", { defaultValue: "Utwórz hasło jednorazowe" })}</span>
+                <span className="text-xs text-muted-foreground">
+                  {t("gabinet.employees.accessModePasswordDesc", { defaultValue: "Administrator ustawia hasło i przekazuje je pracownikowi bezpośrednio." })}
+                </span>
+              </span>
             </label>
-            <label className="flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-accent/40 has-[:checked]:border-primary has-[:checked]:bg-accent/60">
+            <label className="flex cursor-pointer items-start gap-2 rounded-md border px-3 py-2 text-sm transition-colors hover:bg-accent/40 has-[:checked]:border-primary has-[:checked]:bg-accent/60">
               <input
                 type="radio"
                 name="accessMode"
                 value="inactive"
                 checked={accessMode === "inactive"}
                 onChange={() => setAccessMode("inactive")}
-                className="accent-primary"
+                className="accent-primary mt-0.5"
               />
-              {t("gabinet.employees.accessModeInactive", { defaultValue: "Utwórz konto jako nieaktywne" })}
+              <span className="flex flex-col gap-0.5">
+                <span>{t("gabinet.employees.accessModeInactive", { defaultValue: "Utwórz konto jako nieaktywne" })}</span>
+                <span className="text-xs text-muted-foreground">
+                  {t("gabinet.employees.accessModeInactiveDesc", { defaultValue: "Pracownik zostanie dodany bez dostępu do systemu — konto można aktywować później." })}
+                </span>
+              </span>
             </label>
           </div>
         </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4625.

Closes #4625

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 95f33d0 feat(gabinet): add descriptions to account activation options in employee form (closes #4625)

### Files changed

```
 src/components/forms/employee-form.tsx | 33 ++++++++++++++++++++++++---------
 1 file changed, 24 insertions(+), 9 deletions(-)
```