### PR TITLE
Migrate `getDevIds` off `ctx.db` to Supabase read path

### DIFF
--- a/convex/dev/helpers.ts
+++ b/convex/dev/helpers.ts
@@ -1,13 +1,14 @@
-import { query, action } from "../_generated/server";
+import { action } from "../_generated/server";
 import { v } from "convex/values";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 
 /** Get first org + user IDs for dev/seed scripts */
-export const getDevIds = query({
+export const getDevIds = action({
   args: {},
-  handler: async (ctx) => {
-    const org = await ctx.db.query("organizations").first();
-    const user = await ctx.db.query("users").first();
+  handler: async (_ctx) => {
+    const db = createSupabaseDb();
+    const org = await db.query("organizations").first();
+    const user = await db.query("users").first();
     return {
       organizationId: org?._id ?? null,
       userId: user?._id ?? null,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4995.

Closes #4995

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d14dafdb fix(dev/helpers): migrate getDevIds to Supabase read path (closes #4995)

### Files changed

```
 convex/dev/helpers.ts | 11 ++++++-----
 1 file changed, 6 insertions(+), 5 deletions(-)
```