### PR TITLE
fix(gabinet): use document-level formJson in listByPatientToken (closes #5385)

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -946,7 +946,7 @@ export const listByPatientToken = action({
         updatedAt: doc.updatedAt as number,
         templateName: (template?.name as string | undefined) ?? "",
         category: (template?.category as string | undefined) ?? "custom",
-        formJson: (template?.formJson as string | undefined) ?? "{}",
+        formJson: (doc.formJson as string | undefined) ?? "{}",
         requiresSignature:
           (template?.requiresSignature as boolean | undefined) ?? false,
       };


### PR DESCRIPTION
## Summary

- `listByPatientToken` was returning `formJson` from the current live template rather than the document's own value
- `form_documents` has no `form_json`/`formJson` snapshot column, so `doc.formJson` evaluates to `undefined` and falls back to `"{}"` — the document's implicit value
- This stops live-template state from leaking through this legacy field, matching the snapshot-first pattern established for `contentJsonSnapshot` in related fixes (#5381, #5384)

## Test plan

- [ ] Existing patient portal isolation tests in `tests/convex/patientPortalIsolation.test.ts` cover the `listByPatientToken` action; behavior is unchanged for all modern TipTap documents (which always had `formJson: "{}"` on the template anyway)
- [ ] Manual: open patient portal, verify document list still loads and documents remain viewable/signable

🤖 Generated with [Claude Code](https://claude.com/claude-code)