### PR TITLE
Overscroll-behavior on the nested `overflow-x-auto` container in "Pozycje dostaw

### DIFF
--- a/src/components/gabinet/deliveries/deliveries-page.tsx
+++ b/src/components/gabinet/deliveries/deliveries-page.tsx
@@ -909,7 +909,7 @@ export function DeliveriesPage() {
               </Button>
             </div>
 
-            <div className="rounded-md border overflow-x-auto">
+            <div className="rounded-md border overflow-x-auto overscroll-y-contain">
               <div className="min-w-[490px]">
               {/* column headers */}
               <div className="grid grid-cols-[1fr_65px_85px_82px_82px_28px] gap-1 border-b bg-muted/40 px-3 py-2 text-xs font-medium text-muted-foreground">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5132.

Closes #5132

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4fd42c11 fix(magazyn): add overscroll-y-contain to overflow-x-auto wrapper in Nowa dostawa (closes #5132)

### Files changed

```
 src/components/gabinet/deliveries/deliveries-page.tsx | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```