### PR TITLE
Fix sub-action permission locationId gap in DeliveriesPage

### DIFF
--- a/src/components/gabinet/deliveries/deliveries-page.tsx
+++ b/src/components/gabinet/deliveries/deliveries-page.tsx
@@ -106,9 +106,11 @@ export function DeliveriesPage() {
   const queryClient = useQueryClient();
   const routeNavigate = useNavigate();
   const { action: actionParam } = useSearch({ from: "/_app/_auth/dashboard/_layout/gabinet/deliveries" });
-  const { allowed: canCreate } = usePermission("gabinet_inventory", "create");
-  const { allowed: canEdit } = usePermission("gabinet_inventory", "edit");
-  const { allowed: canDelete } = usePermission("gabinet_inventory", "delete");
+  const { activeLocationId, setActiveLocationId } = useActiveLocation();
+  const locationIdParam = (activeLocationId ?? undefined) as Id<"gabinetLocations"> | undefined;
+  const { allowed: canCreate } = usePermission("gabinet_inventory", "create", locationIdParam);
+  const { allowed: canEdit } = usePermission("gabinet_inventory", "edit", locationIdParam);
+  const { allowed: canDelete } = usePermission("gabinet_inventory", "delete", locationIdParam);
 
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen
   const listDeliveriesAction = useAction(api.warehouseDeliveries.listDeliveries);
@@ -130,8 +132,6 @@ export function DeliveriesPage() {
   const saveItemDecisionsAction = useAction(api.warehouseDeliveries.saveItemDecisions);
   // @ts-ignore
   const postDeliveryFromDecisionsAction = useAction(api.warehouseDeliveries.postDeliveryFromDecisions);
-
-  const { activeLocationId, setActiveLocationId } = useActiveLocation();
 
   const queryKey = ["warehouseDeliveries.list", organizationId, activeLocationId];
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4731.

Closes #4731

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 47ab182 fix(gabinet): pass locationId to usePermission in DeliveriesPage (closes #4731)

### Files changed

```
 src/components/gabinet/deliveries/deliveries-page.tsx | 10 +++++-----
 1 file changed, 5 insertions(+), 5 deletions(-)
```