### PR TITLE
Migrate `auditLog.userId` schema field from `v.id("users")` to `v.string()` in `

### DIFF
--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -856,7 +856,7 @@ export function createCrmTables({
 
   auditLog: defineTable({
     organizationId: v.string(),
-    userId: v.id("users"),
+    userId: v.string(),
     action: v.string(),
     entityType: v.optional(v.string()),
     entityId: v.optional(v.string()),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5082.

Closes #5082

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 88ee9652 fix(schema): migrate auditLog.userId from v.id("users") to v.string() (closes #5082)

### Files changed

```
 convex/schema/crm.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```