### PR TITLE
Gate edit/deactivate on employee detail page

### DIFF
--- a/src/components/gabinet/employees/account-tab-content.tsx
+++ b/src/components/gabinet/employees/account-tab-content.tsx
@@ -6,11 +6,11 @@ import type { MappedInvitation } from "@/lib/supabase/mappers";
 import { ChangePasswordDialog } from "./change-password-dialog";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
+import { usePermission } from "@/hooks/use-permission";
 
 export function AccountTabContent({
   employee,
   userEmail,
-  role,
   onChangePassword,
   onEditEmployee,
   onDeactivate,
@@ -21,7 +21,6 @@ export function AccountTabContent({
 }: {
   employee: MappedGabinetEmployee;
   userEmail?: string | null;
-  role?: string | null;
   onChangePassword: (newPassword: string) => Promise<void>;
   onEditEmployee: () => void;
   onDeactivate: () => void;
@@ -30,6 +29,7 @@ export function AccountTabContent({
   onResendInvitation?: () => Promise<void>;
   t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
+  const { allowed: canEdit } = usePermission("gabinet_employees", "edit");
   const [changePasswordOpen, setChangePasswordOpen] = useState(false);
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -106,7 +106,7 @@ export function AccountTabContent({
           </div>
         </div>
 
-        {(role === "admin" || role === "owner") && (
+        {canEdit && (
           <div>
             <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
               {t("gabinet.employees.adminActions", "Akcje administracyjne")}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -717,7 +717,6 @@ function EmployeeDetail() {
         <AccountTabContent
           employee={employee}
           userEmail={user?.email}
-          role={role}
           onChangePassword={async (newPassword) => {
             await changeEmployeePassword({ organizationId, employeeId, newPassword });
           }}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4666.

Closes #4666

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 81b5f8f fix(gabinet): gate edit/deactivate on employee detail page behind permissions (closes #4666)

### Files changed

```
 src/components/gabinet/employees/account-tab-content.tsx            | 6 +++---
 .../_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx  | 1 -
 2 files changed, 3 insertions(+), 4 deletions(-)
```