### PR TITLE
Replace scheduler-based `writeUserToSupabase` calls in `invitations.ts`, `stripe

### DIFF
--- a/convex/app.ts
+++ b/convex/app.ts
@@ -59,21 +59,15 @@ export const getIsPlatformAdmin = action({
   },
 });
 
-// users table is auth — ctx.db.patch is the Convex-side dual-write (needed for
-// auth helpers that read from QueryCtx). The scheduler mirrors to Supabase.
-export const updateUsername = mutation({
-  args: {
-    username: v.string(),
-  },
+export const _updateUsernameInternal = internalMutation({
+  args: { username: v.string() },
   handler: async (ctx, args) => {
     const userId = await auth.getUserId(ctx);
-    if (!userId) {
-      return;
-    }
+    if (!userId) return null;
     const user = await ctx.db.get(userId);
-    if (!user) return;
+    if (!user) return null;
     await ctx.db.patch(userId, { username: args.username });
-    await ctx.scheduler.runAfter(0, internal.supabase.users.writeUserToSupabase, {
+    return {
       userId: String(userId),
       email: user.email,
       name: user.name,
@@ -87,8 +81,27 @@ export const updateUsername = mutation({
       theme: user.theme,
       timezone: user.timezone,
       createdAt: Math.floor(user._creationTime),
-      updatedAt: Date.now(),
+    };
+  },
+});
+
+// users table is auth — Convex write happens in _updateUsernameInternal (needed for
+// auth helpers that read from QueryCtx). The action then mirrors to Supabase directly.
+export const updateUsername = action({
+  args: { username: v.string() },
+  handler: async (ctx, args) => {
+    const userData = await ctx.runMutation(internal.app._updateUsernameInternal, {
+      username: args.username,
     });
+    if (!userData) return;
+    try {
+      await ctx.runAction(internal.supabase.users.writeUserToSupabase, {
+        ...userData,
+        updatedAt: Date.now(),
+      });
+    } catch (e) {
+      console.error("[app.updateUsername] Supabase user write failed:", e);
+    }
   },
 });
 
@@ -277,25 +290,16 @@ export const getStorageUrl = mutation({
   },
 });
 
-// users table is auth — ctx.db.patch is the Convex-side dual-write.
-// Scheduler mirrors to Supabase.
-export const updateUserImage = mutation({
-  args: {
-    imageId: v.id("_storage"),
-  },
+export const _updateUserImageInternal = internalMutation({
+  args: { imageId: v.id("_storage") },
   handler: async (ctx, args) => {
     const userId = await auth.getUserId(ctx);
-    if (!userId) {
-      return;
-    }
+    if (!userId) return null;
     const user = await ctx.db.get(userId);
-    if (!user) return;
+    if (!user) return null;
     const url = await ctx.storage.getUrl(args.imageId);
-    await ctx.db.patch(userId, {
-      imageId: args.imageId,
-      image: url ?? undefined,
-    });
-    await ctx.scheduler.runAfter(0, internal.supabase.users.writeUserToSupabase, {
+    await ctx.db.patch(userId, { imageId: args.imageId, image: url ?? undefined });
+    return {
       userId: String(userId),
       email: user.email,
       name: user.name,
@@ -309,24 +313,39 @@ export const updateUserImage = mutation({
       theme: user.theme,
       timezone: user.timezone,
       createdAt: Math.floor(user._creationTime),
-      updatedAt: Date.now(),
-    });
+    };
   },
 });
 
-// users table is auth — ctx.db.patch is the Convex-side dual-write.
-// Scheduler mirrors to Supabase.
-export const removeUserImage = mutation({
+// users table is auth — Convex write in _updateUserImageInternal (QueryCtx compat).
+// Action mirrors to Supabase directly.
+export const updateUserImage = action({
+  args: { imageId: v.id("_storage") },
+  handler: async (ctx, args) => {
+    const userData = await ctx.runMutation(internal.app._updateUserImageInternal, {
+      imageId: args.imageId,
+    });
+    if (!userData) return;
+    try {
+      await ctx.runAction(internal.supabase.users.writeUserToSupabase, {
+        ...userData,
+        updatedAt: Date.now(),
+      });
+    } catch (e) {
+      console.error("[app.updateUserImage] Supabase user write failed:", e);
+    }
+  },
+});
+
+export const _removeUserImageInternal = internalMutation({
   args: {},
   handler: async (ctx) => {
     const userId = await auth.getUserId(ctx);
-    if (!userId) {
-      return;
-    }
+    if (!userId) return null;
     const user = await ctx.db.get(userId);
-    if (!user) return;
+    if (!user) return null;
     await ctx.db.patch(userId, { imageId: undefined, image: undefined });
-    await ctx.scheduler.runAfter(0, internal.supabase.users.writeUserToSupabase, {
+    return {
       userId: String(userId),
       email: user.email,
       name: user.name,
@@ -340,8 +359,25 @@ export const removeUserImage = mutation({
       theme: user.theme,
       timezone: user.timezone,
       createdAt: Math.floor(user._creationTime),
-      updatedAt: Date.now(),
-    });
+    };
+  },
+});
+
+// users table is auth — Convex write in _removeUserImageInternal (QueryCtx compat).
+// Action mirrors to Supabase directly.
+export const removeUserImage = action({
+  args: {},
+  handler: async (ctx) => {
+    const userData = await ctx.runMutation(internal.app._removeUserImageInternal, {});
+    if (!userData) return;
+    try {
+      await ctx.runAction(internal.supabase.users.writeUserToSupabase, {
+        ...userData,
+        updatedAt: Date.now(),
+      });
+    } catch (e) {
+      console.error("[app.removeUserImage] Supabase user write failed:", e);
+    }
   },
 });
 
@@ -412,9 +448,7 @@ export const getActivePlans = query({
   },
 });
 
-// users table is auth — ctx.db.patch is the Convex-side dual-write.
-// Scheduler mirrors to Supabase.
-export const updateProfile = mutation({
+export const _updateProfileInternal = internalMutation({
   args: {
     name: v.optional(v.string()),
     language: v.optional(v.string()),
@@ -426,9 +460,7 @@ export const updateProfile = mutation({
   },
   handler: async (ctx, args) => {
     const userId = await auth.getUserId(ctx);
-    if (!userId) {
-      throw new Error("Not authenticated");
-    }
+    if (!userId) throw new Error("Not authenticated");
     const user = await ctx.db.get(userId);
     if (!user) throw new Error("User not found");
     const updates: Record<string, unknown> = {};
@@ -448,7 +480,7 @@ export const updateProfile = mutation({
       newImageStorageId = String(args.imageId);
     }
     await ctx.db.patch(userId, updates);
-    await ctx.scheduler.runAfter(0, internal.supabase.users.writeUserToSupabase, {
+    return {
       userId: String(userId),
       email: user.email,
       name: args.name ?? user.name,
@@ -462,9 +494,33 @@ export const updateProfile = mutation({
       theme: args.theme ?? user.theme,
       timezone: args.timezone ?? user.timezone,
       createdAt: Math.floor(user._creationTime),
-      updatedAt: Date.now(),
-    });
-    return userId;
+    };
+  },
+});
+
+// users table is auth — Convex write in _updateProfileInternal (QueryCtx compat).
+// Action mirrors to Supabase directly.
+export const updateProfile = action({
+  args: {
+    name: v.optional(v.string()),
+    language: v.optional(v.string()),
+    theme: v.optional(
+      v.union(v.literal("light"), v.literal("dark"), v.literal("system"))
+    ),
+    timezone: v.optional(v.string()),
+    imageId: v.optional(v.id("_storage")),
+  },
+  handler: async (ctx, args) => {
+    const userData = await ctx.runMutation(internal.app._updateProfileInternal, args);
+    try {
+      await ctx.runAction(internal.supabase.users.writeUserToSupabase, {
+        ...userData,
+        updatedAt: Date.now(),
+      });
+    } catch (e) {
+      console.error("[app.updateProfile] Supabase user write failed:", e);
+    }
+    return userData.userId;
   },
 });
 

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -403,6 +403,18 @@ export const accept = action({
       membershipId: string;
       membershipUserId: string;
       membershipJoinedAt: number;
+      userEmail: string | undefined;
+      userName: string | undefined;
+      userUsername: string | undefined;
+      userImage: string | undefined;
+      userImageId: string | undefined;
+      userPhone: string | undefined;
+      userIsAnonymous: boolean | undefined;
+      userCustomerId: string | undefined;
+      userLanguage: string | undefined;
+      userTheme: string | undefined;
+      userTimezone: string | undefined;
+      userCreatedAt: number;
     } = await ctx.runMutation(
       internal.invitations._acceptInternal,
       {
@@ -441,6 +453,29 @@ export const accept = action({
       });
     } catch (e) {
       console.error("[invitations.accept] Supabase teamMembership write failed:", e);
+    }
+
+    // Mirror the invitee's user row to Supabase. Without this, downstream FK
+    // references (gabinet_employees.user_id, team_memberships, etc.) hit code=23503.
+    try {
+      await ctx.runAction(internal.supabase.users.writeUserToSupabase, {
+        userId: result.membershipUserId,
+        email: result.userEmail,
+        name: result.userName,
+        username: result.userUsername,
+        image: result.userImage,
+        imageStorageId: result.userImageId,
+        phone: result.userPhone,
+        isAnonymous: result.userIsAnonymous,
+        customerId: result.userCustomerId,
+        language: result.userLanguage,
+        theme: result.userTheme,
+        timezone: result.userTimezone,
+        createdAt: result.userCreatedAt,
+        updatedAt: Date.now(),
+      });
+    } catch (e) {
+      console.error("[invitations.accept] Supabase user write failed:", e);
     }
 
     return result.organizationId;
@@ -503,26 +538,8 @@ export const _acceptInternal = internalMutation({
       effectiveUsername = candidate;
     }
 
-    // Mirror the invitee's user row to Supabase. Without this, any
-    // downstream FK reference (gabinet_employees.user_id, team_memberships
-    // mirror that happens just above, etc.) hits `code=23503` on the first
-    // assignment after signup.
-    await ctx.scheduler.runAfter(0, internal.supabase.users.writeUserToSupabase, {
-      userId: String(user._id),
-      email: user.email,
-      name: user.name,
-      username: effectiveUsername,
-      image: user.image,
-      imageStorageId: user.imageId ? String(user.imageId) : undefined,
-      phone: user.phone,
-      isAnonymous: user.isAnonymous,
-      customerId: user.customerId,
-      language: user.language,
-      theme: user.theme,
-      timezone: user.timezone,
-      createdAt: Math.floor(user._creationTime),
-      updatedAt: Date.now(),
-    });
+    // User row is mirrored to Supabase by the parent accept action after this
+    // mutation returns, so downstream FKs (gabinet_employees.user_id, etc.) resolve.
 
     // Module provisioning: if the invite carried a module="gabinet" payload,
     // auto-create the gabinet_employees row using the data captured at invite
@@ -586,6 +603,18 @@ export const _acceptInternal = internalMutation({
       membershipId: String(membershipId),
       membershipUserId: String(user._id),
       membershipJoinedAt: joinedAt,
+      userEmail: user.email,
+      userName: user.name,
+      userUsername: effectiveUsername,
+      userImage: user.image,
+      userImageId: user.imageId ? String(user.imageId) : undefined,
+      userPhone: user.phone,
+      userIsAnonymous: user.isAnonymous,
+      userCustomerId: user.customerId,
+      userLanguage: user.language,
+      userTheme: user.theme,
+      userTimezone: user.timezone,
+      userCreatedAt: Math.floor(user._creationTime),
     };
   },
 });

--- a/convex/stripe.ts
+++ b/convex/stripe.ts
@@ -63,24 +63,22 @@ export const PREAUTH_updateCustomerId = internalMutation({
   handler: async (ctx, args) => {
     const user = await ctx.db.get(args.userId);
     await ctx.db.patch(args.userId, { customerId: args.customerId });
-    if (user) {
-      await ctx.scheduler.runAfter(0, internal.supabase.users.writeUserToSupabase, {
-        userId: String(args.userId),
-        email: user.email,
-        name: user.name,
-        username: user.username,
-        image: user.image,
-        imageStorageId: user.imageId ? String(user.imageId) : undefined,
-        phone: user.phone,
-        isAnonymous: user.isAnonymous,
-        customerId: args.customerId,
-        language: user.language,
-        theme: user.theme,
-        timezone: user.timezone,
-        createdAt: Math.floor(user._creationTime),
-        updatedAt: Date.now(),
-      });
-    }
+    if (!user) return null;
+    return {
+      userId: String(args.userId),
+      email: user.email,
+      name: user.name,
+      username: user.username,
+      image: user.image,
+      imageStorageId: user.imageId ? String(user.imageId) : undefined,
+      phone: user.phone,
+      isAnonymous: user.isAnonymous,
+      customerId: args.customerId,
+      language: user.language,
+      theme: user.theme,
+      timezone: user.timezone,
+      createdAt: Math.floor(user._creationTime),
+    };
   },
 });
 
@@ -470,10 +468,20 @@ export const PREAUTH_createFreeStripeSubscription = internalAction({
       cancelAtPeriodEnd: stripeSubscription.cancel_at_period_end,
     });
 
-    await ctx.runMutation(internal.stripe.PREAUTH_updateCustomerId, {
+    const userData = await ctx.runMutation(internal.stripe.PREAUTH_updateCustomerId, {
       userId: args.userId,
       customerId: args.customerId,
     });
+    if (userData) {
+      try {
+        await ctx.runAction(internal.supabase.users.writeUserToSupabase, {
+          ...userData,
+          updatedAt: Date.now(),
+        });
+      } catch (e) {
+        console.error("[stripe] Supabase user write failed:", e);
+      }
+    }
   },
 });
 

--- a/convex/supabase/users.ts
+++ b/convex/supabase/users.ts
@@ -8,7 +8,9 @@
  *
  * Mirrored on:
  *   - app.completeOnboarding (first time a user signs up + picks a username)
- *   - invitations._acceptInternal (invitee gets a row before any side effects)
+ *   - app.updateUsername, updateUserImage, removeUserImage, updateProfile (profile edits)
+ *   - invitations.accept (invitee gets a row after _acceptInternal mutation settles)
+ *   - stripe.PREAUTH_createFreeStripeSubscription (after PREAUTH_updateCustomerId mutation)
  *   - Plus the backfill helper below for one-shot recovery.
  *
  * IMPORTANT: this module talks to Supabase via raw fetch to PostgREST instead

--- a/scripts/check-convex-db-writes.mjs
+++ b/scripts/check-convex-db-writes.mjs
@@ -131,7 +131,7 @@ const WHITELIST_PATHS = new Set([
   //   _upsertProductSubscriptionInternal (internalMutation) → Convex write;
   //   PREAUTH_upsertProductSubscription (internalAction) → Supabase mirror.
   //   PREAUTH_updateCustomerId (internalMutation) → Convex write;
-  //   mirrors to Supabase via ctx.scheduler → writeUserToSupabase.
+  //   mirrors to Supabase via ctx.runAction → writeUserToSupabase (in parent action).
   // Migrated in issues #4964, #4967. See convex/stripe.ts for inline rationale.
   "stripe",
 

--- a/src/routes/_app/_auth/dashboard/_layout.settings.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.index.tsx
@@ -3,7 +3,7 @@ import { useDoubleCheck } from "@/ui/use-double-check";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/ui/button";
-import { convexQuery, useConvexAction, useConvexMutation } from "@convex-dev/react-query";
+import { convexQuery, useConvexAction } from "@convex-dev/react-query";
 import { api } from "~/convex/_generated/api";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useForm } from "@tanstack/react-form";
@@ -28,7 +28,7 @@ export default function DashboardSettings() {
   const { data: user } = useQuery(convexQuery(api.app.getCurrentUser, {}));
   const signOut = useSignOut();
   const { mutateAsync: updateUsername } = useMutation({
-    mutationFn: useConvexMutation(api.app.updateUsername),
+    mutationFn: useConvexAction(api.app.updateUsername),
   });
   const { mutateAsync: deleteCurrentUserAccount } = useMutation({
     mutationFn: useConvexAction(api.app.deleteCurrentUserAccount),

--- a/src/routes/_app/_auth/dashboard/_layout.settings.profile.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.profile.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { changeLanguage } from "i18next";
-import { convexQuery, useConvexMutation } from "@convex-dev/react-query";
+import { convexQuery, useConvexAction, useConvexMutation } from "@convex-dev/react-query";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { api } from "~/convex/_generated/api";
 import { Input } from "@/components/ui/input";
@@ -121,12 +121,12 @@ function ProfileSettings() {
   });
 
   const { mutateAsync: updateProfile } = useMutation({
-    mutationFn: useConvexMutation(api.app.updateProfile),
+    mutationFn: useConvexAction(api.app.updateProfile),
   });
   const generateUploadUrl = useConvexMutation(api.app.generateUploadUrl);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { mutateAsync: removeUserImage } = useMutation({
-    mutationFn: useConvexMutation(api.app.removeUserImage),
+    mutationFn: useConvexAction(api.app.removeUserImage),
   });
 
   const { startUpload } = useConvexUpload(generateUploadUrl, {

--- a/tests/convex/avatarConsistency.test.ts
+++ b/tests/convex/avatarConsistency.test.ts
@@ -13,7 +13,7 @@ describe("updateUserImage", () => {
     });
 
     // Call updateUserImage
-    await t.withIdentity(identity).mutation(api.app.updateUserImage, {
+    await t.withIdentity(identity).action(api.app.updateUserImage, {
       imageId: storageId,
     });
 
@@ -32,12 +32,12 @@ describe("updateUserImage", () => {
     const storageId = await t.run(async (ctx) => {
       return await ctx.storage.store(new Blob(["fake-image"]));
     });
-    await t.withIdentity(identity).mutation(api.app.updateUserImage, {
+    await t.withIdentity(identity).action(api.app.updateUserImage, {
       imageId: storageId,
     });
 
     // Remove it
-    await t.withIdentity(identity).mutation(api.app.removeUserImage, {});
+    await t.withIdentity(identity).action(api.app.removeUserImage, {});
 
     const user = await t.run(async (ctx) => ctx.db.get(userId));
     expect(user!.imageId).toBeUndefined();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5058.

Closes #5058

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 7f346c61 fix(users): replace scheduler-based writeUserToSupabase calls with direct runAction (closes #5058)

### Files changed

```
 convex/app.ts                                      | 152 ++++++++++++++-------
 convex/invitations.ts                              |  69 +++++++---
 convex/stripe.ts                                   |  46 ++++---
 convex/supabase/users.ts                           |   4 +-
 scripts/check-convex-db-writes.mjs                 |   2 +-
 .../_auth/dashboard/_layout.settings.index.tsx     |   4 +-
 .../_auth/dashboard/_layout.settings.profile.tsx   |   6 +-
 tests/convex/avatarConsistency.test.ts             |   6 +-
 8 files changed, 192 insertions(+), 97 deletions(-)
```