### PR TITLE
Connect patient appointments tab to activeLocationId

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -11,6 +11,7 @@ import {
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
+import { useActiveLocation } from "@/contexts/gabinet-location-context";
 import { useSupabaseGabinetPatient } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
 import {
@@ -95,6 +96,7 @@ export const Route = createFileRoute(
 function PatientDetail() {
   const { patientId } = Route.useParams();
   const { organizationId } = useOrganization();
+  const { activeLocationId } = useActiveLocation();
   const navigate = useNavigate();
   const { t } = useTranslation();
   const { allowed: canEdit } = usePermission("gabinet_patients", "edit");
@@ -219,6 +221,7 @@ function PatientDetail() {
   const { data: patientAppointments } = useSupabaseGabinetAppointmentsByPatient(
     organizationId,
     patientId,
+    { locationId: activeLocationId ?? undefined },
   );
 
   const { data: loyaltyBalance } = useSupabaseGabinetLoyaltyBalance(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4701.

Closes #4701

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 5fe1800 fix(gabinet): filter patient appointments by activeLocationId (closes #4701)

### Files changed

```
 .../_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx       | 3 +++
 1 file changed, 3 insertions(+)
```