### PR TITLE
14/3 — Magazyn — dodać backend sprzedaży produktu bez wizyty

### DIFF
--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -23,6 +23,7 @@ const REASON_VALIDATOR = v.union(
   v.literal("inventory_adjustment"),
   v.literal("appointment_use"),
   v.literal("appointment_return"),
+  v.literal("direct_sale"),
   v.literal("deal_close"),
   v.literal("deal_reopen"),
   v.literal("transfer_in"),

--- a/convex/magazyn/movements.ts
+++ b/convex/magazyn/movements.ts
@@ -1,9 +1,10 @@
-// Dedicated internal actions for appointment-driven stock movements.
+// Dedicated actions for appointment-driven and standalone stock movements.
 // Consolidates FEFO lot selection + multi-movement deduction so callers
 // (e.g. gabinet/appointments.ts updateStatus) delegate the full inventory
 // write sequence rather than reimplementing it inline.
 
-import { internalAction } from "../_generated/server";
+import { action, internalAction } from "../_generated/server";
+import { internal } from "../_generated/api";
 import { v } from "convex/values";
 import { applyMovementInternal, selectFefoLotsForProduct } from "../inventory";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
@@ -128,5 +129,86 @@ export const returnStockForAppointment = internalAction({
         );
       }
     }
+  },
+});
+
+// Sell a product directly without an appointment.
+// Applies FEFO lot selection exactly like consumeForAppointment: if tracked
+// lots exist they are drained in ascending expiry order; any remainder is
+// written as an untracked movement. Returns { negativeStock: true } when the
+// deduction pushes the balance below zero — callers should surface this as a
+// warning, not a hard block (warn-and-allow, consistent with #1700 policy).
+//
+// clientId (optional) — stored as sourceId for later client-history queries.
+// paymentMethod (optional) — stored in note; accepted only when provided
+//   since the productStockMovements table has no dedicated payment column yet.
+//   No undefined-client placeholder is created: absence of clientId is valid.
+export const sellProductStandalone = action({
+  args: {
+    organizationId: v.id("organizations"),
+    productId: v.string(),
+    quantity: v.number(),
+    salePrice: v.number(),
+    locationId: v.union(v.string(), v.null()),
+    clientId: v.optional(v.string()),
+    paymentMethod: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<{ negativeStock: boolean }> => {
+    const auth = await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_inventory", action: "edit" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    if (args.quantity <= 0) throw new Error("Quantity must be positive");
+    if (args.salePrice < 0) throw new Error("Sale price must be non-negative");
+
+    const baseMovement = {
+      organizationId: String(args.organizationId),
+      productId: args.productId,
+      locationId: args.locationId,
+      reason: "direct_sale" as const,
+      sourceType: "direct_sale",
+      sourceId: args.clientId ?? null,
+      unitPrice: args.salePrice,
+      note: args.paymentMethod ?? null,
+      performedBy: String(auth.userId),
+    };
+
+    let negativeStock = false;
+
+    const lots = await selectFefoLotsForProduct(
+      args.productId,
+      String(args.organizationId),
+      args.locationId,
+    );
+
+    if (lots.length === 0) {
+      const result = await applyMovementInternal({ ...baseMovement, delta: -args.quantity });
+      if (result.warning === "negative_stock") negativeStock = true;
+    } else {
+      let remaining = args.quantity;
+      for (const lot of lots) {
+        if (remaining <= 0) break;
+        const consume = Math.min(lot.quantity, remaining);
+        const result = await applyMovementInternal({
+          ...baseMovement,
+          delta: -consume,
+          lotNumber: lot.lotNumber,
+          expiryDate: lot.expiryDate ?? undefined,
+        });
+        if (result.warning === "negative_stock") negativeStock = true;
+        remaining -= consume;
+      }
+      if (remaining > 0) {
+        const result = await applyMovementInternal({ ...baseMovement, delta: -remaining });
+        if (result.warning === "negative_stock") negativeStock = true;
+      }
+    }
+
+    return { negativeStock };
   },
 });

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -378,6 +378,7 @@ export function createCrmTables({
       v.literal("inventory_adjustment"),
       v.literal("appointment_use"),
       v.literal("appointment_return"),
+      v.literal("direct_sale"),
       v.literal("deal_close"),
       v.literal("deal_reopen"),
       v.literal("transfer_in"),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4860.

Closes #4860

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 1fb9f5b feat(inventory): add sellProductStandalone action for standalone product sales (closes #4860)

### Files changed

```
 convex/inventory.ts         |  1 +
 convex/magazyn/movements.ts | 86 +++++++++++++++++++++++++++++++++++++++++++--
 convex/schema/crm.ts        |  1 +
 3 files changed, 86 insertions(+), 2 deletions(-)
```