### PR TITLE
Fix read-modify-write race on `treatmentsUsed` JSONB in `deductPackageEntry`

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -3036,45 +3036,31 @@ async function deductPackageEntry(
   db: ReturnType<typeof createSupabaseDb>,
   args: { packageUsageId: string; treatmentId: string; variantId?: string },
 ) {
-  const now = Date.now();
-  const usage = await db.get("gabinetPackageUsage", args.packageUsageId);
-  if (!usage || usage.status !== "active") return;
-  const matchesTreatment = (t: any) =>
-    t.treatmentId === args.treatmentId &&
-    (args.variantId == null || t.variantId === args.variantId);
-  const entry = (usage.treatmentsUsed as any[]).find(matchesTreatment);
-  if (!entry || entry.usedCount >= entry.totalCount) return;
-  const updatedTreatments = (usage.treatmentsUsed as any[]).map((t) =>
-    matchesTreatment(t) ? { ...t, usedCount: t.usedCount + 1 } : t,
-  );
-  const allUsed = updatedTreatments.every((t: any) => t.usedCount >= t.totalCount);
-  await db.patch("gabinetPackageUsage", args.packageUsageId, {
-    treatmentsUsed: updatedTreatments,
-    status: allUsed ? "completed" : "active",
-    updatedAt: now,
+  // Atomic increment via Postgres SELECT FOR UPDATE — eliminates the
+  // read-modify-write race when two concurrent appointment completions share
+  // the same packageUsageId (closes #5208).
+  const { error } = await db.raw().rpc("deduct_package_entry", {
+    p_usage_id:     args.packageUsageId,
+    p_treatment_id: args.treatmentId,
+    p_variant_id:   args.variantId ?? null,
+    p_now:          Date.now(),
   });
+  if (error) throw new Error(`deduct_package_entry RPC: ${error.message}`);
 }
 
 async function returnPackageEntry(
   db: ReturnType<typeof createSupabaseDb>,
   args: { packageUsageId: string; treatmentId: string; variantId?: string },
 ) {
-  const now = Date.now();
-  const usage = await db.get("gabinetPackageUsage", args.packageUsageId);
-  if (!usage) return;
-  const matchesTreatment = (t: any) =>
-    t.treatmentId === args.treatmentId &&
-    (args.variantId == null || t.variantId === args.variantId);
-  const entry = (usage.treatmentsUsed as any[]).find(matchesTreatment);
-  if (!entry || entry.usedCount <= 0) return;
-  const updatedTreatments = (usage.treatmentsUsed as any[]).map((t) =>
-    matchesTreatment(t) ? { ...t, usedCount: Math.max(0, t.usedCount - 1) } : t,
-  );
-  await db.patch("gabinetPackageUsage", args.packageUsageId, {
-    treatmentsUsed: updatedTreatments,
-    status: usage.status === "completed" ? "active" : (usage.status as string),
-    updatedAt: now,
+  // Atomic decrement via Postgres SELECT FOR UPDATE — same race fix as
+  // deductPackageEntry (closes #5208).
+  const { error } = await db.raw().rpc("return_package_entry", {
+    p_usage_id:     args.packageUsageId,
+    p_treatment_id: args.treatmentId,
+    p_variant_id:   args.variantId ?? null,
+    p_now:          Date.now(),
   });
+  if (error) throw new Error(`return_package_entry RPC: ${error.message}`);
 }
 
 /**

--- a/supabase/migrations/00130_gabinet_package_deduction_atomic_fns.sql
+++ b/supabase/migrations/00130_gabinet_package_deduction_atomic_fns.sql
@@ -1,0 +1,118 @@
+-- Atomic package entry deduction/return via SELECT FOR UPDATE (closes #5208).
+--
+-- The old application-side read-modify-write on `treatments_used` JSONB had a
+-- race: two concurrent appointment completions sharing the same `packageUsageId`
+-- could both read the same `usedCount`, both increment it, and the second writer
+-- would overwrite the first's increment, losing one deduction.
+--
+-- These functions serialize concurrent callers on the row lock so the increment
+-- (or decrement) is applied exactly once per caller.
+
+CREATE OR REPLACE FUNCTION deduct_package_entry(
+  p_usage_id     TEXT,
+  p_treatment_id TEXT,
+  p_variant_id   TEXT,   -- NULL = match any variant for this treatment
+  p_now          BIGINT
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_row           RECORD;
+  v_updated_jsonb JSONB;
+  v_entry         JSONB;
+  v_all_used      BOOLEAN;
+BEGIN
+  -- Lock the row; concurrent callers block here and see the updated usedCount
+  -- from the previous winner once they acquire the lock.
+  SELECT * INTO v_row
+  FROM gabinet_package_usage
+  WHERE id = p_usage_id AND status = 'active'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN RETURN; END IF;
+
+  -- Re-check that a matching entry still has remaining sessions after the lock.
+  SELECT elem INTO v_entry
+  FROM jsonb_array_elements(v_row.treatments_used) elem
+  WHERE elem->>'treatmentId' = p_treatment_id
+    AND (p_variant_id IS NULL OR elem->>'variantId' = p_variant_id)
+    AND (elem->>'usedCount')::int < (elem->>'totalCount')::int
+  LIMIT 1;
+
+  IF NOT FOUND THEN RETURN; END IF;
+
+  -- Increment usedCount on every matching entry (mirrors JS .map() behaviour).
+  SELECT jsonb_agg(
+    CASE
+      WHEN elem->>'treatmentId' = p_treatment_id
+        AND (p_variant_id IS NULL OR elem->>'variantId' = p_variant_id)
+      THEN jsonb_set(elem, '{usedCount}', to_jsonb((elem->>'usedCount')::int + 1))
+      ELSE elem
+    END
+  ) INTO v_updated_jsonb
+  FROM jsonb_array_elements(v_row.treatments_used) elem;
+
+  -- Mark the package completed when every entry is fully used.
+  SELECT NOT EXISTS (
+    SELECT 1 FROM jsonb_array_elements(v_updated_jsonb) e
+    WHERE (e->>'usedCount')::int < (e->>'totalCount')::int
+  ) INTO v_all_used;
+
+  UPDATE gabinet_package_usage
+  SET treatments_used = v_updated_jsonb,
+      status          = CASE WHEN v_all_used THEN 'completed' ELSE 'active' END,
+      updated_at      = p_now
+  WHERE id = p_usage_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION return_package_entry(
+  p_usage_id     TEXT,
+  p_treatment_id TEXT,
+  p_variant_id   TEXT,   -- NULL = match any variant for this treatment
+  p_now          BIGINT
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_row           RECORD;
+  v_updated_jsonb JSONB;
+  v_entry         JSONB;
+BEGIN
+  SELECT * INTO v_row
+  FROM gabinet_package_usage
+  WHERE id = p_usage_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN RETURN; END IF;
+
+  -- Early-exit if there is nothing to return.
+  SELECT elem INTO v_entry
+  FROM jsonb_array_elements(v_row.treatments_used) elem
+  WHERE elem->>'treatmentId' = p_treatment_id
+    AND (p_variant_id IS NULL OR elem->>'variantId' = p_variant_id)
+    AND (elem->>'usedCount')::int > 0
+  LIMIT 1;
+
+  IF NOT FOUND THEN RETURN; END IF;
+
+  -- Decrement usedCount on every matching entry (mirrors JS .map() + GREATEST(0, …) behaviour).
+  SELECT jsonb_agg(
+    CASE
+      WHEN elem->>'treatmentId' = p_treatment_id
+        AND (p_variant_id IS NULL OR elem->>'variantId' = p_variant_id)
+      THEN jsonb_set(elem, '{usedCount}', to_jsonb(GREATEST(0, (elem->>'usedCount')::int - 1)))
+      ELSE elem
+    END
+  ) INTO v_updated_jsonb
+  FROM jsonb_array_elements(v_row.treatments_used) elem;
+
+  UPDATE gabinet_package_usage
+  SET treatments_used = v_updated_jsonb,
+      status          = CASE WHEN v_row.status = 'completed' THEN 'active' ELSE v_row.status END,
+      updated_at      = p_now
+  WHERE id = p_usage_id;
+END;
+$$;

--- a/tests/convex/_supabase_inmemory.ts
+++ b/tests/convex/_supabase_inmemory.ts
@@ -236,6 +236,70 @@ function createInMemoryRawClient() {
           error: null,
         };
       }
+      // Atomic package entry deduction (closes #5208).
+      // Mirrors the PL/pgSQL SELECT FOR UPDATE logic in the production function.
+      if (fn === "deduct_package_entry") {
+        const usageId     = String(params.p_usage_id ?? "");
+        const treatmentId = String(params.p_treatment_id ?? "");
+        const variantId   = params.p_variant_id != null ? String(params.p_variant_id) : null;
+        const now         = Number(params.p_now ?? Date.now());
+        const t = getTable("gabinetPackageUsage");
+        const row = t.get(usageId);
+        if (!row || row.status !== "active") {
+          return { data: null, error: null };
+        }
+        const treatments = (row.treatmentsUsed ?? []) as Array<Record<string, unknown>>;
+        const matchesTreatment = (e: Record<string, unknown>) =>
+          e.treatmentId === treatmentId &&
+          (variantId === null || e.variantId === variantId);
+        const entry = treatments.find(
+          (e) => matchesTreatment(e) && (e.usedCount as number) < (e.totalCount as number),
+        );
+        if (!entry) return { data: null, error: null };
+        const updated = treatments.map((e) =>
+          matchesTreatment(e)
+            ? { ...e, usedCount: (e.usedCount as number) + 1 }
+            : e,
+        );
+        const allUsed = updated.every((e) => (e.usedCount as number) >= (e.totalCount as number));
+        t.set(usageId, {
+          ...row,
+          treatmentsUsed: updated,
+          status: allUsed ? "completed" : "active",
+          updatedAt: now,
+        });
+        return { data: null, error: null };
+      }
+      // Atomic package entry return (closes #5208).
+      if (fn === "return_package_entry") {
+        const usageId     = String(params.p_usage_id ?? "");
+        const treatmentId = String(params.p_treatment_id ?? "");
+        const variantId   = params.p_variant_id != null ? String(params.p_variant_id) : null;
+        const now         = Number(params.p_now ?? Date.now());
+        const t = getTable("gabinetPackageUsage");
+        const row = t.get(usageId);
+        if (!row) return { data: null, error: null };
+        const treatments = (row.treatmentsUsed ?? []) as Array<Record<string, unknown>>;
+        const matchesTreatment = (e: Record<string, unknown>) =>
+          e.treatmentId === treatmentId &&
+          (variantId === null || e.variantId === variantId);
+        const entry = treatments.find(
+          (e) => matchesTreatment(e) && (e.usedCount as number) > 0,
+        );
+        if (!entry) return { data: null, error: null };
+        const updated = treatments.map((e) =>
+          matchesTreatment(e)
+            ? { ...e, usedCount: Math.max(0, (e.usedCount as number) - 1) }
+            : e,
+        );
+        t.set(usageId, {
+          ...row,
+          treatmentsUsed: updated,
+          status: row.status === "completed" ? "active" : row.status,
+          updatedAt: now,
+        });
+        return { data: null, error: null };
+      }
       return { data: null, error: { message: `rpc stub: unknown function ${fn}` } };
     },
   };


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5208.

Closes #5208

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 5efbf8b6 fix(gabinet): atomic package entry deduction via SELECT FOR UPDATE (closes #5208)

### Files changed

```
 convex/gabinet/appointments.ts                     |  48 +++------
 .../00130_gabinet_package_deduction_atomic_fns.sql | 118 +++++++++++++++++++++
 tests/convex/_supabase_inmemory.ts                 |  64 +++++++++++
 3 files changed, 199 insertions(+), 31 deletions(-)
```