### PR TITLE
Add "Anuluj zaproszenie" action for invitation_pending in Account tab

### DIFF
--- a/src/components/gabinet/employees/account-tab-content.tsx
+++ b/src/components/gabinet/employees/account-tab-content.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
-import { ChevronRight, Pencil, Power, Send, Settings } from "@/lib/ez-icons";
+import { ChevronRight, Pencil, Power, Send, Settings, XCircle } from "@/lib/ez-icons";
 import type { MappedGabinetEmployee } from "@/lib/supabase/mappers/gabinet/employees";
 import type { MappedInvitation } from "@/lib/supabase/mappers";
 import { ChangePasswordDialog } from "./change-password-dialog";
@@ -20,6 +20,7 @@ export function AccountTabContent({
   onUnblock,
   pendingInvitation,
   onResendInvitation,
+  onCancelInvitation,
   t,
 }: {
   employee: MappedGabinetEmployee;
@@ -32,6 +33,7 @@ export function AccountTabContent({
   onUnblock?: () => Promise<void>;
   pendingInvitation?: MappedInvitation | null;
   onResendInvitation?: () => Promise<void>;
+  onCancelInvitation?: () => Promise<void>;
   t: (key: string, opts?: Record<string, unknown> | string) => string;
 }) {
   const { allowed: canEdit } = usePermission("gabinet_employees", "edit");
@@ -205,6 +207,22 @@ export function AccountTabContent({
                       <div className="flex-1 min-w-0">
                         <p className="text-sm text-green-600">{t("gabinet.employees.activateAccount", "Aktywuj konto")}</p>
                         <p className="text-xs text-muted-foreground">{t("gabinet.employees.activateAccountDesc", "Przywróć dostęp pracownika do systemu")}</p>
+                      </div>
+                      <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                    </button>
+                  );
+                }
+                if (status === "invitation_pending" && onCancelInvitation) {
+                  return (
+                    <button
+                      type="button"
+                      className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+                      onClick={onCancelInvitation}
+                    >
+                      <XCircle className="h-4 w-4 text-destructive shrink-0" variant="stroke" />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm text-destructive">{t("gabinet.employees.cancelInvitation", "Anuluj zaproszenie")}</p>
+                        <p className="text-xs text-muted-foreground">{t("gabinet.employees.cancelInvitationDesc", "Cofnij wysłane zaproszenie do logowania")}</p>
                       </div>
                       <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
                     </button>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -109,6 +109,7 @@ function EmployeeDetail() {
   const blockEmployee = useAction(api.gabinet.employees.blockEmployee);
   const unblockEmployee = useAction(api.gabinet.employees.unblockEmployee);
   const resendInvitation = useAction(api.invitations.resend);
+  const cancelInvitation = useAction(api.invitations.cancel);
 
   // Supabase cache invalidation helpers
   const invalidateEmployeeCache = () => {
@@ -473,6 +474,23 @@ function EmployeeDetail() {
     }
   };
 
+  const handleCancelInvitation = async () => {
+    if (!pendingInvitation) return;
+    if (!window.confirm(t("gabinet.employees.confirmCancelInvitation", "Czy na pewno chcesz anulować zaproszenie?"))) return;
+    try {
+      await cancelInvitation({ organizationId, invitationId: pendingInvitation._id });
+      toast.success(t("team.invitationCancelled", "Zaproszenie anulowane."));
+      void queryClient.invalidateQueries({ queryKey: supabaseKeys.invitations.list(organizationId) });
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "team.errors.cancelFailed",
+          defaultValue: "Nie udało się anulować zaproszenia.",
+        }),
+      );
+    }
+  };
+
   const handleUpdateActivity = async (data: {
     activityId: string;
     title?: string;
@@ -787,6 +805,7 @@ function EmployeeDetail() {
           onUnblock={handleUnblock}
           pendingInvitation={pendingInvitation}
           onResendInvitation={isExpiredInvitation ? handleResendInvitation : undefined}
+          onCancelInvitation={!isExpiredInvitation && pendingInvitation ? handleCancelInvitation : undefined}
           t={t}
         />
       ),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4838.

Closes #4838

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- bec5aba fix(gabinet): add cancel invitation action for invitation_pending in Account tab (closes #4838)

### Files changed

```
 .../gabinet/employees/account-tab-content.tsx        | 20 +++++++++++++++++++-
 .../_layout.gabinet.employees.$employeeId.tsx        | 19 +++++++++++++++++++
 2 files changed, 38 insertions(+), 1 deletion(-)
```