### PR TITLE
7/16 — Pracownicy — podpiąć activeLocationId do uprawnień Klientów

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -80,18 +80,24 @@ function PatientDetailSkeleton() {
   );
 }
 
-export const Route = createFileRoute(
-  "/_app/_auth/dashboard/_layout/gabinet/patients/$patientId",
-)({
-  component: () => (
+function PatientDetailRoute() {
+  const { activeLocationId } = useActiveLocation();
+  return (
     <PermissionGate
       feature="gabinet_patients"
       action="view"
+      locationId={(activeLocationId ?? undefined) as Id<"gabinetLocations"> | undefined}
       loadingFallback={<PatientDetailSkeleton />}
     >
       <PatientDetail />
     </PermissionGate>
-  ),
+  );
+}
+
+export const Route = createFileRoute(
+  "/_app/_auth/dashboard/_layout/gabinet/patients/$patientId",
+)({
+  component: PatientDetailRoute,
 });
 
 function PatientDetail() {
@@ -100,8 +106,8 @@ function PatientDetail() {
   const { activeLocationId } = useActiveLocation();
   const navigate = useNavigate();
   const { t } = useTranslation();
-  const { allowed: canEdit } = usePermission("gabinet_patients", "edit");
-  const { allowed: canDelete } = usePermission("gabinet_patients", "delete");
+  const { allowed: canEdit } = usePermission("gabinet_patients", "edit", (activeLocationId ?? undefined) as Id<"gabinetLocations"> | undefined);
+  const { allowed: canDelete } = usePermission("gabinet_patients", "delete", (activeLocationId ?? undefined) as Id<"gabinetLocations"> | undefined);
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen for this action
   const updatePatient = useAction(api.gabinet.patients.update);
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen for this action

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -66,18 +66,24 @@ function PatientListSkeleton() {
   );
 }
 
-export const Route = createFileRoute(
-  "/_app/_auth/dashboard/_layout/gabinet/patients/",
-)({
-  component: () => (
+function PatientsIndexRoute() {
+  const { activeLocationId } = useActiveLocation();
+  return (
     <PermissionGate
       feature="gabinet_patients"
       action="view"
+      locationId={(activeLocationId ?? undefined) as Id<"gabinetLocations"> | undefined}
       loadingFallback={<PatientListSkeleton />}
     >
       <PatientsIndex />
     </PermissionGate>
-  ),
+  );
+}
+
+export const Route = createFileRoute(
+  "/_app/_auth/dashboard/_layout/gabinet/patients/",
+)({
+  component: PatientsIndexRoute,
   validateSearch: (search: Record<string, unknown>): { nudge?: PatientNudgeFilter } => {
     const nudge =
       search.nudge === "missing-contact" ||
@@ -106,9 +112,9 @@ function PatientsIndex() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { nudge: nudgeFilter } = useSearch({ from: Route.id });
-  const { allowed: _canCreate } = usePermission("gabinet_patients", "create");
-  const { allowed: canEdit } = usePermission("gabinet_patients", "edit");
-  const { allowed: canDelete } = usePermission("gabinet_patients", "delete");
+  const { allowed: _canCreate } = usePermission("gabinet_patients", "create", (activeLocationId ?? undefined) as Id<"gabinetLocations"> | undefined);
+  const { allowed: canEdit } = usePermission("gabinet_patients", "edit", (activeLocationId ?? undefined) as Id<"gabinetLocations"> | undefined);
+  const { allowed: canDelete } = usePermission("gabinet_patients", "delete", (activeLocationId ?? undefined) as Id<"gabinetLocations"> | undefined);
 
   const createPatient = useAction(api.gabinet.patients.create);
   const removePatient = useAction(api.gabinet.patients.remove);
@@ -611,7 +617,7 @@ function PatientsIndex() {
         title={t("gabinet.patients.title")}
         description={t("gabinet.patients.description")}
         actions={
-          <PermissionGate feature="gabinet_patients" action="create">
+          <PermissionGate feature="gabinet_patients" action="create" locationId={(activeLocationId ?? undefined) as Id<"gabinetLocations"> | undefined}>
             <Button onClick={() => setPanelOpen(true)}>
               <Plus className="mr-2 h-4 w-4" variant="stroke" />
               {t("gabinet.patients.addPatient")}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4727.

Closes #4727

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 9366de1 feat(gabinet): connect PermissionGate in patients routes to activeLocationId (closes #4727)

### Files changed

```
 .../_layout.gabinet.patients.$patientId.tsx        | 20 +++++++++++-------
 .../dashboard/_layout.gabinet.patients.index.tsx   | 24 ++++++++++++++--------
 2 files changed, 28 insertions(+), 16 deletions(-)
```