### PR TITLE
Fix calendar badge to exclude no_show from position counter

### DIFF
--- a/src/hooks/use-supabase-gabinet-appointments.ts
+++ b/src/hooks/use-supabase-gabinet-appointments.ts
@@ -422,7 +422,7 @@ export function useSupabaseGabinetAppointmentPackagePositions(
           .select("id, package_usage_id, date, start_time")
           .eq("organization_id", organizationId)
           .in("package_usage_id", stableIds)
-          .not("status", "eq", "cancelled")
+          .not("status", "in", '("cancelled","no_show")')
           .order("date", { ascending: true })
           .order("start_time", { ascending: true }),
       ]);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5212.

Closes #5212

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 265ae479 fix(gabinet): exclude no_show from calendar badge position counter (closes #5212)

### Files changed

```
 src/hooks/use-supabase-gabinet-appointments.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```