### PR TITLE
fix(gabinet): guard partial failure between stock_deducted CAS flip and consumeForAppointment

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2453,6 +2453,11 @@ export const updateStatus = action({
           .select("id");
         const wonRace = Array.isArray(casRows) && casRows.length === 1;
         if (!wonRace) continue;
+        // Track whether any product action failed so we can reset the CAS.
+        // consumeForAppointment is idempotent (skips if net deduction already
+        // exists), so resetting the CAS allows a safe retry without
+        // double-deducting products that did succeed (#5241).
+        let anyProductFailed = false;
         try {
           const links = await db
             .query("gabinetTreatmentProducts")
@@ -2482,6 +2487,7 @@ export const updateStatus = action({
               );
               if (negativeStock) stockWarnings.push(productId);
             } catch (e) {
+              anyProductFailed = true;
               console.warn(
                 "[updateStatus] stock deduction failed for product",
                 link.productId,
@@ -2491,12 +2497,22 @@ export const updateStatus = action({
             }
           }
         } catch (e) {
+          anyProductFailed = true;
           console.error(
             "[updateStatus] warehouse auto-deduction FAILED for appointment",
             args.appointmentId,
             ":",
             e,
           );
+        }
+        // Reset the CAS guard so a retry can re-enter the deduction path.
+        // consumeForAppointment's idempotency guard prevents double-deduction
+        // for products that already succeeded (#5241).
+        if (anyProductFailed) {
+          await db.raw()
+            .from("gabinet_appointment_treatments")
+            .update({ stock_deducted: false })
+            .eq("id", jt.id);
         }
       }
     }

--- a/convex/magazyn/movements.ts
+++ b/convex/magazyn/movements.ts
@@ -26,6 +26,35 @@ export const consumeForAppointment = internalAction({
     performedBy: v.string(),
   },
   handler: async (_ctx, args): Promise<{ negativeStock: boolean }> => {
+    const db = createSupabaseDb();
+
+    // Idempotency guard: skip if a net deduction already exists for this
+    // appointment+product (countUse > countReturn). This prevents double-deduction
+    // when the CAS guard in updateStatus is reset after an action failure (#5241)
+    // and allows safe retries. Comparing counts (not just checking for uses)
+    // handles the complete→revert→complete cycle: after a successful stock return,
+    // countUse === countReturn so the guard does not fire and re-completion proceeds.
+    const { data: useMovements } = await db.raw()
+      .from("product_stock_movements")
+      .select("id")
+      .eq("source_type", "appointment")
+      .eq("source_id", args.appointmentId)
+      .eq("reason", "appointment_use")
+      .eq("product_id", args.productId);
+    const { data: returnMovements } = await db.raw()
+      .from("product_stock_movements")
+      .select("id")
+      .eq("source_type", "appointment")
+      .eq("source_id", args.appointmentId)
+      .eq("reason", "appointment_return")
+      .eq("product_id", args.productId);
+    const netUse =
+      (Array.isArray(useMovements) ? useMovements.length : 0) -
+      (Array.isArray(returnMovements) ? returnMovements.length : 0);
+    if (netUse > 0) {
+      return { negativeStock: false };
+    }
+
     const baseMovement = {
       organizationId: args.organizationId,
       productId: args.productId,


### PR DESCRIPTION
Closes #5241.

## Summary

- `consumeForAppointment` (`convex/magazyn/movements.ts`): adds a count-based idempotency guard. Before deducting, it counts existing `appointment_use` and `appointment_return` movements for the given appointment+product. If the net deduction is already positive (uses > returns), it returns early — no double-deduction. Using count comparison rather than a simple existence check correctly handles the complete→revert→complete cycle: after a successful stock return the counts are equal, so re-completion proceeds normally.

- `updateStatus` stock deduction loop (`convex/gabinet/appointments.ts`): tracks whether any product action failed (`anyProductFailed` flag covering both the per-product inner catch and the outer treatment-level catch). On any failure, resets `stock_deducted = false` on the junction row, allowing a subsequent retry to re-enter the deduction path. Because `consumeForAppointment` is now idempotent, products that already wrote movements are skipped on retry, preventing double-deduction.

## Test plan
- Existing `appointmentBillingFlow.test.ts` tests cover the happy-path stock deduction and revert cycles — both must remain green.
- `inventoryAvgCost.test.ts` and `packageDeduction.test.ts` cover adjacent inventory and package paths — no regressions expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)