### PR TITLE
No `email` field in `gabinet_employees.ts

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -183,6 +183,7 @@ export const create = action({
     tagIds: v.optional(v.array(v.string())),
     categoryId: v.optional(v.union(v.string(), v.null())),
     customFields: v.optional(v.array(v.any())),
+    email: v.optional(v.union(v.string(), v.null())),
     locationId: v.optional(v.string()),
     locationRole: v.optional(gabinetEmployeeRoleValidator),
   },
@@ -221,6 +222,7 @@ export const create = action({
     const employeeId = await db.insert("gabinetEmployees", {
       organizationId: String(args.organizationId),
       userId: args.userId ?? null,
+      email: args.email ?? null,
       firstName: args.firstName ?? null,
       lastName: args.lastName ?? null,
       role: args.role,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4765.

Closes #4765

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e593239 fix(gabinet): add email field to employees.create action (closes #4765)

### Files changed

```
 convex/gabinet/employees.ts | 2 ++
 1 file changed, 2 insertions(+)
```