### PR TITLE
12/4 — Pracownicy — pokazać kwalifikacje także przy performsServices=false

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3196,6 +3196,7 @@
         "certifications": "Certifications / Courses",
         "certNamePlaceholder": "Certificate name",
         "noQualificationsYet": "No qualifications or skills added yet.",
+        "notPerformingServicesNotice": "The employee currently does not perform services or treatments. Qualification data is available below in read-only mode.",
         "assignedTreatments": "Assigned Treatments",
         "compensation": "Compensation",
         "baseSalary": "Base Salary",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3195,6 +3195,7 @@
         "certifications": "Certyfikaty / Kursy",
         "certNamePlaceholder": "Nazwa certyfikatu",
         "noQualificationsYet": "Brak dodanych kwalifikacji ani umiejętności.",
+        "notPerformingServicesNotice": "Pracownik aktualnie nie wykonuje usług ani zabiegów. Dane kwalifikacji są dostępne poniżej w trybie podglądu.",
         "assignedTreatments": "Przypisane zabiegi",
         "compensation": "Wynagrodzenie",
         "baseSalary": "Wynagrodzenie podstawowe",

--- a/src/components/gabinet/employees/detailed-data-tab.tsx
+++ b/src/components/gabinet/employees/detailed-data-tab.tsx
@@ -9,6 +9,7 @@ import type { TFunction } from "i18next";
 import { toast } from "sonner";
 import { formatActionError } from "@/lib/format-action-error";
 import { usePermission } from "@/hooks/use-permission";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { PersonalInfoSection } from "./sections/personal-info-section";
 import { EmploymentSection } from "./sections/employment-section";
 import { QualificationsSection } from "./sections/qualifications-section";
@@ -229,6 +230,16 @@ export function DetailedDataTab({
 
       {(!limitedView || qualificationsOnlyView) && (
         <>
+          {qualificationsOnlyView && !employee.performsServices && (
+            <Alert>
+              <AlertDescription>
+                {t(
+                  "gabinet.employees.detailedData.notPerformingServicesNotice",
+                  "Pracownik aktualnie nie wykonuje usług ani zabiegów. Dane kwalifikacji są dostępne poniżej w trybie podglądu.",
+                )}
+              </AlertDescription>
+            </Alert>
+          )}
           <QualificationsSection
             {...sharedSectionProps}
             canEdit={canEdit && !!employee.performsServices}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4823.

Closes #4823

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 2f02802 fix(gabinet): show info notice on qualifications tab when performsServices=false (closes #4823)

### Files changed

```
 public/locales/en/translation.json                     |  1 +
 public/locales/pl/translation.json                     |  1 +
 src/components/gabinet/employees/detailed-data-tab.tsx | 11 +++++++++++
 3 files changed, 13 insertions(+)
```