### PR TITLE
Audit remaining `Id<"organizations">` / `Id<"users">` parameter types across Con

### DIFF
--- a/convex/_helpers/auth.ts
+++ b/convex/_helpers/auth.ts
@@ -1,5 +1,4 @@
 import { QueryCtx, MutationCtx } from "../_generated/server";
-import { Id } from "../_generated/dataModel";
 import { auth } from "@cvx/auth";
 
 export async function getCurrentUser(ctx: QueryCtx | MutationCtx) {
@@ -17,7 +16,7 @@ export async function requireUser(ctx: QueryCtx | MutationCtx) {
 
 export async function verifyOrgAccess(
   ctx: QueryCtx | MutationCtx,
-  organizationId: Id<"organizations">
+  organizationId: string
 ) {
   const user = await requireUser(ctx);
 
@@ -35,7 +34,7 @@ export async function verifyOrgAccess(
 
 export async function requireOrgAdmin(
   ctx: QueryCtx | MutationCtx,
-  organizationId: Id<"organizations">
+  organizationId: string
 ) {
   const { user, membership } = await verifyOrgAccess(ctx, organizationId);
   if (membership.role !== "owner" && membership.role !== "admin") {

--- a/convex/_helpers/authAction.ts
+++ b/convex/_helpers/authAction.ts
@@ -103,7 +103,7 @@ export const verifyOrgAccess = internalAction({
     userId: Id<"users">;
     userName: string | undefined;
     userEmail: string | undefined;
-    membershipId: Id<"teamMemberships">;
+    membershipId: string;
     role: string;
   }> => {
     const userId = await auth.getUserId(ctx);
@@ -125,7 +125,7 @@ export const verifyOrgAccess = internalAction({
       userId: userId as Id<"users">,
       userName: user.name as string | undefined,
       userEmail: user.email as string | undefined,
-      membershipId: membership._id as Id<"teamMemberships">,
+      membershipId: membership._id,
       role: membership.role as string,
     };
   },

--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -1,5 +1,4 @@
 import { QueryCtx, MutationCtx } from "../_generated/server";
-import { Id } from "../_generated/dataModel";
 // verifyOrgAccess is intentionally imported from auth.ts (Convex ctx.db path)
 // rather than authAction.ts (Supabase internalAction path). This MUST NOT be
 // changed as part of the Supabase migration. Reason: checkPermission and
@@ -211,7 +210,7 @@ DEFAULT_PERMISSIONS.viewer.categoryDefinitions = {
 // architecture for the query read path. See #3893 and #3896.
 export async function checkPermission(
   ctx: QueryCtx | MutationCtx,
-  orgId: Id<"organizations">,
+  orgId: string,
   feature: Feature,
   action: Action,
   locationId?: string,
@@ -309,7 +308,7 @@ export async function checkPermission(
 // for query callers. (#3893 / #3896)
 export async function getEffectivePermissions(
   ctx: QueryCtx | MutationCtx,
-  orgId: Id<"organizations">,
+  orgId: string,
   locationId?: string,
 ): Promise<FeaturePermissions> {
   const { membership, user } = await verifyOrgAccess(ctx, orgId);

--- a/convex/_helpers/products.ts
+++ b/convex/_helpers/products.ts
@@ -1,6 +1,5 @@
 import { QueryCtx, internalQuery } from "../_generated/server";
 import { v } from "convex/values";
-import { Id } from "../_generated/dataModel";
 import { GABINET_MODULES, GABINET_PRODUCT_ID, type GabinetModule } from "../gabinet/_registry";
 
 /**
@@ -9,7 +8,7 @@ import { GABINET_MODULES, GABINET_PRODUCT_ID, type GabinetModule } from "../gabi
  */
 export async function verifyProductAccess(
   ctx: QueryCtx,
-  organizationId: Id<"organizations">,
+  organizationId: string,
   productId: string,
 ): Promise<void> {
   const subscription = await ctx.db
@@ -38,7 +37,7 @@ export async function verifyProductAccess(
  */
 export async function checkModuleAccess(
   ctx: QueryCtx,
-  organizationId: Id<"organizations">,
+  organizationId: string,
   module: GabinetModule,
 ): Promise<void> {
   await verifyProductAccess(ctx, organizationId, GABINET_MODULES[module]);

--- a/convex/_helpers/seatLimits.ts
+++ b/convex/_helpers/seatLimits.ts
@@ -18,7 +18,7 @@ import { createSupabaseDb } from "./supabaseDb";
 export async function checkSeatLimit(
   ctx: QueryCtx,
   args: {
-    organizationId: Id<"organizations">;
+    organizationId: string;
     skipPendingInvitations?: boolean;
   }
 ): Promise<{
@@ -44,7 +44,7 @@ export async function checkSeatLimit(
 
   const currentSeats = members.length + pendingCount;
 
-  const org = await ctx.db.get(args.organizationId);
+  const org = await ctx.db.get(args.organizationId as Id<"organizations">);
   if (!org) throw new Error("Organization not found");
 
   // Find all active or trialing subscriptions for org owner and take the


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5011.

Closes #5011

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e31aa7b0 fix(types): relax Id<"organizations">/<"teamMemberships"> to string in Convex helpers (closes #5011)

### Files changed

```
 convex/_helpers/auth.ts        | 5 ++---
 convex/_helpers/authAction.ts  | 4 ++--
 convex/_helpers/permissions.ts | 5 ++---
 convex/_helpers/products.ts    | 5 ++---
 convex/_helpers/seatLimits.ts  | 4 ++--
 5 files changed, 10 insertions(+), 13 deletions(-)
```