### PR TITLE
Replace scheduler-based `writeTeamMembershipToSupabase` call in `_inviteMemberIn

### DIFF
--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -301,7 +301,7 @@ export const inviteMember = action({
       );
     }
 
-    const membershipId: string = await ctx.runMutation(
+    const membership = await ctx.runMutation(
       internal.organizations._inviteMemberInternal,
       {
         organizationId: args.organizationId,
@@ -309,7 +309,15 @@ export const inviteMember = action({
         role: args.role,
       },
     );
-    return membershipId;
+    await ctx.runAction(internal.supabase.organizations.writeTeamMembershipToSupabase, {
+      membershipId: membership.membershipId,
+      userId: membership.userId,
+      organizationId: membership.organizationId,
+      role: membership.role,
+      invitedBy: membership.invitedBy,
+      joinedAt: membership.joinedAt,
+    });
+    return membership.membershipId;
   },
 });
 
@@ -339,20 +347,6 @@ export const _inviteMemberInternal = internalMutation({
       joinedAt,
     });
 
-    // Mirror to Supabase — UI reads team_memberships from there.
-    await ctx.scheduler.runAfter(
-      0,
-      internal.supabase.organizations.writeTeamMembershipToSupabase,
-      {
-        membershipId: String(membershipId),
-        userId: String(args.userId),
-        organizationId: String(args.organizationId),
-        role: args.role,
-        invitedBy: String(user._id),
-        joinedAt,
-      },
-    );
-
     await logActivity(ctx, {
       organizationId: args.organizationId,
       entityType: "organization",
@@ -362,7 +356,14 @@ export const _inviteMemberInternal = internalMutation({
       performedBy: user._id,
     });
 
-    return String(membershipId);
+    return {
+      membershipId: String(membershipId),
+      userId: String(args.userId),
+      organizationId: String(args.organizationId),
+      role: args.role,
+      invitedBy: String(user._id),
+      joinedAt,
+    };
   },
 });
 

--- a/convex/supabase/organizations.ts
+++ b/convex/supabase/organizations.ts
@@ -274,11 +274,9 @@ export const writeTeamMembershipToSupabase = internalAction({
   handler: async (ctx, args) => {
     const client = createServiceRoleClient();
 
-    // Self-heal: writeUserToSupabase, writeOrganizationToSupabase, and
-    // writeTeamMembershipToSupabase are all scheduled with runAfter(0) from
-    // org.create / completeOnboarding / invitations._acceptInternal. If this
-    // action fires first, either FK may not exist yet. Ensure both parent rows
-    // are present before attempting the team_memberships upsert.
+    // Self-heal: the user and organization rows may not yet exist in Supabase
+    // (e.g. if org creation and membership creation race, or during backfill).
+    // Ensure both FK parent rows are present before the team_memberships upsert.
     const { data: existingUser } = await client
       .from("users")
       .select("id")


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5055.

Closes #5055

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 116a1a27 fix(organizations): replace scheduler-based writeTeamMembershipToSupabase call in _inviteMemberInternal (closes #5055)

### Files changed

```
 convex/organizations.ts          | 35 ++++++++++++++++++-----------------
 convex/supabase/organizations.ts |  8 +++-----
 2 files changed, 21 insertions(+), 22 deletions(-)
```