### PR TITLE
D29 — Dokumenty — status dokumentacji przy wizycie

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3492,6 +3492,23 @@
       "packageNotSelected": "Choose the package to deduct units from.",
       "packageQuantityMin": "Unit count must be at least 1.",
       "packageQuantityExceeds": "Unit count exceeds the remaining package usage.",
+      "documentStatus": {
+        "title": "Documentation status",
+        "complete": "Documentation complete",
+        "missingRequired": "Missing required documents",
+        "needsAttention": "Needs attention",
+        "progress": "{{satisfied}} / {{total}} satisfied",
+        "optional": "optional",
+        "showAll": "Show all",
+        "showLess": "Hide non-applicable",
+        "statuses": {
+          "satisfied": "Satisfied",
+          "expired": "Expired",
+          "pending": "Pending",
+          "missing": "Missing",
+          "notApplicable": "Not applicable"
+        }
+      },
       "markContraindicationAsDiscussed": "Mark as discussed",
       "contraindicationDiscussed": "Discussed",
       "contraindicationMarked": "Marked as discussed",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -3513,6 +3513,23 @@
           "workflowSms": "SMS workflow wizyty"
         }
       },
+      "documentStatus": {
+        "title": "Status dokumentacji",
+        "complete": "Dokumentacja kompletna",
+        "missingRequired": "Brakuje wymaganych dokumentów",
+        "needsAttention": "Wymaga uwagi",
+        "progress": "{{satisfied}} / {{total}} spełnionych",
+        "optional": "opcjonalny",
+        "showAll": "Pokaż wszystkie",
+        "showLess": "Ukryj niewymagane",
+        "statuses": {
+          "satisfied": "Spełniony",
+          "expired": "Wygasły",
+          "pending": "Oczekujący",
+          "missing": "Brakuje",
+          "notApplicable": "Nie dotyczy"
+        }
+      },
       "markContraindicationAsDiscussed": "Oznacz jako omówione",
       "contraindicationDiscussed": "Omówiono",
       "contraindicationMarked": "Oznaczono jako omówione",

--- a/src/components/gabinet/appointments/appointment-details-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-details-tab.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/components/gabinet/rich-text-editor";
 import { TreatmentPicker } from "@/components/gabinet/appointment-shared/treatment-picker";
 import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
