### PR TITLE
Remove or expose dead `detailedData` tab in employee detail view

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -829,6 +829,7 @@ function EmployeeDetail() {
           tab =>
             tab.label === t("gabinet.employees.tabs.dataAndEmployment") ||
             tab.label === t("gabinet.employees.tabs.qualificationsAndTreatments") ||
+            tab.label === t("gabinet.employees.tabs.detailedData") ||
             tab.label === t("gabinet.employees.tabs.notes")
         );
       case "documentsAndAssets":


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4829.

Closes #4829

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 791f4c8 fix(gabinet): expose dead detailedData tab in employee detail view (closes #4829)

### Files changed

```
 .../_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx       | 1 +
 1 file changed, 1 insertion(+)
```