### PR TITLE
Fix `app-sidebar.tsx` test failure on `api.gabinet.overtime.listOvertime`

### DIFF
--- a/src/components/layout/app-sidebar.test.tsx
+++ b/src/components/layout/app-sidebar.test.tsx
@@ -20,9 +20,12 @@ vi.mock("@convex-dev/react-query", () => ({
 
 vi.mock("@cvx/_generated/api", () => ({
   api: {
-    app: { getCurrentUser: {} },
+    app: { getCurrentUser: {}, getIsPlatformAdmin: {} },
     productSubscriptions: { getActiveProducts: {} },
-    gabinet: { scheduling: { listLeaves: {} } },
+    gabinet: {
+      scheduling: { listLeaves: {} },
+      overtime: { listOvertime: {} },
+    },
   },
 }));
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4896.

Closes #4896

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 759c564e fix(test): add missing overtime mock in app-sidebar test (closes #4896)

### Files changed

```
 src/components/layout/app-sidebar.test.tsx | 7 +++++--
 1 file changed, 5 insertions(+), 2 deletions(-)
```