### PR TITLE
Check `convex/gabinet/patients.ts` reassignByColumn for other dropped table refe

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -859,6 +859,7 @@ export const merge = action({
     movedReferrals: number;
     movedBookedBy: number;
     movedEmails: number;
+    movedWaitlist: number;
     consolidatedLoyaltyBalance: number;
   }> => {
     if (args.targetPatientId === args.sourcePatientId) {
@@ -945,6 +946,7 @@ export const merge = action({
       "referred_by_patient_id",
     );
     const movedEmails = await reassignByColumn("emails", "patient_id");
+    const movedWaitlist = await reassignByColumn("gabinet_waitlist", "patient_id");
 
     // Polymorphic reassignment: activities/notes/object_relationships scope by
     // entity_type so we filter on both the type discriminator and the patient id.
@@ -1123,6 +1125,7 @@ export const merge = action({
       movedReferrals,
       movedBookedBy,
       movedEmails,
+      movedWaitlist,
       consolidatedLoyaltyBalance,
     };
   },

--- a/tests/convex/patientsMerge.test.ts
+++ b/tests/convex/patientsMerge.test.ts
@@ -638,6 +638,58 @@ describe("gabinet/patients.merge", () => {
     });
   });
 
+  describe("waitlist reassignment", () => {
+    test("reassigns gabinet_waitlist.patient_id from source to target during merge", async () => {
+      const t = createTestCtx();
+      const { organizationId, userId, identity } = await seedTestUser(t);
+      const { patientId: targetId } = await seedGabinetPrereqs(t, organizationId, userId);
+      const sourceId = "patient_waitlist_source";
+      await seedSecondPatient(String(organizationId), String(userId), sourceId);
+
+      const db = createSupabaseDb();
+      const orgIdStr = String(organizationId);
+
+      // Waitlist entry for source patient — should move.
+      await db.insert("gabinetWaitlist", {
+        _id: "waitlist_source",
+        organizationId: orgIdStr,
+        patientId: sourceId,
+        status: "waiting",
+        priority: 0,
+        createdBy: String(userId),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+      // Waitlist entry for an unrelated patient — must NOT move.
+      await db.insert("gabinetWaitlist", {
+        _id: "waitlist_other",
+        organizationId: orgIdStr,
+        patientId: "patient_unrelated",
+        status: "waiting",
+        priority: 0,
+        createdBy: String(userId),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+
+      const result = await t
+        .withIdentity(identity)
+        .action(api.gabinet.patients.merge, {
+          organizationId,
+          targetPatientId: String(targetId),
+          sourcePatientId: sourceId,
+        });
+
+      expect(result.movedWaitlist).toBe(1);
+
+      const movedEntry = await db.get<{ patientId: string }>("gabinetWaitlist", "waitlist_source");
+      expect(movedEntry?.patientId).toBe(String(targetId));
+
+      const untouched = await db.get<{ patientId: string }>("gabinetWaitlist", "waitlist_other");
+      expect(untouched?.patientId).toBe("patient_unrelated");
+    });
+  });
+
   describe("source patient deactivation", () => {
     test("marks source patient inactive and annotates medicalNotes", async () => {
       const t = createTestCtx();


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5423.

Closes #5423

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 7831d7aa fix(gabinet): add gabinet_waitlist to patient merge reassignment (closes #5423)

### Files changed

```
 convex/gabinet/patients.ts         |  3 +++
 tests/convex/patientsMerge.test.ts | 52 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 55 insertions(+)
```