### PR TITLE
Fix `PackageUsageSelector` to show effective remaining entries

### DIFF
--- a/convex/gabinet/packages.ts
+++ b/convex/gabinet/packages.ts
@@ -1246,12 +1246,24 @@ export const getActiveUsageCounts = action({
   },
 });
 
+type TreatmentEntryWithScheduled = {
+  treatmentId: string;
+  variantId?: string;
+  usedCount: number;
+  totalCount: number;
+  scheduledCount: number;
+};
+
+export type PatientPackageUsage = Omit<GabinetPackageUsageRow, "treatmentsUsed"> & {
+  treatmentsUsed: TreatmentEntryWithScheduled[];
+};
+
 export const getPatientPackages = action({
   args: {
     organizationId: v.string(),
     patientId: v.string(),
   },
-  handler: async (ctx, args): Promise<GabinetPackageUsageRow[]> => {
+  handler: async (ctx, args): Promise<PatientPackageUsage[]> => {
     await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
@@ -1269,11 +1281,53 @@ export const getPatientPackages = action({
     if (!perm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
-    return (await db
+    const usages = (await db
       .query("gabinetPackageUsage")
       .eq("organizationId", String(args.organizationId))
       .eq("patientId", args.patientId)
       .collect()) as GabinetPackageUsageRow[];
+
+    // Count non-terminal appointments per (package_usage_id, treatment_id, variant_id)
+    // so the selector can display effective remaining = totalCount - usedCount - scheduledCount.
+    const scheduledCountMap: Record<string, number> = {};
+    const usageIds = usages.map(u => String(u._id));
+    if (usageIds.length > 0) {
+      const client = db.raw();
+      const { data: scheduledAppts } = await client
+        .from("gabinet_appointments")
+        .select("package_usage_id, gabinet_appointment_treatments(treatment_id, variant_id)")
+        .in("package_usage_id", usageIds)
+        .in("status", ["scheduled", "confirmed", "in_progress"]);
+
+      for (const appt of (scheduledAppts ?? [])) {
+        const usageId = (appt as { package_usage_id: string }).package_usage_id;
+        const treatments = (appt as {
+          gabinet_appointment_treatments?: Array<{ treatment_id: string | null; variant_id: string | null }>;
+        }).gabinet_appointment_treatments ?? [];
+        for (const at of treatments) {
+          if (!at.treatment_id) continue;
+          const key = `${usageId}|${at.treatment_id}|${at.variant_id ?? ""}`;
+          scheduledCountMap[key] = (scheduledCountMap[key] ?? 0) + 1;
+        }
+      }
+    }
+
+    return usages.map(u => {
+      const usageId = String(u._id);
+      const entries = ((u.treatmentsUsed ?? []) as Array<{
+        treatmentId: string;
+        variantId?: string;
+        usedCount: number;
+        totalCount: number;
+      }>);
+      return {
+        ...u,
+        treatmentsUsed: entries.map(e => ({
+          ...e,
+          scheduledCount: scheduledCountMap[`${usageId}|${e.treatmentId}|${e.variantId ?? ""}`] ?? 0,
+        })),
+      };
+    });
   },
 });
 

--- a/src/components/gabinet/package-usage-selector.tsx
+++ b/src/components/gabinet/package-usage-selector.tsx
@@ -54,14 +54,15 @@ export function PackageUsageSelector({
     return tuVariantId === variantId;
   };
 
-  // Find active usages that have remaining uses for this treatment and variant
+  // Find active usages that have remaining uses for this treatment and variant.
+  // Effective remaining = totalCount - usedCount - scheduledCount (non-terminal appointments).
   const eligibleUsages = usages.filter((u) => {
     if (u.status !== "active") return false;
     if (u.expiresAt && u.expiresAt < Date.now()) return false;
     const entry = u.treatmentsUsed.find(
       (tu) => tu.treatmentId === treatmentId && matchesVariant(tu.variantId),
     );
-    return entry && entry.usedCount < entry.totalCount;
+    return entry && entry.usedCount + (entry.scheduledCount ?? 0) < entry.totalCount;
   });
 
   if (eligibleUsages.length === 0) return null;
@@ -73,7 +74,7 @@ export function PackageUsageSelector({
           (tu) => tu.treatmentId === treatmentId && matchesVariant(tu.variantId),
         )!;
         const pkgName = packageMap.get(usage.packageId) ?? t("common.unknown");
-        const remaining = entry.totalCount - entry.usedCount;
+        const remaining = entry.totalCount - entry.usedCount - (entry.scheduledCount ?? 0);
         const isChecked = selectedUsageId === usage._id;
 
         return (


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5228.

Closes #5228

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 13fc8000 fix(gabinet): show effective remaining in PackageUsageSelector (closes #5228)

### Files changed

```
 convex/gabinet/packages.ts                        | 58 ++++++++++++++++++++++-
 src/components/gabinet/package-usage-selector.tsx |  7 +--
 2 files changed, 60 insertions(+), 5 deletions(-)
```