### PR TITLE
Drop or archive `documentTemplates` and `documentTemplateFields` Convex schema t

### DIFF
--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -639,120 +639,12 @@ export function createGabinetTables({
     .index("by_org", ["organizationId"])
     .index("by_orgAndTier", ["organizationId", "tier"]),
 
-  // --- Platform: Document Templates ---
-
-  documentTemplates: defineTable({
-    organizationId: v.string(),
-    name: v.string(),
-    description: v.optional(v.string()),
-    category: v.union(
-      v.literal("contract"),
-      v.literal("invoice"),
-      v.literal("consent"),
-      v.literal("referral"),
-      v.literal("prescription"),
-      v.literal("report"),
-      v.literal("protocol"),
-      v.literal("custom"),
-    ),
-    content: v.string(),
-    module: v.string(),
-    requiredSources: v.array(v.string()),
-    requiresSignature: v.boolean(),
-    signatureSlots: v.array(
-      v.object({
-        id: v.string(),
-        role: v.union(
-          v.literal("author"),
-          v.literal("client"),
-          v.literal("patient"),
-          v.literal("employee"),
-          v.literal("witness"),
-          v.literal("custom"),
-        ),
-        label: v.string(),
-        verificationMethod: v.optional(
-          v.union(v.literal("click"), v.literal("sms"), v.literal("email_otp")),
-        ),
-        signerType: v.optional(
-          v.union(v.literal("internal"), v.literal("external")),
-        ),
-      }),
-    ),
-    accessControl: v.object({
-      mode: v.union(v.literal("all"), v.literal("roles"), v.literal("users")),
-      roles: v.array(v.string()),
-      userIds: v.array(v.id("users")),
-    }),
-    version: v.number(),
-    parentTemplateId: v.optional(v.id("documentTemplates")),
-    status: v.union(
-      v.literal("draft"),
-      v.literal("active"),
-      v.literal("archived"),
-    ),
-    createdBy: v.id("users"),
-    createdAt: v.number(),
-    updatedAt: v.number(),
-  })
-    .index("by_org", ["organizationId"])
-    .index("by_orgAndModule", ["organizationId", "module"])
-    .index("by_orgAndStatus", ["organizationId", "status"])
-    .index("by_orgAndCategory", ["organizationId", "category"])
-    .index("by_parent", ["parentTemplateId"]),
-
-  documentTemplateFields: defineTable({
-    templateId: v.id("documentTemplates"),
-    fieldKey: v.string(),
-    label: v.string(),
-    type: v.union(
-      v.literal("text"),
-      v.literal("textarea"),
-      v.literal("number"),
-      v.literal("date"),
-      v.literal("select"),
-      v.literal("checkbox"),
-      v.literal("signature"),
-      v.literal("currency"),
-      v.literal("phone"),
-      v.literal("email"),
-      v.literal("pesel"),
-    ),
-    sortOrder: v.number(),
-    group: v.optional(v.string()),
-    options: v.optional(
-      v.array(v.object({ label: v.string(), value: v.string() })),
-    ),
-    defaultValue: v.optional(v.string()),
-    binding: v.optional(
-      v.object({
-        source: v.string(),
-        field: v.string(),
-      }),
-    ),
-    validation: v.optional(
-      v.object({
-        required: v.optional(v.boolean()),
-        min: v.optional(v.number()),
-        max: v.optional(v.number()),
-        pattern: v.optional(v.string()),
-        minLength: v.optional(v.number()),
-        maxLength: v.optional(v.number()),
-      }),
-    ),
-    placeholder: v.optional(v.string()),
-    helpText: v.optional(v.string()),
-    width: v.union(v.literal("full"), v.literal("half")),
-  })
-    .index("by_template", ["templateId"])
-    .index("by_templateAndKey", ["templateId", "fieldKey"]),
-
   documentInstances: defineTable({
     organizationId: v.string(),
     // Type discriminator
     type: v.optional(v.union(v.literal("template"), v.literal("file"))),
     // Template fields (optional for file type)
-    templateId: v.optional(v.id("documentTemplates")),
+    templateId: v.optional(v.string()),
     templateVersion: v.optional(v.number()),
     renderedContent: v.optional(v.string()),
     fieldValues: v.optional(v.any()),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5411.

Closes #5411

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 7121e49c feat(schema): drop documentTemplates and documentTemplateFields Convex table definitions (closes #5411)

### Files changed

```
 convex/schema/gabinet.ts | 110 +----------------------------------------------
 1 file changed, 1 insertion(+), 109 deletions(-)
```