### PR TITLE
Add a Supabase migration to safely drop `document_templates` and `document_templ

### DIFF
--- a/supabase/migrations/00139_drop_document_templates_and_fields.sql
+++ b/supabase/migrations/00139_drop_document_templates_and_fields.sql
@@ -2,6 +2,24 @@
 -- The Convex actions and schema for these tables were removed in #5404/#5411.
 -- No rows are created in production (documentInstances.create had no frontend
 -- callers), so the tables are safe to drop.
+--
+-- Safety audit: verify all document_instances.template_id rows are NULL before
+-- dropping the referenced table.  The FK constraint blocks the DROP otherwise.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM document_instances WHERE template_id IS NOT NULL LIMIT 1
+  ) THEN
+    RAISE EXCEPTION
+      'Cannot drop document_templates: document_instances has rows with non-NULL template_id';
+  END IF;
+END;
+$$;
+
+-- Drop the FK from document_instances before dropping the parent table.
+ALTER TABLE document_instances
+  DROP CONSTRAINT IF EXISTS document_instances_template_id_fkey;
+
 -- document_template_fields has a FK on document_templates; drop child first.
 DROP TABLE IF EXISTS document_template_fields;
 DROP TABLE IF EXISTS document_templates;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5412.

Closes #5412

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c0559072 fix(migration): handle document_instances FK before dropping document_templates (closes #5412)

### Files changed

```
 .../00139_drop_document_templates_and_fields.sql       | 18 ++++++++++++++++++
 1 file changed, 18 insertions(+)
```