### PR TITLE
Fix `autoGenerateAppointmentDocuments` to accept `createdBy

### DIFF
--- a/convex/gabinet/_helpers/autoGenerateDocuments.ts
+++ b/convex/gabinet/_helpers/autoGenerateDocuments.ts
@@ -39,7 +39,7 @@ export async function autoGenerateAppointmentDocuments(
     appointmentId: Id<"gabinetAppointments">;
     treatmentId: Id<"gabinetTreatments">;
     patientId: Id<"gabinetPatients">;
-    createdBy: Id<"users">;
+    createdBy: string;
     /** When set, only generate documents matching this timing. */
     timing?: "before_start" | "during_visit" | "after_completion";
     /** When true, skip sending signing emails (employee fills first). */


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5086.

Closes #5086

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- aeffdb84 fix(gabinet): change autoGenerateAppointmentDocuments createdBy param to string (closes #5086)

### Files changed

```
 convex/gabinet/_helpers/autoGenerateDocuments.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```