### PR TITLE
Add `is_active = true` filter to `useSupabaseGabinetPatientsList` Supabase query

### DIFF
--- a/src/components/gabinet/sell-package-panel.tsx
+++ b/src/components/gabinet/sell-package-panel.tsx
@@ -51,7 +51,7 @@ export function SellPackagePanel({
     queryFn: () => listActivePackages({ organizationId }),
     enabled: !!organizationId,
   });
-  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId);
+  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId, { activeOnly: true });
   const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId);
   const { data: employeesData } = useSupabaseGabinetEmployeesList(String(organizationId), { activeOnly: true });
 

--- a/src/components/gabinet/sell-treatment-panel.tsx
+++ b/src/components/gabinet/sell-treatment-panel.tsx
@@ -45,7 +45,7 @@ export function SellTreatmentPanel({
   const purchaseTreatment = useAction(api.gabinet.packages.purchaseTreatment);
   const createPayment = useAction(api.payments.create);
 
-  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId);
+  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId, { activeOnly: true });
   const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId, { isActive: true });
   const { data: employeesData } = useSupabaseGabinetEmployeesList(String(organizationId), { activeOnly: true });
 

--- a/src/components/gabinet/waitlist-view.tsx
+++ b/src/components/gabinet/waitlist-view.tsx
@@ -104,7 +104,7 @@ function AddWaitlistDialog({
 
   const addToWaitlist = useAction(api.gabinet.waitlist.addToWaitlist);
 
-  const { data: patients } = useSupabaseGabinetPatientsList(organizationId);
+  const { data: patients } = useSupabaseGabinetPatientsList(organizationId, { activeOnly: true });
   const { data: treatments } = useSupabaseGabinetTreatmentsList(organizationId);
   const { data: employees } = useSupabaseGabinetEmployeesList(organizationId, { activeOnly: true });
 
@@ -430,7 +430,7 @@ export function WaitlistView({ organizationId }: WaitlistViewProps) {
     organizationId,
     { status: statusFilter === "all" ? undefined : statusFilter },
   );
-  const { data: patients = [] } = useSupabaseGabinetPatientsList(organizationId);
+  const { data: patients = [] } = useSupabaseGabinetPatientsList(organizationId, { activeOnly: true });
   const { data: treatments = [] } = useSupabaseGabinetTreatmentsList(organizationId);
   const { data: employees = [] } = useSupabaseGabinetEmployeesList(organizationId, { activeOnly: true });
 

--- a/src/hooks/use-supabase-gabinet-patients.ts
+++ b/src/hooks/use-supabase-gabinet-patients.ts
@@ -19,6 +19,7 @@ interface UseSupabaseGabinetPatientsListOptions {
   limit?: number;
   search?: string;
   sortOrder?: "asc" | "desc";
+  activeOnly?: boolean;
 }
 
 export function useSupabaseGabinetPatientsList(
@@ -26,12 +27,13 @@ export function useSupabaseGabinetPatientsList(
   options: UseSupabaseGabinetPatientsListOptions = {},
 ) {
   const { client, isReady } = useSupabase();
-  const { enabled = true, limit, search, sortOrder = "desc" } = options;
+  const { enabled = true, limit, search, sortOrder = "desc", activeOnly = false } = options;
 
   return useQuery<MappedGabinetPatient[], Error>({
     queryKey: [
       ...supabaseKeys.gabinetPatients.list(organizationId),
       search ?? "",
+      activeOnly,
     ],
     queryFn: async (): Promise<MappedGabinetPatient[]> => {
       if (!client) throw new Error("Supabase client not ready");
@@ -40,6 +42,10 @@ export function useSupabaseGabinetPatientsList(
         .from("gabinet_patients")
         .select("*")
         .eq("organization_id", organizationId);
+
+      if (activeOnly) {
+        query = query.eq("is_active", true);
+      }
 
       if (search?.trim()) {
         // Each whitespace-separated token must match either first_name or

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -337,7 +337,7 @@ function GabinetCalendarPage() {
   // Fetch patients from Supabase (flat list, replaces paginated Convex query)
   const { data: patients } = useSupabaseGabinetPatientsList(
     organizationId,
-    { limit: 200 },
+    { limit: 200, activeOnly: true },
   );
   // Fetch treatments from Supabase (flat list, replaces paginated Convex query)
   const { data: treatments } = useSupabaseGabinetTreatmentsList(

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -223,7 +223,7 @@ function GabinetDocumentsPage() {
     return map;
   }, [members]);
 
-  const { data: patients } = useSupabaseGabinetPatientsList(organizationId);
+  const { data: patients } = useSupabaseGabinetPatientsList(organizationId, { activeOnly: true });
   const patientMap = useMemo(() => {
     const map = new Map<string, string>();
     for (const p of patients ?? []) {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx
@@ -122,7 +122,7 @@ function GabinetDashboard() {
     organizationId, today, today,
   );
 
-  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId);
+  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId, { activeOnly: true });
   const { data: treatmentsData } = useSupabaseGabinetTreatmentsList(organizationId);
   const { data: leavesData } = useSupabaseGabinetLeavesList(organizationId);
   const { data: employeesData } = useSupabaseGabinetEmployeesList(organizationId, { activeOnly: true });

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.$packageId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.$packageId.tsx
@@ -102,7 +102,7 @@ function PackageDetail() {
     useSupabaseGabinetTreatmentPackagesList(organizationId);
   const { data: treatmentsData } =
     useSupabaseGabinetTreatmentsList(organizationId);
-  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId);
+  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId, { activeOnly: true });
   const { data: activeUsagesData } =
     useSupabaseGabinetPackageUsageActive(organizationId);
   const { data: unassignedUsagesData } =

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.packages.index.tsx
@@ -264,7 +264,7 @@ function PackagesIndex() {
     organizationId,
     { isActive: true },
   );
-  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId);
+  const { data: patientsData } = useSupabaseGabinetPatientsList(organizationId, { activeOnly: true });
   const { data: unassignedUsagesData } =
     useSupabaseGabinetPackageUsageUnassigned(organizationId);
   const { data: activeUsagesData } =

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -1405,7 +1405,7 @@ function GabinetReports() {
     useSupabaseGabinetTreatmentsList(organizationId);
 
   const { data: patients, isLoading: loadingPatients } =
-    useSupabaseGabinetPatientsList(organizationId, { limit: 500 });
+    useSupabaseGabinetPatientsList(organizationId, { limit: 500, activeOnly: true });
 
   const { data: employees, isLoading: loadingEmployees } =
     useSupabaseGabinetEmployeesList(organizationId, { activeOnly: true });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5269.

Closes #5269

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e32ad090 fix(gabinet): filter inactive patients from non-list callers via activeOnly option (closes #5269)

### Files changed

```
 src/components/gabinet/sell-package-panel.tsx                     | 2 +-
 src/components/gabinet/sell-treatment-panel.tsx                   | 2 +-
 src/components/gabinet/waitlist-view.tsx                          | 4 ++--
 src/hooks/use-supabase-gabinet-patients.ts                        | 8 +++++++-
 .../_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx  | 2 +-
 .../_app/_auth/dashboard/_layout.gabinet.documents.index.tsx      | 2 +-
 src/routes/_app/_auth/dashboard/_layout.gabinet.index.tsx         | 2 +-
 .../_app/_auth/dashboard/_layout.gabinet.packages.$packageId.tsx  | 2 +-
 .../_app/_auth/dashboard/_layout.gabinet.packages.index.tsx       | 2 +-
 src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx  | 2 +-
 10 files changed, 17 insertions(+), 11 deletions(-)
```