### PR TITLE
Add silent-collision error for pre-created employee linking

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -420,6 +420,13 @@ export const _createFromInvitation = internalAction({
 
       // Don't guess when multiple unlinked candidates share the same email.
       const unlinkedCandidates = byEmail.filter((e) => !e.userId);
+      if (unlinkedCandidates.length > 1) {
+        log.warn("email collision — multiple unlinked employees share the same email; skipping pre-created link", {
+          email: args.email,
+          organizationId: String(args.organizationId),
+          candidateIds: unlinkedCandidates.map((e) => e._id),
+        });
+      }
       const preCreated = unlinkedCandidates.length === 1 ? unlinkedCandidates[0] : undefined;
       if (preCreated) {
         const existingEmployeeId = String(preCreated._id);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4802.

Closes #4802

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- adf3ecc fix(gabinet): log warning on email collision in _createFromInvitation (closes #4802)

### Files changed

```
 convex/gabinet/employees.ts | 7 +++++++
 1 file changed, 7 insertions(+)
```