### PR TITLE
Remove dead `gabinet_documents` reassignment from patient merge audit log

### DIFF
--- a/src/components/gabinet/merge-patients-dialog.tsx
+++ b/src/components/gabinet/merge-patients-dialog.tsx
@@ -320,7 +320,6 @@ export function MergePatientsDialog({
       });
       const moved =
         result.movedAppointments +
-        result.movedDocuments +
         result.movedPackageUsage +
         result.movedLoyaltyTransactions +
         result.movedPayments +


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5422.

Closes #5422

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4b4ae319 fix(gabinet): remove dead movedDocuments reference from patient merge dialog (closes #5422)

### Files changed

```
 src/components/gabinet/merge-patients-dialog.tsx | 1 -
 1 file changed, 1 deletion(-)
```