### PR TITLE
Fix expired/inactive session test fixtures to use `sha256Sync` in `patientPortal

### DIFF
--- a/tests/convex/patientPortalIsolation.test.ts
+++ b/tests/convex/patientPortalIsolation.test.ts
@@ -329,7 +329,7 @@ describe("patient portal isolation — cross-patient data access", () => {
     await db.insert("gabinetPortalSessions", {
       patientId: String(patientAId),
       organizationId: String(organizationId),
-      tokenHash: "expired-token-isolation",
+      tokenHash: sha256Sync("expired-token-isolation"),
       isActive: true,
       lastAccessedAt: now,
       createdAt: now,
@@ -360,7 +360,7 @@ describe("patient portal isolation — cross-patient data access", () => {
     await db.insert("gabinetPortalSessions", {
       patientId: String(patientAId),
       organizationId: String(organizationId),
-      tokenHash: "inactive-token-isolation",
+      tokenHash: sha256Sync("inactive-token-isolation"),
       isActive: false,
       lastAccessedAt: now,
       createdAt: now,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5395.

Closes #5395

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d1c45a46 fix(tests): use sha256Sync for tokenHash in expired/inactive session fixtures (closes #5395)

### Files changed

```
 tests/convex/patientPortalIsolation.test.ts | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```