### PR TITLE
Migrate `stripe.ts` ctx.db.patch to createSupabaseDb()

### DIFF
--- a/convex/stripe.ts
+++ b/convex/stripe.ts
@@ -61,7 +61,26 @@ export const PREAUTH_updateCustomerId = internalMutation({
     customerId: v.string(),
   },
   handler: async (ctx, args) => {
+    const user = await ctx.db.get(args.userId);
     await ctx.db.patch(args.userId, { customerId: args.customerId });
+    if (user) {
+      await ctx.scheduler.runAfter(0, internal.supabase.users.writeUserToSupabase, {
+        userId: String(args.userId),
+        email: user.email,
+        name: user.name,
+        username: user.username,
+        image: user.image,
+        imageStorageId: user.imageId ? String(user.imageId) : undefined,
+        phone: user.phone,
+        isAnonymous: user.isAnonymous,
+        customerId: args.customerId,
+        language: user.language,
+        theme: user.theme,
+        timezone: user.timezone,
+        createdAt: Math.floor(user._creationTime),
+        updatedAt: Date.now(),
+      });
+    }
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4967.

Closes #4967

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 025d9367 fix(stripe): mirror PREAUTH_updateCustomerId customerId write to Supabase (closes #4967)

### Files changed

```
 convex/stripe.ts | 19 +++++++++++++++++++
 1 file changed, 19 insertions(+)
```