### PR TITLE
Widen `actorUserId?

### DIFF
--- a/convex/gabinet/appointmentReminders.ts
+++ b/convex/gabinet/appointmentReminders.ts
@@ -234,7 +234,7 @@ export const sendReminder = internalMutation({
     // Send in-app notification to the employee assigned to the appointment
     await createNotificationDirect(ctx, {
       organizationId: String(reminder.organizationId),
-      userId: appointment.employeeId as Id<"users">,
+      userId: String(appointment.employeeId),
       type: "appointment_reminder",
       title: "Przypomnienie o wizycie",
       message: `${patientName} — ${treatmentName}, ${appointment.date} o ${appointment.startTime}`,
@@ -245,7 +245,7 @@ export const sendReminder = internalMutation({
     if (appointment.createdBy !== appointment.employeeId) {
       await createNotificationDirect(ctx, {
         organizationId: String(reminder.organizationId),
-        userId: appointment.createdBy as Id<"users">,
+        userId: String(appointment.createdBy),
         type: "appointment_reminder",
         title: "Przypomnienie o wizycie",
         message: `${patientName} — ${treatmentName}, ${appointment.date} o ${appointment.startTime}`,
@@ -300,7 +300,7 @@ export const sendReminder = internalMutation({
 
       await logAudit(ctx, {
         organizationId: String(reminder.organizationId),
-        userId: appointment.employeeId as Id<"users">,
+        userId: String(appointment.employeeId),
         action: "gabinet:email:sent",
         entityType: "gabinetAppointment",
         entityId: String(appointment._id),
@@ -335,7 +335,7 @@ export const sendReminder = internalMutation({
       eventType: "gabinet.appointment.reminder_due",
       entityType: "gabinetAppointment",
       entityId: String(appointment._id),
-      actorUserId: appointment.createdBy as Id<"users">,
+      actorUserId: String(appointment.createdBy),
       correlationKey: `appointment:${appointment._id}`,
       eventIdempotencyKey: `automation-event:${reminder.organizationId}:${appointment._id}:reminder:${args.reminderId}`,
       payload: JSON.stringify(reminderPayload),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5109.

Closes #5109

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 5fd5b76c fix(gabinet): remove as Id<"users"> casts for Supabase string UUIDs in appointmentReminders.ts (closes #5109)

### Files changed

```
 convex/gabinet/appointmentReminders.ts | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```