### PR TITLE
Migrate `logActivity` / `publishActivityEnvelope` `performedBy

### DIFF
--- a/convex/_helpers/activities.ts
+++ b/convex/_helpers/activities.ts
@@ -12,7 +12,7 @@ export async function logActivity(
     action: ActivityAction;
     description: string;
     metadata?: any;
-    performedBy: Id<"users">;
+    performedBy: string;
     actorLabel?: string;
   }
 ) {

--- a/convex/_helpers/activityEnvelope.ts
+++ b/convex/_helpers/activityEnvelope.ts
@@ -9,7 +9,7 @@ export type ActivityEnvelopeTarget = {
 
 export type ActivityEnvelopeActor = {
   type: string;
-  userId?: Id<"users">;
+  userId?: string;
   label?: string;
 };
 
@@ -122,7 +122,7 @@ export function createActivityEnvelope(args: BuildActivityEnvelopeArgs): Activit
 export async function publishActivityEnvelope(args: {
     organizationId: Id<"organizations">;
     action: ActivityAction;
-    performedBy: Id<"users">;
+    performedBy: string;
     module: string;
     summary: string;
     occurredAt: number;
@@ -154,7 +154,7 @@ export async function publishActivityEnvelope(args: {
       action: args.action,
       description: envelope.summary,
       metadata,
-      performedBy: args.performedBy as string,
+      performedBy: args.performedBy,
       createdAt: args.occurredAt,
     });
   }

--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -766,7 +766,7 @@ export const _recordAutomationEmailResult = internalMutation({
         entityId: emailId,
         action: "email_sent",
         description: `Sent email \"${args.subject}\" to ${args.recipient}`,
-        performedBy: args.sentBy as Id<"users">,
+        performedBy: args.sentBy,
       });
     }
 

--- a/convex/crm/emails.ts
+++ b/convex/crm/emails.ts
@@ -4,7 +4,6 @@ import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
 import { publishActivityEnvelope } from "../_helpers/activityEnvelope";
 import { sendEmail } from "@cvx/email";
-import { Id } from "../_generated/dataModel";
 import type { EmailRow } from "../_helpers/supabaseRows";
 
 // Dual-write refs removed — Supabase is now primary for email writes
@@ -170,18 +169,16 @@ export const _sendSideEffects = internalMutation({
     sentAt: v.number(),
   },
   handler: async (_ctx, args) => {
-    const sentByUserId = args.sentBy as Id<"users">;
-
     await publishActivityEnvelope({
       organizationId: args.organizationId,
       action: "email_sent",
-      performedBy: sentByUserId,
+      performedBy: args.sentBy,
       module: "crm",
       summary: `Sent email "${args.subject}" to ${args.to.join(", ")}`,
       occurredAt: args.sentAt,
       actor: {
         type: "user",
-        userId: sentByUserId,
+        userId: args.sentBy,
       },
       payload: {
         emailId: args.emailId,

--- a/convex/relationships.ts
+++ b/convex/relationships.ts
@@ -3,7 +3,6 @@ import { internal } from "./_generated/api";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 import { v } from "convex/values";
 import { logActivity } from "./_helpers/activities";
-import { Id } from "./_generated/dataModel";
 
 // Dual-write refs removed — Supabase is now primary for relationship writes
 
@@ -179,7 +178,7 @@ export const _createSideEffects = internalMutation({
       action: "relationship_added",
       description: `Added relationship to ${args.targetType} entity`,
       metadata: { targetType: args.targetType, targetId: args.targetId },
-      performedBy: args.createdBy as Id<"users">,
+      performedBy: args.createdBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -242,7 +241,7 @@ export const _removeSideEffects = internalMutation({
       action: "relationship_removed",
       description: `Removed relationship to ${args.targetType} entity`,
       metadata: { targetType: args.targetType, targetId: args.targetId },
-      performedBy: args.deletedBy as Id<"users">,
+      performedBy: args.deletedBy,
       actorLabel: args.actorLabel,
     });
   },

--- a/convex/scheduledActivities.ts
+++ b/convex/scheduledActivities.ts
@@ -35,7 +35,7 @@ export const _createSideEffects = internalMutation({
       entityId: args.activityId as any,
       action: "created",
       description: `Created ${args.activityType} "${args.title}"`,
-      performedBy: args.userId as any,
+      performedBy: args.userId,
       actorLabel: args.actorLabel,
     });
 
@@ -78,7 +78,7 @@ export const _updateSideEffects = internalMutation({
       entityId: args.activityId as any,
       action: "updated",
       description: args.description ?? `Updated ${args.activityType} "${args.title}"`,
-      performedBy: args.userId as any,
+      performedBy: args.userId,
       actorLabel: args.actorLabel,
     });
 
@@ -128,7 +128,7 @@ export const _deleteSideEffects = internalMutation({
       entityId: args.activityId as any,
       action: "deleted",
       description: `Deleted ${args.activityType} "${args.title}"`,
-      performedBy: args.userId as any,
+      performedBy: args.userId,
       actorLabel: args.actorLabel,
     });
   },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4946.

Closes #4946

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0ca6a1fc fix(activityEnvelope): relax performedBy from Id<"users"> to string (closes #4946)

### Files changed

```
 convex/_helpers/activities.ts       | 2 +-
 convex/_helpers/activityEnvelope.ts | 6 +++---
 convex/automation.ts                | 2 +-
 convex/crm/emails.ts                | 7 ++-----
 convex/relationships.ts             | 5 ++---
 convex/scheduledActivities.ts       | 6 +++---
 6 files changed, 12 insertions(+), 16 deletions(-)
```