### PR TITLE
Add fallback org-admin notification in `_createLeaveSideEffects` for employees w

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -1396,6 +1396,25 @@ export const _createLeaveSideEffects = internalMutation({
             message: `${requesterName} submitted a leave request (${args.type}: ${args.startDate} – ${args.endDate}).`,
           });
         }
+      } else {
+        // Fallback: employee has no location assignments — notify org admins/owners.
+        const orgAdminMemberships = await ctx.db
+          .query("teamMemberships")
+          .withIndex("by_organizationId", (q) => q.eq("organizationId", args.organizationId))
+          .collect();
+
+        const requesterName = args.actorLabel ?? "An employee";
+        for (const membership of orgAdminMemberships) {
+          if (membership.role !== "owner" && membership.role !== "admin") continue;
+          if (String(membership.userId) === args.userId) continue;
+          await createNotificationDirect(ctx, {
+            organizationId: args.organizationId,
+            userId: membership.userId,
+            type: "leave_request",
+            title: "New leave request",
+            message: `${requesterName} submitted a leave request (${args.type}: ${args.startDate} – ${args.endDate}).`,
+          });
+        }
       }
     } catch (e) {
       console.error("[scheduling._createLeaveSideEffects] Manager notifications FAILED:", e);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4814.

Closes #4814

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 7c43077 fix(gabinet): notify org admins when leave requester has no location assignments (closes #4814)

### Files changed

```
 convex/gabinet/scheduling.ts | 19 +++++++++++++++++++
 1 file changed, 19 insertions(+)
```