### PR TITLE
Fix ESLint `no-undef` for `process` global

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,7 +29,8 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
   {
     languageOptions: {
-      globals: { ...browserGlobals },
+      // process is included because Vite statically replaces process.env.NODE_ENV at build time
+      globals: { ...browserGlobals, process: "readonly" },
     },
     plugins: {
       "react-refresh": reactRefresh,
@@ -73,6 +74,19 @@ export default tseslint.config(
   // Convex backend files need Node.js globals
   {
     files: ["convex/**/*.ts"],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  },
+  // Non-Convex Node.js scripts and config files need Node.js globals
+  {
+    files: [
+      "automation/**/*.{mjs,js,cjs}",
+      "vite.config.ts",
+      "vitest.config.ts",
+      "vitest.frontend.config.ts",
+      "playwright.config.ts",
+    ],
     languageOptions: {
       globals: { ...globals.node },
     },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4898.

Closes #4898

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 00b4ac0a fix(eslint): declare process global for no-undef rule (closes #4898)

### Files changed

```
 eslint.config.js | 16 +++++++++++++++-
 1 file changed, 15 insertions(+), 1 deletion(-)
```