### PR TITLE
Fix stale locationId when switching between employees in the drawer

### DIFF
--- a/src/components/gabinet/employees/edit-employee-drawer.tsx
+++ b/src/components/gabinet/employees/edit-employee-drawer.tsx
@@ -80,6 +80,7 @@ export function EditEmployeeDrawer({
       return { locationId: data.location_id ?? null, locationRole: (data.role as string | null) ?? null };
     },
     enabled: isReady && !!client,
+    staleTime: 0,
   });
 
   const [userId, setUserId] = useState<string | undefined>(employee.userId);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4658.

Closes #4658

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 9933608 fix(gabinet): add staleTime: 0 to currentPrimaryLocation query to prevent stale locationId when switching employees (closes #4658)

### Files changed

```
 src/components/gabinet/employees/edit-employee-drawer.tsx | 1 +
 1 file changed, 1 insertion(+)
```