### PR TITLE
Relax `v.id("documentInstances")` in `convex/documentInstances.ts

### DIFF
--- a/convex/documentInstances.ts
+++ b/convex/documentInstances.ts
@@ -68,12 +68,15 @@ export const list = query({
   },
 });
 
-export const getById = query({
-  args: { id: v.id("documentInstances") },
+export const getById = action({
+  args: { id: v.string() },
   handler: async (ctx, args) => {
-    const instance = await ctx.db.get(args.id);
+    const db = createSupabaseDb();
+    const instance = await db.get("documentInstances", args.id);
     if (!instance) return null;
-    await verifyOrgAccess(ctx, instance.organizationId);
+    await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: instance.organizationId as string,
+    });
     return instance;
   },
 });

--- a/convex/documentTemplates.ts
+++ b/convex/documentTemplates.ts
@@ -89,12 +89,15 @@ export const list = query({
   },
 });
 
-export const getById = query({
-  args: { id: v.id("documentTemplates") },
+export const getById = action({
+  args: { id: v.string() },
   handler: async (ctx, args) => {
-    const template = await ctx.db.get(args.id);
+    const db = createSupabaseDb();
+    const template = await db.get("documentTemplates", args.id);
     if (!template) return null;
-    await verifyOrgAccess(ctx, template.organizationId);
+    await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: template.organizationId as string,
+    });
     return template;
   },
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5029.

Closes #5029

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c4391142 fix(documents): migrate getById from ctx.db to Supabase, relax v.id() to v.string() (closes #5029)

### Files changed

```
 convex/documentInstances.ts | 11 +++++++----
 convex/documentTemplates.ts | 11 +++++++----
 2 files changed, 14 insertions(+), 8 deletions(-)
```