### PR TITLE
Duplicate "Grafiki pracy" action in employees list toolbar

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -635,11 +635,6 @@ function EmployeesIndex() {
                 },
               ]
             : []),
-          {
-            label: t("gabinet.timetable.title"),
-            icon: <Calendar className="mr-1.5 h-4 w-4" variant="stroke" />,
-            onClick: () => navigate({ to: "/dashboard/gabinet/settings/timetable" }),
-          },
         ]}
         columnDefs={allColumns.map(c => ({ id: c.id, label: c.label ?? c.id }))}
         hiddenColumnIds={hiddenColumnIds}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4830.

Closes #4830

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 50a6a81 fix(gabinet): remove duplicate "Grafiki pracy" action from employees toolbar (closes #4830)

### Files changed

```
 src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx | 5 -----
 1 file changed, 5 deletions(-)
```