### PR TITLE
Fix missing fields in merge action return type annotation

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -850,6 +850,7 @@ export const merge = action({
     movedPackageUsage: number;
     movedLoyaltyTransactions: number;
     movedPayments: number;
+    movedReceipts: number;
     movedNotes: number;
     movedActivities: number;
     movedRelationships: number;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5425.

Closes #5425

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c360a0b8 fix(gabinet): add movedReceipts to merge action return type annotation (closes #5425)

### Files changed

```
 convex/gabinet/patients.ts | 1 +
 1 file changed, 1 insertion(+)
```