### PR TITLE
Fix no_show/usedCount inconsistency

### DIFF
--- a/src/components/gabinet/patient-packages-card.tsx
+++ b/src/components/gabinet/patient-packages-card.tsx
@@ -44,9 +44,9 @@ import { PlateText } from "@/components/plate-text";
 import { useSupabaseGabinetAppointmentsByPatient } from "@/hooks/use-supabase-gabinet-appointments";
 
 // Appointment statuses that still consume a package slot — they haven't been
-// deducted from `usedCount` yet (deduction happens on transition to "completed")
-// but they aren't terminal failures (cancelled/no_show) either, so front-desk
-// needs to see them when planning capacity.
+// deducted from `usedCount` yet (deduction happens on transition to "completed"
+// or "no_show") but they aren't terminal failures (cancelled) either, so
+// front-desk needs to see them when planning capacity.
 const PENDING_USAGE_STATUSES = new Set([
   "pending_confirmation",
   "scheduled",

--- a/src/hooks/use-supabase-gabinet-appointments.ts
+++ b/src/hooks/use-supabase-gabinet-appointments.ts
@@ -422,7 +422,7 @@ export function useSupabaseGabinetAppointmentPackagePositions(
           .select("id, package_usage_id, date, start_time")
           .eq("organization_id", organizationId)
           .in("package_usage_id", stableIds)
-          .not("status", "in", '("cancelled","no_show")')
+          .not("status", "eq", "cancelled")
           .order("date", { ascending: true })
           .order("start_time", { ascending: true }),
       ]);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5202.

Closes #5202

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 459c007b fix(gabinet): include no_show in package position counter to match backend deduction logic (closes #5202)

### Files changed

```
 src/components/gabinet/patient-packages-card.tsx | 6 +++---
 src/hooks/use-supabase-gabinet-appointments.ts   | 2 +-
 2 files changed, 4 insertions(+), 4 deletions(-)
```