### PR TITLE
Remove masking `as Id<"users">` casts in `convex/crm/calls.ts`

### DIFF
--- a/convex/crm/calls.ts
+++ b/convex/crm/calls.ts
@@ -5,8 +5,6 @@ import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
 import { logActivity } from "../_helpers/activities";
 import { callOutcomeValidator } from "@cvx/schema";
-import { Id } from "../_generated/dataModel";
-
 // Dual-write refs removed — Supabase is now primary for call writes
 
 export const list = action({
@@ -150,7 +148,7 @@ export const _createSideEffects = internalMutation({
       entityId: args.callId,
       action: "created",
       description: `Logged a call with outcome "${args.outcome}"`,
-      performedBy: args.createdBy as Id<"users">,
+      performedBy: args.createdBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -219,7 +217,7 @@ export const _updateSideEffects = internalMutation({
       entityId: args.callId,
       action: "updated",
       description: `Updated call`,
-      performedBy: args.updatedBy as Id<"users">,
+      performedBy: args.updatedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -293,7 +291,7 @@ export const _removeSideEffects = internalMutation({
       entityId: args.callId,
       action: "deleted",
       description: `Deleted call`,
-      performedBy: args.deletedBy as Id<"users">,
+      performedBy: args.deletedBy,
       actorLabel: args.actorLabel,
     });
   },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5091.

Closes #5091

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 2886c589 fix(crm): remove masking as Id<"users"> casts in calls.ts (closes #5091)

### Files changed

```
 convex/crm/calls.ts | 8 +++-----
 1 file changed, 3 insertions(+), 5 deletions(-)
```