### PR TITLE
fix(audit): move logAudit calls from action handlers to internalMutation side effects (closes #4867)

### DIFF
--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -1147,13 +1147,10 @@ export const blockEmployee = action({
       });
     }
 
-    await logAudit(ctx, {
+    await ctx.runMutation(internal.gabinet.employees._blockSideEffects, {
       organizationId: args.organizationId,
       userId: authResult.userId as Id<"users">,
-      action: "employee_blocked",
-      entityType: "gabinetEmployee",
-      entityId: args.employeeId,
-      details: `Blocked employee account`,
+      employeeId: args.employeeId,
     });
   },
 });
@@ -1196,9 +1193,42 @@ export const unblockEmployee = action({
       });
     }
 
-    await logAudit(ctx, {
+    await ctx.runMutation(internal.gabinet.employees._unblockSideEffects, {
       organizationId: args.organizationId,
       userId: authResult.userId as Id<"users">,
+      employeeId: args.employeeId,
+    });
+  },
+});
+
+export const _blockSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    userId: v.id("users"),
+    employeeId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: args.userId,
+      action: "employee_blocked",
+      entityType: "gabinetEmployee",
+      entityId: args.employeeId,
+      details: `Blocked employee account`,
+    });
+  },
+});
+
+export const _unblockSideEffects = internalMutation({
+  args: {
+    organizationId: v.id("organizations"),
+    userId: v.id("users"),
+    employeeId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await logAudit(ctx, {
+      organizationId: args.organizationId,
+      userId: args.userId,
       action: "employee_unblocked",
       entityType: "gabinetEmployee",
       entityId: args.employeeId,


### PR DESCRIPTION
## Summary

Audit of all `logAudit` call sites confirmed that two violations existed in `convex/gabinet/employees.ts`:

- `blockEmployee` action called `logAudit(ctx, ...)` directly inside an `action` handler
- `unblockEmployee` action called `logAudit(ctx, ...)` directly inside an `action` handler

Every other `logAudit` call in the codebase is correctly placed inside a `mutation` or `internalMutation` handler. These two were the only exceptions.

## Fix

Added `_blockSideEffects` and `_unblockSideEffects` `internalMutation` handlers following the same pattern as the existing `_removeSideEffects` mutation in the same file. The `blockEmployee` and `unblockEmployee` actions now delegate audit logging via `ctx.runMutation(...)`.

## Test plan

- [ ] Verify `blockEmployee` action still writes audit log entry with action `employee_blocked`
- [ ] Verify `unblockEmployee` action still writes audit log entry with action `employee_unblocked`
- [ ] Grep confirms no remaining `logAudit` calls inside `action` or `internalAction` handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)