### PR TITLE
Fix re-activate button for deactivated employees with userId

### DIFF
--- a/src/components/gabinet/employees/account-tab-content.tsx
+++ b/src/components/gabinet/employees/account-tab-content.tsx
@@ -194,7 +194,7 @@ export function AccountTabContent({
                     </button>
                   );
                 }
-                if (status === "inactive" && !employee.userId && onActivate) {
+                if (status === "inactive" && onActivate) {
                   return (
                     <button
                       type="button"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4799.

Closes #4799

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- cc3018a fix(gabinet): show re-activate button for deactivated employees with userId (closes #4799)

### Files changed

```
 src/components/gabinet/employees/account-tab-content.tsx | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```