### PR TITLE
`onManageLeaves` link in FlexibleScheduleEditor opens global leave list without 

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -727,7 +727,7 @@ function EmployeeDetail() {
           onSavePeriod={async (a) => { await saveSchedulePeriod(a); invalidateScheduleCache(); }}
           onRemovePeriod={async (a) => { await removeSchedulePeriod(a); invalidateScheduleCache(); }}
           onSaveLegacy={async (a) => { await bulkSetEmployeeSchedule(a); invalidateScheduleCache(); }}
-          onManageLeaves={() => navigate({ to: "/dashboard/gabinet/settings/leaves" })}
+          onManageLeaves={() => navigate({ to: "/dashboard/gabinet/settings/leaves", search: { userId: employee.userId } })}
         />
       ) : (
         <p className="text-muted-foreground text-sm">{t("gabinet.employees.noUserAccount", "Pracownik nie ma powiązanego konta użytkownika.")}</p>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -814,7 +814,7 @@ function EmployeesIndex() {
                   invalidateScheduleCache();
                 }}
                 onManageLeaves={() =>
-                  navigate({ to: "/dashboard/gabinet/settings/leaves" })
+                  navigate({ to: "/dashboard/gabinet/settings/leaves", search: { userId: editingScheduleEmployee.userId } })
                 }
               />
             </div>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.leaves.tsx
@@ -76,11 +76,12 @@ export const Route = createFileRoute(
   ),
   validateSearch: (
     search: Record<string, unknown>,
-  ): { nudge?: LeavesNudgeFilter } => ({
+  ): { nudge?: LeavesNudgeFilter; userId?: string } => ({
     nudge:
       search.nudge === "pending"
         ? (search.nudge as LeavesNudgeFilter)
         : undefined,
+    userId: typeof search.userId === "string" ? search.userId : undefined,
   }),
 });
 
@@ -89,7 +90,7 @@ const LEAVE_TYPES = ["vacation", "sick", "personal", "training", "other"] as con
 function LeavesPage() {
   const { t } = useTranslation();
   const { organizationId } = useOrganization();
-  const { nudge: nudgeFilter } = useSearch({ from: Route.id });
+  const { nudge: nudgeFilter, userId: userIdFilter } = useSearch({ from: Route.id });
   const { allowed: canManageLeaves } = usePermission("gabinet_settings", "edit");
   const routeNavigate = useNavigate();
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
@@ -109,6 +110,7 @@ function LeavesPage() {
   // Fetch leaves from Supabase
   const { data: leaves } = useSupabaseGabinetLeavesList(organizationId, {
     status: statusFilter !== "all" ? statusFilter : undefined,
+    userId: userIdFilter,
   });
 
   const { data: employees } = useSupabaseGabinetEmployeesList(organizationId, { activeOnly: true });
@@ -385,6 +387,31 @@ function LeavesPage() {
                   search: { nudge: undefined },
                 });
               }}
+            >
+              <X className="h-3.5 w-3.5" variant="stroke" />
+              {t("common.clearFilters")}
+            </Button>
+          </div>
+        )}
+
+        {userIdFilter && (
+          <div className="flex items-center justify-between rounded-md border border-blue-300 bg-blue-50 px-3 py-2 text-sm text-blue-900 dark:border-blue-700 dark:bg-blue-950/40 dark:text-blue-100">
+            <span>
+              {t("gabinet.leaves.userFilter.active", {
+                name: getEmployeeName(userIdFilter),
+                defaultValue: "Filtrowanie według pracownika: {{name}}",
+              })}
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 text-xs"
+              onClick={() =>
+                routeNavigate({
+                  to: "/dashboard/gabinet/settings/leaves",
+                  search: { nudge: nudgeFilter, userId: undefined },
+                })
+              }
             >
               <X className="h-3.5 w-3.5" variant="stroke" />
               {t("common.clearFilters")}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.timetable.tsx
@@ -1102,7 +1102,7 @@ function TimetablePage() {
                   invalidateScheduleCache();
                 }}
                 onManageLeaves={() =>
-                  navigate({ to: "/dashboard/gabinet/settings/leaves" })
+                  navigate({ to: "/dashboard/gabinet/settings/leaves", search: { userId: editingEmployee.userId } })
                 }
               />
             </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4831.

Closes #4831

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 97f4a34 fix(gabinet): pre-filter leaves page by employee when opened from FlexibleScheduleEditor (closes #4831)

### Files changed

```
 .../_layout.gabinet.employees.$employeeId.tsx      |  2 +-
 .../dashboard/_layout.gabinet.employees.index.tsx  |  2 +-
 .../dashboard/_layout.gabinet.settings.leaves.tsx  | 31 ++++++++++++++++++++--
 .../_layout.gabinet.settings.timetable.tsx         |  2 +-
 4 files changed, 32 insertions(+), 5 deletions(-)
```