### PR TITLE
Fix isOneTime

### DIFF
--- a/convex/gabinet/_helpers/autoGenerateDocuments.ts
+++ b/convex/gabinet/_helpers/autoGenerateDocuments.ts
@@ -142,7 +142,7 @@ export async function autoGenerateAppointmentDocuments(
             .eq("templateId", String(entry.templateId))
             .eq("organizationId", String(args.organizationId))
             .eq("entityType", "appointment")
-            .eq("status", "signed")
+            .in("status", ["signed", "completed"])
             .in("entityId", appointmentIds)
             .first();
           if (alreadySigned) continue;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5328.

Closes #5328

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 21fb83de fix(gabinet): accept 'completed' status in isOneTime already-done check (closes #5328)

### Files changed

```
 convex/gabinet/_helpers/autoGenerateDocuments.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```