### PR TITLE
D20 — Dokumenty — podpisany dokument nie może zmieniać się po edycji szablonu

### DIFF
--- a/src/components/documents/appointment-document-checklist.tsx
+++ b/src/components/documents/appointment-document-checklist.tsx
@@ -351,11 +351,25 @@ export function AppointmentDocumentChecklist({
                     // fall through
                   }
 
-                  // Fallback: re-render from contentJson for document-type templates
+                  // Fallback: re-render from contentJson for document-type templates.
+                  // Guard: signed/completed documents must show an immutable
+                  // snapshot. Re-rendering from the current (possibly edited)
+                  // template would violate that guarantee, so we show a
+                  // placeholder instead.
                   if (
                     viewingTemplate.templateType === "document" &&
                     viewingTemplate.contentJson
                   ) {
+                    if (viewingDoc.status === "signed" || viewingDoc.status === "completed") {
+                      return (
+                        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground gap-3">
+                          <FileText className="h-7 w-7" />
+                          <p className="text-sm text-center">
+                            {t("documents.snapshotUnavailable", "Treść dokumentu z czasu podpisania jest niedostępna.")}
+                          </p>
+                        </div>
+                      );
+                    }
                     try {
                       const scope: Record<string, string> = {};
                       const rd = JSON.parse(viewingDoc.responseData);

--- a/src/components/documents/entity-documents-tab.tsx
+++ b/src/components/documents/entity-documents-tab.tsx
@@ -479,11 +479,25 @@ export function EntityDocumentsTab({
                     }
 
                     // Fallback for document-type templates generated via wrong path:
-                    // re-render from contentJson + scope data on the fly
+                    // re-render from contentJson + scope data on the fly.
+                    // Guard: signed/completed documents must show an immutable
+                    // snapshot. Re-rendering from the current (possibly edited)
+                    // template would violate that guarantee, so we show a
+                    // placeholder instead.
                     if (
                       viewingTemplate.templateType === "document" &&
                       viewingTemplate.contentJson
                     ) {
+                      if (viewingDoc.status === "signed" || viewingDoc.status === "completed") {
+                        return (
+                          <div className="flex flex-col items-center justify-center py-16 text-muted-foreground gap-3">
+                            <FileText className="h-7 w-7" />
+                            <p className="text-sm text-center">
+                              {t("documents.snapshotUnavailable", "Treść dokumentu z czasu podpisania jest niedostępna.")}
+                            </p>
+                          </div>
+                        );
+                      }
                       const scopeFlat: Record<string, string> = {};
                       for (const [k, v] of Object.entries(
                         mergedResponseData,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5377.

Closes #5377

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- ed935d03 fix(gabinet): block fallback viewer re-render for signed/completed docs (closes #5377)

### Files changed

```
 .../documents/appointment-document-checklist.tsx         | 16 +++++++++++++++-
 src/components/documents/entity-documents-tab.tsx        | 16 +++++++++++++++-
 2 files changed, 30 insertions(+), 2 deletions(-)
```