### PR TITLE
feat(gabinet): connect Warehouse/Deliveries to GabinetLocationContext activeLocationId (closes #4705)

### DIFF
--- a/src/components/forms/product-stock-adjust-dialog.tsx
+++ b/src/components/forms/product-stock-adjust-dialog.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
+import { useActiveLocation } from "@/contexts/gabinet-location-context";
 import { useSupabaseProductStockTotals } from "@/hooks/use-supabase-products";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 import { formatActionError } from "@/lib/format-action-error";
@@ -94,9 +95,10 @@ export function ProductStockAdjustDialog({
   );
   const { totalsByProductId } = useSupabaseProductStockTotals(organizationId);
 
+  const { activeLocationId, setActiveLocationId } = useActiveLocation();
+
   const [mode, setMode] = useState<Mode>("receive");
   const [quantity, setQuantity] = useState("");
-  const [locationId, setLocationId] = useState<string>(ALL_LOCATIONS_VALUE);
   const [note, setNote] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -105,7 +107,6 @@ export function ProductStockAdjustDialog({
     if (open) {
       setMode("receive");
       setQuantity("");
-      setLocationId(ALL_LOCATIONS_VALUE);
       setNote("");
     }
   }, [open, product?._id]);
@@ -115,13 +116,11 @@ export function ProductStockAdjustDialog({
 
   const currentBalance = useMemo(() => {
     if (!stockSummary) return 0;
-    const targetLocationId =
-      locationId === ALL_LOCATIONS_VALUE ? null : locationId;
     const match = stockSummary.byLocation.find(
-      (row) => row.locationId === targetLocationId,
+      (row) => row.locationId === activeLocationId,
     );
     return match?.quantity ?? 0;
-  }, [stockSummary, locationId]);
+  }, [stockSummary, activeLocationId]);
 
   const parsedQuantity = (() => {
     if (!quantity.trim()) return null;
@@ -141,10 +140,7 @@ export function ProductStockAdjustDialog({
       const result = await adjustStock({
         organizationId: organizationId as Id<"organizations">,
         productId: product._id,
-        locationId:
-          locationId === ALL_LOCATIONS_VALUE
-            ? null
-            : (locationId as Id<"gabinetLocations">),
+        locationId: activeLocationId as Id<"gabinetLocations"> | null,
         delta,
         reason: mode === "receive" ? "warehouse_receive" : "manual_adjust",
         note: note.trim() || null,
@@ -311,7 +307,7 @@ export function ProductStockAdjustDialog({
                   defaultValue: "Lokalizacja",
                 })}
               </Label>
-              <Select value={locationId} onValueChange={setLocationId}>
+              <Select value={activeLocationId ?? ALL_LOCATIONS_VALUE} onValueChange={(v) => setActiveLocationId(v === ALL_LOCATIONS_VALUE ? null : v)}>
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>

--- a/src/components/gabinet/deliveries/deliveries-page.tsx
+++ b/src/components/gabinet/deliveries/deliveries-page.tsx
@@ -52,6 +52,7 @@ import { useSupabaseProductsList, useSupabaseProductStockTotals } from "@/hooks/
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
 import { cn } from "@/lib/utils";
 import { usePermission } from "@/hooks/use-permission";
+import { useActiveLocation } from "@/contexts/gabinet-location-context";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   NO_LOCATION,
@@ -137,6 +138,8 @@ export function DeliveriesPage() {
     queryFn: () => listDeliveriesAction({ organizationId, limit: 100 }),
     staleTime: 30_000,
   });
+
+  const { activeLocationId, setActiveLocationId } = useActiveLocation();
 
   const { data: productsData = [] } = useSupabaseProductsList(String(organizationId));
   const { data: locations = [] } = useSupabaseGabinetLocationsList(String(organizationId), { activeOnly: true });
@@ -244,7 +247,7 @@ export function DeliveriesPage() {
     setSupplierName("");
     setInvoiceNumber("");
     setDeliveryDate("");
-    setLocationId(NO_LOCATION);
+    setLocationId(activeLocationId ?? NO_LOCATION);
     setNotes("");
     setItems([newLine()]);
     setEditInvoicePageUrls([]);
@@ -252,7 +255,7 @@ export function DeliveriesPage() {
     setEditAnalysisItems([]);
     setEditProposals(null);
     setEditItemDecisions(null);
-  }, []);
+  }, [activeLocationId]);
 
   const handleEditOpen = async (id: string) => {
     setEditLoading(true);
@@ -860,7 +863,7 @@ export function DeliveriesPage() {
                 <Label>
                   {t("gabinet.deliveries.location", "Lokalizacja")}
                 </Label>
-                <Select value={locationId} onValueChange={setLocationId}>
+                <Select value={locationId} onValueChange={(v) => { setLocationId(v); setActiveLocationId(v === NO_LOCATION ? null : v); }}>
                   <SelectTrigger>
                     <SelectValue />
                   </SelectTrigger>

--- a/src/components/gabinet/warehouse-inventory-dialog.tsx
+++ b/src/components/gabinet/warehouse-inventory-dialog.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { useSupabase } from "@/components/supabase-provider";
 import { toast } from "sonner";
 import type { Id } from "@cvx/_generated/dataModel";
+import { useActiveLocation } from "@/contexts/gabinet-location-context";
 import {
   Dialog,
   DialogContent,
@@ -106,15 +107,15 @@ export function WarehouseInventoryDialog({
   // after midnight don't drift todayStr away from the selectedDate initial value.
   const todayStr = useMemo(() => toLocalDateStr(new Date()), [open]);
 
+  const { activeLocationId, setActiveLocationId } = useActiveLocation();
+
   const [step, setStep] = useState<Step>("count");
   const [counts, setCounts] = useState<Map<string, string>>(new Map());
-  const [locationId, setLocationId] = useState<string>(NO_LOCATION_VALUE);
   const [selectedDate, setSelectedDate] = useState<string>(todayStr);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [reportOpen, setReportOpen] = useState(false);
 
-  const resolvedLocationId: string | null =
-    locationId === NO_LOCATION_VALUE ? null : locationId;
+  const resolvedLocationId = activeLocationId;
 
   const isHistoricalMode = selectedDate < todayStr;
 
@@ -208,7 +209,6 @@ export function WarehouseInventoryDialog({
     if (nextOpen) {
       setStep("count");
       setCounts(new Map());
-      setLocationId(NO_LOCATION_VALUE);
       setSelectedDate(toLocalDateStr(new Date()));
     }
     onOpenChange(nextOpen);
@@ -466,7 +466,7 @@ export function WarehouseInventoryDialog({
                   defaultValue: "Lokalizacja",
                 })}
               </Label>
-              <Select value={locationId} onValueChange={(v) => { setLocationId(v); setCounts(new Map()); }}>
+              <Select value={activeLocationId ?? NO_LOCATION_VALUE} onValueChange={(v) => { setActiveLocationId(v === NO_LOCATION_VALUE ? null : v); setCounts(new Map()); }}>
                 <SelectTrigger id="inventory-location">
                   <SelectValue />
                 </SelectTrigger>

--- a/src/components/gabinet/warehouse-shopping-list-dialog.tsx
+++ b/src/components/gabinet/warehouse-shopping-list-dialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import {
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
+import { useActiveLocation } from "@/contexts/gabinet-location-context";
 import { useSupabaseProductsLastDeliveryInfo } from "@/hooks/use-supabase-products";
 import { CopyIcon } from "@/lib/ez-icons";
 import { formatCurrencyPLN } from "@/lib/format-currency";
@@ -211,23 +212,14 @@ export function WarehouseShoppingListDialog({
   plannedUsageByProductId,
 }: WarehouseShoppingListDialogProps) {
   const { t } = useTranslation();
+  const { activeLocationId, setActiveLocationId } = useActiveLocation();
   const { data: locations = [] } = useSupabaseGabinetLocationsList(organizationId, { activeOnly: true });
   const { lastDeliveryByProductId } = useSupabaseProductsLastDeliveryInfo(organizationId, {
     enabled: open,
   });
-  const [locationId, setLocationId] = useState<string>(NO_LOCATION_VALUE);
   const [quantities, setQuantities] = useState<Map<string, string>>(new Map());
-  const hasAutoSelectedRef = useRef(false);
 
-  // Auto-select the single location when locations data loads asynchronously after dialog opens.
-  useEffect(() => {
-    if (open && !hasAutoSelectedRef.current && locations.length === 1) {
-      hasAutoSelectedRef.current = true;
-      setLocationId(locations[0]!._id);
-    }
-  }, [open, locations]);
-
-  const resolvedLocationId: string | null = locationId === NO_LOCATION_VALUE ? null : locationId;
+  const resolvedLocationId = activeLocationId;
 
   function getStock(productId: string): number {
     const stock = totalsByProductId.get(productId);
@@ -262,7 +254,7 @@ export function WarehouseShoppingListDialog({
           unitPriceGross,
         };
       });
-  }, [products, totalsByProductId, locationId, locations, resolvedLocationId, plannedUsageByProductId, lastDeliveryByProductId]);
+  }, [products, totalsByProductId, activeLocationId, locations, resolvedLocationId, plannedUsageByProductId, lastDeliveryByProductId]);
 
   const supplierGroups = useMemo(
     () => groupShoppingItems(shoppingItems),
@@ -286,17 +278,13 @@ export function WarehouseShoppingListDialog({
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (nextOpen) {
-      hasAutoSelectedRef.current = false;
-      const initial = locations.length === 1 ? locations[0]!._id : NO_LOCATION_VALUE;
-      if (locations.length === 1) hasAutoSelectedRef.current = true;
-      setLocationId(initial);
       setQuantities(new Map());
     }
     onOpenChange(nextOpen);
   };
 
   const handleLocationChange = (v: string) => {
-    setLocationId(v);
+    setActiveLocationId(v === NO_LOCATION_VALUE ? null : v);
     setQuantities(new Map());
   };
 
@@ -405,7 +393,7 @@ export function WarehouseShoppingListDialog({
               <Label htmlFor="shopping-list-location">
                 {t("inventory.count.locationLabel", { defaultValue: "Lokalizacja" })}
               </Label>
-              <Select value={locationId} onValueChange={handleLocationChange}>
+              <Select value={activeLocationId ?? NO_LOCATION_VALUE} onValueChange={handleLocationChange}>
                 <SelectTrigger id="shopping-list-location">
                   <SelectValue />
                 </SelectTrigger>


### PR DESCRIPTION
## Summary

- Replaced independent `locationId` local state in four warehouse/delivery components with `activeLocationId` from `GabinetLocationContext`
- Location selectors in warehouse dialogs now call `setActiveLocationId` to control the global context, not a second independent state
- Changing location in the sidebar now automatically changes warehouse data

## Files changed

- `src/components/gabinet/warehouse-inventory-dialog.tsx` — removed local `locationId` state; inventory location selector calls `setActiveLocationId`
- `src/components/gabinet/warehouse-shopping-list-dialog.tsx` — removed local `locationId` state + auto-select ref/effect; uses `activeLocationId` from context
- `src/components/forms/product-stock-adjust-dialog.tsx` — removed local `locationId` state; stock adjust location selector calls `setActiveLocationId`
- `src/components/gabinet/deliveries/deliveries-page.tsx` — delivery create form defaults to `activeLocationId`; selector syncs changes back to context

## Answers to issue questions

1. **Where Warehouse/Deliveries now use activeLocationId**: all four files above
2. **Which filters were connected**: inventory stock lookup, historical stock query, shopping list min-stock filter, stock adjust balance lookup, new delivery locationId default
3. **Does sidebar change automatically change warehouse data**: yes — dialogs read `activeLocationId` directly from context
4. **Remaining independent locationId**: none in scope. Deliveries LIST is not filtered by location (backend `listDeliveries` has no locationId param) — separate backend change needed for that

## Test plan
- [ ] Change location in sidebar → warehouse inventory dialog opens pre-selected to that location
- [ ] Change location in sidebar → shopping list dialog filters stock by that location
- [ ] Change location in sidebar → stock adjust dialog shows balance for that location
- [ ] Create a new delivery → location field pre-filled with active location
- [ ] Select a different location in a warehouse dialog → sidebar location switcher reflects the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)