### PR TITLE
`contactId` reassignment missing from patient merge

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -1067,6 +1067,16 @@ export const merge = action({
       });
     }
 
+    // Transfer the CRM contact link from source to target when the target has
+    // no linked contact. contactId is not a user-selectable override field, so
+    // this implicit fallback is the only place it gets propagated.
+    if (!target.contactId && source.contactId) {
+      await db.patch("gabinetPatients", args.targetPatientId, {
+        contactId: String(source.contactId),
+        updatedAt: Date.now(),
+      });
+    }
+
     // Soft-delete the source patient and annotate why it was deactivated.
     const now = Date.now();
     const sourceNotesPrefix = `[Merged into patient ${args.targetPatientId} at ${new Date(now).toISOString()}]`;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5271.

Closes #5271

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 617bd2a1 fix(gabinet): transfer contactId from source to target patient during merge (closes #5271)

### Files changed

```
 convex/gabinet/patients.ts | 10 ++++++++++
 1 file changed, 10 insertions(+)
```