### PR TITLE
8/2 — Pracownicy — rozdzielić konto nieaktywne od konta zablokowanego

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -1031,6 +1031,104 @@ export const remove = action({
   },
 });
 
+export const blockEmployee = action({
+  args: {
+    organizationId: v.id("organizations"),
+    employeeId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const authResult = await ctx.runAction(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_employees", action: "edit" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    const db = createSupabaseDb();
+    const emp = await db.get("gabinetEmployees", args.employeeId);
+    if (!emp || String(emp.organizationId) !== String(args.organizationId)) {
+      throw new Error("Employee not found");
+    }
+
+    await db.patch("gabinetEmployees", args.employeeId, {
+      isBlocked: true,
+      isActive: false,
+      updatedAt: Date.now(),
+    });
+
+    if (emp.userId) {
+      await ctx.runMutation(internal.gabinet.employees._upsertMembership, {
+        organizationId: args.organizationId,
+        userId: String(emp.userId),
+        gabinetRole: emp.role as GabinetEmployeeRole,
+        isActive: false,
+      });
+    }
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: authResult.userId as Id<"users">,
+      action: "employee_blocked",
+      entityType: "gabinetEmployee",
+      entityId: args.employeeId,
+      details: `Blocked employee account`,
+    });
+  },
+});
+
+export const unblockEmployee = action({
+  args: {
+    organizationId: v.id("organizations"),
+    employeeId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const authResult = await ctx.runAction(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_employees", action: "edit" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    const db = createSupabaseDb();
+    const emp = await db.get("gabinetEmployees", args.employeeId);
+    if (!emp || String(emp.organizationId) !== String(args.organizationId)) {
+      throw new Error("Employee not found");
+    }
+
+    await db.patch("gabinetEmployees", args.employeeId, {
+      isBlocked: false,
+      isActive: true,
+      updatedAt: Date.now(),
+    });
+
+    if (emp.userId) {
+      await ctx.runMutation(internal.gabinet.employees._upsertMembership, {
+        organizationId: args.organizationId,
+        userId: String(emp.userId),
+        gabinetRole: emp.role as GabinetEmployeeRole,
+        isActive: true,
+      });
+    }
+
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: authResult.userId as Id<"users">,
+      action: "employee_unblocked",
+      entityType: "gabinetEmployee",
+      entityId: args.employeeId,
+      details: `Unblocked employee account`,
+    });
+  },
+});
+
 export const _removeSideEffects = internalMutation({
   args: {
     employeeId: v.string(),

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -279,6 +279,10 @@ export function createGabinetTables({
     licenseNumber: v.optional(v.string()),
     hireDate: v.optional(v.string()),
     isActive: v.boolean(),
+    // Explicit block flag — true when an admin has blocked this account.
+    // Separate from isActive so that inactive (deactivated) records are not
+    // automatically treated as blocked. Old rows default to false.
+    isBlocked: v.optional(v.boolean()),
     color: v.optional(v.string()),
     notes: v.optional(v.string()),
     // Detailed employee data (beauty salon context)

--- a/src/components/gabinet/employees/account-tab-content.tsx
+++ b/src/components/gabinet/employees/account-tab-content.tsx
@@ -15,6 +15,8 @@ export function AccountTabContent({
   onEditEmployee,
   onDeactivate,
   onActivate,
+  onBlock,
+  onUnblock,
   pendingInvitation,
   onResendInvitation,
   t,
@@ -25,6 +27,8 @@ export function AccountTabContent({
   onEditEmployee: () => void;
   onDeactivate: () => void;
   onActivate?: () => Promise<void>;
+  onBlock?: () => Promise<void>;
+  onUnblock?: () => Promise<void>;
   pendingInvitation?: MappedInvitation | null;
   onResendInvitation?: () => Promise<void>;
   t: (key: string, opts?: Record<string, unknown> | string) => string;
@@ -95,10 +99,10 @@ export function AccountTabContent({
                 ) : (
                   <Badge variant="secondary">{t("gabinet.employees.statusInvitationPending", "Zaproszenie wysłane — oczekuje na akceptację")}</Badge>
                 )
+              ) : employee.isBlocked ? (
+                <Badge variant="destructive">{t("gabinet.employees.statusBlocked", "Konto zablokowane")}</Badge>
               ) : employee.isActive ? (
                 <Badge variant="default">{t("gabinet.employees.statusActive", "Konto aktywne")}</Badge>
-              ) : employee.userId ? (
-                <Badge variant="destructive">{t("gabinet.employees.statusBlocked", "Konto zablokowane")}</Badge>
               ) : (
                 <Badge variant="secondary">{t("gabinet.employees.statusInactive", "Konto nieaktywne")}</Badge>
               )}
@@ -150,7 +154,33 @@ export function AccountTabContent({
                   <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
                 </button>
               )}
-              {!employee.isActive && !employee.userId && onActivate ? (
+              {employee.isBlocked && onUnblock ? (
+                <button
+                  type="button"
+                  className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+                  onClick={onUnblock}
+                >
+                  <Power className="h-4 w-4 text-green-600 shrink-0" variant="stroke" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-green-600">{t("gabinet.employees.unblockAccount", "Odblokuj konto")}</p>
+                    <p className="text-xs text-muted-foreground">{t("gabinet.employees.unblockAccountDesc", "Przywróć pracownikowi dostęp do systemu")}</p>
+                  </div>
+                  <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                </button>
+              ) : employee.isActive && onBlock ? (
+                <button
+                  type="button"
+                  className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+                  onClick={onBlock}
+                >
+                  <Power className="h-4 w-4 text-destructive shrink-0" variant="stroke" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-destructive">{t("gabinet.employees.blockAccount", "Zablokuj konto")}</p>
+                    <p className="text-xs text-muted-foreground">{t("gabinet.employees.blockAccountDesc", "Zablokuj pracownikowi dostęp do systemu")}</p>
+                  </div>
+                  <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                </button>
+              ) : !employee.isActive && !employee.userId && onActivate ? (
                 <button
                   type="button"
                   className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -123,6 +123,7 @@
  *   • 00116_lead_stage_history.sql
  *   • 00117_gabinet_employees_performs_services.sql
  *   • 00118_gabinet_employees_work_scope.sql
+ *   • 00119_gabinet_employees_is_blocked.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -4125,6 +4126,7 @@ export interface Database {
           bio: string | null;
           avatar_url: string | null;
           work_scope: string | null;
+          is_blocked: boolean;
         };
         Insert: {
           id?: string;
@@ -4138,6 +4140,7 @@ export interface Database {
           license_number?: string | null;
           hire_date?: string | null;
           is_active: boolean;
+          is_blocked?: boolean;
           color?: string | null;
           notes?: string | null;
           phone?: string | null;
@@ -4179,6 +4182,7 @@ export interface Database {
           license_number?: string | null;
           hire_date?: string | null;
           is_active?: boolean;
+          is_blocked?: boolean;
           color?: string | null;
           notes?: string | null;
           phone?: string | null;

--- a/src/lib/supabase/mappers/gabinet/employees.ts
+++ b/src/lib/supabase/mappers/gabinet/employees.ts
@@ -18,6 +18,7 @@ export interface MappedGabinetEmployee {
   licenseNumber?: string;
   hireDate?: string;
   isActive: boolean;
+  isBlocked?: boolean;
   color?: string;
   notes?: string;
   phone?: string;

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -105,6 +105,8 @@ function EmployeeDetail() {
   const trackView = useAction(api.recentlyViewed.track);
   const listDocumentsByEntity = useAction(api.documents.documents.listByEntity);
   const changeEmployeePassword = useAction(api.gabinet.employees.changeEmployeePassword);
+  const blockEmployee = useAction(api.gabinet.employees.blockEmployee);
+  const unblockEmployee = useAction(api.gabinet.employees.unblockEmployee);
   const resendInvitation = useAction(api.invitations.resend);
 
   // Supabase cache invalidation helpers
@@ -422,6 +424,38 @@ function EmployeeDetail() {
     }
   };
 
+  const handleBlock = async () => {
+    if (!window.confirm(t("gabinet.employees.confirmBlock", "Czy na pewno chcesz zablokować konto tego pracownika?"))) return;
+    try {
+      await blockEmployee({ organizationId, employeeId });
+      toast.success(t("gabinet.employees.blocked", "Konto zablokowane."));
+      invalidateEmployeeCache();
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.employees.errors.blockFailed",
+          defaultValue: "Nie udało się zablokować konta.",
+        }),
+      );
+    }
+  };
+
+  const handleUnblock = async () => {
+    if (!window.confirm(t("gabinet.employees.confirmUnblock", "Czy na pewno chcesz odblokować konto tego pracownika?"))) return;
+    try {
+      await unblockEmployee({ organizationId, employeeId });
+      toast.success(t("gabinet.employees.unblocked", "Konto odblokowane."));
+      invalidateEmployeeCache();
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "gabinet.employees.errors.unblockFailed",
+          defaultValue: "Nie udało się odblokować konta.",
+        }),
+      );
+    }
+  };
+
   const handleResendInvitation = async () => {
     if (!pendingInvitation) return;
     try {
@@ -548,11 +582,13 @@ function EmployeeDetail() {
             ? t("gabinet.employees.statusInvitationExpired", "Zaproszenie wygasło")
             : t("gabinet.employees.statusInvitationPending", "Zaproszenie wysłane — oczekuje na akceptację")}
         </Badge>
+      ) : employee.isBlocked ? (
+        <Badge variant="outline" className="text-muted-foreground">
+          {t("gabinet.employees.statusBlocked", "Konto zablokowane")}
+        </Badge>
       ) : !employee.isActive ? (
         <Badge variant="outline" className="text-muted-foreground">
-          {employee.userId
-            ? t("gabinet.employees.statusBlocked", "Konto zablokowane")
-            : t("gabinet.employees.statusInactive", "Konto nieaktywne")}
+          {t("gabinet.employees.statusInactive", "Konto nieaktywne")}
         </Badge>
       ) : null}
     </div>
@@ -735,6 +771,8 @@ function EmployeeDetail() {
           onEditEmployee={() => setEditDrawerOpen(true)}
           onDeactivate={handleDeactivate}
           onActivate={handleActivate}
+          onBlock={handleBlock}
+          onUnblock={handleUnblock}
           pendingInvitation={pendingInvitation}
           onResendInvitation={isExpiredInvitation ? handleResendInvitation : undefined}
           t={t}

--- a/supabase/migrations/00119_gabinet_employees_is_blocked.sql
+++ b/supabase/migrations/00119_gabinet_employees_is_blocked.sql
@@ -1,0 +1,9 @@
+-- Issue #4735: add is_blocked to distinguish a blocked account from a merely
+-- inactive one. Previously both states shared is_active=false so the system
+-- could not tell them apart.
+--
+-- DEFAULT false ensures old rows with is_active=false remain "inactive" (not
+-- "blocked") unless an explicit block action is taken.
+
+ALTER TABLE gabinet_employees
+  ADD COLUMN IF NOT EXISTS is_blocked boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4735.

Closes #4735

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- cadc959 feat(gabinet): separate blocked from inactive employee account state (closes #4735)

### Files changed

```
 convex/gabinet/employees.ts                        | 98 ++++++++++++++++++++++
 convex/schema/gabinet.ts                           |  4 +
 .../gabinet/employees/account-tab-content.tsx      | 36 +++++++-
 src/lib/supabase/database.types.ts                 |  4 +
 src/lib/supabase/mappers/gabinet/employees.ts      |  1 +
 .../_layout.gabinet.employees.$employeeId.tsx      | 44 +++++++++-
 .../00119_gabinet_employees_is_blocked.sql         |  9 ++
 7 files changed, 190 insertions(+), 6 deletions(-)
```