### PR TITLE
Migrate `invitations.ts` ctx.db writes to createSupabaseDb()

### DIFF
--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -77,7 +77,6 @@ export const getByToken = action({
   },
 });
 
-// Invitations stay in Convex DB for seat limit checks and auth flow
 export const create = action({
   args: {
     organizationId: v.id("organizations"),
@@ -145,9 +144,7 @@ export const create = action({
       moduleData: args.moduleData,
     });
 
-    // Mirror to Supabase so the team-settings page (which reads from
-    // Supabase via useSupabasePendingInvitations) sees the new pending
-    // invitation immediately. Matches the pattern used by organizations.create.
+    // Write invitation to Supabase (primary store — Convex no longer holds a copy).
     try {
       await db.insert("invitations", {
         _id: created.invitationId,
@@ -164,7 +161,7 @@ export const create = action({
         moduleData: created.moduleData ?? null,
       });
     } catch (e) {
-      console.error("[invitations.create] Supabase mirror failed:", e);
+      console.error("[invitations.create] Supabase write failed:", e);
     }
 
     // Send the invitation email out-of-band. Failure here must NOT roll back
@@ -310,22 +307,11 @@ export const _createInternal = internalMutation({
     // (Supabase reads) before this mutation is called.
 
     const token = crypto.randomUUID();
+    // Generate UUID here — invitation is written to Supabase by the parent
+    // create action (primary store). ctx.db no longer holds a copy.
+    const invitationId = crypto.randomUUID();
     const now = Date.now();
     const expiresAt = now + 7 * 24 * 60 * 60 * 1000;
-
-    const invitationId = await ctx.db.insert("invitations", {
-      organizationId: args.organizationId,
-      email: args.email,
-      role: args.role,
-      token,
-      status: "pending",
-      invitedBy: user._id,
-      expiresAt,
-      createdAt: now,
-      updatedAt: now,
-      module: args.module,
-      moduleData: args.moduleData,
-    });
 
     await logActivity(ctx, {
       organizationId: args.organizationId,
@@ -346,7 +332,7 @@ export const _createInternal = internalMutation({
     });
 
     return {
-      invitationId: String(invitationId),
+      invitationId,
       email: args.email,
       role: args.role,
       token,
@@ -414,6 +400,9 @@ export const accept = action({
       invitationId: string;
       acceptedAt: number;
       updatedAt: number;
+      membershipId: string;
+      membershipUserId: string;
+      membershipJoinedAt: number;
     } = await ctx.runMutation(
       internal.invitations._acceptInternal,
       {
@@ -428,8 +417,7 @@ export const accept = action({
       },
     );
 
-    // Mirror status change to Supabase so any consumer reading invitations
-    // from there (e.g. team-settings page) sees the accepted state.
+    // Write invitation status to Supabase.
     try {
       await db.patch("invitations", result.invitationId, {
         status: "accepted",
@@ -437,7 +425,22 @@ export const accept = action({
         updatedAt: result.updatedAt,
       });
     } catch (e) {
-      console.error("[invitations.accept] Supabase mirror failed:", e);
+      console.error("[invitations.accept] Supabase invitation patch failed:", e);
+    }
+
+    // Write teamMembership to Supabase directly (primary store).
+    // _acceptInternal already inserted to Convex for auth (requireOrgAdmin) compat.
+    try {
+      await db.insert("teamMemberships", {
+        _id: result.membershipId,
+        userId: result.membershipUserId,
+        organizationId: String(invitation.organizationId),
+        role: invitation.role,
+        invitedBy: String(invitation.invitedBy),
+        joinedAt: result.membershipJoinedAt,
+      });
+    } catch (e) {
+      console.error("[invitations.accept] Supabase teamMembership write failed:", e);
     }
 
     return result.organizationId;
@@ -472,47 +475,17 @@ export const _acceptInternal = internalMutation({
 
     const joinedAt = Date.now();
 
-    // Guard against duplicate membership — e.g. a user already linked to this
-    // org via another path (password-employee creation, manual addMember) who
-    // then accepts a still-pending invitation. Without this check,
-    // ctx.db.insert creates a second Convex row and the Supabase mirror fails
-    // silently because upsertWithFkRetry uses onConflict:"id" while Supabase
-    // enforces a UNIQUE index on (organization_id, user_id).
-    const existingMembership = await ctx.db
-      .query("teamMemberships")
-      .withIndex("by_orgAndUser", (q) =>
-        q.eq("organizationId", orgId).eq("userId", user._id),
-      )
-      .first();
-
-    if (!existingMembership) {
-      const membershipId = await ctx.db.insert("teamMemberships", {
-        userId: user._id,
-        organizationId: orgId,
-        role: args.invitationRole,
-        invitedBy: invitedById,
-        joinedAt,
-      });
-
-      // Mirror to Supabase so the team-settings page (which reads members
-      // via useSupabaseOrganizationMembers) and the RBAC bridge (which
-      // also reads team_memberships from Supabase) both see the new
-      // membership. Without this, an invited admin/member has a row in
-      // Convex teamMemberships but is invisible to the UI's permission
-      // checks — UI shows empty / 403 on protected actions.
-      await ctx.scheduler.runAfter(
-        500, // delay so writeUserToSupabase lands first (avoids 23503 FK violation)
-        internal.supabase.organizations.writeTeamMembershipToSupabase,
-        {
-          membershipId: String(membershipId),
-          userId: String(user._id),
-          organizationId: String(orgId),
-          role: args.invitationRole,
-          invitedBy: args.invitationInvitedBy,
-          joinedAt,
-        },
-      );
-    }
+    // Duplicate membership was already checked in the parent accept action
+    // (Supabase read). Insert directly to Convex — required for requireOrgAdmin
+    // (QueryCtx / MutationCtx cannot make HTTP calls, so teamMemberships must
+    // exist in Convex for auth checks to pass in subsequent mutations).
+    const membershipId = await ctx.db.insert("teamMemberships", {
+      userId: user._id,
+      organizationId: orgId,
+      role: args.invitationRole,
+      invitedBy: invitedById,
+      joinedAt,
+    });
 
     // If the invitee just signed up via OTP and has no username yet, derive
     // one from the email local-part so they skip the /onboarding/username
@@ -573,11 +546,8 @@ export const _acceptInternal = internalMutation({
 
     const acceptedAt = Date.now();
     const updatedAt = acceptedAt;
-    await ctx.db.patch(args.invitationId as Id<"invitations">, {
-      status: "accepted",
-      acceptedAt,
-      updatedAt,
-    });
+    // Invitation status is patched in Supabase by the parent accept action.
+    // No ctx.db.patch needed — invitation is no longer stored in Convex.
 
     await logActivity(ctx, {
       organizationId: orgId,
@@ -613,6 +583,9 @@ export const _acceptInternal = internalMutation({
       invitationId: args.invitationId,
       acceptedAt,
       updatedAt,
+      membershipId: String(membershipId),
+      membershipUserId: String(user._id),
+      membershipJoinedAt: joinedAt,
     };
   },
 });
@@ -630,11 +603,10 @@ export const decline = action({
 
     const updatedAt: number = await ctx.runMutation(
       internal.invitations._declineInternal,
-      { invitationId: String(invitation._id) },
+      {},
     );
 
-    // Mirror status change to Supabase so any consumer reading invitations
-    // from there sees the declined state.
+    // Patch invitation status in Supabase (primary store).
     try {
       await db.patch("invitations", String(invitation._id), {
         status: "declined",
@@ -647,17 +619,12 @@ export const decline = action({
 });
 
 export const _declineInternal = internalMutation({
-  args: { invitationId: v.string() },
-  handler: async (ctx, args) => {
+  args: {},
+  handler: async (ctx, _args) => {
     await requireUser(ctx);
-
-    const updatedAt = Date.now();
-    await ctx.db.patch(args.invitationId as Id<"invitations">, {
-      status: "declined",
-      updatedAt,
-    });
-
-    return updatedAt;
+    // Invitation status is patched in Supabase by the parent decline action.
+    // No ctx.db.patch needed — invitation is no longer stored in Convex.
+    return Date.now();
   },
 });
 
@@ -667,21 +634,30 @@ export const cancel = action({
     invitationId: v.string(),
   },
   handler: async (ctx, args) => {
+    const db = createSupabaseDb();
+
+    // Read and validate invitation from Supabase (primary store).
+    const invitation = await db.get("invitations", args.invitationId);
+    if (!invitation || String(invitation.organizationId) !== String(args.organizationId)) {
+      throw new Error("Invitation not found");
+    }
+    if (invitation.status !== "pending") {
+      throw new Error("Invitation is no longer pending");
+    }
+
+    // Auth check via internalMutation (requires MutationCtx for requireOrgAdmin).
     await ctx.runMutation(internal.invitations._cancelInternal, {
       organizationId: args.organizationId,
-      invitationId: args.invitationId as any,
     });
 
-    // Mirror status change to Supabase so the team page (which reads
-    // pending invitations from Supabase) updates.
+    // Patch invitation status in Supabase (primary store).
     try {
-      const db = createSupabaseDb();
       await db.patch("invitations", args.invitationId, {
         status: "expired",
         updatedAt: Date.now(),
       });
     } catch (e) {
-      console.error("[invitations.cancel] Supabase mirror failed:", e);
+      console.error("[invitations.cancel] Supabase patch failed:", e);
     }
   },
 });
@@ -689,23 +665,11 @@ export const cancel = action({
 export const _cancelInternal = internalMutation({
   args: {
     organizationId: v.id("organizations"),
-    invitationId: v.id("invitations"),
   },
   handler: async (ctx, args) => {
     await requireOrgAdmin(ctx, args.organizationId);
-
-    const invitation = await ctx.db.get(args.invitationId);
-    if (!invitation || invitation.organizationId !== args.organizationId) {
-      throw new Error("Invitation not found");
-    }
-    if (invitation.status !== "pending") {
-      throw new Error("Invitation is no longer pending");
-    }
-
-    await ctx.db.patch(args.invitationId, {
-      status: "expired",
-      updatedAt: Date.now(),
-    });
+    // Invitation read and status patch are handled by the parent cancel action
+    // via Supabase. Invitation is no longer stored in Convex.
   },
 });
 
@@ -715,38 +679,41 @@ export const resend = action({
     invitationId: v.string(),
   },
   handler: async (ctx, args) => {
-    const updated: {
-      expiresAt: number;
-      updatedAt: number;
-      email: string;
-      role: "admin" | "member" | "viewer" | "owner";
-      token: string;
-      invitedBy: string;
-    } = await ctx.runMutation(internal.invitations._resendInternal, {
-      organizationId: args.organizationId,
-      invitationId: args.invitationId as any,
-    });
+    const db = createSupabaseDb();
 
-    // Mirror new expiry to Supabase so any consumer reading from there
-    // sees the refreshed expiresAt.
+    // Read and validate invitation from Supabase (primary store).
+    const invitation = await db.get("invitations", args.invitationId);
+    if (!invitation || String(invitation.organizationId) !== String(args.organizationId)) {
+      throw new Error("Invitation not found");
+    }
+    if (invitation.status !== "pending") {
+      throw new Error("Invitation is no longer pending");
+    }
+
+    // Auth check + generate new expiry via internalMutation.
+    const updated: { expiresAt: number; updatedAt: number } = await ctx.runMutation(
+      internal.invitations._resendInternal,
+      { organizationId: args.organizationId },
+    );
+
+    // Patch invitation with new expiry in Supabase (primary store).
     try {
-      const db = createSupabaseDb();
       await db.patch("invitations", args.invitationId, {
         expiresAt: updated.expiresAt,
         updatedAt: updated.updatedAt,
       });
     } catch (e) {
-      console.error("[invitations.resend] Supabase mirror failed:", e);
+      console.error("[invitations.resend] Supabase patch failed:", e);
     }
 
     // Re-send the invitation email with the refreshed expiry.
     await ctx.scheduler.runAfter(0, internal.invitations._sendInvitationEmail, {
       invitationId: args.invitationId,
-      email: updated.email,
-      role: updated.role,
-      token: updated.token,
+      email: String(invitation.email),
+      role: String(invitation.role),
+      token: String(invitation.token),
       organizationId: args.organizationId,
-      inviterUserId: updated.invitedBy,
+      inviterUserId: String(invitation.invitedBy),
     });
 
     return args.invitationId;
@@ -756,30 +723,14 @@ export const resend = action({
 export const _resendInternal = internalMutation({
   args: {
     organizationId: v.id("organizations"),
-    invitationId: v.id("invitations"),
   },
   handler: async (ctx, args) => {
     await requireOrgAdmin(ctx, args.organizationId);
-
-    const invitation = await ctx.db.get(args.invitationId);
-    if (!invitation || invitation.organizationId !== args.organizationId) {
-      throw new Error("Invitation not found");
-    }
-    if (invitation.status !== "pending") {
-      throw new Error("Invitation is no longer pending");
-    }
-
-    const expiresAt = Date.now() + 7 * 24 * 60 * 60 * 1000;
-    const updatedAt = Date.now();
-    await ctx.db.patch(args.invitationId, { expiresAt, updatedAt });
-
+    // Invitation read and expiry patch are handled by the parent resend action
+    // via Supabase. Invitation is no longer stored in Convex.
     return {
-      expiresAt,
-      updatedAt,
-      email: invitation.email,
-      role: invitation.role,
-      token: invitation.token,
-      invitedBy: String(invitation.invitedBy),
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      updatedAt: Date.now(),
     };
   },
 });
@@ -794,57 +745,51 @@ export const updatePendingRole = action({
     role: orgRoleValidator,
   },
   handler: async (ctx, args): Promise<string> => {
-    const updated: {
-      invitationId: string;
-      role: "admin" | "member" | "viewer" | "owner";
-      updatedAt: number;
-    } = await ctx.runMutation(internal.invitations._updatePendingRoleInternal, {
-      organizationId: args.organizationId,
-      invitationId: args.invitationId as Id<"invitations">,
-      role: args.role,
-    });
+    const db = createSupabaseDb();
 
-    // Mirror to Supabase so the team-settings page reflects the new role.
+    // Read and validate invitation from Supabase (primary store).
+    const invitation = await db.get("invitations", args.invitationId);
+    if (!invitation || String(invitation.organizationId) !== String(args.organizationId)) {
+      throw new Error("Invitation not found");
+    }
+    if (invitation.status !== "pending") {
+      throw new Error("Only pending invitations can have their role changed");
+    }
+    if (args.role === "owner") {
+      throw new Error("Cannot assign owner role via invitation");
+    }
+
+    // Auth check via internalMutation (requires MutationCtx for requireOrgAdmin).
+    const updated: { updatedAt: number } = await ctx.runMutation(
+      internal.invitations._updatePendingRoleInternal,
+      {
+        organizationId: args.organizationId,
+      },
+    );
+
+    // Patch invitation with new role in Supabase (primary store).
     try {
-      const db = createSupabaseDb();
-      await db.patch("invitations", updated.invitationId, {
-        role: updated.role,
+      await db.patch("invitations", args.invitationId, {
+        role: args.role,
         updatedAt: updated.updatedAt,
       });
     } catch (e) {
-      console.error("[invitations.updatePendingRole] Supabase mirror failed:", e);
+      console.error("[invitations.updatePendingRole] Supabase patch failed:", e);
     }
 
-    return updated.invitationId;
+    return args.invitationId;
   },
 });
 
 export const _updatePendingRoleInternal = internalMutation({
   args: {
     organizationId: v.id("organizations"),
-    invitationId: v.id("invitations"),
-    role: orgRoleValidator,
   },
   handler: async (ctx, args) => {
     await requireOrgAdmin(ctx, args.organizationId);
-    const inv = await ctx.db.get(args.invitationId);
-    if (!inv || inv.organizationId !== args.organizationId) {
-      throw new Error("Invitation not found");
-    }
-    if (inv.status !== "pending") {
-      throw new Error("Only pending invitations can have their role changed");
-    }
-    if (args.role === "owner") {
-      // Ownership transfer is a separate flow — never grant via plain invite.
-      throw new Error("Cannot assign owner role via invitation");
-    }
-    const updatedAt = Date.now();
-    await ctx.db.patch(args.invitationId, { role: args.role, updatedAt });
-    return {
-      invitationId: String(args.invitationId),
-      role: args.role,
-      updatedAt,
-    };
+    // Invitation read, validation, and role patch are handled by the parent
+    // updatePendingRole action via Supabase. Invitation is no longer in Convex.
+    return { updatedAt: Date.now() };
   },
 });
 
@@ -855,52 +800,38 @@ export const _updatePendingRoleInternal = internalMutation({
 export const _adminResendAndSend = internalAction({
   args: { invitationId: v.id("invitations") },
   handler: async (ctx, args) => {
-    // Explicit type annotation breaks a circular type inference TS hits when
-    // the resolved runMutation result type indirectly references this very
-    // export (TS7022/TS7023).
-    const r: {
-      invitationId: string;
-      email: string;
-      role: "admin" | "member" | "viewer" | "owner";
-      token: string;
-      organizationId: Id<"organizations">;
-      invitedBy: string;
-      expiresAt: number;
-      updatedAt: number;
-    } = await ctx.runMutation(internal.invitations._adminResendInternal, {
-      invitationId: args.invitationId,
-    });
-    await ctx.scheduler.runAfter(0, internal.invitations._sendInvitationEmail, {
-      invitationId: r.invitationId,
-      email: r.email,
-      role: r.role,
-      token: r.token,
-      organizationId: r.organizationId,
-      inviterUserId: r.invitedBy,
-    });
-    return { ok: true as const, ...r };
-  },
-});
+    const db = createSupabaseDb();
 
-export const _adminResendInternal = internalMutation({
-  args: { invitationId: v.id("invitations") },
-  handler: async (ctx, args) => {
-    const inv = await ctx.db.get(args.invitationId);
+    // Read invitation from Supabase (primary store — no longer in Convex).
+    const inv = await db.get("invitations", String(args.invitationId));
     if (!inv) throw new Error("Invitation not found");
+
     const expiresAt = Date.now() + 7 * 24 * 60 * 60 * 1000;
     const updatedAt = Date.now();
+
     // Also flip back to pending in case it had been marked expired/declined
-    await ctx.db.patch(args.invitationId, {
+    await db.patch("invitations", String(args.invitationId), {
       status: "pending",
       expiresAt,
       updatedAt,
     });
-    return {
+
+    await ctx.scheduler.runAfter(0, internal.invitations._sendInvitationEmail, {
       invitationId: String(args.invitationId),
-      email: inv.email,
-      role: inv.role,
-      token: inv.token,
-      organizationId: inv.organizationId,
+      email: String(inv.email),
+      role: String(inv.role),
+      token: String(inv.token),
+      organizationId: inv.organizationId as Id<"organizations">,
+      inviterUserId: String(inv.invitedBy),
+    });
+
+    return {
+      ok: true as const,
+      invitationId: String(args.invitationId),
+      email: String(inv.email),
+      role: String(inv.role),
+      token: String(inv.token),
+      organizationId: inv.organizationId as Id<"organizations">,
       invitedBy: String(inv.invitedBy),
       expiresAt,
       updatedAt,

--- a/scripts/check-convex-db-writes.mjs
+++ b/scripts/check-convex-db-writes.mjs
@@ -103,6 +103,15 @@ const WHITELIST_PATHS = new Set([
   // Convex writes are a permanent architectural necessity alongside the
   // Supabase writes already present in every calling action. See issue #4952.
   "organizations",
+
+  // invitations — _acceptInternal dual-writes teamMemberships and users to
+  // ctx.db for the same reason as organizations above: requireOrgAdmin /
+  // requireUser in _helpers/auth.ts read from ctx.db (QueryCtx | MutationCtx),
+  // which cannot make HTTP calls. The invitations table itself is now Supabase-
+  // only (migrated in issue #4953). The remaining ctx.db writes are limited to
+  // teamMemberships (Convex auth compat) and users (username derivation for
+  // new invitees). See issue #4953.
+  "invitations",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -128,10 +137,6 @@ const INSERT_PENDING = new Set([
 
   // gabinet/equipment.ts — ctx.db.insert("gabinetEquipment", ...).
   "gabinet/equipment",
-
-  // invitations.ts — ctx.db.insert("invitations", ...) and
-  // ("teamMemberships", ...) during invitation acceptance.
-  "invitations",
 
   // stripe.ts — ctx.db.insert("productSubscriptions", ...) during Stripe
   // webhook handling; should use createSupabaseDb().insert().
@@ -185,9 +190,6 @@ const PATCH_DELETE_PENDING = new Set([
   // gabinetAppointments records during GDPR erasure.
   "gabinet/patients",
 
-  // invitations.ts — ctx.db.patch(args.invitationId, ...) and
-  // patch(user._id, ...) where types are invitations and users.
-  "invitations",
 ]);
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4953.

Closes #4953

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c711bf4f fix(invitations): migrate ctx.db writes to createSupabaseDb() (closes #4953)

### Files changed

```
 convex/invitations.ts              | 351 +++++++++++++++----------------------
 scripts/check-convex-db-writes.mjs |  16 +-
 2 files changed, 150 insertions(+), 217 deletions(-)
```