### PR TITLE
Remove `as Id<"users">` cast for `actorUserId` in `appointments.ts

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2161,7 +2161,7 @@ export const _sendRescheduleNotification = internalMutation({
       eventType: "gabinet.appointment.rescheduled",
       entityType: "gabinetAppointment",
       entityId: args.appointmentId,
-      actorUserId: args.actorUserId as Id<"users">,
+      actorUserId: args.actorUserId,
       correlationKey: `appointment:${args.appointmentId}`,
       eventIdempotencyKey: `automation-event:${args.organizationId}:${args.appointmentId}:${args.updatedAt}:rescheduled`,
       payload: {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5112.

Closes #5112

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d141f593 fix(gabinet): remove as Id<"users"> cast for actorUserId in appointments.ts (closes #5112)

### Files changed

```
 convex/gabinet/appointments.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```