### PR TITLE
Wire location-scoped role overrides into checkPermission

### DIFF
--- a/convex/_helpers/authAction.ts
+++ b/convex/_helpers/authAction.ts
@@ -31,6 +31,7 @@ export const _getGabinetPermissionData = internalQuery({
   args: {
     organizationId: v.id("organizations"),
     userId: v.id("users"),
+    locationId: v.optional(v.id("gabinetLocations")),
   },
   handler: async (ctx, args) => {
     const gabinetMembership = await ctx.db
@@ -44,7 +45,24 @@ export const _getGabinetPermissionData = internalQuery({
       return { membership: null, rolePermissions: null, membershipPermissions: null };
     }
 
-    const gRole = gabinetMembership.gabinetRole;
+    let gRole = gabinetMembership.gabinetRole;
+
+    // Location-scoped role override: if a locationId is provided, check the
+    // Convex mirror (gabinetLocationMemberships) for a per-location role
+    // override. When found, it replaces the global gabinet role for this check.
+    if (args.locationId) {
+      const locationMembership = await ctx.db
+        .query("gabinetLocationMemberships")
+        .withIndex("by_orgAndUserAndLocation", (q) =>
+          q.eq("organizationId", args.organizationId)
+           .eq("userId", args.userId)
+           .eq("locationId", args.locationId!),
+        )
+        .unique();
+      if (locationMembership) {
+        gRole = locationMembership.role;
+      }
+    }
 
     const gOverride = await ctx.db
       .query("gabinetRolePermissions")
@@ -123,6 +141,7 @@ export const checkPermission = internalAction({
     organizationId: v.id("organizations"),
     feature: v.string(),
     action: v.string(),
+    locationId: v.optional(v.id("gabinetLocations")),
   },
   handler: async (ctx, args): Promise<PermissionResult> => {
     const userId = await auth.getUserId(ctx);
@@ -170,7 +189,7 @@ export const checkPermission = internalAction({
     if (feature.startsWith("gabinet_")) {
       const gabinetData = await ctx.runQuery(
         internal._helpers.authAction._getGabinetPermissionData,
-        { organizationId: args.organizationId, userId },
+        { organizationId: args.organizationId, userId, locationId: args.locationId },
       );
       if (gabinetData.membership) {
         const gRole = gabinetData.membership.gabinetRole;

--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -176,6 +176,7 @@ export async function checkPermission(
   orgId: Id<"organizations">,
   feature: Feature,
   action: Action,
+  locationId?: Id<"gabinetLocations">,
 ): Promise<PermissionResult> {
   const { user, membership } = await verifyOrgAccess(ctx, orgId);
   const role = membership.role as OrgRole;
@@ -215,7 +216,22 @@ export async function checkPermission(
       )
       .unique();
     if (gabinetMembership && gabinetMembership.isActive) {
-      const gRole = gabinetMembership.gabinetRole;
+      let gRole = gabinetMembership.gabinetRole;
+
+      // Location-scoped role override: when locationId is provided, check the
+      // Convex mirror for a per-location role that replaces the global gabinet role.
+      if (locationId) {
+        const locationMembership = await ctx.db
+          .query("gabinetLocationMemberships")
+          .withIndex("by_orgAndUserAndLocation", (q) =>
+            q.eq("organizationId", orgId).eq("userId", user._id).eq("locationId", locationId),
+          )
+          .unique();
+        if (locationMembership) {
+          gRole = locationMembership.role;
+        }
+      }
+
       const gOverride = await ctx.db
         .query("gabinetRolePermissions")
         .withIndex("by_orgAndRole", (q) =>
@@ -256,6 +272,7 @@ export async function checkPermission(
 export async function getEffectivePermissions(
   ctx: QueryCtx | MutationCtx,
   orgId: Id<"organizations">,
+  locationId?: Id<"gabinetLocations">,
 ): Promise<FeaturePermissions> {
   const { membership, user } = await verifyOrgAccess(ctx, orgId);
   const role = membership.role as OrgRole;
@@ -298,7 +315,22 @@ export async function getEffectivePermissions(
     .unique();
 
   if (gabinetMembership && gabinetMembership.isActive) {
-    const gRole = gabinetMembership.gabinetRole;
+    let gRole = gabinetMembership.gabinetRole;
+
+    // Location-scoped role override: when locationId is provided, check the
+    // Convex mirror for a per-location role that replaces the global gabinet role.
+    if (locationId) {
+      const locationMembership = await ctx.db
+        .query("gabinetLocationMemberships")
+        .withIndex("by_orgAndUserAndLocation", (q) =>
+          q.eq("organizationId", orgId).eq("userId", user._id).eq("locationId", locationId),
+        )
+        .unique();
+      if (locationMembership) {
+        gRole = locationMembership.role;
+      }
+    }
+
     const gOverride = await ctx.db
       .query("gabinetRolePermissions")
       .withIndex("by_orgAndRole", (q) =>

--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -277,6 +277,14 @@ export const create = action({
         gabinetRole: args.role,
         isActive: true,
       });
+      if (args.locationId && args.locationRole) {
+        await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
+          organizationId: args.organizationId,
+          userId: args.userId,
+          locationId: args.locationId,
+          role: args.locationRole,
+        });
+      }
     }
 
     if (args.customFields && args.customFields.length > 0) {
@@ -380,6 +388,14 @@ export const _createFromInvitation = internalAction({
               role: locationRole2,
               createdAt: Date.now(),
             });
+            if (locationRole2) {
+              await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
+                organizationId: args.organizationId,
+                userId: args.userId,
+                locationId: locationId2,
+                role: locationRole2,
+              });
+            }
           }
         } catch (e) {
           console.error(
@@ -438,6 +454,14 @@ export const _createFromInvitation = internalAction({
           role: locationRole,
           createdAt: now,
         });
+        if (locationRole) {
+          await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
+            organizationId: args.organizationId,
+            userId: args.userId,
+            locationId,
+            role: locationRole,
+          });
+        }
       } catch (e) {
         console.error(
           `[gabinet.employees._createFromInvitation] location insert failed:`,
@@ -580,6 +604,60 @@ export const _upsertMembership = internalMutation({
       updatedAt: now,
     });
     return { id: String(id), updated: false };
+  },
+});
+
+// Mirror gabinetEmployeeLocations.role into Convex so checkPermission
+// (QueryCtx/MutationCtx, no Supabase access) can resolve location-scoped roles.
+export const _upsertLocationMembership = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    userId: v.string(),
+    locationId: v.string(),
+    role: gabinetEmployeeRoleValidator,
+  },
+  handler: async (ctx, args) => {
+    const userId = args.userId as Id<"users">;
+    const locationId = args.locationId as Id<"gabinetLocations">;
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("gabinetLocationMemberships")
+      .withIndex("by_orgAndUserAndLocation", (q) =>
+        q.eq("organizationId", args.organizationId).eq("userId", userId).eq("locationId", locationId),
+      )
+      .unique();
+    if (existing) {
+      await ctx.db.patch(existing._id, { role: args.role, updatedAt: now });
+    } else {
+      await ctx.db.insert("gabinetLocationMemberships", {
+        organizationId: args.organizationId,
+        userId,
+        locationId,
+        role: args.role,
+        updatedAt: now,
+      });
+    }
+  },
+});
+
+export const _deleteLocationMembership = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    userId: v.string(),
+    locationId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = args.userId as Id<"users">;
+    const locationId = args.locationId as Id<"gabinetLocations">;
+    const existing = await ctx.db
+      .query("gabinetLocationMemberships")
+      .withIndex("by_orgAndUserAndLocation", (q) =>
+        q.eq("organizationId", args.organizationId).eq("userId", userId).eq("locationId", locationId),
+      )
+      .unique();
+    if (existing) {
+      await ctx.db.delete(existing._id);
+    }
   },
 });
 
@@ -755,6 +833,13 @@ export const update = action({
         .collect();
       for (const loc of existingLocs) {
         await db.delete("gabinetEmployeeLocations", String(loc._id));
+        if (emp.userId) {
+          await ctx.runMutation(internal.gabinet.employees._deleteLocationMembership, {
+            organizationId,
+            userId: String(emp.userId),
+            locationId: String(loc.locationId),
+          });
+        }
       }
       if (locationId) {
         const effectiveLocationRole = locationRole != null ? locationRole : undefined;
@@ -767,6 +852,14 @@ export const update = action({
             role: effectiveLocationRole,
             createdAt: Date.now(),
           });
+          if (emp.userId && effectiveLocationRole) {
+            await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
+              organizationId,
+              userId: String(emp.userId),
+              locationId,
+              role: effectiveLocationRole,
+            });
+          }
         } catch (e) {
           console.error("[employees.update] location insert failed:", e);
         }
@@ -784,6 +877,22 @@ export const update = action({
           await db.patch("gabinetEmployeeLocations", String(loc._id), {
             role: effectiveLocationRole,
           });
+          if (emp.userId) {
+            if (effectiveLocationRole) {
+              await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
+                organizationId,
+                userId: String(emp.userId),
+                locationId: String(loc.locationId),
+                role: effectiveLocationRole,
+              });
+            } else {
+              await ctx.runMutation(internal.gabinet.employees._deleteLocationMembership, {
+                organizationId,
+                userId: String(emp.userId),
+                locationId: String(loc.locationId),
+              });
+            }
+          }
         } catch (e) {
           console.error("[employees.update] location role patch failed:", e);
         }
@@ -1379,6 +1488,14 @@ export const createWithPassword = action({
       gabinetRole: args.role,
       isActive: true,
     });
+    if (userId && args.locationId && args.locationRole) {
+      await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
+        organizationId: args.organizationId,
+        userId,
+        locationId: args.locationId,
+        role: args.locationRole,
+      });
+    }
 
     return String(employeeId);
   },

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -781,6 +781,23 @@ export function createCrmTables({
     .index("by_orgAndUser", ["organizationId", "userId"])
     .index("by_user", ["userId"]),
 
+  // --- RBAC: Gabinet Location Role Mirror ---
+  // Convex mirror of gabinetEmployeeLocations.role so that checkPermission
+  // (which runs in QueryCtx and cannot reach Supabase) can resolve the
+  // location-scoped gabinet role for the current user. Maintained alongside
+  // the Supabase row writes in convex/gabinet/employees.ts. Rows are absent
+  // when the location row has no role override (null role → global role wins).
+  gabinetLocationMemberships: defineTable({
+    organizationId: v.id("organizations"),
+    userId: v.id("users"),
+    locationId: v.id("gabinetLocations"),
+    role: gabinetEmployeeRoleValidator,
+    updatedAt: v.number(),
+  })
+    .index("by_org", ["organizationId"])
+    .index("by_orgAndUser", ["organizationId", "userId"])
+    .index("by_orgAndUserAndLocation", ["organizationId", "userId", "locationId"]),
+
   // --- RBAC: Resource Invites (External Guests) ---
 
   resourceInvites: defineTable({


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4685.

Closes #4685

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 28b3320 fix(gabinet): wire location-scoped role overrides into checkPermission (closes #4685)

### Files changed

```
 convex/_helpers/authAction.ts  |  23 +++++++-
 convex/_helpers/permissions.ts |  36 ++++++++++++-
 convex/gabinet/employees.ts    | 117 +++++++++++++++++++++++++++++++++++++++++
 convex/schema/crm.ts           |  17 ++++++
 4 files changed, 189 insertions(+), 4 deletions(-)
```