### PR TITLE
10/6 — Pracownicy — końcowy retest obiegu urlopów

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -604,12 +604,24 @@ export const createLeave = action({
       endDate: args.endDate,
       startTime: args.startTime ?? null,
       endTime: args.endTime ?? null,
-      status: initialStatus,
+      status: "pending",
       reason: args.reason ?? null,
       createdBy: authResult.userId,
       createdAt: now,
       updatedAt: now,
     });
+
+    // Auto-approve atomically when requiresApproval=false so balance is
+    // updated in the same Postgres transaction as the status change.
+    if (initialStatus === "approved") {
+      const { error: rpcError } = await db.raw().rpc("approve_gabinet_leave", {
+        p_leave_id:    leaveId,
+        p_org_id:      String(args.organizationId),
+        p_approved_by: String(authResult.userId),
+        p_now:         now,
+      });
+      if (rpcError) throw new Error(`Auto-approve RPC failed: ${rpcError.message}`);
+    }
 
     try {
       await ctx.runMutation(internal.gabinet.scheduling._createLeaveSideEffects, {
@@ -680,12 +692,24 @@ export const requestLeave = action({
         endDate: args.endDate,
         startTime: args.startTime ?? null,
         endTime: args.endTime ?? null,
-        status: initialStatus,
+        status: "pending",
         reason: args.reason ?? null,
         createdBy: userId,
         createdAt: now,
         updatedAt: now,
       });
+
+      // Auto-approve atomically when requiresApproval=false so balance is
+      // updated in the same Postgres transaction as the status change.
+      if (initialStatus === "approved") {
+        const { error: rpcError } = await db.raw().rpc("approve_gabinet_leave", {
+          p_leave_id:    leaveId,
+          p_org_id:      String(args.organizationId),
+          p_approved_by: userId,
+          p_now:         now,
+        });
+        if (rpcError) throw new Error(`Auto-approve RPC failed: ${rpcError.message}`);
+      }
 
       try {
         await ctx.runMutation(internal.gabinet.scheduling._createLeaveSideEffects, {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4795.

Closes #4795

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 97f45cb fix(gabinet): update balance atomically for auto-approved leaves (closes #4795)

### Files changed

```
 convex/gabinet/scheduling.ts | 28 ++++++++++++++++++++++++++--
 1 file changed, 26 insertions(+), 2 deletions(-)
```