### PR TITLE
Relax v.id("gabinetEquipment") in gabinetEquipmentTransfers

### DIFF
--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -1021,7 +1021,7 @@ export function createGabinetTables({
 
   gabinetEquipmentTransfers: defineTable({
     organizationId: v.string(),
-    equipmentId: v.id("gabinetEquipment"),
+    equipmentId: v.string(),
     fromLocationId: v.optional(v.string()),
     toLocationId: v.string(),
     toRoomId: v.optional(v.string()),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5048.

Closes #5048

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 5491e2d5 fix(schema): relax v.id("gabinetEquipment") to v.string() in gabinetEquipmentTransfers (closes #5048)

### Files changed

```
 convex/schema/gabinet.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```