### PR TITLE
Migrate 29 legacy `ctx.db` reads in CRM module to Supabase

### DIFF
--- a/convex/crm/calls.ts
+++ b/convex/crm/calls.ts
@@ -1,4 +1,4 @@
-import { action, internalMutation, internalQuery } from "../_generated/server";
+import { action, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
@@ -46,18 +46,6 @@ export const list = action({
   },
 });
 
-export const _getRelationshipsBySource = internalQuery({
-  args: { callId: v.string() },
-  handler: async (ctx, args) => {
-    return await ctx.db
-      .query("objectRelationships")
-      .withIndex("by_source", (q) =>
-        q.eq("sourceType", "call").eq("sourceId", args.callId)
-      )
-      .collect();
-  },
-});
-
 export const getById = action({
   args: {
     organizationId: v.id("organizations"),
@@ -86,10 +74,11 @@ export const getById = action({
       throw new Error("Permission denied");
     }
 
-    const relationships = await ctx.runQuery(
-      internal.crm.calls._getRelationshipsBySource,
-      { callId: args.callId },
-    );
+    const relationships = await db
+      .query("objectRelationships")
+      .eq("sourceType", "call")
+      .eq("sourceId", args.callId)
+      .collect();
 
     return { ...call, relationships };
   },
@@ -262,10 +251,15 @@ export const remove = action({
       throw new Error("Permission denied: you can only delete your own records");
     }
 
-    // Clean up relationships via internalMutation (needs ctx.db)
-    await ctx.runMutation(internal.crm.calls._removeRelationships, {
-      callId: args.callId,
-    });
+    // Clean up relationships from Supabase before deleting the call
+    const sourceRels = await db
+      .query("objectRelationships")
+      .eq("sourceType", "call")
+      .eq("sourceId", args.callId)
+      .collect();
+    for (const rel of sourceRels) {
+      await db.delete("objectRelationships", String(rel._id));
+    }
 
     // Delete from Supabase
     await db.delete("calls", args.callId);
@@ -282,21 +276,6 @@ export const remove = action({
     }
 
     return args.callId;
-  },
-});
-
-export const _removeRelationships = internalMutation({
-  args: { callId: v.string() },
-  handler: async (ctx, args) => {
-    const sourceRels = await ctx.db
-      .query("objectRelationships")
-      .withIndex("by_source", (q) =>
-        q.eq("sourceType", "call").eq("sourceId", args.callId)
-      )
-      .collect();
-    for (const rel of sourceRels) {
-      await ctx.db.delete(rel._id);
-    }
   },
 });
 

--- a/convex/crm/emails.ts
+++ b/convex/crm/emails.ts
@@ -1,97 +1,14 @@
-import { query, action, internalMutation } from "../_generated/server";
+import { action, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
-import { paginationOptsValidator } from "convex/server";
-import { verifyOrgAccess } from "../_helpers/auth";
 import { publishActivityEnvelope } from "../_helpers/activityEnvelope";
-import { emailDirectionValidator } from "@cvx/schema";
 import { sendEmail } from "@cvx/email";
 import { Id } from "../_generated/dataModel";
 import type { EmailRow } from "../_helpers/supabaseRows";
 
 // Dual-write refs removed — Supabase is now primary for email writes
-
-export const listInbox = query({
-  args: {
-    organizationId: v.id("organizations"),
-    paginationOpts: paginationOptsValidator,
-    direction: v.optional(emailDirectionValidator),
-    isRead: v.optional(v.boolean()),
-    mailProviderId: v.optional(v.id("mailProviders")),
-  },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-
-    const baseQuery = args.mailProviderId
-      ? ctx.db
-          .query("emails")
-          .withIndex("by_org_provider", (q) =>
-            q
-              .eq("organizationId", args.organizationId)
-              .eq("mailProviderId", args.mailProviderId)
-          )
-          .order("desc")
-      : ctx.db
-          .query("emails")
-          .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-          .order("desc");
-
-    if (args.direction || args.isRead !== undefined) {
-      const all = await baseQuery.collect();
-      const filtered = all.filter((e) => {
-        if (args.direction && e.direction !== args.direction) return false;
-        if (args.isRead !== undefined && e.isRead !== args.isRead) return false;
-        return true;
-      });
-      const numItems = args.paginationOpts.numItems;
-      const page = filtered.slice(0, numItems);
-      return {
-        page,
-        isDone: filtered.length <= numItems,
-        continueCursor: "",
-      };
-    }
-
-    return await baseQuery.paginate(args.paginationOpts);
-  },
-});
-
-export const getThread = query({
-  args: {
-    organizationId: v.id("organizations"),
-    threadId: v.string(),
-  },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-
-    const emails = await ctx.db
-      .query("emails")
-      .withIndex("by_thread", (q) =>
-        q.eq("organizationId", args.organizationId).eq("threadId", args.threadId)
-      )
-      .collect();
-
-    return emails.sort((a, b) => a.sentAt - b.sentAt);
-  },
-});
-
-export const getById = query({
-  args: {
-    organizationId: v.id("organizations"),
-    emailId: v.id("emails"),
-  },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-
-    const email = await ctx.db.get(args.emailId);
-    if (!email || email.organizationId !== args.organizationId) {
-      throw new Error("Email not found");
-    }
-
-    return email;
-  },
-});
+// listInbox, getThread, getById, getUnreadCount removed — frontend reads from Supabase via use-supabase-emails.ts
 
 export const listByEntity = action({
   args: {
@@ -128,22 +45,6 @@ export const listByEntity = action({
     }
 
     return emails.sort((a, b) => (b.sentAt ?? 0) - (a.sentAt ?? 0));
-  },
-});
-
-export const getUnreadCount = query({
-  args: {
-    organizationId: v.id("organizations"),
-  },
-  handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-
-    const emails = await ctx.db
-      .query("emails")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
-      .collect();
-
-    return emails.filter((e) => e.isRead === false).length;
   },
 });
 

