### PR TITLE
Add overbooking guard in `create` appointment

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1266,6 +1266,29 @@ export const create = action({
       }
     }
 
+    // --- Package overbooking guard (closes #5227) ---
+    // Lock the package usage row and count non-terminal appointments already
+    // booked against the same slot. Rejects the booking if usedCount +
+    // pending_count would reach or exceed totalCount.
+    if (resolvedPackageUsageId) {
+      const treatmentIdForCheck = args.packageTreatmentId ?? primaryTreatmentId;
+      const variantIdForCheck = args.packageTreatmentId
+        ? (treatmentsList.find((t) => t.treatmentId === args.packageTreatmentId)?.variantId ?? null)
+        : (args.variantId ?? null);
+      const { error: overbookError } = await db.raw().rpc("check_package_overbooking", {
+        p_usage_id:                         resolvedPackageUsageId,
+        p_treatment_id:                     treatmentIdForCheck,
+        p_variant_id:                       variantIdForCheck ?? null,
+        p_appointment_package_treatment_id: args.packageTreatmentId ?? null,
+      });
+      if (overbookError) {
+        if (overbookError.message?.includes("package_overbooking")) {
+          throw new Error("Brak dostępnych sesji w pakiecie dla tego zabiegu.");
+        }
+        throw new Error(`check_package_overbooking: ${overbookError.message}`);
+      }
+    }
+
     // --- Resolve location (Supabase-primary) ---
     let resolvedLocationId = args.locationId ?? null;
     if (!resolvedLocationId) {

--- a/supabase/migrations/00131_gabinet_appointment_package_overbooking_guard.sql
+++ b/supabase/migrations/00131_gabinet_appointment_package_overbooking_guard.sql
@@ -1,0 +1,69 @@
+-- Overbooking guard for package-linked appointments (closes #5227).
+--
+-- The session counter (usedCount) in gabinet_package_usage.treatments_used is
+-- decremented only when an appointment reaches "completed". Without a guard at
+-- booking time a practitioner can create more appointments than the package has
+-- remaining sessions, causing the later deductions to silently fail.
+--
+-- This function is called from gabinet/appointments.create before inserting the
+-- new row. It acquires a row-level lock on gabinet_package_usage, counts
+-- non-terminal appointments (scheduled/confirmed/in_progress) already booked
+-- against the same package+treatment slot, and raises an error if adding one
+-- more booking would exceed totalCount.
+--
+-- p_appointment_package_treatment_id mirrors the value that will be stored in
+-- gabinet_appointments.package_treatment_id. When NULL (simple single-treatment
+-- booking) all pending appointments for this package are counted; when non-NULL
+-- only appointments with the matching package_treatment_id are counted.
+
+CREATE OR REPLACE FUNCTION check_package_overbooking(
+  p_usage_id                          TEXT,
+  p_treatment_id                      TEXT,   -- entry in treatments_used to check
+  p_variant_id                        TEXT,   -- NULL = match any variant
+  p_appointment_package_treatment_id  TEXT    -- NULL for simple appointments
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_row     RECORD;
+  v_entry   JSONB;
+  v_used    INT;
+  v_total   INT;
+  v_pending BIGINT;
+BEGIN
+  -- Lock the usage row so concurrent creates for the same package+treatment
+  -- slot are serialised here, not at deduction time.
+  SELECT * INTO v_row
+  FROM gabinet_package_usage
+  WHERE id = p_usage_id AND status = 'active'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN RETURN; END IF;
+
+  -- Locate the relevant entry in the JSONB array.
+  SELECT elem INTO v_entry
+  FROM jsonb_array_elements(v_row.treatments_used) elem
+  WHERE elem->>'treatmentId' = p_treatment_id
+    AND (p_variant_id IS NULL OR elem->>'variantId' = p_variant_id)
+  LIMIT 1;
+
+  IF NOT FOUND THEN RETURN; END IF;
+
+  v_used  := (v_entry->>'usedCount')::int;
+  v_total := (v_entry->>'totalCount')::int;
+
+  -- Count non-terminal appointments already booked against this package slot.
+  -- IS NOT DISTINCT FROM handles NULL equality (NULL = NULL is TRUE).
+  SELECT COUNT(*) INTO v_pending
+  FROM gabinet_appointments
+  WHERE package_usage_id = p_usage_id
+    AND status IN ('scheduled', 'confirmed', 'in_progress')
+    AND package_treatment_id IS NOT DISTINCT FROM p_appointment_package_treatment_id;
+
+  IF v_used + v_pending >= v_total THEN
+    RAISE EXCEPTION 'package_overbooking: % sessions used/pending out of % total',
+      (v_used + v_pending), v_total;
+  END IF;
+END;
+$$;

--- a/tests/convex/_supabase_inmemory.ts
+++ b/tests/convex/_supabase_inmemory.ts
@@ -300,6 +300,55 @@ function createInMemoryRawClient() {
         });
         return { data: null, error: null };
       }
+      // Overbooking guard for package-linked appointments (closes #5227).
+      // Mirrors the PL/pgSQL SELECT FOR UPDATE logic in the production function.
+      if (fn === "check_package_overbooking") {
+        const usageId     = String(params.p_usage_id ?? "");
+        const treatmentId = String(params.p_treatment_id ?? "");
+        const variantId   = params.p_variant_id != null ? String(params.p_variant_id) : null;
+        const appointmentPkgTreatmentId =
+          params.p_appointment_package_treatment_id != null
+            ? String(params.p_appointment_package_treatment_id)
+            : null;
+
+        const t = getTable("gabinetPackageUsage");
+        const row = t.get(usageId);
+        if (!row || row.status !== "active") return { data: null, error: null };
+
+        const treatments = (row.treatmentsUsed ?? []) as Array<Record<string, unknown>>;
+        const entry = treatments.find(
+          (e) =>
+            e.treatmentId === treatmentId &&
+            (variantId === null || e.variantId === variantId),
+        );
+        if (!entry) return { data: null, error: null };
+
+        const usedCount  = entry.usedCount as number;
+        const totalCount = entry.totalCount as number;
+
+        // Count non-terminal appointments for this package+slot.
+        const apptTable = getTable("gabinetAppointments");
+        let pendingCount = 0;
+        for (const appt of apptTable.values()) {
+          if (
+            appt.packageUsageId === usageId &&
+            (appt.status === "scheduled" || appt.status === "confirmed" || appt.status === "in_progress") &&
+            (appt.packageTreatmentId ?? null) === appointmentPkgTreatmentId
+          ) {
+            pendingCount++;
+          }
+        }
+
+        if (usedCount + pendingCount >= totalCount) {
+          return {
+            data: null,
+            error: {
+              message: `package_overbooking: ${usedCount + pendingCount} sessions used/pending out of ${totalCount} total`,
+            },
+          };
+        }
+        return { data: null, error: null };
+      }
       return { data: null, error: { message: `rpc stub: unknown function ${fn}` } };
     },
   };

