### PR TITLE
M43 — Magazyn — lista dostaw ma przewijać się poziomo na iPadzie

### DIFF
--- a/src/components/gabinet/deliveries/deliveries-page.tsx
+++ b/src/components/gabinet/deliveries/deliveries-page.tsx
@@ -640,8 +640,8 @@ export function DeliveriesPage() {
           </p>
         </div>
       ) : (
-        <div className="rounded-md border">
-          <table className="w-full text-sm">
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full min-w-[800px] text-sm">
             <thead>
               <tr className="border-b bg-muted/40">
                 <th className="px-4 py-3 text-left font-medium text-muted-foreground">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5186.

Closes #5186

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 30f0d41b fix(deliveries): add horizontal scroll to deliveries table on iPad (closes #5186)

### Files changed

```
 src/components/gabinet/deliveries/deliveries-page.tsx | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```