### PR TITLE
Fix appointmentBillingFlow package session deduction

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1398,6 +1398,8 @@ export const create = action({
             variantId: t.variantId ?? null,
             priceAtBooking: treatmentPrices[i] ?? null,
             sortOrder: i,
+            stockDeducted: false,
+            packageDeducted: false,
             createdAt: now,
             updatedAt: now,
           });
@@ -1830,6 +1832,8 @@ export const update = action({
           variantId: effectiveVariantId,
           priceAtBooking: tPrice,
           sortOrder: i,
+          stockDeducted: false,
+          packageDeducted: false,
           createdAt: now,
           updatedAt: now,
         });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4926.

Closes #4926

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4fcdcea5 fix(gabinet): explicitly set packageDeducted/stockDeducted=false on junction row insert (closes #4926)

### Files changed

```
 convex/gabinet/appointments.ts | 4 ++++
 1 file changed, 4 insertions(+)
```