### PR TITLE
Gate blokuje `expired` dokumenty bez możliwości resend

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -726,7 +726,11 @@ export const resendSigningEmail = action({
     const doc = await db.get("formDocuments", args.documentId);
     if (!doc || String(doc.organizationId) !== String(args.organizationId))
       throw new Error("Document not found");
-    if (doc.status !== "draft" && doc.status !== "pending_signature")
+    if (
+      doc.status !== "draft" &&
+      doc.status !== "pending_signature" &&
+      doc.status !== "expired"
+    )
       throw new Error("Document is not awaiting signature");
     if (!doc.signingToken)
       throw new Error("Document has no signing token");
@@ -760,6 +764,16 @@ export const resendSigningEmail = action({
 
     if (!recipientEmail) {
       throw new Error("Nie znaleziono adresu e-mail pacjenta");
+    }
+
+    // Expired documents must be reset to pending_signature so the document gate
+    // passes once the patient re-signs. sendSigningEmailInternal bumps the token
+    // expiry on its own, so we only need to fix the status here.
+    if (doc.status === "expired") {
+      await db.patch("formDocuments", args.documentId, {
+        status: "pending_signature",
+        updatedAt: Date.now(),
+      });
     }
 
     // Call the send action directly (not via scheduler) so failures

--- a/src/components/documents/appointment-document-checklist.tsx
+++ b/src/components/documents/appointment-document-checklist.tsx
@@ -465,7 +465,6 @@ function DocumentSection({
         {documents.map((doc) => {
           const canResend =
             !isDocumentCompleted(doc.status) &&
-            doc.status !== "expired" &&
             doc.status !== "voided" &&
             !!doc.signingToken;
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -566,7 +566,8 @@ function GabinetDocumentsPage() {
                 {t("common.view", "Podgląd")}
               </DropdownMenuItem>
               {canEdit && (item.status === "draft" ||
-              item.status === "pending_signature") ? (
+              item.status === "pending_signature" ||
+              item.status === "expired") ? (
                 <DropdownMenuItem
                   onClick={() => handleResendSigningEmail(item._id)}
                 >


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5345.

Closes #5345

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c7d2e347 fix(gabinet): allow resend for expired documents and unblock gate (closes #5345)

### Files changed

```
 convex/documents/documents.ts                            | 16 +++++++++++++++-
 .../documents/appointment-document-checklist.tsx         |  1 -
 .../_auth/dashboard/_layout.gabinet.documents.index.tsx  |  3 ++-
 3 files changed, 17 insertions(+), 3 deletions(-)
```