### PR TITLE
Align color picker UI between create form and edit drawer

### DIFF
--- a/src/components/gabinet/employees/edit-employee-drawer.tsx
+++ b/src/components/gabinet/employees/edit-employee-drawer.tsx
@@ -28,6 +28,17 @@ import { EMPLOYEE_ROLES } from "@/lib/options";
 
 export { EMPLOYEE_ROLES as ROLES };
 
+const COLOR_OPTIONS = [
+  { value: "#3b82f6", label: "Blue" },
+  { value: "#22c55e", label: "Green" },
+  { value: "#ef4444", label: "Red" },
+  { value: "#f59e0b", label: "Yellow" },
+  { value: "#8b5cf6", label: "Purple" },
+  { value: "#ec4899", label: "Pink" },
+  { value: "#f97316", label: "Orange" },
+  { value: "#6b7280", label: "Gray" },
+];
+
 export function EditEmployeeDrawer({
   open,
   onOpenChange,
@@ -383,12 +394,22 @@ export function EditEmployeeDrawer({
         {showInCalendar && (
           <div className="space-y-1.5">
             <Label>{t("gabinet.employees.color")}</Label>
-            <input
-              type="color"
-              className="h-9 w-16 cursor-pointer rounded border bg-transparent"
-              value={color}
-              onChange={(e) => setColor(e.target.value)}
-            />
+            <div className="flex gap-2">
+              {COLOR_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  className={`h-7 w-7 rounded-full border-2 transition-all ${
+                    color === opt.value
+                      ? "border-foreground scale-110"
+                      : "border-transparent hover:border-muted-foreground/40"
+                  }`}
+                  style={{ backgroundColor: opt.value }}
+                  onClick={() => setColor(color === opt.value ? "" : opt.value)}
+                  title={opt.label}
+                />
+              ))}
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4637.

Closes #4637

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0febf8b fix(gabinet): align color picker UI between create form and edit drawer (closes #4637)

### Files changed

```
 .../gabinet/employees/edit-employee-drawer.tsx     | 33 ++++++++++++++++++----
 1 file changed, 27 insertions(+), 6 deletions(-)
```