### PR TITLE
Relax remaining v.id("gabinetLocations") in gabinetWorkingHours, gabinetEmployee

### DIFF
--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -351,7 +351,7 @@ export function createCrmTables({
   productStockLevels: defineTable({
     organizationId: v.string(),
     productId: v.id("products"),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
     quantity: v.number(),
     avgCost: v.optional(v.number()),
     updatedAt: v.number(),
@@ -368,7 +368,7 @@ export function createCrmTables({
   productStockMovements: defineTable({
     organizationId: v.string(),
     productId: v.id("products"),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
     delta: v.number(),
     balanceAfter: v.optional(v.number()),
     reason: v.union(
@@ -410,7 +410,7 @@ export function createCrmTables({
     supplierName: v.optional(v.string()),
     invoiceNumber: v.optional(v.string()),
     deliveryDate: v.optional(v.string()),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
     notes: v.optional(v.string()),
     status: v.union(v.literal("draft"), v.literal("posted")),
     // Denormalized SUM(quantity × unit_price) across all items (#2968).

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -196,7 +196,7 @@ export function createGabinetTables({
     isOpen: v.boolean(),
     breakStart: v.optional(v.string()),
     breakEnd: v.optional(v.string()),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),
@@ -216,7 +216,7 @@ export function createGabinetTables({
     breakEnd: v.optional(v.string()),
     effectiveFrom: v.optional(v.string()),
     effectiveTo: v.optional(v.string()),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),
@@ -367,7 +367,7 @@ export function createGabinetTables({
   gabinetEmployeeLocations: defineTable({
     organizationId: v.string(),
     employeeId: v.id("gabinetEmployees"),
-    locationId: v.id("gabinetLocations"),
+    locationId: v.string(),
     isPrimary: v.boolean(),
     role: v.optional(gabinetEmployeeRoleValidator),
     createdAt: v.number(),
@@ -494,7 +494,7 @@ export function createGabinetTables({
     cancellationReason: v.optional(v.string()),
     bookedFromPortal: v.optional(v.boolean()),
     bookedByPatientId: v.optional(v.id("gabinetPatients")),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
     roomId: v.optional(v.id("gabinetRooms")),
     tagIds: v.optional(v.array(v.id("tagDefinitions"))),
     categoryId: v.optional(v.id("categoryDefinitions")),
@@ -1040,7 +1040,7 @@ export function createGabinetTables({
     paymentId: v.string(),
     appointmentId: v.optional(v.string()),
     patientId: v.optional(v.string()),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
     receiptNumber: v.string(), // e.g. 2026/001/LOC
     issuedAt: v.number(),
     // Receipt lifecycle: issued (default) | void
@@ -1080,7 +1080,7 @@ export function createGabinetTables({
   // OCC) so no two receipts can get the same number within an org+location+year.
   gabinetReceiptSequences: defineTable({
     organizationId: v.string(),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
     year: v.number(),
     lastNumber: v.number(),
     updatedAt: v.number(),
@@ -1094,7 +1094,7 @@ export function createGabinetTables({
   // end-of-day close.
   gabinetCashTransactions: defineTable({
     organizationId: v.string(),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
     date: v.string(), // YYYY-MM-DD
     type: v.union(v.literal("deposit"), v.literal("withdrawal")),
     amount: v.float64(),
@@ -1111,7 +1111,7 @@ export function createGabinetTables({
   // date). Immutable once created — corrections must open the next day.
   gabinetDayCloses: defineTable({
     organizationId: v.string(),
-    locationId: v.optional(v.id("gabinetLocations")),
+    locationId: v.optional(v.string()),
     date: v.string(), // YYYY-MM-DD
     paymentSummary: v.string(), // JSON: { method: totalAmount }
     totalCollected: v.float64(),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5046.

Closes #5046

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d41bdfa3 fix(schema): relax v.id("gabinetLocations") to v.string() in remaining tables (closes #5046)

### Files changed

```
 convex/schema/crm.ts     |  6 +++---
 convex/schema/gabinet.ts | 16 ++++++++--------
 2 files changed, 11 insertions(+), 11 deletions(-)
```