### PR TITLE
Fix appointmentSms provider and organizationId

### DIFF
--- a/convex/gabinet/appointmentSms.ts
+++ b/convex/gabinet/appointmentSms.ts
@@ -429,7 +429,7 @@ export const markEventFailed = internalMutation({
 
 export const processIncomingMessage = internalMutation({
   args: {
-    organizationId: v.string(),
+    organizationId: v.id("organizations"),
     provider: v.union(v.literal("twilio"), v.literal("smsapi")),
     to: v.string(),
     from: v.string(),
@@ -531,7 +531,7 @@ export const processIncomingMessage = internalMutation({
       (matchingAppointmentId || matchingPatientId)
     ) {
       await logSmsSharedActivities(ctx, {
-        organizationId: args.organizationId as Id<"organizations">,
+        organizationId: args.organizationId,
         appointmentId: matchingAppointmentId,
         patientId: matchingPatientId,
         action: "sms_received",
@@ -552,7 +552,7 @@ export const processIncomingMessage = internalMutation({
     }
 
     await ctx.scheduler.runAfter(0, internal.automation.emitEvent, {
-      organizationId: args.organizationId as Id<"organizations">,
+      organizationId: args.organizationId,
       module: "gabinet",
       eventType: "gabinet.appointment.sms_reply_received",
       entityType: matchingOutbound?.appointmentId ? "gabinetAppointment" : undefined,
@@ -605,7 +605,7 @@ export const processIncomingMessage = internalMutation({
       processingStatus: "processed" | "ignored";
       reason?: string;
     } = await ctx.runMutation(internal.gabinet.appointments.applySmsReplyTransition, {
-      organizationId: args.organizationId as Id<"organizations">,
+      organizationId: args.organizationId,
       appointmentId: String(matchingOutbound.appointmentId),
       intent: parsedIntent,
       smsEventId: eventId,

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -678,7 +678,7 @@ http.route({
         : `${provider}:${to}:${from}:${body.trim()}`;
 
       await ctx.runMutation(internal.gabinet.appointmentSms.processIncomingMessage, {
-        organizationId: config.organizationId as string,
+        organizationId: config.organizationId,
         provider,
         to,
         from,

--- a/convex/sms.ts
+++ b/convex/sms.ts
@@ -1,11 +1,12 @@
 import { action, internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
+import { Id } from "./_generated/dataModel";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 
 type OrgSmsConfigRow = {
   _id: string;
-  organizationId: string;
+  organizationId: Id<"organizations">;
   provider: "smsapi" | "twilio";
   apiToken: string;
   apiSecret?: string | null;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4928.

Closes #4928

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8f939d04 fix(gabinet/sms): resolve schema divergence in processIncomingMessage organizationId (closes #4928)

### Files changed

```
 convex/gabinet/appointmentSms.ts | 8 ++++----
 convex/http.ts                   | 2 +-
 convex/sms.ts                    | 3 ++-
 3 files changed, 7 insertions(+), 6 deletions(-)
```