### PR TITLE
Fix stale schema comment on `purchasePrice` in crm.ts

### DIFF
--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -331,7 +331,7 @@ export function createCrmTables({
     manufacturer: v.optional(v.string()),
     catalogNumber: v.optional(v.string()),
     stockNote: v.optional(v.string()),
-    // Net purchase price per unit (#2956, migration 00050). Used to calculate
+    // Gross purchase price per unit (#2956, migration 00050). Used to calculate
     // warehouse value. Distinct from unitPrice (the selling price).
     purchasePrice: v.optional(v.number()),
     // Optional retail sale price per unit (#3201/#3203, migration 00066).


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5148.

Closes #5148

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 90a410fa fix(schema): correct stale comment on purchasePrice from Net to Gross (closes #5148)

### Files changed

```
 convex/schema/crm.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```