### PR TITLE
Remove cast at `patients.ts

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -1074,8 +1074,6 @@ export const _mergeSideEffects = internalMutation({
     actorLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const performedByUserId = args.performedBy;
-
     await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetPatient",
@@ -1085,7 +1083,7 @@ export const _mergeSideEffects = internalMutation({
       metadata: {
         merge: { sourcePatientId: args.sourcePatientId },
       },
-      performedBy: performedByUserId,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
 
@@ -1098,7 +1096,7 @@ export const _mergeSideEffects = internalMutation({
       metadata: {
         merge: { targetPatientId: args.targetPatientId },
       },
-      performedBy: performedByUserId,
+      performedBy: args.performedBy,
       actorLabel: args.actorLabel,
     });
   },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5088.

Closes #5088

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d9d37e0e fix(gabinet): remove unnecessary performedByUserId alias in _mergeSideEffects (closes #5088)

### Files changed

```
 convex/gabinet/patients.ts | 6 ++----
 1 file changed, 2 insertions(+), 4 deletions(-)
```