### PR TITLE
`updateStatus` action can silently set status to `"voided"` bypassing the new `v

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -397,6 +397,12 @@ export const updateStatus = action({
     status: formDocumentStatusValidator,
   },
   handler: async (ctx, args) => {
+    if (args.status === "voided") {
+      throw new Error(
+        "Use voidDocument to void a document — updateStatus cannot set status to 'voided'",
+      );
+    }
+
     await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5474.

Closes #5474

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 254c6e4e fix(documents): block voided status in updateStatus to prevent audit bypass (closes #5474)

### Files changed

```
 convex/documents/documents.ts | 6 ++++++
 1 file changed, 6 insertions(+)
```