### PR TITLE
Extend PermissionGate with locationId in Reports route

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -1,4 +1,5 @@
 import { createLazyFileRoute } from "@tanstack/react-router";
+import type { Id } from "@cvx/_generated/dataModel";
 import Papa from "papaparse";
 import { toast } from "sonner";
 import { useSupabaseGabinetAppointmentsByDateRange } from "@/hooks/use-supabase-gabinet-appointments";
@@ -92,18 +93,24 @@ function GabinetReportsSkeleton() {
   );
 }
 
-export const Route = createLazyFileRoute(
-  "/_app/_auth/dashboard/_layout/gabinet/reports"
-)({
-  component: () => (
+function GabinetReportsRoute() {
+  const { activeLocationId } = useActiveLocation();
+  return (
     <PermissionGate
       feature="gabinet_reports"
       action="view"
+      locationId={(activeLocationId ?? undefined) as Id<"gabinetLocations"> | undefined}
       loadingFallback={<GabinetReportsSkeleton />}
     >
       <GabinetReports />
     </PermissionGate>
-  ),
+  );
+}
+
+export const Route = createLazyFileRoute(
+  "/_app/_auth/dashboard/_layout/gabinet/reports"
+)({
+  component: GabinetReportsRoute,
 });
 
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4720.

Closes #4720

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b46ea06 feat(gabinet): connect PermissionGate in reports route to activeLocationId (closes #4720)

### Files changed

```
 .../_auth/dashboard/_layout.gabinet.reports.lazy.tsx    | 17 ++++++++++++-----
 1 file changed, 12 insertions(+), 5 deletions(-)
```