### PR TITLE
Add i18n keys for `contactSearchPlaceholder` and `contactSearchHint` to both tra

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2568,6 +2568,8 @@
       "referralSourceCustomGroup": "Custom sources",
       "referredBy": "Referred By",
       "linkedContact": "Linked CRM Contact",
+      "contactSearchPlaceholder": "Search CRM contact...",
+      "contactSearchHint": "Optional: link the new client to an existing CRM contact.",
       "address": "Address",
       "street": "Street",
       "city": "City",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -2567,6 +2567,8 @@
       "referralSourceCustomGroup": "Własne źródła",
       "referredBy": "Skierowany przez",
       "linkedContact": "Powiązany kontakt CRM",
+      "contactSearchPlaceholder": "Szukaj kontaktu CRM...",
+      "contactSearchHint": "Opcjonalnie: powiąż nowego klienta z istniejącym kontaktem CRM.",
       "address": "Adres",
       "street": "Ulica",
       "city": "Miasto",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5258.

Closes #5258

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 86e6389b feat(i18n): add contactSearchPlaceholder and contactSearchHint keys to gabinet.patients (closes #5258)

### Files changed

```
 public/locales/en/translation.json | 2 ++
 public/locales/pl/translation.json | 2 ++
 2 files changed, 4 insertions(+)
```