### PR TITLE
Fix "Proceed anyway" button in `DocumentGateDialog`

### DIFF
--- a/src/components/gabinet/calendar/appointment-preview-content.tsx
+++ b/src/components/gabinet/calendar/appointment-preview-content.tsx
@@ -581,7 +581,7 @@ export function AppointmentPreviewContent({
     }
   };
 
-  const performStatusChange = async (newStatus: AppointmentStatus) => {
+  const performStatusChange = async (newStatus: AppointmentStatus, forceSkip = false) => {
     if (savingStatus) return;
     const previous = status;
     setStatus(newStatus);
@@ -591,6 +591,7 @@ export function AppointmentPreviewContent({
         organizationId,
         appointmentId: appointment._id,
         status: newStatus,
+        ...(forceSkip && { forceSkipDocumentGate: true }),
       });
       await Promise.all([
         queryClient.invalidateQueries({
@@ -1713,7 +1714,7 @@ export function AppointmentPreviewContent({
         organizationId={organizationId}
         timing={gateTiming}
         targetStatus={gateTargetStatus}
-        onProceed={() => performStatusChange(gateTargetStatus)}
+        onProceed={() => performStatusChange(gateTargetStatus, true)}
         onFillDocument={() => setGateDialogOpen(false)}
       />
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -632,7 +632,7 @@ function AppointmentDetail() {
     return endMinutes - startMinutes;
   };
 
-  const performStatusChange = async (newStatus: string) => {
+  const performStatusChange = async (newStatus: string, forceSkip = false) => {
     setIsUpdating(true);
     try {
       const result = await updateStatus({
@@ -646,6 +646,7 @@ function AppointmentDetail() {
           | "cancelled"
           | "no_show"
           | "pending_confirmation",
+        ...(forceSkip && { forceSkipDocumentGate: true }),
       });
       toast.success(t("gabinet.appointments.statusUpdated"));
       if (result?.warnings && result.warnings.length > 0) {
@@ -1357,7 +1358,7 @@ function AppointmentDetail() {
         organizationId={organizationId}
         timing={gateTiming}
         targetStatus={gateTargetStatus}
-        onProceed={() => performStatusChange(gateTargetStatus)}
+        onProceed={() => performStatusChange(gateTargetStatus, true)}
         onFillDocument={(_docId) => {
           // Navigate to the documents tab — the user can click the document there
           // For now, we just close the dialog so they can use the documents tab


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5298.

Closes #5298

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- cd967272 fix(gabinet): pass forceSkipDocumentGate: true when proceeding anyway in DocumentGateDialog (closes #5298)

### Files changed

```
 src/components/gabinet/calendar/appointment-preview-content.tsx      | 5 +++--
 .../dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx   | 5 +++--
 2 files changed, 6 insertions(+), 4 deletions(-)
```