### PR TITLE
Show qualifications tab (read-only) when performsServices=false

### DIFF
--- a/src/components/gabinet/employees/detailed-data-tab.tsx
+++ b/src/components/gabinet/employees/detailed-data-tab.tsx
@@ -229,37 +229,36 @@ export function DetailedDataTab({
 
       {(!limitedView || qualificationsOnlyView) && (
         <>
+          <QualificationsSection
+            {...sharedSectionProps}
+            canEdit={canEdit && !!employee.performsServices}
+            employee={employee}
+            certifications={certifications}
+            setCertifications={setCertifications}
+            newCertName={newCertName}
+            setNewCertName={setNewCertName}
+            newCertDate={newCertDate}
+            setNewCertDate={setNewCertDate}
+            newCertExpiry={newCertExpiry}
+            setNewCertExpiry={setNewCertExpiry}
+          />
           {employee.performsServices && (
-            <>
-              <QualificationsSection
-                {...sharedSectionProps}
-                employee={employee}
-                certifications={certifications}
-                setCertifications={setCertifications}
-                newCertName={newCertName}
-                setNewCertName={setNewCertName}
-                newCertDate={newCertDate}
-                setNewCertDate={setNewCertDate}
-                newCertExpiry={newCertExpiry}
-                setNewCertExpiry={setNewCertExpiry}
-              />
-              <AssignedTreatmentsSection
-                employee={employee}
-                treatmentMap={treatmentMap}
-                editing={editing}
-                saving={saving}
-                canEdit={canEdit}
-                treatmentSearchLocal={treatmentSearchLocal}
-                setTreatmentSearchLocal={setTreatmentSearchLocal}
-                filteredTreatments={filteredTreatments}
-                pendingTreatmentIds={pendingTreatmentIds}
-                setPendingTreatmentIds={setPendingTreatmentIds}
-                onStartEdit={startEdit}
-                onCancelEdit={cancelEdit}
-                onSaveSection={saveSection}
-                t={t}
-              />
-            </>
+            <AssignedTreatmentsSection
+              employee={employee}
+              treatmentMap={treatmentMap}
+              editing={editing}
+              saving={saving}
+              canEdit={canEdit}
+              treatmentSearchLocal={treatmentSearchLocal}
+              setTreatmentSearchLocal={setTreatmentSearchLocal}
+              filteredTreatments={filteredTreatments}
+              pendingTreatmentIds={pendingTreatmentIds}
+              setPendingTreatmentIds={setPendingTreatmentIds}
+              onStartEdit={startEdit}
+              onCancelEdit={cancelEdit}
+              onSaveSection={saveSection}
+              t={t}
+            />
           )}
 
           {!qualificationsOnlyView && (

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -681,7 +681,7 @@ function EmployeeDetail() {
         />
       ),
     },
-    ...(employee.performsServices ? [{
+    {
       label: t("gabinet.employees.tabs.qualificationsAndTreatments"),
       content: (
         <DetailedDataTab
@@ -698,7 +698,7 @@ function EmployeeDetail() {
           qualificationsOnlyView={true}
         />
       ),
-    }] : []),
+    },
     {
       label: t("gabinet.employees.tabs.detailedData"),
       content: (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4816.

Closes #4816

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- cae777d fix(gabinet): show qualifications tab read-only when performsServices=false (closes #4816)

### Files changed

```
 .../gabinet/employees/detailed-data-tab.tsx        | 59 +++++++++++-----------
 .../_layout.gabinet.employees.$employeeId.tsx      |  4 +-
 2 files changed, 31 insertions(+), 32 deletions(-)
```