### PR TITLE
5/8 — Pracownicy — uporządkować sekcję uprawnień

### DIFF
--- a/src/components/gabinet/employees/employee-permissions-tab.tsx
+++ b/src/components/gabinet/employees/employee-permissions-tab.tsx
@@ -213,6 +213,14 @@ export function EmployeePermissionsTab({
           )}
         </CardHeader>
         <CardContent>
+          <div className="flex items-center justify-between py-2 mb-3 border-b text-sm">
+            <span className="text-muted-foreground">
+              {t("gabinet.employees.role", "Rola pracownika")}
+            </span>
+            <span className="font-medium">
+              {t(`gabinet.employees.roles.${gabinetRole}`, gabinetRole)}
+            </span>
+          </div>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4627.

Closes #4627

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 67b4444 feat(gabinet): separate permissions section from role/workScope in employee form (closes #4627)

### Files changed

```
 src/components/gabinet/employees/employee-permissions-tab.tsx | 8 ++++++++
 1 file changed, 8 insertions(+)
```