### PR TITLE
Migrate `emailSendLog.record` `triggeredBy

### DIFF
--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -538,7 +538,7 @@ export const _sendAutomationEmail = internalAction({
         relatedEntityType: args.appointmentId ? "gabinetAppointment" : undefined,
         relatedEntityId: args.appointmentId,
         idempotencyKey: args.idempotencyKey,
-        triggeredBy: args.sentBy as Id<"users"> | undefined,
+        triggeredBy: args.sentBy,
       });
       await ctx.runMutation(internal.automation._recordAutomationEmailResult, {
         organizationId: args.organizationId,
@@ -572,7 +572,7 @@ export const _sendAutomationEmail = internalAction({
       relatedEntityType: args.appointmentId ? "gabinetAppointment" : undefined,
       relatedEntityId: args.appointmentId,
       idempotencyKey: args.idempotencyKey,
-      triggeredBy: args.sentBy as Id<"users"> | undefined,
+      triggeredBy: args.sentBy,
     };
     try {
       const response = await fetch("https://api.resend.com/emails", {

--- a/convex/crm/emails.ts
+++ b/convex/crm/emails.ts
@@ -103,7 +103,7 @@ export const send = action({
         ctx,
         organizationId: args.organizationId,
         source: "manual_compose",
-        triggeredBy: authResult.userId as Id<"users">,
+        triggeredBy: authResult.userId,
         relatedEntityType: args.contactId
           ? "contact"
           : args.companyId

--- a/convex/email/index.ts
+++ b/convex/email/index.ts
@@ -36,7 +36,7 @@ export type EmailSendLogContext = {
   relatedEntityType?: string;
   relatedEntityId?: string;
   idempotencyKey?: string;
-  triggeredBy?: Id<"users">;
+  triggeredBy?: string;
   recipientName?: string;
 };
 

--- a/convex/emailEventTrigger.ts
+++ b/convex/emailEventTrigger.ts
@@ -45,7 +45,7 @@ export const triggerEmailEvent = internalAction({
     relatedEntityType: v.optional(v.string()),
     relatedEntityId: v.optional(v.string()),
     idempotencyKey: v.optional(v.string()),
-    triggeredBy: v.optional(v.id("users")),
+    triggeredBy: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const db = createSupabaseDb();
@@ -72,7 +72,7 @@ export const triggerEmailEvent = internalAction({
       idempotencyKey: args.idempotencyKey ?? null,
       recipientEmail: args.recipientEmail,
       recipientName: args.recipientName ?? null,
-      triggeredBy: args.triggeredBy ? String(args.triggeredBy) : null,
+      triggeredBy: args.triggeredBy ?? null,
       createdAt: Date.now(),
     });
 

--- a/convex/emailSendLog.ts
+++ b/convex/emailSendLog.ts
@@ -48,7 +48,7 @@ export const record = internalMutation({
     relatedEntityType: v.optional(v.string()),
     relatedEntityId: v.optional(v.string()),
     idempotencyKey: v.optional(v.string()),
-    triggeredBy: v.optional(v.id("users")),
+    triggeredBy: v.optional(v.string()),
     sentAt: v.optional(v.number()),
   },
   handler: async (ctx, args) => {

--- a/convex/schema/platform.ts
+++ b/convex/schema/platform.ts
@@ -297,7 +297,7 @@ export function createPlatformTables({
     relatedEntityType: v.optional(v.string()),
     relatedEntityId: v.optional(v.string()),
     idempotencyKey: v.optional(v.string()),
-    triggeredBy: v.optional(v.id("users")),
+    triggeredBy: v.optional(v.string()),
     sentAt: v.number(),
   })
     .index("by_org_sentAt", ["organizationId", "sentAt"])


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4945.

Closes #4945

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 45f33bff fix(emailSendLog): migrate triggeredBy from v.id("users") to v.string() (closes #4945)

### Files changed

```
 convex/automation.ts        | 4 ++--
 convex/crm/emails.ts        | 2 +-
 convex/email/index.ts       | 2 +-
 convex/emailEventTrigger.ts | 4 ++--
 convex/emailSendLog.ts      | 2 +-
 convex/schema/platform.ts   | 2 +-
 6 files changed, 8 insertions(+), 8 deletions(-)
```