### PR TITLE
Audit Convex mirror tables (`gabinetLocationMemberships`, `gabinetMemberships`) 

### DIFF
--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -206,7 +206,7 @@ export async function checkPermission(
   orgId: Id<"organizations">,
   feature: Feature,
   action: Action,
-  locationId?: Id<"gabinetLocations">,
+  locationId?: string,
 ): Promise<PermissionResult> {
   const { user, membership } = await verifyOrgAccess(ctx, orgId);
   const role = membership.role as OrgRole;
@@ -302,7 +302,7 @@ export async function checkPermission(
 export async function getEffectivePermissions(
   ctx: QueryCtx | MutationCtx,
   orgId: Id<"organizations">,
-  locationId?: Id<"gabinetLocations">,
+  locationId?: string,
 ): Promise<FeaturePermissions> {
   const { membership, user } = await verifyOrgAccess(ctx, orgId);
   const role = membership.role as OrgRole;

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -793,7 +793,7 @@ export function createCrmTables({
   gabinetLocationMemberships: defineTable({
     organizationId: v.string(),
     userId: v.id("users"),
-    locationId: v.id("gabinetLocations"),
+    locationId: v.string(),
     role: v.optional(gabinetEmployeeRoleValidator),
     updatedAt: v.number(),
   })


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5031.

Closes #5031

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 1f8dc947 fix(schema): relax gabinetLocationMemberships.locationId from v.id() to v.string() (closes #5031)

### Files changed

```
 convex/_helpers/permissions.ts | 4 ++--
 convex/schema/crm.ts           | 2 +-
 2 files changed, 3 insertions(+), 3 deletions(-)
```