### PR TITLE
Fix full-table scan in `emailAccounts.upsert` for duplicate check

### DIFF
--- a/convex/crm/emailAccounts.ts
+++ b/convex/crm/emailAccounts.ts
@@ -48,10 +48,10 @@ export const upsert = action({
     }
 
     // Check if account with same fromEmail already exists for this org
-    const accounts = await db.query("emailAccounts")
+    const existingAccount = await db.query("emailAccounts")
       .eq("organizationId", String(args.organizationId))
-      .collect();
-    const existingAccount = accounts.find((a: any) => a.fromEmail === args.fromEmail);
+      .eq("fromEmail", args.fromEmail)
+      .first();
 
     if (existingAccount) {
       await db.patch("emailAccounts", existingAccount._id as string, {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5071.

Closes #5071

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 7819d36f fix(crm): replace full-table scan with indexed query in emailAccounts.upsert (closes #5071)

### Files changed

```
 convex/crm/emailAccounts.ts | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```