### PR TITLE
12/5 — Pracownicy — dodać ostrzeżenie przy wielu pre-created kandydatach w createWithPassword

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -1524,6 +1524,7 @@ export const createWithPassword = action({
       [args.firstName, args.lastName].filter(Boolean).join(" ") || undefined;
 
     const db = createSupabaseDb();
+    const log = createLogger("gabinet.employees", { correlationId: db.correlationId });
     const now = Date.now();
 
     // Check if a user with this email already exists before creating a new account.
@@ -1586,14 +1587,11 @@ export const createWithPassword = action({
       .collect()) as Array<{ _id: string; userId: string | null }>;
     const unlinkedByEmail = byEmail.filter((e) => !e.userId);
     if (unlinkedByEmail.length > 1) {
-      console.warn(
-        "[employees.createWithPassword] email collision — multiple unlinked employees share the same email; skipping pre-created link",
-        {
-          email: args.email,
-          organizationId: String(args.organizationId),
-          candidateIds: unlinkedByEmail.map((e) => e._id),
-        },
-      );
+      log.warn("email collision — multiple unlinked employees share the same email; skipping pre-created link", {
+        email: args.email,
+        organizationId: String(args.organizationId),
+        candidateIds: unlinkedByEmail.map((e) => e._id),
+      });
     }
     const preCreated = unlinkedByEmail.length === 1 ? unlinkedByEmail[0] : undefined;
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4824.

Closes #4824

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b58365c fix(gabinet): use structured logger for multi-candidate warning in createWithPassword (closes #4824)

### Files changed

```
 convex/gabinet/employees.ts | 14 ++++++--------
 1 file changed, 6 insertions(+), 8 deletions(-)
```