### PR TITLE
Add `(organization_id, email)` index on `gabinet_employees` for email-based look

### DIFF
--- a/supabase/migrations/00120_gabinet_employees_org_email_idx.sql
+++ b/supabase/migrations/00120_gabinet_employees_org_email_idx.sql
@@ -1,0 +1,7 @@
+-- Issue #4764: add (organization_id, email) index on gabinet_employees.
+-- _createFromInvitation and createWithPassword both do
+-- eq("organizationId", ...).eq("email", ...) to find pre-created employee
+-- rows; without this index those queries do a sequential scan within the org.
+
+CREATE INDEX IF NOT EXISTS gabinet_employees_org_email_idx
+  ON gabinet_employees (organization_id, email);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4764.

Closes #4764

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- bf9e65b perf(gabinet): add (organization_id, email) index on gabinet_employees (closes #4764)

### Files changed

```
 supabase/migrations/00120_gabinet_employees_org_email_idx.sql | 7 +++++++
 1 file changed, 7 insertions(+)
```