### PR TITLE
A1 — Magazyn — nazwa produktu w „Produktach wymagających działania” nie reaguje na kliknięcie

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -1217,7 +1217,13 @@ function ProductsPage() {
               const unitStr = item.unit?.trim() ? ` ${item.unit.trim()}` : "";
               return (
                 <li key={item.productId} className="text-sm text-amber-900 dark:text-amber-100">
-                  <span className="font-medium">{item.productName}</span>
+                  <button
+                    type="button"
+                    className="font-medium underline underline-offset-2 hover:opacity-75"
+                    onClick={() => setSearchValue(item.productName)}
+                  >
+                    {item.productName}
+                  </button>
                   <div className="mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-amber-800 dark:text-amber-200">
                     <span>{t("products.actionRequired.stock", { defaultValue: "Stan:" })} {item.currentStock}{unitStr}</span>
                     <span>{t("products.actionRequired.planned", { defaultValue: "Planowane:" })} {item.plannedUsage}{unitStr}</span>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5177.

Closes #5177

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 37b2d609 fix(products): make action-required product name clickable to filter table (closes #5177)

### Files changed

```
 src/routes/_app/_auth/dashboard/_layout.products.index.tsx | 8 +++++++-
 1 file changed, 7 insertions(+), 1 deletion(-)
```