### PR TITLE
Google Calendar sync skips `_createSideEffects`

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1074,6 +1074,40 @@ export const _createSideEffects = internalMutation({
 });
 
 // ---------------------------------------------------------------------------
+// Internal mutation: generate treatment documents for sync-imported appointments.
+// Called by the Google Calendar sync action after creating an appointment via
+// the Supabase helper path (which bypasses _createSideEffects entirely).
+// ---------------------------------------------------------------------------
+export const _generateDocsOnSync = internalMutation({
+  args: {
+    organizationId: v.string(),
+    appointmentId: v.string(),
+    treatmentId: v.string(),
+    patientId: v.string(),
+    createdBy: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await autoGenerateAppointmentDocuments(ctx, {
+      organizationId: args.organizationId as Id<"organizations">,
+      appointmentId: args.appointmentId as Id<"gabinetAppointments">,
+      treatmentId: args.treatmentId as Id<"gabinetTreatments">,
+      patientId: args.patientId as Id<"gabinetPatients">,
+      createdBy: args.createdBy,
+      timing: "before_start",
+    });
+    await autoGenerateAppointmentDocuments(ctx, {
+      organizationId: args.organizationId as Id<"organizations">,
+      appointmentId: args.appointmentId as Id<"gabinetAppointments">,
+      treatmentId: args.treatmentId as Id<"gabinetTreatments">,
+      patientId: args.patientId as Id<"gabinetPatients">,
+      createdBy: args.createdBy,
+      timing: "during_visit",
+      deferEmails: true,
+    });
+  },
+});
+
+// ---------------------------------------------------------------------------
 // PUBLIC create action — Supabase-primary write
 // ---------------------------------------------------------------------------
 

--- a/convex/google/calendarSync.ts
+++ b/convex/google/calendarSync.ts
@@ -254,7 +254,7 @@ async function resolveCrmEvents(
 }
 
 async function resolveGabinetEvents(
-  _ctx: any,
+  ctx: any,
   config: Record<string, unknown>,
   events: GoogleCalendarEvent[]
 ): Promise<number> {
@@ -353,7 +353,7 @@ async function resolveGabinetEvents(
 
     const requiresCompletion = !treatmentId || patientIsNew;
 
-    await createAppointmentFromSyncSupabase(db, {
+    const syncResult = await createAppointmentFromSyncSupabase(db, {
       organizationId: orgId,
       patientId,
       treatmentId,
@@ -374,6 +374,22 @@ async function resolveGabinetEvents(
       syncConfigId: String(config._id),
       visibilityOverride: config.visibility,
     });
+
+    // Generate treatment documents for newly created appointments so the
+    // document gate isn't trivially bypassed on the sync path (#5353).
+    if (syncResult.type === "created" && treatmentId) {
+      await ctx.runMutation(
+        internal.gabinet.appointments._generateDocsOnSync,
+        {
+          organizationId: orgId,
+          appointmentId: syncResult.appointmentId,
+          treatmentId,
+          patientId,
+          createdBy: ownerId,
+        },
+      );
+    }
+
     synced++;
   }
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5353.

Closes #5353

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 68c0e19c fix(gabinet): generate treatment docs for Google Calendar sync imports (closes #5353)

### Files changed

```
 convex/gabinet/appointments.ts | 34 ++++++++++++++++++++++++++++++++++
 convex/google/calendarSync.ts  | 20 ++++++++++++++++++--
 2 files changed, 52 insertions(+), 2 deletions(-)
```