### PR TITLE
Emit an assignment audit log entry in `_assignGiftSideEffects` unconditionally (

### DIFF
--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -1457,24 +1457,22 @@ export const assignGiftPackage = action({
       });
     }
 
-    if (loyaltyPointsAwarded > 0) {
-      try {
-        await ctx.runMutation(internal.gabinet.packages._assignGiftSideEffects, {
-          usageId: args.usageId,
-          organizationId: args.organizationId,
-          patientId: args.patientId,
-          packageName: (pkg?.name as string) ?? "",
-          loyaltyPointsAwarded,
-          performedBy: String(authResult.userId),
-        });
-      } catch (e) {
-        console.error(
-          "[packages.assignGiftPackage] Side effects FAILED for usage",
-          args.usageId,
-          ":",
-          e,
-        );
-      }
+    try {
+      await ctx.runMutation(internal.gabinet.packages._assignGiftSideEffects, {
+        usageId: args.usageId,
+        organizationId: args.organizationId,
+        patientId: args.patientId,
+        packageName: (pkg?.name as string) ?? "",
+        loyaltyPointsAwarded,
+        performedBy: String(authResult.userId),
+      });
+    } catch (e) {
+      console.error(
+        "[packages.assignGiftPackage] Side effects FAILED for usage",
+        args.usageId,
+        ":",
+        e,
+      );
     }
   },
 });
@@ -1492,16 +1490,30 @@ export const _assignGiftSideEffects = internalMutation({
     await logAudit(ctx, {
       organizationId: args.organizationId,
       userId: args.performedBy,
-      action: "loyalty_points_earned",
+      action: "gift_package_assigned",
       entityType: "gabinetPatient",
       entityId: args.patientId,
       details: JSON.stringify({
-        points: args.loyaltyPointsAwarded,
-        reason: `Gift package assigned: ${args.packageName}`,
+        packageName: args.packageName,
         referenceType: "packageUsage",
         referenceId: args.usageId,
       }),
     });
+    if (args.loyaltyPointsAwarded > 0) {
+      await logAudit(ctx, {
+        organizationId: args.organizationId,
+        userId: args.performedBy,
+        action: "loyalty_points_earned",
+        entityType: "gabinetPatient",
+        entityId: args.patientId,
+        details: JSON.stringify({
+          points: args.loyaltyPointsAwarded,
+          reason: `Gift package assigned: ${args.packageName}`,
+          referenceType: "packageUsage",
+          referenceId: args.usageId,
+        }),
+      });
+    }
   },
 });
 

--- a/tests/convex/assignGiftAudit.test.ts
+++ b/tests/convex/assignGiftAudit.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Verifies that every gift package assignment emits a `gift_package_assigned`
+ * audit log entry, regardless of whether loyalty points were awarded.
+ *
+ * Regression test for #5221.
+ */
+
+import { afterEach, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedGabinetPrereqs, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+describe("assignGiftPackage audit trail", () => {
+  test("emits gift_package_assigned audit entry even when loyaltyPointsAwarded is 0", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    // Create a package with no loyalty points
+    const packageId = await t.withIdentity(identity).action(api.gabinet.packages.create, {
+      organizationId,
+      name: "Gift Package No Points",
+      treatments: [{ treatmentId: String(treatmentId), quantity: 2 }],
+      totalPrice: 300,
+    });
+
+    // Purchase as gift (no patientId)
+    const usageId = await t.withIdentity(identity).action(
+      api.gabinet.packages.purchasePackage,
+      {
+        organizationId,
+        packageId,
+        paidAmount: 300,
+        paymentMethod: "cash",
+        isGift: true,
+      },
+    );
+
+    // Assign the gift to the patient
+    await t.withIdentity(identity).action(api.gabinet.packages.assignGiftPackage, {
+      organizationId,
+      usageId,
+      patientId: String(patientId),
+    });
+
+    const db = createSupabaseDb();
+    const auditEntries = await db
+      .query("auditLog")
+      .eq("organizationId", String(organizationId))
+      .collect();
+
+    const assignmentEntry = auditEntries.find(
+      (e) => e.action === "gift_package_assigned",
+    );
+    expect(assignmentEntry).toBeTruthy();
+    expect(assignmentEntry?.entityType).toBe("gabinetPatient");
+    expect(assignmentEntry?.entityId).toBe(String(patientId));
+
+    // No loyalty points awarded, so loyalty_points_earned should NOT be present
+    const loyaltyEntry = auditEntries.find(
+      (e) => e.action === "loyalty_points_earned",
+    );
+    expect(loyaltyEntry).toBeUndefined();
+  });
+
+  test("emits both gift_package_assigned and loyalty_points_earned when points > 0", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    // Create a package with loyalty points
+    const packageId = await t.withIdentity(identity).action(api.gabinet.packages.create, {
+      organizationId,
+      name: "Gift Package With Points",
+      treatments: [{ treatmentId: String(treatmentId), quantity: 2 }],
+      totalPrice: 300,
+      loyaltyPointsAwarded: 50,
+    });
+
+    // Purchase as gift
+    const usageId = await t.withIdentity(identity).action(
+      api.gabinet.packages.purchasePackage,
+      {
+        organizationId,
+        packageId,
+        paidAmount: 300,
+        paymentMethod: "cash",
+        isGift: true,
+      },
+    );
+
+    // Assign the gift to the patient
+    await t.withIdentity(identity).action(api.gabinet.packages.assignGiftPackage, {
+      organizationId,
+      usageId,
+      patientId: String(patientId),
+    });
+
+    const db = createSupabaseDb();
+    const auditEntries = await db
+      .query("auditLog")
+      .eq("organizationId", String(organizationId))
+      .collect();
+
+    const assignmentEntry = auditEntries.find(
+      (e) => e.action === "gift_package_assigned",
+    );
+    expect(assignmentEntry).toBeTruthy();
+
+    const loyaltyEntry = auditEntries.find(
+      (e) => e.action === "loyalty_points_earned",
+    );
+    expect(loyaltyEntry).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5221.

Closes #5221

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- dcff778d fix(gabinet): emit gift_package_assigned audit entry unconditionally in _assignGiftSideEffects (closes #5221)

### Files changed

```
 convex/gabinet/packages.ts           |  54 +++++++++------
 tests/convex/assignGiftAudit.test.ts | 127 +++++++++++++++++++++++++++++++++++
 2 files changed, 160 insertions(+), 21 deletions(-)
```