### PR TITLE
Migrate `organizationId

### DIFF
--- a/convex/crm/emails_internal.ts
+++ b/convex/crm/emails_internal.ts
@@ -80,7 +80,7 @@ export const findContactByEmail = internalAction({
 
 export const insertOutboundGmail = internalAction({
   args: {
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     to: v.array(v.string()),
     cc: v.optional(v.array(v.string())),
     bcc: v.optional(v.array(v.string())),
@@ -142,7 +142,7 @@ export const insertOutboundGmail = internalAction({
 
 export const insertInboundGmail = internalAction({
   args: {
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     gmailMessageId: v.string(),
     gmailThreadId: v.string(),
     from: v.string(),
@@ -263,7 +263,7 @@ export const insertInbound = internalAction({
 export const _publishInboundActivity = internalMutation({
   args: {
     emailId: v.string(),
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     performedBy: v.string(),
     subject: v.string(),
     from: v.string(),
@@ -272,7 +272,7 @@ export const _publishInboundActivity = internalMutation({
   },
   handler: async (ctx, args) => {
     await publishActivityEnvelope(ctx, {
-      organizationId: args.organizationId,
+      organizationId: args.organizationId as any,
       action: "email_received",
       performedBy: args.performedBy as any,
       module: "crm",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4911.

Closes #4911

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c7c81510 fix(gmail): migrate organizationId from v.id("organizations") to v.string() in insertOutboundGmail/insertInboundGmail (closes #4911)

### Files changed

```
 convex/crm/emails_internal.ts | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```