### PR TITLE
Whitelist legitimate public Convex functions in `check

### DIFF
--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -56,8 +56,12 @@ export const markAsRead = action({
 export const _markAsReadInternal = internalMutation({
   args: { notificationId: v.id("notifications") },
   handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
     const notification = await ctx.db.get(args.notificationId);
     if (!notification) return;
+    if (notification.userId !== user._id) {
+      throw new Error("Not authorized");
+    }
     await ctx.db.patch(args.notificationId, { isRead: true });
   },
 });

--- a/scripts/check-convex-auth.mjs
+++ b/scripts/check-convex-auth.mjs
@@ -146,6 +146,25 @@ const WHITELIST = new Set([
   //   types. No org data; hard-coded list used by the template builder UI.
   "documentDataSources:listAvailableSources",
 
+  // ── Application health & public marketing endpoints ──────────────────────
+  // getPublicStatus: returns { ts: Date.now() } proving Convex is alive.
+  //   Used by the /status page to verify backend health. No user or org data.
+  "app:getPublicStatus",
+
+  // getPublicPricingPlans: returns PLN monthly/yearly prices for CRM Pro and
+  //   Gabinet Pro plans so the public pricing page can display live prices.
+  //   Only exposes price amounts (numbers). Returns null when plans are not
+  //   seeded (Stripe not configured). No user or org data exposed.
+  "app:getPublicPricingPlans",
+
+  // ── Signing link stub resolution ──────────────────────────────────────────
+  // resolveStub: browser receives an opaque stubId via SMS URL and calls this
+  //   to exchange it for the real signing token. The stubId IS the auth — it
+  //   is single-use, time-limited (≤48 h), and burned on first use by
+  //   _consumeStub. This is the same token-as-auth pattern as
+  //   signatureRequests:getByToken.
+  "signingStubs:resolveStub",
+
   // ── Dev / seed utilities ──────────────────────────────────────────────────
   // These are only deployed in non-production environments (dev namespace).
   // They never run in production; no RLS required.


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4899.

Closes #4899

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8a52c198 fix(convex-auth): whitelist public endpoints and add auth guard to markAsRead (closes #4899)

### Files changed

```
 convex/notifications.ts       |  4 ++++
 scripts/check-convex-auth.mjs | 19 +++++++++++++++++++
 2 files changed, 23 insertions(+)
```