### PR TITLE
Migrate `organizationId

### DIFF
--- a/convex/_helpers/activities.ts
+++ b/convex/_helpers/activities.ts
@@ -1,12 +1,11 @@
 import { MutationCtx } from "../_generated/server";
-import { Id } from "../_generated/dataModel";
 import { ActivityAction } from "@cvx/schema";
 import { publishActivityEnvelope } from "./activityEnvelope";
 
 export async function logActivity(
   ctx: MutationCtx,
   args: {
-    organizationId: Id<"organizations">;
+    organizationId: string;
     entityType: string;
     entityId: string;
     action: ActivityAction;

--- a/convex/_helpers/activityEnvelope.ts
+++ b/convex/_helpers/activityEnvelope.ts
@@ -1,4 +1,3 @@
-import type { Id } from "../_generated/dataModel";
 import type { ActivityAction } from "@cvx/schema";
 import { createSupabaseDb } from "./supabaseDb";
 
@@ -120,7 +119,7 @@ export function createActivityEnvelope(args: BuildActivityEnvelopeArgs): Activit
 }
 
 export async function publishActivityEnvelope(args: {
-    organizationId: Id<"organizations">;
+    organizationId: string;
     action: ActivityAction;
     performedBy: string;
     module: string;
@@ -148,7 +147,7 @@ export async function publishActivityEnvelope(args: {
     };
 
     await db.insert("activities", {
-      organizationId: args.organizationId as string,
+      organizationId: args.organizationId,
       entityType: target.entityType,
       entityId: target.entityId,
       action: args.action,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5007.

Closes #5007

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 419fe289 fix(activities): relax organizationId from Id<"organizations"> to string (closes #5007)

### Files changed

```
 convex/_helpers/activities.ts       | 3 +--
 convex/_helpers/activityEnvelope.ts | 5 ++---
 2 files changed, 3 insertions(+), 5 deletions(-)
```