### PR TITLE
M26 — Magazyn — naprawić avgCost netto dla fallbacku i nowych produktów

### DIFF
--- a/convex/crm/products.ts
+++ b/convex/crm/products.ts
@@ -101,7 +101,7 @@ export const create = action({
           locationId: null,
           delta: initial,
           reason: "initial",
-          unitPrice: args.purchasePrice ?? undefined,
+          unitPrice: args.unitPrice ?? undefined,
           performedBy: String(authResult.userId),
         });
       } catch (e) {

--- a/src/components/gabinet/warehouse-inventory-dialog.tsx
+++ b/src/components/gabinet/warehouse-inventory-dialog.tsx
@@ -532,7 +532,7 @@ export function WarehouseInventoryDialog({
                     const unit = product.stockUnit?.trim() ?? "";
                     const u = unit ? ` ${unit}` : "";
                     const rawAvgCost = historicalStockQuery.data?.avgCostMap.get(product._id) ?? avgCostByProductId.get(product._id) ?? null;
-                    const avgCost = rawAvgCost ?? (product.purchasePrice != null && product.purchasePrice > 0 ? product.purchasePrice : null);
+                    const avgCost = rawAvgCost ?? (product.unitPrice != null && product.unitPrice > 0 ? product.unitPrice : null);
                     const isEstimatedCost = rawAvgCost == null && avgCost != null;
                     const valueNet = avgCost != null ? qty * avgCost : null;
                     return (
@@ -641,7 +641,7 @@ export function WarehouseInventoryDialog({
                   const unit = product.stockUnit?.trim() ?? "";
                   const u = unit ? ` ${unit}` : "";
                   const rawAvgCost = avgCostByProductId.get(product._id) ?? null;
-                  const avgCost = rawAvgCost ?? (product.purchasePrice != null && product.purchasePrice > 0 ? product.purchasePrice : null);
+                  const avgCost = rawAvgCost ?? (product.unitPrice != null && product.unitPrice > 0 ? product.unitPrice : null);
                   const isEstimatedCost = rawAvgCost == null && avgCost != null;
                   const valueNet = avgCost != null ? systemStock * avgCost : null;
                   return (
@@ -784,13 +784,13 @@ export function WarehouseInventoryDialog({
           ? new Map(
               trackedProducts.map((p) => [
                 p._id,
-                historicalStockQuery.data!.avgCostMap.get(p._id) ?? avgCostByProductId.get(p._id) ?? (p.purchasePrice != null && p.purchasePrice > 0 ? p.purchasePrice : null),
+                historicalStockQuery.data!.avgCostMap.get(p._id) ?? avgCostByProductId.get(p._id) ?? (p.unitPrice != null && p.unitPrice > 0 ? p.unitPrice : null),
               ]),
             )
           : new Map(
               trackedProducts.map((p) => [
                 p._id,
-                avgCostByProductId.get(p._id) ?? (p.purchasePrice != null && p.purchasePrice > 0 ? p.purchasePrice : null),
+                avgCostByProductId.get(p._id) ?? (p.unitPrice != null && p.unitPrice > 0 ? p.unitPrice : null),
               ]),
             )
       }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5144.

Closes #5144

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d11e69c7 fix(magazyn): use net unitPrice for avgCost fallback and initial stock seed (closes #5144)

### Files changed

```
 convex/crm/products.ts                                | 2 +-
 src/components/gabinet/warehouse-inventory-dialog.tsx | 8 ++++----
 2 files changed, 5 insertions(+), 5 deletions(-)
```