### PR TITLE
Add `gabinet_salary` (or `gabinet_payroll`) feature to FEATURES registry

### DIFF
--- a/convex/_helpers/gabinetRolePermissions.ts
+++ b/convex/_helpers/gabinetRolePermissions.ts
@@ -157,6 +157,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_photos: { view: "all" },
     gabinet_online_booking: { view: "all", edit: "all" },
     gabinet_inventory: { view: "all", create: "all", edit: "all" },
+    gabinet_salary: { view: "all" },
     gabinet_settings: { view: "all" },
   }),
   admin: buildGabinet({
@@ -174,6 +175,7 @@ export const DEFAULT_GABINET_ROLE_PERMISSIONS: Record<SystemGabinetRole, Feature
     gabinet_photos: { view: "all", create: "all", edit: "all", delete: "all" },
     gabinet_online_booking: { view: "all", create: "all", edit: "all", delete: "all" },
     gabinet_inventory: { view: "all", create: "all", edit: "all", delete: "all" },
+    gabinet_salary: { view: "all", create: "all", edit: "all", delete: "all" },
     gabinet_settings: { view: "all", create: "all", edit: "all", delete: "all" },
   }),
   other: buildGabinet({

--- a/convex/_helpers/permissionTypes.ts
+++ b/convex/_helpers/permissionTypes.ts
@@ -27,6 +27,7 @@ export const FEATURES = [
   "gabinet_photos",
   "gabinet_online_booking",
   "gabinet_inventory",
+  "gabinet_salary",
   "gabinet_settings",
   "settings",
   "team",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4659.

Closes #4659

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 7f042e3 feat(gabinet): add gabinet_salary to FEATURES registry (closes #4659)

### Files changed

```
 convex/_helpers/gabinetRolePermissions.ts | 2 ++
 convex/_helpers/permissionTypes.ts        | 1 +
 2 files changed, 3 insertions(+)
```