### PR TITLE
Remove dead `getDataSource` export from convex/documentDataSources.ts

### DIFF
--- a/convex/documentDataSources.ts
+++ b/convex/documentDataSources.ts
@@ -144,10 +144,6 @@ for (const src of ALL_DATA_SOURCES) {
   sourceMap.set(src.key, src);
 }
 
-export function getDataSource(key: string): DataSourceDefinition | undefined {
-  return sourceMap.get(key);
-}
-
 export function getDataSourcesForModule(module: string): DataSourceDefinition[] {
   return ALL_DATA_SOURCES.filter(
     (s) => s.module === "platform" || s.module === module,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5419.

Closes #5419

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c993d1d3 feat(cleanup): remove dead getDataSource export from documentDataSources (closes #5419)

### Files changed

```
 convex/documentDataSources.ts | 4 ----
 1 file changed, 4 deletions(-)
```