### PR TITLE
Update docs/document-templates-system.md to remove stale reference to `listAvail

### DIFF
--- a/docs/document-templates-system.md
+++ b/docs/document-templates-system.md
@@ -538,7 +538,6 @@ PDF EXPORT:
 1.7. convex/documentTemplates.ts — CRUD + publish + archive + duplicate.
 1.8. convex/documentTemplateFields.ts — CRUD + reorder.
 1.9. convex/documentInstances.ts — create (z resolve sources + render), update draft, workflow transitions, sign, archive.
-1.10. Query: listAvailableSources(module) — zwraca deklaracje source'ów (bez resolverów) do UI.
 
 ### Etap 2: UI edytora szablonów
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5420.

Closes #5420

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8849e974 docs: remove stale listAvailableSources reference from document-templates-system.md (closes #5420)

### Files changed

```
 docs/document-templates-system.md | 1 -
 1 file changed, 1 deletion(-)
```