### PR TITLE
Preserve color/location when toggling showInCalendar off then on

### DIFF
--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -195,7 +195,7 @@ export function EmployeeForm({
       role,
       specialization: performsServices ? specialization || undefined : undefined,
       licenseNumber: performsServices ? licenseNumber || undefined : undefined,
-      color: showInCalendar ? color || undefined : undefined,
+      color: color || undefined,
       showInCalendar,
       performsServices,
       qualifiedTreatmentIds: performsServices

--- a/src/components/gabinet/employees/edit-employee-drawer.tsx
+++ b/src/components/gabinet/employees/edit-employee-drawer.tsx
@@ -157,7 +157,7 @@ export function EditEmployeeDrawer({
         specialization: performsServices ? specialization || null : undefined,
         licenseNumber: performsServices ? licenseNumber || null : undefined,
         hireDate: hireDate || null,
-        color: showInCalendar ? color || null : null,
+        color: color || null,
         showInCalendar,
         performsServices,
         workScope: workScope ?? null,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4638.

Closes #4638

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 1c7d539 fix(gabinet): preserve employee color when toggling showInCalendar off then on (closes #4638)

### Files changed

```
 src/components/forms/employee-form.tsx                    | 2 +-
 src/components/gabinet/employees/edit-employee-drawer.tsx | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```