### PR TITLE
Migrate `sentBy

### DIFF
--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -913,7 +913,7 @@ export function createCrmTables({
     mailProviderId: v.optional(v.id("mailProviders")),
     gmailMessageId: v.optional(v.string()),
     gmailThreadId: v.optional(v.string()),
-    sentBy: v.optional(v.id("users")),
+    sentBy: v.optional(v.string()),
     templateId: v.optional(v.id("emailTemplates")),
     patientId: v.optional(v.id("gabinetPatients")),
     appointmentId: v.optional(v.id("gabinetAppointments")),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #4917.

Closes #4917

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 5fdb5b3e fix(schema): migrate sentBy from v.id("users") to v.string() in emails table (closes #4917)

### Files changed

```
 convex/schema/crm.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```