### PR TITLE
Reassign `emails.patient_id` during patient merge

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -858,6 +858,7 @@ export const merge = action({
     movedSmsEvents: number;
     movedReferrals: number;
     movedBookedBy: number;
+    movedEmails: number;
     consolidatedLoyaltyBalance: number;
   }> => {
     if (args.targetPatientId === args.sourcePatientId) {
@@ -944,6 +945,7 @@ export const merge = action({
       "gabinet_patients",
       "referred_by_patient_id",
     );
+    const movedEmails = await reassignByColumn("emails", "patient_id");
 
     // Polymorphic reassignment: activities/notes/object_relationships scope by
     // entity_type so we filter on both the type discriminator and the patient id.
@@ -1122,6 +1124,7 @@ export const merge = action({
       movedSmsEvents,
       movedReferrals,
       movedBookedBy,
+      movedEmails,
       consolidatedLoyaltyBalance,
     };
   },

--- a/tests/convex/patientsMerge.test.ts
+++ b/tests/convex/patientsMerge.test.ts
@@ -582,6 +582,62 @@ describe("gabinet/patients.merge", () => {
     });
   });
 
+  describe("emails reassignment", () => {
+    test("reassigns emails.patient_id from source to target during merge", async () => {
+      const t = createTestCtx();
+      const { organizationId, userId, identity } = await seedTestUser(t);
+      const { patientId: targetId } = await seedGabinetPrereqs(
+        t,
+        organizationId,
+        userId,
+      );
+      const sourceId = "patient_emails_source";
+      await seedSecondPatient(String(organizationId), String(userId), sourceId);
+
+      const db = createSupabaseDb();
+      const orgIdStr = String(organizationId);
+
+      // Email linked to source patient — should move.
+      await db.insert("emails", {
+        _id: "email_source_patient",
+        organizationId: orgIdStr,
+        patientId: sourceId,
+        subject: "Follow-up from source patient",
+        direction: "inbound",
+      });
+      // Email linked to a different patient — must NOT move.
+      await db.insert("emails", {
+        _id: "email_other_patient",
+        organizationId: orgIdStr,
+        patientId: "patient_unrelated",
+        subject: "Other patient email",
+        direction: "inbound",
+      });
+
+      const result = await t
+        .withIdentity(identity)
+        .action(api.gabinet.patients.merge, {
+          organizationId,
+          targetPatientId: String(targetId),
+          sourcePatientId: sourceId,
+        });
+
+      expect(result.movedEmails).toBe(1);
+
+      const movedEmail = await db.get<{ patientId: string }>(
+        "emails",
+        "email_source_patient",
+      );
+      expect(movedEmail?.patientId).toBe(String(targetId));
+
+      const untouchedEmail = await db.get<{ patientId: string }>(
+        "emails",
+        "email_other_patient",
+      );
+      expect(untouchedEmail?.patientId).toBe("patient_unrelated");
+    });
+  });
+
   describe("source patient deactivation", () => {
     test("marks source patient inactive and annotates medicalNotes", async () => {
       const t = createTestCtx();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5279.

Closes #5279

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8af36731 fix(gabinet): reassign emails.patient_id during patient merge (closes #5279)

### Files changed

```
 convex/gabinet/patients.ts         |  3 ++
 tests/convex/patientsMerge.test.ts | 56 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 59 insertions(+)
```