### PR TITLE
Add route-level PermissionGate to Cash (Kasa) lazy route

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.cash.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.cash.lazy.tsx
@@ -7,7 +7,7 @@ import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { toast } from "sonner";
 import { useOrganization } from "@/components/org-context";
-import { usePermission } from "@/hooks/use-permission";
+import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { formatCurrencyPLN } from "@/lib/format-currency";
 import { PageHeader } from "@/components/layout/page-header";
 import { SidePanel } from "@/components/crm/side-panel";
@@ -43,10 +43,26 @@ import { useSupabasePaymentsRevenueByDateRange } from "@/hooks/use-supabase-paym
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 
+function GabinetCashSkeleton() {
+  return (
+    <div className="flex flex-col gap-4 p-4 sm:gap-6 sm:p-6">
+      <Skeleton className="h-10 w-64" />
+    </div>
+  );
+}
+
 export const Route = createLazyFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/cash"
 )({
-  component: GabinetCash,
+  component: () => (
+    <PermissionGate
+      feature="gabinet_reports"
+      action="view"
+      loadingFallback={<GabinetCashSkeleton />}
+    >
+      <GabinetCash />
+    </PermissionGate>
+  ),
 });
 
 const PAYMENT_METHOD_COLORS: Record<string, string> = {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4664.

Closes #4664

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 5ce5677 fix(gabinet): add route-level PermissionGate to Cash lazy route (closes #4664)

### Files changed

```
 .../_auth/dashboard/_layout.gabinet.cash.lazy.tsx    | 20 ++++++++++++++++++--
 1 file changed, 18 insertions(+), 2 deletions(-)
```