### PR TITLE
Fix "Stwórz wizytę" context loss in appointments tab

### DIFF
--- a/src/components/gabinet/employees/appointments-tab-content.tsx
+++ b/src/components/gabinet/employees/appointments-tab-content.tsx
@@ -19,6 +19,7 @@ export function AppointmentsTabContent({
   appointmentsView,
   setAppointmentsView,
   treatmentMap,
+  employeeUserId,
   navigate,
   t,
   i18nLanguage,
@@ -31,7 +32,8 @@ export function AppointmentsTabContent({
   appointmentsView: "calendar" | "list";
   setAppointmentsView: (v: "calendar" | "list") => void;
   treatmentMap: Map<string, string>;
-  navigate: (opts: { to: string }) => void;
+  employeeUserId?: string;
+  navigate: (opts: { to: string; search?: Record<string, unknown> }) => void;
   t: (key: string, opts?: Record<string, unknown> | string) => string;
   i18nLanguage: string;
 }) {
@@ -63,7 +65,15 @@ export function AppointmentsTabContent({
           <Button
             size="sm"
             variant="outline"
-            onClick={() => navigate({ to: "/dashboard/gabinet/calendar" })}
+            onClick={() =>
+              navigate({
+                to: "/dashboard/gabinet/calendar",
+                search: {
+                  action: "create-appointment",
+                  ...(employeeUserId ? { employeeId: employeeUserId } : {}),
+                },
+              })
+            }
           >
             <Plus className="mr-1 h-4 w-4" variant="stroke" />
             {t("gabinet.appointments.createAppointment")}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -154,6 +154,7 @@ function GabinetCalendarPage() {
   const routeNavigate = useNavigate();
   const nudgeFilter = search.nudge;
   const actionParam = search.action;
+  const initialEmployeeId = search.employeeId;
 
   // Indicate this page has wide content (hides Column 2 on 1024-1400px screens)
   useWideContent(true);
@@ -170,7 +171,7 @@ function GabinetCalendarPage() {
     }
   }, []);
   const [currentDate, setCurrentDate] = useState(new Date());
-  const [employeeFilter, setEmployeeFilter] = useState<string>("all");
+  const [employeeFilter, setEmployeeFilter] = useState<string>(initialEmployeeId ?? "all");
   const [treatmentFilter, setTreatmentFilter] = useState<string>("all");
   const [statusFilter, setStatusFilter] = useState<string>(
     nudgeFilter === "unconfirmed-today" ? "scheduled" : "all",
@@ -1054,6 +1055,9 @@ function GabinetCalendarPage() {
       setSellPackageOpen(true);
     } else if (actionParam === "create-appointment") {
       openCreateDialog();
+      if (initialEmployeeId) {
+        setCreateDefaultUserId(initialEmployeeId);
+      }
     } else {
       return;
     }
@@ -1062,7 +1066,7 @@ function GabinetCalendarPage() {
       search: { nudge: nudgeFilter, action: undefined },
       replace: true,
     });
-  }, [actionParam, nudgeFilter, routeNavigate, openCreateDialog]);
+  }, [actionParam, nudgeFilter, routeNavigate, openCreateDialog, initialEmployeeId]);
 
   // Click-to-create handler
   const handleSlotClick = useCallback(

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute(
 )({
   validateSearch: (
     search: Record<string, unknown>,
-  ): { nudge?: CalendarNudgeFilter; action?: CalendarAction } => ({
+  ): { nudge?: CalendarNudgeFilter; action?: CalendarAction; employeeId?: string } => ({
     nudge:
       search.nudge === "unconfirmed-today"
         ? (search.nudge as CalendarNudgeFilter)
@@ -17,5 +17,7 @@ export const Route = createFileRoute(
       search.action === "sell-package" || search.action === "create-appointment"
         ? (search.action as CalendarAction)
         : undefined,
+    employeeId:
+      typeof search.employeeId === "string" ? search.employeeId : undefined,
   }),
 });

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -637,6 +637,7 @@ function EmployeeDetail() {
           appointmentsView={appointmentsView}
           setAppointmentsView={setAppointmentsView}
           treatmentMap={treatmentMap}
+          employeeUserId={employee?.userId}
           navigate={navigate}
           t={t}
           i18nLanguage={i18n.language}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4836.

Closes #4836

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 155c39e fix(gabinet): pass employeeId context when navigating to calendar from appointments tab (closes #4836)

### Files changed

```
 .../gabinet/employees/appointments-tab-content.tsx         | 14 ++++++++++++--
 .../dashboard/_layout.gabinet.calendar.index.lazy.tsx      |  8 ++++++--
 .../_auth/dashboard/_layout.gabinet.calendar.index.tsx     |  4 +++-
 .../dashboard/_layout.gabinet.employees.$employeeId.tsx    |  1 +
 4 files changed, 22 insertions(+), 5 deletions(-)
```