### PR TITLE
14/3E — i18n — naprawić typowanie t() wyłącznie w src/components/dashboard/

### DIFF
--- a/src/components/dashboard/kpi-cards.tsx
+++ b/src/components/dashboard/kpi-cards.tsx
@@ -29,12 +29,14 @@ export function KpiCards({
         value: totalContacts.toLocaleString(),
         icon: Users,
         href: "/dashboard/contacts" as const,
+        subtitle: undefined as string | undefined,
       },
       {
         title: t("dashboard.companies"),
         value: totalCompanies.toLocaleString(),
         icon: Building2,
         href: "/dashboard/companies" as const,
+        subtitle: undefined as string | undefined,
       },
       {
         title: t("dashboard.openDeals"),
@@ -48,6 +50,7 @@ export function KpiCards({
         value: formatCurrencyPLN(pipelineValue, "PLN", { fractionDigits: 0 }),
         icon: DollarSign,
         href: "/dashboard/pipelines" as const,
+        subtitle: undefined as string | undefined,
       },
     ],
     [t, totalContacts, totalCompanies, openDeals, pipelineValue, winRate]


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4878.

Closes #4878

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0a4a0d03 fix(i18n): resolve TFunction union narrowing error in dashboard kpi-cards (closes #4878)

### Files changed

```
 src/components/dashboard/kpi-cards.tsx | 3 +++
 1 file changed, 3 insertions(+)
```