### PR TITLE
Remove masking `as Id<"users">` casts in other callers of `logAudit`

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2004,7 +2004,7 @@ export const _updateSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const actorUserId = args.actorUserId as Id<"users">;
+    const actorUserId = args.actorUserId;
 
     // scheduledActivity patches moved to the parent action (Supabase-primary).
 
@@ -2848,7 +2848,7 @@ export const _cancelSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const actorUserId = args.actorUserId as Id<"users">;
+    const actorUserId = args.actorUserId;
     const appointmentId = args.appointmentId as Id<"gabinetAppointments">;
 
     // scheduledActivity patched in Supabase by the parent action.
@@ -2879,8 +2879,8 @@ export const _cancelSideEffects = internalMutation({
     });
 
     // Notify appointment creator and employee about cancellation
-    const createdBy = args.createdBy as Id<"users">;
-    const employeeId = args.employeeId as Id<"users">;
+    const createdBy = args.createdBy;
+    const employeeId = args.employeeId;
 
     if (createdBy !== actorUserId) {
       await createNotificationDirect(ctx, {

--- a/convex/gabinet/employees.ts
+++ b/convex/gabinet/employees.ts
@@ -743,7 +743,7 @@ export const _createSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const createdByUserId = args.createdBy as Id<"users">;
+    const createdByUserId = args.createdBy;
 
     await logActivity({
       organizationId: args.organizationId,
@@ -1023,7 +1023,7 @@ export const _updateSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const updatedByUserId = args.updatedBy as Id<"users">;
+    const updatedByUserId = args.updatedBy;
 
     await logActivity({
       organizationId: args.organizationId,
@@ -1245,7 +1245,7 @@ export const _removeSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const deletedByUserId = args.deletedBy as Id<"users">;
+    const deletedByUserId = args.deletedBy;
 
     await logActivity({
       organizationId: args.organizationId,
@@ -1357,7 +1357,7 @@ export const _setQualifiedSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const updatedByUserId = args.updatedBy as Id<"users">;
+    const updatedByUserId = args.updatedBy;
 
     await logActivity({
       organizationId: args.organizationId,
@@ -1792,7 +1792,7 @@ export const _changePasswordSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const changedByUserId = args.changedBy as Id<"users">;
+    const changedByUserId = args.changedBy;
 
     await logAudit(ctx, {
       organizationId: args.organizationId,

--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -467,7 +467,7 @@ export const _createSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const createdByUserId = args.createdBy as Id<"users">;
+    const createdByUserId = args.createdBy;
 
     await logActivity({
       organizationId: args.organizationId,
@@ -631,7 +631,7 @@ export const _updateSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const updatedByUserId = args.updatedBy as Id<"users">;
+    const updatedByUserId = args.updatedBy;
 
     await logActivity({
       organizationId: args.organizationId,
@@ -727,7 +727,7 @@ export const _removeSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const deletedByUserId = args.deletedBy as Id<"users">;
+    const deletedByUserId = args.deletedBy;
 
     await logActivity({
       organizationId: args.organizationId,
@@ -1217,7 +1217,7 @@ export const _gdprEraseSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const erasedByUserId = args.erasedBy as Id<"users">;
+    const erasedByUserId = args.erasedBy;
 
     // Supabase-side erasure of activities, notes, and appointment clinical
     // fields is handled by the caller (gdprErase action / _purgeExpiredPatients)

--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -1437,14 +1437,14 @@ export const _leaveSideEffects = internalMutation({
       action: args.action,
       description: args.description,
       metadata: { leaveId: args.leaveId },
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
 
     if (args.auditAction) {
       await logAudit(ctx, {
         organizationId: args.organizationId,
-        userId: args.performedBy as Id<"users">,
+        userId: args.performedBy,
         action: args.auditAction,
         entityType: "gabinetLeave",
         entityId: args.leaveId,
@@ -1456,7 +1456,7 @@ export const _leaveSideEffects = internalMutation({
       const actorSuffix = args.actorLabel ? ` by ${args.actorLabel}` : "";
       await createNotificationDirect(ctx, {
         organizationId: args.organizationId,
-        userId: args.userId as Id<"users">,
+        userId: args.userId,
         type: "leave_decision",
         title: args.description,
         message: `${args.description}${actorSuffix}.`,

--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -311,7 +311,7 @@ export const _createSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const createdByUserId = args.createdBy as Id<"users">;
+    const createdByUserId = args.createdBy;
 
     await logActivity({
       organizationId: args.organizationId,
@@ -474,7 +474,7 @@ export const _updateSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const updatedByUserId = args.updatedBy as Id<"users">;
+    const updatedByUserId = args.updatedBy;
 
     await logActivity({
       organizationId: args.organizationId,
@@ -563,7 +563,7 @@ export const _removeSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const deletedByUserId = args.deletedBy as Id<"users">;
+    const deletedByUserId = args.deletedBy;
 
     await logActivity({
       organizationId: args.organizationId,

--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -1884,7 +1884,7 @@ export const _resolveRefundAuthSideEffects = internalMutation({
 
     // Tell the requester what happened so they don't keep refreshing the
     // patient page wondering whether their request landed.
-    const requesterUserId = args.requesterId as Id<"users">;
+    const requesterUserId = args.requesterId;
     const amountLabel = formatCurrencyPLN(args.amount, "zł");
     const title =
       args.decision === "approved"


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5081.

Closes #5081

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8c8f135e fix(logAudit): remove masking as Id<"users"> casts in gabinet/payments callers (closes #5081)

### Files changed

```
 convex/gabinet/appointments.ts |  8 ++++----
 convex/gabinet/employees.ts    | 10 +++++-----
 convex/gabinet/patients.ts     |  8 ++++----
 convex/gabinet/scheduling.ts   |  6 +++---
 convex/gabinet/treatments.ts   |  6 +++---
 convex/payments.ts             |  2 +-
 6 files changed, 20 insertions(+), 20 deletions(-)
```