### PR TITLE
Migrate `sentBy

### DIFF
--- a/convex/crm/emails_internal.ts
+++ b/convex/crm/emails_internal.ts
@@ -95,7 +95,7 @@ export const insertOutboundGmail = internalAction({
     contactId: v.optional(v.string()),
     companyId: v.optional(v.string()),
     leadId: v.optional(v.string()),
-    sentBy: v.id("users"),
+    sentBy: v.string(),
   },
   handler: async (_ctx, args) => {
     const db = createSupabaseDb();

--- a/convex/google/gmail.ts
+++ b/convex/google/gmail.ts
@@ -17,7 +17,7 @@ export const sendViaGmail = action({
     leadId: v.optional(v.string()),
     inReplyTo: v.optional(v.string()),
     threadId: v.optional(v.string()),
-    sentBy: v.id("users"),
+    sentBy: v.string(),
     fromEmail: v.string(),
   },
   handler: async (ctx, args) => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4910.

Closes #4910

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 85ca8e5c fix(gmail): migrate sentBy from v.id("users") to v.string() in sendViaGmail/insertOutboundGmail (closes #4910)

### Files changed

```
 convex/crm/emails_internal.ts | 2 +-
 convex/google/gmail.ts        | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```