### PR TITLE
Sidebar package progress bar uses DB usedCount, calendar badge uses dynamic posi

### DIFF
--- a/src/components/gabinet/appointments/appointment-sidebar-extra.tsx
+++ b/src/components/gabinet/appointments/appointment-sidebar-extra.tsx
@@ -249,7 +249,14 @@ export function AppointmentSidebarExtra({
                       <span className="text-muted-foreground truncate">
                         {tu.treatmentName ?? "-"}
                       </span>
-                      <span className="tabular-nums text-muted-foreground shrink-0">
+                      <span
+                        className="tabular-nums text-muted-foreground shrink-0"
+                        title={t(
+                          "gabinet.packages.sidebarProgressTooltip",
+                          "Ukończone sesje: {{used}} z {{total}}",
+                          { used, total },
+                        )}
+                      >
                         {used} / {total}
                       </span>
                     </div>

--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -854,8 +854,9 @@ export function AppointmentPreviewContent({
         kind: "count",
         label: `${pkgPos.position}/${pkgPos.total}`,
         title: t(
-          "gabinet.calendar.indicators.packageVisit",
-          "Wizyta pakietowa",
+          "gabinet.calendar.indicators.packageVisitPosition",
+          "Numer wizyty w pakiecie: {{position}} z {{total}}",
+          { position: pkgPos.position, total: pkgPos.total },
         ),
       });
     } else if (appointment.isRecurring && appointment.recurringRule) {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -776,8 +776,9 @@ function GabinetCalendarPage() {
             kind: "count",
             label: `${pkgPos.position}/${pkgPos.total}`,
             title: t(
-              "gabinet.calendar.indicators.packageVisit",
-              "Wizyta pakietowa",
+              "gabinet.calendar.indicators.packageVisitPosition",
+              "Numer wizyty w pakiecie: {{position}} z {{total}}",
+              { position: pkgPos.position, total: pkgPos.total },
             ),
           });
         } else if (a.isRecurring && a.recurringRule) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5203.

Closes #5203

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- bff3a489 fix(gabinet): disambiguate calendar package badge vs sidebar usage counter (closes #5203)

### Files changed

```
 .../gabinet/appointments/appointment-sidebar-extra.tsx           | 9 ++++++++-
 src/components/gabinet/calendar/appointment-preview-content.tsx  | 5 +++--
 .../_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx | 5 +++--
 3 files changed, 14 insertions(+), 5 deletions(-)
```