### PR TITLE
`getLeavesByDateRange` filtruje po `startDate >= min AND startDate <= max` zamia

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -854,8 +854,8 @@ export const getLeavesByDateRange = action({
     const leaves = (await db
       .query("gabinetLeaves")
       .eq("organizationId", String(args.organizationId))
-      .gte("startDate", args.startDate)
       .lte("startDate", args.endDate)
+      .gte("endDate", args.startDate)
       .collect()) as GabinetLeaveRow[];
 
     return leaves.filter((l) => l.status === "approved");


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4772.

Closes #4772

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3b58d39 fix(gabinet): fix getLeavesByDateRange to use full date overlap (closes #4772)

### Files changed

```
 convex/gabinet/scheduling.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```