### PR TITLE
Partial-day leaves odliczają pełny dzień z salda

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -765,7 +765,14 @@ export const deleteLeave = action({
     if (leave.status === "approved" && leave.leaveTypeId) {
       const startD = new Date(leave.startDate as string);
       const endD = new Date(leave.endDate as string);
-      const days = Math.max(1, Math.ceil((endD.getTime() - startD.getTime()) / (1000 * 60 * 60 * 24)) + 1);
+      let days: number;
+      if (leave.startTime && leave.endTime) {
+        const [sh, sm] = (leave.startTime as string).split(":").map(Number);
+        const [eh, em] = (leave.endTime as string).split(":").map(Number);
+        days = Math.max(0, (eh * 60 + em - sh * 60 - sm) / 480);
+      } else {
+        days = Math.max(1, Math.ceil((endD.getTime() - startD.getTime()) / (1000 * 60 * 60 * 24)) + 1);
+      }
       const year = startD.getFullYear();
 
       const employee = await db.query("gabinetEmployees")

--- a/supabase/migrations/00122_approve_gabinet_leave_partial_day.sql
+++ b/supabase/migrations/00122_approve_gabinet_leave_partial_day.sql
@@ -1,0 +1,85 @@
+-- Fix partial-day leave balance deduction (issue #4773).
+--
+-- The previous approve_gabinet_leave function always deducted
+-- GREATEST(1, date_diff + 1) full days, ignoring start_time/end_time.
+-- When a leave has both start_time and end_time set it is a partial-day
+-- leave and the deduction should be proportional to the fraction of a
+-- standard 8-hour working day (480 minutes).
+--
+-- Example: start_time="09:00", end_time="13:00" → 240 min / 480 min = 0.5 days.
+
+CREATE OR REPLACE FUNCTION approve_gabinet_leave(
+  p_leave_id    TEXT,
+  p_org_id      TEXT,
+  p_approved_by TEXT,
+  p_now         BIGINT
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_id       TEXT;
+  v_leave_type_id TEXT;
+  v_start_date    TEXT;
+  v_end_date      TEXT;
+  v_start_time    TEXT;
+  v_end_time      TEXT;
+  v_days          NUMERIC;
+  v_year          INT;
+  v_employee_id   TEXT;
+  v_start_minutes INT;
+  v_end_minutes   INT;
+BEGIN
+  -- Step 1: approve the leave (verify org ownership via WHERE clause).
+  UPDATE gabinet_leaves
+  SET
+    status      = 'approved',
+    approved_by = p_approved_by,
+    approved_at = p_now,
+    updated_at  = p_now
+  WHERE id = p_leave_id
+    AND organization_id = p_org_id
+  RETURNING user_id, leave_type_id, start_date, end_date, start_time, end_time
+  INTO v_user_id, v_leave_type_id, v_start_date, v_end_date, v_start_time, v_end_time;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Leave not found or org mismatch: %', p_leave_id;
+  END IF;
+
+  -- Step 2: update the leave balance if the leave is typed (has a leaveTypeId).
+  IF v_leave_type_id IS NOT NULL THEN
+    IF v_start_time IS NOT NULL AND v_end_time IS NOT NULL THEN
+      -- Partial-day leave: deduct the fraction of a standard 8-hour day (480 min).
+      v_start_minutes := (SPLIT_PART(v_start_time, ':', 1)::INT * 60)
+                       + SPLIT_PART(v_start_time, ':', 2)::INT;
+      v_end_minutes   := (SPLIT_PART(v_end_time,   ':', 1)::INT * 60)
+                       + SPLIT_PART(v_end_time,   ':', 2)::INT;
+      v_days := GREATEST(0, (v_end_minutes - v_start_minutes)::NUMERIC / 480);
+    ELSE
+      -- Full-day leave: GREATEST(1, (end_date - start_date) + 1).
+      v_days := GREATEST(1, (v_end_date::DATE - v_start_date::DATE) + 1);
+    END IF;
+
+    v_year := EXTRACT(YEAR FROM v_start_date::DATE)::INT;
+
+    -- Resolve the employee record for this user in this org.
+    SELECT id INTO v_employee_id
+    FROM gabinet_employees
+    WHERE organization_id = p_org_id
+      AND user_id = v_user_id
+    LIMIT 1;
+
+    IF v_employee_id IS NOT NULL THEN
+      UPDATE gabinet_leave_balances
+      SET
+        used_days  = used_days + v_days,
+        updated_at = p_now
+      WHERE organization_id = p_org_id
+        AND employee_id    = v_employee_id
+        AND leave_type_id  = v_leave_type_id
+        AND year           = v_year;
+      -- No error if the balance row doesn't exist — matches previous behaviour.
+    END IF;
+  END IF;
+END;
+$$;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4773.

Closes #4773

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b8b64ba fix(gabinet): deduct proportional days for partial-day leaves (closes #4773)

### Files changed

```
 convex/gabinet/scheduling.ts                       |  9 ++-
 .../00122_approve_gabinet_leave_partial_day.sql    | 85 ++++++++++++++++++++++
 2 files changed, 93 insertions(+), 1 deletion(-)
```