### PR TITLE
Restrict `updateStatus` from setting `"signed"` status directly

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -402,6 +402,11 @@ export const updateStatus = action({
         "Use voidDocument to void a document — updateStatus cannot set status to 'voided'",
       );
     }
+    if (args.status === "signed") {
+      throw new Error(
+        "Use recordSignature to sign a document — updateStatus cannot set status to 'signed'",
+      );
+    }
 
     await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5478.

Closes #5478

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 3df661f8 fix(documents): block signed status in updateStatus to prevent signature bypass (closes #5478)

### Files changed

```
 convex/documents/documents.ts | 5 +++++
 1 file changed, 5 insertions(+)
```