### PR TITLE
Remove gross fallback from movement unit_price snapshot

### DIFF
--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -241,10 +241,7 @@ export async function applyMovementInternal(
     }
   }
 
-  const snapshotPrice =
-    params.unitPrice != null
-      ? params.unitPrice
-      : product.purchasePrice ?? null;
+  const snapshotPrice = params.unitPrice ?? null;
 
   const movementId = await db.insert("productStockMovements", {
     organizationId: params.organizationId,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5149.

Closes #5149

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 91188353 fix(magazyn): remove gross purchasePrice fallback from movement unitPrice snapshot (closes #5149)

### Files changed

```
 convex/inventory.ts | 5 +----
 1 file changed, 1 insertion(+), 4 deletions(-)
```