### PR TITLE
Relax `v.id("formDocuments")` in `convex/dev/emails.ts

### DIFF
--- a/convex/dev/emails.ts
+++ b/convex/dev/emails.ts
@@ -97,7 +97,7 @@ export const findSignableDocument = action({
 
 export const triggerSigningEmail = action({
   args: {
-    documentId: v.id("formDocuments"),
+    documentId: v.string(),
     recipientEmail: v.string(),
     recipientName: v.optional(v.string()),
   },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5030.

Closes #5030

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4acaaee4 fix(dev/emails): relax v.id("formDocuments") to v.string() (closes #5030)

### Files changed

```
 convex/dev/emails.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```