### PR TITLE
Migrate `stripe.ts` productSubscriptions ctx.db writes

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -201,7 +201,7 @@ const handleCheckoutSessionCompleted = async (
   // the newly purchased module without requiring manual backfill.
   if (organizationId && productKey) {
     const normalizedStatus = toProductSubscriptionStatus(subscription.status);
-    await ctx.runMutation(internal.stripe.PREAUTH_upsertProductSubscription, {
+    await ctx.runAction(internal.stripe.PREAUTH_upsertProductSubscription, {
       organizationId: organizationId as Id<"organizations">,
       productId: productKey,
       stripeSubscriptionId: subscription.id,
@@ -280,7 +280,7 @@ const handleCustomerSubscriptionUpdated = async (
   const organizationId = subscription.metadata?.organizationId;
   if (organizationId && productKey) {
     const normalizedStatus = toProductSubscriptionStatus(subscription.status);
-    await ctx.runMutation(internal.stripe.PREAUTH_upsertProductSubscription, {
+    await ctx.runAction(internal.stripe.PREAUTH_upsertProductSubscription, {
       organizationId: organizationId as Id<"organizations">,
       productId: productKey,
       stripeSubscriptionId: subscription.id,
@@ -337,7 +337,7 @@ const handleCustomerSubscriptionCreated = async (
   const organizationId = subscription.metadata?.organizationId;
   if (organizationId && productKey) {
     const normalizedStatus = toProductSubscriptionStatus(subscription.status);
-    await ctx.runMutation(internal.stripe.PREAUTH_upsertProductSubscription, {
+    await ctx.runAction(internal.stripe.PREAUTH_upsertProductSubscription, {
       organizationId: organizationId as Id<"organizations">,
       productId: productKey,
       stripeSubscriptionId: subscription.id,
@@ -364,7 +364,7 @@ const handleCustomerSubscriptionDeleted = async (
   const productKey = subscription.metadata?.productKey;
   const organizationId = subscription.metadata?.organizationId;
   if (organizationId && productKey) {
-    await ctx.runMutation(internal.stripe.PREAUTH_upsertProductSubscription, {
+    await ctx.runAction(internal.stripe.PREAUTH_upsertProductSubscription, {
       organizationId: organizationId as Id<"organizations">,
       productId: productKey,
       stripeSubscriptionId: subscription.id,

--- a/convex/migrations/backfillProductSubscriptions.ts
+++ b/convex/migrations/backfillProductSubscriptions.ts
@@ -151,7 +151,7 @@ export const backfillProductSubscriptions = internalAction({
       }
 
       if (!dryRun) {
-        await ctx.runMutation(internal.stripe.PREAUTH_upsertProductSubscription, {
+        await ctx.runAction(internal.stripe.PREAUTH_upsertProductSubscription, {
           organizationId: org._id,
           productId: plan.productKey,
           stripeSubscriptionId: sub.stripeId,

--- a/convex/stripe.ts
+++ b/convex/stripe.ts
@@ -14,6 +14,7 @@ import { currencyValidator, intervalValidator, PLANS, PRODUCT_KEYS } from "@cvx/
 import { api, internal } from "~/convex/_generated/api";
 import { SITE_URL, STRIPE_SECRET_KEY } from "@cvx/env";
 import { asyncMap } from "convex-helpers";
+import { createSupabaseDb } from "./_helpers/supabaseDb";
 
 const TRIAL_PERIOD_DAYS = 14;
 
@@ -302,33 +303,32 @@ export const PREAUTH_deleteSubscription = internalMutation({
   },
 });
 
-/**
- * Upserts a per-organization per-product subscription record.
- * Called from Stripe webhook handlers to keep the productSubscriptions table
- * in sync with actual Stripe subscription state.
- */
-export const PREAUTH_upsertProductSubscription = internalMutation({
-  args: {
-    organizationId: v.id("organizations"),
-    productId: v.string(),
-    stripeSubscriptionId: v.string(),
-    status: v.union(
-      v.literal("active"),
-      v.literal("trialing"),
-      v.literal("past_due"),
-      v.literal("canceled"),
-      v.literal("incomplete"),
-    ),
-    currentPeriodStart: v.optional(v.number()),
-    currentPeriodEnd: v.optional(v.number()),
-    cancelAtPeriodEnd: v.boolean(),
-    trialEndDate: v.optional(v.number()),
-  },
+const upsertProductSubscriptionArgs = {
+  organizationId: v.id("organizations"),
+  productId: v.string(),
+  stripeSubscriptionId: v.string(),
+  status: v.union(
+    v.literal("active"),
+    v.literal("trialing"),
+    v.literal("past_due"),
+    v.literal("canceled"),
+    v.literal("incomplete"),
+  ),
+  currentPeriodStart: v.optional(v.number()),
+  currentPeriodEnd: v.optional(v.number()),
+  cancelAtPeriodEnd: v.boolean(),
+  trialEndDate: v.optional(v.number()),
+};
+
+// Convex-side write kept as a mutation so verifyProductAccess (QueryCtx) sees
+// the updated row immediately within the same deployment.
+export const _upsertProductSubscriptionInternal = internalMutation({
+  args: upsertProductSubscriptionArgs,
   handler: async (ctx, args) => {
     const existing = await ctx.db
       .query("productSubscriptions")
       .withIndex("by_orgAndProduct", (q) =>
-        q.eq("organizationId", args.organizationId).eq("productId", args.productId)
+        q.eq("organizationId", args.organizationId).eq("productId", args.productId),
       )
       .first();
 
@@ -356,6 +356,60 @@ export const PREAUTH_upsertProductSubscription = internalMutation({
         createdAt: now,
         updatedAt: now,
       });
+    }
+  },
+});
+
+/**
+ * Upserts a per-organization per-product subscription record.
+ * Called from Stripe webhook handlers to keep the productSubscriptions table
+ * in sync with actual Stripe subscription state.
+ * Dual-writes: Convex (for verifyProductAccess reads) and Supabase (primary store).
+ */
+export const PREAUTH_upsertProductSubscription = internalAction({
+  args: upsertProductSubscriptionArgs,
+  handler: async (ctx, args) => {
+    // Convex write (dual-write requirement: verifyProductAccess reads ctx.db).
+    await ctx.runMutation(internal.stripe._upsertProductSubscriptionInternal, args);
+
+    // Mirror to Supabase (primary data store).
+    const db = createSupabaseDb();
+    try {
+      const now = Date.now();
+      const orgIdStr = String(args.organizationId);
+
+      const existing = await db
+        .query("productSubscriptions")
+        .eq("organizationId", orgIdStr)
+        .eq("productId", args.productId)
+        .unique();
+
+      if (existing) {
+        await db.patch("productSubscriptions", String(existing._id), {
+          stripeSubscriptionId: args.stripeSubscriptionId,
+          status: args.status,
+          currentPeriodStart: args.currentPeriodStart ?? null,
+          currentPeriodEnd: args.currentPeriodEnd ?? null,
+          cancelAtPeriodEnd: args.cancelAtPeriodEnd,
+          trialEndDate: args.trialEndDate ?? null,
+          updatedAt: now,
+        });
+      } else {
+        await db.insert("productSubscriptions", {
+          organizationId: orgIdStr,
+          productId: args.productId,
+          stripeSubscriptionId: args.stripeSubscriptionId,
+          status: args.status,
+          currentPeriodStart: args.currentPeriodStart ?? null,
+          currentPeriodEnd: args.currentPeriodEnd ?? null,
+          cancelAtPeriodEnd: args.cancelAtPeriodEnd,
+          trialEndDate: args.trialEndDate ?? null,
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+    } catch (e) {
+      console.error("[stripe.PREAUTH_upsertProductSubscription] Supabase write failed:", e);
     }
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4964.

Closes #4964

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b73c1cfd fix(stripe): migrate productSubscriptions ctx.db writes to createSupabaseDb() (closes #4964)

### Files changed

```
 convex/http.ts                                    |   8 +-
 convex/migrations/backfillProductSubscriptions.ts |   2 +-
 convex/stripe.ts                                  | 100 +++++++++++++++++-----
 3 files changed, 82 insertions(+), 28 deletions(-)
```