### PR TITLE
Relax v.id("gabinetLocations") in gabinetRooms, gabinetEquipment, gabinetEquipme

### DIFF
--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -984,7 +984,7 @@ export function createGabinetTables({
 
   gabinetRooms: defineTable({
     organizationId: v.string(),
-    locationId: v.id("gabinetLocations"),
+    locationId: v.string(),
     name: v.string(),
     description: v.optional(v.string()),
     floor: v.optional(v.string()),
@@ -999,7 +999,7 @@ export function createGabinetTables({
     name: v.string(),
     description: v.optional(v.string()),
     serialNumber: v.optional(v.string()),
-    currentLocationId: v.optional(v.id("gabinetLocations")),
+    currentLocationId: v.optional(v.string()),
     currentRoomId: v.optional(v.id("gabinetRooms")),
     status: v.union(
       v.literal("available"),
@@ -1022,8 +1022,8 @@ export function createGabinetTables({
   gabinetEquipmentTransfers: defineTable({
     organizationId: v.string(),
     equipmentId: v.id("gabinetEquipment"),
-    fromLocationId: v.optional(v.id("gabinetLocations")),
-    toLocationId: v.id("gabinetLocations"),
+    fromLocationId: v.optional(v.string()),
+    toLocationId: v.string(),
     toRoomId: v.optional(v.id("gabinetRooms")),
     transferredBy: v.id("users"),
     transferredAt: v.number(),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5040.

Closes #5040

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b92612af fix(schema): relax v.id("gabinetLocations") to v.string() in gabinetRooms, gabinetEquipment, gabinetEquipmentTransfers (closes #5040)

### Files changed

```
 convex/schema/gabinet.ts | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```