### PR TITLE
D3 — Dokumenty — dodać flagę globalnego dokumentu organizacji

### DIFF
--- a/convex/documents/templates.ts
+++ b/convex/documents/templates.ts
@@ -124,6 +124,7 @@ export const create = action({
       }),
     ),
     accessRoles: v.optional(v.array(v.string())),
+    isOrgRequired: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     // requireOrgAdmin via authAction
@@ -153,6 +154,7 @@ export const create = action({
       requiresSignature: args.requiresSignature,
       signatureConfig: args.signatureConfig ? JSON.stringify(args.signatureConfig) : null,
       accessRoles: args.accessRoles ?? null,
+      isOrgRequired: args.isOrgRequired ?? false,
       version: 1,
       isActive: true,
       createdBy: String(authResult.userId),
@@ -200,6 +202,7 @@ export const duplicate = action({
       requiresSignature: source.requiresSignature ?? false,
       signatureConfig: source.signatureConfig ? (typeof source.signatureConfig === "string" ? source.signatureConfig : JSON.stringify(source.signatureConfig)) : null,
       accessRoles: source.accessRoles ?? null,
+      isOrgRequired: false,
       version: 1,
       isActive: true,
       createdBy: String(authResult.userId),
@@ -246,6 +249,7 @@ export const update = action({
     ),
     isActive: v.optional(v.boolean()),
     accessRoles: v.optional(v.array(v.string())),
+    isOrgRequired: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runAction(

--- a/convex/schema/documents.ts
+++ b/convex/schema/documents.ts
@@ -105,6 +105,8 @@ export const documentTables = {
     })),
     // Access control — which roles can use this template
     accessRoles: v.optional(v.array(v.string())),
+    // Organization-level required flag — template is mandatory for all appointments in this org
+    isOrgRequired: v.optional(v.boolean()),
     // Versioning
     version: v.number(),
     isActive: v.boolean(),

--- a/supabase/migrations/00134_form_templates_is_org_required.sql
+++ b/supabase/migrations/00134_form_templates_is_org_required.sql
@@ -1,0 +1,7 @@
+-- Add isOrgRequired flag to form_templates (closes #5290).
+-- Marks a document template as mandatory at the organization level,
+-- independent of any specific treatment. Defaults to false so all
+-- existing templates are unaffected.
+
+ALTER TABLE form_templates
+  ADD COLUMN is_org_required BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5290.

Closes #5290

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c14506b6 feat(gabinet): add isOrgRequired flag to formTemplates (closes #5290)

### Files changed

```
 convex/documents/templates.ts                                | 4 ++++
 convex/schema/documents.ts                                   | 2 ++
 supabase/migrations/00134_form_templates_is_org_required.sql | 7 +++++++
 3 files changed, 13 insertions(+)
```