### PR TITLE
`window.confirm` used for detail-page patient delete instead of the app's standa

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -71,6 +71,16 @@ import { AddPaymentDialog } from "@/components/gabinet/patients/add-payment-dial
 import { GdprEraseDialog } from "@/components/gabinet/patients/gdpr-erase-dialog";
 import { CancelPaymentDialog } from "@/components/gabinet/patients/cancel-payment-dialog";
 import { MergePatientsDialog } from "@/components/gabinet/merge-patients-dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 function PatientDetailSkeleton() {
   return (
@@ -141,6 +151,7 @@ function PatientDetail() {
   const [gdprConfirmText, setGdprConfirmText] = useState("");
   const [isGdprSubmitting, setIsGdprSubmitting] = useState(false);
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   // Issue #1928: collapse the "Last appointments" overview card by default on
   // mobile so other sections (medical info, status tiles) aren't pushed below
   // the fold. On desktop (md+) the section stays expanded.
@@ -690,14 +701,16 @@ function PatientDetail() {
     }
   };
 
-  const handleDelete = async () => {
-    if (window.confirm(t("gabinet.patients.confirmDelete"))) {
-      await removePatient({ organizationId, patientId });
-      void queryClient.invalidateQueries({
-        queryKey: supabaseKeys.gabinetPatients.list(organizationId),
-      });
-      navigate({ to: "/dashboard/gabinet/patients" });
-    }
+  const handleDelete = () => {
+    setDeleteDialogOpen(true);
+  };
+
+  const handleDeleteConfirm = async () => {
+    await removePatient({ organizationId, patientId });
+    void queryClient.invalidateQueries({
+      queryKey: supabaseKeys.gabinetPatients.list(organizationId),
+    });
+    navigate({ to: "/dashboard/gabinet/patients" });
   };
 
   const handleGdprErase = async () => {
@@ -1279,6 +1292,26 @@ function PatientDetail() {
           }}
         />
       )}
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("common.confirmDelete")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("gabinet.patients.confirmDelete")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteConfirm}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {t("common.delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5272.

Closes #5272

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a32ef251 fix(gabinet): replace window.confirm with AlertDialog for patient delete (closes #5272)

### Files changed

```
 .../_layout.gabinet.patients.$patientId.tsx        | 49 ++++++++++++++++++----
 1 file changed, 41 insertions(+), 8 deletions(-)
```