### PR TITLE
M46 — Magazyn — naprawić błędne otwieranie kalendarza w „Pozycje dostawy”

### DIFF
--- a/src/components/gabinet/deliveries/deliveries-page.tsx
+++ b/src/components/gabinet/deliveries/deliveries-page.tsx
@@ -979,7 +979,7 @@ export function DeliveriesPage() {
                         <SelectTrigger className="h-8 text-xs">
                           <SelectValue placeholder="VAT" />
                         </SelectTrigger>
-                        <SelectContent position="item-aligned">
+                        <SelectContent>
                           {VAT_OPTIONS.map((o) => (
                             <SelectItem key={o.code} value={o.code}>
                               {o.label}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5192.

Closes #5192

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 5566a0ac fix(deliveries): fix date calendar opening when clicking VAT in 'Pozycje dostawy' (closes #5192)

### Files changed

```
 src/components/gabinet/deliveries/deliveries-page.tsx | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```