### PR TITLE
Backfill gabinetLocationMemberships for existing data

### DIFF
--- a/convex/supabase/backfill.ts
+++ b/convex/supabase/backfill.ts
@@ -5,6 +5,7 @@ import type { Id } from "../_generated/dataModel";
 import type { Database } from "~/src/lib/supabase/database.types";
 import { createServiceRoleClient } from "./client";
 import { stripe } from "../stripe";
+import { isSystemGabinetRole } from "../_helpers/gabinetRolePermissions";
 
 const BATCH_SIZE = 50;
 
@@ -619,6 +620,105 @@ export const backfillEmployees = internalAction({
     );
     if (result.errors.length > 0) console.error("Errors:", result.errors);
     return result;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Backfill gabinetLocationMemberships from existing gabinet_employee_locations
+// rows in Supabase (closes #4688).
+//
+// Direction: Supabase → Convex (opposite of other backfills here).
+// gabinetLocationMemberships is a Convex-native mirror used by checkPermission
+// (QueryCtx, no Supabase access). It is only populated on forward writes, so
+// any gabinet_employee_locations rows that pre-date the mirror introduction
+// (#4685) silently fall back to the global role. This action is idempotent:
+// _upsertLocationMembership does a patch-or-insert.
+// ---------------------------------------------------------------------------
+
+export const backfillLocationMemberships = internalAction({
+  args: { organizationId: v.id("organizations") },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ synced: number; skipped: number; errors: string[] }> => {
+    const client = createServiceRoleClient();
+    const orgId = String(args.organizationId);
+    const errors: string[] = [];
+    let synced = 0;
+    let skipped = 0;
+
+    // Build employee_id → user_id map for this org (employees without a linked
+    // user account have no mirror entry — skip them).
+    const { data: employees, error: empError } = await client
+      .from("gabinet_employees")
+      .select("id, user_id")
+      .eq("organization_id", orgId)
+      .not("user_id", "is", null);
+
+    if (empError) {
+      return { synced: 0, skipped: 0, errors: [empError.message] };
+    }
+
+    const employeeToUser = new Map<string, string>();
+    for (const emp of employees ?? []) {
+      if (emp.user_id) employeeToUser.set(emp.id, emp.user_id);
+    }
+
+    // Paginate through gabinet_employee_locations and upsert each row into the
+    // Convex mirror table.
+    const PAGE = 100;
+    let from = 0;
+
+    while (true) {
+      const { data, error } = await client
+        .from("gabinet_employee_locations")
+        .select("id, employee_id, location_id, role")
+        .eq("organization_id", orgId)
+        .range(from, from + PAGE - 1);
+
+      if (error) {
+        errors.push(`Page at offset ${from}: ${error.message}`);
+        break;
+      }
+      if (!data || data.length === 0) break;
+
+      for (const row of data) {
+        const userId = employeeToUser.get(row.employee_id);
+        if (!userId) {
+          skipped++;
+          continue;
+        }
+
+        const role =
+          row.role && isSystemGabinetRole(row.role) ? row.role : undefined;
+
+        try {
+          await ctx.runMutation(
+            internal.gabinet.employees._upsertLocationMembership,
+            {
+              organizationId: args.organizationId,
+              userId,
+              locationId: row.location_id,
+              role,
+            },
+          );
+          synced++;
+        } catch (e) {
+          errors.push(
+            `row ${row.id}: ${e instanceof Error ? e.message : String(e)}`,
+          );
+        }
+      }
+
+      if (data.length < PAGE) break;
+      from += PAGE;
+    }
+
+    console.info(
+      `backfillLocationMemberships: synced=${synced}, skipped=${skipped}, errors=${errors.length}`,
+    );
+    if (errors.length > 0) console.error("Errors:", errors);
+    return { synced, skipped, errors };
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4688.

Closes #4688

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 6680111 fix(gabinet): backfill gabinetLocationMemberships from existing Supabase rows (closes #4688)

### Files changed

```
 convex/supabase/backfill.ts | 100 ++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 100 insertions(+)
```