### PR TITLE
`_helpers/permissions.ts` imports `verifyOrgAccess` from `auth.ts` directly

### DIFF
--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -1,5 +1,13 @@
 import { QueryCtx, MutationCtx } from "../_generated/server";
 import { Id } from "../_generated/dataModel";
+// verifyOrgAccess is intentionally imported from auth.ts (Convex ctx.db path)
+// rather than authAction.ts (Supabase internalAction path). This MUST NOT be
+// changed as part of the Supabase migration. Reason: checkPermission and
+// getEffectivePermissions below accept QueryCtx | MutationCtx so they can be
+// called from both queries and mutations. Convex queries cannot invoke
+// internalActions, making the authAction.ts version unusable in this context.
+// teamMemberships is dual-written to Convex (TABLE_MAP primary → Supabase,
+// mirror → Convex ctx.db), so ctx.db reads here remain correct. (#3893, #3896)
 import { verifyOrgAccess } from "./auth";
 import { OrgRole } from "../schema";
 import {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4971.

Closes #4971

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- cb30c752 docs(permissions): explain why verifyOrgAccess must stay on the Convex path (closes #4971)

### Files changed

```
 convex/_helpers/permissions.ts | 8 ++++++++
 1 file changed, 8 insertions(+)
```