### PR TITLE
Migrate `_listEntitlementsInternal` to read from Supabase

### DIFF
--- a/convex/admin/entitlements.ts
+++ b/convex/admin/entitlements.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { action, internalMutation, internalQuery } from "../_generated/server";
+import { action, internalAction, internalMutation } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { logAudit } from "../auditLog";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
@@ -80,17 +80,16 @@ const orgEntitlementRowValidator = v.object({
   gabinet: entStatusValidator,
 });
 
-export const _listEntitlementsInternal = internalQuery({
+export const _listEntitlementsInternal = internalAction({
   args: {},
   returns: v.array(entitlementRowValidator),
-  handler: async (
-    ctx,
-  ): Promise<Array<{ organizationId: string; productId: string; status: string }>> => {
-    const rows = await ctx.db.query("productSubscriptions").collect();
+  handler: async (): Promise<Array<{ organizationId: string; productId: string; status: string }>> => {
+    const db = createSupabaseDb();
+    const rows = await db.query("productSubscriptions").collect();
     return rows.map((r) => ({
       organizationId: String(r.organizationId),
-      productId: r.productId,
-      status: r.status,
+      productId: String(r.productId),
+      status: String(r.status),
     }));
   },
 });

--- a/convex/migrations/backfillEntitlements.ts
+++ b/convex/migrations/backfillEntitlements.ts
@@ -21,7 +21,7 @@ export const run = internalAction({
     const dryRun = args.dryRun ?? false;
     const db = createSupabaseDb();
     const orgs = await db.query("organizations").collect();
-    const existing = await ctx.runQuery(
+    const existing = await ctx.runAction(
       internal.admin.entitlements._listEntitlementsInternal,
       {},
     );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4976.

Closes #4976

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- cb2a5a01 fix(admin/entitlements): migrate _listEntitlementsInternal to read from Supabase (closes #4976)

### Files changed

```
 convex/admin/entitlements.ts              | 15 +++++++--------
 convex/migrations/backfillEntitlements.ts |  2 +-
 2 files changed, 8 insertions(+), 9 deletions(-)
```