### PR TITLE
Migrate `automation.ts` migration-compat ctx.db.patch to remove legacy Convex mi

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -930,20 +930,6 @@ export const _recordUpdateFieldResult = internalMutation({
       return;
     }
 
-    // Mirror to Convex if a doc with this id still exists there (gabinet
-    // entities seeded by tests, or legacy data not yet migrated). For
-    // Supabase-only ids, normalizeId returns null and we silently skip.
-    if (args.targetEntityType && args.targetId && args.updates) {
-      const descriptor = AUTOMATION_UPDATE_FIELD_DESCRIPTORS[args.targetEntityType];
-      const convexId = ctx.db.normalizeId(descriptor.table, args.targetId);
-      if (convexId) {
-        const convexDoc = await ctx.db.get(convexId);
-        if (convexDoc) {
-          await ctx.db.patch(convexId, args.updates as never);
-        }
-      }
-    }
-
     if (args.actorUserId && args.linkedEntityType && args.targetId && args.fieldKey) {
       const activityLabelByEntity: Record<AutomationTargetEntityType, string> = {
         gabinetPatient: "patient",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4956.

Closes #4956

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 851b88fe fix(automation): remove migration-compat Convex mirror in _recordUpdateFieldResult (closes #4956)

### Files changed

```
 convex/automation.ts | 14 --------------
 1 file changed, 14 deletions(-)
```