### PR TITLE
Migrate `_createNotification` internalMutation args to `v.string()`

### DIFF
--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -98,8 +98,8 @@ export const _markAllReadInternal = internalMutation({
 
 export const _createNotification = internalMutation({
   args: {
-    organizationId: v.id("organizations"),
-    userId: v.id("users"),
+    organizationId: v.string(),
+    userId: v.string(),
     type: v.string(),
     title: v.string(),
     message: v.string(),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5014.

Closes #5014

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 03d99fbc fix(notifications): relax _createNotification args from v.id() to v.string() (closes #5014)

### Files changed

```
 convex/notifications.ts | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```