### PR TITLE
Add success toast after patient creation

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -516,6 +516,7 @@ function PatientsIndex() {
           queryKey: supabaseKeys.gabinetPatients.list(organizationId),
         });
         setPanelOpen(false);
+        toast.success(t("gabinet.patients.created", { defaultValue: "Klient utworzony" }));
       } catch (e) {
         const inner = extractActionErrorMessage(e);
         if (/duplicate patient detected/i.test(inner)) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5253.

Closes #5253

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- ca96c49a feat(gabinet): show success toast after patient creation (closes #5253)

### Files changed

```
 src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx | 1 +
 1 file changed, 1 insertion(+)
```