### PR TITLE
M35 — Magazyn — import CSV kategorii produktu po nazwie

### DIFF
--- a/convex/crm/csvImport.ts
+++ b/convex/crm/csvImport.ts
@@ -237,6 +237,7 @@ export const batchCreateProducts = action({
         catalogNumber: v.optional(v.string()),
         stockNote: v.optional(v.string()),
         tags: v.optional(v.array(v.string())),
+        category: v.optional(v.string()),
       })
     ),
   },
@@ -267,6 +268,17 @@ export const batchCreateProducts = action({
         .map((t) => [t.name as string, t._id as string])
     );
 
+    // Build a name→id map from existing categoryDefinitions (entityType="product") for this org
+    const allCategoryDefs = (await db
+      .query("categoryDefinitions")
+      .eq("organizationId", String(args.organizationId))
+      .collect()) as Array<Record<string, any>>;
+    const categoryNameToId = new Map<string, string>(
+      allCategoryDefs
+        .filter((c) => !c.isDeleted && c.entityType === "product")
+        .map((c) => [c.name as string, c._id as string])
+    );
+
     for (let i = 0; i < args.records.length; i++) {
       const record = args.records[i];
       try {
@@ -294,6 +306,17 @@ export const batchCreateProducts = action({
           tagIds = resolved;
         }
 
+        let categoryId: string | null = null;
+        const categoryName = record.category?.trim();
+        if (categoryName) {
+          const resolvedCategoryId = categoryNameToId.get(categoryName);
+          if (!resolvedCategoryId) {
+            errors.push({ row: i, error: `Unknown category: "${categoryName}"` });
+            continue;
+          }
+          categoryId = resolvedCategoryId;
+        }
+
         await db.insert("products", {
           organizationId: String(args.organizationId),
           name: record.name.trim(),
@@ -304,6 +327,7 @@ export const batchCreateProducts = action({
           isActive: record.isActive ?? true,
           description: record.description?.trim() ?? null,
           tagIds,
+          categoryId,
           purchasePrice: record.purchasePrice ?? null,
           salePrice: record.salePrice ?? null,
           trackStock: record.trackStock ?? null,

--- a/src/components/csv/csv-import-dialog.tsx
+++ b/src/components/csv/csv-import-dialog.tsx
@@ -43,7 +43,7 @@ const ALL_FIELDS: Record<EntityType, string[]> = {
   contacts: ["firstName", "lastName", "email", "phone", "title", "source", "tags", "notes"],
   companies: ["name", "domain", "industry", "size", "website", "phone", "street", "city", "state", "zip", "country", "notes"],
   leads: ["title", "value", "currency", "status", "priority", "source", "notes", "tags"],
-  products: ["name", "sku", "unitPrice", "taxRate", "isActive", "description", "purchasePrice", "salePrice", "trackStock", "stockUnit", "minStock", "productSection", "manufacturer", "catalogNumber", "stockNote", "tags"],
+  products: ["name", "sku", "unitPrice", "taxRate", "isActive", "description", "purchasePrice", "salePrice", "trackStock", "stockUnit", "minStock", "productSection", "manufacturer", "catalogNumber", "stockNote", "tags", "category"],
 };
 
 function downloadTemplate(entityType: EntityType) {

--- a/tests/convex/batchCreateProductsCategory.test.ts
+++ b/tests/convex/batchCreateProductsCategory.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+describe("batchCreateProducts — category import (#5171)", () => {
+  test("resolves category name to categoryId when category exists", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const db = createSupabaseDb();
+    const now = Date.now();
+    const categoryId = await db.insert("categoryDefinitions", {
+      organizationId: String(organizationId),
+      entityType: "product",
+      name: "Electronics",
+      sortOrder: 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.crm.csvImport.batchCreateProducts, {
+        organizationId,
+        records: [{ name: "P1", sku: "S1", unitPrice: 10, category: "Electronics" }],
+      });
+
+    expect(result.created).toBe(1);
+    expect(result.errors).toHaveLength(0);
+
+    const inserted = await db.query("products").eq("organizationId", String(organizationId)).collect() as any[];
+    expect(inserted[0].categoryId).toEqual(categoryId);
+  });
+
+  test("trims whitespace from category name before lookup", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const db = createSupabaseDb();
+    const now = Date.now();
+    await db.insert("categoryDefinitions", {
+      organizationId: String(organizationId),
+      entityType: "product",
+      name: "Clothing",
+      sortOrder: 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.crm.csvImport.batchCreateProducts, {
+        organizationId,
+        records: [{ name: "P1", sku: "S1", unitPrice: 10, category: "  Clothing  " }],
+      });
+
+    expect(result.created).toBe(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("returns error and skips product when category name is unknown", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.crm.csvImport.batchCreateProducts, {
+        organizationId,
+        records: [
+          { name: "Good", sku: "S-OK", unitPrice: 10 },
+          { name: "Bad", sku: "S-BAD", unitPrice: 10, category: "NonExistent" },
+        ],
+      });
+
+    expect(result.created).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].row).toBe(1);
+    expect(result.errors[0].error).toMatch(/Unknown category: "NonExistent"/);
+  });
+
+  test("empty category field creates product with null categoryId", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.crm.csvImport.batchCreateProducts, {
+        organizationId,
+        records: [{ name: "P1", sku: "S1", unitPrice: 10, category: "" }],
+      });
+
+    expect(result.created).toBe(1);
+    expect(result.errors).toHaveLength(0);
+
+    const db = createSupabaseDb();
+    const inserted = await db.query("products").eq("organizationId", String(organizationId)).collect() as any[];
+    expect(inserted[0].categoryId).toBeNull();
+  });
+
+  test("does not create new categoryDefinitions", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const db = createSupabaseDb();
+    const before = await db.query("categoryDefinitions").eq("organizationId", String(organizationId)).collect();
+
+    await t
+      .withIdentity(identity)
+      .action(api.crm.csvImport.batchCreateProducts, {
+        organizationId,
+        records: [{ name: "P1", sku: "S1", unitPrice: 10, category: "PhantomCategory" }],
+      });
+
+    const after = await db.query("categoryDefinitions").eq("organizationId", String(organizationId)).collect();
+    expect(after.length).toBe(before.length);
+  });
+
+  test("ignores categories from other organizations", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    const { organizationId: otherOrg } = await seedTestUser(t);
+
+    const db = createSupabaseDb();
+    const now = Date.now();
+    // Category only exists in the other org
+    await db.insert("categoryDefinitions", {
+      organizationId: String(otherOrg),
+      entityType: "product",
+      name: "SharedName",
+      sortOrder: 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.crm.csvImport.batchCreateProducts, {
+        organizationId,
+        records: [{ name: "P1", sku: "S1", unitPrice: 10, category: "SharedName" }],
+      });
+
+    expect(result.created).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].error).toMatch(/Unknown category: "SharedName"/);
+  });
+
+  test("ignores soft-deleted categories", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const db = createSupabaseDb();
+    const now = Date.now();
+    await db.insert("categoryDefinitions", {
+      organizationId: String(organizationId),
+      entityType: "product",
+      name: "Deleted",
+      sortOrder: 0,
+      isDeleted: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.crm.csvImport.batchCreateProducts, {
+        organizationId,
+        records: [{ name: "P1", sku: "S1", unitPrice: 10, category: "Deleted" }],
+      });
+
+    expect(result.created).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].error).toMatch(/Unknown category: "Deleted"/);
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5171.

Closes #5171

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f39f10e2 feat(csvImport): resolve category names to categoryId in batchCreateProducts (closes #5171)

### Files changed

```
 convex/crm/csvImport.ts                          |  24 ++++
 src/components/csv/csv-import-dialog.tsx         |   2 +-
 tests/convex/batchCreateProductsCategory.test.ts | 175 +++++++++++++++++++++++
 3 files changed, 200 insertions(+), 1 deletion(-)
```