### PR TITLE
Remove `as Id<"users">` cast for `emitAutomationEvent.actorUserId` in `_createSi

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -841,7 +841,7 @@ export const _createSideEffects = internalMutation({
   },
   handler: async (ctx, args) => {
     const now = args.createdAt;
-    const createdByUserId = args.createdBy as Id<"users">;
+    const createdByUserId = args.createdBy;
 
     const scheduledActivityId = args.scheduledActivityId;
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5106.

Closes #5106

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e67404e3 fix(gabinet): remove as Id<"users"> cast for createdByUserId in _createSideEffects (closes #5106)

### Files changed

```
 convex/gabinet/appointments.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```