### PR TITLE
17. Usuń nieużywany import useState w patient-overview-tab.tsx

### DIFF
--- a/src/components/gabinet/patients/patient-overview-tab.tsx
+++ b/src/components/gabinet/patients/patient-overview-tab.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Calendar, Heart, Star, ChevronDown } from "@/lib/ez-icons";
 import type { TFunction } from "i18next";


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4891.

Closes #4891

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3fa7c55b fix(ts): remove unused useState import in patient-overview-tab (closes #4891)

### Files changed

```
 src/components/gabinet/patients/patient-overview-tab.tsx | 1 -
 1 file changed, 1 deletion(-)
```