### PR TITLE
M22 — Magazyn — naprawić „Zapisz dostawę” otwierające kalendarz

### DIFF
--- a/src/components/gabinet/deliveries/deliveries-page.tsx
+++ b/src/components/gabinet/deliveries/deliveries-page.tsx
@@ -1230,6 +1230,7 @@ export function DeliveriesPage() {
           )}
 
           <Button
+            type="button"
             className="w-full"
             disabled={!canSubmit}
             onClick={handleSave}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5137.

Closes #5137

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 66564132 fix(magazyn): add type=button to Zapisz dostawę to prevent calendar opening (closes #5137)

### Files changed

```
 src/components/gabinet/deliveries/deliveries-page.tsx | 1 +
 1 file changed, 1 insertion(+)
```