### PR TITLE
Fix `bookFromPortal` missing `_createSideEffects` call

### DIFF
--- a/convex/gabinet/patientPortal.ts
+++ b/convex/gabinet/patientPortal.ts
@@ -551,7 +551,74 @@ export const bookFromPortal = action({
       updatedAt: now,
     });
 
-    // Delegate notifications to internalMutation
+    // Create calendar entry (scheduledActivity) so the appointment appears on
+    // the employee calendar and satisfies the scheduledActivityId arg in
+    // _createSideEffects.
+    const calendarTitle = `${treatment.name as string} — ${patientName}`;
+    const dueDateMs = new Date(`${args.preferredDate}T${args.preferredTime}:00`).getTime();
+    const endDateMs = new Date(`${args.preferredDate}T${endTime}:00`).getTime();
+    let scheduledActivityId = "";
+    try {
+      scheduledActivityId = await db.insert("scheduledActivities", {
+        organizationId: String(organizationId),
+        title: calendarTitle,
+        activityType: "gabinet:appointment",
+        dueDate: dueDateMs,
+        endDate: endDateMs,
+        isCompleted: false,
+        ownerId: ownerUserId,
+        description: `Rezerwacja online — ${patientName}`,
+        linkedEntityType: "gabinetAppointment",
+        linkedEntityId: appointmentId,
+        moduleRef: {
+          moduleId: "gabinet",
+          entityType: "gabinetAppointment",
+          entityId: appointmentId,
+        },
+        resourceId: employeeId,
+        createdBy: ownerUserId,
+        createdAt: now,
+        updatedAt: now,
+      });
+      await db.patch("gabinetAppointments", appointmentId, { scheduledActivityId });
+    } catch (e) {
+      console.error("[bookFromPortal] scheduledActivity creation failed (non-fatal):", e);
+    }
+
+    // Run post-write side effects: automation event, document generation
+    // (RODO / org-required / treatment-required), audit log, and reminders.
+    try {
+      await ctx.runMutation(
+        internal.gabinet.appointments._createSideEffects,
+        {
+          appointmentId,
+          organizationId: String(organizationId),
+          patientId,
+          treatmentId: args.treatmentId,
+          employeeId,
+          date: args.preferredDate,
+          startTime: args.preferredTime,
+          endTime,
+          notes: `Rezerwacja online — ${patientName}`,
+          status: "pending_confirmation",
+          isRecurring: false,
+          sendReminder: true,
+          createdBy: ownerUserId,
+          createdAt: now,
+          patientName,
+          treatmentName: treatment.name as string,
+          patientEmail: (patient.email as string) ?? undefined,
+          patientPhone: (patient.phone as string) ?? undefined,
+          scheduledActivityId,
+          recurActivityIds: [],
+        },
+      );
+    } catch (e) {
+      console.error("[bookFromPortal] Side effects FAILED for appointment", appointmentId, ":", e);
+    }
+
+    // Notify staff (owners/admins) and the assigned employee about the new
+    // portal booking request — this is separate from the automation event above.
     try {
       await ctx.runMutation(
         internal.gabinet.patientPortal._bookingNotifications,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5297.

Closes #5297

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 6451640d fix(gabinet): call _createSideEffects in bookFromPortal to generate appointment documents (closes #5297)

### Files changed

```
 convex/gabinet/patientPortal.ts | 69 ++++++++++++++++++++++++++++++++++++++++-
 1 file changed, 68 insertions(+), 1 deletion(-)
```