### PR TITLE
Fix `getSeatLimit` missing the max-wins multi-subscription logic

### DIFF
--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -501,7 +501,7 @@ export const getSeatLimit = query({
       .first();
     if (!ownerMembership) throw new Error("Organization not found");
 
-    const subscription = await ctx.db
+    const subscriptions = await ctx.db
       .query("subscriptions")
       .withIndex("userId", (q) => q.eq("userId", ownerMembership.userId))
       .filter((q) =>
@@ -510,11 +510,18 @@ export const getSeatLimit = query({
           q.eq(q.field("status"), "trialing"),
         ),
       )
-      .first();
+      .collect();
 
-    if (!subscription) return { seatLimit: 20 };
+    if (subscriptions.length === 0) return { seatLimit: 20 };
 
-    const plan = await ctx.db.get(subscription.planId);
-    return { seatLimit: plan?.seatLimit ?? 20 };
+    let maxSeatLimit: number | null = null;
+    for (const sub of subscriptions) {
+      const plan = await ctx.db.get(sub.planId);
+      if (!plan) continue;
+      if (maxSeatLimit === null || plan.seatLimit > maxSeatLimit) {
+        maxSeatLimit = plan.seatLimit;
+      }
+    }
+    return { seatLimit: maxSeatLimit ?? 20 };
   },
 });

--- a/tests/convex/seatLimits.test.ts
+++ b/tests/convex/seatLimits.test.ts
@@ -462,3 +462,82 @@ describe("member removal frees seat", () => {
     expect(usage.canAddMore).toBe(true);
   });
 });
+
+describe("getSeatLimit max-wins with multiple subscriptions", () => {
+  test("returns highest seatLimit across multiple active subscriptions", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    await t.run(async (ctx) => {
+      const planLow = await ctx.db.insert("plans", {
+        key: "crm",
+        stripeId: "price_crm_multi",
+        name: "CRM",
+        description: "CRM module plan",
+        seatLimit: 15,
+        prices: {
+          month: {
+            usd: { stripeId: "price_crm_m_usd", amount: 1900 },
+            eur: { stripeId: "price_crm_m_eur", amount: 1900 },
+            pln: { stripeId: "price_crm_m_pln", amount: 7900 },
+          },
+          year: {
+            usd: { stripeId: "price_crm_y_usd", amount: 19000 },
+            eur: { stripeId: "price_crm_y_eur", amount: 19000 },
+            pln: { stripeId: "price_crm_y_pln", amount: 79000 },
+          },
+        },
+      });
+      const planHigh = await ctx.db.insert("plans", {
+        key: "gabinet",
+        stripeId: "price_gabinet_multi",
+        name: "Gabinet",
+        description: "Gabinet module plan",
+        seatLimit: 40,
+        prices: {
+          month: {
+            usd: { stripeId: "price_gab_m_usd", amount: 3900 },
+            eur: { stripeId: "price_gab_m_eur", amount: 3900 },
+            pln: { stripeId: "price_gab_m_pln", amount: 15900 },
+          },
+          year: {
+            usd: { stripeId: "price_gab_y_usd", amount: 39000 },
+            eur: { stripeId: "price_gab_y_eur", amount: 39000 },
+            pln: { stripeId: "price_gab_y_pln", amount: 159000 },
+          },
+        },
+      });
+
+      await ctx.db.insert("subscriptions", {
+        userId,
+        planId: planLow,
+        priceStripeId: "price_crm_m_usd",
+        stripeId: "sub_crm",
+        currency: "usd",
+        interval: "month",
+        status: "active",
+        currentPeriodStart: Date.now(),
+        currentPeriodEnd: Date.now() + 30 * 24 * 60 * 60 * 1000,
+        cancelAtPeriodEnd: false,
+      });
+      await ctx.db.insert("subscriptions", {
+        userId,
+        planId: planHigh,
+        priceStripeId: "price_gab_m_usd",
+        stripeId: "sub_gabinet",
+        currency: "usd",
+        interval: "month",
+        status: "active",
+        currentPeriodStart: Date.now(),
+        currentPeriodEnd: Date.now() + 30 * 24 * 60 * 60 * 1000,
+        cancelAtPeriodEnd: false,
+      });
+    });
+
+    const result = await t
+      .withIdentity(identity)
+      .query(api.organizations.getSeatLimit, { organizationId });
+
+    expect(result.seatLimit).toBe(40);
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5066.

Closes #5066

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c5ea4bb0 fix(seatLimits): apply max-wins logic to getSeatLimit (closes #5066)

### Files changed

```
 convex/organizations.ts         | 17 ++++++---
 tests/convex/seatLimits.test.ts | 79 +++++++++++++++++++++++++++++++++++++++++
 2 files changed, 91 insertions(+), 5 deletions(-)
```