### PR TITLE
Show linked contact info on the patient detail page

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, useNavigate, Link } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { toast } from "sonner";
@@ -13,6 +13,7 @@ import type { Id } from "@cvx/_generated/dataModel";
 import { useOrganization } from "@/components/org-context";
 import { useActiveLocation } from "@/contexts/gabinet-location-context";
 import { useSupabaseGabinetPatient } from "@/hooks/use-supabase-gabinet-patients";
+import { useSupabaseContact } from "@/hooks/use-supabase-contacts";
 import { useSupabaseActivitiesByEntity } from "@/hooks/use-supabase-activities";
 import {
   useSupabaseGabinetAppointmentsByPatient,
@@ -200,6 +201,12 @@ function PatientDetail() {
   const { data: patient, isLoading } = useSupabaseGabinetPatient(
     organizationId,
     patientId,
+  );
+
+  const { data: linkedContact } = useSupabaseContact(
+    organizationId,
+    patient?.contactId,
+    { enabled: !!patient?.contactId },
   );
 
   useEffect(() => {
@@ -474,6 +481,24 @@ function PatientDetail() {
       });
     if (patient.allergies)
       fields.push({ label: t("gabinet.patients.allergies"), value: patient.allergies, fieldKey: "allergies" });
+    if (patient.contactId && linkedContact) {
+      const contactName = [linkedContact.firstName, linkedContact.lastName]
+        .filter(Boolean)
+        .join(" ");
+      fields.push({
+        label: t("gabinet.patients.crmContact", "Kontakt CRM"),
+        value: (
+          <Link
+            to="/dashboard/contacts/$contactId"
+            params={{ contactId: patient.contactId }}
+            className="text-primary hover:underline"
+          >
+            {contactName}
+          </Link>
+        ),
+        fieldKey: "crmContact",
+      });
+    }
     return fields;
   })();
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5259.

Closes #5259

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4993eaa8 feat(gabinet): show linked CRM contact on patient detail page (closes #5259)

### Files changed

```
 .../_layout.gabinet.patients.$patientId.tsx        | 27 +++++++++++++++++++++-
 1 file changed, 26 insertions(+), 1 deletion(-)
```