### PR TITLE
Remove masking `as Id<"users">` casts in `crm/contacts.ts` and `crm/companies.ts

### DIFF
--- a/convex/crm/companies.ts
+++ b/convex/crm/companies.ts
@@ -3,7 +3,6 @@ import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
 import { logActivity } from "../_helpers/activities";
-import { Id } from "../_generated/dataModel";
 
 // Dual-write refs removed — Supabase is now primary for company writes
 // list query removed — browser reads companies directly from Supabase via use-supabase-companies.ts
@@ -110,15 +109,13 @@ export const _createSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const createdByUserId = args.createdBy as Id<"users">;
-
     await logActivity({
       organizationId: args.organizationId,
       entityType: "company",
-      entityId: args.companyId as Id<"companies">,
+      entityId: args.companyId,
       action: "created",
       description: `Created company "${args.name}"`,
-      performedBy: createdByUserId,
+      performedBy: args.createdBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -233,15 +230,13 @@ export const _updateSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const updatedByUserId = args.updatedBy as Id<"users">;
-
     await logActivity({
       organizationId: args.organizationId,
       entityType: "company",
-      entityId: args.companyId as Id<"companies">,
+      entityId: args.companyId,
       action: "updated",
       description: `Updated company "${args.name}"`,
-      performedBy: updatedByUserId,
+      performedBy: args.updatedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -330,15 +325,13 @@ export const _removeSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const deletedByUserId = args.deletedBy as Id<"users">;
-
     await logActivity({
       organizationId: args.organizationId,
       entityType: "company",
-      entityId: args.companyId as Id<"companies">,
+      entityId: args.companyId,
       action: "deleted",
       description: `Deleted company "${args.name}"`,
-      performedBy: deletedByUserId,
+      performedBy: args.deletedBy,
       actorLabel: args.actorLabel,
     });
   },

--- a/convex/crm/contacts.ts
+++ b/convex/crm/contacts.ts
@@ -4,7 +4,6 @@ import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { v } from "convex/values";
 import { logActivity } from "../_helpers/activities";
 import { logAudit } from "../auditLog";
-import { Id } from "../_generated/dataModel";
 
 // Dual-write refs removed — Supabase is now primary for contact writes
 // list query removed — browser reads contacts directly from Supabase via use-supabase-contacts.ts
@@ -107,15 +106,13 @@ export const _createSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const createdByUserId = args.createdBy as Id<"users">;
-
     await logActivity({
       organizationId: args.organizationId,
       entityType: "contact",
-      entityId: args.contactId as Id<"contacts">,
+      entityId: args.contactId,
       action: "created",
       description: `Created contact "${args.firstName}${args.lastName ? ` ${args.lastName}` : ""}"`,
-      performedBy: createdByUserId,
+      performedBy: args.createdBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -224,15 +221,13 @@ export const _updateSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const updatedByUserId = args.updatedBy as Id<"users">;
-
     await logActivity({
       organizationId: args.organizationId,
       entityType: "contact",
-      entityId: args.contactId as Id<"contacts">,
+      entityId: args.contactId,
       action: "updated",
       description: `Updated contact "${args.firstName}"`,
-      performedBy: updatedByUserId,
+      performedBy: args.updatedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -321,15 +316,13 @@ export const _removeSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const deletedByUserId = args.deletedBy as Id<"users">;
-
     await logActivity({
       organizationId: args.organizationId,
       entityType: "contact",
-      entityId: args.contactId as Id<"contacts">,
+      entityId: args.contactId,
       action: "deleted",
       description: `Deleted contact "${args.firstName}"`,
-      performedBy: deletedByUserId,
+      performedBy: args.deletedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -421,7 +414,6 @@ export const _gdprEraseSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const erasedByUserId = args.erasedBy as Id<"users">;
     const GDPR_REDACTED = "[RODO: dane usunięte]";
 
     const db = createSupabaseDb();
@@ -446,7 +438,7 @@ export const _gdprEraseSideEffects = internalMutation({
 
     await logAudit(ctx, {
       organizationId: args.organizationId,
-      userId: erasedByUserId,
+      userId: args.erasedBy,
       action: "gdpr_contact_erased",
       entityType: "contact",
       entityId: args.contactId,
@@ -456,10 +448,10 @@ export const _gdprEraseSideEffects = internalMutation({
     await logActivity({
       organizationId: args.organizationId,
       entityType: "contact",
-      entityId: args.contactId as Id<"contacts">,
+      entityId: args.contactId,
       action: "deleted",
       description: "RODO: dane kontaktu zostały usunięte",
-      performedBy: erasedByUserId,
+      performedBy: args.erasedBy,
       actorLabel: args.actorLabel,
     });
   },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5085.

Closes #5085

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- eab2addc fix(crm): remove masking as Id<"users"> casts in contacts.ts and companies.ts (closes #5085)

### Files changed

```
 convex/crm/companies.ts | 19 ++++++-------------
 convex/crm/contacts.ts  | 26 +++++++++-----------------
 2 files changed, 15 insertions(+), 30 deletions(-)
```