### PR TITLE
12/3 — Pracownicy — dodać fallback powiadomienia o urlopie dla pracownika bez lokalizacji

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -1397,15 +1397,11 @@ export const _createLeaveSideEffects = internalMutation({
           });
         }
       } else {
-        // Fallback: employee has no location assignments — notify org admins/owners.
-        const orgAdminMemberships = await ctx.db
-          .query("teamMemberships")
-          .withIndex("by_organizationId", (q) => q.eq("organizationId", args.organizationId))
-          .collect();
-
+        // Fallback: employee has no location assignments — notify active gabinet managers/admins.
         const requesterName = args.actorLabel ?? "An employee";
-        for (const membership of orgAdminMemberships) {
-          if (membership.role !== "owner" && membership.role !== "admin") continue;
+        for (const membership of orgMemberships) {
+          if (!membership.isActive) continue;
+          if (membership.gabinetRole !== "manager" && membership.gabinetRole !== "admin") continue;
           if (String(membership.userId) === args.userId) continue;
           await createNotificationDirect(ctx, {
             organizationId: args.organizationId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4822.

Closes #4822

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d46204e fix(gabinet): use gabinet manager/admin roles for leave notification fallback (closes #4822)

### Files changed

```
 convex/gabinet/scheduling.ts | 12 ++++--------
 1 file changed, 4 insertions(+), 8 deletions(-)
```