### PR TITLE
8/5 — Pracownicy — końcowy retest statusów i aktywacji konta

### DIFF
--- a/src/components/gabinet/employees/account-tab-content.tsx
+++ b/src/components/gabinet/employees/account-tab-content.tsx
@@ -210,6 +210,9 @@ export function AccountTabContent({
                     </button>
                   );
                 }
+                if (status === "invitation_pending") {
+                  return null;
+                }
                 return (
                   <button
                     type="button"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4741.

Closes #4741

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 7e42c69 fix(gabinet): suppress deactivate button in account tab for pending invitation (closes #4741)

### Files changed

```
 src/components/gabinet/employees/account-tab-content.tsx | 3 +++
 1 file changed, 3 insertions(+)
```