### PR TITLE
Fix unused `ctx` parameter in convex/crm/emails.ts, convex/crm/emails_internal.t

### DIFF
--- a/convex/crm/emails.ts
+++ b/convex/crm/emails.ts
@@ -169,7 +169,7 @@ export const _sendSideEffects = internalMutation({
     sentBy: v.string(),
     sentAt: v.number(),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     const sentByUserId = args.sentBy as Id<"users">;
 
     await publishActivityEnvelope({

--- a/convex/crm/emails_internal.ts
+++ b/convex/crm/emails_internal.ts
@@ -270,7 +270,7 @@ export const _publishInboundActivity = internalMutation({
     to: v.array(v.string()),
     now: v.number(),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     await publishActivityEnvelope({
       organizationId: args.organizationId as any,
       action: "email_received",

--- a/convex/crm/notes.ts
+++ b/convex/crm/notes.ts
@@ -63,7 +63,7 @@ export const _createSideEffects = internalMutation({
     createdBy: v.string(),
     createdAt: v.number(),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     await publishActivityEnvelope({
       organizationId: args.organizationId,
       action: "note_added",
@@ -143,7 +143,7 @@ export const _updateSideEffects = internalMutation({
     updatedBy: v.string(),
     updatedAt: v.number(),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     await publishActivityEnvelope({
       organizationId: args.organizationId,
       action: "updated",
@@ -239,7 +239,7 @@ export const _removeSideEffects = internalMutation({
     entityId: v.string(),
     deletedBy: v.string(),
   },
-  handler: async (ctx, args) => {
+  handler: async (_ctx, args) => {
     await publishActivityEnvelope({
       organizationId: args.organizationId,
       action: "deleted",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5002.

Closes #5002

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- fdfa19e4 fix(ts): prefix unused ctx params with _ in crm emails and notes (closes #5002)

### Files changed

```
 convex/crm/emails.ts          | 2 +-
 convex/crm/emails_internal.ts | 2 +-
 convex/crm/notes.ts           | 6 +++---
 3 files changed, 5 insertions(+), 5 deletions(-)
```