### PR TITLE
8/3 — Pracownicy — ujednolicić statusy konta i akcje w UI

### DIFF
--- a/src/components/gabinet/employees/account-tab-content.tsx
+++ b/src/components/gabinet/employees/account-tab-content.tsx
@@ -7,6 +7,7 @@ import { ChangePasswordDialog } from "./change-password-dialog";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
 import { usePermission } from "@/hooks/use-permission";
+import { computeEmployeeAccountStatus } from "@/lib/gabinet/employee-account-status";
 
 export function AccountTabContent({
   employee,
@@ -93,19 +94,18 @@ export function AccountTabContent({
             </div>
             <div className="flex items-center justify-between px-4 py-3">
               <span className="text-sm text-muted-foreground">{t("gabinet.employees.accountStatus", "Status konta")}</span>
-              {pendingInvitation ? (
-                pendingInvitation.expiresAt <= Date.now() ? (
-                  <Badge variant="outline">{t("gabinet.employees.statusInvitationExpired", "Zaproszenie wygasło")}</Badge>
-                ) : (
-                  <Badge variant="secondary">{t("gabinet.employees.statusInvitationPending", "Zaproszenie wysłane — oczekuje na akceptację")}</Badge>
-                )
-              ) : employee.isBlocked ? (
-                <Badge variant="destructive">{t("gabinet.employees.statusBlocked", "Konto zablokowane")}</Badge>
-              ) : employee.isActive ? (
-                <Badge variant="default">{t("gabinet.employees.statusActive", "Konto aktywne")}</Badge>
-              ) : (
-                <Badge variant="secondary">{t("gabinet.employees.statusInactive", "Konto nieaktywne")}</Badge>
-              )}
+              {(() => {
+                const status = computeEmployeeAccountStatus({
+                  isActive: employee.isActive,
+                  isBlocked: employee.isBlocked,
+                  invitation: pendingInvitation ?? null,
+                });
+                if (status === "blocked") return <Badge variant="destructive">{t("gabinet.employees.statusBlocked", "Konto zablokowane")}</Badge>;
+                if (status === "active") return <Badge variant="default">{t("gabinet.employees.statusActive", "Konto aktywne")}</Badge>;
+                if (status === "invitation_pending") return <Badge variant="secondary">{t("gabinet.employees.statusInvitationPending", "Zaproszenie wysłane — oczekuje na akceptację")}</Badge>;
+                if (status === "invitation_expired") return <Badge variant="outline">{t("gabinet.employees.statusInvitationExpired", "Zaproszenie wygasło")}</Badge>;
+                return <Badge variant="secondary">{t("gabinet.employees.statusInactive", "Konto nieaktywne")}</Badge>;
+              })()}
             </div>
           </div>
         </div>
@@ -140,73 +140,91 @@ export function AccountTabContent({
                 </div>
                 <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
               </button>
-              {pendingInvitation && pendingInvitation.expiresAt <= Date.now() && onResendInvitation && (
-                <button
-                  type="button"
-                  className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
-                  onClick={onResendInvitation}
-                >
-                  <Send className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm">{t("gabinet.employees.resendInvitation", "Wyślij zaproszenie ponownie")}</p>
-                    <p className="text-xs text-muted-foreground">{t("gabinet.employees.resendInvitationDesc", "Ponów wysyłkę zaproszenia z nowym terminem ważności")}</p>
-                  </div>
-                  <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
-                </button>
-              )}
-              {employee.isBlocked && onUnblock ? (
-                <button
-                  type="button"
-                  className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
-                  onClick={onUnblock}
-                >
-                  <Power className="h-4 w-4 text-green-600 shrink-0" variant="stroke" />
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm text-green-600">{t("gabinet.employees.unblockAccount", "Odblokuj konto")}</p>
-                    <p className="text-xs text-muted-foreground">{t("gabinet.employees.unblockAccountDesc", "Przywróć pracownikowi dostęp do systemu")}</p>
-                  </div>
-                  <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
-                </button>
-              ) : employee.isActive && onBlock ? (
-                <button
-                  type="button"
-                  className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
-                  onClick={onBlock}
-                >
-                  <Power className="h-4 w-4 text-destructive shrink-0" variant="stroke" />
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm text-destructive">{t("gabinet.employees.blockAccount", "Zablokuj konto")}</p>
-                    <p className="text-xs text-muted-foreground">{t("gabinet.employees.blockAccountDesc", "Zablokuj pracownikowi dostęp do systemu")}</p>
-                  </div>
-                  <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
-                </button>
-              ) : !employee.isActive && !employee.userId && onActivate ? (
-                <button
-                  type="button"
-                  className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
-                  onClick={onActivate}
-                >
-                  <Power className="h-4 w-4 text-green-600 shrink-0" variant="stroke" />
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm text-green-600">{t("gabinet.employees.activateAccount", "Aktywuj konto")}</p>
-                    <p className="text-xs text-muted-foreground">{t("gabinet.employees.activateAccountDesc", "Przywróć dostęp pracownika do systemu")}</p>
-                  </div>
-                  <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
-                  onClick={onDeactivate}
-                >
-                  <Power className="h-4 w-4 text-destructive shrink-0" variant="stroke" />
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm text-destructive">{t("gabinet.employees.deactivate")}</p>
-                    <p className="text-xs text-muted-foreground">{t("gabinet.employees.deactivateDesc", "Wyłącz dostęp pracownika do systemu")}</p>
-                  </div>
-                  <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
-                </button>
-              )}
+              {(() => {
+                const status = computeEmployeeAccountStatus({
+                  isActive: employee.isActive,
+                  isBlocked: employee.isBlocked,
+                  invitation: pendingInvitation ?? null,
+                });
+                if (status === "blocked" && onUnblock) {
+                  return (
+                    <button
+                      type="button"
+                      className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+                      onClick={onUnblock}
+                    >
+                      <Power className="h-4 w-4 text-green-600 shrink-0" variant="stroke" />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm text-green-600">{t("gabinet.employees.unblockAccount", "Odblokuj konto")}</p>
+                        <p className="text-xs text-muted-foreground">{t("gabinet.employees.unblockAccountDesc", "Przywróć pracownikowi dostęp do systemu")}</p>
+                      </div>
+                      <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                    </button>
+                  );
+                }
+                if (status === "active" && onBlock) {
+                  return (
+                    <button
+                      type="button"
+                      className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+                      onClick={onBlock}
+                    >
+                      <Power className="h-4 w-4 text-destructive shrink-0" variant="stroke" />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm text-destructive">{t("gabinet.employees.blockAccount", "Zablokuj konto")}</p>
+                        <p className="text-xs text-muted-foreground">{t("gabinet.employees.blockAccountDesc", "Zablokuj pracownikowi dostęp do systemu")}</p>
+                      </div>
+                      <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                    </button>
+                  );
+                }
+                if (status === "invitation_expired" && onResendInvitation) {
+                  return (
+                    <button
+                      type="button"
+                      className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+                      onClick={onResendInvitation}
+                    >
+                      <Send className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm">{t("gabinet.employees.resendInvitation", "Wyślij zaproszenie ponownie")}</p>
+                        <p className="text-xs text-muted-foreground">{t("gabinet.employees.resendInvitationDesc", "Ponów wysyłkę zaproszenia z nowym terminem ważności")}</p>
+                      </div>
+                      <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                    </button>
+                  );
+                }
+                if (status === "inactive" && !employee.userId && onActivate) {
+                  return (
+                    <button
+                      type="button"
+                      className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+                      onClick={onActivate}
+                    >
+                      <Power className="h-4 w-4 text-green-600 shrink-0" variant="stroke" />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm text-green-600">{t("gabinet.employees.activateAccount", "Aktywuj konto")}</p>
+                        <p className="text-xs text-muted-foreground">{t("gabinet.employees.activateAccountDesc", "Przywróć dostęp pracownika do systemu")}</p>
+                      </div>
+                      <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                    </button>
+                  );
+                }
+                return (
+                  <button
+                    type="button"
+                    className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+                    onClick={onDeactivate}
+                  >
+                    <Power className="h-4 w-4 text-destructive shrink-0" variant="stroke" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm text-destructive">{t("gabinet.employees.deactivate")}</p>
+                      <p className="text-xs text-muted-foreground">{t("gabinet.employees.deactivateDesc", "Wyłącz dostęp pracownika do systemu")}</p>
+                    </div>
+                    <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                  </button>
+                );
+              })()}
             </div>
           </div>
         )}

--- a/src/lib/gabinet/employee-account-status.ts
+++ b/src/lib/gabinet/employee-account-status.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared helper for computing gabinet employee account status.
+ *
+ * Used in the employee list, employee detail header, and the account tab so
+ * the same logic drives every status badge and every action menu.
+ *
+ * Priority order (matches issue #4737 spec):
+ *   1. isBlocked  → "blocked"
+ *   2. isActive   → "active"
+ *   3. pending invitation, not yet expired → "invitation_pending"
+ *   4. pending invitation, expired         → "invitation_expired"
+ *   5. everything else                     → "inactive"
+ */
+
+export type EmployeeAccountStatus =
+  | "blocked"
+  | "active"
+  | "invitation_pending"
+  | "invitation_expired"
+  | "inactive";
+
+export function computeEmployeeAccountStatus(params: {
+  isActive: boolean;
+  isBlocked?: boolean;
+  invitation: { expiresAt: number } | null;
+}): EmployeeAccountStatus {
+  if (params.isBlocked) return "blocked";
+  if (params.isActive) return "active";
+  if (params.invitation) {
+    return params.invitation.expiresAt <= Date.now()
+      ? "invitation_expired"
+      : "invitation_pending";
+  }
+  return "inactive";
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -41,6 +41,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
 import { useSidebarSlot } from "@/components/layout/sidebar-slot-context";
+import { computeEmployeeAccountStatus } from "@/lib/gabinet/employee-account-status";
 import { PermissionGate, useRole } from "@/hooks/use-permission";
 import { EmployeeNavGroups } from "@/components/gabinet/employees/employee-nav-groups";
 import { AppointmentsTabContent } from "@/components/gabinet/employees/appointments-tab-content";
@@ -565,6 +566,14 @@ function EmployeeDetail() {
   const sidebarExtra = undefined;
 
   // Header subtitle with color swatch, role badge, and account/invitation status badge
+  const accountStatus = employee
+    ? computeEmployeeAccountStatus({
+        isActive: employee.isActive,
+        isBlocked: employee.isBlocked,
+        invitation: pendingInvitation,
+      })
+    : null;
+
   const headerSubtitle = !employee ? undefined : (
     <div className="flex items-center gap-2">
       {employee.color && (
@@ -576,17 +585,19 @@ function EmployeeDetail() {
       <Badge variant={employee.isActive ? "default" : "secondary"}>
         {t(`gabinet.employees.roles.${employee.role}`)}
       </Badge>
-      {pendingInvitation ? (
-        <Badge variant="outline" className="text-muted-foreground">
-          {isExpiredInvitation
-            ? t("gabinet.employees.statusInvitationExpired", "Zaproszenie wygasło")
-            : t("gabinet.employees.statusInvitationPending", "Zaproszenie wysłane — oczekuje na akceptację")}
-        </Badge>
-      ) : employee.isBlocked ? (
+      {accountStatus === "blocked" ? (
         <Badge variant="outline" className="text-muted-foreground">
           {t("gabinet.employees.statusBlocked", "Konto zablokowane")}
         </Badge>
-      ) : !employee.isActive ? (
+      ) : accountStatus === "invitation_pending" ? (
+        <Badge variant="outline" className="text-muted-foreground">
+          {t("gabinet.employees.statusInvitationPending", "Zaproszenie wysłane — oczekuje na akceptację")}
+        </Badge>
+      ) : accountStatus === "invitation_expired" ? (
+        <Badge variant="outline" className="text-muted-foreground">
+          {t("gabinet.employees.statusInvitationExpired", "Zaproszenie wygasło")}
+        </Badge>
+      ) : accountStatus === "inactive" ? (
         <Badge variant="outline" className="text-muted-foreground">
           {t("gabinet.employees.statusInactive", "Konto nieaktywne")}
         </Badge>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -35,6 +35,7 @@ import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
 import { Id } from "@cvx/_generated/dataModel";
 import type { MappedGabinetEmployee } from "@/lib/supabase/mappers/gabinet/employees";
+import { computeEmployeeAccountStatus } from "@/lib/gabinet/employee-account-status";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
 import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
@@ -156,6 +157,8 @@ function EmployeesIndex() {
 
   const updateEmployee = useAction(api.gabinet.employees.update);
   const removeEmployee = useAction(api.gabinet.employees.remove);
+  const blockEmployee = useAction(api.gabinet.employees.blockEmployee);
+  const unblockEmployee = useAction(api.gabinet.employees.unblockEmployee);
   const resendInvitation = useAction(api.invitations.resend);
   const cancelInvitation = useAction(api.invitations.cancel);
   const bulkSetEmployeeSchedule = useAction(
@@ -271,25 +274,23 @@ function EmployeesIndex() {
                 <p className="text-xs text-fg-quaternary">{user.email}</p>
               )}
             </div>
-            {!item.isActive && (() => {
-              if (!item.userId && item.email) {
-                const inv = invitationByEmail.get(item.email);
-                if (inv) {
-                  const isExpired = inv.expiresAt <= Date.now();
-                  return (
-                    <Badge variant="outline" className="text-xs text-muted-foreground">
-                      {isExpired
-                        ? t("gabinet.employees.statusInvitationExpired", "Zaproszenie wygasło")
-                        : t("gabinet.employees.statusInvitationPending", "Zaproszenie wysłane — oczekuje na akceptację")}
-                    </Badge>
-                  );
-                }
-              }
+            {(() => {
+              const inv = item.email ? invitationByEmail.get(item.email) : undefined;
+              const status = computeEmployeeAccountStatus({
+                isActive: item.isActive,
+                isBlocked: item.isBlocked,
+                invitation: inv ?? null,
+              });
+              if (status === "active") return null;
+              const statusLabels: Record<string, string> = {
+                blocked: t("gabinet.employees.statusBlocked", "Konto zablokowane"),
+                invitation_pending: t("gabinet.employees.statusInvitationPending", "Zaproszenie wysłane — oczekuje"),
+                invitation_expired: t("gabinet.employees.statusInvitationExpired", "Zaproszenie wygasło"),
+                inactive: t("gabinet.employees.statusInactive", "Konto nieaktywne"),
+              };
               return (
                 <Badge variant="outline" className="text-xs text-muted-foreground">
-                  {item.userId
-                    ? t("gabinet.employees.statusBlocked", "Konto zablokowane")
-                    : t("gabinet.employees.statusInactive", "Konto nieaktywne")}
+                  {statusLabels[status]}
                 </Badge>
               );
             })()}
@@ -437,8 +438,61 @@ function EmployeesIndex() {
       },
       ...(canEdit
         ? (() => {
-            const hasUser = !!row.userId;
-            if (!hasUser && !row.isActive) {
+            const inv = row.email ? invitationByEmail.get(row.email) : undefined;
+            const status = computeEmployeeAccountStatus({
+              isActive: row.isActive,
+              isBlocked: row.isBlocked,
+              invitation: inv ?? null,
+            });
+            if (status === "blocked") {
+              return [{
+                label: t("gabinet.employees.unblockAccount", "Odblokuj konto"),
+                onClick: async () => {
+                  if (!window.confirm(t("gabinet.employees.confirmUnblock", "Czy na pewno chcesz odblokować konto tego pracownika?"))) return;
+                  try {
+                    await unblockEmployee({ organizationId, employeeId: row._id });
+                    toast.success(t("gabinet.employees.unblocked", "Konto odblokowane."));
+                    invalidateEmployeesCache();
+                  } catch (e) {
+                    toast.error(formatActionError(e, t, { key: "gabinet.employees.errors.unblockFailed", defaultValue: "Nie udało się odblokować konta." }));
+                  }
+                },
+              }];
+            }
+            if (status === "active") {
+              return [{
+                label: t("gabinet.employees.blockAccount", "Zablokuj konto"),
+                onClick: async () => {
+                  if (!window.confirm(t("gabinet.employees.confirmBlock", "Czy na pewno chcesz zablokować konto tego pracownika?"))) return;
+                  try {
+                    await blockEmployee({ organizationId, employeeId: row._id });
+                    toast.success(t("gabinet.employees.blocked", "Konto zablokowane."));
+                    invalidateEmployeesCache();
+                  } catch (e) {
+                    toast.error(formatActionError(e, t, { key: "gabinet.employees.errors.blockFailed", defaultValue: "Nie udało się zablokować konta." }));
+                  }
+                },
+              }];
+            }
+            if (status === "invitation_pending" && inv) {
+              return [
+                {
+                  label: t("team.resendInvitation"),
+                  onClick: () => handleResendInvitation(inv._id),
+                },
+                {
+                  label: t("team.cancelInvitation"),
+                  onClick: () => handleCancelInvitation(inv._id),
+                },
+              ];
+            }
+            if (status === "invitation_expired" && inv) {
+              return [{
+                label: t("team.resendInvitation"),
+                onClick: () => handleResendInvitation(inv._id),
+              }];
+            }
+            if (status === "inactive" && !row.userId) {
               return [{
                 label: t("gabinet.employees.activateAccount", "Aktywuj konto"),
                 onClick: async () => {
@@ -449,36 +503,6 @@ function EmployeesIndex() {
                     invalidateEmployeesCache();
                   } catch (e) {
                     toast.error(formatActionError(e, t, { key: "gabinet.employees.errors.activateFailed", defaultValue: "Nie udało się aktywować konta." }));
-                  }
-                },
-              }];
-            }
-            if (hasUser && row.isActive) {
-              return [{
-                label: t("gabinet.employees.blockAccount", "Zablokuj konto"),
-                onClick: async () => {
-                  if (!window.confirm(t("gabinet.employees.confirmBlock", "Czy na pewno chcesz zablokować konto tego pracownika?"))) return;
-                  try {
-                    await updateEmployee({ organizationId, employeeId: row._id, isActive: false });
-                    toast.success(t("gabinet.employees.blocked", "Konto zablokowane."));
-                    invalidateEmployeesCache();
-                  } catch (e) {
-                    toast.error(formatActionError(e, t, { key: "gabinet.employees.errors.blockFailed", defaultValue: "Nie udało się zablokować konta." }));
-                  }
-                },
-              }];
-            }
-            if (hasUser && !row.isActive) {
-              return [{
-                label: t("gabinet.employees.unblockAccount", "Odblokuj konto"),
-                onClick: async () => {
-                  if (!window.confirm(t("gabinet.employees.confirmUnblock", "Czy na pewno chcesz odblokować konto tego pracownika?"))) return;
-                  try {
-                    await updateEmployee({ organizationId, employeeId: row._id, isActive: true });
-                    toast.success(t("gabinet.employees.unblocked", "Konto odblokowane."));
-                    invalidateEmployeesCache();
-                  } catch (e) {
-                    toast.error(formatActionError(e, t, { key: "gabinet.employees.errors.unblockFailed", defaultValue: "Nie udało się odblokować konta." }));
                   }
                 },
               }];
@@ -510,7 +534,7 @@ function EmployeesIndex() {
           ]
         : []),
     ],
-    [navigate, updateEmployee, removeEmployee, organizationId, t, canEdit, canDelete, invalidateEmployeesCache]
+    [navigate, updateEmployee, blockEmployee, unblockEmployee, removeEmployee, organizationId, t, canEdit, canDelete, invalidateEmployeesCache, invitationByEmail, handleResendInvitation, handleCancelInvitation]
   );
 
   const handleBulkAction = useCallback(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4737.

Closes #4737

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 1997ad4 feat(gabinet): unify employee account status logic with shared helper (closes #4737)

### Files changed

```
 .../gabinet/employees/account-tab-content.tsx      | 178 ++++++++++++---------
 src/lib/gabinet/employee-account-status.ts         |  35 ++++
 .../_layout.gabinet.employees.$employeeId.tsx      |  25 ++-
 .../dashboard/_layout.gabinet.employees.index.tsx  |  88 ++++++----
 4 files changed, 207 insertions(+), 119 deletions(-)
```