### PR TITLE
Brak powiadomień po decyzji o urlopie

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -6,6 +6,7 @@ import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { logError } from "../_helpers/logged";
 import { logActivity } from "../_helpers/activities";
 import { logAudit } from "../auditLog";
+import { createNotificationDirect } from "../notifications";
 import { gabinetLeaveTypeValidator, gabinetLeaveStatusValidator } from "../schema";
 import { getAvailableSlotsSupabase } from "./_availability_supabase";
 import type {
@@ -1155,6 +1156,17 @@ export const _leaveSideEffects = internalMutation({
         entityType: "gabinetLeave",
         entityId: args.leaveId,
         details: args.description,
+      });
+    }
+
+    if (args.action === "status_changed" && args.userId !== args.performedBy) {
+      const actorSuffix = args.actorLabel ? ` by ${args.actorLabel}` : "";
+      await createNotificationDirect(ctx, {
+        organizationId: args.organizationId,
+        userId: args.userId as Id<"users">,
+        type: "leave_decision",
+        title: args.description,
+        message: `${args.description}${actorSuffix}.`,
       });
     }
   },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4770.

Closes #4770

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0188591 fix(gabinet): notify employee on leave approve/reject (closes #4770)

### Files changed

```
 convex/gabinet/scheduling.ts | 12 ++++++++++++
 1 file changed, 12 insertions(+)
```