### PR TITLE
11/4 — Pracownicy — rozdzielić etykiety „Złóż wniosek” dla admina i pracownika

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2948,6 +2948,7 @@
       "title": "Leave Management",
       "description": "Manage employee leaves and time off",
       "requestLeave": "Request Leave",
+      "addLeaveRequest": "Add Leave Request",
       "type": "Type",
       "startDate": "Start Date",
       "endDate": "End Date",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2947,6 +2947,7 @@
       "title": "Zarządzanie urlopami",
       "description": "Zarządzaj urlopami i dniami wolnymi pracowników",
       "requestLeave": "Złóż wniosek",
+      "addLeaveRequest": "Dodaj wniosek urlopowy",
       "type": "Typ",
       "startDate": "Data rozpoczęcia",
       "endDate": "Data zakończenia",

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
@@ -281,12 +281,12 @@ function LeavesPage() {
                 <DialogTrigger asChild>
                   <Button size="sm">
                     <Plus className="mr-2 h-4 w-4" variant="stroke" />
-                    {t("gabinet.leaves.requestLeave")}
+                    {t("gabinet.leaves.addLeaveRequest")}
                   </Button>
                 </DialogTrigger>
                 <DialogContent className="sm:max-w-md">
                   <DialogHeader>
-                    <DialogTitle>{t("gabinet.leaves.requestLeave")}</DialogTitle>
+                    <DialogTitle>{t("gabinet.leaves.addLeaveRequest")}</DialogTitle>
                   </DialogHeader>
                   <div className="space-y-4">
                     <div className="space-y-1.5">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4811.

Closes #4811

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 7ffaf4a fix(gabinet): split i18n keys for admin vs employee leave request labels (closes #4811)

### Files changed

```
 public/locales/en/translation.json                                  | 1 +
 public/locales/pl/translation.json                                  | 1 +
 src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx | 4 ++--
 3 files changed, 4 insertions(+), 2 deletions(-)
```