### PR TITLE
Unify gabinetMemberships (Convex) and gabinetEmployeeLocations (Supabase) into a

### DIFF
--- a/convex/_helpers/authAction.ts
+++ b/convex/_helpers/authAction.ts
@@ -59,7 +59,7 @@ export const _getGabinetPermissionData = internalQuery({
            .eq("locationId", args.locationId!),
         )
         .unique();
-      if (locationMembership) {
+      if (locationMembership?.role) {
         gRole = locationMembership.role;
       }
     }

--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -227,7 +227,7 @@ export async function checkPermission(
             q.eq("organizationId", orgId).eq("userId", user._id).eq("locationId", locationId),
           )
           .unique();
-        if (locationMembership) {
+        if (locationMembership?.role) {
           gRole = locationMembership.role;
         }
       }
@@ -326,7 +326,7 @@ export async function getEffectivePermissions(
           q.eq("organizationId", orgId).eq("userId", user._id).eq("locationId", locationId),
         )
         .unique();
-      if (locationMembership) {
+      if (locationMembership?.role) {
         gRole = locationMembership.role;
       }
     }

--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -277,12 +277,12 @@ export const create = action({
         gabinetRole: args.role,
         isActive: true,
       });
-      if (args.locationId && args.locationRole) {
+      if (args.locationId) {
         await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
           organizationId: args.organizationId,
           userId: args.userId,
           locationId: args.locationId,
-          role: args.locationRole,
+          role: args.locationRole ?? undefined,
         });
       }
     }
@@ -388,14 +388,12 @@ export const _createFromInvitation = internalAction({
               role: locationRole2,
               createdAt: Date.now(),
             });
-            if (locationRole2) {
-              await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
-                organizationId: args.organizationId,
-                userId: args.userId,
-                locationId: locationId2,
-                role: locationRole2,
-              });
-            }
+            await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
+              organizationId: args.organizationId,
+              userId: args.userId,
+              locationId: locationId2,
+              role: locationRole2 ?? undefined,
+            });
           }
         } catch (e) {
           console.error(
@@ -454,14 +452,12 @@ export const _createFromInvitation = internalAction({
           role: locationRole,
           createdAt: now,
         });
-        if (locationRole) {
-          await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
-            organizationId: args.organizationId,
-            userId: args.userId,
-            locationId,
-            role: locationRole,
-          });
-        }
+        await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
+          organizationId: args.organizationId,
+          userId: args.userId,
+          locationId,
+          role: locationRole ?? undefined,
+        });
       } catch (e) {
         console.error(
           `[gabinet.employees._createFromInvitation] location insert failed:`,
@@ -607,14 +603,14 @@ export const _upsertMembership = internalMutation({
   },
 });
 
-// Mirror gabinetEmployeeLocations.role into Convex so checkPermission
-// (QueryCtx/MutationCtx, no Supabase access) can resolve location-scoped roles.
+// Mirror gabinetEmployeeLocations into Convex so checkPermission (QueryCtx/MutationCtx,
+// no Supabase access) can resolve both location assignments and optional role overrides.
 export const _upsertLocationMembership = internalMutation({
   args: {
     organizationId: v.id("organizations"),
     userId: v.string(),
     locationId: v.string(),
-    role: gabinetEmployeeRoleValidator,
+    role: v.optional(gabinetEmployeeRoleValidator),
   },
   handler: async (ctx, args) => {
     const userId = args.userId as Id<"users">;
@@ -852,7 +848,7 @@ export const update = action({
             role: effectiveLocationRole,
             createdAt: Date.now(),
           });
-          if (emp.userId && effectiveLocationRole) {
+          if (emp.userId) {
             await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
               organizationId,
               userId: String(emp.userId),
@@ -878,20 +874,12 @@ export const update = action({
             role: effectiveLocationRole,
           });
           if (emp.userId) {
-            if (effectiveLocationRole) {
-              await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
-                organizationId,
-                userId: String(emp.userId),
-                locationId: String(loc.locationId),
-                role: effectiveLocationRole,
-              });
-            } else {
-              await ctx.runMutation(internal.gabinet.employees._deleteLocationMembership, {
-                organizationId,
-                userId: String(emp.userId),
-                locationId: String(loc.locationId),
-              });
-            }
+            await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
+              organizationId,
+              userId: String(emp.userId),
+              locationId: String(loc.locationId),
+              role: effectiveLocationRole ?? undefined,
+            });
           }
         } catch (e) {
           console.error("[employees.update] location role patch failed:", e);
@@ -1488,12 +1476,12 @@ export const createWithPassword = action({
       gabinetRole: args.role,
       isActive: true,
     });
-    if (userId && args.locationId && args.locationRole) {
+    if (userId && args.locationId) {
       await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
         organizationId: args.organizationId,
         userId,
         locationId: args.locationId,
-        role: args.locationRole,
+        role: args.locationRole ?? undefined,
       });
     }
 

--- a/convex/permissions.ts
+++ b/convex/permissions.ts
@@ -36,6 +36,36 @@ export const getMyGabinetRole = query({
   },
 });
 
