### PR TITLE
Fix logAudit signature to accept unknown context

### DIFF
--- a/convex/auditLog.ts
+++ b/convex/auditLog.ts
@@ -1,9 +1,8 @@
-import { MutationCtx } from "./_generated/server";
 import { Id } from "./_generated/dataModel";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 
 export async function logAudit(
-  _ctx: MutationCtx,
+  _ctx: unknown,
   data: {
     organizationId: Id<"organizations">;
     userId: Id<"users">;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4866.

Closes #4866

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 223a0df9 fix(audit): change logAudit _ctx type from MutationCtx to unknown (closes #4866)

### Files changed

```
 convex/auditLog.ts | 3 +--
 1 file changed, 1 insertion(+), 2 deletions(-)
```