### PR TITLE
Location state race condition in edit drawer

### DIFF
--- a/src/components/gabinet/employees/edit-employee-drawer.tsx
+++ b/src/components/gabinet/employees/edit-employee-drawer.tsx
@@ -100,7 +100,7 @@ export function EditEmployeeDrawer({
     employee.workScope,
   );
   const [notes, setNotes] = useState(employee.notes ?? "");
-  const [locationId, setLocationId] = useState<string | null>(null);
+  const [locationId, setLocationId] = useState<string | null | undefined>(undefined);
   const [locationRole, setLocationRole] = useState<GabinetEmployeeRole | null>(null);
 
   // Re-sync form state when drawer opens
@@ -118,6 +118,8 @@ export function EditEmployeeDrawer({
       setPerformsServices(employee.performsServices ?? true);
       setWorkScope(employee.workScope);
       setNotes(employee.notes ?? "");
+      setLocationId(undefined);
+      setLocationRole(null);
     }
   }, [open, employee]);
 
@@ -162,8 +164,8 @@ export function EditEmployeeDrawer({
         performsServices,
         workScope: workScope ?? null,
         notes: notes || null,
-        locationId: locationId ?? null,
-        locationRole: locationRole ?? null,
+        locationId: locationId,
+        locationRole: locationId !== undefined ? (locationRole ?? null) : undefined,
       });
       toast.success(t("common.saved"));
       onOpenChange(false);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4655.

Closes #4655

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a2232e6 fix(gabinet): prevent race condition clearing employee primary location on fast save (closes #4655)

### Files changed

```
 src/components/gabinet/employees/edit-employee-drawer.tsx | 8 +++++---
 1 file changed, 5 insertions(+), 3 deletions(-)
```