### PR TITLE
Migrate `calendar.ts` organizationId args from `v.id("organizations")` to `v.str

### DIFF
--- a/convex/google/calendar.ts
+++ b/convex/google/calendar.ts
@@ -8,7 +8,7 @@ import { upsertFromGoogleImportSupabase } from "./calendarSyncHelpers_supabase";
 
 export const createEvent = internalAction({
   args: {
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     activityId: v.string(),
   },
   handler: async (ctx, args) => {
@@ -62,7 +62,7 @@ export const createEvent = internalAction({
 
 export const updateEvent = internalAction({
   args: {
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     activityId: v.string(),
   },
   handler: async (ctx, args) => {
@@ -103,7 +103,7 @@ export const updateEvent = internalAction({
 
 export const deleteEvent = internalAction({
   args: {
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     activityId: v.string(),
   },
   handler: async (ctx, args) => {
@@ -161,8 +161,8 @@ function parseGoogleDateTime(dt?: { dateTime?: string; date?: string }): number 
 
 export const importFromGoogle = action({
   args: {
-    organizationId: v.id("organizations"),
-    ownerId: v.id("users"),
+    organizationId: v.string(),
+    ownerId: v.string(),
     daysBack: v.optional(v.number()),
     daysForward: v.optional(v.number()),
   },
@@ -276,7 +276,7 @@ export const importFromGoogle = action({
 });
 
 export const listUserCalendars = action({
-  args: { organizationId: v.id("organizations"), connectionId: v.id("oauthConnections") },
+  args: { organizationId: v.string(), connectionId: v.id("oauthConnections") },
   handler: async (ctx, args) => {
     const userId = await authModule.getUserId(ctx);
     if (!userId) throw new Error("Not authenticated");


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4948.

Closes #4948

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- ebdaa926 fix(calendar): migrate organizationId from v.id("organizations") to v.string() in calendar.ts (closes #4948)

### Files changed

```
 convex/google/calendar.ts | 12 ++++++------
 1 file changed, 6 insertions(+), 6 deletions(-)
```