### PR TITLE
Remove dead `resolveSource` export from convex/documentDataSources.ts

### DIFF
--- a/convex/documentDataSources.ts
+++ b/convex/documentDataSources.ts
@@ -149,14 +149,3 @@ export function getDataSourcesForModule(module: string): DataSourceDefinition[] 
     (s) => s.module === "platform" || s.module === module,
   );
 }
-
-export async function resolveSource(
-  ctx: GenericQueryCtx<DataModel>,
-  sourceKey: string,
-  instanceId: string | null,
-  rctx: DataSourceResolverContext,
-): Promise<Record<string, string>> {
-  const src = sourceMap.get(sourceKey);
-  if (!src) return {};
-  return src.resolve(ctx, instanceId, rctx);
-}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5430.

Closes #5430

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 82a09dce feat(cleanup): remove dead resolveSource export from convex/documentDataSources.ts (closes #5430)

### Files changed

```
 convex/documentDataSources.ts | 11 -----------
 1 file changed, 11 deletions(-)
```