### PR TITLE
Fix stale `database.types.ts` generation

### DIFF
--- a/scripts/gen-db-types.mjs
+++ b/scripts/gen-db-types.mjs
@@ -379,6 +379,17 @@ function applyMigration(sql) {
     }
   }
 
+  // ─── DROP TABLE [IF EXISTS] <name> [, <name> ...] ──
+  // Removes tables that were dropped by a migration so they don't appear in
+  // the generated types.  Handles both single-table and comma-separated forms.
+  const dropTableRe = /DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?([^\n;]+)/gi;
+  for (const m of sql.matchAll(dropTableRe)) {
+    for (const raw of m[1].split(",")) {
+      const tableName = raw.trim().replace(/^"|"$/g, "").split(/\s/)[0];
+      if (tableName) tables.delete(tableName);
+    }
+  }
+
   // ─── CREATE [OR REPLACE] FUNCTION public.<name>(<args>) RETURNS <type> ──
   // Only public-schema functions are exposed via PostgREST RPC; unqualified
   // helper functions (RLS helpers, triggers) are intentionally skipped.

--- a/src/lib/supabase/database.columns.ts
+++ b/src/lib/supabase/database.columns.ts
@@ -142,6 +142,12 @@
  *   • 00135_form_documents_generated_for_treatment_id.sql
  *   • 00136_form_documents_template_version.sql
  *   • 00137_form_documents_content_json_snapshot.sql
+ *   • 00138_form_templates_d24_categories_and_updated_by.sql
+ *   • 00139_drop_document_templates_and_fields.sql
+ *   • 00140_signature_requests_embed_document.sql
+ *   • 00141_drop_document_instances.sql
+ *   • 00142_form_documents_expires_at.sql
+ *   • 00143_form_documents_is_required.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  */
@@ -227,8 +233,6 @@ export type TableName =
   | "appointment_reminders"
   | "appointment_workflow_history"
   | "appointment_sms_events"
-  | "document_templates"
-  | "document_template_fields"
   | "signature_requests"
   | "form_templates"
   | "form_documents"
@@ -338,11 +342,9 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   appointment_reminders: new Set(["id", "organization_id", "appointment_id", "type", "scheduled_for", "sent_at", "status", "scheduled_function_id", "created_at"]),
   appointment_workflow_history: new Set(["id", "organization_id", "appointment_id", "workflow_event", "channel", "direction", "source", "recipient", "recipient_name", "status", "rendered_subject", "rendered_body", "email_event_log_id", "error_message", "idempotency_key", "processed_at", "created_at", "updated_at"]),
   appointment_sms_events: new Set(["id", "organization_id", "appointment_id", "patient_id", "normalized_phone", "direction", "provider", "event_type", "provider_message_id", "correlation_key", "reply_to_event_id", "raw_body", "normalized_body", "parsed_intent", "processing_status", "processing_error", "webhook_signature_verified", "metadata", "idempotency_key", "processed_at", "created_at", "updated_at"]),
-  document_templates: new Set(["id", "organization_id", "name", "description", "category", "content", "module", "required_sources", "requires_signature", "signature_slots", "access_control", "version", "parent_template_id", "status", "created_by", "created_at", "updated_at"]),
-  document_template_fields: new Set(["id", "template_id", "field_key", "label", "type", "sort_order", "group", "options", "default_value", "binding", "validation", "placeholder", "help_text", "width"]),
   signature_requests: new Set(["id", "organization_id", "instance_id", "slot_id", "token", "signer_email", "signer_name", "signer_phone", "signer_user_id", "verification_method", "status", "otp_hash", "otp_sent_at", "otp_attempts", "expires_at", "signed_at", "created_at", "document_title", "rendered_content", "document_created_by", "slot_label", "signature_data"]),
