### PR TITLE
14/3H — i18n — naprawić 2 błędy t() w app-footer.tsx

### DIFF
--- a/src/components/layout/app-footer.tsx
+++ b/src/components/layout/app-footer.tsx
@@ -158,7 +158,7 @@ export function AppFooter() {
 
         <div className="flex items-center gap-2 max-sm:min-w-0 max-sm:flex-1 max-sm:flex-nowrap max-sm:justify-end sm:flex-wrap">
           {actions.map((action) => {
-            const label = t(action.labelKey);
+            const label = t(action.labelKey) as string;
             return (
               <Button
                 key={action.labelKey}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4884.

Closes #4884

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 5b644840 fix(i18n): cast t() return to string in app-footer aria-label and children (closes #4884)

### Files changed

```
 src/components/layout/app-footer.tsx | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```