### PR TITLE
Add smsConsent to create/update handlers

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -286,6 +286,7 @@ export const create = action({
     customFields: v.optional(v.any()),
     tagIds: v.optional(v.array(v.string())),
     categoryId: v.optional(v.union(v.string(), v.null())),
+    smsConsent: v.optional(v.union(v.boolean(), v.null())),
   },
   handler: async (ctx, args) => {
     try {
@@ -401,6 +402,7 @@ export const create = action({
       customFields: args.customFields ?? null,
       tagIds: args.tagIds ?? null,
       categoryId: args.categoryId ?? null,
+      smsConsent: args.smsConsent ?? null,
       createdBy: String(authResult.userId),
       createdAt: now,
       updatedAt: now,
@@ -543,6 +545,7 @@ export const update = action({
     customFields: v.optional(v.any()),
     tagIds: v.optional(v.array(v.string())),
     categoryId: v.optional(v.union(v.string(), v.null())),
+    smsConsent: v.optional(v.union(v.boolean(), v.null())),
   },
   handler: async (ctx, args) => {
     try {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5247.

Closes #5247

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 1826dcbd fix(gabinet): expose smsConsent in patients create/update handlers (closes #5247)

### Files changed

```
 convex/gabinet/patients.ts | 3 +++
 1 file changed, 3 insertions(+)
```