### PR TITLE
Add `isOneTime` to `getRequiredFormTemplates` return type

### DIFF
--- a/convex/gabinet/treatments.ts
+++ b/convex/gabinet/treatments.ts
@@ -1285,6 +1285,7 @@ export const getRequiredFormTemplates = action({
   handler: async (ctx, args): Promise<Array<{
     templateId: string;
     timing: "before_start" | "during_visit" | "after_completion";
+    isOneTime: boolean;
     templateName: string;
     templateCategory: string;
     requiresSignature: boolean;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5334.

Closes #5334

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- fdb8830c fix(gabinet): add isOneTime to getRequiredFormTemplates return type (closes #5334)

### Files changed

```
 convex/gabinet/treatments.ts | 1 +
 1 file changed, 1 insertion(+)
```