### PR TITLE
Brak typu `GabinetLeaveBalanceRow` w `convex/_helpers/supabaseRows.ts`

### DIFF
--- a/convex/_helpers/supabaseRows.ts
+++ b/convex/_helpers/supabaseRows.ts
@@ -23,6 +23,7 @@ export type GabinetEmployeeScheduleRow = SupabaseRow<"gabinetEmployeeSchedules">
 export type GabinetWorkingHoursRow = SupabaseRow<"gabinetWorkingHours">;
 export type GabinetLeaveRow = SupabaseRow<"gabinetLeaves">;
 export type GabinetLeaveTypeRow = SupabaseRow<"gabinetLeaveTypes">;
+export type GabinetLeaveBalanceRow = SupabaseRow<"gabinetLeaveBalances">;
 export type GabinetOvertimeRow = SupabaseRow<"gabinetOvertime">;
 export type GabinetPaymentMethodRow = SupabaseRow<"gabinetPaymentMethods">;
 export type GabinetLocationRow = SupabaseRow<"gabinetLocations">;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4774.

Closes #4774

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 2fb7df6 fix(gabinet): add GabinetLeaveBalanceRow type to supabaseRows.ts (closes #4774)

### Files changed

```
 convex/_helpers/supabaseRows.ts | 1 +
 1 file changed, 1 insertion(+)
```