### PR TITLE
Migrate `sendViaGmail.organizationId` and `syncInbox.organizationId` in `gmail.t

### DIFF
--- a/convex/documents/signing.ts
+++ b/convex/documents/signing.ts
@@ -349,7 +349,7 @@ export const sendSigningEmailInternal = internalAction({
     // Try sending via Gmail OAuth (tenant's configured connection)
     const googleToken = await getValidAccessToken(
       ctx,
-      data.organizationId as Id<"organizations">,
+      data.organizationId as string,
     );
 
     let gmailError: string | null = null;

--- a/convex/google/_helpers.ts
+++ b/convex/google/_helpers.ts
@@ -9,7 +9,7 @@ import { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET } from "@cvx/env";
  */
 export async function getValidAccessToken(
   ctx: ActionCtx,
-  organizationId: Id<"organizations">
+  organizationId: string
 ): Promise<{ accessToken: string; connectionId: Id<"oauthConnections"> } | null> {
   const connection = await ctx.runQuery(
     internal.oauthConnections.getActiveGoogle,

--- a/convex/google/gmail.ts
+++ b/convex/google/gmail.ts
@@ -5,7 +5,7 @@ import { getValidAccessToken } from "./_helpers";
 
 export const sendViaGmail = action({
   args: {
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     to: v.array(v.string()),
     cc: v.optional(v.array(v.string())),
     bcc: v.optional(v.array(v.string())),
@@ -93,7 +93,7 @@ export const sendViaGmail = action({
 
 export const syncInbox = action({
   args: {
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
   },
   handler: async (ctx, args) => {
     const token = await getValidAccessToken(ctx, args.organizationId);

--- a/convex/oauthConnections.ts
+++ b/convex/oauthConnections.ts
@@ -157,7 +157,7 @@ export const revokeAndDeactivate = action({
 // --- Internal functions for backend use ---
 
 export const getActiveGoogle = internalQuery({
-  args: { organizationId: v.id("organizations") },
+  args: { organizationId: v.string() },
   handler: async (ctx, args) => {
     return await ctx.db
       .query("oauthConnections")


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4923.

Closes #4923

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- cf36d10c fix(gmail): migrate sendViaGmail/syncInbox organizationId from v.id("organizations") to v.string() (closes #4923)

### Files changed

```
 convex/documents/signing.ts | 2 +-
 convex/google/_helpers.ts   | 2 +-
 convex/google/gmail.ts      | 4 ++--
 convex/oauthConnections.ts  | 2 +-
 4 files changed, 5 insertions(+), 5 deletions(-)
```