### PR TITLE
A2 — Magazyn — kafelek „Poniżej min. stanu” ma działać także przy wartości 0

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.products.index.tsx
@@ -1195,12 +1195,10 @@ function ProductsPage() {
           value={inventoryStats.belowMin}
           highlight={inventoryStats.belowMin > 0}
           active={nudgeFilter === "low_stock"}
-          onClick={inventoryStats.belowMin > 0
-            ? () => {
-                onViewChange("all");
-                navigate({ to: "/dashboard/products", search: { nudge: "low_stock" } });
-              }
-            : undefined}
+          onClick={() => {
+            onViewChange("all");
+            navigate({ to: "/dashboard/products", search: { nudge: "low_stock" } });
+          }}
         />
       </div>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5179.

Closes #5179

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 2efdc694 fix(products): make 'Poniżej min. stanu' tile always clickable (closes #5179)

### Files changed

```
 src/routes/_app/_auth/dashboard/_layout.products.index.tsx | 10 ++++------
 1 file changed, 4 insertions(+), 6 deletions(-)
```