### PR TITLE
Remove duplicated `ALLOWED_EMPLOYEE_ROLES` constant in csvImport.ts

### DIFF
--- a/convex/gabinet/csvImport.ts
+++ b/convex/gabinet/csvImport.ts
@@ -2,18 +2,11 @@ import { action } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
-import { GabinetEmployeeRole } from "../schema";
+import { GabinetEmployeeRole, gabinetEmployeeRoleValidator } from "../schema";
 
-const ALLOWED_EMPLOYEE_ROLES = [
-  "doctor",
-  "cosmetologist",
-  "nurse",
-  "therapist",
-  "receptionist",
-  "manager",
-  "admin",
-  "other",
-] as const;
+const ALLOWED_EMPLOYEE_ROLES = gabinetEmployeeRoleValidator.members.map(
+  (m) => m.value,
+) as GabinetEmployeeRole[];
 
 /**
  * Batch-import patients from CSV. Unlike the single-record `patients.create`,
@@ -360,7 +353,7 @@ export const batchImportEmployees = action({
         const safeRole: GabinetEmployeeRole =
           rec.role &&
           ALLOWED_EMPLOYEE_ROLES.includes(
-            rec.role as (typeof ALLOWED_EMPLOYEE_ROLES)[number],
+            rec.role as GabinetEmployeeRole,
           )
             ? (rec.role as GabinetEmployeeRole)
             : "other";


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4632.

Closes #4632

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4eb3ee3 refactor(gabinet): derive ALLOWED_EMPLOYEE_ROLES from schema validator (closes #4632)

### Files changed

```
 convex/gabinet/csvImport.ts | 19 ++++++-------------
 1 file changed, 6 insertions(+), 13 deletions(-)
```