### PR TITLE
Remove stale `ctx.db.insert("emails", ...)` in `convex/automation.ts

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -737,8 +737,9 @@ export const _recordAutomationEmailResult = internalMutation({
       return;
     }
 
-    const emailId = await ctx.db.insert("emails", {
-      organizationId: args.organizationId,
+    const db = createSupabaseDb();
+    const emailId = await db.insert("emails", {
+      organizationId: String(args.organizationId),
       threadId: `<${crypto.randomUUID()}@crm.app>`,
       messageId: `<${crypto.randomUUID()}@crm.app>`,
       direction: "outbound",
@@ -750,7 +751,7 @@ export const _recordAutomationEmailResult = internalMutation({
       snippet: args.bodyText.slice(0, 200),
       isRead: true,
       isStarred: false,
-      sentBy: args.sentBy,
+      sentBy: args.sentBy ? String(args.sentBy) : null,
       sentAt: now,
       createdAt: now,
       updatedAt: now,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4914.

Closes #4914

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 72c33426 fix(automation): migrate ctx.db.insert(\"emails\") to Supabase in _recordAutomationEmailResult (closes #4914)

### Files changed

```
 convex/automation.ts | 7 ++++---
 1 file changed, 4 insertions(+), 3 deletions(-)
```