### PR TITLE
Remove remaining `as Id<"users">` and `as Id<"leads">` casts on plain `string` a

### DIFF
--- a/convex/auditLog.ts
+++ b/convex/auditLog.ts
@@ -1,11 +1,10 @@
-import { Id } from "./_generated/dataModel";
 import { createSupabaseDb } from "./_helpers/supabaseDb";
 
 export async function logAudit(
   _ctx: unknown,
   data: {
     organizationId: string;
-    userId: Id<"users">;
+    userId: string;
     action: string;
     entityType?: string;
     entityId?: string;

--- a/convex/crm/leads.ts
+++ b/convex/crm/leads.ts
@@ -7,8 +7,6 @@ import { logActivity } from "../_helpers/activities";
 import { leadStatusValidator, leadPriorityValidator } from "@cvx/schema";
 import { logAudit } from "../auditLog";
 import { createNotificationDirect } from "../notifications";
-import { Id } from "../_generated/dataModel";
-
 // Dual-write refs removed — Supabase is now primary for lead writes
 
 export const list = action({
@@ -165,12 +163,12 @@ export const _createSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const createdByUserId = args.createdBy as Id<"users">;
+    const createdByUserId = args.createdBy;
 
     await logActivity({
       organizationId: args.organizationId,
       entityType: "lead",
-      entityId: args.leadId as Id<"leads">,
+      entityId: args.leadId,
       action: "created",
       description: `Created lead "${args.title}"`,
       performedBy: createdByUserId,
@@ -338,14 +336,14 @@ export const _updateSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const updatedByUserId = args.updatedBy as Id<"users">;
+    const updatedByUserId = args.updatedBy;
     const now = args.updatedAt;
 
     if (args.newStatus && args.newStatus !== args.oldStatus) {
       await logActivity({
         organizationId: args.organizationId,
         entityType: "lead",
-        entityId: args.leadId as Id<"leads">,
+        entityId: args.leadId,
         action: "status_changed",
         description: `Changed lead status from "${args.oldStatus}" to "${args.newStatus}"`,
         metadata: { oldStatus: args.oldStatus, newStatus: args.newStatus },
@@ -360,7 +358,7 @@ export const _updateSideEffects = internalMutation({
           userId: updatedByUserId,
           action: "status_changed",
           entityType: "lead",
-          entityId: args.leadId as Id<"leads">,
+          entityId: args.leadId,
           details: JSON.stringify({
             oldStatus: args.oldStatus,
             newStatus: args.newStatus,
@@ -369,7 +367,7 @@ export const _updateSideEffects = internalMutation({
       }
 
       // Notify lead owner on won/lost
-      const leadOwner = args.leadOwnerId as Id<"users">;
+      const leadOwner = args.leadOwnerId;
       if (args.newStatus === "won" && leadOwner !== updatedByUserId) {
         await createNotificationDirect(ctx, {
           organizationId: args.organizationId,
@@ -416,7 +414,7 @@ export const _updateSideEffects = internalMutation({
       await logActivity({
         organizationId: args.organizationId,
         entityType: "lead",
-        entityId: args.leadId as Id<"leads">,
+        entityId: args.leadId,
         action: "updated",
         description: `Updated lead "${args.title}"`,
         performedBy: updatedByUserId,
@@ -531,12 +529,12 @@ export const _removeSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const deletedByUserId = args.deletedBy as Id<"users">;
+    const deletedByUserId = args.deletedBy;
 
     await logActivity({
       organizationId: args.organizationId,
       entityType: "lead",
-      entityId: args.leadId as Id<"leads">,
+      entityId: args.leadId,
       action: "deleted",
       description: `Deleted lead "${args.title}"`,
       performedBy: deletedByUserId,
@@ -548,7 +546,7 @@ export const _removeSideEffects = internalMutation({
       userId: deletedByUserId,
       action: "entity_deleted",
       entityType: "lead",
-      entityId: args.leadId as Id<"leads">,
+      entityId: args.leadId,
       details: JSON.stringify({ title: args.title }),
     });
   },
@@ -844,7 +842,7 @@ export const _gdprEraseSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const erasedByUserId = args.erasedBy as Id<"users">;
+    const erasedByUserId = args.erasedBy;
     const GDPR_REDACTED = "[RODO: dane usunięte]";
 
     const db = createSupabaseDb();
@@ -879,7 +877,7 @@ export const _gdprEraseSideEffects = internalMutation({
     await logActivity({
       organizationId: args.organizationId,
       entityType: "lead",
-      entityId: args.leadId as Id<"leads">,
+      entityId: args.leadId,
       action: "deleted",
       description: "RODO: dane leadu zostały usunięte",
       performedBy: erasedByUserId,
@@ -1022,7 +1020,7 @@ export const _moveToStageSideEffects = internalMutation({
           }),
         });
 
-        const leadOwner = (args.leadAssignedTo ?? args.leadCreatedBy) as unknown as Id<"users">;
+        const leadOwner = args.leadAssignedTo ?? args.leadCreatedBy;
         if (args.newStatus === "won" && leadOwner !== args.userId) {
           await createNotificationDirect(ctx, {
             organizationId: args.organizationId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5077.

Closes #5077

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 2d9ceac8 fix(crm): remove masking Id<> casts on string args in leads.ts (closes #5077)

### Files changed

```
 convex/auditLog.ts  |  3 +--
 convex/crm/leads.ts | 28 +++++++++++++---------------
 2 files changed, 14 insertions(+), 17 deletions(-)
```