### PR TITLE
Fix `src/components/shadcn-studio/blocks/widget-audience.tsx` Next.js env var

### DIFF
--- a/src/components/shadcn-studio/blocks/widget-audience.tsx
+++ b/src/components/shadcn-studio/blocks/widget-audience.tsx
@@ -168,7 +168,7 @@ const AudienceCard = ({ className }: { className?: string }) => {
         </div>
         <Separator />
       </CardContent>
-      <APIProvider apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!}>
+      <APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY}>
         <Map
           style={{ width: '340px', minHeight: '205px' }}
           defaultCenter={{ lat: 22.7, lng: 78.7 }}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4903.

Closes #4903

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8665c482 fix(shadcn-studio): replace Next.js env var with Vite convention in widget-audience (closes #4903)

### Files changed

```
 src/components/shadcn-studio/blocks/widget-audience.tsx | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```