### PR TITLE
D15 — Dokumenty — UI nie powinno liczyć dokumentów voided jako brakujące

### DIFF
--- a/src/components/documents/appointment-document-checklist.tsx
+++ b/src/components/documents/appointment-document-checklist.tsx
@@ -571,13 +571,13 @@ export function useAppointmentDocumentCounts(
   const afterDocs = allDocs.filter((d) => d.timing === "after_completion");
 
   const missingBeforeDocs = beforeDocs.filter(
-    (d) => !isDocumentCompleted(d.status),
+    (d) => !isDocumentCompleted(d.status) && d.status !== "voided",
   );
   const missingDuringDocs = duringDocs.filter(
-    (d) => !isDocumentCompleted(d.status),
+    (d) => !isDocumentCompleted(d.status) && d.status !== "voided",
   );
   const missingAfterDocs = afterDocs.filter(
-    (d) => !isDocumentCompleted(d.status),
+    (d) => !isDocumentCompleted(d.status) && d.status !== "voided",
   );
 
   return {

--- a/src/components/documents/document-gate-dialog.tsx
+++ b/src/components/documents/document-gate-dialog.tsx
@@ -89,7 +89,8 @@ export function DocumentGateDialog({
     (d) =>
       d.timing === timing &&
       d.status !== "signed" &&
-      d.status !== "completed",
+      d.status !== "completed" &&
+      d.status !== "voided",
   );
 
   // Count completed docs for progress


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5369.

Closes #5369

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f1f9390f fix(gabinet): exclude voided docs from missing-document counts (closes #5369)

### Files changed

```
 src/components/documents/appointment-document-checklist.tsx | 6 +++---
 src/components/documents/document-gate-dialog.tsx           | 3 ++-
 2 files changed, 5 insertions(+), 4 deletions(-)
```