### PR TITLE
M34 — Magazyn — import CSV tagów po nazwach

### DIFF
--- a/convex/crm/csvImport.ts
+++ b/convex/crm/csvImport.ts
@@ -236,6 +236,7 @@ export const batchCreateProducts = action({
         manufacturer: v.optional(v.string()),
         catalogNumber: v.optional(v.string()),
         stockNote: v.optional(v.string()),
+        tags: v.optional(v.array(v.string())),
       })
     ),
   },
@@ -255,6 +256,17 @@ export const batchCreateProducts = action({
 
     const VALID_TAX_RATES = [0, 5, 8, 23];
 
+    // Build a name→id map from existing tagDefinitions for this org
+    const allTagDefs = (await db
+      .query("tagDefinitions")
+      .eq("organizationId", String(args.organizationId))
+      .collect()) as Array<Record<string, any>>;
+    const tagNameToId = new Map<string, string>(
+      allTagDefs
+        .filter((t) => !t.isDeleted)
+        .map((t) => [t.name as string, t._id as string])
+    );
+
     for (let i = 0; i < args.records.length; i++) {
       const record = args.records[i];
       try {
@@ -266,6 +278,22 @@ export const batchCreateProducts = action({
           errors.push({ row: i, error: `Invalid taxRate ${record.taxRate}: must be one of ${VALID_TAX_RATES.join(", ")}` });
           continue;
         }
+
+        let tagIds: string[] | null = null;
+        if (record.tags && record.tags.length > 0) {
+          const resolved: string[] = [];
+          for (const name of record.tags) {
+            const id = tagNameToId.get(name);
+            if (!id) {
+              errors.push({ row: i, error: `Unknown tag: "${name}"` });
+              break;
+            }
+            resolved.push(id);
+          }
+          if (resolved.length !== record.tags.length) continue;
+          tagIds = resolved;
+        }
+
         await db.insert("products", {
           organizationId: String(args.organizationId),
           name: record.name.trim(),
@@ -275,6 +303,7 @@ export const batchCreateProducts = action({
           taxExempt: record.taxExempt ?? null,
           isActive: record.isActive ?? true,
           description: record.description?.trim() ?? null,
+          tagIds,
           purchasePrice: record.purchasePrice ?? null,
           salePrice: record.salePrice ?? null,
           trackStock: record.trackStock ?? null,

--- a/src/components/csv/csv-import-dialog.tsx
+++ b/src/components/csv/csv-import-dialog.tsx
@@ -43,7 +43,7 @@ const ALL_FIELDS: Record<EntityType, string[]> = {
   contacts: ["firstName", "lastName", "email", "phone", "title", "source", "tags", "notes"],
   companies: ["name", "domain", "industry", "size", "website", "phone", "street", "city", "state", "zip", "country", "notes"],
   leads: ["title", "value", "currency", "status", "priority", "source", "notes", "tags"],
-  products: ["name", "sku", "unitPrice", "taxRate", "isActive", "description", "purchasePrice", "salePrice", "trackStock", "stockUnit", "minStock", "productSection", "manufacturer", "catalogNumber", "stockNote"],
+  products: ["name", "sku", "unitPrice", "taxRate", "isActive", "description", "purchasePrice", "salePrice", "trackStock", "stockUnit", "minStock", "productSection", "manufacturer", "catalogNumber", "stockNote", "tags"],
 };
 
 function downloadTemplate(entityType: EntityType) {

--- a/tests/convex/batchCreateProductsTags.test.ts
+++ b/tests/convex/batchCreateProductsTags.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+describe("batchCreateProducts — tags import (#5169)", () => {
+  test("resolves tag names to tagIds when tags exist", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const db = createSupabaseDb();
+    const now = Date.now();
+    const tagId = await db.insert("tagDefinitions", {
+      organizationId: String(organizationId),
+      name: "Bestseller",
+      color: "#ff0000",
+      sortOrder: 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.crm.csvImport.batchCreateProducts, {
+        organizationId,
+        records: [{ name: "P1", sku: "S1", unitPrice: 10, tags: ["Bestseller"] }],
+      });
+
+    expect(result.created).toBe(1);
+    expect(result.errors).toHaveLength(0);
+
+    const inserted = await db.query("products").eq("organizationId", String(organizationId)).collect() as any[];
+    expect(inserted[0].tagIds).toEqual([tagId]);
+  });
+
+  test("returns error and skips product when tag name is unknown", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.crm.csvImport.batchCreateProducts, {
+        organizationId,
+        records: [
+          { name: "Good", sku: "S-OK", unitPrice: 10 },
+          { name: "Bad", sku: "S-BAD", unitPrice: 10, tags: ["NonExistentTag"] },
+        ],
+      });
+
+    expect(result.created).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].row).toBe(1);
+    expect(result.errors[0].error).toMatch(/Unknown tag: "NonExistentTag"/);
+  });
+
+  test("empty tags field creates product with no tagIds", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.crm.csvImport.batchCreateProducts, {
+        organizationId,
+        records: [{ name: "P1", sku: "S1", unitPrice: 10, tags: [] }],
+      });
+
+    expect(result.created).toBe(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("does not create new tagDefinitions", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const db = createSupabaseDb();
+    const before = await db.query("tagDefinitions").eq("organizationId", String(organizationId)).collect();
+
+    await t
+      .withIdentity(identity)
+      .action(api.crm.csvImport.batchCreateProducts, {
+        organizationId,
+        records: [{ name: "P1", sku: "S1", unitPrice: 10, tags: ["Phantom"] }],
+      });
+
+    const after = await db.query("tagDefinitions").eq("organizationId", String(organizationId)).collect();
+    expect(after.length).toBe(before.length);
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5169.

Closes #5169

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- db0175a4 feat(csvImport): resolve tag names to tagIds in batchCreateProducts (closes #5169)

### Files changed

```
 convex/crm/csvImport.ts                      | 29 +++++++++
 src/components/csv/csv-import-dialog.tsx     |  2 +-
 tests/convex/batchCreateProductsTags.test.ts | 88 ++++++++++++++++++++++++++++
 3 files changed, 118 insertions(+), 1 deletion(-)
```