### PR TITLE
Gate edit/delete on patient detail page

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -97,6 +97,8 @@ function PatientDetail() {
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const { allowed: canEdit } = usePermission("gabinet_patients", "edit");
+  const { allowed: canDelete } = usePermission("gabinet_patients", "delete");
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen for this action
   const updatePatient = useAction(api.gabinet.patients.update);
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen for this action
@@ -1044,13 +1046,13 @@ function PatientDetail() {
             ? `${patient.firstName?.[0] ?? ""}${patient.lastName?.[0] ?? ""}`.toUpperCase()
             : "?"
         }
-        onEdit={() => setEditDrawerOpen(true)}
+        onEdit={canEdit ? () => setEditDrawerOpen(true) : undefined}
         secondaryActions={[
-          {
+          ...(canDelete ? [{
             label: t("common.delete"),
             onClick: handleDelete,
             variant: "destructive" as const,
-          },
+          }] : []),
           ...(canGdprErase
             ? [
                 {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4665.

Closes #4665

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d560918 fix(gabinet): gate edit/delete on patient detail page behind permissions (closes #4665)

### Files changed

```
 .../_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx  | 8 +++++---
 1 file changed, 5 insertions(+), 3 deletions(-)
```