### PR TITLE
Drop `document_instances` Supabase table after migrating signatureRequests to em

### DIFF
--- a/convex/_helpers/permissionTypes.ts
+++ b/convex/_helpers/permissionTypes.ts
@@ -32,7 +32,6 @@ export const FEATURES = [
   "settings",
   "team",
   "document_templates",
-  "document_instances",
   "tagDefinitions",
   "categoryDefinitions",
 ] as const;

--- a/convex/_helpers/permissions.ts
+++ b/convex/_helpers/permissions.ts
@@ -163,23 +163,6 @@ DEFAULT_PERMISSIONS.member.document_templates = {
   view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
 };
 
-// --- Per-feature overrides for document_instances ---
-// owner/admin: all actions allowed
-DEFAULT_PERMISSIONS.owner.document_instances = {
-  view: "all", create: "all", edit: "all", delete: "all", approve: "all", sign: "all", refund: "none",
-};
-DEFAULT_PERMISSIONS.admin.document_instances = {
-  view: "all", create: "all", edit: "all", delete: "all", approve: "all", sign: "all", refund: "none",
-};
-// member: view, create, edit, sign; NO approve or delete
-DEFAULT_PERMISSIONS.member.document_instances = {
-  view: "all", create: "all", edit: "own", delete: "none", approve: "none", sign: "all", refund: "none",
-};
-// viewer: view only
-DEFAULT_PERMISSIONS.viewer.document_instances = {
-  view: "all", create: "none", edit: "none", delete: "none", approve: "none", sign: "none", refund: "none",
-};
-
 // --- Per-feature overrides for tagDefinitions ---
 // member: create only (no edit/delete)
 DEFAULT_PERMISSIONS.member.tagDefinitions = {

--- a/convex/_helpers/supabaseDb.ts
+++ b/convex/_helpers/supabaseDb.ts
@@ -40,7 +40,6 @@ const TABLE_MAP: Record<string, string> = {
   sources: "sources",
   lostReasons: "lost_reasons",
   documents: "documents",
-  documentInstances: "document_instances",
   documentComponents: "document_components",
   documentAnalysisJobs: "document_analysis_jobs",
   formTemplates: "form_templates",

--- a/convex/signatureRequests.ts
+++ b/convex/signatureRequests.ts
@@ -54,9 +54,6 @@ export const getByToken = action({
     if (request.status !== "pending") return { expired: true };
     if (Date.now() > (request.expiresAt as number)) return { expired: true };
 
-    const instance = await db.get("documentInstances", request.instanceId as string);
-    if (!instance) return null;
-
     const org = await db.get("organizations", request.organizationId as string);
 
     return {
@@ -73,10 +70,9 @@ export const getByToken = action({
         status: request.status as string,
       },
       document: {
-        _id: instance._id as string,
-        title: instance.title as string,
-        renderedContent: instance.renderedContent as string | undefined,
-        status: instance.status as string,
+        title: (request.documentTitle as string) ?? "",
+        renderedContent: request.renderedContent as string | undefined,
+        status: "pending_signature",
       },
       organization: org ? { name: org.name as string } : undefined,
     };
@@ -88,15 +84,18 @@ export const listByInstance = action({
   args: { instanceId: v.string() },
   handler: async (ctx, args) => {
     const db = createSupabaseDb();
-    const instance = await db.get("documentInstances", args.instanceId);
-    if (!instance) return [];
-    await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
-      organizationId: String(instance.organizationId),
-    });
 
-    return await db.query("signatureRequests")
+    const requests = await db.query("signatureRequests")
       .eq("instanceId", args.instanceId)
       .collect();
+
+    if (requests.length === 0) return [];
+
+    await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
+      organizationId: String(requests[0].organizationId),
+    });
+
+    return requests;
   },
 });
 
@@ -106,7 +105,11 @@ export const listByInstance = action({
 
 export const sendForSigning = action({
   args: {
-    instanceId: v.string(),
+    organizationId: v.string(),
+    documentTitle: v.string(),
+    renderedContent: v.optional(v.string()),
+    documentCreatedBy: v.optional(v.string()),
+    instanceId: v.optional(v.string()),
     signers: v.array(v.object({
       slotId: v.string(),
       signerType: v.union(v.literal("internal"), v.literal("external")),
@@ -122,28 +125,22 @@ export const sendForSigning = action({
     })),
   },
   handler: async (ctx, args) => {
-    const db = createSupabaseDb();
-    const instance = await db.get("documentInstances", args.instanceId);
-    if (!instance) throw new Error("Document not found");
-    if (instance.status !== "approved" && instance.status !== "draft") {
-      throw new Error("Document must be approved or draft to send for signing");
-    }
-
     await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
-      { organizationId: String(instance.organizationId) },
+      { organizationId: args.organizationId },
     );
 
+    const db = createSupabaseDb();
     const now = Date.now();
     const expiresAt = now + EXPIRY_DAYS * 24 * 60 * 60 * 1000;
     const createdTokens: Array<{ slotId: string; token: string; requestId: string }> = [];
-
-    let updatedSignatures: any[];
-    if (typeof instance.signatures === "string") {
-      updatedSignatures = JSON.parse(instance.signatures);
-    } else {
-      updatedSignatures = [...(instance.signatures as any[])];
-    }
+    const signersForEmail: Array<{
+      slotId: string;
+      signerEmail?: string;
+      signerName?: string;
+      signerPhone?: string;
+      verificationMethod: string;
+    }> = [];
 
     for (const signer of args.signers) {
       if (signer.signerType === "external" && !signer.signerEmail) {
@@ -160,7 +157,6 @@ export const sendForSigning = action({
 
       const token = generateToken();
 
-      // Resolve internal signer names via side effect
       let signerName = signer.signerName;
       let signerEmail = signer.signerEmail;
       if (signer.signerType === "internal" && signer.signerUserId) {
@@ -175,9 +171,15 @@ export const sendForSigning = action({
         }
       }
 
+      const slotLabel = signerName || signerEmail || "Sygnatariusz";
+
       const requestId = await db.insert("signatureRequests", {
-        organizationId: String(instance.organizationId),
-        instanceId: args.instanceId,
+        organizationId: args.organizationId,
+        instanceId: args.instanceId ?? null,
+        documentTitle: args.documentTitle,
+        renderedContent: args.renderedContent ?? null,
+        documentCreatedBy: args.documentCreatedBy ?? null,
+        slotLabel,
         slotId: signer.slotId,
         token,
         signerEmail: signerEmail ?? null,
@@ -191,48 +193,23 @@ export const sendForSigning = action({
       });
 
       createdTokens.push({ slotId: signer.slotId, token, requestId });
-
-      const slotIndex = updatedSignatures.findIndex((s: any) => s.slotId === signer.slotId);
-      if (slotIndex !== -1) {
-        updatedSignatures[slotIndex] = {
-          ...updatedSignatures[slotIndex],
-          signerType: signer.signerType,
-          signerUserId: signer.signerUserId,
-          signerEmail,
-          signerName,
-          signerPhone: signer.signerPhone,
-          verificationMethod: signer.verificationMethod,
-        };
-      } else {
-        updatedSignatures.push({
-          slotId: signer.slotId,
-          slotLabel: signerName || signerEmail || "Sygnatariusz",
-          signerType: signer.signerType,
-          signerUserId: signer.signerUserId,
-          signerEmail,
-          signerName,
-          signerPhone: signer.signerPhone,
-          verificationMethod: signer.verificationMethod,
-        });
-      }
+      signersForEmail.push({
+        slotId: signer.slotId,
+        signerEmail,
+        signerName,
+        signerPhone: signer.signerPhone,
+        verificationMethod: signer.verificationMethod,
+      });
     }
 
-    // Update instance
-    await db.patch("documentInstances", args.instanceId, {
-      signatures: JSON.stringify(updatedSignatures),
-      status: "pending_signature",
-      updatedAt: now,
-    });
-
-    // Schedule email notifications via side effects
     try {
-      const orgData = await db.get("organizations", instance.organizationId as string);
+      const orgData = await db.get("organizations", args.organizationId);
       await ctx.runMutation(internal.signatureRequests._sendSigningEmails, {
-        organizationId: instance.organizationId as string,
+        organizationId: args.organizationId,
         orgName: (orgData?.name as string) ?? "Organizacja",
-        instanceTitle: instance.title as string,
+        instanceTitle: args.documentTitle,
         createdTokens: JSON.stringify(createdTokens),
-        signatures: JSON.stringify(updatedSignatures),
+        signatures: JSON.stringify(signersForEmail),
         expiresAt,
       });
     } catch (e) {
@@ -325,55 +302,37 @@ export const signExternal = action({
     const updated = await db.patchConditional(
       "signatureRequests",
       request._id as string,
-      { status: "signed", signedAt: now },
+      { status: "signed", signedAt: now, signatureData: args.signatureData },
       { status: "pending" },
     );
     if (!updated) throw new Error("This signing request has already been used");
 
-    // Update document instance signature
-    const instance = await db.get("documentInstances", request.instanceId as string);
-    if (!instance) throw new Error("Document not found");
-
-    let signatures: any[];
-    if (typeof instance.signatures === "string") {
-      signatures = JSON.parse(instance.signatures);
-    } else {
-      signatures = [...(instance.signatures as any[])];
+    // Determine if all slots for this document are now signed by querying siblings.
+    let allSigned = true;
+    if (request.instanceId) {
+      const allRequests = await db.query("signatureRequests")
+        .eq("instanceId", String(request.instanceId))
+        .collect();
+      // The CAS update above committed before this query, so the current row shows "signed".
+      allSigned = allRequests.every((r: any) => r.status === "signed");
     }
-
-    const slotIndex = signatures.findIndex((s: any) => s.slotId === request.slotId);
-    if (slotIndex === -1) throw new Error("Signature slot not found");
-
-    signatures[slotIndex] = {
-      ...signatures[slotIndex],
-      signatureData: args.signatureData,
-      signedByName: (request.signerName as string) ?? "",
-      signedAt: now,
-    };
-
-    const allSigned = signatures.every((s: any) => s.signatureData);
-
-    await db.patch("documentInstances", request.instanceId as string, {
-      signatures: JSON.stringify(signatures),
-      status: allSigned ? "signed" : "pending_signature",
-      updatedAt: now,
-    });
 
     // Notify document author via side effects
     try {
       let authorEmail: string | undefined;
       let authorName: string | undefined;
-      if (instance.createdBy) {
-        const authorUser = await db.get("users", String(instance.createdBy));
+      const documentCreatedBy = request.documentCreatedBy ? String(request.documentCreatedBy) : null;
+      if (documentCreatedBy) {
+        const authorUser = await db.get("users", documentCreatedBy);
         authorEmail = authorUser?.email as string | undefined;
         authorName = (authorUser?.name as string) ?? authorEmail;
       }
       await ctx.runMutation(internal.signatureRequests._notifyAuthor, {
         authorEmail,
         authorName,
-        documentTitle: instance.title as string,
+        documentTitle: (request.documentTitle as string) ?? "",
         signerName: (request.signerName as string) ?? (request.signerEmail as string) ?? "Sygnatariusz",
-        slotLabel: signatures[slotIndex].slotLabel ?? "",
+        slotLabel: (request.slotLabel as string) ?? "",
         allSigned,
       });
     } catch (e) {
@@ -382,15 +341,15 @@ export const signExternal = action({
 
     // Audit log: record the signing event. Best-effort — a log failure must
     // never roll back a successfully completed signature.
-    const createdBy = instance.createdBy ? String(instance.createdBy) : null;
-    if (createdBy) {
+    const auditUserId = request.documentCreatedBy ? String(request.documentCreatedBy) : null;
+    if (auditUserId) {
       try {
         await db.insert("auditLog", {
           organizationId: String(request.organizationId),
-          userId: createdBy,
+          userId: auditUserId,
           action: "document.signed",
-          entityType: "documentInstance",
-          entityId: String(request.instanceId),
+          entityType: "signatureRequest",
+          entityId: String(request._id),
           details: JSON.stringify({
             requestId: String(request._id),
             slotId: String(request.slotId),
@@ -524,11 +483,15 @@ export const resend = action({
     // Expire old request
     await db.patch("signatureRequests", args.requestId, { status: "expired" });
 
-    // Create new one
+    // Create new one, copying all embedded document metadata from the original
     const token = generateToken();
     const newId = await db.insert("signatureRequests", {
       organizationId: String(request.organizationId),
-      instanceId: String(request.instanceId),
+      instanceId: request.instanceId ? String(request.instanceId) : null,
+      documentTitle: (request.documentTitle as string) ?? "",
+      renderedContent: request.renderedContent as string | null ?? null,
+      documentCreatedBy: request.documentCreatedBy as string | null ?? null,
+      slotLabel: request.slotLabel as string | null ?? null,
       slotId: request.slotId,
       token,
       signerEmail: request.signerEmail ?? null,
@@ -541,14 +504,12 @@ export const resend = action({
       createdAt: now,
     });
 
-    // Dispatch email/SMS notification with the new token
-    const instance = await db.get("documentInstances", String(request.instanceId));
     const orgData = await db.get("organizations", String(request.organizationId));
     try {
       await ctx.runMutation(internal.signatureRequests._sendSigningEmails, {
         organizationId: String(request.organizationId),
         orgName: (orgData?.name as string) ?? "Organizacja",
-        instanceTitle: String(instance?.title ?? ""),
+        instanceTitle: (request.documentTitle as string) ?? "",
         createdTokens: JSON.stringify([{ slotId: request.slotId, token, requestId: newId }]),
         signatures: JSON.stringify([{
           slotId: request.slotId,

--- a/scripts/seed-from-convex.mts
+++ b/scripts/seed-from-convex.mts
@@ -303,7 +303,6 @@ async function seed() {
   await seedTable('form_templates', 'formTemplates', forOrg);
   await seedTable('form_documents', 'formDocuments', forOrg);
   await seedTable('document_templates', 'documentTemplates', forOrg);
-  await seedTable('document_instances', 'documentInstances', forOrg);
   await seedTable('signature_requests', 'signatureRequests', forOrg);
   
   // ── 12. Scheduled activities ──

--- a/src/components/gabinet/employees/employee-permissions-tab.tsx
+++ b/src/components/gabinet/employees/employee-permissions-tab.tsx
@@ -44,7 +44,7 @@ const ALL_PERMS_FEATURES = [
   "gabinet_treatments", "gabinet_packages", "gabinet_employees", "gabinet_payments",
   "gabinet_reports", "gabinet_financial_reports", "gabinet_purchase_prices", "gabinet_photos",
   "gabinet_online_booking", "gabinet_inventory", "gabinet_settings", "settings", "team",
-  "document_templates", "document_instances", "tagDefinitions", "categoryDefinitions",
+  "document_templates", "tagDefinitions", "categoryDefinitions",
 ] as const;
 
 const ALL_PERMS_ACTIONS = ["view", "create", "edit", "delete", "approve", "sign", "refund"] as const;

--- a/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
+++ b/src/components/sidebar-widgets/gabinet/quick-actions-dropdown.tsx
@@ -5,7 +5,6 @@ import {
   CalendarCheck,
   UserPlus,
   Package,
-  FileText,
   Plus,
   ShoppingCart,
   TruckIcon,
@@ -125,15 +124,6 @@ export function GabinetQuickActionsDropdown() {
           >
             <TruckIcon className="text-foreground size-5 shrink-0" />
             {t("sidebar.gabinet.addDelivery", "Dodaj dostawę")}
-          </DropdownMenuItem>
-        )}
-        {can("document_instances") && (
-          <DropdownMenuItem
-            className="px-3 py-2.5 text-sm"
-            onSelect={() => navigate({ to: "/dashboard/gabinet/documents" })}
-          >
-            <FileText className="text-foreground size-5" />
-            {t("sidebar.gabinet.issueDocument", "Wystaw dokument")}
           </DropdownMenuItem>
         )}
       </DropdownMenuContent>

--- a/src/lib/supabase/database.columns.ts
+++ b/src/lib/supabase/database.columns.ts
@@ -229,7 +229,6 @@ export type TableName =
   | "appointment_sms_events"
   | "document_templates"
   | "document_template_fields"
-  | "document_instances"
   | "signature_requests"
   | "form_templates"
   | "form_documents"
@@ -341,8 +340,7 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   appointment_sms_events: new Set(["id", "organization_id", "appointment_id", "patient_id", "normalized_phone", "direction", "provider", "event_type", "provider_message_id", "correlation_key", "reply_to_event_id", "raw_body", "normalized_body", "parsed_intent", "processing_status", "processing_error", "webhook_signature_verified", "metadata", "idempotency_key", "processed_at", "created_at", "updated_at"]),
   document_templates: new Set(["id", "organization_id", "name", "description", "category", "content", "module", "required_sources", "requires_signature", "signature_slots", "access_control", "version", "parent_template_id", "status", "created_by", "created_at", "updated_at"]),
   document_template_fields: new Set(["id", "template_id", "field_key", "label", "type", "sort_order", "group", "options", "default_value", "binding", "validation", "placeholder", "help_text", "width"]),
-  document_instances: new Set(["id", "organization_id", "type", "template_id", "template_version", "rendered_content", "field_values", "resolved_sources", "file_id", "file_url", "file_name", "mime_type", "file_size", "category", "title", "status", "module", "signatures", "pdf_file_id", "created_by", "created_at", "updated_at", "assigned_reviewer_id", "assigned_reviewer_name", "reviewed_by", "reviewed_at", "approved_by", "approved_at"]),
-  signature_requests: new Set(["id", "organization_id", "instance_id", "slot_id", "token", "signer_email", "signer_name", "signer_phone", "signer_user_id", "verification_method", "status", "otp_hash", "otp_sent_at", "otp_attempts", "expires_at", "signed_at", "created_at"]),
+  signature_requests: new Set(["id", "organization_id", "instance_id", "slot_id", "token", "signer_email", "signer_name", "signer_phone", "signer_user_id", "verification_method", "status", "otp_hash", "otp_sent_at", "otp_attempts", "expires_at", "signed_at", "created_at", "document_title", "rendered_content", "document_created_by", "slot_label", "signature_data"]),
   form_templates: new Set(["id", "organization_id", "name", "description", "category", "folder_path", "template_type", "form_json", "content_json", "theme_json", "modules", "entity_types", "variable_bindings", "requires_signature", "signature_config", "access_roles", "version", "is_active", "is_org_required", "created_by", "updated_by", "created_at", "updated_at"]),
   form_documents: new Set(["id", "organization_id", "template_id", "title", "response_data", "entity_type", "entity_id", "scope_entities", "status", "signature_data", "signed_at", "signed_by_name", "signed_by_email", "signed_by_ip", "signature_verification_method", "signing_token", "signing_token_expires_at", "signing_email_sent_at", "signing_reminder_count", "timing", "auto_generated", "pdf_storage_id", "pdf_generated_at", "created_by", "created_at", "updated_at", "sort_order", "generated_for_treatment_id", "template_version", "content_json_snapshot"]),
   automation_rules: new Set(["id", "organization_id", "name", "description", "module", "event_type", "entity_type", "trigger", "graph", "definition_version", "conditions", "actions", "enabled", "created_by", "created_at", "updated_at"]),

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -5789,147 +5789,11 @@ export interface Database {
           },
         ];
       };
-      document_instances: {
-        Row: {
-          id: string;
-          organization_id: string;
-          type: string | null;
-          template_id: string | null;
-          template_version: number | null;
-          rendered_content: string | null;
-          field_values: unknown | null;
-          resolved_sources: unknown | null;
-          file_id: string | null;
-          file_url: string | null;
-          file_name: string | null;
-          mime_type: string | null;
-          file_size: number | null;
-          category: string | null;
-          title: string;
-          status: string;
-          module: string | null;
-          signatures: unknown;
-          pdf_file_id: string | null;
-          created_by: string;
-          created_at: number;
-          updated_at: number;
-          assigned_reviewer_id: string | null;
-          assigned_reviewer_name: string | null;
-          reviewed_by: string | null;
-          reviewed_at: number | null;
-          approved_by: string | null;
-          approved_at: number | null;
-        };
-        Insert: {
-          id?: string;
-          organization_id: string;
-          type?: string | null;
-          template_id?: string | null;
-          template_version?: number | null;
-          rendered_content?: string | null;
-          field_values?: unknown | null;
-          resolved_sources?: unknown | null;
-          file_id?: string | null;
-          file_url?: string | null;
-          file_name?: string | null;
-          mime_type?: string | null;
-          file_size?: number | null;
-          category?: string | null;
-          title: string;
-          status: string;
-          module?: string | null;
-          signatures: unknown;
-          pdf_file_id?: string | null;
-          created_by: string;
-          created_at: number;
-          updated_at: number;
-          assigned_reviewer_id?: string | null;
-          assigned_reviewer_name?: string | null;
-          reviewed_by?: string | null;
-          reviewed_at?: number | null;
-          approved_by?: string | null;
-          approved_at?: number | null;
-        };
-        Update: {
-          id?: string;
-          organization_id?: string;
-          type?: string | null;
-          template_id?: string | null;
-          template_version?: number | null;
-          rendered_content?: string | null;
-          field_values?: unknown | null;
-          resolved_sources?: unknown | null;
-          file_id?: string | null;
-          file_url?: string | null;
-          file_name?: string | null;
-          mime_type?: string | null;
-          file_size?: number | null;
-          category?: string | null;
-          title?: string;
-          status?: string;
-          module?: string | null;
-          signatures?: unknown;
-          pdf_file_id?: string | null;
-          created_by?: string;
-          created_at?: number;
-          updated_at?: number;
-          assigned_reviewer_id?: string | null;
-          assigned_reviewer_name?: string | null;
-          reviewed_by?: string | null;
-          reviewed_at?: number | null;
-          approved_by?: string | null;
-          approved_at?: number | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "document_instances_organization_id_fkey";
-            columns: ["organization_id"];
-            isOneToOne: false;
-            referencedRelation: "organizations";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "document_instances_template_id_fkey";
-            columns: ["template_id"];
-            isOneToOne: false;
-            referencedRelation: "document_templates";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "document_instances_created_by_fkey";
-            columns: ["created_by"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "document_instances_assigned_reviewer_id_fkey";
-            columns: ["assigned_reviewer_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "document_instances_reviewed_by_fkey";
-            columns: ["reviewed_by"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "document_instances_approved_by_fkey";
-            columns: ["approved_by"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
       signature_requests: {
         Row: {
           id: string;
           organization_id: string;
-          instance_id: string;
+          instance_id: string | null;
           slot_id: string;
           token: string;
           signer_email: string | null;
@@ -5944,11 +5808,16 @@ export interface Database {
           expires_at: number;
           signed_at: number | null;
           created_at: number;
+          document_title: string;
+          rendered_content: string | null;
+          document_created_by: string | null;
+          slot_label: string | null;
+          signature_data: string | null;
         };
         Insert: {
           id?: string;
           organization_id: string;
-          instance_id: string;
+          instance_id?: string | null;
           slot_id: string;
           token: string;
           signer_email?: string | null;
@@ -5963,11 +5832,16 @@ export interface Database {
           expires_at: number;
           signed_at?: number | null;
           created_at: number;
+          document_title?: string;
+          rendered_content?: string | null;
+          document_created_by?: string | null;
+          slot_label?: string | null;
+          signature_data?: string | null;
         };
         Update: {
           id?: string;
           organization_id?: string;
-          instance_id?: string;
+          instance_id?: string | null;
           slot_id?: string;
           token?: string;
           signer_email?: string | null;
@@ -5982,6 +5856,11 @@ export interface Database {
           expires_at?: number;
           signed_at?: number | null;
           created_at?: number;
+          document_title?: string;
+          rendered_content?: string | null;
+          document_created_by?: string | null;
+          slot_label?: string | null;
+          signature_data?: string | null;
         };
         Relationships: [
           {
@@ -5989,13 +5868,6 @@ export interface Database {
             columns: ["organization_id"];
             isOneToOne: false;
             referencedRelation: "organizations";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "signature_requests_instance_id_fkey";
-            columns: ["instance_id"];
-            isOneToOne: false;
-            referencedRelation: "document_instances";
             referencedColumns: ["id"];
           },
           {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -80,7 +80,7 @@ export const Route = createFileRoute(
   "/_app/_auth/dashboard/_layout/gabinet/documents/",
 )({
   component: () => (
-    <PermissionGate feature="document_instances" action="view" loadingFallback={<GabinetDocumentsSkeleton />}>
+    <PermissionGate feature="documents" action="view" loadingFallback={<GabinetDocumentsSkeleton />}>
       <GabinetDocumentsPage />
     </PermissionGate>
   ),
@@ -179,8 +179,8 @@ function GabinetDocumentsPage() {
     api.documents.components.resolveContentJson,
   );
 
-  const { allowed: canDelete } = usePermission("document_instances", "delete");
-  const { allowed: canEdit } = usePermission("document_instances", "edit");
+  const { allowed: canDelete } = usePermission("documents", "delete");
+  const { allowed: canEdit } = usePermission("documents", "edit");
 
   // --- Edit mode state ---
   const [isEditing, setIsEditing] = useState(false);

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.roles.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.roles.tsx
@@ -124,7 +124,7 @@ const ALL_FEATURES = [
   "gabinet_treatments", "gabinet_packages", "gabinet_employees", "gabinet_payments",
   "gabinet_reports", "gabinet_financial_reports", "gabinet_purchase_prices", "gabinet_photos",
   "gabinet_online_booking", "gabinet_inventory", "gabinet_settings", "settings", "team",
-  "document_templates", "document_instances", "tagDefinitions", "categoryDefinitions",
+  "document_templates", "tagDefinitions", "categoryDefinitions",
 ] as const;
 
 const ALL_ACTIONS = ["view", "create", "edit", "delete", "approve", "sign", "refund"] as const;

--- a/src/routes/_app/_auth/dashboard/_layout.settings.permissions.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.permissions.tsx
@@ -58,7 +58,6 @@ const FEATURE_LABELS: Record<string, { labelKey: string; label: string }> = {
   settings: { labelKey: "permissions.features.settings", label: "Settings" },
   team: { labelKey: "permissions.features.team", label: "Team" },
   document_templates: { labelKey: "permissions.features.document_templates", label: "Document Templates" },
-  document_instances: { labelKey: "permissions.features.document_instances", label: "Document Instances" },
   tagDefinitions: { labelKey: "permissions.features.tagDefinitions", label: "Tags" },
   categoryDefinitions: { labelKey: "permissions.features.categoryDefinitions", label: "Categories" },
 };

--- a/supabase/migrations/00140_signature_requests_embed_document.sql
+++ b/supabase/migrations/00140_signature_requests_embed_document.sql
@@ -1,0 +1,23 @@
+-- Embed document metadata directly in signature_requests so the table can be
+-- decoupled from document_instances (issue #5417).
+-- Columns added:
+--   document_title      — human-readable title shown on the signing page
+--   rendered_content    — HTML shown for review on the signing page (nullable)
+--   document_created_by — user ID of the document author (for signed notifications)
+--   slot_label          — display label for this signature slot
+--   signature_data      — the actual signature value recorded at sign time
+ALTER TABLE signature_requests
+  ADD COLUMN document_title      TEXT NOT NULL DEFAULT '',
+  ADD COLUMN rendered_content    TEXT,
+  ADD COLUMN document_created_by TEXT,
+  ADD COLUMN slot_label          TEXT,
+  ADD COLUMN signature_data      TEXT;
+
+-- Backfill embedded fields from still-present document_instances rows.
+UPDATE signature_requests sr
+SET
+  document_title      = COALESCE(di.title, ''),
+  rendered_content    = di.rendered_content,
+  document_created_by = di.created_by
+FROM document_instances di
+WHERE sr.instance_id = di.id;

--- a/supabase/migrations/00141_drop_document_instances.sql
+++ b/supabase/migrations/00141_drop_document_instances.sql
@@ -1,0 +1,16 @@
+-- Drop document_instances and free signature_requests from its FK.
+-- Prerequisite: migration 00140 must have run so existing signing links
+-- already carry their own document_title / rendered_content.
+--
+-- Steps:
+--   1. Drop the FK constraint that chains signature_requests to document_instances
+--      (otherwise dropping the parent table would cascade-delete all signing rows).
+--   2. Make instance_id nullable — future requests are no longer tied to an instance row.
+--   3. Drop document_instances and the associated status enum.
+
+ALTER TABLE signature_requests
+  DROP CONSTRAINT IF EXISTS signature_requests_instance_id_fkey,
+  ALTER COLUMN instance_id DROP NOT NULL;
+
+DROP TABLE IF EXISTS document_instances;
+DROP TYPE IF EXISTS document_instance_status_enum;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5417.

Closes #5417

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- bc6f8225 feat(cleanup): drop document_instances table and decouple signatureRequests (closes #5417)

### Files changed

```
 convex/_helpers/permissionTypes.ts                 |   1 -
 convex/_helpers/permissions.ts                     |  17 --
 convex/_helpers/supabaseDb.ts                      |   1 -
 convex/signatureRequests.ts                        | 181 ++++++++-------------
 scripts/seed-from-convex.mts                       |   1 -
 .../gabinet/employees/employee-permissions-tab.tsx |   2 +-
 .../gabinet/quick-actions-dropdown.tsx             |  10 --
 src/lib/supabase/database.columns.ts               |   4 +-
 src/lib/supabase/database.types.ts                 | 164 ++-----------------
 .../dashboard/_layout.gabinet.documents.index.tsx  |   6 +-
 .../dashboard/_layout.gabinet.settings.roles.tsx   |   2 +-
 .../dashboard/_layout.settings.permissions.tsx     |   1 -
 .../00140_signature_requests_embed_document.sql    |  23 +++
 .../migrations/00141_drop_document_instances.sql   |  16 ++
 14 files changed, 134 insertions(+), 295 deletions(-)
```