-  form_templates: new Set(["id", "organization_id", "name", "description", "category", "folder_path", "template_type", "form_json", "content_json", "theme_json", "modules", "entity_types", "variable_bindings", "requires_signature", "signature_config", "access_roles", "version", "is_active", "is_org_required", "created_by", "updated_by", "created_at", "updated_at"]),
-  form_documents: new Set(["id", "organization_id", "template_id", "title", "response_data", "entity_type", "entity_id", "scope_entities", "status", "signature_data", "signed_at", "signed_by_name", "signed_by_email", "signed_by_ip", "signature_verification_method", "signing_token", "signing_token_expires_at", "signing_email_sent_at", "signing_reminder_count", "timing", "auto_generated", "pdf_storage_id", "pdf_generated_at", "created_by", "created_at", "updated_at", "sort_order", "generated_for_treatment_id", "template_version", "content_json_snapshot"]),
+  form_templates: new Set(["id", "organization_id", "name", "description", "category", "folder_path", "template_type", "form_json", "content_json", "theme_json", "modules", "entity_types", "variable_bindings", "requires_signature", "signature_config", "access_roles", "version", "is_active", "created_by", "created_at", "updated_at", "is_org_required", "updated_by"]),
+  form_documents: new Set(["id", "organization_id", "template_id", "title", "response_data", "entity_type", "entity_id", "scope_entities", "status", "signature_data", "signed_at", "signed_by_name", "signed_by_email", "signed_by_ip", "signature_verification_method", "signing_token", "signing_token_expires_at", "signing_email_sent_at", "signing_reminder_count", "timing", "auto_generated", "pdf_storage_id", "pdf_generated_at", "created_by", "created_at", "updated_at", "sort_order", "generated_for_treatment_id", "template_version", "content_json_snapshot", "expires_at", "document_validity_days", "is_required"]),
   automation_rules: new Set(["id", "organization_id", "name", "description", "module", "event_type", "entity_type", "trigger", "graph", "definition_version", "conditions", "actions", "enabled", "created_by", "created_at", "updated_at"]),
   automation_runs: new Set(["id", "organization_id", "rule_id", "module", "event_type", "entity_type", "entity_id", "event_idempotency_key", "correlation_key", "payload_snapshot", "actor_user_id", "status", "error_message", "occurred_at", "processed_at", "created_at", "updated_at"]),
   automation_run_steps: new Set(["id", "organization_id", "run_id", "rule_id", "action_index", "action_type", "idempotency_key", "status", "recipient", "recipient_name", "linked_entity_type", "linked_entity_id", "rendered_subject", "rendered_body", "metadata_snapshot", "error_message", "email_event_log_id", "appointment_sms_event_id", "processed_at", "created_at", "updated_at"]),

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -130,6 +130,24 @@
  *   • 00123_reject_gabinet_leave_atomic_fn.sql
  *   • 00124_delete_gabinet_leave_atomic_fn.sql
  *   • 00125_product_stock_movements_payment_method.sql
