### PR TITLE
Fix full-table scan in `emailAccounts.upsert` "clear defaults" block

### DIFF
--- a/convex/crm/emailAccounts.ts
+++ b/convex/crm/emailAccounts.ts
@@ -35,15 +35,14 @@ export const upsert = action({
     if (args.isDefault) {
       const existing = await db.query("emailAccounts")
         .eq("organizationId", String(args.organizationId))
+        .eq("isDefault", true)
         .collect();
 
       for (const account of existing) {
-        if (account.isDefault) {
-          await db.patch("emailAccounts", account._id as string, {
-            isDefault: false,
-            updatedAt: now,
-          });
-        }
+        await db.patch("emailAccounts", account._id as string, {
+          isDefault: false,
+          updatedAt: now,
+        });
       }
     }
 

--- a/supabase/migrations/00128_email_accounts_org_is_default_idx.sql
+++ b/supabase/migrations/00128_email_accounts_org_is_default_idx.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS email_accounts_org_is_default_idx
+  ON email_accounts (organization_id, is_default);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5114.

Closes #5114

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 64c90129 fix(crm): push isDefault filter to Postgres in emailAccounts.upsert (closes #5114)

### Files changed

```
 convex/crm/emailAccounts.ts                                   | 11 +++++------
 .../migrations/00128_email_accounts_org_is_default_idx.sql    |  2 ++
 2 files changed, 7 insertions(+), 6 deletions(-)
```