### PR TITLE
Remove masking `as Id<"users">` casts in `convex/crm/documents.ts`

### DIFF
--- a/convex/crm/documents.ts
+++ b/convex/crm/documents.ts
@@ -6,8 +6,6 @@ import { verifyOrgAccess } from "../_helpers/auth";
 import { logActivity } from "../_helpers/activities";
 
 import { documentCategoryValidator, documentStatusValidator } from "@cvx/schema";
-import type { Id } from "../_generated/dataModel";
-
 // Dual-write refs removed — Supabase is primary for document writes
 
 export const create = action({
@@ -90,7 +88,7 @@ export const _createSideEffects = internalMutation({
       entityId: args.documentId,
       action: "document_uploaded",
       description: `Uploaded document "${args.name}"`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -171,7 +169,7 @@ export const _updateSideEffects = internalMutation({
       entityId: args.documentId,
       action: "updated",
       description: `Updated document "${args.name}"`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -245,7 +243,7 @@ export const _removeSideEffects = internalMutation({
       entityId: args.documentId,
       action: "deleted",
       description: `Deleted document "${args.name}"`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -327,7 +325,7 @@ export const _updateStatusSideEffects = internalMutation({
       action: "status_changed",
       description: `Changed document "${args.name}" status to "${args.newStatus}"`,
       metadata: { oldStatus: args.oldStatus, newStatus: args.newStatus },
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5090.

Closes #5090

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 7e14310f fix(crm): remove masking as Id<"users"> casts in documents.ts (closes #5090)

### Files changed

```
 convex/crm/documents.ts | 10 ++++------
 1 file changed, 4 insertions(+), 6 deletions(-)
```