### PR TITLE
8/4 — Pracownicy — uporządkować hasło startowe bez wymuszonej zmiany

### DIFF
--- a/src/components/forms/employee-form.tsx
+++ b/src/components/forms/employee-form.tsx
@@ -590,9 +590,9 @@ export function EmployeeForm({
                 className="accent-primary mt-0.5"
               />
               <span className="flex flex-col gap-0.5">
-                <span>{t("gabinet.employees.accessModePassword", { defaultValue: "Utwórz hasło jednorazowe" })}</span>
+                <span>{t("gabinet.employees.accessModePassword", { defaultValue: "Utwórz hasło startowe" })}</span>
                 <span className="text-xs text-muted-foreground">
-                  {t("gabinet.employees.accessModePasswordDesc", { defaultValue: "Administrator ustawia hasło i przekazuje je pracownikowi bezpośrednio." })}
+                  {t("gabinet.employees.accessModePasswordDesc", { defaultValue: "Administrator ustawia hasło startowe, które pracownik może samodzielnie zmienić po zalogowaniu." })}
                 </span>
               </span>
             </label>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4739.

Closes #4739

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3ea9be1 fix(gabinet): rename "hasło jednorazowe" to "hasło startowe" in employee form (closes #4739)

### Files changed

```
 src/components/forms/employee-form.tsx | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```