### PR TITLE
M44 — Magazyn — naprawić szerokość panelu „Nowa dostawa” na iPadzie

### DIFF
--- a/src/components/gabinet/deliveries/deliveries-page.tsx
+++ b/src/components/gabinet/deliveries/deliveries-page.tsx
@@ -823,6 +823,7 @@ export function DeliveriesPage() {
           "gabinet.deliveries.newDeliveryDesc",
           "Wypełnij dane dostawy. Po zapisaniu możesz ją zaksięgować, co zaktualizuje stany magazynowe.",
         )}
+        className="sm:max-w-[560px]"
       >
         <div className="space-y-5">
           {/* Header fields */}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5188.

Closes #5188

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 645d5b84 fix(deliveries): widen 'Nowa dostawa' panel to fit Pozycje dostawy on iPad (closes #5188)

### Files changed

```
 src/components/gabinet/deliveries/deliveries-page.tsx | 1 +
 1 file changed, 1 insertion(+)
```