+export const getMyGabinetContext = query({
+  args: { organizationId: v.id("organizations") },
+  handler: async (ctx, args) => {
+    const { user } = await verifyOrgAccess(ctx, args.organizationId);
+    const membership = await ctx.db
+      .query("gabinetMemberships")
+      .withIndex("by_orgAndUser", (q) =>
+        q.eq("organizationId", args.organizationId).eq("userId", user._id)
+      )
+      .unique();
+    if (!membership) {
+      return { gabinetRole: null, isActive: null, assignedLocations: [] };
+    }
+    const locationMemberships = await ctx.db
+      .query("gabinetLocationMemberships")
+      .withIndex("by_orgAndUser", (q) =>
+        q.eq("organizationId", args.organizationId).eq("userId", user._id)
+      )
+      .collect();
+    return {
+      gabinetRole: membership.gabinetRole,
+      isActive: membership.isActive,
+      assignedLocations: locationMemberships.map((lm) => ({
+        locationId: lm.locationId,
+        role: lm.role ?? null,
+      })),
+    };
+  },
+});
+
 export const getOrgPermissionOverrides = action({
   args: { organizationId: v.id("organizations") },
   handler: async (ctx, args) => {

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -782,16 +782,17 @@ export function createCrmTables({
     .index("by_user", ["userId"]),
 
   // --- RBAC: Gabinet Location Role Mirror ---
-  // Convex mirror of gabinetEmployeeLocations.role so that checkPermission
-  // (which runs in QueryCtx and cannot reach Supabase) can resolve the
-  // location-scoped gabinet role for the current user. Maintained alongside
-  // the Supabase row writes in convex/gabinet/employees.ts. Rows are absent
-  // when the location row has no role override (null role → global role wins).
+  // Convex mirror of gabinetEmployeeLocations so that checkPermission
+  // (which runs in QueryCtx and cannot reach Supabase) can resolve both which
+  // locations the current user is assigned to and any per-location role override.
+  // A row exists for every location assignment; role is absent when there is no
+  // override (global gabinetMemberships role wins). Maintained alongside the
+  // Supabase row writes in convex/gabinet/employees.ts.
   gabinetLocationMemberships: defineTable({
     organizationId: v.id("organizations"),
     userId: v.id("users"),
     locationId: v.id("gabinetLocations"),
-    role: gabinetEmployeeRoleValidator,
+    role: v.optional(gabinetEmployeeRoleValidator),
     updatedAt: v.number(),
   })
     .index("by_org", ["organizationId"])

--- a/src/hooks/use-permission.ts
+++ b/src/hooks/use-permission.ts
@@ -102,6 +102,31 @@ export function useGabinetRole(): {
   return { gabinetRole: result.gabinetRole, isActive: result.isActive, loading: false };
 }
 
+export function useMyGabinetContext(): {
+  gabinetRole: string | null;
+  isActive: boolean | null;
+  assignedLocations: Array<{ locationId: string; role: string | null }>;
+  loading: boolean;
+} {
+  const { organizationId } = useOrganization();
+
+  const result = useQuery(
+    api.permissions.getMyGabinetContext,
+    organizationId ? { organizationId } : "skip"
+  );
+
+  if (result === undefined) {
+    return { gabinetRole: null, isActive: null, assignedLocations: [], loading: true };
+  }
+
+  return {
+    gabinetRole: result.gabinetRole,
+    isActive: result.isActive,
+    assignedLocations: result.assignedLocations,
+    loading: false,
+  };
+}
+
 export function PermissionGate({
   feature,
   action,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4686.

Closes #4686

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e2fe8a1 feat(gabinet): unify gabinetMemberships + gabinetEmployeeLocations into getMyGabinetContext (closes #4686)

### Files changed

```
 convex/_helpers/authAction.ts  |  2 +-
 convex/_helpers/permissions.ts |  4 +--
 convex/gabinet/employees.ts    | 64 +++++++++++++++++-------------------------
 convex/permissions.ts          | 30 ++++++++++++++++++++
 convex/schema/crm.ts           | 13 +++++----
 src/hooks/use-permission.ts    | 25 +++++++++++++++++
 6 files changed, 91 insertions(+), 47 deletions(-)
```