### PR TITLE
Fix misleading "Sprzedaj produkt" label in `quick-actions-dropdown.tsx`

### DIFF
--- a/src/components/gabinet/sell-treatment-panel.tsx
+++ b/src/components/gabinet/sell-treatment-panel.tsx
@@ -290,7 +290,7 @@ export function SellTreatmentPanel({
         onOpenChange(o);
         if (!o) reset();
       }}
-      title={t("sidebar.gabinet.sellProduct", "Sprzedaj produkt")}
+      title={t("sidebar.gabinet.sellTreatment", "Sprzedaj usługę")}
     >
       <div className="space-y-4">
         <div className="space-y-1.5">

--- a/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
+++ b/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
@@ -88,7 +88,7 @@ export function GabinetQuickActionsDropdown() {
             onSelect={() => setSellTreatmentOpen(true)}
           >
             <ShoppingCart className="text-foreground size-5 shrink-0" />
-            {t("sidebar.gabinet.sellProduct", "Sprzedaj produkt")}
+            {t("sidebar.gabinet.sellTreatment", "Sprzedaj usługę")}
           </DropdownMenuItem>
         )}
         {can("gabinet_payments") && (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4852.

Closes #4852

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 60db994 fix(gabinet): rename misleading "Sprzedaj produkt" label to "Sprzedaj usługę" (closes #4852)

### Files changed

```
 src/components/gabinet/sell-treatment-panel.tsx                   | 2 +-
 src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```