### PR TITLE
D5 — Dokumenty — dodać w UI oznaczenie dokumentu jako wymaganego dla całej organizacji

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1596,6 +1596,8 @@
       "requiresSignature": "Requires Signature",
       "signatureMethodLabel": "Signature Method",
       "signerRoleLabel": "Signer Role",
+      "isOrgRequired": "Required for entire organization",
+      "isOrgRequiredHint": "The document will be automatically required for every client regardless of the selected treatment. Once signed, it will not be required again.",
       "variableBindingsTitle": "Variable Bindings",
       "variableBindingsDescription": "Map form variables to entity fields for auto-fill.",
       "colName": "Name",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -1596,6 +1596,8 @@
       "requiresSignature": "Wymaga podpisu",
       "signatureMethodLabel": "Metoda podpisu",
       "signerRoleLabel": "Rola podpisującego",
+      "isOrgRequired": "Wymagany dla całej organizacji",
+      "isOrgRequiredHint": "Dokument będzie automatycznie wymagany dla każdego klienta niezależnie od wybranego zabiegu. Po podpisaniu nie będzie wymagany ponownie.",
       "variableBindingsTitle": "Powiązania zmiennych",
       "variableBindingsDescription": "Przypisz zmienne formularza do pól podmiotu w celu automatycznego uzupełniania.",
       "colName": "Nazwa",

--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.$id.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.$id.tsx
@@ -126,6 +126,7 @@ function EditFormTemplatePage() {
   const [signatureMethod, setSignatureMethod] =
     useState<SignatureMethod>("click");
   const [signerRole, setSignerRole] = useState<SignerRole>("client");
+  const [isOrgRequired, setIsOrgRequired] = useState(false);
   const [contentJson, setContentJson] = useState("{}");
 
   // Initialize form from loaded template
@@ -145,6 +146,7 @@ function EditFormTemplatePage() {
         setSignatureMethod(signatureConfig.method);
         setSignerRole(signatureConfig.signerRole);
       }
+      setIsOrgRequired((template.isOrgRequired as boolean | undefined) ?? false);
       setContentJson((template.contentJson as string | undefined) ?? "{}");
       setInitialized(true);
     }
@@ -194,6 +196,7 @@ function EditFormTemplatePage() {
         modules,
         entityTypes,
         requiresSignature,
+        isOrgRequired,
         ...(requiresSignature
           ? {
               signatureConfig: {
@@ -364,7 +367,7 @@ function EditFormTemplatePage() {
                 ))}
               </div>
 
-              {/* Signature */}
+              {/* Signature & org-required */}
               <div className="space-y-4">
                 <div className="flex items-center gap-3">
                   <Switch
@@ -428,6 +431,22 @@ function EditFormTemplatePage() {
                     </div>
                   </div>
                 )}
+
+                <div className="space-y-1">
+                  <div className="flex items-center gap-3">
+                    <Switch
+                      id="is-org-required"
+                      checked={isOrgRequired}
+                      onCheckedChange={setIsOrgRequired}
+                    />
+                    <Label htmlFor="is-org-required" className="font-normal">
+                      {t("settings.formTemplates.isOrgRequired")}
+                    </Label>
+                  </div>
+                  <p className="pl-10 text-xs text-muted-foreground">
+                    {t("settings.formTemplates.isOrgRequiredHint")}
+                  </p>
+                </div>
               </div>
             </div>
 

--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.new.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.new.tsx
@@ -116,6 +116,7 @@ function NewFormTemplatePage() {
   const [signatureMethod, setSignatureMethod] =
     useState<SignatureMethod>("click");
   const [signerRole, setSignerRole] = useState<SignerRole>("client");
+  const [isOrgRequired, setIsOrgRequired] = useState(false);
   const [contentJson, setContentJson] = useState("{}");
 
   const createTemplate = useAction(api.documents.templates.create);
@@ -198,6 +199,7 @@ function NewFormTemplatePage() {
         modules,
         entityTypes,
         requiresSignature,
+        isOrgRequired,
         ...(requiresSignature
           ? {
               signatureConfig: {
@@ -360,7 +362,7 @@ function NewFormTemplatePage() {
                 ))}
               </div>
 
-              {/* Signature */}
+              {/* Signature & org-required */}
               <div className="space-y-4">
                 <div className="flex items-center gap-3">
                   <Switch
@@ -424,6 +426,22 @@ function NewFormTemplatePage() {
                     </div>
                   </div>
                 )}
+
+                <div className="space-y-1">
+                  <div className="flex items-center gap-3">
+                    <Switch
+                      id="is-org-required"
+                      checked={isOrgRequired}
+                      onCheckedChange={setIsOrgRequired}
+                    />
+                    <Label htmlFor="is-org-required" className="font-normal">
+                      {t("settings.formTemplates.isOrgRequired")}
+                    </Label>
+                  </div>
+                  <p className="pl-10 text-xs text-muted-foreground">
+                    {t("settings.formTemplates.isOrgRequiredHint")}
+                  </p>
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5294.

Closes #5294

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 1e045edc feat(gabinet): expose isOrgRequired toggle in form template create/edit UI (closes #5294)

### Files changed

```
 public/locales/en/translation.json                  |  2 ++
 public/locales/pl/translation.json                  |  2 ++
 .../_layout.settings.form-templates.$id.tsx         | 21 ++++++++++++++++++++-
 .../_layout.settings.form-templates.new.tsx         | 20 +++++++++++++++++++-
 4 files changed, 43 insertions(+), 2 deletions(-)
```