### PR TITLE
`during_visit` signing token expiry starts at appointment creation

### DIFF
--- a/convex/gabinet/_helpers/autoGenerateDocuments.ts
+++ b/convex/gabinet/_helpers/autoGenerateDocuments.ts
@@ -217,10 +217,11 @@ export async function autoGenerateAppointmentDocuments(
         const tokenBytes = new Uint8Array(32);
         crypto.getRandomValues(tokenBytes);
         signingToken = Array.from(tokenBytes).map(b => b.toString(16).padStart(2, "0")).join("");
-        if (patientEmail) {
+        if (patientEmail && entry.timing !== "during_visit") {
           signingTokenExpiresAt = now + 48 * 60 * 60 * 1000; // 48 hours
         }
-        // No expiry when there is no email — expiry starts when the first email is sent.
+        // No expiry when there is no email, or when timing is during_visit (visit may be
+        // days away) — expiry starts when the first signing email is actually sent.
       }
 
       const insertPayload = {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5354.

Closes #5354

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4c9b2db1 fix(gabinet): defer during_visit signing token expiry until email is sent (closes #5354)

### Files changed

```
 convex/gabinet/_helpers/autoGenerateDocuments.ts | 5 +++--
 1 file changed, 3 insertions(+), 2 deletions(-)
```