### PR TITLE
Recalculate `expiresAt` in `assignGiftPackage`

### DIFF
--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -1391,17 +1391,24 @@ export const assignGiftPackage = action({
       throw new Error("Package is already assigned");
 
     const now = Date.now();
-    await db.patch("gabinetPackageUsage", args.usageId, {
-      patientId: args.patientId,
-      status: "active",
-      updatedAt: now,
-    });
 
     // Award loyalty points that were deferred at purchase time
     const pkg = await db.get(
       "gabinetTreatmentPackages",
       String(usage.packageId),
     );
+
+    const pkgValidityDays = pkg?.validityDays as number | null | undefined;
+    const expiresAt = pkgValidityDays
+      ? now + pkgValidityDays * 24 * 60 * 60 * 1000
+      : null;
+
+    await db.patch("gabinetPackageUsage", args.usageId, {
+      patientId: args.patientId,
+      status: "active",
+      expiresAt,
+      updatedAt: now,
+    });
     const loyaltyPointsAwarded =
       (pkg?.loyaltyPointsAwarded as number | undefined) ?? 0;
     if (loyaltyPointsAwarded > 0) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5220.

Closes #5220

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 30a87bf4 fix(gabinet): recalculate expiresAt in assignGiftPackage (closes #5220)

### Files changed

```
 convex/gabinet/packages.ts | 17 ++++++++++++-----
 1 file changed, 12 insertions(+), 5 deletions(-)
```