### PR TITLE
Guard partial failure between packageDeducted CAS flip and Postgres RPC

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2401,8 +2401,9 @@ export const updateStatus = action({
     }
 
     // Package return: when reverting from completed, restore one package entry
-    // per junction treatment. CAS lives on
-    // gabinet_appointment_treatments.package_deducted per junction row (#3367).
+    // per junction treatment. cas_return_package_entry atomically flips the CAS
+    // flag and decrements usedCount in a single Postgres transaction, preventing
+    // partial failure between the two operations (#5239).
     // If packageTreatmentId is set, only the covered treatment is returned (#3590).
     // no_show does not deduct, so reverting from no_show has nothing to restore.
     if (
@@ -2413,29 +2414,20 @@ export const updateStatus = action({
         ? statusJunctionRows.filter((jt) => jt.treatmentId === String(appt.packageTreatmentId))
         : statusJunctionRows;
       for (const jt of pkgReturnRows) {
-        const { data: pkgReturnCasRows } = await db.raw()
-          .from("gabinet_appointment_treatments")
-          .update({ package_deducted: false })
-          .eq("appointment_id", args.appointmentId)
-          .eq("treatment_id", jt.treatmentId)
-          .eq("package_deducted", true)
-          .select("id");
-        const wonPkgReturnRace = Array.isArray(pkgReturnCasRows) && pkgReturnCasRows.length > 0;
-        if (wonPkgReturnRace) {
-          try {
-            await returnPackageEntry(db, {
-              packageUsageId: String(appt.packageUsageId),
-              treatmentId: jt.treatmentId,
-              variantId: jt.variantId ?? undefined,
-            });
-          } catch (e) {
-            console.error(
-              "[updateStatus] package entry return FAILED for appointment",
-              args.appointmentId,
-              ":",
-              e,
-            );
-          }
+        const { error: pkgReturnError } = await db.raw().rpc("cas_return_package_entry", {
+          p_appointment_id: args.appointmentId,
+          p_treatment_id:   jt.treatmentId,
+          p_usage_id:       String(appt.packageUsageId),
+          p_variant_id:     jt.variantId ?? null,
+          p_now:            Date.now(),
+        });
+        if (pkgReturnError) {
+          console.error(
+            "[updateStatus] package entry return FAILED for appointment",
+            args.appointmentId,
+            ":",
+            pkgReturnError,
+          );
         }
       }
     }
@@ -2511,8 +2503,10 @@ export const updateStatus = action({
 
     // Package deduction: only completed consumes one entry per junction treatment.
     // no_show must NOT deduct — patient did not attend, session should be preserved.
-    // CAS lives on gabinet_appointment_treatments.package_deducted per junction row
-    // (#3367), replacing the old appointment-level flag. Closes #3206, #5207.
+    // cas_deduct_package_entry atomically flips package_deducted and increments
+    // usedCount in a single Postgres transaction, eliminating the partial-failure
+    // window between the two operations (#5239). Replaces the old two-step CAS +
+    // RPC approach. Closes #3206, #5207.
     // If packageTreatmentId is set, only the covered treatment is deducted (#3590).
     if (
       args.status === "completed" &&
@@ -2522,29 +2516,20 @@ export const updateStatus = action({
         ? statusJunctionRows.filter((jt) => jt.treatmentId === String(appt.packageTreatmentId))
         : statusJunctionRows;
       for (const jt of pkgDeductRows) {
-        const { data: pkgCasRows } = await db.raw()
-          .from("gabinet_appointment_treatments")
-          .update({ package_deducted: true })
-          .eq("appointment_id", args.appointmentId)
-          .eq("treatment_id", jt.treatmentId)
-          .eq("package_deducted", false)
-          .select("id");
-        const wonPkgRace = Array.isArray(pkgCasRows) && pkgCasRows.length > 0;
-        if (wonPkgRace) {
-          try {
-            await deductPackageEntry(db, {
-              packageUsageId: String(appt.packageUsageId),
-              treatmentId: jt.treatmentId,
-              variantId: jt.variantId ?? undefined,
-            });
-          } catch (e) {
-            console.error(
-              "[updateStatus] package entry deduction FAILED for appointment",
-              args.appointmentId,
-              ":",
-              e,
-            );
-          }
+        const { error: pkgDeductError } = await db.raw().rpc("cas_deduct_package_entry", {
+          p_appointment_id: args.appointmentId,
+          p_treatment_id:   jt.treatmentId,
+          p_usage_id:       String(appt.packageUsageId),
+          p_variant_id:     jt.variantId ?? null,
+          p_now:            Date.now(),
+        });
+        if (pkgDeductError) {
+          console.error(
+            "[updateStatus] package entry deduction FAILED for appointment",
+            args.appointmentId,
+            ":",
+            pkgDeductError,
+          );
         }
       }
     }
@@ -3065,36 +3050,6 @@ async function resolveAutoPackageUsageSupabase(
   return usageId;
 }
 
-async function deductPackageEntry(
-  db: ReturnType<typeof createSupabaseDb>,
-  args: { packageUsageId: string; treatmentId: string; variantId?: string },
-) {
-  // Atomic increment via Postgres SELECT FOR UPDATE — eliminates the
-  // read-modify-write race when two concurrent appointment completions share
-  // the same packageUsageId (closes #5208).
-  const { error } = await db.raw().rpc("deduct_package_entry", {
-    p_usage_id:     args.packageUsageId,
-    p_treatment_id: args.treatmentId,
-    p_variant_id:   args.variantId ?? null,
-    p_now:          Date.now(),
-  });
-  if (error) throw new Error(`deduct_package_entry RPC: ${error.message}`);
-}
-
-async function returnPackageEntry(
-  db: ReturnType<typeof createSupabaseDb>,
-  args: { packageUsageId: string; treatmentId: string; variantId?: string },
-) {
-  // Atomic decrement via Postgres SELECT FOR UPDATE — same race fix as
-  // deductPackageEntry (closes #5208).
-  const { error } = await db.raw().rpc("return_package_entry", {
-    p_usage_id:     args.packageUsageId,
-    p_treatment_id: args.treatmentId,
-    p_variant_id:   args.variantId ?? null,
-    p_now:          Date.now(),
-  });
-  if (error) throw new Error(`return_package_entry RPC: ${error.message}`);
-}
 
 /**
  * When an appointment is completed, award loyalty points based on

--- a/supabase/migrations/00133_gabinet_package_cas_atomic_fns.sql
+++ b/supabase/migrations/00133_gabinet_package_cas_atomic_fns.sql
@@ -1,0 +1,155 @@
+-- Atomic combined CAS-flip + package-entry deduction/return (closes #5239).
+--
+-- Previously, updateStatus did two separate round-trips:
+--   1. UPDATE gabinet_appointment_treatments SET package_deducted = <bool> (CAS)
+--   2. deduct_package_entry / return_package_entry RPC
+--
+-- If the process aborted between the two calls (network fault, server crash),
+-- the junction flag and usedCount would diverge: the flag would say "already
+-- deducted" but the package usage count would be stale (or vice versa).
+--
+-- These functions fuse both operations into a single Postgres transaction so
+-- the flag flip and the usedCount update are always applied together or not
+-- at all.
+
+CREATE OR REPLACE FUNCTION cas_deduct_package_entry(
+  p_appointment_id TEXT,
+  p_treatment_id   TEXT,
+  p_usage_id       TEXT,
+  p_variant_id     TEXT,   -- NULL = match any variant for this treatment
+  p_now            BIGINT
+) RETURNS BOOLEAN           -- TRUE if CAS won and deduction applied, FALSE if already deducted
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_rows_affected INT;
+  v_row           RECORD;
+  v_entry         JSONB;
+  v_updated_jsonb JSONB;
+  v_all_used      BOOLEAN;
+BEGIN
+  -- Step 1: CAS flip false → true on the junction row.
+  -- If package_deducted is already true another caller won the race; exit early.
+  UPDATE gabinet_appointment_treatments
+  SET    package_deducted = true
+  WHERE  appointment_id   = p_appointment_id
+    AND  treatment_id     = p_treatment_id
+    AND  package_deducted = false;
+
+  GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+  IF v_rows_affected = 0 THEN
+    RETURN FALSE;
+  END IF;
+
+  -- Step 2: Lock the package usage row and increment usedCount.
+  -- Uses SELECT FOR UPDATE so concurrent completions on the same package
+  -- are serialized here (same guarantee as the standalone deduct_package_entry).
+  SELECT * INTO v_row
+  FROM gabinet_package_usage
+  WHERE id = p_usage_id AND status = 'active'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    -- Package gone or inactive; flag stays true to prevent re-entry.
+    RETURN TRUE;
+  END IF;
+
+  SELECT elem INTO v_entry
+  FROM jsonb_array_elements(v_row.treatments_used) elem
+  WHERE elem->>'treatmentId' = p_treatment_id
+    AND (p_variant_id IS NULL OR elem->>'variantId' = p_variant_id)
+    AND (elem->>'usedCount')::int < (elem->>'totalCount')::int
+  LIMIT 1;
+
+  IF NOT FOUND THEN RETURN TRUE; END IF;
+
+  SELECT jsonb_agg(
+    CASE
+      WHEN elem->>'treatmentId' = p_treatment_id
+        AND (p_variant_id IS NULL OR elem->>'variantId' = p_variant_id)
+      THEN jsonb_set(elem, '{usedCount}', to_jsonb((elem->>'usedCount')::int + 1))
+      ELSE elem
+    END
+  ) INTO v_updated_jsonb
+  FROM jsonb_array_elements(v_row.treatments_used) elem;
+
+  SELECT NOT EXISTS (
+    SELECT 1 FROM jsonb_array_elements(v_updated_jsonb) e
+    WHERE (e->>'usedCount')::int < (e->>'totalCount')::int
+  ) INTO v_all_used;
+
+  UPDATE gabinet_package_usage
+  SET treatments_used = v_updated_jsonb,
+      status          = CASE WHEN v_all_used THEN 'completed' ELSE 'active' END,
+      updated_at      = p_now
+  WHERE id = p_usage_id;
+
+  RETURN TRUE;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION cas_return_package_entry(
+  p_appointment_id TEXT,
+  p_treatment_id   TEXT,
+  p_usage_id       TEXT,
+  p_variant_id     TEXT,   -- NULL = match any variant for this treatment
+  p_now            BIGINT
+) RETURNS BOOLEAN           -- TRUE if CAS won and return applied, FALSE if already returned
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_rows_affected INT;
+  v_row           RECORD;
+  v_entry         JSONB;
+  v_updated_jsonb JSONB;
+BEGIN
+  -- Step 1: CAS flip true → false on the junction row.
+  UPDATE gabinet_appointment_treatments
+  SET    package_deducted = false
+  WHERE  appointment_id   = p_appointment_id
+    AND  treatment_id     = p_treatment_id
+    AND  package_deducted = true;
+
+  GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+  IF v_rows_affected = 0 THEN
+    RETURN FALSE;
+  END IF;
+
+  -- Step 2: Lock and decrement usedCount.
+  SELECT * INTO v_row
+  FROM gabinet_package_usage
+  WHERE id = p_usage_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN RETURN TRUE; END IF;
+
+  SELECT elem INTO v_entry
+  FROM jsonb_array_elements(v_row.treatments_used) elem
+  WHERE elem->>'treatmentId' = p_treatment_id
+    AND (p_variant_id IS NULL OR elem->>'variantId' = p_variant_id)
+    AND (elem->>'usedCount')::int > 0
+  LIMIT 1;
+
+  IF NOT FOUND THEN RETURN TRUE; END IF;
+
+  SELECT jsonb_agg(
+    CASE
+      WHEN elem->>'treatmentId' = p_treatment_id
+        AND (p_variant_id IS NULL OR elem->>'variantId' = p_variant_id)
+      THEN jsonb_set(elem, '{usedCount}', to_jsonb(GREATEST(0, (elem->>'usedCount')::int - 1)))
+      ELSE elem
+    END
+  ) INTO v_updated_jsonb
+  FROM jsonb_array_elements(v_row.treatments_used) elem;
+
+  UPDATE gabinet_package_usage
+  SET treatments_used = v_updated_jsonb,
+      status          = CASE WHEN v_row.status = 'completed' THEN 'active' ELSE v_row.status END,
+      updated_at      = p_now
+  WHERE id = p_usage_id;
+
+  RETURN TRUE;
+END;
+$$;

--- a/tests/convex/_supabase_inmemory.ts
+++ b/tests/convex/_supabase_inmemory.ts
@@ -350,6 +350,109 @@ function createInMemoryRawClient() {
         }
         return { data: null, error: null };
       }
+      // Atomic CAS + package deduction in one transaction (closes #5239).
+      // Mirrors cas_deduct_package_entry: flips package_deducted false→true on
+      // the junction row, then increments usedCount if the flip succeeded.
+      if (fn === "cas_deduct_package_entry") {
+        const appointmentId = String(params.p_appointment_id ?? "");
+        const treatmentId   = String(params.p_treatment_id ?? "");
+        const usageId       = String(params.p_usage_id ?? "");
+        const variantId     = params.p_variant_id != null ? String(params.p_variant_id) : null;
+        const now           = Number(params.p_now ?? Date.now());
+
+        // Step 1: CAS flip on junction row.
+        const junctionTable = getTable("gabinetAppointmentTreatments");
+        let casWon = false;
+        for (const [id, row] of junctionTable.entries()) {
+          if (
+            row.appointmentId === appointmentId &&
+            row.treatmentId === treatmentId &&
+            row.packageDeducted === false
+          ) {
+            junctionTable.set(id, { ...row, packageDeducted: true, updatedAt: now });
+            casWon = true;
+            break;
+          }
+        }
+        if (!casWon) return { data: false, error: null };
+
+        // Step 2: Deduct from package usage.
+        const t = getTable("gabinetPackageUsage");
+        const usageRow = t.get(usageId);
+        if (!usageRow || usageRow.status !== "active") return { data: true, error: null };
+        const treatments = (usageRow.treatmentsUsed ?? []) as Array<Record<string, unknown>>;
+        const matchesTreatment = (e: Record<string, unknown>) =>
+          e.treatmentId === treatmentId &&
+          (variantId === null || e.variantId === variantId);
+        const entry = treatments.find(
+          (e) => matchesTreatment(e) && (e.usedCount as number) < (e.totalCount as number),
+        );
+        if (!entry) return { data: true, error: null };
+        const updated = treatments.map((e) =>
+          matchesTreatment(e)
+            ? { ...e, usedCount: (e.usedCount as number) + 1 }
+            : e,
+        );
+        const allUsed = updated.every((e) => (e.usedCount as number) >= (e.totalCount as number));
+        t.set(usageId, {
+          ...usageRow,
+          treatmentsUsed: updated,
+          status: allUsed ? "completed" : "active",
+          updatedAt: now,
+        });
+        return { data: true, error: null };
+      }
+      // Atomic CAS + package return in one transaction (closes #5239).
+      // Mirrors cas_return_package_entry: flips package_deducted true→false on
+      // the junction row, then decrements usedCount if the flip succeeded.
+      if (fn === "cas_return_package_entry") {
+        const appointmentId = String(params.p_appointment_id ?? "");
+        const treatmentId   = String(params.p_treatment_id ?? "");
+        const usageId       = String(params.p_usage_id ?? "");
+        const variantId     = params.p_variant_id != null ? String(params.p_variant_id) : null;
+        const now           = Number(params.p_now ?? Date.now());
+
+        // Step 1: CAS flip on junction row.
+        const junctionTable = getTable("gabinetAppointmentTreatments");
+        let casWon = false;
+        for (const [id, row] of junctionTable.entries()) {
+          if (
+            row.appointmentId === appointmentId &&
+            row.treatmentId === treatmentId &&
+            row.packageDeducted === true
+          ) {
+            junctionTable.set(id, { ...row, packageDeducted: false, updatedAt: now });
+            casWon = true;
+            break;
+          }
+        }
+        if (!casWon) return { data: false, error: null };
+
+        // Step 2: Return to package usage.
+        const t = getTable("gabinetPackageUsage");
+        const usageRow = t.get(usageId);
+        if (!usageRow) return { data: true, error: null };
+        const treatments = (usageRow.treatmentsUsed ?? []) as Array<Record<string, unknown>>;
+        const matchesTreatment = (e: Record<string, unknown>) =>
+          e.treatmentId === treatmentId &&
+          (variantId === null || e.variantId === variantId);
+        const entry = treatments.find(
+          (e) => matchesTreatment(e) && (e.usedCount as number) > 0,
+        );
+        if (!entry) return { data: true, error: null };
+        const updated = treatments.map((e) =>
+          matchesTreatment(e)
+            ? { ...e, usedCount: Math.max(0, (e.usedCount as number) - 1) }
+            : e,
+        );
+        t.set(usageId, {
+          ...usageRow,
+          treatmentsUsed: updated,
+          status: usageRow.status === "completed" ? "active" : usageRow.status,
+          updatedAt: now,
+        });
+        return { data: true, error: null };
+      }
       return { data: null, error: { message: `rpc stub: unknown function ${fn}` } };
     },
   };


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5239.

Closes #5239

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f633be5b fix(gabinet): guard partial failure between packageDeducted CAS flip and Postgres RPC (closes #5239)

### Files changed

```
 convex/gabinet/appointments.ts                     | 115 +++++----------
 .../00133_gabinet_package_cas_atomic_fns.sql       | 155 +++++++++++++++++++++
 tests/convex/_supabase_inmemory.ts                 | 103 ++++++++++++++
 3 files changed, 293 insertions(+), 80 deletions(-)
```