### PR TITLE
M23 — Magazyn — ujednolicić dwie ścieżki dodawania dostawy

### DIFF
--- a/src/components/gabinet/deliveries/deliveries-page.tsx
+++ b/src/components/gabinet/deliveries/deliveries-page.tsx
@@ -189,11 +189,13 @@ export function DeliveriesPage() {
   const [panelOpen, setPanelOpen] = useState(false);
 
   // ?action=create navigates here from the sidebar quick-action and auto-opens
-  // the new-delivery panel (issue #3153). Clear the param after consuming so a
-  // refresh doesn't reopen it.
+  // the new-delivery panel (issue #3153, #5139). Clear the param after consuming so a
+  // refresh doesn't reopen it. Opens the panel directly (same as the "Nowa dostawa"
+  // button) to keep both paths consistent — the page header already provides the
+  // separate "Z faktury" button for invoice-based entry.
   useEffect(() => {
     if (actionParam === "create") {
-      if (canCreate) setChoiceDialogOpen(true);
+      if (canCreate) setPanelOpen(true);
       void routeNavigate({
         to: "/dashboard/gabinet/deliveries",
         search: { action: undefined },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5139.

Closes #5139

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 770fac33 fix(magazyn): unify both delivery-add paths to open the same panel (closes #5139)

### Files changed

```
 src/components/gabinet/deliveries/deliveries-page.tsx | 8 +++++---
 1 file changed, 5 insertions(+), 3 deletions(-)
```