### PR TITLE
Fix `getDocumentGateStatus` runtime

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -2678,7 +2678,7 @@ export const _updateStatusSideEffects = internalMutation({
   },
 });
 
-export const getDocumentGateStatus = query({
+export const getDocumentGateStatus = action({
   args: {
     organizationId: v.string(),
     appointmentId: v.string(),
@@ -2689,8 +2689,12 @@ export const getDocumentGateStatus = query({
     ),
   },
   handler: async (ctx, args) => {
-    await verifyOrgAccess(ctx, args.organizationId);
-    await checkModuleAccess(ctx, args.organizationId, "appointments");
+    await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: args.organizationId,
+    });
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, {
+      organizationId: args.organizationId,
+    });
 
     return await checkDocumentGate(
       args.appointmentId as Id<"gabinetAppointments">,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5323.

Closes #5323

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- ed1469fe fix(gabinet): convert getDocumentGateStatus to action (closes #5323)

### Files changed

```
 convex/gabinet/appointments.ts | 10 +++++++---
 1 file changed, 7 insertions(+), 3 deletions(-)
```