### PR TITLE
Mirror createWithPassword multi-candidate warning to match `_createFromInvitatio

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -1585,6 +1585,16 @@ export const createWithPassword = action({
       .eq("email", args.email)
       .collect()) as Array<{ _id: string; userId: string | null }>;
     const unlinkedByEmail = byEmail.filter((e) => !e.userId);
+    if (unlinkedByEmail.length > 1) {
+      console.warn(
+        "[employees.createWithPassword] email collision — multiple unlinked employees share the same email; skipping pre-created link",
+        {
+          email: args.email,
+          organizationId: String(args.organizationId),
+          candidateIds: unlinkedByEmail.map((e) => e._id),
+        },
+      );
+    }
     const preCreated = unlinkedByEmail.length === 1 ? unlinkedByEmail[0] : undefined;
 
     let employeeId: string;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4815.

Closes #4815

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b682b92 fix(gabinet): mirror multi-candidate email collision warning in createWithPassword (closes #4815)

### Files changed

```
 convex/gabinet/employees.ts | 10 ++++++++++
 1 file changed, 10 insertions(+)
```