### PR TITLE
Audit v.id() for other entity tables

### DIFF
--- a/convex/_helpers/authAction.ts
+++ b/convex/_helpers/authAction.ts
@@ -31,7 +31,7 @@ export const _getGabinetPermissionData = internalQuery({
   args: {
     organizationId: v.string(),
     userId: v.id("users"),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const gabinetMembership = await ctx.db
@@ -141,7 +141,7 @@ export const checkPermission = internalAction({
     organizationId: v.string(),
     feature: v.string(),
     action: v.string(),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<PermissionResult> => {
     const userId = await auth.getUserId(ctx);

--- a/convex/categoryDefinitions.ts
+++ b/convex/categoryDefinitions.ts
@@ -248,9 +248,9 @@ export const reorder = action({
 export const cleanupCategoryReferences = internalMutation({
   args: {
     organizationId: v.string(),
-    categoryId: v.id("categoryDefinitions"),
+    categoryId: v.string(),
     entityType: v.string(),
-    childIds: v.array(v.id("categoryDefinitions")),
+    childIds: v.array(v.string()),
   },
   handler: async (ctx, args) => {
     const idsToClean = [args.categoryId, ...args.childIds];

--- a/convex/crm/leads.ts
+++ b/convex/crm/leads.ts
@@ -557,7 +557,7 @@ export const _removeSideEffects = internalMutation({
 export const getByPipeline = action({
   args: {
     organizationId: v.string(),
-    pipelineId: v.id("pipelines"),
+    pipelineId: v.string(),
   },
   handler: async (ctx, args): Promise<Array<Record<string, unknown> & { leads: Array<Record<string, unknown>> }>> => {
     const authResult = await ctx.runAction(
@@ -959,8 +959,8 @@ export const gdprExport = action({
 export const _moveToStageSideEffects = internalMutation({
   args: {
     organizationId: v.string(),
-    leadId: v.id("leads"),
-    pipelineStageId: v.id("pipelineStages"),
+    leadId: v.string(),
+    pipelineStageId: v.string(),
     userId: v.id("users"),
     leadTitle: v.string(),
     stageName: v.string(),

--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -161,7 +161,7 @@ export const getBySigningToken = action({
 export const listByTemplate = action({
   args: {
     organizationId: v.string(),
-    templateId: v.id("formTemplates"),
+    templateId: v.string(),
   },
   handler: async (ctx, args): Promise<FormDocumentRow[]> => {
     await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {

--- a/convex/emailTemplates.ts
+++ b/convex/emailTemplates.ts
@@ -98,9 +98,9 @@ export const renderTemplate = query({
     organizationId: v.string(),
     templateId: v.string(),
     // CRM entities
-    contactId: v.optional(v.id("contacts")),
-    companyId: v.optional(v.id("companies")),
-    leadId: v.optional(v.id("leads")),
+    contactId: v.optional(v.string()),
+    companyId: v.optional(v.string()),
+    leadId: v.optional(v.string()),
     // Gabinet entities (Supabase-primary — strings, not Convex Ids)
     patientId: v.optional(v.string()),
     employeeId: v.optional(v.string()),

--- a/convex/gabinet/appointmentSms.ts
+++ b/convex/gabinet/appointmentSms.ts
@@ -279,7 +279,7 @@ export const queueConfirmationRequest = internalMutation({
   args: {
     organizationId: v.string(),
     appointmentId: v.string(),
-    reminderId: v.optional(v.id("appointmentReminders")),
+    reminderId: v.optional(v.string()),
     trigger: v.optional(v.union(v.literal("reminder"), v.literal("manual"), v.literal("booking"))),
   },
   handler: async (ctx, args) => {

--- a/convex/gabinet/nudges.ts
+++ b/convex/gabinet/nudges.ts
@@ -21,7 +21,7 @@ async function verify(ctx: any, organizationId: string) {
 
 // --- Appointment nudges ---
 export const getAppointmentNudges = action({
-  args: { organizationId: v.string(), locationId: v.optional(v.id("gabinetLocations")) },
+  args: { organizationId: v.string(), locationId: v.optional(v.string()) },
   handler: async (ctx, args): Promise<NudgeData[]> => {
     await verify(ctx, args.organizationId);
     const db = createSupabaseDb();
@@ -128,7 +128,7 @@ export const getPackageNudges = action({
 
 // --- Patient nudges ---
 export const getPatientNudges = action({
-  args: { organizationId: v.string(), locationId: v.optional(v.id("gabinetLocations")) },
+  args: { organizationId: v.string(), locationId: v.optional(v.string()) },
   handler: async (ctx, args): Promise<NudgeData[]> => {
     await verify(ctx, args.organizationId);
     const db = createSupabaseDb();
@@ -235,7 +235,7 @@ export const getTreatmentNudges = action({
 
 // --- Get all Gabinet nudges ---
 export const getAll = action({
-  args: { organizationId: v.string(), locationId: v.optional(v.id("gabinetLocations")) },
+  args: { organizationId: v.string(), locationId: v.optional(v.string()) },
   handler: async (ctx, args): Promise<NudgeData[]> => {
     await verify(ctx, args.organizationId);
     const nudges: NudgeData[] = [];

--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -101,7 +101,7 @@ export const adjustStock = action({
   args: {
     organizationId: v.string(),
     productId: v.string(),
-    locationId: v.optional(v.union(v.id("gabinetLocations"), v.null())),
+    locationId: v.optional(v.union(v.string(), v.null())),
     delta: v.optional(v.number()),
     setTo: v.optional(v.number()),
     reason: v.optional(REASON_VALIDATOR),

--- a/convex/permissions.ts
+++ b/convex/permissions.ts
@@ -9,7 +9,7 @@ import { logAudit } from "./auditLog";
 export const getMyPermissions = query({
   args: {
     organizationId: v.string(),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     return await getEffectivePermissions(ctx, args.organizationId, args.locationId);

--- a/convex/warehouseDeliveries.ts
+++ b/convex/warehouseDeliveries.ts
@@ -83,7 +83,7 @@ export const listDeliveries = action({
   args: {
     organizationId: v.string(),
     status: v.optional(v.union(v.literal("draft"), v.literal("posted"))),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<DeliveryRow[]> => {
@@ -163,7 +163,7 @@ export const createDelivery = action({
     supplierName: v.optional(v.string()),
     invoiceNumber: v.optional(v.string()),
     deliveryDate: v.optional(v.string()),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
     notes: v.optional(v.string()),
     items: v.array(v.object({
       productId: v.string(),
@@ -246,7 +246,7 @@ export const updateDelivery = action({
     supplierName: v.optional(v.string()),
     invoiceNumber: v.optional(v.string()),
     deliveryDate: v.optional(v.string()),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
     notes: v.optional(v.string()),
     items: v.optional(v.array(v.object({
       productId: v.string(),
@@ -404,7 +404,7 @@ export const createDeliveryFromInvoice = action({
     supplierName: v.optional(v.string()),
     invoiceNumber: v.optional(v.string()),
     deliveryDate: v.optional(v.string()),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<{ deliveryId: string }> => {
     const auth = await ctx.runAction(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5026.

Closes #5026

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0b9c97ad fix(validators): relax v.id() to v.string() for Supabase-stored entity args (closes #5026)

### Files changed

```
 convex/_helpers/authAction.ts    | 4 ++--
 convex/categoryDefinitions.ts    | 4 ++--
 convex/crm/leads.ts              | 6 +++---
 convex/documents/documents.ts    | 2 +-
 convex/emailTemplates.ts         | 6 +++---
 convex/gabinet/appointmentSms.ts | 2 +-
 convex/gabinet/nudges.ts         | 6 +++---
 convex/inventory.ts              | 2 +-
 convex/permissions.ts            | 2 +-
 convex/warehouseDeliveries.ts    | 8 ++++----
 10 files changed, 21 insertions(+), 21 deletions(-)
```