### PR TITLE
Deduplicate location insert guard in `createWithPassword`

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -1622,14 +1622,22 @@ export const createWithPassword = action({
 
     if (args.locationId) {
       try {
-        await db.insert("gabinetEmployeeLocations", {
-          organizationId: String(args.organizationId),
-          employeeId: String(employeeId),
-          locationId: args.locationId,
-          isPrimary: true,
-          role: args.locationRole,
-          createdAt: now,
-        });
+        const existingLocation = await db
+          .query("gabinetEmployeeLocations")
+          .eq("organizationId", String(args.organizationId))
+          .eq("employeeId", String(employeeId))
+          .eq("locationId", args.locationId)
+          .collect();
+        if (existingLocation.length === 0) {
+          await db.insert("gabinetEmployeeLocations", {
+            organizationId: String(args.organizationId),
+            employeeId: String(employeeId),
+            locationId: args.locationId,
+            isPrimary: true,
+            role: args.locationRole,
+            createdAt: now,
+          });
+        }
       } catch (e) {
         console.error("[employees.createWithPassword] location insert failed:", e);
       }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4759.

Closes #4759

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- ef1f74c fix(gabinet): add existence check before location insert in createWithPassword (closes #4759)

### Files changed

```
 convex/gabinet/employees.ts | 24 ++++++++++++++++--------
 1 file changed, 16 insertions(+), 8 deletions(-)
```