### PR TITLE
Link inactive employee record to userId on invitation acceptance

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -351,6 +351,7 @@ export const _createFromInvitation = internalAction({
     userId: v.string(),
     invitedBy: v.string(),
     data: v.any(),
+    email: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const db = createSupabaseDb();
@@ -404,6 +405,70 @@ export const _createFromInvitation = internalAction({
       }
 
       return { skipped: true, employeeId: existingEmployeeId };
+    }
+
+    // Fallback: if no userId match but an email is known, look for a pre-created
+    // employee row (userId=null) so we link it instead of inserting a duplicate.
+    if (args.email) {
+      const byEmail = (await db
+        .query("gabinetEmployees")
+        .eq("organizationId", String(args.organizationId))
+        .eq("email", args.email)
+        .collect()) as Array<{ _id: string; userId: string | null; role: string; isActive: boolean }>;
+
+      const preCreated = byEmail.find((e) => !e.userId);
+      if (preCreated) {
+        const existingEmployeeId = String(preCreated._id);
+        log.info("linking pre-created employee by email", { email: args.email, employeeId: existingEmployeeId });
+
+        await db.patch("gabinetEmployees", existingEmployeeId, {
+          userId: args.userId,
+          updatedAt: Date.now(),
+        });
+
+        const d2 = (args.data ?? {}) as Record<string, unknown>;
+        const locationId2 = typeof d2.locationId === "string" && d2.locationId.length > 0 ? d2.locationId : null;
+        const locationRole2Raw = typeof d2.locationRole === "string" ? d2.locationRole : null;
+        const locationRole2 = locationRole2Raw && isSystemGabinetRole(locationRole2Raw) ? locationRole2Raw : undefined;
+        if (locationId2) {
+          try {
+            const existingLocation = await db
+              .query("gabinetEmployeeLocations")
+              .eq("organizationId", String(args.organizationId))
+              .eq("employeeId", existingEmployeeId)
+              .eq("locationId", locationId2)
+              .collect();
+            if (existingLocation.length === 0) {
+              await db.insert("gabinetEmployeeLocations", {
+                organizationId: String(args.organizationId),
+                employeeId: existingEmployeeId,
+                locationId: locationId2,
+                isPrimary: false,
+                role: locationRole2,
+                createdAt: Date.now(),
+              });
+              await ctx.runMutation(internal.gabinet.employees._upsertLocationMembership, {
+                organizationId: args.organizationId,
+                userId: args.userId,
+                locationId: locationId2,
+                role: locationRole2 ?? undefined,
+              });
+            }
+          } catch (e) {
+            console.error(`[gabinet.employees._createFromInvitation] location insert on email-link failed:`, e);
+          }
+        }
+
+        const empRole = isSystemGabinetRole(preCreated.role) ? (preCreated.role as GabinetEmployeeRole) : "doctor";
+        await ctx.runMutation(internal.gabinet.employees._upsertMembership, {
+          organizationId: args.organizationId,
+          userId: args.userId,
+          gabinetRole: empRole,
+          isActive: preCreated.isActive ?? true,
+        });
+
+        return { skipped: true, employeeId: existingEmployeeId };
+      }
     }
 
     const d = (args.data ?? {}) as Record<string, unknown>;

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -534,6 +534,7 @@ export const _acceptInternal = internalMutation({
           userId: String(user._id),
           invitedBy: args.invitationInvitedBy,
           data: args.invitationModuleData,
+          email: args.invitationEmail,
         },
       );
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4745.

Closes #4745

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c6503d4 fix(gabinet): link pre-created employee by email on invitation acceptance (closes #4745)

### Files changed

```
 convex/gabinet/employees.ts | 65 +++++++++++++++++++++++++++++++++++++++++++++
 convex/invitations.ts       |  1 +
 2 files changed, 66 insertions(+)
```