### PR TITLE
fix(gabinet): resolve scheduling.ts pre-existing type errors (#5100)

### DIFF
--- a/convex/gabinet/scheduling.ts
+++ b/convex/gabinet/scheduling.ts
@@ -641,7 +641,7 @@ export const createLeave = action({
       await ctx.runMutation(internal.gabinet.scheduling._createLeaveSideEffects, {
         organizationId: args.organizationId,
         leaveId,
-        userId: args.userId,
+        userId: args.userId as Id<"users">,
         type: args.type,
         startDate: args.startDate,
         endDate: args.endDate,
@@ -685,7 +685,7 @@ export const requestLeave = action({
         { organizationId: args.organizationId },
       );
       await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
-      const userId = String(authResult.userId);
+      const userId = authResult.userId;
       const now = Date.now();
       const db = createSupabaseDb();
 
@@ -855,7 +855,7 @@ export const _leaveApprovalData = internalQuery({
 //   4. everything else → denied
 async function canApproveOrRejectLeave(
   ctx: ActionCtx,
-  organizationId: Id<"organizations">,
+  organizationId: string,
   orgRole: string,
   approverUserId: Id<"users">,
   employeeUserId: Id<"users">,
@@ -1323,7 +1323,7 @@ export const _createLeaveSideEffects = internalMutation({
   args: {
     organizationId: v.string(),
     leaveId: v.string(),
-    userId: v.string(),
+    userId: v.id("users"),
     type: v.string(),
     startDate: v.string(),
     endDate: v.string(),
@@ -1348,7 +1348,7 @@ export const _createLeaveSideEffects = internalMutation({
         ctx.db
           .query("gabinetLocationMemberships")
           .withIndex("by_orgAndUser", (q) =>
-            q.eq("organizationId", args.organizationId).eq("userId", args.userId as Id<"users">)
+            q.eq("organizationId", args.organizationId).eq("userId", args.userId)
           )
           .collect(),
         ctx.db


### PR DESCRIPTION
## Summary

- `canApproveOrRejectLeave` declared `organizationId: Id<"organizations">` but was called with `args.organizationId: string` (from a `v.string()` action validator). Changed the parameter type to `string` — the function only passes the value to `_leaveApprovalData` which also declares `organizationId: v.string()`, so `Id<"organizations">` was never the right type here.
- `_createLeaveSideEffects` had `userId: v.string()` in its args validator, but the handler was using `args.userId as Id<"users">` to query the `gabinetLocationMemberships` Convex table whose `userId` column is `v.id("users")`. Fixed by changing the arg to `v.id("users")` and removing the internal cast. Updated both callers:
  - `requestLeave`: dropped `String()` wrapping around `authResult.userId` (which is already `Id<"users">`)
  - `createLeave`: added `as Id<"users">` cast at the call-site boundary where a client-provided string enters Convex-typed territory

## Test plan

- [ ] TypeScript compile: `npm run typecheck` — all three tsconfigs should pass for this file
- [ ] Convex unit tests: `npm run test:unit` — no regressions in scheduling-related tests
- [ ] Manual: create/request/approve/reject/withdraw leave in Gabinet module to verify runtime behavior is unchanged

Closes #5100

🤖 Generated with [Claude Code](https://claude.com/claude-code)