### PR TITLE
Remove unused `scheduledActivityId` local variable in `appointments._createSideE

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -843,8 +843,6 @@ export const _createSideEffects = internalMutation({
     const now = args.createdAt;
     const createdByUserId = args.createdBy;
 
-    const scheduledActivityId = args.scheduledActivityId;
-
     // --- 2. Emit automation event ---
     await emitAutomationEvent(ctx, {
       organizationId: args.organizationId,
@@ -1027,7 +1025,7 @@ export const _createSideEffects = internalMutation({
       }
     }
 
-    return { scheduledActivityId, recurActivityIds };
+    return { scheduledActivityId: args.scheduledActivityId, recurActivityIds };
   },
 });
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5302.

Closes #5302

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e90ccc9e fix(gabinet): remove unnecessary local alias for scheduledActivityId in _createSideEffects (closes #5302)

### Files changed

```
 convex/gabinet/appointments.ts | 4 +---
 1 file changed, 1 insertion(+), 3 deletions(-)
```