### PR TITLE
Add sale-price-below-purchase warning to ProductForm

### DIFF
--- a/src/components/forms/product-form.tsx
+++ b/src/components/forms/product-form.tsx
@@ -451,6 +451,19 @@ export function ProductForm({
         <p className="text-xs text-muted-foreground sm:col-span-2">
           {t("products.form.salePriceHelp", { defaultValue: "Cena brutto w złotych, po której sprzedajesz produkt. Opcjonalna." })}
         </p>
+        {(() => {
+          const parsedSale = parseFloat(salePrice.replace(",", "."));
+          const parsedPurchase = parseFloat(purchasePrice.replace(",", "."));
+          return Number.isFinite(parsedSale) && parsedSale > 0 &&
+            Number.isFinite(parsedPurchase) && parsedPurchase > 0 &&
+            parsedSale < parsedPurchase ? (
+            <p className="text-sm text-amber-600 dark:text-amber-400 sm:col-span-2">
+              {t("products.form.saleBelowPurchaseWarning", {
+                defaultValue: "Uwaga: cena sprzedaży brutto jest niższa niż cena zakupu brutto. Sprzedajesz poniżej kosztów.",
+              })}
+            </p>
+          ) : null;
+        })()}
         <div className="flex items-center gap-2 self-end">
           <Switch checked={isActive} onCheckedChange={setIsActive} />
           <Label>{t("products.form.isActive")}</Label>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4850.

Closes #4850

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 44fe501 fix(products): warn when sale price is below purchase price in ProductForm (closes #4850)

### Files changed

```
 src/components/forms/product-form.tsx | 13 +++++++++++++
 1 file changed, 13 insertions(+)
```