### PR TITLE
Nieatomowy update salda przy approve

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -663,12 +663,15 @@ export const approveLeave = action({
       throw new Error("Leave not found");
     }
 
-    await db.patch("gabinetLeaves", args.leaveId, {
-      status: "approved",
-      approvedBy: authResult.userId,
-      approvedAt: now,
-      updatedAt: now,
+    // Atomic: approve status + balance increment happen in one Postgres
+    // transaction via RPC (issue #4771 — two separate patches were non-atomic).
+    const { error: rpcError } = await db.raw().rpc("approve_gabinet_leave", {
+      p_leave_id:    args.leaveId,
+      p_org_id:      String(args.organizationId),
+      p_approved_by: String(authResult.userId),
+      p_now:         now,
     });
+    if (rpcError) throw new Error(`approveLeave RPC failed: ${rpcError.message}`);
 
     try {
       await ctx.runMutation(internal.gabinet.scheduling._leaveSideEffects, {
@@ -683,36 +686,6 @@ export const approveLeave = action({
       });
     } catch (e) {
       console.error("[scheduling.approveLeave] Side effects FAILED:", e);
-    }
-
-    // Update leave balance if leaveTypeId is set
-    if (leave.leaveTypeId) {
-      const startD = new Date(leave.startDate as string);
-      const endD = new Date(leave.endDate as string);
-      const days = Math.max(1, Math.ceil((endD.getTime() - startD.getTime()) / (1000 * 60 * 60 * 24)) + 1);
-      const year = startD.getFullYear();
-
-      // Find employee record from Supabase
-      const employee = await db.query("gabinetEmployees")
-        .eq("organizationId", String(args.organizationId))
-        .eq("userId", leave.userId as string)
-        .first();
-
-      if (employee) {
-        const balance = (await db.query("gabinetLeaveBalances")
-          .eq("organizationId", String(args.organizationId))
-          .eq("employeeId", employee._id as string)
-          .eq("leaveTypeId", leave.leaveTypeId as string)
-          .eq("year", year)
-          .first()) as GabinetLeaveBalanceRow | null;
-
-        if (balance) {
-          await db.patch("gabinetLeaveBalances", balance._id as string, {
-            usedDays: (balance.usedDays as number) + days,
-            updatedAt: now,
-          });
-        }
-      }
     }
   },
 });

--- a/supabase/migrations/00121_approve_gabinet_leave_atomic_fn.sql
+++ b/supabase/migrations/00121_approve_gabinet_leave_atomic_fn.sql
@@ -1,0 +1,75 @@
+-- Atomic leave approval: update leave status + increment used_days in one
+-- Postgres transaction (issue #4771).
+--
+-- Previously, approveLeave made two separate PostgREST calls: first patching
+-- gabinet_leaves.status to "approved", then patching gabinet_leave_balances.
+-- used_days. If the second write failed (network blip, constraint violation),
+-- the leave was left as "approved" with stale balance — inconsistent state
+-- with no automatic recovery path.
+--
+-- By wrapping both operations in a single plpgsql function they share one
+-- transaction: if the balance UPDATE raises an exception, Postgres rolls back
+-- the leave status UPDATE automatically.
+
+CREATE OR REPLACE FUNCTION approve_gabinet_leave(
+  p_leave_id    TEXT,
+  p_org_id      TEXT,
+  p_approved_by TEXT,
+  p_now         BIGINT
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_id       TEXT;
+  v_leave_type_id TEXT;
+  v_start_date    TEXT;
+  v_end_date      TEXT;
+  v_days          NUMERIC;
+  v_year          INT;
+  v_employee_id   TEXT;
+BEGIN
+  -- Step 1: approve the leave (verify org ownership via WHERE clause).
+  UPDATE gabinet_leaves
+  SET
+    status      = 'approved',
+    approved_by = p_approved_by,
+    approved_at = p_now,
+    updated_at  = p_now
+  WHERE id = p_leave_id
+    AND organization_id = p_org_id
+  RETURNING user_id, leave_type_id, start_date, end_date
+  INTO v_user_id, v_leave_type_id, v_start_date, v_end_date;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Leave not found or org mismatch: %', p_leave_id;
+  END IF;
+
+  -- Step 2: update the leave balance if the leave is typed (has a leaveTypeId).
+  IF v_leave_type_id IS NOT NULL THEN
+    -- Calculate business days the same way the JS code did:
+    -- GREATEST(1, (end_date - start_date) + 1)
+    v_days := GREATEST(1, (v_end_date::DATE - v_start_date::DATE) + 1);
+    v_year := EXTRACT(YEAR FROM v_start_date::DATE)::INT;
+
+    -- Resolve the employee record for this user in this org.
+    SELECT id INTO v_employee_id
+    FROM gabinet_employees
+    WHERE organization_id = p_org_id
+      AND user_id = v_user_id
+    LIMIT 1;
+
+    IF v_employee_id IS NOT NULL THEN
+      UPDATE gabinet_leave_balances
+      SET
+        used_days  = used_days + v_days,
+        updated_at = p_now
+      WHERE organization_id = p_org_id
+        AND employee_id    = v_employee_id
+        AND leave_type_id  = v_leave_type_id
+        AND year           = v_year;
+      -- No error if the balance row doesn't exist — matches previous behaviour.
+    END IF;
+  END IF;
+END;
+$$;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4771.

Closes #4771

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 5a92af3 fix(gabinet): make approveLeave atomic via Postgres RPC (closes #4771)

### Files changed

```
 convex/gabinet/scheduling.ts                       | 43 +++----------
 .../00121_approve_gabinet_leave_atomic_fn.sql      | 75 ++++++++++++++++++++++
 2 files changed, 83 insertions(+), 35 deletions(-)
```