### PR TITLE
MZ2 — Magazyn ↔ Zabieg — powiązać ruch magazynowy z konkretnym zabiegiem

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2450,6 +2450,7 @@ export const updateStatus = action({
                   locationId: (appt.locationId ?? null) as string | null,
                   totalNeeded,
                   appointmentId: args.appointmentId,
+                  treatmentId: jt.treatment_id ?? undefined,
                   performedBy: authResult.userId,
                 },
               );

--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -158,6 +158,7 @@ interface ApplyMovementParams {
   unitPrice?: number | null;
   lotNumber?: string | null;
   expiryDate?: string | null;
+  treatmentId?: string | null;
   performedBy: string;
 }
 
@@ -258,6 +259,7 @@ export async function applyMovementInternal(
     ...(newAvgCost !== null ? { avgCostAfter: newAvgCost } : {}),
     ...(params.lotNumber ? { lotNumber: params.lotNumber } : {}),
     ...(params.expiryDate ? { expiryDate: params.expiryDate } : {}),
+    ...(params.treatmentId ? { treatmentId: params.treatmentId } : {}),
     performedBy: params.performedBy,
     createdAt: now,
   });

--- a/convex/magazyn/movements.ts
+++ b/convex/magazyn/movements.ts
@@ -22,6 +22,7 @@ export const consumeForAppointment = internalAction({
     locationId: v.union(v.string(), v.null()),
     totalNeeded: v.number(),
     appointmentId: v.string(),
+    treatmentId: v.optional(v.string()),
     performedBy: v.string(),
   },
   handler: async (_ctx, args): Promise<{ negativeStock: boolean }> => {
@@ -32,6 +33,7 @@ export const consumeForAppointment = internalAction({
       reason: "appointment_use" as const,
       sourceType: "appointment",
       sourceId: args.appointmentId,
+      treatmentId: args.treatmentId ?? null,
       performedBy: args.performedBy,
     };
 
@@ -94,7 +96,7 @@ export const returnStockForAppointment = internalAction({
 
     const { data: useMovements } = await db.raw()
       .from("product_stock_movements")
-      .select("product_id, delta, lot_number, expiry_date, location_id")
+      .select("product_id, delta, lot_number, expiry_date, location_id, treatment_id")
       .eq("source_type", "appointment")
       .eq("source_id", args.appointmentId)
       .eq("reason", "appointment_use");
@@ -104,6 +106,7 @@ export const returnStockForAppointment = internalAction({
       lot_number: string | null;
       expiry_date: string | null;
       location_id: string | null;
+      treatment_id: string | null;
     }>;
 
     for (const mv of movements) {
@@ -118,6 +121,7 @@ export const returnStockForAppointment = internalAction({
           sourceId: args.appointmentId,
           lotNumber: mv.lot_number ?? undefined,
           expiryDate: mv.expiry_date ?? undefined,
+          treatmentId: mv.treatment_id ?? undefined,
           performedBy: args.performedBy,
         });
       } catch (e) {

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -397,6 +397,7 @@ export function createCrmTables({
     avgCostAfter: v.optional(v.number()),
     lotNumber: v.optional(v.string()),        // LOT/batch number (#2989)
     expiryDate: v.optional(v.string()),       // ISO date YYYY-MM-DD (#2989)
+    treatmentId: v.optional(v.string()),      // which treatment drove the deduction (#5198)
     performedBy: v.id("users"),
     createdAt: v.number(),
   })

--- a/supabase/migrations/00129_product_stock_movements_treatment_id.sql
+++ b/supabase/migrations/00129_product_stock_movements_treatment_id.sql
@@ -1,0 +1,18 @@
+-- Link stock movements to a specific treatment within an appointment (#5198).
+--
+-- When an appointment contains multiple treatments each treatment can consume
+-- different products. Previously all movements shared the same source_type /
+-- source_id pointing at the appointment, but there was no way to tell which
+-- treatment within that appointment drove a given deduction.
+--
+-- treatment_id is nullable so that:
+--   • existing movements without treatment context are unaffected,
+--   • non-appointment movements (manual adjustments, direct sales, etc.) remain
+--     valid without ever setting this field.
+
+ALTER TABLE product_stock_movements
+  ADD COLUMN IF NOT EXISTS treatment_id TEXT REFERENCES gabinet_treatments(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS product_stock_movements_treatment_idx
+  ON product_stock_movements (treatment_id)
+  WHERE treatment_id IS NOT NULL;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5198.

Closes #5198

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f336cb6a feat(magazyn): link stock movements to specific treatment in appointment (closes #5198)

### Files changed

```
 convex/gabinet/appointments.ts                         |  1 +
 convex/inventory.ts                                    |  2 ++
 convex/magazyn/movements.ts                            |  6 +++++-
 convex/schema/crm.ts                                   |  1 +
 .../00129_product_stock_movements_treatment_id.sql     | 18 ++++++++++++++++++
 5 files changed, 27 insertions(+), 1 deletion(-)
```