### PR TITLE
Expose `smsConsent` in the edit form

### DIFF
--- a/src/lib/supabase/mappers/gabinet/patients.ts
+++ b/src/lib/supabase/mappers/gabinet/patients.ts
@@ -25,6 +25,7 @@ export interface MappedGabinetPatient {
   emergencyContactPhone?: string;
   referralSource?: string;
   referredByPatientId?: string;
+  smsConsent?: boolean;
   isActive: boolean;
   preferredLocationId?: string;
   tags?: string[];

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -523,6 +523,7 @@ function PatientDetail() {
     referralSource?: string | null;
     referredByPatientId?: string | null;
     preferredLocationId?: string | null;
+    smsConsent?: boolean | null;
     tagIds?: Id<"tagDefinitions">[];
     categoryId?: Id<"categoryDefinitions">;
   }) => {
@@ -1153,6 +1154,7 @@ function PatientDetail() {
               referralSource: patient.referralSource ?? undefined,
               referredByPatientId: patient.referredByPatientId ?? undefined,
               preferredLocationId: patient.preferredLocationId ?? undefined,
+              smsConsent: patient.smsConsent ?? undefined,
               tagIds: patient.tagIds as Id<"tagDefinitions">[] | undefined,
               categoryId: patient.categoryId as
                 | Id<"categoryDefinitions">


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5262.

Closes #5262

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 46109b2d fix(gabinet): expose smsConsent in patient edit form (closes #5262)

### Files changed

```
 src/lib/supabase/mappers/gabinet/patients.ts                            | 1 +
 src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx | 2 ++
 2 files changed, 3 insertions(+)
```