### PR TITLE
13/6 — Pracownicy — ujednolicić ponowne wysyłanie aktywnego zaproszenia

### DIFF
--- a/src/components/gabinet/employees/account-tab-content.tsx
+++ b/src/components/gabinet/employees/account-tab-content.tsx
@@ -210,20 +210,38 @@ export function AccountTabContent({
                     </button>
                   );
                 }
-                if (status === "invitation_pending" && onCancelInvitation) {
+                if (status === "invitation_pending") {
                   return (
-                    <button
-                      type="button"
-                      className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
-                      onClick={onCancelInvitation}
-                    >
-                      <XCircle className="h-4 w-4 text-destructive shrink-0" variant="stroke" />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm text-destructive">{t("gabinet.employees.cancelInvitation", "Anuluj zaproszenie")}</p>
-                        <p className="text-xs text-muted-foreground">{t("gabinet.employees.cancelInvitationDesc", "Cofnij wysłane zaproszenie do logowania")}</p>
-                      </div>
-                      <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
-                    </button>
+                    <>
+                      {onResendInvitation && (
+                        <button
+                          type="button"
+                          className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+                          onClick={onResendInvitation}
+                        >
+                          <Send className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                          <div className="flex-1 min-w-0">
+                            <p className="text-sm">{t("gabinet.employees.resendInvitation", "Wyślij zaproszenie ponownie")}</p>
+                            <p className="text-xs text-muted-foreground">{t("gabinet.employees.resendInvitationDesc", "Ponów wysyłkę zaproszenia z nowym terminem ważności")}</p>
+                          </div>
+                          <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                        </button>
+                      )}
+                      {onCancelInvitation && (
+                        <button
+                          type="button"
+                          className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+                          onClick={onCancelInvitation}
+                        >
+                          <XCircle className="h-4 w-4 text-destructive shrink-0" variant="stroke" />
+                          <div className="flex-1 min-w-0">
+                            <p className="text-sm text-destructive">{t("gabinet.employees.cancelInvitation", "Anuluj zaproszenie")}</p>
+                            <p className="text-xs text-muted-foreground">{t("gabinet.employees.cancelInvitationDesc", "Cofnij wysłane zaproszenie do logowania")}</p>
+                          </div>
+                          <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" variant="stroke" />
+                        </button>
+                      )}
+                    </>
                   );
                 }
                 return null;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4845.

Closes #4845

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3ea67c0 fix(gabinet): show resend invitation action for invitation_pending in AccountTabContent (closes #4845)

### Files changed

```
 .../gabinet/employees/account-tab-content.tsx      | 44 +++++++++++++++-------
 1 file changed, 31 insertions(+), 13 deletions(-)
```