### PR TITLE
Add `gabinet_salary` to `FEATURE_LABELS` in settings.permissions.tsx

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.settings.permissions.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.permissions.tsx
@@ -49,6 +49,7 @@ const FEATURE_LABELS: Record<string, { labelKey: string; label: string }> = {
   gabinet_documents: { labelKey: "permissions.features.gabinet_documents", label: "Gabinet: Documents" },
   gabinet_payments: { labelKey: "permissions.features.gabinet_payments", label: "Gabinet: Payments" },
   gabinet_receipts: { labelKey: "permissions.features.gabinet_receipts", label: "Gabinet: Receipts" },
+  gabinet_salary: { labelKey: "permissions.features.gabinet_salary", label: "Gabinet: Salary" },
   gabinet_reports: { labelKey: "permissions.features.gabinet_reports", label: "Gabinet: Reports" },
   gabinet_financial_reports: { labelKey: "permissions.features.gabinet_financial_reports", label: "Gabinet: Financial Reports" },
   gabinet_purchase_prices: { labelKey: "permissions.features.gabinet_purchase_prices", label: "Gabinet: Purchase Prices" },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5439.

Closes #5439

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- d1987024 fix(permissions): add gabinet_salary to FEATURE_LABELS in settings.permissions.tsx (closes #5439)

### Files changed

```
 src/routes/_app/_auth/dashboard/_layout.settings.permissions.tsx | 1 +
 1 file changed, 1 insertion(+)
```