### PR TITLE
Migrate `sentBy

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -511,7 +511,8 @@ export const _sendAutomationEmail = internalAction({
     subject: v.string(),
     bodyHtml: v.string(),
     bodyText: v.string(),
-    sentBy: v.optional(v.id("users")),
+    // Supabase UUID; users moved off Convex ids (same migration as appointmentId in #353).
+    sentBy: v.optional(v.string()),
     // Supabase UUID; gabinet appointments moved off Convex ids in #353.
     appointmentId: v.optional(v.string()),
     actionType: v.string(),
@@ -537,7 +538,7 @@ export const _sendAutomationEmail = internalAction({
         relatedEntityType: args.appointmentId ? "gabinetAppointment" : undefined,
         relatedEntityId: args.appointmentId,
         idempotencyKey: args.idempotencyKey,
-        triggeredBy: args.sentBy,
+        triggeredBy: args.sentBy as Id<"users"> | undefined,
       });
       await ctx.runMutation(internal.automation._recordAutomationEmailResult, {
         organizationId: args.organizationId,
@@ -571,7 +572,7 @@ export const _sendAutomationEmail = internalAction({
       relatedEntityType: args.appointmentId ? "gabinetAppointment" : undefined,
       relatedEntityId: args.appointmentId,
       idempotencyKey: args.idempotencyKey,
-      triggeredBy: args.sentBy,
+      triggeredBy: args.sentBy as Id<"users"> | undefined,
     };
     try {
       const response = await fetch("https://api.resend.com/emails", {
@@ -697,7 +698,8 @@ export const _recordAutomationEmailResult = internalMutation({
     subject: v.string(),
     bodyHtml: v.string(),
     bodyText: v.string(),
-    sentBy: v.optional(v.id("users")),
+    // Supabase UUID; users moved off Convex ids (same migration as appointmentId in #353).
+    sentBy: v.optional(v.string()),
     // Supabase UUID; gabinet appointments moved off Convex ids in #353.
     appointmentId: v.optional(v.string()),
     actionType: v.string(),
@@ -764,7 +766,7 @@ export const _recordAutomationEmailResult = internalMutation({
         entityId: emailId,
         action: "email_sent",
         description: `Sent email \"${args.subject}\" to ${args.recipient}`,
-        performedBy: args.sentBy,
+        performedBy: args.sentBy as Id<"users">,
       });
     }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4918.

Closes #4918

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 5715c56b fix(automation): migrate sentBy from v.id("users") to v.string() in _sendAutomationEmail and _recordAutomationEmailResult (closes #4918)

### Files changed

```
 convex/automation.ts | 12 +++++++-----
 1 file changed, 7 insertions(+), 5 deletions(-)
```