### PR TITLE
Fix pre-existing TS18046 errors in `DocumentsGroupedView` callback props

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -51,11 +51,16 @@ import { useCategoryDefinitions } from "@/hooks/use-category-definitions";
 import { TagsManagerSlideout } from "@/components/categories-tags/tags-manager-slideout";
 import { CategoriesManagerSlideout } from "@/components/categories-tags/categories-manager-slideout";
 import { useSupabaseFormDocumentsList } from "@/hooks/use-supabase-form-documents";
+import type { MappedFormDocument } from "@/lib/supabase/mappers/form-documents";
 import { useSupabaseGabinetPatientsList } from "@/hooks/use-supabase-gabinet-patients";
 import { useSupabaseGabinetTreatmentsList } from "@/hooks/use-supabase-gabinet-treatments";
 import { useSupabaseGabinetAppointmentsByIds } from "@/hooks/use-supabase-gabinet-appointments";
 import { useSavedViews, applyFilterConditions } from "@/hooks/use-saved-views";
 import { useSidebarDispatch } from "@/components/layout/sidebar-context";
+
+// Enriched document row — MappedFormDocument with the derived `category` field
+// added in filteredDocuments so filters can operate on it.
+type DocumentRow = MappedFormDocument & { category: string | null };
 
 // ---------------------------------------------------------------------------
 // Route
@@ -570,7 +575,7 @@ function GabinetDocumentsPage() {
 
   // --- Column definitions ---
   const columns = useMemo(() => {
-    const result: CrmColumn<any>[] = [
+    const result: CrmColumn<DocumentRow>[] = [
       {
         id: "title",
         label: t("gabinet.formDocuments.colTitle", "Tytuł"),


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5464.

Closes #5464

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3b511327 fix(types): thread DocumentRow generic through DocumentsGroupedView callbacks (closes #5464)

### Files changed

```
 .../_app/_auth/dashboard/_layout.gabinet.documents.index.tsx       | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)
```