### PR TITLE
`findEmailAccountByAddress` in `emails_internal.ts` does a full table scan (`col

### DIFF
--- a/convex/crm/emails_internal.ts
+++ b/convex/crm/emails_internal.ts
@@ -15,18 +15,15 @@ type EmailAccountRow = SupabaseRow<"emailAccounts">;
 export const findEmailAccountByAddress = internalAction({
   args: { addresses: v.array(v.string()) },
   handler: async (_ctx, args): Promise<EmailAccountRow | null> => {
+    if (args.addresses.length === 0) return null;
     const db = createSupabaseDb();
-    // No `fromEmail` index in Supabase either, so scan all accounts once
-    // and match in memory. Pulled out of the address loop since each
-    // iteration would otherwise re-fetch the same set.
-    const allAccounts = (await db
+    const normalizedAddresses = args.addresses.map((a) => a.toLowerCase().trim());
+    const matches = (await db
       .query("emailAccounts")
+      .in("fromEmail", normalizedAddresses)
       .collect()) as EmailAccountRow[];
-    for (const address of args.addresses) {
-      const normalizedAddress = address.toLowerCase().trim();
-      const match = allAccounts.find(
-        (a) => a.fromEmail.toLowerCase() === normalizedAddress,
-      );
+    for (const address of normalizedAddresses) {
+      const match = matches.find((a) => a.fromEmail.toLowerCase() === address);
       if (match) return match;
     }
     return null;

--- a/supabase/migrations/00127_email_accounts_from_email_idx.sql
+++ b/supabase/migrations/00127_email_accounts_from_email_idx.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS email_accounts_from_email_idx
+  ON email_accounts (from_email);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4915.

Closes #4915

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 403b97a5 fix(emails): replace full-table scan in findEmailAccountByAddress with indexed .in() query (closes #4915)

### Files changed

```
 convex/crm/emails_internal.ts                             | 15 ++++++---------
 .../migrations/00127_email_accounts_from_email_idx.sql    |  2 ++
 2 files changed, 8 insertions(+), 9 deletions(-)
```