### PR TITLE
11/3 — Pracownicy — zablokować składanie urlopu bez profilu pracownika

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -689,6 +689,16 @@ export const requestLeave = action({
       const now = Date.now();
       const db = createSupabaseDb();
 
+      const employeeProfile = await db
+        .query("gabinetEmployees")
+        .eq("organizationId", String(args.organizationId))
+        .eq("userId", userId)
+        .eq("isActive", true)
+        .collect();
+      if (employeeProfile.length === 0) {
+        throw new Error("Brak profilu pracownika. Tylko pracownicy z aktywnym profilem mogą składać wnioski urlopowe.");
+      }
+
       const initialStatus = await resolveInitialLeaveStatus(db, args.leaveTypeId);
 
       const leaveId = await db.insert("gabinetLeaves", {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4809.

Closes #4809

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0584ad8 fix(gabinet): block requestLeave for users without an active employee profile (closes #4809)

### Files changed

```
 convex/gabinet/scheduling.ts | 10 ++++++++++
 1 file changed, 10 insertions(+)
```