### PR TITLE
Resolve components eagerly into `contentJsonSnapshot` at creation time

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -344,11 +344,16 @@ export const create = action({
 
     const template = await db.get("formTemplates", args.templateId);
 
+    const rawContentJson = (template?.contentJson as string | null | undefined) ?? null;
+    const resolvedContentJson = rawContentJson
+      ? (await resolveComponentsInContent(db, rawContentJson)) ?? null
+      : null;
+
     const docId = await db.insert("formDocuments", {
       organizationId: String(args.organizationId),
       templateId: args.templateId,
       templateVersion: (template?.version as number | null | undefined) ?? null,
-      contentJsonSnapshot: (template?.contentJson as string | null | undefined) ?? null,
+      contentJsonSnapshot: resolvedContentJson,
       title: args.title,
       responseData: args.responseData,
       entityType: args.entityType,

--- a/convex/documents/generate.ts
+++ b/convex/documents/generate.ts
@@ -183,11 +183,16 @@ export const generateDocument = action({
       }
     }
 
+    const rawContentJson = (template.contentJson as string | null | undefined) ?? null;
+    const resolvedContentJson = rawContentJson
+      ? (await resolveComponentsInContent(db, rawContentJson)) ?? null
+      : null;
+
     const docId = await db.insert("formDocuments", {
       organizationId: String(args.organizationId),
       templateId: args.templateId,
       templateVersion: (template.version as number | null | undefined) ?? null,
-      contentJsonSnapshot: (template.contentJson as string | null | undefined) ?? null,
+      contentJsonSnapshot: resolvedContentJson,
       title,
       responseData: args.responseData,
       entityType: args.entityType,

--- a/convex/gabinet/_helpers/autoGenerateDocuments.ts
+++ b/convex/gabinet/_helpers/autoGenerateDocuments.ts
@@ -3,6 +3,7 @@ import { internal } from "../../_generated/api";
 import { Id } from "../../_generated/dataModel";
 import { createSupabaseDb } from "../../_helpers/supabaseDb";
 import { resolveScopeSupabase } from "../../documents/scopeResolver_supabase";
+import { resolveComponentsInContent } from "../../documents/resolveComponents";
 
 // ---------------------------------------------------------------------------
 // Server-safe TipTap JSON helpers (no DOM needed)
@@ -191,6 +192,12 @@ export async function autoGenerateAppointmentDocuments(
       const documentHasFormFields =
         isDocumentType && hasFormFields(JSON.parse(contentJson!));
 
+      // Resolve componentBlock nodes now so future component edits never
+      // affect the stored snapshot for this document.
+      const resolvedContentJson = contentJson
+        ? (await resolveComponentsInContent(supabaseDb, contentJson)) ?? null
+        : null;
+
       // Fetch the patient before determining status — we need their email to
       // decide whether we can create a deliverable pending_signature document.
       const patient = await supabaseDb.get(
@@ -241,7 +248,7 @@ export async function autoGenerateAppointmentDocuments(
         organizationId: String(args.organizationId),
         templateId: String(entry.templateId),
         templateVersion: (template.version as number | null | undefined) ?? null,
-        contentJsonSnapshot: (template.contentJson as string | null | undefined) ?? null,
+        contentJsonSnapshot: resolvedContentJson,
         title: template.name,
         responseData: JSON.stringify(prefilledData),
         entityType: "appointment",

--- a/tests/convex/documentComponentSnapshot.test.ts
+++ b/tests/convex/documentComponentSnapshot.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Verifies that contentJsonSnapshot stored at document creation time has all
+ * componentBlock nodes resolved to their actual content, so future edits to a
+ * component never affect historical documents (issue #5383).
+ */
+
+import { afterEach, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+describe("contentJsonSnapshot — eager component resolution at creation", () => {
+  async function setup() {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+    const db = createSupabaseDb();
+    const now = Date.now();
+
+    // A component whose content we will later mutate
+    const componentId = "comp-uuid-001";
+    await db.insert("documentComponents", {
+      _id: componentId,
+      organizationId: String(organizationId),
+      name: "Consent Footer",
+      contentJson: JSON.stringify({
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "Original content" }] }],
+      }),
+      scope: "org",
+      isActive: true,
+      protected: false,
+      createdBy: String(userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Template that embeds the component via a componentBlock node
+    const templateId = "tmpl-comp-001";
+    await db.insert("formTemplates", {
+      _id: templateId,
+      organizationId: String(organizationId),
+      name: "Template With Component",
+      category: "consent",
+      templateType: "document",
+      contentJson: JSON.stringify({
+        type: "doc",
+        content: [
+          { type: "componentBlock", attrs: { componentId } },
+        ],
+      }),
+      formJson: "{}",
+      modules: ["gabinet"],
+      entityTypes: ["patient"],
+      requiresSignature: false,
+      version: 1,
+      isActive: true,
+      createdBy: String(userId),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return { t, organizationId, userId, identity, db, now, componentId, templateId };
+  }
+
+  test("documents.create stores resolved snapshot without componentBlock nodes", async () => {
+    const { t, organizationId, identity, db, componentId, templateId } = await setup();
+
+    const docId = await t.withIdentity(identity).action(api.documents.documents.create, {
+      organizationId,
+      templateId,
+      title: "Test Doc",
+      responseData: "{}",
+      entityType: "patient",
+      entityId: "patient-001",
+      status: "draft",
+    });
+
+    const doc = await db.get("formDocuments", docId as string);
+    expect(doc).not.toBeNull();
+
+    const snapshot = JSON.parse(doc!.contentJsonSnapshot as string);
+    // No componentBlock nodes in the stored snapshot
+    const hasComponentBlock = snapshot.content.some(
+      (n: { type: string }) => n.type === "componentBlock",
+    );
+    expect(hasComponentBlock).toBe(false);
+
+    // The resolved component content is inlined
+    expect(snapshot.content).toHaveLength(1);
+    expect(snapshot.content[0].type).toBe("paragraph");
+
+    // Mutate the component AFTER document creation
+    await db.patch("documentComponents", componentId, {
+      contentJson: JSON.stringify({
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "Updated content" }] }],
+      }),
+    });
+
+    // Reload the document — snapshot must be unchanged
+    const docAfter = await db.get("formDocuments", docId as string);
+    const snapshotAfter = JSON.parse(docAfter!.contentJsonSnapshot as string);
+    expect(snapshotAfter.content[0].content[0].text).toBe("Original content");
+  });
+
+  test("documents.generate.generateDocument stores resolved snapshot", async () => {
+    const { t, organizationId, identity, db, componentId, templateId } = await setup();
+
+    const result = await t.withIdentity(identity).action(api.documents.generate.generateDocument, {
+      organizationId,
+      templateId,
+      entityType: "patient",
+      entityId: "patient-001",
+      responseData: JSON.stringify({ formFieldValues: {} }),
+    });
+
+    const doc = await db.get("formDocuments", result.documentId);
+    expect(doc).not.toBeNull();
+
+    const snapshot = JSON.parse(doc!.contentJsonSnapshot as string);
+    const hasComponentBlock = snapshot.content.some(
+      (n: { type: string }) => n.type === "componentBlock",
+    );
+    expect(hasComponentBlock).toBe(false);
+
+    // Mutate component and verify snapshot is frozen
+    await db.patch("documentComponents", componentId, {
+      contentJson: JSON.stringify({
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "Updated content" }] }],
+      }),
+    });
+
+    const docAfter = await db.get("formDocuments", result.documentId);
+    const snapshotAfter = JSON.parse(docAfter!.contentJsonSnapshot as string);
+    expect(snapshotAfter.content[0].content[0].text).toBe("Original content");
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5383.

Closes #5383

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 689f119b fix(documents): resolve componentBlocks eagerly into contentJsonSnapshot at creation time (closes #5383)

### Files changed

```
 convex/documents/documents.ts                    |   7 +-
 convex/documents/generate.ts                     |   7 +-
 convex/gabinet/_helpers/autoGenerateDocuments.ts |   9 +-
 tests/convex/documentComponentSnapshot.test.ts   | 142 +++++++++++++++++++++++
 4 files changed, 162 insertions(+), 3 deletions(-)
```