### PR TITLE
Fix VAT Select opening calendar picker instead of dropdown in "Nowa dostawa" lin

### DIFF
--- a/src/components/gabinet/deliveries/deliveries-page.tsx
+++ b/src/components/gabinet/deliveries/deliveries-page.tsx
@@ -973,7 +973,7 @@ export function DeliveriesPage() {
                         <SelectTrigger className="h-8 text-xs">
                           <SelectValue placeholder="VAT" />
                         </SelectTrigger>
-                        <SelectContent>
+                        <SelectContent position="item-aligned">
                           {VAT_OPTIONS.map((o) => (
                             <SelectItem key={o.code} value={o.code}>
                               {o.label}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5131.

Closes #5131

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b8404f6b fix(magazyn): use item-aligned positioning for VAT Select in Nowa dostawa (closes #5131)

### Files changed

```
 src/components/gabinet/deliveries/deliveries-page.tsx | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```