### PR TITLE
Fix `_checkDocumentGateQuery` runtime

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -798,7 +798,7 @@ export const _getOrgSettings = internalAction({
   },
 });
 
-export const _checkDocumentGateQuery = internalQuery({
+export const _checkDocumentGateAction = internalAction({
   args: {
     appointmentId: v.string(),
     timing: v.union(
@@ -2301,8 +2301,8 @@ export const updateStatus = action({
     // Document gate: check required documents before status transitions
     if (!args.forceSkipDocumentGate) {
       if (args.status === "in_progress") {
-        const gate = await ctx.runQuery(
-          internal.gabinet.appointments._checkDocumentGateQuery,
+        const gate = await ctx.runAction(
+          internal.gabinet.appointments._checkDocumentGateAction,
           { appointmentId: args.appointmentId, timing: "before_start" },
         ) as { canProceed: boolean; missing: Array<{ title: string }> };
         if (!gate.canProceed) {
@@ -2312,8 +2312,8 @@ export const updateStatus = action({
           );
         }
       } else if (args.status === "completed") {
-        const gate = await ctx.runQuery(
-          internal.gabinet.appointments._checkDocumentGateQuery,
+        const gate = await ctx.runAction(
+          internal.gabinet.appointments._checkDocumentGateAction,
           { appointmentId: args.appointmentId, timing: "during_visit" },
         ) as { canProceed: boolean; missing: Array<{ title: string }> };
         if (!gate.canProceed) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5321.

Closes #5321

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 24f1778b fix(gabinet): convert _checkDocumentGateQuery to internalAction (closes #5321)

### Files changed

```
 convex/gabinet/appointments.ts | 10 +++++-----
 1 file changed, 5 insertions(+), 5 deletions(-)
```