### PR TITLE
`createWithPassword` does not attempt email-based pre-created employee linking

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -1567,26 +1567,57 @@ export const createWithPassword = action({
       throw new Error("Employee profile already exists for this user");
     }
 
-    const employeeId = await db.insert("gabinetEmployees", {
-      organizationId: String(args.organizationId),
-      userId,
-      firstName: args.firstName ?? null,
-      lastName: args.lastName ?? null,
-      role: args.role,
-      specialization: args.specialization ?? null,
-      qualifiedTreatmentIds: args.qualifiedTreatmentIds ?? [],
-      licenseNumber: args.licenseNumber ?? null,
-      hireDate: args.hireDate ?? null,
-      isActive: true,
-      color: args.color ?? null,
-      notes: null,
-      showInCalendar: args.showInCalendar ?? true,
-      tagIds: args.tagIds ?? null,
-      categoryId: args.categoryId ?? null,
-      createdBy: String(authResult.userId),
-      createdAt: now,
-      updatedAt: now,
-    });
+    // Check for a pre-created employee row (userId=null) matched by email — link
+    // it instead of inserting a duplicate that would leave the pre-created row orphaned.
+    const byEmail = (await db
+      .query("gabinetEmployees")
+      .eq("organizationId", String(args.organizationId))
+      .eq("email", args.email)
+      .collect()) as Array<{ _id: string; userId: string | null }>;
+    const unlinkedByEmail = byEmail.filter((e) => !e.userId);
+    const preCreated = unlinkedByEmail.length === 1 ? unlinkedByEmail[0] : undefined;
+
+    let employeeId: string;
+    if (preCreated) {
+      employeeId = String(preCreated._id);
+      await db.patch("gabinetEmployees", employeeId, {
+        userId,
+        firstName: args.firstName ?? null,
+        lastName: args.lastName ?? null,
+        role: args.role,
+        specialization: args.specialization ?? null,
+        qualifiedTreatmentIds: args.qualifiedTreatmentIds ?? [],
+        licenseNumber: args.licenseNumber ?? null,
+        hireDate: args.hireDate ?? null,
+        isActive: true,
+        color: args.color ?? null,
+        showInCalendar: args.showInCalendar ?? true,
+        tagIds: args.tagIds ?? null,
+        categoryId: args.categoryId ?? null,
+        updatedAt: now,
+      });
+    } else {
+      employeeId = String(await db.insert("gabinetEmployees", {
+        organizationId: String(args.organizationId),
+        userId,
+        firstName: args.firstName ?? null,
+        lastName: args.lastName ?? null,
+        role: args.role,
+        specialization: args.specialization ?? null,
+        qualifiedTreatmentIds: args.qualifiedTreatmentIds ?? [],
+        licenseNumber: args.licenseNumber ?? null,
+        hireDate: args.hireDate ?? null,
+        isActive: true,
+        color: args.color ?? null,
+        notes: null,
+        showInCalendar: args.showInCalendar ?? true,
+        tagIds: args.tagIds ?? null,
+        categoryId: args.categoryId ?? null,
+        createdBy: String(authResult.userId),
+        createdAt: now,
+        updatedAt: now,
+      }));
+    }
 
     if (args.locationId) {
       try {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4753.

Closes #4753

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8caa1b9 fix(gabinet): link pre-created employee by email in createWithPassword (closes #4753)

### Files changed

```
 convex/gabinet/employees.ts | 71 ++++++++++++++++++++++++++++++++-------------
 1 file changed, 51 insertions(+), 20 deletions(-)
```