--- a/tests/convex/packageDeduction.test.ts
+++ b/tests/convex/packageDeduction.test.ts
@@ -8,7 +8,7 @@
  * auto-complete transition when the last session is used.
  */
 
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { api } from "../../convex/_generated/api";
 import {
   createTestCtx,
@@ -339,5 +339,111 @@ describe("package session deduction guards", () => {
     ).rejects.toThrow(
       "Cannot delete a package that has been purchased by patients",
     );
+  });
+});
+
+describe("appointment overbooking guard", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        text: async () => JSON.stringify({ sid: "SM_TEST_123" }),
+      })) as unknown as typeof fetch,
+    );
+  });
+
+  afterEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    vi.unstubAllGlobals();
+  });
+
+  test("booking within package capacity succeeds", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    const { usageId } = await setupPackage(t, identity, {
+      organizationId,
+      patientId,
+      treatmentId,
+      quantity: 2,
+    });
+
+    const apptId = await t.withIdentity(identity).action(
+      api.gabinet.appointments.create,
+      {
+        organizationId,
+        patientId: String(patientId),
+        treatmentId: String(treatmentId),
+        employeeId: String(userId),
+        date: "2026-09-01",
+        startTime: "09:00",
+        endTime: "09:30",
+        packageUsageId: usageId,
+        allowPast: true,
+      },
+    );
+    expect(apptId).toBeTruthy();
+  });
+
+  test("booking beyond package capacity is rejected", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    const { usageId } = await setupPackage(t, identity, {
+      organizationId,
+      patientId,
+      treatmentId,
+      quantity: 2,
+    });
+
+    // Book both sessions — these should succeed.
+    await t.withIdentity(identity).action(api.gabinet.appointments.create, {
+      organizationId,
+      patientId: String(patientId),
+      treatmentId: String(treatmentId),
+      employeeId: String(userId),
+      date: "2026-09-01",
+      startTime: "09:00",
+      endTime: "09:30",
+      packageUsageId: usageId,
+      allowPast: true,
+    });
+    await t.withIdentity(identity).action(api.gabinet.appointments.create, {
+      organizationId,
+      patientId: String(patientId),
+      treatmentId: String(treatmentId),
+      employeeId: String(userId),
+      date: "2026-09-02",
+      startTime: "09:00",
+      endTime: "09:30",
+      packageUsageId: usageId,
+      allowPast: true,
+    });
+
+    // Third booking exceeds the 2-session limit.
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.appointments.create, {
+        organizationId,
+        patientId: String(patientId),
+        treatmentId: String(treatmentId),
+        employeeId: String(userId),
+        date: "2026-09-03",
+        startTime: "09:00",
+        endTime: "09:30",
+        packageUsageId: usageId,
+        allowPast: true,
+      }),
+    ).rejects.toThrow("Brak dostępnych sesji w pakiecie dla tego zabiegu.");
   });
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5227.

Closes #5227

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e65a29b6 fix(gabinet): add atomic overbooking guard in appointments.create (closes #5227)

### Files changed

```
 convex/gabinet/appointments.ts                     |  23 +++++
 ...binet_appointment_package_overbooking_guard.sql |  69 +++++++++++++
 tests/convex/_supabase_inmemory.ts                 |  49 ++++++++++
 tests/convex/packageDeduction.test.ts              | 108 ++++++++++++++++++++-
 4 files changed, 248 insertions(+), 1 deletion(-)
```