### PR TITLE
Fix "Wypełnij" shown for voided/expired documents in DocumentSection

### DIFF
--- a/src/components/documents/appointment-document-checklist.tsx
+++ b/src/components/documents/appointment-document-checklist.tsx
@@ -466,6 +466,7 @@ function DocumentSection({
           const canResend =
             !isDocumentCompleted(doc.status) &&
             doc.status !== "voided" &&
+            doc.status !== "expired" &&
             !!doc.signingToken;
 
           return (
@@ -499,7 +500,7 @@ function DocumentSection({
                     <Eye className="h-3.5 w-3.5 mr-1" />
                     {t("documents.preview", "Podglad")}
                   </Button>
-                ) : (
+                ) : doc.status === "voided" || doc.status === "expired" ? null : (
                   <>
                     {canResend && (
                       <Button


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5365.

Closes #5365

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 2a2acb99 fix(gabinet): hide Wypełnij button for voided/expired documents (closes #5365)

### Files changed

```
 src/components/documents/appointment-document-checklist.tsx | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```