### PR TITLE
Fix overbooking guard to account for full series size

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1266,20 +1266,30 @@ export const create = action({
       }
     }
 
-    // --- Package overbooking guard (closes #5227) ---
+    // --- Package overbooking guard (closes #5227, #5232) ---
     // Lock the package usage row and count non-terminal appointments already
-    // booked against the same slot. Rejects the booking if usedCount +
-    // pending_count would reach or exceed totalCount.
+    // booked against the same slot. For a recurring series of N appointments
+    // we pass p_new_count=N so the guard rejects the entire series when there
+    // is not enough capacity — not just the first occurrence.
     if (resolvedPackageUsageId) {
       const treatmentIdForCheck = args.packageTreatmentId ?? primaryTreatmentId;
       const variantIdForCheck = args.packageTreatmentId
         ? (treatmentsList.find((t) => t.treatmentId === args.packageTreatmentId)?.variantId ?? null)
         : (args.variantId ?? null);
+      // Base appointment always counts as 1; add recurring occurrences if any.
+      const seriesLength =
+        isRecurring && args.recurringRule
+          ? 1 +
+            (args.recurringOverrides && args.recurringOverrides.length > 0
+              ? args.recurringOverrides.length
+              : generateRecurringDates(args.date, args.recurringRule).length)
+          : 1;
       const { error: overbookError } = await db.raw().rpc("check_package_overbooking", {
         p_usage_id:                         resolvedPackageUsageId,
         p_treatment_id:                     treatmentIdForCheck,
         p_variant_id:                       variantIdForCheck ?? null,
         p_appointment_package_treatment_id: args.packageTreatmentId ?? null,
+        p_new_count:                        seriesLength,
       });
       if (overbookError) {
         if (overbookError.message?.includes("package_overbooking")) {

--- a/supabase/migrations/00132_gabinet_overbooking_guard_series_count.sql
+++ b/supabase/migrations/00132_gabinet_overbooking_guard_series_count.sql
@@ -1,0 +1,56 @@
+-- Extend check_package_overbooking to account for the full series size
+-- when booking recurring appointments (closes #5232).
+--
+-- Previously the function was called once before any insertion with an implicit
+-- new_count of 1, so a series of N recurring appointments only checked whether
+-- one more slot was available rather than N. The new p_new_count parameter lets
+-- the caller pass the total number of appointments about to be inserted so the
+-- guard can reject the entire series if there is not enough capacity.
+
+CREATE OR REPLACE FUNCTION check_package_overbooking(
+  p_usage_id                          TEXT,
+  p_treatment_id                      TEXT,
+  p_variant_id                        TEXT,
+  p_appointment_package_treatment_id  TEXT,
+  p_new_count                         INT DEFAULT 1
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_row     RECORD;
+  v_entry   JSONB;
+  v_used    INT;
+  v_total   INT;
+  v_pending BIGINT;
+BEGIN
+  SELECT * INTO v_row
+  FROM gabinet_package_usage
+  WHERE id = p_usage_id AND status = 'active'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN RETURN; END IF;
+
+  SELECT elem INTO v_entry
+  FROM jsonb_array_elements(v_row.treatments_used) elem
+  WHERE elem->>'treatmentId' = p_treatment_id
+    AND (p_variant_id IS NULL OR elem->>'variantId' = p_variant_id)
+  LIMIT 1;
+
+  IF NOT FOUND THEN RETURN; END IF;
+
+  v_used  := (v_entry->>'usedCount')::int;
+  v_total := (v_entry->>'totalCount')::int;
+
+  SELECT COUNT(*) INTO v_pending
+  FROM gabinet_appointments
+  WHERE package_usage_id = p_usage_id
+    AND status IN ('scheduled', 'confirmed', 'in_progress')
+    AND package_treatment_id IS NOT DISTINCT FROM p_appointment_package_treatment_id;
+
+  IF v_used + v_pending + p_new_count > v_total THEN
+    RAISE EXCEPTION 'package_overbooking: % sessions used/pending + % new out of % total',
+      (v_used + v_pending), p_new_count, v_total;
+  END IF;
+END;
+$$;

--- a/tests/convex/_supabase_inmemory.ts
+++ b/tests/convex/_supabase_inmemory.ts
@@ -300,7 +300,7 @@ function createInMemoryRawClient() {
         });
         return { data: null, error: null };
       }
-      // Overbooking guard for package-linked appointments (closes #5227).
+      // Overbooking guard for package-linked appointments (closes #5227, #5232).
       // Mirrors the PL/pgSQL SELECT FOR UPDATE logic in the production function.
       if (fn === "check_package_overbooking") {
         const usageId     = String(params.p_usage_id ?? "");
@@ -310,6 +310,7 @@ function createInMemoryRawClient() {
           params.p_appointment_package_treatment_id != null
             ? String(params.p_appointment_package_treatment_id)
             : null;
+        const newCount = typeof params.p_new_count === "number" ? params.p_new_count : 1;
 
         const t = getTable("gabinetPackageUsage");
         const row = t.get(usageId);
@@ -339,11 +340,11 @@ function createInMemoryRawClient() {
           }
         }
 
-        if (usedCount + pendingCount >= totalCount) {
+        if (usedCount + pendingCount + newCount > totalCount) {
           return {
             data: null,
             error: {
-              message: `package_overbooking: ${usedCount + pendingCount} sessions used/pending out of ${totalCount} total`,
+              message: `package_overbooking: ${usedCount + pendingCount} sessions used/pending + ${newCount} new out of ${totalCount} total`,
             },
           };
         }

--- a/tests/convex/packageDeduction.test.ts
+++ b/tests/convex/packageDeduction.test.ts
@@ -446,4 +446,40 @@ describe("appointment overbooking guard", () => {
       }),
     ).rejects.toThrow("Brak dostępnych sesji w pakiecie dla tego zabiegu.");
   });
+
+  test("recurring series that exceeds package capacity is rejected before any insertion", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const { patientId, treatmentId } = await seedGabinetPrereqs(
+      t,
+      organizationId,
+      userId,
+    );
+
+    // Package with only 2 sessions.
+    const { usageId } = await setupPackage(t, identity, {
+      organizationId,
+      patientId,
+      treatmentId,
+      quantity: 2,
+    });
+
+    // A weekly series of 3 occurrences (base + 2 recurrences = 3 total) must be
+    // rejected because the package only has 2 sessions.
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.appointments.create, {
+        organizationId,
+        patientId: String(patientId),
+        treatmentId: String(treatmentId),
+        employeeId: String(userId),
+        date: "2026-09-01",
+        startTime: "09:00",
+        endTime: "09:30",
+        packageUsageId: usageId,
+        isRecurring: true,
+        recurringRule: { frequency: "weekly", count: 3 },
+        allowPast: true,
+      }),
+    ).rejects.toThrow("Brak dostępnych sesji w pakiecie dla tego zabiegu.");
+  });
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5232.

Closes #5232

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0f5a96b0 fix(gabinet): account for full series size in overbooking guard (closes #5232)

### Files changed

```
 convex/gabinet/appointments.ts                     | 16 +++++--
 ...0132_gabinet_overbooking_guard_series_count.sql | 56 ++++++++++++++++++++++
 tests/convex/_supabase_inmemory.ts                 |  7 +--
 tests/convex/packageDeduction.test.ts              | 36 ++++++++++++++
 4 files changed, 109 insertions(+), 6 deletions(-)
```