### PR TITLE
Add `queryClient.invalidateQueries` after successful create on the patients list

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -511,6 +511,9 @@ function PatientsIndex() {
           organizationId,
           ...formData,
         });
+        void queryClient.invalidateQueries({
+          queryKey: supabaseKeys.gabinetPatients.list(organizationId),
+        });
         setPanelOpen(false);
       } catch (e) {
         const inner = extractActionErrorMessage(e);
@@ -532,7 +535,7 @@ function PatientsIndex() {
         setIsCreating(false);
       }
     },
-    [createPatient, organizationId, t],
+    [createPatient, organizationId, queryClient, t],
   );
 
   const handleBulkAction = useCallback(


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5252.

Closes #5252

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a9b2a77e fix(gabinet): invalidate patients list query after successful create (closes #5252)

### Files changed

```
 src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)
```