### PR TITLE
Remove unused imports in `equipment.ts`

### DIFF
--- a/convex/gabinet/equipment.ts
+++ b/convex/gabinet/equipment.ts
@@ -1,9 +1,7 @@
-import { query, action, internalMutation, internalAction } from "../_generated/server";
+import { action, internalMutation, internalAction } from "../_generated/server";
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
-import { verifyOrgAccess } from "../_helpers/auth";
-import { checkModuleAccess } from "../_helpers/products";
 import { logError } from "../_helpers/logged";
 import { logActivity } from "../_helpers/activities";
 import type {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5101.

Closes #5101

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d1db079b fix(gabinet): remove unused imports in equipment.ts (closes #5101)

### Files changed

```
 convex/gabinet/equipment.ts | 4 +---
 1 file changed, 1 insertion(+), 3 deletions(-)
```