### PR TITLE
Remove stale `ctx.db.insert("emails", ...)` dual-write pattern in `gmail.ts

### DIFF
--- a/convex/crm/emails_internal.ts
+++ b/convex/crm/emails_internal.ts
@@ -44,6 +44,25 @@ export const findByMessageId = internalAction({
   },
 });
 
+export const findExistingGmailMessageIds = internalAction({
+  args: {
+    organizationId: v.id("organizations"),
+    gmailMessageIds: v.array(v.string()),
+  },
+  handler: async (_ctx, args): Promise<string[]> => {
+    if (args.gmailMessageIds.length === 0) return [];
+    const db = createSupabaseDb();
+    const rows = await db
+      .query("emails")
+      .eq("organizationId", String(args.organizationId))
+      .in("gmailMessageId", args.gmailMessageIds)
+      .collect();
+    return rows
+      .map((r) => r.gmailMessageId)
+      .filter((id): id is string => id != null);
+  },
+});
+
 export const findContactByEmail = internalAction({
   args: {
     organizationId: v.id("organizations"),

--- a/convex/google/gmail.ts
+++ b/convex/google/gmail.ts
@@ -114,9 +114,20 @@ export const syncInbox = action({
     const listData = await listResponse.json();
     const messages = (listData.messages ?? []) as { id: string; threadId: string }[];
 
+    // Batch pre-check: fetch all already-synced IDs in one query so we don't
+    // fire 50 individual Supabase dedup queries inside insertInboundGmail.
+    const existingIds = new Set(
+      await ctx.runAction(internal.crm.emails_internal.findExistingGmailMessageIds, {
+        organizationId: args.organizationId,
+        gmailMessageIds: messages.map((m) => m.id),
+      })
+    );
+
     let synced = 0;
 
     for (const msg of messages) {
+      if (existingIds.has(msg.id)) continue;
+
       // Fetch full message
       const msgResponse = await fetch(
         `https://gmail.googleapis.com/gmail/v1/users/me/messages/${msg.id}?format=metadata&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Subject&metadataHeaders=Date`,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4907.

Closes #4907

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 94ea619e perf(gmail): batch pre-check synced message IDs before syncInbox loop (closes #4907)

### Files changed

```
 convex/crm/emails_internal.ts | 19 +++++++++++++++++++
 convex/google/gmail.ts        | 11 +++++++++++
 2 files changed, 30 insertions(+)
```