--- a/convex/crm/emails_internal.ts
+++ b/convex/crm/emails_internal.ts
@@ -1,12 +1,9 @@
-import { internalQuery, internalMutation, internalAction } from "../_generated/server";
+import { internalMutation, internalAction } from "../_generated/server";
 import { v } from "convex/values";
 import { publishActivityEnvelope } from "../_helpers/activityEnvelope";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import type { SupabaseRow } from "../_helpers/supabaseRows";
-
-// @ts-ignore — TS2589: deep type instantiation in Convex codegen (known, non-deterministic)
-const writeEmailRef = internal.supabase.emails.writeEmailToSupabase;
 
 type EmailAccountRow = SupabaseRow<"emailAccounts">;
 
@@ -36,32 +33,33 @@ export const findEmailAccountByAddress = internalAction({
   },
 });
 
-export const findByMessageId = internalQuery({
+export const findByMessageId = internalAction({
   args: { messageId: v.string() },
-  handler: async (ctx, args) => {
-    return await ctx.db
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
+    return await db
       .query("emails")
-      .withIndex("by_messageId", (q) => q.eq("messageId", args.messageId))
-      .unique();
-  },
-});
-
-export const findContactByEmail = internalQuery({
-  args: {
-    organizationId: v.id("organizations"),
-    email: v.string(),
-  },
-  handler: async (ctx, args) => {
-    return await ctx.db
-      .query("contacts")
-      .withIndex("by_orgAndEmail", (q) =>
-        q.eq("organizationId", args.organizationId).eq("email", args.email)
-      )
+      .eq("messageId", args.messageId)
       .first();
   },
 });
 
-export const insertOutboundGmail = internalMutation({
+export const findContactByEmail = internalAction({
+  args: {
+    organizationId: v.id("organizations"),
+    email: v.string(),
+  },
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
+    return await db
+      .query("contacts")
+      .eq("organizationId", String(args.organizationId))
+      .eq("email", args.email)
+      .first();
+  },
+});
+
+export const insertOutboundGmail = internalAction({
   args: {
     organizationId: v.id("organizations"),
     to: v.array(v.string()),
@@ -80,7 +78,8 @@ export const insertOutboundGmail = internalMutation({
     leadId: v.optional(v.id("leads")),
     sentBy: v.id("users"),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
     const now = Date.now();
     const messageId = `<${args.gmailMessageId}@gmail>`;
     const threadId = args.threadId ?? messageId;
@@ -92,59 +91,29 @@ export const insertOutboundGmail = internalMutation({
       snippet = args.bodyHtml.replace(/<[^>]*>/g, "").slice(0, 200);
     }
 
-    const emailId = await ctx.db.insert("emails", {
-      organizationId: args.organizationId,
+    await db.insert("emails", {
+      organizationId: String(args.organizationId),
       threadId,
       messageId,
-      inReplyTo: args.inReplyTo,
+      inReplyTo: args.inReplyTo ?? null,
       direction: "outbound",
       from: args.fromEmail,
       to: args.to,
-      cc: args.cc,
-      bcc: args.bcc,
+      cc: args.cc ?? null,
+      bcc: args.bcc ?? null,
       subject: args.subject,
-      bodyHtml: args.bodyHtml,
-      bodyText: args.bodyText,
-      snippet,
+      bodyHtml: args.bodyHtml ?? null,
+      bodyText: args.bodyText ?? null,
+      snippet: snippet ?? null,
       isRead: true,
       isStarred: false,
       provider: "google",
       gmailMessageId: args.gmailMessageId,
-      gmailThreadId: args.gmailThreadId,
-      contactId: args.contactId,
-      companyId: args.companyId,
-      leadId: args.leadId,
-      sentBy: args.sentBy,
-      sentAt: now,
-      createdAt: now,
-      updatedAt: now,
-    });
-
-    // Dual-write: replicate new email to Supabase
-    await ctx.scheduler.runAfter(0, writeEmailRef, {
-      emailId: emailId as string,
-      organizationId: args.organizationId as string,
-      threadId,
-      messageId,
-      inReplyTo: args.inReplyTo,
-      direction: "outbound",
-      from: args.fromEmail,
-      to: args.to,
-      cc: args.cc,
-      bcc: args.bcc,
-      subject: args.subject,
-      bodyHtml: args.bodyHtml,
-      bodyText: args.bodyText,
-      snippet,
-      isRead: true,
-      isStarred: false,
-      provider: "google",
-      gmailMessageId: args.gmailMessageId,
-      gmailThreadId: args.gmailThreadId,
-      contactId: args.contactId as string | undefined,
-      companyId: args.companyId as string | undefined,
-      leadId: args.leadId as string | undefined,
-      sentBy: args.sentBy as string,
+      gmailThreadId: args.gmailThreadId ?? null,
+      contactId: args.contactId ? String(args.contactId) : null,
+      companyId: args.companyId ? String(args.companyId) : null,
+      leadId: args.leadId ? String(args.leadId) : null,
+      sentBy: String(args.sentBy),
       sentAt: now,
       createdAt: now,
       updatedAt: now,
@@ -152,7 +121,7 @@ export const insertOutboundGmail = internalMutation({
   },
 });
 
-export const insertInboundGmail = internalMutation({
+export const insertInboundGmail = internalAction({
   args: {
     organizationId: v.id("organizations"),
     gmailMessageId: v.string(),
@@ -163,102 +132,62 @@ export const insertInboundGmail = internalMutation({
     snippet: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
+    const db = createSupabaseDb();
+
     // Check for duplicates by gmailMessageId
-    const existing = await ctx.db
+    const existing = await db
       .query("emails")
-      .withIndex("by_gmailMessageId", (q) =>
-        q.eq("gmailMessageId", args.gmailMessageId)
-      )
+      .eq("gmailMessageId", args.gmailMessageId)
       .first();
     if (existing) return; // Already synced
 
     const now = Date.now();
     const messageId = `<${args.gmailMessageId}@gmail>`;
 
-    const organization = await ctx.db.get(args.organizationId);
+    const organization = await db.get("organizations", String(args.organizationId));
 
     // Auto-link to contact by from email
-    const contact = await ctx.db
+    const contact = await db
       .query("contacts")
-      .withIndex("by_orgAndEmail", (q) =>
-        q.eq("organizationId", args.organizationId).eq("email", args.from)
-      )
+      .eq("organizationId", String(args.organizationId))
+      .eq("email", args.from)
       .first();
 
-    const emailId = await ctx.db.insert("emails", {
-      organizationId: args.organizationId,
+    const emailId = await db.insert("emails", {
+      organizationId: String(args.organizationId),
       threadId: args.gmailThreadId,
       messageId,
       direction: "inbound",
       from: args.from,
       to: args.to,
       subject: args.subject,
-      snippet: args.snippet,
+      snippet: args.snippet ?? null,
       isRead: false,
       isStarred: false,
       provider: "google",
       gmailMessageId: args.gmailMessageId,
       gmailThreadId: args.gmailThreadId,
-      contactId: contact?._id,
-      sentAt: now,
-      createdAt: now,
-      updatedAt: now,
-    });
-
-    // Dual-write: replicate new email to Supabase
-    await ctx.scheduler.runAfter(0, writeEmailRef, {
-      emailId: emailId as string,
-      organizationId: args.organizationId as string,
-      threadId: args.gmailThreadId,
-      messageId,
-      direction: "inbound",
-      from: args.from,
-      to: args.to,
-      subject: args.subject,
-      snippet: args.snippet,
-      isRead: false,
-      isStarred: false,
-      provider: "google",
-      gmailMessageId: args.gmailMessageId,
-      gmailThreadId: args.gmailThreadId,
-      contactId: contact?._id as string | undefined,
+      contactId: contact?._id ? String(contact._id) : null,
       sentAt: now,
       createdAt: now,
       updatedAt: now,
     });
 
     if (organization) {
-      await publishActivityEnvelope(ctx, {
+      await ctx.runMutation(internal.crm.emails_internal._publishInboundActivity, {
+        emailId,
         organizationId: args.organizationId,
-        action: "email_received",
-        performedBy: organization.ownerId,
-        module: "crm",
-        summary: `Received email "${args.subject}" from ${args.from}`,
-        occurredAt: now,
-        actor: {
-          type: "external",
-          label: args.from,
-        },
-        payload: {
-          emailId,
-          direction: "inbound",
-          from: args.from,
-          to: args.to,
-          subject: args.subject,
-        },
-        eventKey: `crm:email:${emailId}:email_received`,
-        targets: [
-          {
-            entityType: "email",
-            entityId: emailId,
-          },
-        ],
+        performedBy: String(organization.ownerId),
+        subject: args.subject,
+        from: args.from,
+        to: args.to,
+        now,
       });
     }
   },
 });
 
-export const insertInbound = internalMutation({
+export const insertInbound = internalAction({
   args: {
     organizationId: v.id("organizations"),
     threadId: v.string(),
@@ -270,81 +199,84 @@ export const insertInbound = internalMutation({
     bodyHtml: v.optional(v.string()),
     bodyText: v.optional(v.string()),
     snippet: v.optional(v.string()),
-    contactId: v.optional(v.id("contacts")),
+    contactId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
+    const db = createSupabaseDb();
     const now = Date.now();
-    const organization = await ctx.db.get(args.organizationId);
 
-    const emailId = await ctx.db.insert("emails", {
-      organizationId: args.organizationId,
+    const organization = await db.get("organizations", String(args.organizationId));
+
+    const emailId = await db.insert("emails", {
+      organizationId: String(args.organizationId),
       threadId: args.threadId,
       messageId: args.messageId,
-      inReplyTo: args.inReplyTo,
+      inReplyTo: args.inReplyTo ?? null,
       direction: "inbound",
       from: args.from,
       to: args.to,
       subject: args.subject,
-      bodyHtml: args.bodyHtml,
-      bodyText: args.bodyText,
-      snippet: args.snippet,
+      bodyHtml: args.bodyHtml ?? null,
+      bodyText: args.bodyText ?? null,
+      snippet: args.snippet ?? null,
       isRead: false,
       isStarred: false,
-      contactId: args.contactId,
-      sentAt: now,
-      createdAt: now,
-      updatedAt: now,
-    });
-
-    // Dual-write: replicate new email to Supabase
-    await ctx.scheduler.runAfter(0, writeEmailRef, {
-      emailId: emailId as string,
-      organizationId: args.organizationId as string,
-      threadId: args.threadId,
-      messageId: args.messageId,
-      inReplyTo: args.inReplyTo,
-      direction: "inbound",
-      from: args.from,
-      to: args.to,
-      subject: args.subject,
-      bodyHtml: args.bodyHtml,
-      bodyText: args.bodyText,
-      snippet: args.snippet,
-      isRead: false,
-      isStarred: false,
-      contactId: args.contactId as string | undefined,
+      contactId: args.contactId ?? null,
       sentAt: now,
       createdAt: now,
       updatedAt: now,
     });
 
     if (organization) {
-      await publishActivityEnvelope(ctx, {
+      await ctx.runMutation(internal.crm.emails_internal._publishInboundActivity, {
+        emailId,
         organizationId: args.organizationId,
-        action: "email_received",
-        performedBy: organization.ownerId,
-        module: "crm",
-        summary: `Received email "${args.subject}" from ${args.from}`,
-        occurredAt: now,
-        actor: {
-          type: "external",
-          label: args.from,
-        },
-        payload: {
-          emailId,
-          direction: "inbound",
-          from: args.from,
-          to: args.to,
-          subject: args.subject,
-        },
-        eventKey: `crm:email:${emailId}:email_received`,
-        targets: [
-          {
-            entityType: "email",
-            entityId: emailId,
-          },
-        ],
+        performedBy: String(organization.ownerId),
+        subject: args.subject,
+        from: args.from,
+        to: args.to,
+        now,
       });
     }
+  },
+});
+
+export const _publishInboundActivity = internalMutation({
+  args: {
+    emailId: v.string(),
+    organizationId: v.id("organizations"),
+    performedBy: v.string(),
+    subject: v.string(),
+    from: v.string(),
+    to: v.array(v.string()),
+    now: v.number(),
+  },
+  handler: async (ctx, args) => {
+    await publishActivityEnvelope(ctx, {
+      organizationId: args.organizationId,
+      action: "email_received",
+      performedBy: args.performedBy as any,
+      module: "crm",
+      summary: `Received email "${args.subject}" from ${args.from}`,
+      occurredAt: args.now,
+      actor: {
+        type: "external",
+        label: args.from,
+      },
+      payload: {
+        emailId: args.emailId,
+        direction: "inbound",
+        from: args.from,
+        to: args.to,
+        subject: args.subject,
+      },
+      eventKey: `crm:email:${args.emailId}:email_received`,
+      targets: [
+        {
+          entityType: "email",
+          entityId: args.emailId,
+        },
+      ],
+    });
   },
 });

--- a/convex/google/gmail.ts
+++ b/convex/google/gmail.ts
@@ -68,7 +68,7 @@ export const sendViaGmail = action({
     const result = await response.json();
 
     // Store email record
-    await ctx.runMutation(internal.crm.emails_internal.insertOutboundGmail, {
+    await ctx.runAction(internal.crm.emails_internal.insertOutboundGmail, {
       organizationId: args.organizationId,
       to: args.to,
       cc: args.cc,
@@ -154,7 +154,7 @@ export const syncInbox = action({
         })
         .filter(Boolean);
 
-      await ctx.runMutation(internal.crm.emails_internal.insertInboundGmail, {
+      await ctx.runAction(internal.crm.emails_internal.insertInboundGmail, {
         organizationId: args.organizationId,
         gmailMessageId: msg.id,
         gmailThreadId: msg.threadId,

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -581,17 +581,17 @@ http.route({
       const inReplyTo = headers?.["In-Reply-To"] ?? headers?.["in-reply-to"];
       let threadId: string | undefined;
       if (inReplyTo) {
-        const existingEmail = await ctx.runQuery(
+        const existingEmail = await ctx.runAction(
           internal.crm.emails_internal.findByMessageId,
           { messageId: inReplyTo }
         );
         if (existingEmail) {
-          threadId = existingEmail.threadId;
+          threadId = existingEmail.threadId as string | undefined;
         }
       }
 
       // Auto-link to contact by from email
-      const contact = await ctx.runQuery(
+      const contact = await ctx.runAction(
         internal.crm.emails_internal.findContactByEmail,
         { organizationId, email: fromEmail }
       );
@@ -604,7 +604,7 @@ http.route({
 
       const snippet = text ? text.slice(0, 200) : html ? html.replace(/<[^>]*>/g, "").slice(0, 200) : undefined;
 
-      await ctx.runMutation(internal.crm.emails_internal.insertInbound, {
+      await ctx.runAction(internal.crm.emails_internal.insertInbound, {
         organizationId,
         threadId: finalThreadId,
         messageId,
@@ -615,7 +615,7 @@ http.route({
         bodyHtml: html,
         bodyText: text,
         snippet,
-        contactId: contact?._id,
+        contactId: contact?._id ? String(contact._id) : undefined,
       });
 
       return new Response("OK", { status: 200 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4897.

Closes #4897

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a63abcf8 fix(crm): migrate 29 legacy ctx.db reads to Supabase in calls, emails (closes #4897)

### Files changed

```
 convex/crm/calls.ts           |  51 +++-----
 convex/crm/emails.ts          | 103 +--------------
 convex/crm/emails_internal.ts | 282 ++++++++++++++++--------------------------
 convex/google/gmail.ts        |   4 +-
 convex/http.ts                |  10 +-
 5 files changed, 131 insertions(+), 319 deletions(-)
```