### PR TITLE
Consider exporting computed `salePriceNet` in `exportProducts`

### DIFF
--- a/convex/crm/csvExport.ts
+++ b/convex/crm/csvExport.ts
@@ -192,6 +192,11 @@ export const exportProducts = action({
       catalogNumber: p.catalogNumber ?? "",
       purchasePrice: p.purchasePrice != null ? p.purchasePrice.toString() : "",
       salePrice: p.salePrice != null ? p.salePrice.toString() : "",
+      salePriceNet: (() => {
+        if (p.salePrice == null) return "";
+        if (p.taxExempt || p.taxRate == null) return p.salePrice.toString();
+        return (Math.round((p.salePrice / (1 + (p.taxRate as number) / 100)) * 100) / 100).toString();
+      })(),
       trackStock: p.trackStock ? "Yes" : "No",
       stockUnit: p.stockUnit ?? "",
       minStock: p.minStock != null ? p.minStock.toString() : "",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5159.

Closes #5159

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e28e88fa feat(csvExport): add computed salePriceNet to exportProducts (closes #5159)

### Files changed

```
 convex/crm/csvExport.ts | 5 +++++
 1 file changed, 5 insertions(+)
```