### PR TITLE
Guard partial failure in the stock-return path (`returnStockForAppointment` reve

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2396,6 +2396,13 @@ export const updateStatus = action({
             ":",
             e,
           );
+          // Reset the CAS guard so a retry can re-enter the return path.
+          // returnStockForAppointment's idempotency guard prevents double-return
+          // for movements that already succeeded (#5244).
+          await db.raw()
+            .from("gabinet_appointment_treatments")
+            .update({ stock_deducted: true })
+            .in("id", (returnCasRows as Array<{ id: string }>).map((r) => r.id));
         }
       }
     }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5244.

Closes #5244

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 1cf3f6fe fix(gabinet): reset CAS on returnStockForAppointment failure (closes #5244)

### Files changed

```
 convex/gabinet/appointments.ts | 7 +++++++
 1 file changed, 7 insertions(+)
```