### PR TITLE
`publishActivityEnvelope` signature takes `_ctx

### DIFF
--- a/convex/_helpers/activities.ts
+++ b/convex/_helpers/activities.ts
@@ -18,7 +18,7 @@ export async function logActivity(
 ) {
   const occurredAt = Date.now();
 
-  await publishActivityEnvelope(ctx, {
+  await publishActivityEnvelope({
     organizationId: args.organizationId,
     action: args.action,
     performedBy: args.performedBy,

--- a/convex/_helpers/activityEnvelope.ts
+++ b/convex/_helpers/activityEnvelope.ts
@@ -1,5 +1,4 @@
 import type { Id } from "../_generated/dataModel";
-import type { MutationCtx } from "../_generated/server";
 import type { ActivityAction } from "@cvx/schema";
 import { createSupabaseDb } from "./supabaseDb";
 
@@ -120,9 +119,7 @@ export function createActivityEnvelope(args: BuildActivityEnvelopeArgs): Activit
   };
 }
 
-export async function publishActivityEnvelope(
-  _ctx: MutationCtx,
-  args: {
+export async function publishActivityEnvelope(args: {
     organizationId: Id<"organizations">;
     action: ActivityAction;
     performedBy: Id<"users">;

--- a/convex/crm/emails.ts
+++ b/convex/crm/emails.ts
@@ -172,7 +172,7 @@ export const _sendSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const sentByUserId = args.sentBy as Id<"users">;
 
-    await publishActivityEnvelope(ctx, {
+    await publishActivityEnvelope({
       organizationId: args.organizationId,
       action: "email_sent",
       performedBy: sentByUserId,

--- a/convex/crm/emails_internal.ts
+++ b/convex/crm/emails_internal.ts
@@ -271,7 +271,7 @@ export const _publishInboundActivity = internalMutation({
     now: v.number(),
   },
   handler: async (ctx, args) => {
-    await publishActivityEnvelope(ctx, {
+    await publishActivityEnvelope({
       organizationId: args.organizationId as any,
       action: "email_received",
       performedBy: args.performedBy as any,

--- a/convex/crm/notes.ts
+++ b/convex/crm/notes.ts
@@ -64,7 +64,7 @@ export const _createSideEffects = internalMutation({
     createdAt: v.number(),
   },
   handler: async (ctx, args) => {
-    await publishActivityEnvelope(ctx, {
+    await publishActivityEnvelope({
       organizationId: args.organizationId,
       action: "note_added",
       performedBy: args.createdBy as Id<"users">,
@@ -144,7 +144,7 @@ export const _updateSideEffects = internalMutation({
     updatedAt: v.number(),
   },
   handler: async (ctx, args) => {
-    await publishActivityEnvelope(ctx, {
+    await publishActivityEnvelope({
       organizationId: args.organizationId,
       action: "updated",
       performedBy: args.updatedBy as Id<"users">,
@@ -240,7 +240,7 @@ export const _removeSideEffects = internalMutation({
     deletedBy: v.string(),
   },
   handler: async (ctx, args) => {
-    await publishActivityEnvelope(ctx, {
+    await publishActivityEnvelope({
       organizationId: args.organizationId,
       action: "deleted",
       performedBy: args.deletedBy as Id<"users">,

--- a/convex/gabinet/appointmentSms.ts
+++ b/convex/gabinet/appointmentSms.ts
@@ -119,7 +119,7 @@ async function logSmsSharedActivities(
     ? `gabinet:sms:${semanticEventId}:${args.action}`
     : `gabinet:sms:${args.organizationId}:${occurredAt}:${args.action}`;
 
-  await publishActivityEnvelope(ctx, {
+  await publishActivityEnvelope({
     organizationId: args.organizationId,
     action: args.action,
     performedBy: args.performedBy,

--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -609,7 +609,7 @@ export const _purchaseTreatmentSideEffects = internalMutation({
     createdAt: v.number(),
   },
   handler: async (ctx, args) => {
-    await publishActivityEnvelope(ctx, {
+    await publishActivityEnvelope({
       organizationId: args.organizationId,
       action: "package_assigned",
       performedBy: args.createdBy as Id<"users">,
@@ -863,7 +863,7 @@ export const _purchaseSideEffects = internalMutation({
       targets.push({ entityType: "gabinetPatient", entityId: args.patientId });
     }
 
-    await publishActivityEnvelope(ctx, {
+    await publishActivityEnvelope({
       organizationId: args.organizationId,
       action: "package_assigned",
       performedBy: args.createdBy as Id<"users">,

--- a/tests/convex/activityEnvelope.test.ts
+++ b/tests/convex/activityEnvelope.test.ts
@@ -53,7 +53,7 @@ describe("activity envelope helper", () => {
       };
     }) => {
       await t.run(async (ctx) => {
-        await publishActivityEnvelope(ctx, {
+        await publishActivityEnvelope({
           organizationId,
           action: "sms_sent",
           performedBy: userId,
@@ -102,7 +102,7 @@ describe("activity envelope helper", () => {
       targets?: ActivityEnvelopeTarget[];
     }) => {
       await t.run(async (ctx) => {
-        await publishActivityEnvelope(ctx, {
+        await publishActivityEnvelope({
           organizationId,
           action: "sms_sent",
           performedBy: userId,
@@ -204,7 +204,7 @@ describe("activity envelope helper", () => {
 
     await expect(
       t.run(async (ctx) => {
-        await publishActivityEnvelope(ctx, {
+        await publishActivityEnvelope({
           organizationId,
           action: "sms_sent",
           performedBy: userId,
@@ -257,7 +257,7 @@ describe("activity envelope helper", () => {
     ];
 
     await t.run(async (ctx) => {
-      await publishActivityEnvelope(ctx, {
+      await publishActivityEnvelope({
         organizationId,
         action: "sms_sent",
         performedBy: userId,
@@ -316,7 +316,7 @@ describe("activity envelope helper", () => {
     ];
 
     await t.run(async (ctx) => {
-      await publishActivityEnvelope(ctx, {
+      await publishActivityEnvelope({
         organizationId,
         action: "sms_sent",
         performedBy: userId,
@@ -385,7 +385,7 @@ describe("activity envelope helper", () => {
     ];
 
     await t.run(async (ctx) => {
-      await publishActivityEnvelope(ctx, {
+      await publishActivityEnvelope({
         organizationId,
         action: "sms_sent",
         performedBy: userId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4908.

Closes #4908

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e85d099f fix(activityEnvelope): remove unused _ctx param from publishActivityEnvelope (closes #4908)

### Files changed

```
 convex/_helpers/activities.ts         |  2 +-
 convex/_helpers/activityEnvelope.ts   |  5 +----
 convex/crm/emails.ts                  |  2 +-
 convex/crm/emails_internal.ts         |  2 +-
 convex/crm/notes.ts                   |  6 +++---
 convex/gabinet/appointmentSms.ts      |  2 +-
 convex/gabinet/packages.ts            |  4 ++--
 tests/convex/activityEnvelope.test.ts | 12 ++++++------
 8 files changed, 16 insertions(+), 19 deletions(-)
```