### PR TITLE
Reassign `gabinet_receipts.patient_id` during patient merge

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -931,6 +931,7 @@ export const merge = action({
       "patient_id",
     );
     const movedPayments = await reassignByColumn("payments", "patient_id");
+    const movedReceipts = await reassignByColumn("gabinet_receipts", "patient_id");
     const movedPortalSessions = await reassignByColumn(
       "gabinet_portal_sessions",
       "patient_id",
@@ -1113,6 +1114,7 @@ export const merge = action({
       movedPackageUsage,
       movedLoyaltyTransactions,
       movedPayments,
+      movedReceipts,
       movedNotes,
       movedActivities,
       movedRelationships,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5278.

Closes #5278

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- ff7b1b85 fix(gabinet): reassign gabinet_receipts.patient_id during patient merge (closes #5278)

### Files changed

```
 convex/gabinet/patients.ts | 2 ++
 1 file changed, 2 insertions(+)
```