### PR TITLE
Remove redundant `as Id<"users">` casts in `crm/leads.ts` at `createNotification

### DIFF
--- a/convex/crm/leads.ts
+++ b/convex/crm/leads.ts
@@ -181,7 +181,7 @@ export const _createSideEffects = internalMutation({
     if (args.assignedTo && args.assignedTo !== args.createdBy) {
       await createNotificationDirect(ctx, {
         organizationId: args.organizationId,
-        userId: args.assignedTo as Id<"users">,
+        userId: args.assignedTo,
         type: "assigned",
         title: "Lead assigned",
         message: `You have been assigned to lead "${args.title}"`,
@@ -432,7 +432,7 @@ export const _updateSideEffects = internalMutation({
     ) {
       await createNotificationDirect(ctx, {
         organizationId: args.organizationId,
-        userId: args.newAssignedTo as Id<"users">,
+        userId: args.newAssignedTo,
         type: "assigned",
         title: "Lead assigned",
         message: `You have been assigned to lead "${args.title}"`,
@@ -998,7 +998,7 @@ export const _moveToStageSideEffects = internalMutation({
       if (created.ownerId !== String(args.userId)) {
         await createNotificationDirect(ctx, {
           organizationId: args.organizationId,
-          userId: created.ownerId as Id<"users">,
+          userId: created.ownerId,
           type: "assigned",
           title: "New task from pipeline",
           message: `Task "${created.title}" created for lead "${args.leadTitle}"`,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5013.

Closes #5013

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f6df9c86 refactor(leads): remove redundant as Id<"users"> casts at createNotificationDirect call sites (closes #5013)

### Files changed

```
 convex/crm/leads.ts | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```