### PR TITLE
Extend PermissionGate with locationId in Deliveries route

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.deliveries.tsx
@@ -1,15 +1,27 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { PermissionGate } from "@/hooks/use-permission";
 import { DeliveriesPageSkeleton, DeliveriesPage } from "@/components/gabinet/deliveries/deliveries-page";
+import { useActiveLocation } from "@/contexts/gabinet-location-context";
+import type { Id } from "@cvx/_generated/dataModel";
+
+function DeliveriesRoute() {
+  const { activeLocationId } = useActiveLocation();
+  return (
+    <PermissionGate
+      feature="gabinet_inventory"
+      action="view"
+      locationId={(activeLocationId ?? undefined) as Id<"gabinetLocations"> | undefined}
+      loadingFallback={<DeliveriesPageSkeleton />}
+    >
+      <DeliveriesPage />
+    </PermissionGate>
+  );
+}
 
 export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/deliveries",
 )({
-  component: () => (
-    <PermissionGate feature="gabinet_inventory" action="view" loadingFallback={<DeliveriesPageSkeleton />}>
-      <DeliveriesPage />
-    </PermissionGate>
-  ),
+  component: DeliveriesRoute,
   validateSearch: (search: Record<string, unknown>): { action?: "create" } => ({
     action: search.action === "create" ? "create" : undefined,
   }),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4719.

Closes #4719

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 700e104 feat(gabinet): connect PermissionGate in deliveries route to activeLocationId (closes #4719)

### Files changed

```
 .../_auth/dashboard/_layout.gabinet.deliveries.tsx | 22 +++++++++++++++++-----
 1 file changed, 17 insertions(+), 5 deletions(-)
```