### PR TITLE
fix(schema): relax organizationId from v.id(organizations) to v.string() (closes #5027)

### DIFF
--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -128,11 +128,9 @@ export async function createNotificationDirect(
   }
 ) {
   // Notifications live in Convex for real-time push (live queries on the bell).
-  // Cast as any: callers post-Supabase-migration pass string IDs; Convex
-  // accepts them at runtime since the values are still valid ID strings.
   await ctx.db.insert("notifications", {
     ...data,
     isRead: false,
     createdAt: Date.now(),
-  } as any);
+  });
 }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -563,7 +563,7 @@ const automationTables = createAutomationTables({
 
 const tagAndCategoryTables = {
   tagDefinitions: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     color: v.string(),
     sortOrder: v.number(),
@@ -575,7 +575,7 @@ const tagAndCategoryTables = {
     .index("by_orgAndName", ["organizationId", "name"]),
 
   categoryDefinitions: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     entityType: entityTypeValidator,
     name: v.string(),
     parentId: v.optional(v.id("categoryDefinitions")),
@@ -613,7 +613,7 @@ const signingStubTables = {
   signingLinkStubs: defineTable({
     stubId: v.string(),
     token: v.string(),
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     expiresAt: v.number(),
     usedAt: v.optional(v.number()),
     destination: v.optional(v.string()),

--- a/convex/schema/automation.ts
+++ b/convex/schema/automation.ts
@@ -18,7 +18,7 @@ export function createAutomationTables({
 }: AutomationSchemaDeps) {
   return {
   automationRules: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     description: v.optional(v.string()),
     module: automationModuleValidator,

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -50,7 +50,7 @@ export function createCrmTables({
 
   teamMemberships: defineTable({
     userId: v.id("users"),
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     role: orgRoleValidator,
     invitedBy: v.optional(v.id("users")),
     joinedAt: v.number(),
@@ -60,7 +60,7 @@ export function createCrmTables({
     .index("by_orgAndUser", ["organizationId", "userId"]),
 
   contacts: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     firstName: v.string(),
     lastName: v.optional(v.string()),
     email: v.optional(v.string()),
@@ -80,7 +80,7 @@ export function createCrmTables({
     .index("by_orgAndEmail", ["organizationId", "email"]),
 
   companies: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     domain: v.optional(v.string()),
     industry: v.optional(v.string()),
@@ -108,7 +108,7 @@ export function createCrmTables({
     .index("by_orgAndDomain", ["organizationId", "domain"]),
 
   leads: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     title: v.string(),
     value: v.optional(v.number()),
     currency: v.optional(v.string()),
@@ -138,7 +138,7 @@ export function createCrmTables({
     .index("by_companyId", ["companyId"]),
 
   documents: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     description: v.optional(v.string()),
     fileId: v.optional(v.string()),
@@ -162,7 +162,7 @@ export function createCrmTables({
     .index("by_orgAndStatus", ["organizationId", "status"]),
 
   pipelines: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     description: v.optional(v.string()),
     type: v.optional(v.string()),
@@ -174,7 +174,7 @@ export function createCrmTables({
 
   pipelineStages: defineTable({
     pipelineId: v.id("pipelines"),
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     color: v.optional(v.string()),
     order: v.number(),
@@ -187,7 +187,7 @@ export function createCrmTables({
     .index("by_org", ["organizationId"]),
 
   pipelineStageActions: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     stageId: v.id("pipelineStages"),
     actionType: v.literal("create_activity"),
     config: v.object({
@@ -204,7 +204,7 @@ export function createCrmTables({
     .index("by_org", ["organizationId"]),
 
   leadStageHistory: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     leadId: v.id("leads"),
     stageId: v.id("pipelineStages"),
     enteredAt: v.number(),
@@ -214,7 +214,7 @@ export function createCrmTables({
     .index("by_org_stage", ["organizationId", "stageId"]),
 
   customFieldDefinitions: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     entityType: entityTypeValidator,
     name: v.string(),
     fieldKey: v.string(),
@@ -237,7 +237,7 @@ export function createCrmTables({
     ]),
 
   customFieldValues: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     fieldDefinitionId: v.id("customFieldDefinitions"),
     entityType: entityTypeValidator,
     entityId: v.string(),
@@ -255,7 +255,7 @@ export function createCrmTables({
     ]),
 
   activityTypeDefinitions: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     key: v.string(),
     name: v.string(),
     icon: v.string(),
@@ -269,7 +269,7 @@ export function createCrmTables({
     .index("by_orgAndKey", ["organizationId", "key"]),
 
   objectRelationships: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     sourceType: v.string(),
     sourceId: v.string(),
     targetType: v.string(),
@@ -289,7 +289,7 @@ export function createCrmTables({
     ]),
 
   activities: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     entityType: v.string(),
     entityId: v.string(),
     action: activityActionValidator,
@@ -305,7 +305,7 @@ export function createCrmTables({
   // --- Products ---
 
   products: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     sku: v.string(),
     unitPrice: v.number(),
@@ -349,7 +349,7 @@ export function createCrmTables({
   // (product, location). locationId is optional so CRM-only orgs (no
   // gabinetLocations) can keep a single null-location row per product.
   productStockLevels: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     productId: v.id("products"),
     locationId: v.optional(v.id("gabinetLocations")),
     quantity: v.number(),
@@ -366,7 +366,7 @@ export function createCrmTables({
   // the per-(product, location) running balance after this movement so we can
   // render history without recomputing.
   productStockMovements: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     productId: v.id("products"),
     locationId: v.optional(v.id("gabinetLocations")),
     delta: v.number(),
@@ -406,7 +406,7 @@ export function createCrmTables({
   // are still editable; 'posted' means stock movements have been created and
   // the record is read-only.
   warehouseDeliveries: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     supplierName: v.optional(v.string()),
     invoiceNumber: v.optional(v.string()),
     deliveryDate: v.optional(v.string()),
@@ -457,7 +457,7 @@ export function createCrmTables({
   // in when the parent delivery is posted and links this line back to the
   // product_stock_movements audit trail.
   warehouseDeliveryItems: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     deliveryId: v.id("warehouseDeliveries"),
     productId: v.id("products"),
     quantity: v.number(),
@@ -481,7 +481,7 @@ export function createCrmTables({
   // exact-name matches.  One mapping per (org, invoiceName) — enforced by the
   // unique index in the Supabase migration.
   deliveryNameMappings: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     invoiceName: v.string(),
     productId: v.id("products"),
     createdAt: v.number(),
@@ -490,7 +490,7 @@ export function createCrmTables({
     .index("by_org_and_name", ["organizationId", "invoiceName"]),
 
   dealProducts: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     dealId: v.id("leads"),
     productId: v.id("products"),
     quantity: v.number(),
@@ -505,7 +505,7 @@ export function createCrmTables({
   // --- Calls ---
 
   calls: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     outcome: callOutcomeValidator,
     callDate: v.number(),
     note: v.optional(v.string()),
@@ -523,7 +523,7 @@ export function createCrmTables({
   // --- Scheduled Activities ---
 
   scheduledActivities: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     title: v.string(),
     activityType: activityTypeValidator,
     dueDate: v.number(),
@@ -575,7 +575,7 @@ export function createCrmTables({
   // --- Payments ---
 
   payments: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     patientId: v.optional(v.id("gabinetPatients")),
     appointmentId: v.optional(v.id("gabinetAppointments")),
     packageUsageId: v.optional(v.id("gabinetPackageUsage")),
@@ -647,7 +647,7 @@ export function createCrmTables({
   // --- Saved Views ---
 
   savedViews: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     entityType: v.string(),
     name: v.string(),
     filters: v.any(),
@@ -665,7 +665,7 @@ export function createCrmTables({
   // --- Lost Reasons ---
 
   lostReasons: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     label: v.string(),
     order: v.number(),
     isActive: v.boolean(),
@@ -677,7 +677,7 @@ export function createCrmTables({
   // --- Org Settings ---
 
   orgSettings: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     allowCustomLostReason: v.boolean(),
     lostReasonRequired: v.boolean(),
     defaultCurrency: v.optional(v.string()),
@@ -701,7 +701,7 @@ export function createCrmTables({
   // --- RBAC: Permission Overrides ---
 
   orgPermissions: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     role: v.union(v.literal("member"), v.literal("viewer")),
     // Record<Feature, Record<Action, Scope>> stored as JSON
     // Feature: leads, contacts, companies, documents, activities, calls, email, products, pipelines,
@@ -721,7 +721,7 @@ export function createCrmTables({
   // / therapist / receptionist / admin / other — isSystem=true) seeded on
   // first use; tenants can add custom roles on top (isSystem=false).
   gabinetRoleDefinitions: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     key: v.string(), // stable identifier used in gabinetEmployees.role
     labelPl: v.string(),
     labelEn: v.string(),
@@ -742,7 +742,7 @@ export function createCrmTables({
   // gabinetRoleScope). An absent row means use the baked-in default for the
   // role key (or "none" for custom roles, until the admin fills it in).
   gabinetRolePermissions: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     gabinetRole: v.string(), // FK to gabinetRoleDefinitions.key (per org)
     permissions: v.any(), // FeaturePermissions JSON
     updatedBy: v.id("users"),
@@ -758,7 +758,7 @@ export function createCrmTables({
   // financial reports) and restriction (e.g. doctor cannot view payments).
   // Missing entries inherit from the role. Absent row → role-level applies.
   gabinetMembershipPermissions: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     userId: v.id("users"),
     permissions: v.any(), // FeaturePermissions JSON
     updatedBy: v.id("users"),
@@ -773,7 +773,7 @@ export function createCrmTables({
   // resolve the gabinet-role for the current user. Maintained alongside the
   // Supabase row writes in convex/gabinet/employees.ts.
   gabinetMemberships: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     userId: v.id("users"),
     gabinetRole: gabinetEmployeeRoleValidator,
     isActive: v.boolean(),
@@ -791,7 +791,7 @@ export function createCrmTables({
   // override (global gabinetMemberships role wins). Maintained alongside the
   // Supabase row writes in convex/gabinet/employees.ts.
   gabinetLocationMemberships: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     userId: v.id("users"),
     locationId: v.id("gabinetLocations"),
     role: v.optional(gabinetEmployeeRoleValidator),
@@ -804,7 +804,7 @@ export function createCrmTables({
   // --- RBAC: Resource Invites (External Guests) ---
 
   resourceInvites: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     email: v.string(),
     userId: v.optional(v.id("users")),
     resourceType: v.string(),
@@ -833,7 +833,7 @@ export function createCrmTables({
   // --- Notifications ---
 
   notifications: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     userId: v.id("users"),
     type: v.string(),
     title: v.string(),
@@ -855,7 +855,7 @@ export function createCrmTables({
   // --- Audit Log ---
 
   auditLog: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     userId: v.id("users"),
     action: v.string(),
     entityType: v.optional(v.string()),
@@ -871,7 +871,7 @@ export function createCrmTables({
   // --- Sources ---
 
   sources: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     order: v.number(),
     isActive: v.boolean(),
@@ -883,7 +883,7 @@ export function createCrmTables({
   // --- Emails ---
 
   emails: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     threadId: v.string(),
     messageId: v.string(),
     inReplyTo: v.optional(v.string()),
@@ -936,7 +936,7 @@ export function createCrmTables({
     .index("by_org_provider", ["organizationId", "mailProviderId", "sentAt"]),
 
   emailAccounts: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     fromName: v.string(),
     fromEmail: v.string(),
     isDefault: v.boolean(),
@@ -947,7 +947,7 @@ export function createCrmTables({
   // --- Mail Providers ---
 
   mailProviders: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     providerType: v.union(
       v.literal("google"),
@@ -1005,7 +1005,7 @@ export function createCrmTables({
   // --- Email Templates ---
 
   emailTemplates: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     subject: v.string(),
     body: v.string(), // kept for backward compat
@@ -1038,7 +1038,7 @@ export function createCrmTables({
   // --- Email Layouts (global wrapper per org) ---
 
   emailLayouts: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     headerBlocks: v.string(),
     footerBlocks: v.string(),
     backgroundColor: v.string(),
@@ -1054,7 +1054,7 @@ export function createCrmTables({
   // --- Invitations ---
 
   invitations: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     email: v.string(),
     role: orgRoleValidator,
     token: v.string(),
@@ -1080,7 +1080,7 @@ export function createCrmTables({
   // --- OAuth Connections ---
 
   oauthConnections: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     provider: v.literal("google"),
     providerAccountId: v.string(),
     userId: v.optional(v.id("users")),
@@ -1103,7 +1103,7 @@ export function createCrmTables({
   // --- Notes ---
 
   notes: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     entityType: v.string(),
     entityId: v.string(),
     content: v.string(),

--- a/convex/schema/documents.ts
+++ b/convex/schema/documents.ts
@@ -55,7 +55,7 @@ export const componentCategoryValidator = v.union(
 
 export const documentTables = {
   documentComponents: defineTable({
-    organizationId: v.optional(v.id("organizations")),
+    organizationId: v.optional(v.string()),
     scope: componentScopeValidator,
     createdBy: v.id("users"),
     name: v.string(),
@@ -74,7 +74,7 @@ export const documentTables = {
     .index("by_orgAndCategory", ["organizationId", "category"]),
 
   formTemplates: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     description: v.optional(v.string()),
     category: formCategoryValidator,
@@ -116,7 +116,7 @@ export const documentTables = {
     .index("by_orgAndCategory", ["organizationId", "category"]),
 
   formDocuments: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     templateId: v.id("formTemplates"),
     title: v.string(),
     // SurveyJS response data — all filled field values as JSON string
@@ -171,7 +171,7 @@ export const documentTables = {
   // request for kinds that have no natural host row (e.g. a template that does
   // not exist yet). Deliveries keep their own inline analysis fields.
   documentAnalysisJobs: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     kind: v.string(), // registry id: "form_template" | ...
     pages: v.array(v.object({
       storageId: v.string(),

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -38,7 +38,7 @@ export function createGabinetTables({
   // --- Gabinet (Medical Office) ---
 
   gabinetPatients: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     contactId: v.optional(v.id("contacts")),
     firstName: v.string(),
     lastName: v.string(),
@@ -80,7 +80,7 @@ export function createGabinetTables({
     .index("by_orgAndSmsConsent", ["organizationId", "smsConsent"]),
 
   gabinetTreatments: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     description: v.optional(v.string()),
     // Legacy free-text category. Superseded by `categoryId` (see below) which
@@ -153,7 +153,7 @@ export function createGabinetTables({
     .index("by_orgAndActive", ["organizationId", "isActive"]),
 
   gabinetTreatmentVariants: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     treatmentId: v.id("gabinetTreatments"),
     name: v.string(),
     price: v.optional(v.number()),
@@ -173,7 +173,7 @@ export function createGabinetTables({
   // product_section mirrors products.productSection: "treatment" | "disposable".
   // unit is a snapshot of products.stockUnit at link time.
   gabinetTreatmentProducts: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     treatmentId: v.id("gabinetTreatments"),
     productId: v.id("products"),
     productSection: v.string(), // "treatment" | "disposable"
@@ -189,7 +189,7 @@ export function createGabinetTables({
   // --- Gabinet: Employee Scheduling (Phase 2) ---
 
   gabinetWorkingHours: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     dayOfWeek: v.number(), // 0-6
     startTime: v.string(), // "HH:MM"
     endTime: v.string(),
@@ -206,7 +206,7 @@ export function createGabinetTables({
     .index("by_orgAndLocation", ["organizationId", "locationId"]),
 
   gabinetEmployeeSchedules: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     userId: v.id("users"),
     dayOfWeek: v.number(),
     startTime: v.string(),
@@ -226,7 +226,7 @@ export function createGabinetTables({
     .index("by_orgUserAndDay", ["organizationId", "userId", "dayOfWeek"]),
 
   gabinetLeaves: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     userId: v.id("users"),
     type: gabinetLeaveTypeValidator,
     leaveTypeId: v.optional(v.id("gabinetLeaveTypes")),
@@ -248,7 +248,7 @@ export function createGabinetTables({
     .index("by_orgAndDate", ["organizationId", "startDate"]),
 
   gabinetOvertime: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     userId: v.id("users"),
     date: v.string(),
     hours: v.number(),
@@ -266,7 +266,7 @@ export function createGabinetTables({
   // --- Gabinet: Employees (HR) ---
 
   gabinetEmployees: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     // Application policy: new employees must always have a linked user account.
     // The DB column is nullable (migration 00042) only to preserve historical rows;
     // the `create` action and CSV import both reject writes with userId = null.
@@ -365,7 +365,7 @@ export function createGabinetTables({
   // role: optional override — when set, the employee acts in this role at this
   // location instead of their default role from gabinetEmployees.role.
   gabinetEmployeeLocations: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     employeeId: v.id("gabinetEmployees"),
     locationId: v.id("gabinetLocations"),
     isPrimary: v.boolean(),
@@ -380,7 +380,7 @@ export function createGabinetTables({
   // --- Gabinet: Leave Types & Balances (HR) ---
 
   gabinetLeaveTypes: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     color: v.optional(v.string()),
     isPaid: v.boolean(),
@@ -395,7 +395,7 @@ export function createGabinetTables({
     .index("by_orgAndActive", ["organizationId", "isActive"]),
 
   gabinetPaymentMethods: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     key: v.string(),
     name: v.string(),
     isSystem: v.boolean(),
@@ -415,7 +415,7 @@ export function createGabinetTables({
     .index("by_orgAndKey", ["organizationId", "key"]),
 
   gabinetLeaveBalances: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     employeeId: v.id("gabinetEmployees"),
     leaveTypeId: v.id("gabinetLeaveTypes"),
     year: v.number(),
@@ -436,7 +436,7 @@ export function createGabinetTables({
   // --- Gabinet: Appointments (Phase 3) ---
 
   gabinetAppointments: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     patientId: v.id("gabinetPatients"),
     employeeId: v.id("users"),
     // DEPRECATED (#3399): replaced by gabinetAppointmentTreatments junction
@@ -517,7 +517,7 @@ export function createGabinetTables({
   // Junction table: appointment → treatment(s) (#3360).
   // Canonical multi-treatment model introduced in #3356.
   gabinetAppointmentTreatments: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     appointmentId: v.id("gabinetAppointments"),
     treatmentId: v.optional(v.id("gabinetTreatments")),
     variantId: v.optional(v.id("gabinetTreatmentVariants")),
@@ -538,7 +538,7 @@ export function createGabinetTables({
   // --- Gabinet: Packages & Loyalty (Phase 4) ---
 
   gabinetTreatmentPackages: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     description: v.optional(v.string()),
     treatments: v.array(
@@ -566,7 +566,7 @@ export function createGabinetTables({
     .index("by_orgAndAutoTreatment", ["organizationId", "autoGeneratedForTreatmentId"]),
 
   gabinetPackageUsage: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     patientId: v.optional(v.id("gabinetPatients")),
     packageId: v.id("gabinetTreatmentPackages"),
     purchasedAt: v.number(),
@@ -599,7 +599,7 @@ export function createGabinetTables({
     .index("by_package", ["packageId"]),
 
   gabinetLoyaltyPoints: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     patientId: v.id("gabinetPatients"),
     balance: v.number(),
     lifetimeEarned: v.number(),
@@ -612,7 +612,7 @@ export function createGabinetTables({
     .index("by_orgAndPatient", ["organizationId", "patientId"]),
 
   gabinetLoyaltyTransactions: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     patientId: v.id("gabinetPatients"),
     type: gabinetLoyaltyTxTypeValidator,
     points: v.number(),
@@ -627,7 +627,7 @@ export function createGabinetTables({
     .index("by_orgAndPatient", ["organizationId", "patientId"]),
 
   gabinetLoyaltyTiers: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     tier: gabinetLoyaltyTierValidator,
     name: v.string(),
     threshold: v.number(),
@@ -642,7 +642,7 @@ export function createGabinetTables({
   // --- Platform: Document Templates ---
 
   documentTemplates: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     description: v.optional(v.string()),
     category: v.union(
@@ -748,7 +748,7 @@ export function createGabinetTables({
     .index("by_templateAndKey", ["templateId", "fieldKey"]),
 
   documentInstances: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     // Type discriminator
     type: v.optional(v.union(v.literal("template"), v.literal("file"))),
     // Template fields (optional for file type)
@@ -814,7 +814,7 @@ export function createGabinetTables({
   // --- Document Signing ---
 
   signatureRequests: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     instanceId: v.id("documentInstances"),
     slotId: v.string(),
     token: v.string(),
@@ -844,7 +844,7 @@ export function createGabinetTables({
     .index("by_org", ["organizationId"]),
 
   orgSmsConfig: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     provider: v.union(v.literal("smsapi"), v.literal("twilio")),
     apiToken: v.string(),
     apiSecret: v.optional(v.string()),
@@ -859,7 +859,7 @@ export function createGabinetTables({
     .index("by_providerAndSenderId", ["provider", "senderId"]),
 
   appointmentSmsEvents: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     appointmentId: v.optional(v.string()),
     patientId: v.optional(v.string()),
     normalizedPhone: v.string(),
@@ -893,7 +893,7 @@ export function createGabinetTables({
 
   gabinetPortalSessions: defineTable({
     patientId: v.id("gabinetPatients"),
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     tokenHash: v.string(),
     otpHash: v.optional(v.string()),
     otpExpiresAt: v.optional(v.number()),
@@ -915,7 +915,7 @@ export function createGabinetTables({
   // --- Gabinet: Appointment Reminders ---
 
   appointmentReminders: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     appointmentId: v.string(),
     type: v.union(
       v.literal("email"),
@@ -938,7 +938,7 @@ export function createGabinetTables({
     .index("by_orgAndStatus", ["organizationId", "status"]),
 
   appointmentWorkflowHistory: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     appointmentId: v.string(),
     workflowEvent: appointmentWorkflowEventValidator,
     channel: appointmentWorkflowChannelValidator,
@@ -963,7 +963,7 @@ export function createGabinetTables({
   // --- Gabinet: Locations, Rooms & Equipment ---
 
   gabinetLocations: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     address: v.optional(v.object({
       street: v.optional(v.string()),
@@ -983,7 +983,7 @@ export function createGabinetTables({
     .index("by_org", ["organizationId"]),
 
   gabinetRooms: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     locationId: v.id("gabinetLocations"),
     name: v.string(),
     description: v.optional(v.string()),
@@ -995,7 +995,7 @@ export function createGabinetTables({
     .index("by_location", ["locationId"]),
 
   gabinetEquipment: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     description: v.optional(v.string()),
     serialNumber: v.optional(v.string()),
@@ -1020,7 +1020,7 @@ export function createGabinetTables({
     .index("by_room", ["organizationId", "currentRoomId"]),
 
   gabinetEquipmentTransfers: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     equipmentId: v.id("gabinetEquipment"),
     fromLocationId: v.optional(v.id("gabinetLocations")),
     toLocationId: v.id("gabinetLocations"),
@@ -1036,7 +1036,7 @@ export function createGabinetTables({
   // --- Gabinet: PDF Receipts (issue #3739) ---
 
   gabinetReceipts: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     paymentId: v.string(),
     appointmentId: v.optional(v.string()),
     patientId: v.optional(v.string()),
@@ -1079,7 +1079,7 @@ export function createGabinetTables({
   // lastNumber is incremented inside a Convex mutation (serialised by Convex's
   // OCC) so no two receipts can get the same number within an org+location+year.
   gabinetReceiptSequences: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     locationId: v.optional(v.id("gabinetLocations")),
     year: v.number(),
     lastNumber: v.number(),
@@ -1093,7 +1093,7 @@ export function createGabinetTables({
   // (not tied to patient payments). Feeds the cash_expected calculation in the
   // end-of-day close.
   gabinetCashTransactions: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     locationId: v.optional(v.id("gabinetLocations")),
     date: v.string(), // YYYY-MM-DD
     type: v.union(v.literal("deposit"), v.literal("withdrawal")),
@@ -1110,7 +1110,7 @@ export function createGabinetTables({
   // End-of-day cash register closure snapshots. One per (org, optional-location,
   // date). Immutable once created — corrections must open the next day.
   gabinetDayCloses: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     locationId: v.optional(v.id("gabinetLocations")),
     date: v.string(), // YYYY-MM-DD
     paymentSummary: v.string(), // JSON: { method: totalAmount }
@@ -1136,7 +1136,7 @@ export function createGabinetTables({
   // employee preference, flexible preferred-date/time arrays, and priority
   // ordering within the queue.
   gabinetWaitlist: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     patientId: v.id("gabinetPatients"),
     treatmentId: v.optional(v.id("gabinetTreatments")),
     employeeId: v.optional(v.id("gabinetEmployees")),

--- a/convex/schema/platform.ts
+++ b/convex/schema/platform.ts
@@ -91,7 +91,7 @@ export function createPlatformTables({
     .index("by_stripeProductId", ["stripeProductId"]),
 
   productSubscriptions: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     productId: v.string(),
     stripeSubscriptionId: v.optional(v.string()),
     status: v.union(
@@ -118,7 +118,7 @@ export function createPlatformTables({
   // --- Platform: Email Event Bus ---
 
   emailEventTypes: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     eventType: v.string(),
     module: v.union(
       v.literal("crm"),
@@ -137,7 +137,7 @@ export function createPlatformTables({
     .index("by_orgAndType", ["organizationId", "eventType"]),
 
   emailEventBindings: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     eventType: v.string(),
     templateId: v.id("emailTemplates"),
     enabled: v.boolean(),
@@ -156,7 +156,7 @@ export function createPlatformTables({
   // ---------------------------------------------------------------------------
 
   emailSequences: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     name: v.string(),
     /** Event type that triggers this sequence, e.g. "appointment.created" */
     triggerEventType: v.string(),
@@ -167,7 +167,7 @@ export function createPlatformTables({
 
   emailSequenceSteps: defineTable({
     sequenceId: v.id("emailSequences"),
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     /** Step order (0-indexed) */
     order: v.number(),
     /** Delay in milliseconds after enrollment (or after previous step) */
@@ -182,7 +182,7 @@ export function createPlatformTables({
 
   emailSequenceEnrollments: defineTable({
     sequenceId: v.id("emailSequences"),
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     recipientEmail: v.string(),
     recipientName: v.optional(v.string()),
     /** JSON string payload passed from trigger event */
@@ -206,7 +206,7 @@ export function createPlatformTables({
   // ---------------------------------------------------------------------------
 
   emailBrandConfig: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     logoStorageId: v.optional(v.id("_storage")),
     logoUrl: v.optional(v.string()),
     companyName: v.optional(v.string()),
@@ -245,7 +245,7 @@ export function createPlatformTables({
     url: v.optional(v.string()),         // frontend: window.location
     userAgent: v.optional(v.string()),   // frontend
     userId: v.optional(v.id("users")),
-    organizationId: v.optional(v.id("organizations")),
+    organizationId: v.optional(v.string()),
     argsJson: v.optional(v.string()),    // sanitized JSON of inputs (truncated)
     requestId: v.optional(v.string()),   // optional correlation id
   })
@@ -264,7 +264,7 @@ export function createPlatformTables({
   // Covers non-templated sends (signing emails, ad-hoc compose, OTP, system
   // invitations). See `/dashboard/settings/mail` → "Logs" tab.
   emailSendLog: defineTable({
-    organizationId: v.id("organizations"),
+    organizationId: v.string(),
     source: v.union(
       v.literal("signing"),
       v.literal("automation"),


### PR DESCRIPTION
## Summary

- Replaces `organizationId: v.id("organizations")` with `organizationId: v.string()` across all 6 schema files (97 required + 2 optional fields)
- Removes the `as any` workaround in `createNotificationDirect` in `convex/notifications.ts`

## Why

After the Convex→Supabase migration, `organizationId` values are Supabase UUIDs, not Convex document IDs. Tables that still live in Convex — notably `notifications` and `signingLinkStubs` — are written via `ctx.db.insert()`, which validates data against the schema at runtime. Passing a UUID where `v.id("organizations")` is declared would cause a runtime validation failure. The previous fix series (#5014-#5028) relaxed function argument validators but left the stored-document schema validators untouched; this PR completes the migration.

## Files changed

- `convex/schema.ts` — 3 fields (tagDefinitions, categoryDefinitions, signingLinkStubs)
- `convex/schema/platform.ts` — 8 required + 1 optional field
- `convex/schema/documents.ts` — 3 required + 1 optional field
- `convex/schema/automation.ts` — 1 field
- `convex/schema/crm.ts` — 45 fields
- `convex/schema/gabinet.ts` — 37 fields
- `convex/notifications.ts` — removes `as any` cast in `createNotificationDirect`

## Test plan

- [ ] Verify no remaining `v.id("organizations")` in any `convex/schema*.ts` file
- [ ] Confirm `createNotificationDirect` no longer needs `as any`
- [ ] Run `npm run test:unit` to confirm no schema-related test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)