### PR TITLE
New employee rows created via `_createFromInvitation` do not populate the `email

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -488,6 +488,7 @@ export const _createFromInvitation = internalAction({
     const employeeId = await db.insert("gabinetEmployees", {
       organizationId: String(args.organizationId),
       userId: args.userId,
+      email: args.email ?? null,
       firstName: asString(d.firstName),
       lastName: asString(d.lastName),
       role: safeRole,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4754.

Closes #4754

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d1dd947 fix(gabinet): populate email field in _createFromInvitation employee insert (closes #4754)

### Files changed

```
 convex/gabinet/employees.ts | 1 +
 1 file changed, 1 insertion(+)
```