### PR TITLE
Add `gabinet_documents

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -738,6 +738,15 @@ export const resendSigningEmail = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      {
+        organizationId: args.organizationId,
+        feature: "gabinet_documents",
+        action: "edit",
+      },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
     const doc = await db.get("formDocuments", args.documentId);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5438.

Closes #5438

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- fb1fedab fix(rbac): add gabinet_documents:edit permission check to resendSigningEmail (closes #5438)

### Files changed

```
 convex/documents/documents.ts | 9 +++++++++
 1 file changed, 9 insertions(+)
```