### PR TITLE
Relax `organizationId

### DIFF
--- a/convex/emailEvents.ts
+++ b/convex/emailEvents.ts
@@ -20,7 +20,7 @@ const moduleValidator = v.union(
 
 export const registerEventType = action({
   args: {
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     eventType: v.string(),
     module: moduleValidator,
     displayName: v.string(),
@@ -73,7 +73,7 @@ export const registerEventType = action({
  */
 export const emitEvent = action({
   args: {
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     eventType: v.string(),
     payload: v.optional(v.string()), // JSON string
     recipientEmail: v.string(),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5017.

Closes #5017

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- def14181 fix(emailEvents): relax organizationId from v.id("organizations") to v.string() (closes #5017)

### Files changed

```
 convex/emailEvents.ts | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```