### PR TITLE
D31 — Dokumenty — audit trail dokumentu i wersja szablonu

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -367,6 +367,25 @@ export const create = action({
       updatedAt: now,
     });
 
+    // Audit trail: record document creation with template version snapshot.
+    try {
+      await db.insert("auditLog", {
+        organizationId: String(args.organizationId),
+        userId: String(authResult.userId),
+        action: "document.created",
+        entityType: "formDocument",
+        entityId: String(docId),
+        details: JSON.stringify({
+          title: args.title,
+          templateVersion: (template?.version as number | null | undefined) ?? null,
+          status: args.status,
+        }),
+        createdAt: now,
+      });
+    } catch (err) {
+      console.error("[create] audit log write failed", err);
+    }
+
     return docId;
   },
 });
@@ -494,10 +513,10 @@ export const submitEmployeeFormFields = action({
     scopeData: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
-    );
+    ) as { userId: string };
 
     const db = createSupabaseDb();
     const doc = await db.get("formDocuments", args.documentId);
@@ -571,13 +590,17 @@ export const submitEmployeeFormFields = action({
     const nextStatus: "draft" | "pending_signature" =
       doc.signingToken && !recipientEmail ? "draft" : "pending_signature";
 
+    const nowMs = Date.now();
     const patchPayload: Record<string, unknown> = {
       responseData: JSON.stringify(responseObj),
       status: nextStatus,
-      updatedAt: Date.now(),
+      updatedAt: nowMs,
     };
     if (doc.signingToken && !recipientEmail) {
       patchPayload.signingTokenExpiresAt = null;
+    }
+    if (recipientEmail) {
+      patchPayload.sentByUserId = String(authResult.userId);
     }
 
     await db.patch("formDocuments", args.documentId, patchPayload);
@@ -592,6 +615,24 @@ export const submitEmployeeFormFields = action({
           recipientName,
         },
       );
+
+      // Audit trail: record that staff triggered the signing email.
+      try {
+        await db.insert("auditLog", {
+          organizationId: String(args.organizationId),
+          userId: String(authResult.userId),
+          action: "document.sent",
+          entityType: "formDocument",
+          entityId: args.documentId,
+          details: JSON.stringify({
+            recipientEmail,
+            recipientName: recipientName ?? undefined,
+          }),
+          createdAt: nowMs,
+        });
+      } catch (err) {
+        console.error("[submitEmployeeFormFields] audit log write failed", err);
+      }
     }
 
     return args.documentId;
@@ -743,10 +784,10 @@ export const resendSigningEmail = action({
     documentId: v.string(),
   },
   handler: async (ctx, args) => {
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
-    );
+    ) as { userId: string };
     const perm = await ctx.runAction(
       internal._helpers.authAction.checkPermission,
       {
@@ -801,15 +842,19 @@ export const resendSigningEmail = action({
       throw new Error("Nie znaleziono adresu e-mail pacjenta");
     }
 
+    const now = Date.now();
+
     // Expired documents must be reset to pending_signature so the document gate
     // passes once the patient re-signs. sendSigningEmailInternal bumps the token
     // expiry on its own, so we only need to fix the status here.
+    const patchPayload: Record<string, unknown> = {
+      sentByUserId: String(authResult.userId),
+      updatedAt: now,
+    };
     if (doc.status === "expired") {
-      await db.patch("formDocuments", args.documentId, {
-        status: "pending_signature",
-        updatedAt: Date.now(),
-      });
+      patchPayload.status = "pending_signature";
     }
+    await db.patch("formDocuments", args.documentId, patchPayload);
 
     // Call the send action directly (not via scheduler) so failures
     // propagate back to the UI instead of being silently swallowed.
@@ -818,6 +863,24 @@ export const resendSigningEmail = action({
       recipientEmail,
       recipientName,
     });
+
+    // Audit trail: record send event after successful delivery.
+    try {
+      await db.insert("auditLog", {
+        organizationId: String(args.organizationId),
+        userId: String(authResult.userId),
+        action: "document.sent",
+        entityType: "formDocument",
+        entityId: args.documentId,
+        details: JSON.stringify({
+          recipientEmail,
+          recipientName: recipientName ?? undefined,
+        }),
+        createdAt: now,
+      });
+    } catch (err) {
+      console.error("[resendSigningEmail] audit log write failed", err);
+    }
 
     return { sent: true };
   },
@@ -853,6 +916,68 @@ export const remove = action({
     }
 
     await db.delete("formDocuments", args.documentId);
+    return args.documentId;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Void document (D31) — transitions a signed/completed document to "voided",
+// records who voided it and when, and writes a document.voided audit log entry.
+// Uses the gabinet_documents edit permission so the same staff who can edit
+// documents can void them; owner-scoped staff can only void their own.
+// ---------------------------------------------------------------------------
+
+export const voidDocument = action({
+  args: {
+    organizationId: v.string(),
+    documentId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const authResult = await ctx.runAction(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    ) as { userId: string };
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      {
+        organizationId: args.organizationId,
+        feature: "gabinet_documents",
+        action: "edit",
+      },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    const db = createSupabaseDb();
+    const doc = await db.get("formDocuments", args.documentId);
+    if (!doc || String(doc.organizationId) !== String(args.organizationId))
+      throw new Error("Document not found");
+    if (perm.scope === "own" && String(doc.createdBy) !== String(authResult.userId))
+      throw new Error("Permission denied: you can only void your own documents");
+    if (doc.status === "voided")
+      throw new Error("Document is already voided");
+
+    const now = Date.now();
+    await db.patch("formDocuments", args.documentId, {
+      status: "voided",
+      voidedByUserId: String(authResult.userId),
+      voidedAt: now,
+      updatedAt: now,
+    });
+
+    try {
+      await db.insert("auditLog", {
+        organizationId: String(args.organizationId),
+        userId: String(authResult.userId),
+        action: "document.voided",
+        entityType: "formDocument",
+        entityId: args.documentId,
+        details: JSON.stringify({ previousStatus: doc.status }),
+        createdAt: now,
+      });
+    } catch (err) {
+      console.error("[voidDocument] audit log write failed", err);
+    }
+
     return args.documentId;
   },
 });

--- a/convex/schema/documents.ts
+++ b/convex/schema/documents.ts
@@ -184,6 +184,11 @@ export const documentTables = {
     // Display order within an (entityType, entityId) scope — used for
     // drag-and-drop reordering on entity detail "Documents" tabs.
     sortOrder: v.optional(v.number()),
+    // D31 — Audit trail: who sent the signing email (last sender) and who voided.
+    // Every send/void event is also written to auditLog for full chronological history.
+    sentByUserId: v.optional(v.string()),
+    voidedByUserId: v.optional(v.string()),
+    voidedAt: v.optional(v.number()),
     // Metadata
     createdBy: v.id("users"),
     createdAt: v.number(),

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -869,6 +869,19 @@
       "filled": "Document filled in and sent to the client for signing.",
       "sent": "Document sent to the client for signing.",
       "later": "Fill in later"
+    },
+    "void": "Void",
+    "voided": "Document voided",
+    "voidFailed": "Failed to void document",
+    "voidDialogTitle": "Void document",
+    "voidDialogDescription": "Are you sure you want to void this document? This cannot be undone.",
+    "resend": "Resend",
+    "view": "View",
+    "audit": {
+      "created": "Created",
+      "sent": "Sent for signing",
+      "signed": "Signed",
+      "voided": "Voided"
     }
   },
   "products": {

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -869,6 +869,19 @@
       "filled": "Dokument wypełniony i wysłany do klienta do podpisu.",
       "sent": "Dokument wysłany do klienta do podpisu.",
       "later": "Wypełnię później"
+    },
+    "void": "Unieważnij",
+    "voided": "Dokument unieważniony",
+    "voidFailed": "Nie udało się unieważnić dokumentu",
+    "voidDialogTitle": "Unieważnij dokument",
+    "voidDialogDescription": "Czy na pewno chcesz unieważnić ten dokument? Operacja jest nieodwracalna.",
+    "resend": "Wyślij ponownie",
+    "view": "Podgląd",
+    "audit": {
+      "created": "Utworzono",
+      "sent": "Wysłano do podpisu",
+      "signed": "Podpisano",
+      "voided": "Unieważniono"
     }
   },
   "products": {

--- a/src/components/documents/entity-documents-tab.tsx
+++ b/src/components/documents/entity-documents-tab.tsx
@@ -50,6 +50,8 @@ import {
   CircleCheck,
   GripVertical,
   Trash2,
+  OctagonX,
+  UserCheck,
 } from "@/lib/ez-icons";
 import { ScrollShadow } from "@/components/ui/scroll-shadow";
 import { cn } from "@/lib/utils";
@@ -83,13 +85,18 @@ interface FormDocument {
   title: string;
   status: FormDocumentStatus;
   templateId: Id<"formTemplates">;
+  templateVersion?: number;
   createdAt: number;
   responseData?: string;
   signedAt?: number;
   signatureData?: string;
   signedByName?: string;
+  signedByEmail?: string;
   signingToken?: string;
   signingEmailSentAt?: number;
+  sentByUserId?: string;
+  voidedAt?: number;
+  voidedByUserId?: string;
   contentJsonSnapshot?: string | null;
 }
 
@@ -116,10 +123,13 @@ export function EntityDocumentsTab({
   const [sendSuccessDocId, setSendSuccessDocId] = useState<string | null>(null);
   const [deletingDocId, setDeletingDocId] = useState<Id<"formDocuments"> | null>(null);
   const [docToDelete, setDocToDelete] = useState<Id<"formDocuments"> | null>(null);
+  const [voidingDocId, setVoidingDocId] = useState<Id<"formDocuments"> | null>(null);
+  const [docToVoid, setDocToVoid] = useState<Id<"formDocuments"> | null>(null);
 
   const resendSigningEmail = useAction(api.documents.documents.resendSigningEmail);
   const reorderByEntity = useAction(api.documents.documents.reorderByEntity);
   const removeDocument = useAction(api.documents.documents.remove);
+  const voidDocument = useAction(api.documents.documents.voidDocument);
 
   // --- Document list ---
 
@@ -252,6 +262,35 @@ export function EntityDocumentsTab({
       setDeletingDocId(null);
     }
   }, [docToDelete, removeDocument, organizationId, refetch, t]);
+
+  const handleVoidClick = useCallback(
+    (e: React.MouseEvent, docId: Id<"formDocuments">) => {
+      e.stopPropagation();
+      setDocToVoid(docId);
+    },
+    [],
+  );
+
+  const handleVoidConfirm = useCallback(async () => {
+    if (!docToVoid) return;
+    const docId = docToVoid;
+    setVoidingDocId(docId);
+    setDocToVoid(null);
+    if (viewingDocId === docId) setViewingDocId(null);
+    try {
+      await voidDocument({ organizationId, documentId: docId });
+      toast.success(t("documents.voided", "Dokument unieważniony"));
+      refetch();
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : t("documents.voidFailed", "Nie udało się unieważnić dokumentu"),
+      );
+    } finally {
+      setVoidingDocId(null);
+    }
+  }, [docToVoid, voidDocument, organizationId, refetch, t, viewingDocId]);
 
   // --- Viewing document ---
 
@@ -402,9 +441,11 @@ export function EntityDocumentsTab({
                   sendingDocId={sendingDocId}
                   sendSuccessDocId={sendSuccessDocId}
                   deletingDocId={deletingDocId}
+                  voidingDocId={voidingDocId}
                   onOpen={() => setViewingDocId(doc._id)}
                   onSend={handleSend}
                   onDelete={handleDeleteClick}
+                  onVoid={handleVoidClick}
                 />
               ))}
             </div>
@@ -445,17 +486,65 @@ export function EntityDocumentsTab({
 
             {viewingDoc && (
               <div className="space-y-4 mt-4">
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 flex-wrap">
                   <DocumentStatusBadge status={viewingDoc.status} />
-                  {viewingDoc.signedAt && (
-                    <span className="text-xs text-muted-foreground">
-                      {t("documents.signedAt", "Podpisano")}:{" "}
-                      {new Date(viewingDoc.signedAt).toLocaleDateString(
-                        i18n.language === "en" ? "en-US" : "pl-PL",
-                      )}
+                  {viewingDoc.templateVersion != null && (
+                    <span className="inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-mono text-muted-foreground">
+                      v{viewingDoc.templateVersion}
                     </span>
                   )}
                 </div>
+
+                {/* Chronological audit timeline */}
+                <div className="rounded-lg border divide-y text-sm">
+                  <DocumentAuditEvent
+                    icon={<FileText className="h-3.5 w-3.5" />}
+                    label={t("documents.audit.created", "Utworzono")}
+                    ts={viewingDoc.createdAt}
+                    locale={i18n.language === "en" ? "en-US" : "pl-PL"}
+                  />
+                  {viewingDoc.signingEmailSentAt && (
+                    <DocumentAuditEvent
+                      icon={<Send className="h-3.5 w-3.5" />}
+                      label={t("documents.audit.sent", "Wysłano do podpisu")}
+                      ts={viewingDoc.signingEmailSentAt}
+                      locale={i18n.language === "en" ? "en-US" : "pl-PL"}
+                    />
+                  )}
+                  {viewingDoc.signedAt && (
+                    <DocumentAuditEvent
+                      icon={<UserCheck className="h-3.5 w-3.5" />}
+                      label={t("documents.audit.signed", "Podpisano")}
+                      ts={viewingDoc.signedAt}
+                      detail={viewingDoc.signedByName ?? viewingDoc.signedByEmail}
+                      locale={i18n.language === "en" ? "en-US" : "pl-PL"}
+                    />
+                  )}
+                  {viewingDoc.voidedAt && (
+                    <DocumentAuditEvent
+                      icon={<OctagonX className="h-3.5 w-3.5 text-destructive" />}
+                      label={t("documents.audit.voided", "Unieważniono")}
+                      ts={viewingDoc.voidedAt}
+                      locale={i18n.language === "en" ? "en-US" : "pl-PL"}
+                    />
+                  )}
+                </div>
+
+                {/* Void action for signed/completed docs */}
+                {(viewingDoc.status === "signed" || viewingDoc.status === "completed") && (
+                  <div className="flex justify-end">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="text-destructive border-destructive/40 hover:bg-destructive/5"
+                      onClick={(e) => handleVoidClick(e, viewingDoc._id)}
+                    >
+                      <OctagonX className="h-3.5 w-3.5 mr-1.5" />
+                      {t("documents.void", "Unieważnij")}
+                    </Button>
+                  </div>
+                )}
+
 
                 {viewingTemplate &&
                   (() => {
@@ -570,6 +659,37 @@ export function EntityDocumentsTab({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Void confirmation dialog */}
+      <AlertDialog
+        open={!!docToVoid}
+        onOpenChange={(open) => !open && setDocToVoid(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("documents.voidDialogTitle", "Unieważnij dokument")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t(
+                "documents.voidDialogDescription",
+                "Czy na pewno chcesz unieważnić ten dokument? Operacja jest nieodwracalna.",
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              {t("common.cancel", "Anuluj")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleVoidConfirm}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {t("documents.void", "Unieważnij")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }
@@ -584,9 +704,11 @@ interface SortableDocumentRowProps {
   sendingDocId: string | null;
   sendSuccessDocId: string | null;
   deletingDocId: Id<"formDocuments"> | null;
+  voidingDocId: Id<"formDocuments"> | null;
   onOpen: () => void;
   onSend: (e: React.MouseEvent, docId: Id<"formDocuments">) => void;
   onDelete: (e: React.MouseEvent, docId: Id<"formDocuments">) => void;
+  onVoid: (e: React.MouseEvent, docId: Id<"formDocuments">) => void;
 }
 
 function SortableDocumentRow({
@@ -595,9 +717,11 @@ function SortableDocumentRow({
   sendingDocId,
   sendSuccessDocId,
   deletingDocId,
+  voidingDocId,
   onOpen,
   onSend,
   onDelete,
+  onVoid,
 }: SortableDocumentRowProps) {
   const { t } = useTranslation();
   const {
@@ -699,6 +823,22 @@ function SortableDocumentRow({
         >
           <Eye className="h-4 w-4" variant="stroke" />
         </Button>
+        {(doc.status === "signed" || doc.status === "completed") && (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="hidden sm:flex h-7 w-7 p-0 text-muted-foreground hover:text-destructive shrink-0"
+            disabled={voidingDocId === doc._id}
+            aria-label={t("documents.void", "Unieważnij")}
+            onClick={(e) => onVoid(e, doc._id)}
+          >
+            {voidingDocId === doc._id ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <OctagonX className="h-3.5 w-3.5" variant="stroke" />
+            )}
+          </Button>
+        )}
         <Button
           size="sm"
           variant="ghost"
@@ -714,6 +854,38 @@ function SortableDocumentRow({
           )}
         </Button>
       </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Audit timeline event row
+// ---------------------------------------------------------------------------
+
+function DocumentAuditEvent({
+  icon,
+  label,
+  ts,
+  detail,
+  locale,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  ts: number;
+  detail?: string;
+  locale: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 px-3 py-2 text-xs">
+      <span className="text-muted-foreground shrink-0">{icon}</span>
+      <span className="flex-1 text-muted-foreground">{label}</span>
+      {detail && (
+        <span className="text-foreground font-medium truncate max-w-[120px]">{detail}</span>
+      )}
+      <span className="text-muted-foreground shrink-0 tabular-nums">
+        {new Date(ts).toLocaleDateString(locale)}{" "}
+        {new Date(ts).toLocaleTimeString(locale, { hour: "2-digit", minute: "2-digit" })}
+      </span>
     </div>
   );
 }

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -148,6 +148,7 @@
  *   • 00141_drop_document_instances.sql
  *   • 00142_form_documents_expires_at.sql
  *   • 00143_form_documents_is_required.sql
+ *   • 00144_form_documents_audit_fields.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -5911,6 +5912,9 @@ export interface Database {
           expires_at: number | null;
           document_validity_days: number | null;
           is_required: boolean | null;
+          sent_by_user_id: string | null;
+          voided_by_user_id: string | null;
+          voided_at: number | null;
         };
         Insert: {
           id?: string;
@@ -5946,6 +5950,9 @@ export interface Database {
           expires_at?: number | null;
           document_validity_days?: number | null;
           is_required?: boolean | null;
+          sent_by_user_id?: string | null;
+          voided_by_user_id?: string | null;
+          voided_at?: number | null;
         };
         Update: {
           id?: string;
@@ -5981,6 +5988,9 @@ export interface Database {
           expires_at?: number | null;
           document_validity_days?: number | null;
           is_required?: boolean | null;
+          sent_by_user_id?: string | null;
+          voided_by_user_id?: string | null;
+          voided_at?: number | null;
         };
         Relationships: [
           {

--- a/src/lib/supabase/mappers/form-documents.ts
+++ b/src/lib/supabase/mappers/form-documents.ts
@@ -38,6 +38,9 @@ export interface MappedFormDocument {
   createdBy: string;
   createdAt: number;
   updatedAt: number;
+  sentByUserId?: string;
+  voidedByUserId?: string;
+  voidedAt?: number;
   _source: "supabase";
 }
 

--- a/supabase/migrations/00144_form_documents_audit_fields.sql
+++ b/supabase/migrations/00144_form_documents_audit_fields.sql
@@ -1,0 +1,8 @@
+-- D31: Complete document audit trail
+-- Adds who-sent and who-voided tracking to form_documents so every lifecycle
+-- event (created, sent, signed, voided) has both a user ID (stored on the row
+-- and written to audit_log) and a timestamp.
+ALTER TABLE form_documents
+  ADD COLUMN IF NOT EXISTS sent_by_user_id   text,
+  ADD COLUMN IF NOT EXISTS voided_by_user_id text,
+  ADD COLUMN IF NOT EXISTS voided_at         bigint;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5470.

Closes #5470

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 13c06a4a feat(gabinet/documents): complete audit trail with sent/voided tracking and timeline UI (closes #5470)

### Files changed

```
 convex/documents/documents.ts                      | 143 +++++++++++++++-
 convex/schema/documents.ts                         |   5 +
 public/locales/en/translation.json                 |  15 +-
 public/locales/pl/translation.json                 |  15 +-
 src/components/documents/entity-documents-tab.tsx  | 186 ++++++++++++++++++++-
 src/lib/supabase/database.types.ts                 |  10 ++
 src/lib/supabase/mappers/form-documents.ts         |   3 +
 .../00144_form_documents_audit_fields.sql          |   8 +
 8 files changed, 367 insertions(+), 18 deletions(-)
```