+ *   • 00126_product_subscriptions_source_granted_by.sql
+ *   • 00127_email_accounts_from_email_idx.sql
+ *   • 00128_email_accounts_org_is_default_idx.sql
+ *   • 00129_product_stock_movements_treatment_id.sql
+ *   • 00130_gabinet_package_deduction_atomic_fns.sql
+ *   • 00131_gabinet_appointment_package_overbooking_guard.sql
+ *   • 00132_gabinet_overbooking_guard_series_count.sql
+ *   • 00133_gabinet_package_cas_atomic_fns.sql
+ *   • 00134_form_templates_is_org_required.sql
+ *   • 00135_form_documents_generated_for_treatment_id.sql
+ *   • 00136_form_documents_template_version.sql
+ *   • 00137_form_documents_content_json_snapshot.sql
+ *   • 00138_form_templates_d24_categories_and_updated_by.sql
+ *   • 00139_drop_document_templates_and_fields.sql
+ *   • 00140_signature_requests_embed_document.sql
+ *   • 00141_drop_document_instances.sql
+ *   • 00142_form_documents_expires_at.sql
+ *   • 00143_form_documents_is_required.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -536,6 +554,8 @@ export interface Database {
           created_at: number;
           updated_at: number;
           trial_end_date: number | null;
+          source: string | null;
+          granted_by_user_id: string | null;
         };
         Insert: {
           id?: string;
@@ -549,6 +569,8 @@ export interface Database {
           created_at: number;
           updated_at: number;
           trial_end_date?: number | null;
+          source?: string | null;
+          granted_by_user_id?: string | null;
         };
         Update: {
           id?: string;
@@ -562,6 +584,8 @@ export interface Database {
           created_at?: number;
           updated_at?: number;
           trial_end_date?: number | null;
+          source?: string | null;
+          granted_by_user_id?: string | null;
         };
         Relationships: [
           {
@@ -569,6 +593,13 @@ export interface Database {
             columns: ["organization_id"];
             isOneToOne: false;
             referencedRelation: "organizations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "product_subscriptions_granted_by_user_id_fkey";
+            columns: ["granted_by_user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
             referencedColumns: ["id"];
           },
         ];
@@ -5648,147 +5679,6 @@ export interface Database {
           },
         ];
       };
-      document_templates: {
-        Row: {
-          id: string;
-          organization_id: string;
-          name: string;
-          description: string | null;
-          category: string;
-          content: string;
-          module: string;
-          required_sources: string[];
-          requires_signature: boolean;
-          signature_slots: unknown;
-          access_control: unknown;
-          version: number;
-          parent_template_id: string | null;
-          status: string;
-          created_by: string;
-          created_at: number;
-          updated_at: number;
-        };
-        Insert: {
-          id?: string;
-          organization_id: string;
-          name: string;
-          description?: string | null;
-          category: string;
-          content: string;
-          module: string;
-          required_sources: string[];
-          requires_signature: boolean;
-          signature_slots: unknown;
-          access_control: unknown;
-          version: number;
-          parent_template_id?: string | null;
-          status: string;
-          created_by: string;
-          created_at: number;
-          updated_at: number;
-        };
-        Update: {
-          id?: string;
-          organization_id?: string;
-          name?: string;
-          description?: string | null;
-          category?: string;
-          content?: string;
-          module?: string;
-          required_sources?: string[];
-          requires_signature?: boolean;
-          signature_slots?: unknown;
-          access_control?: unknown;
-          version?: number;
-          parent_template_id?: string | null;
-          status?: string;
-          created_by?: string;
-          created_at?: number;
-          updated_at?: number;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "document_templates_organization_id_fkey";
-            columns: ["organization_id"];
-            isOneToOne: false;
-            referencedRelation: "organizations";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "document_templates_parent_template_id_fkey";
-            columns: ["parent_template_id"];
-            isOneToOne: false;
-            referencedRelation: "document_templates";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "document_templates_created_by_fkey";
-            columns: ["created_by"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
-      document_template_fields: {
-        Row: {
-          id: string;
-          template_id: string;
-          field_key: string;
-          label: string;
-          type: string;
-          sort_order: number;
-          group: string | null;
-          options: unknown | null;
-          default_value: string | null;
-          binding: unknown | null;
-          validation: unknown | null;
-          placeholder: string | null;
-          help_text: string | null;
-          width: string;
-        };
-        Insert: {
-          id?: string;
-          template_id: string;
-          field_key: string;
-          label: string;
-          type: string;
-          sort_order: number;
-          group?: string | null;
-          options?: unknown | null;
-          default_value?: string | null;
-          binding?: unknown | null;
-          validation?: unknown | null;
-          placeholder?: string | null;
-          help_text?: string | null;
-          width: string;
-        };
-        Update: {
-          id?: string;
-          template_id?: string;
-          field_key?: string;
-          label?: string;
-          type?: string;
-          sort_order?: number;
-          group?: string | null;
-          options?: unknown | null;
-          default_value?: string | null;
-          binding?: unknown | null;
-          validation?: unknown | null;
-          placeholder?: string | null;
-          help_text?: string | null;
-          width?: string;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "document_template_fields_template_id_fkey";
-            columns: ["template_id"];
-            isOneToOne: false;
-            referencedRelation: "document_templates";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
       signature_requests: {
         Row: {
           id: string;
@@ -5871,6 +5761,13 @@ export interface Database {
             referencedColumns: ["id"];
           },
           {
+            foreignKeyName: "signature_requests_instance_id_fkey";
+            columns: ["instance_id"];
+            isOneToOne: false;
+            referencedRelation: "document_instances";
+            referencedColumns: ["id"];
+          },
+          {
             foreignKeyName: "signature_requests_signer_user_id_fkey";
             columns: ["signer_user_id"];
             isOneToOne: false;
@@ -5902,6 +5799,8 @@ export interface Database {
           created_by: string;
           created_at: number;
           updated_at: number;
+          is_org_required: boolean;
+          updated_by: string | null;
         };
         Insert: {
           id?: string;
@@ -5925,6 +5824,8 @@ export interface Database {
           created_by: string;
           created_at: number;
           updated_at: number;
+          is_org_required?: boolean;
+          updated_by?: string | null;
         };
         Update: {
           id?: string;
@@ -5948,6 +5849,8 @@ export interface Database {
           created_by?: string;
           created_at?: number;
           updated_at?: number;
+          is_org_required?: boolean;
+          updated_by?: string | null;
         };
         Relationships: [
           {
@@ -5960,6 +5863,13 @@ export interface Database {
           {
             foreignKeyName: "form_templates_created_by_fkey";
             columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "form_templates_updated_by_fkey";
+            columns: ["updated_by"];
             isOneToOne: false;
             referencedRelation: "users";
             referencedColumns: ["id"];
@@ -5995,9 +5905,12 @@ export interface Database {
           created_at: number;
           updated_at: number;
           sort_order: number | null;
+          generated_for_treatment_id: string | null;
           template_version: number | null;
+          content_json_snapshot: string | null;
           expires_at: number | null;
           document_validity_days: number | null;
+          is_required: boolean | null;
         };
         Insert: {
           id?: string;
@@ -6027,9 +5940,12 @@ export interface Database {
           created_at: number;
           updated_at: number;
           sort_order?: number | null;
+          generated_for_treatment_id?: string | null;
           template_version?: number | null;
+          content_json_snapshot?: string | null;
           expires_at?: number | null;
           document_validity_days?: number | null;
+          is_required?: boolean | null;
         };
         Update: {
           id?: string;
@@ -6059,9 +5975,12 @@ export interface Database {
           created_at?: number;
           updated_at?: number;
           sort_order?: number | null;
+          generated_for_treatment_id?: string | null;
           template_version?: number | null;
+          content_json_snapshot?: string | null;
           expires_at?: number | null;
           document_validity_days?: number | null;
+          is_required?: boolean | null;
         };
         Relationships: [
           {
@@ -6083,6 +6002,13 @@ export interface Database {
             columns: ["created_by"];
             isOneToOne: false;
             referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "form_documents_generated_for_treatment_id_fkey";
+            columns: ["generated_for_treatment_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_treatments";
             referencedColumns: ["id"];
           },
         ];
@@ -6486,6 +6412,7 @@ export interface Database {
           lot_number: string | null;
           expiry_date: string | null;
           payment_method: string | null;
+          treatment_id: string | null;
         };
         Insert: {
           id?: string;
@@ -6505,6 +6432,7 @@ export interface Database {
           lot_number?: string | null;
           expiry_date?: string | null;
           payment_method?: string | null;
+          treatment_id?: string | null;
         };
         Update: {
           id?: string;
@@ -6524,6 +6452,7 @@ export interface Database {
           lot_number?: string | null;
           expiry_date?: string | null;
           payment_method?: string | null;
+          treatment_id?: string | null;
         };
         Relationships: [
           {
@@ -6552,6 +6481,13 @@ export interface Database {
             columns: ["performed_by"];
             isOneToOne: false;
             referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "product_stock_movements_treatment_id_fkey";
+            columns: ["treatment_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_treatments";
             referencedColumns: ["id"];
           },
         ];
@@ -7734,7 +7670,6 @@ export type GabinetLeaveUpdate = Database["public"]["Tables"]["gabinet_leaves"][
 export type GabinetOvertimeRow = Database["public"]["Tables"]["gabinet_overtime"]["Row"];
 export type GabinetOvertimeInsert = Database["public"]["Tables"]["gabinet_overtime"]["Insert"];
 export type GabinetOvertimeUpdate = Database["public"]["Tables"]["gabinet_overtime"]["Update"];
-
 export type GabinetTreatmentPackageRow = Database["public"]["Tables"]["gabinet_treatment_packages"]["Row"];
 export type GabinetTreatmentPackageInsert = Database["public"]["Tables"]["gabinet_treatment_packages"]["Insert"];
 export type GabinetTreatmentPackageUpdate = Database["public"]["Tables"]["gabinet_treatment_packages"]["Update"];


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5463.

Closes #5463

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 623dbb60 fix(types): regenerate database.types.ts through migration 00143 (closes #5463)

### Files changed

```
 scripts/gen-db-types.mjs             |  11 ++
 src/lib/supabase/database.columns.ts |  14 ++-
 src/lib/supabase/database.types.ts   | 219 ++++++++++++-----------------------
 3 files changed, 96 insertions(+), 148 deletions(-)
```