### PR TITLE
D19 — Dokumenty — odświeżyć responseData przy ponownym completed po zmianie danych wizyty

### DIFF
--- a/convex/gabinet/_helpers/autoGenerateDocuments.ts
+++ b/convex/gabinet/_helpers/autoGenerateDocuments.ts
@@ -157,6 +157,19 @@ export async function autoGenerateAppointmentDocuments(
         .eq("entityId", args.appointmentId as string)
         .first();
       if (existing) {
+        // When the appointment is re-completed after a data change (date/time/
+        // employee/treatment), the draft document's responseData may contain
+        // stale values from the first completion. Refresh it now so the
+        // employee sees current appointment data when they open the form.
+        // Only draft documents are patched — signed, completed, voided, and
+        // expired documents are left unchanged.
+        if ((existing as Record<string, unknown>).status === "draft") {
+          await supabaseDb.patch(
+            "formDocuments",
+            String((existing as Record<string, unknown>)._id),
+            { responseData: JSON.stringify(prefilledData), updatedAt: Date.now() },
+          );
+        }
         createdDocIds.push(
           (existing as Record<string, unknown>)._id as Id<"formDocuments">,
         );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5375.

Closes #5375

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0626d5fb fix(gabinet): refresh responseData on re-completion of draft after_completion doc (closes #5375)

### Files changed

```
 convex/gabinet/_helpers/autoGenerateDocuments.ts | 13 +++++++++++++
 1 file changed, 13 insertions(+)
```