### PR TITLE
Remove unused `ctx

### DIFF
--- a/convex/_helpers/activities.ts
+++ b/convex/_helpers/activities.ts
@@ -1,9 +1,7 @@
-import { MutationCtx } from "../_generated/server";
 import { ActivityAction } from "@cvx/schema";
 import { publishActivityEnvelope } from "./activityEnvelope";
 
 export async function logActivity(
-  ctx: MutationCtx,
   args: {
     organizationId: string;
     entityType: string;

--- a/convex/automation.ts
+++ b/convex/automation.ts
@@ -478,7 +478,7 @@ export const _logActivityForRun = internalMutation({
     performedBy: v.string(),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: args.entityType,
       entityId: args.entityId,
@@ -760,7 +760,7 @@ export const _recordAutomationEmailResult = internalMutation({
     });
 
     if (args.sentBy) {
-      await logActivity(ctx, {
+      await logActivity({
         organizationId: args.organizationId,
         entityType: "email",
         entityId: emailId,
@@ -940,7 +940,7 @@ export const _recordUpdateFieldResult = internalMutation({
       const entityLabel = args.targetEntityType
         ? (activityLabelByEntity[args.targetEntityType] ?? args.targetEntityType)
         : args.linkedEntityType;
-      await logActivity(ctx, {
+      await logActivity({
         organizationId: args.organizationId,
         entityType: args.linkedEntityType,
         entityId: args.targetId,

--- a/convex/crm/calls.ts
+++ b/convex/crm/calls.ts
@@ -144,7 +144,7 @@ export const _createSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "call",
       entityId: args.callId,
@@ -213,7 +213,7 @@ export const _updateSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "call",
       entityId: args.callId,
@@ -287,7 +287,7 @@ export const _removeSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "call",
       entityId: args.callId,

--- a/convex/crm/companies.ts
+++ b/convex/crm/companies.ts
@@ -112,7 +112,7 @@ export const _createSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const createdByUserId = args.createdBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "company",
       entityId: args.companyId as Id<"companies">,
@@ -235,7 +235,7 @@ export const _updateSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const updatedByUserId = args.updatedBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "company",
       entityId: args.companyId as Id<"companies">,
@@ -332,7 +332,7 @@ export const _removeSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const deletedByUserId = args.deletedBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "company",
       entityId: args.companyId as Id<"companies">,

--- a/convex/crm/contacts.ts
+++ b/convex/crm/contacts.ts
@@ -109,7 +109,7 @@ export const _createSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const createdByUserId = args.createdBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "contact",
       entityId: args.contactId as Id<"contacts">,
@@ -226,7 +226,7 @@ export const _updateSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const updatedByUserId = args.updatedBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "contact",
       entityId: args.contactId as Id<"contacts">,
@@ -323,7 +323,7 @@ export const _removeSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const deletedByUserId = args.deletedBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "contact",
       entityId: args.contactId as Id<"contacts">,
@@ -453,7 +453,7 @@ export const _gdprEraseSideEffects = internalMutation({
       details: `GDPR erasure performed on contact "${args.originalName}" (ID: ${args.contactId})`,
     });
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "contact",
       entityId: args.contactId as Id<"contacts">,

--- a/convex/crm/documents.ts
+++ b/convex/crm/documents.ts
@@ -84,7 +84,7 @@ export const _createSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "document",
       entityId: args.documentId,
@@ -165,7 +165,7 @@ export const _updateSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "document",
       entityId: args.documentId,
@@ -239,7 +239,7 @@ export const _removeSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "document",
       entityId: args.documentId,
@@ -320,7 +320,7 @@ export const _updateStatusSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "document",
       entityId: args.documentId,

--- a/convex/crm/leads.ts
+++ b/convex/crm/leads.ts
@@ -167,7 +167,7 @@ export const _createSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const createdByUserId = args.createdBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "lead",
       entityId: args.leadId as Id<"leads">,
@@ -342,7 +342,7 @@ export const _updateSideEffects = internalMutation({
     const now = args.updatedAt;
 
     if (args.newStatus && args.newStatus !== args.oldStatus) {
-      await logActivity(ctx, {
+      await logActivity({
         organizationId: args.organizationId,
         entityType: "lead",
         entityId: args.leadId as Id<"leads">,
@@ -413,7 +413,7 @@ export const _updateSideEffects = internalMutation({
         occurredAt: now,
       });
     } else {
-      await logActivity(ctx, {
+      await logActivity({
         organizationId: args.organizationId,
         entityType: "lead",
         entityId: args.leadId as Id<"leads">,
@@ -533,7 +533,7 @@ export const _removeSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const deletedByUserId = args.deletedBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "lead",
       entityId: args.leadId as Id<"leads">,
@@ -876,7 +876,7 @@ export const _gdprEraseSideEffects = internalMutation({
       details: `GDPR erasure performed on lead "${args.originalTitle}" (ID: ${args.leadId})`,
     });
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "lead",
       entityId: args.leadId as Id<"leads">,
@@ -977,7 +977,7 @@ export const _moveToStageSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "lead",
       entityId: args.leadId,

--- a/convex/crm/pipelines.ts
+++ b/convex/crm/pipelines.ts
@@ -136,7 +136,7 @@ export const _sideEffects = internalMutation({
     const userId = args.userId as any;
 
     if (args.type === "pipeline_created" && args.pipelineId) {
-      await logActivity(ctx, {
+      await logActivity({
         organizationId: args.organizationId,
         entityType: "pipeline",
         entityId: args.pipelineId as any,
@@ -146,7 +146,7 @@ export const _sideEffects = internalMutation({
         actorLabel: args.actorLabel,
       });
     } else if (args.type === "pipeline_updated" && args.pipelineId) {
-      await logActivity(ctx, {
+      await logActivity({
         organizationId: args.organizationId,
         entityType: "pipeline",
         entityId: args.pipelineId as any,
@@ -168,7 +168,7 @@ export const _sideEffects = internalMutation({
           } catch { /* lead may not exist */ }
         }
       }
-      await logActivity(ctx, {
+      await logActivity({
         organizationId: args.organizationId,
         entityType: "pipeline",
         entityId: args.pipelineId as any,
@@ -178,7 +178,7 @@ export const _sideEffects = internalMutation({
         actorLabel: args.actorLabel,
       });
     } else if (args.type === "stage_added" && args.pipelineId) {
-      await logActivity(ctx, {
+      await logActivity({
         organizationId: args.organizationId,
         entityType: "pipeline",
         entityId: args.pipelineId as any,
@@ -188,7 +188,7 @@ export const _sideEffects = internalMutation({
         actorLabel: args.actorLabel,
       });
     } else if (args.type === "stage_updated" && args.pipelineId) {
-      await logActivity(ctx, {
+      await logActivity({
         organizationId: args.organizationId,
         entityType: "pipeline",
         entityId: args.pipelineId as any,
@@ -217,7 +217,7 @@ export const _sideEffects = internalMutation({
           } catch { /* lead may not exist */ }
         }
       }
-      await logActivity(ctx, {
+      await logActivity({
         organizationId: args.organizationId,
         entityType: "pipeline",
         entityId: args.pipelineId as any,
@@ -227,7 +227,7 @@ export const _sideEffects = internalMutation({
         actorLabel: args.actorLabel,
       });
     } else if (args.type === "stages_reordered" && args.pipelineId) {
-      await logActivity(ctx, {
+      await logActivity({
         organizationId: args.organizationId,
         entityType: "pipeline",
         entityId: args.pipelineId as any,

--- a/convex/crm/products.ts
+++ b/convex/crm/products.ts
@@ -135,7 +135,7 @@ export const _createSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "product",
       entityId: args.productId,
@@ -245,7 +245,7 @@ export const _updateSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "product",
       entityId: args.productId,
@@ -318,7 +318,7 @@ export const _removeSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "product",
       entityId: args.productId,
@@ -389,7 +389,7 @@ export const _toggleActiveSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "product",
       entityId: args.productId,
@@ -505,7 +505,7 @@ export const _addToDealSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "lead",
       entityId: args.dealId,
@@ -570,7 +570,7 @@ export const _removeFromDealSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "lead",
       entityId: args.dealId,

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -245,7 +245,7 @@ async function applyAppointmentStatusChange(
     }
   }
 
-  await logActivity(ctx, {
+  await logActivity({
     organizationId: args.organizationId,
     entityType: "gabinetAppointment",
     entityId: args.appointment._id,
@@ -902,7 +902,7 @@ export const _createSideEffects = internalMutation({
     const recurActivityIds = args.recurActivityIds;
 
     // --- 5. Log activity ---
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetAppointment",
       entityId: args.appointmentId,
@@ -2022,7 +2022,7 @@ export const _updateSideEffects = internalMutation({
       description = `Rescheduled appointment from ${args.previousDate} ${prevStart} to ${args.newDate} ${nextStart}`;
     }
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetAppointment",
       entityId: args.appointmentId,
@@ -2860,7 +2860,7 @@ export const _cancelSideEffects = internalMutation({
       { appointmentId: appointmentId },
     );
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetAppointment",
       entityId: args.appointmentId,

--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -745,7 +745,7 @@ export const _createSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const createdByUserId = args.createdBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetEmployee",
       entityId: args.employeeId as Id<"gabinetEmployees">,
@@ -1025,7 +1025,7 @@ export const _updateSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const updatedByUserId = args.updatedBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetEmployee",
       entityId: args.employeeId as Id<"gabinetEmployees">,
@@ -1247,7 +1247,7 @@ export const _removeSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const deletedByUserId = args.deletedBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetEmployee",
       entityId: args.employeeId as Id<"gabinetEmployees">,
@@ -1359,7 +1359,7 @@ export const _setQualifiedSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const updatedByUserId = args.updatedBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetEmployee",
       entityId: args.employeeId as Id<"gabinetEmployees">,

--- a/convex/gabinet/equipment.ts
+++ b/convex/gabinet/equipment.ts
@@ -345,7 +345,7 @@ export const _createEquipmentSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetEquipment",
       entityId: args.equipmentId,
@@ -365,7 +365,7 @@ export const _updateEquipmentSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetEquipment",
       entityId: args.equipmentId,
@@ -386,7 +386,7 @@ export const _transferEquipmentSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetEquipment",
       entityId: args.equipmentId,

--- a/convex/gabinet/leaveTypes.ts
+++ b/convex/gabinet/leaveTypes.ts
@@ -455,7 +455,7 @@ export const _createSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetLeaveType",
       entityId: args.leaveTypeId,
@@ -475,7 +475,7 @@ export const _updateSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetLeaveType",
       entityId: args.leaveTypeId,
@@ -495,7 +495,7 @@ export const _removeSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetLeaveType",
       entityId: args.leaveTypeId,
@@ -515,7 +515,7 @@ export const _adjustBalanceSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetLeaveBalance",
       entityId: args.balanceId,
@@ -537,7 +537,7 @@ export const _initializeBalanceSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetLeaveBalance",
       entityId: args.balanceId,

--- a/convex/gabinet/locations.ts
+++ b/convex/gabinet/locations.ts
@@ -496,7 +496,7 @@ export const _createLocationSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetLocation",
       entityId: args.locationId,
@@ -516,7 +516,7 @@ export const _updateLocationSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetLocation",
       entityId: args.locationId,
@@ -536,7 +536,7 @@ export const _deleteLocationSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetLocation",
       entityId: args.locationId,
@@ -558,7 +558,7 @@ export const _createRoomSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetRoom",
       entityId: args.roomId,
@@ -579,7 +579,7 @@ export const _updateRoomSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetRoom",
       entityId: args.roomId,
@@ -599,7 +599,7 @@ export const _deleteRoomSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetRoom",
       entityId: args.roomId,

--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -277,7 +277,7 @@ export const _createSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetPackage",
       entityId: args.packageId as Id<"gabinetTreatmentPackages">,
@@ -1172,7 +1172,7 @@ export const _batchUsageSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const db = createSupabaseDb();
     const pkg = await db.get("gabinetTreatmentPackages", args.packageId);
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetPackage",
       entityId: args.packageId as Id<"gabinetTreatmentPackages">,

--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -469,7 +469,7 @@ export const _createSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const createdByUserId = args.createdBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetPatient",
       entityId: args.patientId as Id<"gabinetPatients">,
@@ -633,7 +633,7 @@ export const _updateSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const updatedByUserId = args.updatedBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetPatient",
       entityId: args.patientId as Id<"gabinetPatients">,
@@ -729,7 +729,7 @@ export const _removeSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const deletedByUserId = args.deletedBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetPatient",
       entityId: args.patientId as Id<"gabinetPatients">,
@@ -1076,7 +1076,7 @@ export const _mergeSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const performedByUserId = args.performedBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetPatient",
       entityId: args.targetPatientId as Id<"gabinetPatients">,
@@ -1089,7 +1089,7 @@ export const _mergeSideEffects = internalMutation({
       actorLabel: args.actorLabel,
     });
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetPatient",
       entityId: args.sourcePatientId as Id<"gabinetPatients">,
@@ -1234,7 +1234,7 @@ export const _gdprEraseSideEffects = internalMutation({
     });
 
     // Activity entry without PII marks the erasure in the patient timeline
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetPatient",
       entityId: args.patientId as Id<"gabinetPatients">,

--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -1196,7 +1196,7 @@ export const _workingHoursSideEffects = internalMutation({
   },
   handler: async (ctx, args) => {
     const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetWorkingHours",
       entityId: args.workingHoursId,
@@ -1216,7 +1216,7 @@ export const _bulkWorkingHoursSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetWorkingHours",
       entityId: String(args.organizationId),
@@ -1237,7 +1237,7 @@ export const _employeeScheduleSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetEmployeeSchedule",
       entityId: args.scheduleId,
@@ -1258,7 +1258,7 @@ export const _bulkEmployeeScheduleSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetEmployeeSchedule",
       entityId: args.userId,
@@ -1280,7 +1280,7 @@ export const _saveSchedulePeriodSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetEmployeeSchedule",
       entityId: args.userId,
@@ -1304,7 +1304,7 @@ export const _removeSchedulePeriodSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetEmployeeSchedule",
       entityId: args.userId,
@@ -1331,7 +1331,7 @@ export const _createLeaveSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetLeave",
       entityId: args.userId,
@@ -1430,7 +1430,7 @@ export const _leaveSideEffects = internalMutation({
     auditAction: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetLeave",
       entityId: args.userId,

--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -313,7 +313,7 @@ export const _createSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const createdByUserId = args.createdBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetTreatment",
       entityId: args.treatmentId as Id<"gabinetTreatments">,
@@ -476,7 +476,7 @@ export const _updateSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const updatedByUserId = args.updatedBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetTreatment",
       entityId: args.treatmentId as Id<"gabinetTreatments">,
@@ -565,7 +565,7 @@ export const _removeSideEffects = internalMutation({
   handler: async (ctx, args) => {
     const deletedByUserId = args.deletedBy as Id<"users">;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetTreatment",
       entityId: args.treatmentId as Id<"gabinetTreatments">,

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -313,7 +313,7 @@ export const _createInternal = internalMutation({
     const now = Date.now();
     const expiresAt = now + 7 * 24 * 60 * 60 * 1000;
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "organization",
       entityId: args.organizationId,
@@ -566,7 +566,7 @@ export const _acceptInternal = internalMutation({
     // Invitation status is patched in Supabase by the parent accept action.
     // No ctx.db.patch needed — invitation is no longer stored in Convex.
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: orgId,
       entityType: "organization",
       entityId: String(orgId),

--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -96,7 +96,7 @@ export const _createOrgInternal = internalMutation({
       joinedAt: now,
     });
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: orgId,
       entityType: "organization",
       entityId: orgId,
@@ -244,7 +244,7 @@ export const _updateOrgInternal = internalMutation({
 
     await ctx.db.patch(organizationId, { ...updates, updatedAt: Date.now() });
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId,
       entityType: "organization",
       entityId: organizationId,
@@ -347,7 +347,7 @@ export const _inviteMemberInternal = internalMutation({
       joinedAt,
     });
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "organization",
       entityId: args.organizationId,
@@ -412,7 +412,7 @@ export const _updateMemberRoleInternal = internalMutation({
 
     await ctx.db.patch(args.membershipId, { role: args.role });
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "organization",
       entityId: args.organizationId,
@@ -466,7 +466,7 @@ export const _removeMemberInternal = internalMutation({
 
     await ctx.db.delete(args.membershipId);
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "organization",
       entityId: args.organizationId,

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -856,7 +856,7 @@ export const _markPaidSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetAppointment",
       entityId: (args.appointmentId ?? args.paymentId) as any,

--- a/convex/relationships.ts
+++ b/convex/relationships.ts
@@ -171,7 +171,7 @@ export const _createSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: args.sourceType,
       entityId: args.sourceId,
@@ -234,7 +234,7 @@ export const _removeSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: args.sourceType,
       entityId: args.sourceId,

--- a/convex/scheduledActivities.ts
+++ b/convex/scheduledActivities.ts
@@ -29,7 +29,7 @@ export const _createSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "scheduledActivity",
       entityId: args.activityId as any,
@@ -72,7 +72,7 @@ export const _updateSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "scheduledActivity",
       entityId: args.activityId as any,
@@ -122,7 +122,7 @@ export const _deleteSideEffects = internalMutation({
       });
     }
 
-    await logActivity(ctx, {
+    await logActivity({
       organizationId: args.organizationId,
       entityType: "scheduledActivity",
       entityId: args.activityId as any,

--- a/tests/convex/activityEnvelope.test.ts
+++ b/tests/convex/activityEnvelope.test.ts
@@ -149,7 +149,7 @@ describe("activity envelope helper", () => {
     const { organizationId, userId } = await seedTestUser(t);
 
     await t.run(async (ctx) => {
-      await logActivity(ctx, {
+      await logActivity({
         organizationId,
         entityType: "contact",
         entityId: "contact-1",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5000.

Closes #5000

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d3e5b4b0 fix(activities): remove unused ctx param from logActivity (closes #5000)

### Files changed

```
 convex/_helpers/activities.ts         |  2 --
 convex/automation.ts                  |  6 +++---
 convex/crm/calls.ts                   |  6 +++---
 convex/crm/companies.ts               |  6 +++---
 convex/crm/contacts.ts                |  8 ++++----
 convex/crm/documents.ts               |  8 ++++----
 convex/crm/leads.ts                   | 12 ++++++------
 convex/crm/pipelines.ts               | 14 +++++++-------
 convex/crm/products.ts                | 12 ++++++------
 convex/gabinet/appointments.ts        |  8 ++++----
 convex/gabinet/employees.ts           |  8 ++++----
 convex/gabinet/equipment.ts           |  6 +++---
 convex/gabinet/leaveTypes.ts          | 10 +++++-----
 convex/gabinet/locations.ts           | 12 ++++++------
 convex/gabinet/packages.ts            |  4 ++--
 convex/gabinet/patients.ts            | 12 ++++++------
 convex/gabinet/scheduling.ts          | 16 ++++++++--------
 convex/gabinet/treatments.ts          |  6 +++---
 convex/invitations.ts                 |  4 ++--
 convex/organizations.ts               | 10 +++++-----
 convex/payments.ts                    |  2 +-
 convex/relationships.ts               |  4 ++--
 convex/scheduledActivities.ts         |  6 +++---
 tests/convex/activityEnvelope.test.ts |  2 +-
 24 files changed, 91 insertions(+), 93 deletions(-)
```