+import { AppointmentDocumentStatus } from "./appointment-document-status";
 
 type TreatmentListItem = {
   _id: string;
@@ -70,6 +71,8 @@ type SmsEvent = Record<string, unknown>;
 
 export function AppointmentDetailsTab({
   appointment,
+  appointmentId,
+  organizationId,
   treatment,
   employee,
   junctionTreatments,
@@ -99,6 +102,8 @@ export function AppointmentDetailsTab({
   t,
 }: {
   appointment: Record<string, unknown>;
+  appointmentId: string;
+  organizationId: string;
   treatment: Record<string, unknown> | null | undefined;
   employee: Record<string, unknown> | null | undefined;
   junctionTreatments: JunctionTreatment[];
@@ -503,6 +508,12 @@ export function AppointmentDetailsTab({
           </CardContent>
         </Card>
       )}
+
+      {/* Document Completeness Status Card */}
+      <AppointmentDocumentStatus
+        appointmentId={appointmentId}
+        organizationId={organizationId}
+      />
 
       {/* Internal Notes Card */}
       <Card>

--- a/src/components/gabinet/appointments/appointment-document-status.tsx
+++ b/src/components/gabinet/appointments/appointment-document-status.tsx
@@ -1,0 +1,290 @@
+import { useState } from "react";
+import { useAction } from "convex/react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@cvx/_generated/api";
+import { useTranslation } from "react-i18next";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  AlertCircle,
+  ChevronDown,
+  ChevronUp,
+  CircleCheck,
+  Clock,
+  FileText,
+  Minus,
+} from "@/lib/ez-icons";
+import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// ---------------------------------------------------------------------------
+// Local types mirroring convex/gabinet/_helpers/documentGate.ts
+// ---------------------------------------------------------------------------
+
+type DocStatus =
+  | "satisfied"
+  | "expired"
+  | "pending"
+  | "missing"
+  | "not_applicable";
+
+interface DocItem {
+  templateId: string;
+  title: string;
+  isRequired: boolean;
+  status: DocStatus;
+  blocksCompletion: boolean;
+}
+
+interface DocCompleteness {
+  isComplete: boolean;
+  items: DocItem[];
+  summary: {
+    total: number;
+    satisfied: number;
+    expired: number;
+    pending: number;
+    missing: number;
+    notApplicable: number;
+    blocking: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getStatusIcon(status: DocStatus) {
+  switch (status) {
+    case "satisfied":
+      return (
+        <CircleCheck className="h-4 w-4 text-green-600 dark:text-green-400 shrink-0" />
+      );
+    case "expired":
+      return (
+        <AlertCircle className="h-4 w-4 text-red-500 dark:text-red-400 shrink-0" />
+      );
+    case "pending":
+      return (
+        <Clock className="h-4 w-4 text-yellow-500 dark:text-yellow-400 shrink-0" />
+      );
+    case "missing":
+      return (
+        <AlertCircle className="h-4 w-4 text-red-500 dark:text-red-400 shrink-0" />
+      );
+    case "not_applicable":
+      return (
+        <Minus className="h-4 w-4 text-muted-foreground shrink-0" />
+      );
+  }
+}
+
+function getStatusBadgeClass(status: DocStatus): string {
+  switch (status) {
+    case "satisfied":
+      return "border-green-400 text-green-700 bg-green-50 dark:border-green-600 dark:text-green-400 dark:bg-green-950";
+    case "expired":
+      return "border-red-400 text-red-700 bg-red-50 dark:border-red-600 dark:text-red-400 dark:bg-red-950";
+    case "pending":
+      return "border-yellow-400 text-yellow-700 bg-yellow-50 dark:border-yellow-600 dark:text-yellow-400 dark:bg-yellow-950";
+    case "missing":
+      return "border-red-400 text-red-700 bg-red-50 dark:border-red-600 dark:text-red-400 dark:bg-red-950";
+    case "not_applicable":
+      return "";
+  }
+}
+
+type OverallStatus = "complete" | "missing" | "attention";
+
+function getOverallStatus(c: DocCompleteness): OverallStatus {
+  if (c.isComplete) return "complete";
+  if (c.summary.missing > 0 || c.summary.expired > 0) return "missing";
+  return "attention";
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface AppointmentDocumentStatusProps {
+  appointmentId: string;
+  organizationId: string;
+}
+
+export function AppointmentDocumentStatus({
+  appointmentId,
+  organizationId,
+}: AppointmentDocumentStatusProps) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+
+  const getCompleteness = useAction(
+    api.gabinet.appointments.getAppointmentDocCompletenessAction,
+  );
+  const { data: completeness, isLoading } = useQuery({
+    queryKey: [
+      "gabinet.appointments.docCompleteness",
+      organizationId,
+      appointmentId,
+    ],
+    queryFn: () =>
+      getCompleteness({ organizationId, appointmentId }) as Promise<DocCompleteness>,
+    enabled: !!organizationId && !!appointmentId,
+  });
+
+  if (isLoading) {
+    return <Skeleton className="h-16 w-full rounded-lg" />;
+  }
+
+  if (!completeness || completeness.items.length === 0) {
+    return null;
+  }
+
+  const overall = getOverallStatus(completeness);
+
+  const overallConfig = {
+    complete: {
+      labelKey: "gabinet.appointmentDetail.documentStatus.complete",
+      fallback: "Dokumentacja kompletna",
+      containerClass:
+        "border-green-400 text-green-700 bg-green-50 dark:border-green-600 dark:text-green-400 dark:bg-green-950",
+      icon: (
+        <CircleCheck className="h-4 w-4 text-green-600 dark:text-green-400 shrink-0" />
+      ),
+    },
+    missing: {
+      labelKey: "gabinet.appointmentDetail.documentStatus.missingRequired",
+      fallback: "Brakuje wymaganych dokumentów",
+      containerClass:
+        "border-red-400 text-red-700 bg-red-50 dark:border-red-600 dark:text-red-400 dark:bg-red-950",
+      icon: (
+        <AlertCircle className="h-4 w-4 text-red-600 dark:text-red-400 shrink-0" />
+      ),
+    },
+    attention: {
+      labelKey: "gabinet.appointmentDetail.documentStatus.needsAttention",
+      fallback: "Wymaga uwagi",
+      containerClass:
+        "border-yellow-400 text-yellow-700 bg-yellow-50 dark:border-yellow-600 dark:text-yellow-400 dark:bg-yellow-950",
+      icon: (
+        <Clock className="h-4 w-4 text-yellow-600 dark:text-yellow-400 shrink-0" />
+      ),
+    },
+  }[overall];
+
+  // Default view: show items that are not "not_applicable" — they're the ones that
+  // matter to the user at a glance. Expand to reveal all items including n/a.
+  const hasNotApplicable = completeness.items.some(
+    (i) => i.status === "not_applicable",
+  );
+  const visibleItems = expanded
+    ? completeness.items
+    : completeness.items.filter((i) => i.status !== "not_applicable");
+
+  return (
+    <Card>
+      <CardHeader className="px-6 py-3 border-b">
+        <CardTitle className="text-sm flex items-center gap-2">
+          <FileText className="h-4 w-4" variant="stroke" />
+          {t(
+            "gabinet.appointmentDetail.documentStatus.title",
+            "Status dokumentacji",
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="px-6 py-4 space-y-3">
+        {/* Overall status badge + progress */}
+        <div className="flex items-center justify-between gap-2">
+          <div
+            className={cn(
+              "flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium",
+              overallConfig.containerClass,
+            )}
+          >
+            {overallConfig.icon}
+            {t(overallConfig.labelKey, overallConfig.fallback)}
+          </div>
+          <span className="text-xs text-muted-foreground shrink-0">
+            {t("gabinet.appointmentDetail.documentStatus.progress", {
+              satisfied: completeness.summary.satisfied,
+              total: completeness.summary.total - completeness.summary.notApplicable,
+              defaultValue: "{{satisfied}} / {{total}}",
+            })}
+          </span>
+        </div>
+
+        {/* Document item list */}
+        <div className="space-y-1.5">
+          {visibleItems.map((item) => (
+            <div
+              key={item.templateId}
+              className="flex items-center justify-between gap-2 text-sm"
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                {getStatusIcon(item.status)}
+                <span className="truncate text-sm">{item.title}</span>
+                {!item.isRequired && (
+                  <Badge
+                    variant="outline"
+                    className="text-xs shrink-0 text-muted-foreground"
+                  >
+                    {t(
+                      "gabinet.appointmentDetail.documentStatus.optional",
+                      "opcjonalny",
+                    )}
+                  </Badge>
+                )}
+              </div>
+              <Badge
+                variant="outline"
+                className={cn(
+                  "text-xs shrink-0",
+                  getStatusBadgeClass(item.status),
+                )}
+              >
+                {t(
+                  `gabinet.appointmentDetail.documentStatus.statuses.${item.status === "not_applicable" ? "notApplicable" : item.status}`,
+                  item.status,
+                )}
+              </Badge>
+            </div>
+          ))}
+        </div>
+
+        {/* Toggle: only when there are not_applicable items to hide/show */}
+        {hasNotApplicable && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full h-7 text-xs text-muted-foreground"
+            onClick={() => setExpanded((prev) => !prev)}
+          >
+            {expanded ? (
+              <>
+                {t(
+                  "gabinet.appointmentDetail.documentStatus.showLess",
+                  "Ukryj niewymagane",
+                )}
+                <ChevronUp className="h-3 w-3 ml-1" variant="stroke" />
+              </>
+            ) : (
+              <>
+                {t(
+                  "gabinet.appointmentDetail.documentStatus.showAll",
+                  "Pokaż wszystkie",
+                )}
+                <ChevronDown className="h-3 w-3 ml-1" variant="stroke" />
+              </>
+            )}
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -1089,6 +1089,8 @@ function AppointmentDetail() {
       content: (
         <AppointmentDetailsTab
           appointment={appointment}
+          appointmentId={appointmentId}
+          organizationId={organizationId}
           treatment={treatment}
           employee={employee}
           junctionTreatments={junctionTreatments}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5459.

Closes #5459

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 98cc3fd9 feat(gabinet/appointments): add documentation status card to appointment details (closes #5459)

### Files changed

```
 public/locales/en/translation.json                 |  17 ++
 public/locales/pl/translation.json                 |  17 ++
 .../appointments/appointment-details-tab.tsx       |  11 +
 .../appointments/appointment-document-status.tsx   | 290 +++++++++++++++++++++
 ...ut.gabinet.appointments.$appointmentId.lazy.tsx |   2 +
 5 files changed, 337 insertions(+)
```