### PR TITLE
fix(gabinet): remove masking as Id<"users"> casts in gabinet files (closes #5094)

### DIFF
--- a/convex/gabinet/equipment.ts
+++ b/convex/gabinet/equipment.ts
@@ -1,6 +1,5 @@
 import { query, action, internalMutation, internalAction } from "../_generated/server";
 import { v } from "convex/values";
-import { Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { verifyOrgAccess } from "../_helpers/auth";
@@ -351,7 +350,7 @@ export const _createEquipmentSideEffects = internalMutation({
       entityId: args.equipmentId,
       action: "created",
       description: `Created equipment "${args.name}"`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -371,7 +370,7 @@ export const _updateEquipmentSideEffects = internalMutation({
       entityId: args.equipmentId,
       action: "updated",
       description: `Updated equipment`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -393,7 +392,7 @@ export const _transferEquipmentSideEffects = internalMutation({
       action: "updated",
       description: `Transferred equipment to location`,
       metadata: { toLocationId: args.toLocationId },
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },

--- a/convex/gabinet/leaveTypes.ts
+++ b/convex/gabinet/leaveTypes.ts
@@ -461,7 +461,7 @@ export const _createSideEffects = internalMutation({
       entityId: args.leaveTypeId,
       action: "created",
       description: `Created leave type "${args.name}"`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -481,7 +481,7 @@ export const _updateSideEffects = internalMutation({
       entityId: args.leaveTypeId,
       action: "updated",
       description: `Updated leave type`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -501,7 +501,7 @@ export const _removeSideEffects = internalMutation({
       entityId: args.leaveTypeId,
       action: "deleted",
       description: `Deactivated leave type`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -521,7 +521,7 @@ export const _adjustBalanceSideEffects = internalMutation({
       entityId: args.balanceId,
       action: "updated",
       description: `Adjusted leave balance`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -545,7 +545,7 @@ export const _initializeBalanceSideEffects = internalMutation({
       description: args.action === "created"
         ? `Initialized leave balance for year ${args.year}`
         : `Updated leave balance for year ${args.year}`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },

--- a/convex/gabinet/locations.ts
+++ b/convex/gabinet/locations.ts
@@ -1,6 +1,5 @@
 import { action, internalMutation } from "../_generated/server";
 import { v } from "convex/values";
-import { Id } from "../_generated/dataModel";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 import { logError } from "../_helpers/logged";
@@ -502,7 +501,7 @@ export const _createLocationSideEffects = internalMutation({
       entityId: args.locationId,
       action: "created",
       description: `Created location "${args.name}"`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -522,7 +521,7 @@ export const _updateLocationSideEffects = internalMutation({
       entityId: args.locationId,
       action: "updated",
       description: `Updated location`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -542,7 +541,7 @@ export const _deleteLocationSideEffects = internalMutation({
       entityId: args.locationId,
       action: "deleted",
       description: `Deactivated location`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -565,7 +564,7 @@ export const _createRoomSideEffects = internalMutation({
       action: "created",
       description: `Created room "${args.name}"`,
       metadata: { locationId: args.locationId },
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -585,7 +584,7 @@ export const _updateRoomSideEffects = internalMutation({
       entityId: args.roomId,
       action: "updated",
       description: `Updated room`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -605,7 +604,7 @@ export const _deleteRoomSideEffects = internalMutation({
       entityId: args.roomId,
       action: "deleted",
       description: `Deactivated room`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },

--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -283,7 +283,7 @@ export const _createSideEffects = internalMutation({
       entityId: args.packageId as Id<"gabinetTreatmentPackages">,
       action: "created",
       description: `Created package ${args.name}`,
-      performedBy: args.createdBy as Id<"users">,
+      performedBy: args.createdBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -612,13 +612,13 @@ export const _purchaseTreatmentSideEffects = internalMutation({
     await publishActivityEnvelope({
       organizationId: args.organizationId,
       action: "package_assigned",
-      performedBy: args.createdBy as Id<"users">,
+      performedBy: args.createdBy,
       module: "gabinet",
       summary: `Sold treatment ${args.treatmentName} to patient`,
       occurredAt: args.createdAt,
       actor: {
         type: "user",
-        userId: args.createdBy as Id<"users">,
+        userId: args.createdBy,
       },
       payload: {
         usageId: args.usageId,
@@ -642,7 +642,7 @@ export const _purchaseTreatmentSideEffects = internalMutation({
 
     await logAudit(ctx, {
       organizationId: args.organizationId,
-      userId: args.createdBy as Id<"users">,
+      userId: args.createdBy,
       action: "package_treatment_sold",
       entityType: "gabinetPatient",
       entityId: args.patientId,
@@ -866,7 +866,7 @@ export const _purchaseSideEffects = internalMutation({
     await publishActivityEnvelope({
       organizationId: args.organizationId,
       action: "package_assigned",
-      performedBy: args.createdBy as Id<"users">,
+      performedBy: args.createdBy,
       module: "gabinet",
       summary: args.patientId
         ? `Assigned package ${args.packageName} to patient`
@@ -874,7 +874,7 @@ export const _purchaseSideEffects = internalMutation({
       occurredAt: args.createdAt,
       actor: {
         type: "user",
-        userId: args.createdBy as Id<"users">,
+        userId: args.createdBy,
       },
       payload: {
         usageId: args.usageId,
@@ -889,7 +889,7 @@ export const _purchaseSideEffects = internalMutation({
 
     await logAudit(ctx, {
       organizationId: args.organizationId,
-      userId: args.createdBy as Id<"users">,
+      userId: args.createdBy,
       action: "package_purchased",
       entityType: args.patientId ? "gabinetPatient" : "gabinetPackage",
       entityId: args.patientId ?? args.packageId,
@@ -908,7 +908,7 @@ export const _purchaseSideEffects = internalMutation({
     if (args.loyaltyPointsAwarded > 0 && args.patientId) {
       await logAudit(ctx, {
         organizationId: args.organizationId,
-        userId: args.createdBy as Id<"users">,
+        userId: args.createdBy,
         action: "loyalty_points_earned",
         entityType: "gabinetPatient",
         entityId: args.patientId,
@@ -1026,7 +1026,7 @@ export const _usePackageTreatmentSideEffects = internalMutation({
   handler: async (ctx, args) => {
     await logAudit(ctx, {
       organizationId: args.organizationId,
-      userId: args.performedBy as Id<"users">,
+      userId: args.performedBy,
       action: "package_treatment_used",
       entityType: "gabinetPatient",
       entityId: args.patientId,
@@ -1178,7 +1178,7 @@ export const _batchUsageSideEffects = internalMutation({
       entityId: args.packageId as Id<"gabinetTreatmentPackages">,
       action: "updated",
       description: `Used ${args.totalUsed} treatment(s) from package ${pkg?.name ?? ""}`,
-      performedBy: args.createdBy as Id<"users">,
+      performedBy: args.createdBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -1458,7 +1458,7 @@ export const _assignGiftSideEffects = internalMutation({
   handler: async (ctx, args) => {
     await logAudit(ctx, {
       organizationId: args.organizationId,
-      userId: args.performedBy as Id<"users">,
+      userId: args.performedBy,
       action: "loyalty_points_earned",
       entityType: "gabinetPatient",
       entityId: args.patientId,

--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -1074,7 +1074,7 @@ export const _mergeSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const performedByUserId = args.performedBy as Id<"users">;
+    const performedByUserId = args.performedBy;
 
     await logActivity({
       organizationId: args.organizationId,

--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -1203,7 +1203,7 @@ export const _workingHoursSideEffects = internalMutation({
       action: "updated",
       description: `Updated working hours for ${days[args.dayOfWeek] ?? `day ${args.dayOfWeek}`}`,
       metadata: { dayOfWeek: args.dayOfWeek },
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -1222,7 +1222,7 @@ export const _bulkWorkingHoursSideEffects = internalMutation({
       entityId: String(args.organizationId),
       action: "updated",
       description: `Updated organization working hours`,
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -1244,7 +1244,7 @@ export const _employeeScheduleSideEffects = internalMutation({
       action: "updated",
       description: `Updated employee schedule`,
       metadata: { userId: args.userId },
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -1265,7 +1265,7 @@ export const _bulkEmployeeScheduleSideEffects = internalMutation({
       action: "updated",
       description: `Updated employee weekly schedule`,
       metadata: { userId: args.userId },
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -1289,7 +1289,7 @@ export const _saveSchedulePeriodSideEffects = internalMutation({
         ? `Saved schedule period from ${args.effectiveFrom}`
         : `Saved default schedule period`,
       metadata: { userId: args.userId, effectiveFrom: args.effectiveFrom },
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -1313,7 +1313,7 @@ export const _removeSchedulePeriodSideEffects = internalMutation({
         ? `Removed schedule period from ${args.effectiveFrom}`
         : `Removed default schedule period`,
       metadata: { userId: args.userId, effectiveFrom: args.effectiveFrom },
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },
@@ -1338,7 +1338,7 @@ export const _createLeaveSideEffects = internalMutation({
       action: "created",
       description: `Leave request created (${args.type}: ${args.startDate} – ${args.endDate})`,
       metadata: { leaveId: args.leaveId, type: args.type, startDate: args.startDate, endDate: args.endDate },
-      performedBy: args.performedBy as Id<"users">,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
 


### PR DESCRIPTION
## Summary

- Removes 33 `as Id<"users">` casts on `v.string()` args passed to `logActivity`, `logAudit`, and `publishActivityEnvelope` across six gabinet files
- All three functions already accept `string` for `performedBy`/`userId`, making the casts redundant and masking
- Removes now-unused `Id` imports from `equipment.ts` and `locations.ts`

Files: `patients.ts` (1 cast), `equipment.ts` (3 + import), `scheduling.ts` (7), `leaveTypes.ts` (5), `locations.ts` (6 + import), `packages.ts` (11)

Note: Three remaining `as Id<"users">` casts in `scheduling.ts` (lines 922, 977, 1351) are intentionally left — they bridge Supabase string results to `Id<"users">` for `canApproveOrRejectLeave` and a Convex DB index query, which are different contexts than logActivity/logAudit.

## Test plan

- [x] Verified no new TypeScript errors introduced (pre-existing errors in `scheduling.ts` and `equipment.ts` are unchanged)
- [x] All removed casts were on `v.string()` args flowing into functions that already accept `string`

🤖 Generated with [Claude Code](https://claude.com/claude-code)