### PR TITLE
Audit remaining `as Id<"organizations">` casts at call sites

### DIFF
--- a/convex/auditLog.ts
+++ b/convex/auditLog.ts
@@ -4,7 +4,7 @@ import { createSupabaseDb } from "./_helpers/supabaseDb";
 export async function logAudit(
   _ctx: unknown,
   data: {
-    organizationId: Id<"organizations">;
+    organizationId: string;
     userId: Id<"users">;
     action: string;
     entityType?: string;

--- a/convex/documentInstances.ts
+++ b/convex/documentInstances.ts
@@ -253,7 +253,7 @@ export const updateDraft = action({
 
     await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: instance.organizationId as Id<"organizations"> },
+      { organizationId: String(instance.organizationId) },
     );
 
     const patch: Record<string, unknown> = { updatedAt: Date.now() };
@@ -303,7 +303,7 @@ export const updateStatus = action({
 
     const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: instance.organizationId as Id<"organizations"> },
+      { organizationId: String(instance.organizationId) },
     );
 
     const now = Date.now();
@@ -375,7 +375,7 @@ export const sign = action({
 
     const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: instance.organizationId as Id<"organizations"> },
+      { organizationId: String(instance.organizationId) },
     );
 
     const now = Date.now();
@@ -494,7 +494,7 @@ export const remove = action({
 
     await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: instance.organizationId as Id<"organizations"> },
+      { organizationId: String(instance.organizationId) },
     );
 
     await db.delete("documentInstances", args.id);

--- a/convex/documentTemplateFields.ts
+++ b/convex/documentTemplateFields.ts
@@ -47,7 +47,7 @@ export const listByTemplate = action({
 
     await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: orgId as Id<"organizations"> },
+      { organizationId: orgId },
     );
 
     const db = createSupabaseDb();
@@ -86,7 +86,7 @@ export const create = action({
 
     await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: orgId as Id<"organizations"> },
+      { organizationId: orgId },
     );
 
     const db = createSupabaseDb();
@@ -156,7 +156,7 @@ export const update = action({
 
     await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: orgId as Id<"organizations"> },
+      { organizationId: orgId },
     );
 
     // Check fieldKey uniqueness if changing
@@ -198,7 +198,7 @@ export const remove = action({
 
     await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: orgId as Id<"organizations"> },
+      { organizationId: orgId },
     );
 
     await db.delete("documentTemplateFields", args.id);
@@ -218,7 +218,7 @@ export const reorder = action({
 
     await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: orgId as Id<"organizations"> },
+      { organizationId: orgId },
     );
 
     const db = createSupabaseDb();

--- a/convex/documentTemplates.ts
+++ b/convex/documentTemplates.ts
@@ -217,7 +217,7 @@ export const update = action({
 
     await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: template.organizationId as Id<"organizations"> },
+      { organizationId: String(template.organizationId) },
     );
 
     const { id, ...patch } = args;
@@ -246,7 +246,7 @@ export const publish = action({
 
     await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: template.organizationId as Id<"organizations"> },
+      { organizationId: String(template.organizationId) },
     );
 
     if (template.status === "active") {
@@ -277,7 +277,7 @@ export const archive = action({
 
     await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: template.organizationId as Id<"organizations"> },
+      { organizationId: String(template.organizationId) },
     );
 
     await db.patch("documentTemplates", args.id, {
@@ -296,7 +296,7 @@ export const duplicate = action({
 
     const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: template.organizationId as Id<"organizations"> },
+      { organizationId: String(template.organizationId) },
     );
     const now = Date.now();
 
@@ -374,7 +374,7 @@ export const createNewVersion = action({
 
     const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: template.organizationId as Id<"organizations"> },
+      { organizationId: String(template.organizationId) },
     );
     const now = Date.now();
 

--- a/convex/documents/signing.ts
+++ b/convex/documents/signing.ts
@@ -1,7 +1,6 @@
 import { internalAction } from "../_generated/server";
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
-import type { Id } from "../_generated/dataModel";
 import { createSupabaseDb, type SupabaseDb } from "../_helpers/supabaseDb";
 import { createLogger } from "../_helpers/logger";
 import { getJunctionTreatmentIds } from "../gabinet/_helpers/junctionTreatments";
@@ -167,7 +166,7 @@ export const sendSigningEmailInternal = internalAction({
     // in email provider logs (Resend, Gmail) or browser history / Referer headers.
     const stubId = await ctx.runMutation(internal.signingStubs.createStub, {
       token: data.signingToken,
-      organizationId: data.organizationId as Id<"organizations">,
+      organizationId: String(data.organizationId),
       signingTokenExpiresAt: newExpiry,
       destination: "sign_form",
     });
@@ -225,7 +224,7 @@ export const sendSigningEmailInternal = internalAction({
     `;
 
     const logBase = {
-      organizationId: data.organizationId as Id<"organizations">,
+      organizationId: String(data.organizationId),
       source: "signing" as const,
       recipientEmail: args.recipientEmail,
       recipientName: args.recipientName,
@@ -284,7 +283,7 @@ export const sendSigningEmailInternal = internalAction({
       status: string;
     } | null = await ctx.runAction(
       internal.mailProviders._getActiveDefaultForOrg,
-      { organizationId: data.organizationId as Id<"organizations"> },
+      { organizationId: String(data.organizationId) },
     );
 
     if (defaultProvider && (defaultProvider.providerType === "resend" || defaultProvider.providerType === "mailgun")) {

--- a/convex/gabinet/appointmentReminders.ts
+++ b/convex/gabinet/appointmentReminders.ts
@@ -233,7 +233,7 @@ export const sendReminder = internalMutation({
 
     // Send in-app notification to the employee assigned to the appointment
     await createNotificationDirect(ctx, {
-      organizationId: reminder.organizationId as Id<"organizations">,
+      organizationId: String(reminder.organizationId),
       userId: appointment.employeeId as Id<"users">,
       type: "appointment_reminder",
       title: "Przypomnienie o wizycie",
@@ -244,7 +244,7 @@ export const sendReminder = internalMutation({
     // Also notify the appointment creator if different from employee
     if (appointment.createdBy !== appointment.employeeId) {
       await createNotificationDirect(ctx, {
-        organizationId: reminder.organizationId as Id<"organizations">,
+        organizationId: String(reminder.organizationId),
         userId: appointment.createdBy as Id<"users">,
         type: "appointment_reminder",
         title: "Przypomnienie o wizycie",
@@ -284,7 +284,7 @@ export const sendReminder = internalMutation({
               : "gabinet.appointment.reminder_custom";
 
       await ctx.scheduler.runAfter(0, internal.emailEventTrigger.triggerEmailEvent, {
-        organizationId: reminder.organizationId as Id<"organizations">,
+        organizationId: String(reminder.organizationId),
         eventType: reminderEventType,
         recipientEmail: patient.email as string,
         recipientName: patientName,
@@ -299,7 +299,7 @@ export const sendReminder = internalMutation({
       });
 
       await logAudit(ctx, {
-        organizationId: reminder.organizationId as Id<"organizations">,
+        organizationId: String(reminder.organizationId),
         userId: appointment.employeeId as Id<"users">,
         action: "gabinet:email:sent",
         entityType: "gabinetAppointment",
@@ -330,7 +330,7 @@ export const sendReminder = internalMutation({
     };
 
     await ctx.scheduler.runAfter(0, internal.automation.emitEvent, {
-      organizationId: reminder.organizationId as Id<"organizations">,
+      organizationId: String(reminder.organizationId),
       module: "gabinet",
       eventType: "gabinet.appointment.reminder_due",
       entityType: "gabinetAppointment",
@@ -345,7 +345,7 @@ export const sendReminder = internalMutation({
     // Queue appointment confirmation SMS if enabled for this timing and patient has phone
     if (sendSms && patient?.phone) {
       await ctx.runMutation(internal.gabinet.appointmentSms.queueConfirmationRequest, {
-        organizationId: reminder.organizationId as Id<"organizations">,
+        organizationId: String(reminder.organizationId),
         appointmentId: appointment._id as Id<"gabinetAppointments">,
         reminderId: args.reminderId as Id<"appointmentReminders">,
         trigger: "reminder",

--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -626,7 +626,7 @@ export const _backfillMemberships = internalAction({
       }
       try {
         await ctx.runMutation(internal.gabinet.employees._upsertMembership, {
-          organizationId: e.organizationId as Id<"organizations">,
+          organizationId: String(e.organizationId),
           userId: e.userId,
           gabinetRole: e.role as GabinetEmployeeRole,
           isActive: Boolean(e.isActive),

--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -427,7 +427,7 @@ export const bookFromPortal = action({
     const db = createSupabaseDb();
     const { patientId, organizationId: orgIdStr } =
       await validatePortalSessionSupabase(db, args.tokenHash);
-    const organizationId = orgIdStr as Id<"organizations">;
+    const organizationId = orgIdStr;
 
     // Past-time guard (issue #1415). The portal slot picker already hides
     // past slots client-side, but a crafted request could send any
@@ -658,7 +658,7 @@ export const requestReschedule = action({
     const db = createSupabaseDb();
     const { patientId, organizationId: orgIdStr } =
       await validatePortalSessionSupabase(db, args.tokenHash);
-    const organizationId = orgIdStr as Id<"organizations">;
+    const organizationId = orgIdStr;
 
     // Read appointment from Supabase
     const appt = await db.get("gabinetAppointments", args.appointmentId);

--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -1349,7 +1349,7 @@ export const _purgeExpiredPatients = internalAction({
         try {
           await ctx.runMutation(internal.gabinet.patients._gdprEraseSideEffects, {
             patientId: patient.id,
-            organizationId: orgId as Id<"organizations">,
+            organizationId: orgId,
             originalName,
             erasedBy: performedBy,
           });

--- a/convex/google/oauth.ts
+++ b/convex/google/oauth.ts
@@ -108,7 +108,7 @@ export const callback = httpAction(async (ctx, request) => {
 
     // Store the connection
     await ctx.runMutation(internal.oauthConnections.createOrUpdate, {
-      organizationId: state.organizationId as Id<"organizations">,
+      organizationId: state.organizationId,
       providerAccountId: userInfo.email as string,
       accessToken: tokens.access_token as string,
       refreshToken: tokens.refresh_token as string,

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -13,7 +13,7 @@ import {
   sendTrialWillEndEmail,
 } from "@cvx/email/templates/subscriptionEmail";
 import Stripe from "stripe";
-import { Doc, Id } from "@cvx/_generated/dataModel";
+import { Doc } from "@cvx/_generated/dataModel";
 import { createLogger } from "@cvx/_helpers/logger";
 
 function normalizeWebhookValue(value: FormDataEntryValue | unknown): string | undefined {
@@ -202,7 +202,7 @@ const handleCheckoutSessionCompleted = async (
   if (organizationId && productKey) {
     const normalizedStatus = toProductSubscriptionStatus(subscription.status);
     await ctx.runAction(internal.stripe.PREAUTH_upsertProductSubscription, {
-      organizationId: organizationId as Id<"organizations">,
+      organizationId: organizationId,
       productId: productKey,
       stripeSubscriptionId: subscription.id,
       status: normalizedStatus,
@@ -281,7 +281,7 @@ const handleCustomerSubscriptionUpdated = async (
   if (organizationId && productKey) {
     const normalizedStatus = toProductSubscriptionStatus(subscription.status);
     await ctx.runAction(internal.stripe.PREAUTH_upsertProductSubscription, {
-      organizationId: organizationId as Id<"organizations">,
+      organizationId: organizationId,
       productId: productKey,
       stripeSubscriptionId: subscription.id,
       status: normalizedStatus,
@@ -338,7 +338,7 @@ const handleCustomerSubscriptionCreated = async (
   if (organizationId && productKey) {
     const normalizedStatus = toProductSubscriptionStatus(subscription.status);
     await ctx.runAction(internal.stripe.PREAUTH_upsertProductSubscription, {
-      organizationId: organizationId as Id<"organizations">,
+      organizationId: organizationId,
       productId: productKey,
       stripeSubscriptionId: subscription.id,
       status: normalizedStatus,
@@ -365,7 +365,7 @@ const handleCustomerSubscriptionDeleted = async (
   const organizationId = subscription.metadata?.organizationId;
   if (organizationId && productKey) {
     await ctx.runAction(internal.stripe.PREAUTH_upsertProductSubscription, {
-      organizationId: organizationId as Id<"organizations">,
+      organizationId: organizationId,
       productId: productKey,
       stripeSubscriptionId: subscription.id,
       status: "canceled",

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -505,7 +505,7 @@ export const _acceptInternal = internalMutation({
       throw new Error("This invitation was sent to a different email address");
     }
 
-    const orgId = args.invitationOrgId as Id<"organizations">;
+    const orgId = args.invitationOrgId;
     const invitedById = args.invitationInvitedBy as Id<"users">;
 
     const joinedAt = Date.now();
@@ -850,7 +850,7 @@ export const _adminResendAndSend = internalAction({
       email: String(inv.email),
       role: String(inv.role),
       token: String(inv.token),
-      organizationId: inv.organizationId as Id<"organizations">,
+      organizationId: String(inv.organizationId),
       inviterUserId: String(inv.invitedBy),
     });
 
@@ -860,7 +860,7 @@ export const _adminResendAndSend = internalAction({
       email: String(inv.email),
       role: String(inv.role),
       token: String(inv.token),
-      organizationId: inv.organizationId as Id<"organizations">,
+      organizationId: String(inv.organizationId),
       invitedBy: String(inv.invitedBy),
       expiresAt,
       updatedAt,

--- a/convex/microsoft/oauth.ts
+++ b/convex/microsoft/oauth.ts
@@ -135,7 +135,7 @@ export const callback = httpAction(async (ctx, request) => {
 
     // Store the connection
     await ctx.runMutation(internal.oauthConnections.createOrUpdate, {
-      organizationId: state.organizationId as Id<"organizations">,
+      organizationId: state.organizationId,
       providerAccountId: accountEmail,
       accessToken: tokens.access_token,
       refreshToken: tokens.refresh_token,

--- a/convex/migrations/backfillEntitlements.ts
+++ b/convex/migrations/backfillEntitlements.ts
@@ -47,7 +47,7 @@ export const run = internalAction({
         crmGranted++;
         if (!dryRun) {
           await ctx.runMutation(internal.admin.entitlements._upsertEntitlement, {
-            organizationId: orgId as unknown as Id<"organizations">,
+            organizationId: orgId,
             productId: "crm",
             grant: true,
             grantedByUserId: grantedBy as unknown as Id<"users">,
@@ -58,7 +58,7 @@ export const run = internalAction({
         gabinetGranted++;
         if (!dryRun) {
           await ctx.runMutation(internal.admin.entitlements._upsertEntitlement, {
-            organizationId: orgId as unknown as Id<"organizations">,
+            organizationId: orgId,
             productId: "gabinet",
             grant: true,
             grantedByUserId: grantedBy as unknown as Id<"users">,

--- a/convex/signatureRequests.ts
+++ b/convex/signatureRequests.ts
@@ -1,7 +1,6 @@
 import { action, internalAction, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
-import type { Id } from "./_generated/dataModel";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 
 // Dual-write refs removed — Supabase is now primary for signature request writes
@@ -92,7 +91,7 @@ export const listByInstance = action({
     const instance = await db.get("documentInstances", args.instanceId);
     if (!instance) return [];
     await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
-      organizationId: instance.organizationId as Id<"organizations">,
+      organizationId: String(instance.organizationId),
     });
 
     return await db.query("signatureRequests")
@@ -132,7 +131,7 @@ export const sendForSigning = action({
 
     await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: instance.organizationId as Id<"organizations"> },
+      { organizationId: String(instance.organizationId) },
     );
 
     const now = Date.now();
@@ -280,12 +279,12 @@ export const _sendSigningEmails = internalMutation({
           organizationName: orgName,
           token: ct.token,
           expiresAt: args.expiresAt,
-          organizationId: args.organizationId as Id<"organizations">,
+          organizationId: args.organizationId,
         });
       }
       if (sig?.signerPhone && sig?.verificationMethod === "sms") {
         await ctx.scheduler.runAfter(0, internal.sms.sendSigningLinkSms, {
-          organizationId: args.organizationId as Id<"organizations">,
+          organizationId: args.organizationId,
           phone: sig.signerPhone,
           signerName: sig.signerName ?? sig.signerPhone,
           documentTitle: args.instanceTitle,
@@ -516,7 +515,7 @@ export const resend = action({
 
     await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: request.organizationId as Id<"organizations"> },
+      { organizationId: String(request.organizationId) },
     );
 
     const now = Date.now();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5063.

Closes #5063

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 6d41bd16 fix(types): remove unnecessary as Id<"organizations"> casts at call sites (closes #5063)

### Files changed

```
 convex/auditLog.ts                        |  2 +-
 convex/documentInstances.ts               |  8 ++++----
 convex/documentTemplateFields.ts          | 10 +++++-----
 convex/documentTemplates.ts               | 10 +++++-----
 convex/documents/signing.ts               |  7 +++----
 convex/gabinet/appointmentReminders.ts    | 12 ++++++------
 convex/gabinet/employees.ts               |  2 +-
 convex/gabinet/patientPortal.ts           |  4 ++--
 convex/gabinet/patients.ts                |  2 +-
 convex/google/oauth.ts                    |  2 +-
 convex/http.ts                            | 10 +++++-----
 convex/invitations.ts                     |  6 +++---
 convex/microsoft/oauth.ts                 |  2 +-
 convex/migrations/backfillEntitlements.ts |  4 ++--
 convex/signatureRequests.ts               | 11 +++++------
 15 files changed, 45 insertions(+), 47 deletions(-)
```