### PR TITLE
M21 — Magazyn — naprawić dynamiczne wiersze pozycji dostawy

### DIFF
--- a/src/components/gabinet/deliveries/deliveries-page.tsx
+++ b/src/components/gabinet/deliveries/deliveries-page.tsx
@@ -946,6 +946,8 @@ export function DeliveriesPage() {
                         className="h-8 text-right text-xs tabular-nums"
                         placeholder="0"
                         inputMode="decimal"
+                        name={`line-qty-${line.id}`}
+                        autoComplete="off"
                         value={line.quantity}
                         onChange={(e) => {
                           const v = e.target.value;
@@ -958,6 +960,8 @@ export function DeliveriesPage() {
                         className="h-8 text-right text-xs tabular-nums"
                         placeholder="—"
                         inputMode="decimal"
+                        name={`line-price-${line.id}`}
+                        autoComplete="off"
                         value={line.unitPrice}
                         onChange={(e) => {
                           const v = e.target.value;
@@ -986,6 +990,8 @@ export function DeliveriesPage() {
                         className="h-8 text-right text-xs tabular-nums"
                         placeholder="—"
                         inputMode="decimal"
+                        name={`line-gross-${line.id}`}
+                        autoComplete="off"
                         value={line.unitPriceGross}
                         onChange={(e) => {
                           const v = e.target.value;
@@ -1025,6 +1031,8 @@ export function DeliveriesPage() {
                       <Input
                         className="h-7 text-xs"
                         placeholder={t("gabinet.deliveries.lotNumber", "Nr LOT (opcjonalnie)")}
+                        name={`line-lot-${line.id}`}
+                        autoComplete="off"
                         value={line.lotNumber}
                         onChange={(e) => updateLine(line.id, "lotNumber", e.target.value)}
                       />
@@ -1032,6 +1040,8 @@ export function DeliveriesPage() {
                         className="h-7 text-xs"
                         type="date"
                         title={t("gabinet.deliveries.expiryDate", "Termin ważności")}
+                        name={`line-exp-${line.id}`}
+                        autoComplete="off"
                         value={line.expiryDate}
                         onChange={(e) => updateLine(line.id, "expiryDate", e.target.value)}
                       />


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5135.

Closes #5135

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- ffd1631e fix(magazyn): stabilize dynamic delivery row inputs with unique names and autoComplete=off (closes #5135)

### Files changed

```
 src/components/gabinet/deliveries/deliveries-page.tsx | 10 ++++++++++
 1 file changed, 10 insertions(+)
```