### PR TITLE
Purge stale Convex-ID rows from gabinetLocationMemberships

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -34,6 +34,7 @@ import type * as _test from "../_test.js";
 import type * as _test_helpers from "../_test_helpers.js";
 import type * as activities from "../activities.js";
 import type * as activityTypes from "../activityTypes.js";
+import type * as admin_cleanup from "../admin/cleanup.js";
 import type * as admin_entitlements from "../admin/entitlements.js";
 import type * as app from "../app.js";
 import type * as auditLog from "../auditLog.js";
@@ -235,6 +236,7 @@ declare const fullApi: ApiFromModules<{
   _test_helpers: typeof _test_helpers;
   activities: typeof activities;
   activityTypes: typeof activityTypes;
+  "admin/cleanup": typeof admin_cleanup;
   "admin/entitlements": typeof admin_entitlements;
   app: typeof app;
   auditLog: typeof auditLog;

--- a/convex/admin/cleanup.ts
+++ b/convex/admin/cleanup.ts
@@ -1,0 +1,37 @@
+import { v } from "convex/values";
+import { action, internalMutation } from "../_generated/server";
+import { internal } from "../_generated/api";
+
+// UUID v4 pattern: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Deletes gabinetLocationMemberships rows whose locationId is a Convex ID
+// (not a UUID). These orphan rows were inserted during the dual-write era and
+// are unreachable by permission lookups after the Supabase migration.
+export const _purgeStaleConvexIdLocationMemberships = internalMutation({
+  args: {},
+  returns: v.object({ deleted: v.number(), scanned: v.number() }),
+  handler: async (ctx): Promise<{ deleted: number; scanned: number }> => {
+    const all = await ctx.db.query("gabinetLocationMemberships").collect();
+    const stale = all.filter((row) => !UUID_REGEX.test(row.locationId));
+    for (const row of stale) {
+      await ctx.db.delete(row._id);
+    }
+    return { deleted: stale.length, scanned: all.length };
+  },
+});
+
+// Platform-admin action to purge stale Convex-ID rows from
+// gabinetLocationMemberships. Safe to call multiple times (idempotent).
+export const purgeStaleConvexIdLocationMemberships = action({
+  args: {},
+  returns: v.object({ deleted: v.number(), scanned: v.number() }),
+  handler: async (ctx): Promise<{ deleted: number; scanned: number }> => {
+    await ctx.runAction(internal._helpers.authAction.verifyPlatformAdmin, {});
+    return ctx.runMutation(
+      internal.admin.cleanup._purgeStaleConvexIdLocationMemberships,
+      {},
+    );
+  },
+});

--- a/tests/convex/purgeStaleLocationMemberships.test.ts
+++ b/tests/convex/purgeStaleLocationMemberships.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+async function makePlatformAdmin(userId: string) {
+  await createSupabaseDb().insert("users", {
+    _id: userId,
+    name: "Admin",
+    email: `admin-${userId}@example.com`,
+    isPlatformAdmin: true,
+  });
+}
+
+describe("admin/cleanup.purgeStaleConvexIdLocationMemberships", () => {
+  test("deletes rows with Convex IDs and keeps rows with UUID locationIds", async () => {
+    const t = createTestCtx();
+    const { userId, organizationId, identity } = await seedTestUser(t);
+    await makePlatformAdmin(String(userId));
+
+    // Seed one stale row (Convex-style ID, no hyphens) and one valid row (UUID).
+    await t.run(async (ctx) => {
+      const now = Date.now();
+      await ctx.db.insert("gabinetLocationMemberships", {
+        organizationId: String(organizationId),
+        userId,
+        locationId: "k57abcdefghijklmnopqrstu",
+        updatedAt: now,
+      });
+      await ctx.db.insert("gabinetLocationMemberships", {
+        organizationId: String(organizationId),
+        userId,
+        locationId: "550e8400-e29b-41d4-a716-446655440000",
+        updatedAt: now,
+      });
+    });
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.admin.cleanup.purgeStaleConvexIdLocationMemberships, {});
+
+    expect(result.scanned).toBe(2);
+    expect(result.deleted).toBe(1);
+
+    const remaining = await t.run((ctx) =>
+      ctx.db.query("gabinetLocationMemberships").collect(),
+    );
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].locationId).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  test("is idempotent — second call finds nothing to delete", async () => {
+    const t = createTestCtx();
+    const { userId, organizationId, identity } = await seedTestUser(t);
+    await makePlatformAdmin(String(userId));
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("gabinetLocationMemberships", {
+        organizationId: String(organizationId),
+        userId,
+        locationId: "j97staleconvexxidxnohuph",
+        updatedAt: Date.now(),
+      });
+    });
+
+    const first = await t
+      .withIdentity(identity)
+      .action(api.admin.cleanup.purgeStaleConvexIdLocationMemberships, {});
+    expect(first.deleted).toBe(1);
+
+    const second = await t
+      .withIdentity(identity)
+      .action(api.admin.cleanup.purgeStaleConvexIdLocationMemberships, {});
+    expect(second.deleted).toBe(0);
+    expect(second.scanned).toBe(0);
+  });
+
+  test("rejects non-platform-admin callers", async () => {
+    const t = createTestCtx();
+    const { identity } = await seedTestUser(t);
+    // NOT calling makePlatformAdmin — user is a regular org member
+
+    await expect(
+      t
+        .withIdentity(identity)
+        .action(api.admin.cleanup.purgeStaleConvexIdLocationMemberships, {}),
+    ).rejects.toThrow(/platform admin/i);
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5039.

Closes #5039

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 12ac09ef fix(gabinetLocationMemberships): add admin action to purge stale Convex-ID rows (closes #5039)

### Files changed

```
 convex/_generated/api.d.ts                         |  2 +
 convex/admin/cleanup.ts                            | 37 +++++++++
 tests/convex/purgeStaleLocationMemberships.test.ts | 93 ++++++++++++++++++++++
 3 files changed, 132 insertions(+)
```