### PR TITLE
Migrate `convex/dev/helpers.ts` formTemplates ctx.db reads to Supabase

### DIFF
--- a/convex/dev/helpers.ts
+++ b/convex/dev/helpers.ts
@@ -1,5 +1,6 @@
-import { query } from "../_generated/server";
+import { query, action } from "../_generated/server";
 import { v } from "convex/values";
+import { createSupabaseDb } from "../_helpers/supabaseDb";
 
 /** Get first org + user IDs for dev/seed scripts */
 export const getDevIds = query({
@@ -15,16 +16,17 @@ export const getDevIds = query({
 });
 
 /** Count templates + components for a given org (no auth required) */
-export const countDocs = query({
+export const countDocs = action({
   args: { organizationId: v.id("organizations") },
-  handler: async (ctx, args) => {
-    const templates = await ctx.db
+  handler: async (_ctx, args) => {
+    const db = createSupabaseDb();
+    const templates = await db
       .query("formTemplates")
-      .withIndex("by_org", (q) => q.eq("organizationId", args.organizationId))
+      .eq("organizationId", String(args.organizationId))
       .collect();
-    const components = await ctx.db
+    const components = await db
       .query("documentComponents")
-      .withIndex("by_scope", (q) => q.eq("scope", "system"))
+      .eq("scope", "system")
       .collect();
     return {
       templateCount: templates.length,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4992.

Closes #4992

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 6561c66e fix(dev/helpers): migrate countDocs to Supabase read path (closes #4992)

### Files changed

```
 convex/dev/helpers.ts | 16 +++++++++-------
 1 file changed, 9 insertions(+), 7 deletions(-)
```