### PR TITLE
Add taxRate validation in batchCreateProducts import

### DIFF
--- a/convex/crm/csvImport.ts
+++ b/convex/crm/csvImport.ts
@@ -250,11 +250,17 @@ export const batchCreateProducts = action({
     let created = 0;
     const errors: { row: number; error: string }[] = [];
 
+    const VALID_TAX_RATES = [0, 5, 8, 23];
+
     for (let i = 0; i < args.records.length; i++) {
       const record = args.records[i];
       try {
         if (!record.name?.trim() || !record.sku?.trim()) {
           errors.push({ row: i, error: "name and sku are required" });
+          continue;
+        }
+        if (record.taxRate !== undefined && !record.taxExempt && !VALID_TAX_RATES.includes(record.taxRate)) {
+          errors.push({ row: i, error: `Invalid taxRate ${record.taxRate}: must be one of ${VALID_TAX_RATES.join(", ")}` });
           continue;
         }
         await db.insert("products", {

--- a/tests/convex/batchCreateProductsTaxRate.test.ts
+++ b/tests/convex/batchCreateProductsTaxRate.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+
+describe("batchCreateProducts — taxRate validation (#5164)", () => {
+  test("accepts valid tax rates 0, 5, 8, 23", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.crm.csvImport.batchCreateProducts, {
+        organizationId,
+        records: [
+          { name: "P1", sku: "S1", unitPrice: 10, taxRate: 0 },
+          { name: "P2", sku: "S2", unitPrice: 20, taxRate: 5 },
+          { name: "P3", sku: "S3", unitPrice: 30, taxRate: 8 },
+          { name: "P4", sku: "S4", unitPrice: 40, taxRate: 23 },
+        ],
+      });
+
+    expect(result.created).toBe(4);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("rejects out-of-range taxRate and reports a row error", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.crm.csvImport.batchCreateProducts, {
+        organizationId,
+        records: [
+          { name: "Good", sku: "S-OK", unitPrice: 10, taxRate: 23 },
+          { name: "Bad", sku: "S-BAD", unitPrice: 10, taxRate: 15 },
+        ],
+      });
+
+    expect(result.created).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].row).toBe(1);
+    expect(result.errors[0].error).toMatch(/Invalid taxRate 15/);
+  });
+
+  test("skips taxRate validation when taxExempt is true", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.crm.csvImport.batchCreateProducts, {
+        organizationId,
+        records: [
+          { name: "Exempt", sku: "S-ZW", unitPrice: 100, taxExempt: true },
+        ],
+      });
+
+    expect(result.created).toBe(1);
+    expect(result.errors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5164.

Closes #5164

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 6ff19093 fix(csvImport): validate taxRate in batchCreateProducts (closes #5164)

### Files changed

```
 convex/crm/csvImport.ts                         |  6 +++
 tests/convex/batchCreateProductsTaxRate.test.ts | 62 +++++++++++++++++++++++++
 2 files changed, 68 insertions(+)
```