### PR TITLE
Address t()/TFunction type wave at the root

### DIFF
--- a/src/components/documents/appointment-document-checklist.tsx
+++ b/src/components/documents/appointment-document-checklist.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import type { TFunction } from "i18next";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { toast } from "sonner";
@@ -236,7 +237,7 @@ export function AppointmentDocumentChecklist({
             documents={beforeDocs}
             organizationId={organizationId}
             onDocumentClick={handleDocClick}
-            t={t as (key: string, fallback?: string) => string}
+            t={t}
           />
         )}
 
@@ -247,7 +248,7 @@ export function AppointmentDocumentChecklist({
             documents={duringDocs}
             organizationId={organizationId}
             onDocumentClick={handleDocClick}
-            t={t as (key: string, fallback?: string) => string}
+            t={t}
           />
         )}
 
@@ -258,7 +259,7 @@ export function AppointmentDocumentChecklist({
             documents={afterDocs}
             organizationId={organizationId}
             onDocumentClick={handleDocClick}
-            t={t as (key: string, fallback?: string) => string}
+            t={t}
           />
         )}
 
@@ -269,7 +270,7 @@ export function AppointmentDocumentChecklist({
             documents={untimed}
             organizationId={organizationId}
             onDocumentClick={handleDocClick}
-            t={t as (key: string, fallback?: string) => string}
+            t={t}
           />
         )}
 
@@ -408,7 +409,7 @@ function DocumentSection({
   documents: FormDocument[];
   organizationId: Id<"organizations">;
   onDocumentClick: (docId: string) => void;
-  t: (key: string, fallback?: string) => string;
+  t: TFunction;
 }) {
   const resendSigningEmail = useAction(api.documents.documents.resendSigningEmail);
   const [resendingDocId, setResendingDocId] = useState<string | null>(null);

--- a/src/components/documents/treatment-required-documents-field.tsx
+++ b/src/components/documents/treatment-required-documents-field.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import type { TFunction } from "i18next";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
@@ -157,7 +158,7 @@ export function TreatmentRequiredDocumentsField({
                       onTimingChange={(newTiming) =>
                         handleTimingChange(req.templateId, newTiming)
                       }
-                      t={t as (key: string, fallback?: string) => string}
+                      t={t}
                     />
                     <Button
                       type="button"
@@ -350,7 +351,7 @@ const TIMING_STYLES: Record<RequiredFormTemplateTiming, string> = {
 
 function timingLabel(
   timing: RequiredFormTemplateTiming,
-  t: (key: string, fallback?: string) => string,
+  t: TFunction,
 ): string {
   switch (timing) {
     case "before_start":
@@ -369,7 +370,7 @@ function TimingBadge({
 }: {
   timing: RequiredFormTemplateTiming;
   onTimingChange: (newTiming: RequiredFormTemplateTiming) => void;
-  t: (key: string, fallback?: string) => string;
+  t: TFunction;
 }) {
   const nextTiming = (current: RequiredFormTemplateTiming) => {
     const idx = TIMING_ORDER.indexOf(current);

--- a/src/components/documents/treatment-required-documents.tsx
+++ b/src/components/documents/treatment-required-documents.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from "react";
+import type { TFunction } from "i18next";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
@@ -278,7 +279,7 @@ export function TreatmentRequiredDocuments({
                         onTimingChange={(newTiming) =>
                           handleTimingChange(req.templateId, newTiming)
                         }
-                        t={t as (key: string, fallback?: string) => string}
+                        t={t}
                       />
                       <button
                         type="button"
@@ -522,7 +523,7 @@ const TIMING_STYLES: Record<RequiredFormTemplateTiming, string> = {
 
 function timingLabel(
   timing: RequiredFormTemplateTiming,
-  t: (key: string, fallback?: string) => string,
+  t: TFunction,
 ): string {
   switch (timing) {
     case "before_start":
@@ -541,7 +542,7 @@ function TimingBadge({
 }: {
   timing: RequiredFormTemplateTiming;
   onTimingChange: (newTiming: RequiredFormTemplateTiming) => void;
-  t: (key: string, fallback?: string) => string;
+  t: TFunction;
 }) {
   const nextTiming = (current: RequiredFormTemplateTiming) => {
     const idx = TIMING_ORDER.indexOf(current);

--- a/src/components/gabinet/documentation-tab.tsx
+++ b/src/components/gabinet/documentation-tab.tsx
@@ -5,6 +5,7 @@ import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import type { Id } from "@cvx/_generated/dataModel";
 import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
 import {
   Card,
   CardContent,
@@ -618,7 +619,7 @@ export function DocumentationTab({
         onRemove={handleRemovePhoto}
         uploadFile={uploadFile}
         uploadingFiles={uploadingFiles}
-        t={t as (key: string, opts?: Record<string, unknown> | string) => string}
+        t={t}
       />
 
     </div>
@@ -644,7 +645,7 @@ function PhotosSection({
   onRemove: (storageId: Id<"_storage">) => void;
   uploadFile: (file: File, type: "before" | "after") => void;
   uploadingFiles: UploadingFile[];
-  t: (key: string, opts?: Record<string, unknown> | string) => string;
+  t: TFunction;
 }) {
   const orderedPhotos = useMemo(
     () => [...beforePhotos, ...afterPhotos],
@@ -744,7 +745,7 @@ function PhotoColumn({
   onPreview: (globalIndex: number) => void;
   uploadFile: (file: File, type: "before" | "after") => void;
   uploadingFiles: UploadingFile[];
-  t: (key: string, opts?: Record<string, unknown> | string) => string;
+  t: TFunction;
 }) {
   const [isDragging, setIsDragging] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -949,7 +950,7 @@ function PhotoPreviewDialog({
   compareMode: boolean;
   onToggleCompare: (next: boolean) => void;
   onClose: () => void;
-  t: (key: string, opts?: Record<string, unknown> | string) => string;
+  t: TFunction;
 }) {
   const open = index !== null;
   const photo = index !== null ? photos[index] : undefined;
@@ -1153,7 +1154,7 @@ function ComparePane({
   label: string;
   url: string | null | undefined;
   photo: Photo | undefined;
-  t: (key: string, opts?: Record<string, unknown> | string) => string;
+  t: TFunction;
 }) {
   return (
     <div className="flex flex-col gap-2">

--- a/src/i18next.d.ts
+++ b/src/i18next.d.ts
@@ -1,0 +1,8 @@
+import "i18next";
+
+declare module "i18next" {
+  interface CustomTypeOptions {
+    returnNull: false;
+    returnObjects: false;
+  }
+}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4868.

Closes #4868

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3ed9ebe6 fix(types): add i18next.d.ts augmentation and replace t() casts with TFunction (closes #4868)

### Files changed

```
 src/components/documents/appointment-document-checklist.tsx   | 11 ++++++-----
 .../documents/treatment-required-documents-field.tsx          |  7 ++++---
 src/components/documents/treatment-required-documents.tsx     |  7 ++++---
 src/components/gabinet/documentation-tab.tsx                  | 11 ++++++-----
 src/i18next.d.ts                                              |  8 ++++++++
 5 files changed, 28 insertions(+), 16 deletions(-)
```