### PR TITLE
Add `preferredLocationId` to patient create/edit form

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2667,7 +2667,8 @@
           "medicalNotes": "Medical notes",
           "referralSource": "Referral source"
         }
-      }
+      },
+      "preferredLocation": "Preferred location"
     },
     "treatments": {
       "title": "Treatments",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2666,7 +2666,8 @@
           "medicalNotes": "Notatki medyczne",
           "referralSource": "Źródło polecenia"
         }
-      }
+      },
+      "preferredLocation": "Preferowana lokalizacja"
     },
     "treatments": {
       "title": "Zabiegi",

--- a/src/components/forms/patient-form.tsx
+++ b/src/components/forms/patient-form.tsx
@@ -56,8 +56,14 @@ interface PatientFormData {
   emergencyContactName?: string | null;
   emergencyContactPhone?: string | null;
   referralSource?: string | null;
+  preferredLocationId?: string | null;
   tagIds?: Id<"tagDefinitions">[];
   categoryId?: Id<"categoryDefinitions">;
+}
+
+interface LocationOption {
+  id: string;
+  name: string;
 }
 
 interface PatientFormProps {
@@ -69,6 +75,7 @@ interface PatientFormProps {
   tagDefinitions?: TagDef[];
   categoryDefinitions?: CategoryDef[];
   organizationId?: Id<"organizations">;
+  locations?: LocationOption[];
 }
 
 const ADD_NEW_REFERRAL_SOURCE = "__add_new__";
@@ -82,6 +89,7 @@ export function PatientForm({
   tagDefinitions = [],
   categoryDefinitions = [],
   organizationId,
+  locations = [],
 }: PatientFormProps) {
   const isEditMode = mode === "edit" || (!mode && !!initialData);
   const { t } = useTranslation();
@@ -113,6 +121,7 @@ export function PatientForm({
   const referralOptions = patientReferralSourceOptions(t).filter((opt) => opt.value !== "other");
   const [tagIds, setTagIds] = useState<Id<"tagDefinitions">[]>(initialData?.tagIds ?? []);
   const [categoryId, setCategoryId] = useState<Id<"categoryDefinitions"> | undefined>(initialData?.categoryId);
+  const [preferredLocationId, setPreferredLocationId] = useState<string>(initialData?.preferredLocationId ?? "");
 
   const listCustomReferralSources = useAction(api.gabinet.patients.listCustomReferralSources);
 
@@ -186,6 +195,7 @@ export function PatientForm({
       emergencyContactName: emergencyContactName || null,
       emergencyContactPhone: emergencyContactPhone || null,
       referralSource,
+      preferredLocationId: preferredLocationId || null,
       tagIds: tagIds.length > 0 ? tagIds : undefined,
       categoryId: categoryId || undefined,
     });
@@ -390,6 +400,21 @@ export function PatientForm({
             </div>
           )}
         </div>
+        {locations.length > 0 && (
+          <div className="space-y-1.5">
+            <Label>{t("gabinet.patients.preferredLocation")}</Label>
+            <Select value={preferredLocationId} onValueChange={setPreferredLocationId}>
+              <SelectTrigger className="h-9">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {locations.map((loc) => (
+                  <SelectItem key={loc.id} value={loc.id}>{loc.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
         <div className="space-y-1.5 sm:col-span-2">
           <Label>{t("gabinet.patients.medicalNotes")}</Label>
           <RichTextEditor

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -36,6 +36,7 @@ import { useSupabasePaymentsByPatient } from "@/hooks/use-supabase-payments";
 import { useSupabaseGabinetReceiptsByPatient } from "@/hooks/use-supabase-gabinet-receipts";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
+import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { SidePanel } from "@/components/crm/side-panel";
 import { PatientForm } from "@/components/forms/patient-form";
@@ -142,6 +143,7 @@ function PatientDetail() {
     organizationId,
     "gabinetPatient",
   );
+  const { data: orgLocations = [] } = useSupabaseGabinetLocationsList(organizationId, { activeOnly: true });
 
   const [generatingReceiptFor, setGeneratingReceiptFor] = useState<string | null>(null);
 
@@ -488,6 +490,7 @@ function PatientDetail() {
     emergencyContactName?: string | null;
     emergencyContactPhone?: string | null;
     referralSource?: string | null;
+    preferredLocationId?: string | null;
     tagIds?: Id<"tagDefinitions">[];
     categoryId?: Id<"categoryDefinitions">;
   }) => {
@@ -1116,6 +1119,7 @@ function PatientDetail() {
               emergencyContactName: patient.emergencyContactName ?? undefined,
               emergencyContactPhone: patient.emergencyContactPhone ?? undefined,
               referralSource: patient.referralSource ?? undefined,
+              preferredLocationId: patient.preferredLocationId ?? undefined,
               tagIds: patient.tagIds as Id<"tagDefinitions">[] | undefined,
               categoryId: patient.categoryId as
                 | Id<"categoryDefinitions">
@@ -1127,6 +1131,7 @@ function PatientDetail() {
             organizationId={organizationId}
             tagDefinitions={orgTags}
             categoryDefinitions={patientCategories}
+            locations={orgLocations.map((l) => ({ id: l.id, name: l.name }))}
           />
         </SidePanel>
       )}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -34,6 +34,7 @@ import type { MiniChartData } from "@/components/crm/mini-charts";
 import { useSavedViews, applyFilterConditions } from "@/hooks/use-saved-views";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
+import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
 import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
 import { formatPhoneNumber } from "@/lib/phone";
@@ -126,6 +127,7 @@ function PatientsIndex() {
 
   const { tags } = useTagDefinitions(organizationId);
   const { categories } = useCategoryDefinitions(organizationId, "gabinetPatient");
+  const { data: locations = [] } = useSupabaseGabinetLocationsList(organizationId, { activeOnly: true });
   const [tagsSlideoutOpen, setTagsSlideoutOpen] = useState(false);
   const [categoriesSlideoutOpen, setCategoriesSlideoutOpen] = useState(false);
   const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor | undefined>({
@@ -491,6 +493,7 @@ function PatientsIndex() {
       emergencyContactName?: string | null;
       emergencyContactPhone?: string | null;
       referralSource?: string | null;
+      preferredLocationId?: string | null;
       tagIds?: Id<"tagDefinitions">[];
       categoryId?: Id<"categoryDefinitions">;
     }) => {
@@ -769,6 +772,7 @@ function PatientsIndex() {
           organizationId={organizationId}
           tagDefinitions={tags}
           categoryDefinitions={categories}
+          locations={locations.map((l) => ({ id: l.id, name: l.name }))}
         />
       </SidePanel>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4702.

Closes #4702

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d373b8f feat(gabinet): add preferredLocationId to patient create/edit form (closes #4702)

### Files changed

```
 public/locales/en/translation.json                 |  3 ++-
 public/locales/pl/translation.json                 |  3 ++-
 src/components/forms/patient-form.tsx              | 25 ++++++++++++++++++++++
 .../_layout.gabinet.patients.$patientId.tsx        |  5 +++++
 .../dashboard/_layout.gabinet.patients.index.tsx   |  4 ++++
 5 files changed, 38 insertions(+), 2 deletions(-)
```