### PR TITLE
Add idempotency check in `purchasePackage` for regular mode

### DIFF
--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -744,6 +744,20 @@ export const purchasePackage = action({
         throw new Error("Could not generate unique voucher code");
     }
 
+    // Idempotency guard for regular (non-gift) purchases: if an active usage
+    // already exists for this patient × package, return it instead of creating
+    // a duplicate. Guards against double-click / network-retry scenarios.
+    if (!isGift && args.patientId) {
+      const existing = await db
+        .query("gabinetPackageUsage")
+        .eq("organizationId", String(args.organizationId))
+        .eq("patientId", args.patientId)
+        .eq("packageId", args.packageId)
+        .in("status", ["active", "unassigned"])
+        .first();
+      if (existing) return String(existing._id);
+    }
+
     const usageId = await db.insert("gabinetPackageUsage", {
       organizationId: String(args.organizationId),
       patientId: args.patientId ?? null,

--- a/tests/convex/packageDeduction.test.ts
+++ b/tests/convex/packageDeduction.test.ts
@@ -276,6 +276,46 @@ describe("package session deduction guards", () => {
     ).rejects.toThrow("Package is not active");
   });
 
+  test("purchasePackage is idempotent: returns existing usageId when active usage already exists", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    const { packageId, usageId: firstUsageId } = await setupPackage(t, identity, {
+      organizationId,
+      patientId,
+      treatmentId,
+      quantity: 4,
+    });
+
+    const secondUsageId = await t.withIdentity(identity).action(
+      api.gabinet.packages.purchasePackage,
+      {
+        organizationId,
+        patientId: String(patientId),
+        packageId,
+        paidAmount: 200,
+        paymentMethod: "cash",
+      },
+    );
+
+    expect(secondUsageId).toBe(firstUsageId);
+
+    const db = createSupabaseDb();
+    const rows = await db
+      .query("gabinetPackageUsage")
+      .eq("organizationId", organizationId)
+      .eq("patientId", String(patientId))
+      .eq("packageId", packageId)
+      .collect();
+
+    expect(rows).toHaveLength(1);
+  });
+
   test("cannot delete a package that has been purchased by a patient", async () => {
     const t = createTestCtx();
     const { organizationId, userId, identity } = await seedTestUser(t);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5218.

Closes #5218

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 7e5b77b4 fix(gabinet): add idempotency check in purchasePackage for regular mode (closes #5218)

### Files changed

```
 convex/gabinet/packages.ts            | 14 ++++++++++++
 tests/convex/packageDeduction.test.ts | 40 +++++++++++++++++++++++++++++++++++
 2 files changed, 54 insertions(+)
```