### PR TITLE
Move `bloodType` to create mode in PatientForm

### DIFF
--- a/src/components/forms/patient-form.tsx
+++ b/src/components/forms/patient-form.tsx
@@ -472,15 +472,13 @@ export function PatientForm({
             </SelectContent>
           </Select>
         </div>
-        {isEditMode && (
-          <div className="space-y-1.5">
-            <Label>{t("gabinet.patients.bloodType")}</Label>
-            <Input
-              value={bloodType}
-              onChange={(e) => setBloodType(e.target.value)}
-            />
-          </div>
-        )}
+        <div className="space-y-1.5">
+          <Label>{t("gabinet.patients.bloodType")}</Label>
+          <Input
+            value={bloodType}
+            onChange={(e) => setBloodType(e.target.value)}
+          />
+        </div>
         <div className="space-y-1.5 sm:col-span-2">
           <Label>{t("gabinet.patients.allergies")}</Label>
           <Input


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5255.

Closes #5255

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 41ae551b fix(gabinet): show bloodType field in patient create mode (closes #5255)

### Files changed

```
 src/components/forms/patient-form.tsx | 16 +++++++---------
 1 file changed, 7 insertions(+), 9 deletions(-)
```