### PR TITLE
Relax v.id("gabinetEquipment") to v.string() in gabinetTreatments.requiredEquipm

### DIFF
--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -95,7 +95,7 @@ export function createGabinetTables({
     // numeric taxRate is ignored. Replaces a legacy -1 sentinel in taxRate.
     taxExempt: v.optional(v.boolean()),
     requiredEquipment: v.optional(v.array(v.string())),
-    requiredEquipmentIds: v.optional(v.array(v.id("gabinetEquipment"))),
+    requiredEquipmentIds: v.optional(v.array(v.string())),
     contraindications: v.optional(v.string()),
     preparationInstructions: v.optional(v.string()),
     aftercareInstructions: v.optional(v.string()),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5052.

Closes #5052

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3029e4eb fix(schema): relax v.id("gabinetEquipment") to v.string() in gabinetTreatments.requiredEquipmentIds (closes #5052)

### Files changed

```
 convex/schema/gabinet.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```