### PR TITLE
Gate `DetailedDataTab` inline editing behind `gabinet_employees/edit`

### DIFF
--- a/src/components/gabinet/employees/detailed-data-tab.tsx
+++ b/src/components/gabinet/employees/detailed-data-tab.tsx
@@ -8,6 +8,7 @@ import { parseBirthDateToIso } from "@/lib/format-date";
 import type { TFunction } from "i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
+import { usePermission } from "@/hooks/use-permission";
 import { PersonalInfoSection } from "./sections/personal-info-section";
 import { EmploymentSection } from "./sections/employment-section";
 import { QualificationsSection } from "./sections/qualifications-section";
@@ -48,6 +49,8 @@ export function DetailedDataTab({
   limitedView?: boolean;
   qualificationsOnlyView?: boolean;
 }) {
+  const { allowed: canEdit } = usePermission("gabinet_employees", "edit");
+
   const [editing, setEditing] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -195,6 +198,7 @@ export function DetailedDataTab({
   const sharedSectionProps = {
     editing,
     saving,
+    canEdit,
     formData,
     setFormData,
     onStartEdit: startEdit,
@@ -244,6 +248,7 @@ export function DetailedDataTab({
                 treatmentMap={treatmentMap}
                 editing={editing}
                 saving={saving}
+                canEdit={canEdit}
                 treatmentSearchLocal={treatmentSearchLocal}
                 setTreatmentSearchLocal={setTreatmentSearchLocal}
                 filteredTreatments={filteredTreatments}

--- a/src/components/gabinet/employees/sections/assigned-treatments-section.tsx
+++ b/src/components/gabinet/employees/sections/assigned-treatments-section.tsx
@@ -23,6 +23,7 @@ export function AssignedTreatmentsSection({
   filteredTreatments,
   pendingTreatmentIds,
   setPendingTreatmentIds,
+  canEdit,
   onStartEdit,
   onCancelEdit,
   onSaveSection,
@@ -37,6 +38,7 @@ export function AssignedTreatmentsSection({
   filteredTreatments: Array<{ _id: string; name: string }>;
   pendingTreatmentIds: string[];
   setPendingTreatmentIds: (ids: string[]) => void;
+  canEdit?: boolean;
   onStartEdit: (s: string) => void;
   onCancelEdit: () => void;
   onSaveSection: (s: string) => Promise<void>;
@@ -51,10 +53,12 @@ export function AssignedTreatmentsSection({
               <span className="text-primary"><ClipboardList className="h-4 w-4" /></span>
               <h4 className="text-base font-semibold">{t("gabinet.employees.detailedData.assignedTreatments")}</h4>
             </div>
-            <Button variant="ghost" size="sm" onClick={() => onStartEdit("treatments")}>
-              <Pencil className="h-3.5 w-3.5 mr-1" variant="stroke" />
-              {t("common.edit")}
-            </Button>
+            {canEdit !== false && (
+              <Button variant="ghost" size="sm" onClick={() => onStartEdit("treatments")}>
+                <Pencil className="h-3.5 w-3.5 mr-1" variant="stroke" />
+                {t("common.edit")}
+              </Button>
+            )}
           </div>
           {employee.qualifiedTreatmentIds.length > 0 ? (
             <div className="flex flex-wrap gap-1.5">

--- a/src/components/gabinet/employees/sections/compensation-section.tsx
+++ b/src/components/gabinet/employees/sections/compensation-section.tsx
@@ -14,6 +14,7 @@ export function CompensationSection({
   editing,
   saving,
   i18nLanguage,
+  canEdit,
   onStartEdit,
   onCancelEdit,
   onSaveSection,
@@ -25,6 +26,7 @@ export function CompensationSection({
   editing: string | null;
   saving: boolean;
   i18nLanguage: string;
+  canEdit?: boolean;
   onStartEdit: (s: string) => void;
   onCancelEdit: () => void;
   onSaveSection: (s: string) => Promise<void>;
@@ -39,6 +41,7 @@ export function CompensationSection({
           icon={<DollarSign className="h-4 w-4" />}
           editing={editing}
           saving={saving}
+          canEdit={canEdit}
           onStartEdit={onStartEdit}
           onCancelEdit={onCancelEdit}
           onSaveSection={onSaveSection}

--- a/src/components/gabinet/employees/sections/employment-section.tsx
+++ b/src/components/gabinet/employees/sections/employment-section.tsx
@@ -24,6 +24,7 @@ export function EmploymentSection({
   setFormData,
   editing,
   saving,
+  canEdit,
   onStartEdit,
   onCancelEdit,
   onSaveSection,
@@ -34,6 +35,7 @@ export function EmploymentSection({
   setFormData: (data: EmployeeFormData) => void;
   editing: string | null;
   saving: boolean;
+  canEdit?: boolean;
   onStartEdit: (s: string) => void;
   onCancelEdit: () => void;
   onSaveSection: (s: string) => Promise<void>;
@@ -48,6 +50,7 @@ export function EmploymentSection({
           icon={<Briefcase className="h-4 w-4" variant="stroke" />}
           editing={editing}
           saving={saving}
+          canEdit={canEdit}
           onStartEdit={onStartEdit}
           onCancelEdit={onCancelEdit}
           onSaveSection={onSaveSection}

--- a/src/components/gabinet/employees/sections/personal-info-section.tsx
+++ b/src/components/gabinet/employees/sections/personal-info-section.tsx
@@ -27,6 +27,7 @@ export function PersonalInfoSection({
   setFormData,
   editing,
   saving,
+  canEdit,
   role,
   userEmail,
   onChangePassword,
@@ -44,6 +45,7 @@ export function PersonalInfoSection({
   saving: boolean;
   role?: string | null;
   userEmail?: string | null;
+  canEdit?: boolean;
   onChangePassword?: () => void;
   onUpdate: (args: FunctionArgs<typeof api.gabinet.employees.update>) => Promise<void>;
   onStartEdit: (s: string) => void;
@@ -91,6 +93,7 @@ export function PersonalInfoSection({
           icon={<User className="h-4 w-4" variant="stroke" />}
           editing={editing}
           saving={saving}
+          canEdit={canEdit}
           onStartEdit={onStartEdit}
           onCancelEdit={onCancelEdit}
           onSaveSection={onSaveSection}

--- a/src/components/gabinet/employees/sections/qualifications-section.tsx
+++ b/src/components/gabinet/employees/sections/qualifications-section.tsx
@@ -25,6 +25,7 @@ export function QualificationsSection({
   setNewCertDate,
   newCertExpiry,
   setNewCertExpiry,
+  canEdit,
   onStartEdit,
   onCancelEdit,
   onSaveSection,
@@ -43,6 +44,7 @@ export function QualificationsSection({
   setNewCertDate: (v: string) => void;
   newCertExpiry: string;
   setNewCertExpiry: (v: string) => void;
+  canEdit?: boolean;
   onStartEdit: (s: string) => void;
   onCancelEdit: () => void;
   onSaveSection: (s: string) => Promise<void>;
@@ -76,6 +78,7 @@ export function QualificationsSection({
           icon={<Star className="h-4 w-4" />}
           editing={editing}
           saving={saving}
+          canEdit={canEdit}
           onStartEdit={onStartEdit}
           onCancelEdit={onCancelEdit}
           onSaveSection={onSaveSection}

--- a/src/components/gabinet/employees/sections/section-header.tsx
+++ b/src/components/gabinet/employees/sections/section-header.tsx
@@ -9,6 +9,7 @@ export function SectionHeader({
   icon,
   editing,
   saving,
+  canEdit = true,
   onStartEdit,
   onCancelEdit,
   onSaveSection,
@@ -19,6 +20,7 @@ export function SectionHeader({
   icon: ReactNode;
   editing: string | null;
   saving: boolean;
+  canEdit?: boolean;
   onStartEdit: (s: string) => void;
   onCancelEdit: () => void;
   onSaveSection: (s: string) => Promise<void>;
@@ -31,10 +33,12 @@ export function SectionHeader({
         <h4 className="text-base font-semibold">{title}</h4>
       </div>
       {editing !== sectionKey ? (
-        <Button variant="ghost" size="sm" onClick={() => onStartEdit(sectionKey)}>
-          <Pencil className="h-3.5 w-3.5 mr-1" variant="stroke" />
-          {t("common.edit")}
-        </Button>
+        canEdit && (
+          <Button variant="ghost" size="sm" onClick={() => onStartEdit(sectionKey)}>
+            <Pencil className="h-3.5 w-3.5 mr-1" variant="stroke" />
+            {t("common.edit")}
+          </Button>
+        )
       ) : (
         <div className="flex gap-1">
           <Button variant="ghost" size="sm" onClick={onCancelEdit}>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4678.

Closes #4678

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 204a394 fix(gabinet): gate DetailedDataTab inline editing behind gabinet_employees/edit (closes #4678)

### Files changed

```
 src/components/gabinet/employees/detailed-data-tab.tsx       |  5 +++++
 .../employees/sections/assigned-treatments-section.tsx       | 12 ++++++++----
 .../gabinet/employees/sections/compensation-section.tsx      |  3 +++
 .../gabinet/employees/sections/employment-section.tsx        |  3 +++
 .../gabinet/employees/sections/personal-info-section.tsx     |  3 +++
 .../gabinet/employees/sections/qualifications-section.tsx    |  3 +++
 src/components/gabinet/employees/sections/section-header.tsx | 12 ++++++++----
 7 files changed, 33 insertions(+), 8 deletions(-)
```