### PR TITLE
14/3A — Magazyn — zapisać sprzedającego i formę płatności przy sprzedaży standalone

### DIFF
--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -154,6 +154,7 @@ interface ApplyMovementParams {
   sourceType?: string | null;
   sourceId?: string | null;
   note?: string | null;
+  paymentMethod?: string | null;
   unitPrice?: number | null;
   lotNumber?: string | null;
   expiryDate?: string | null;
@@ -255,6 +256,7 @@ export async function applyMovementInternal(
     sourceType: params.sourceType ?? null,
     sourceId: params.sourceId ?? null,
     note: params.note ?? null,
+    paymentMethod: params.paymentMethod ?? null,
     unitPrice: snapshotPrice,
     ...(newAvgCost !== null ? { avgCostAfter: newAvgCost } : {}),
     ...(params.lotNumber ? { lotNumber: params.lotNumber } : {}),

--- a/convex/magazyn/movements.ts
+++ b/convex/magazyn/movements.ts
@@ -140,8 +140,7 @@ export const returnStockForAppointment = internalAction({
 // warning, not a hard block (warn-and-allow, consistent with #1700 policy).
 //
 // clientId (optional) — stored as sourceId for later client-history queries.
-// paymentMethod (optional) — stored in note; accepted only when provided
-//   since the productStockMovements table has no dedicated payment column yet.
+// paymentMethod (optional) — stored in the dedicated payment_method column.
 //   No undefined-client placeholder is created: absence of clientId is valid.
 export const sellProductStandalone = action({
   args: {
@@ -174,7 +173,7 @@ export const sellProductStandalone = action({
       sourceType: "direct_sale",
       sourceId: args.clientId ?? null,
       unitPrice: args.salePrice,
-      note: args.paymentMethod ?? null,
+      paymentMethod: args.paymentMethod ?? null,
       performedBy: String(auth.userId),
     };
 

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -388,6 +388,7 @@ export function createCrmTables({
     sourceType: v.optional(v.string()),
     sourceId: v.optional(v.string()),
     note: v.optional(v.string()),
+    paymentMethod: v.optional(v.string()),
     unitPrice: v.optional(v.number()),
     avgCostAfter: v.optional(v.number()),
     lotNumber: v.optional(v.string()),        // LOT/batch number (#2989)

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -6771,6 +6771,7 @@ export interface Database {
           source_type: string | null;
           source_id: string | null;
           note: string | null;
+          payment_method: string | null;
           performed_by: string;
           created_at: number;
           unit_price: number | null;
@@ -6789,6 +6790,7 @@ export interface Database {
           source_type?: string | null;
           source_id?: string | null;
           note?: string | null;
+          payment_method?: string | null;
           performed_by: string;
           created_at: number;
           unit_price?: number | null;
@@ -6807,6 +6809,7 @@ export interface Database {
           source_type?: string | null;
           source_id?: string | null;
           note?: string | null;
+          payment_method?: string | null;
           performed_by?: string;
           created_at?: number;
           unit_price?: number | null;

--- a/supabase/migrations/00125_product_stock_movements_payment_method.sql
+++ b/supabase/migrations/00125_product_stock_movements_payment_method.sql
@@ -1,0 +1,6 @@
+-- Add dedicated payment_method column to product_stock_movements.
+-- Previously, payment method was stored in the free-text `note` column which
+-- makes reporting on payment breakdown impossible. This column is nullable so
+-- existing movements (appointment use, warehouse receipts, etc.) remain valid.
+ALTER TABLE product_stock_movements
+  ADD COLUMN payment_method TEXT;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4862.

Closes #4862

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- adfdbfc2 feat(inventory): add payment_method column to stock movements, wire up in sellProductStandalone (closes #4862)

### Files changed

```
 convex/inventory.ts                                                 | 2 ++
 convex/magazyn/movements.ts                                         | 5 ++---
 convex/schema/crm.ts                                                | 1 +
 src/lib/supabase/database.types.ts                                  | 3 +++
 .../migrations/00125_product_stock_movements_payment_method.sql     | 6 ++++++
 5 files changed, 14 insertions(+), 3 deletions(-)
```