### PR TITLE
D32 — Dokumenty — audyt powiązania dokument ↔ klient ↔ wizyta ↔ Zabieg w UI

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.documents.index.tsx
@@ -1072,6 +1072,51 @@ function GabinetDocumentsPage() {
                   </span>
                 </div>
                 {(() => {
+                  const patientName = getDocPatientName(selectedDoc);
+                  return patientName ? (
+                    <div className="flex items-center justify-between">
+                      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                        <User size={12} variant="stroke" />
+                        {t("gabinet.formDocuments.colPatient", "Klient")}
+                      </span>
+                      <span className="text-xs font-semibold truncate max-w-[150px]">
+                        {patientName}
+                      </span>
+                    </div>
+                  ) : null;
+                })()}
+                {(() => {
+                  const appt = getDocAppointmentInfo(selectedDoc);
+                  return appt ? (
+                    <div className="flex items-center justify-between">
+                      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                        <Calendar size={12} variant="stroke" />
+                        {t("gabinet.formDocuments.colAppointment", "Wizyta")}
+                      </span>
+                      <span className="text-xs font-semibold tabular-nums">
+                        {new Date(appt.date).toLocaleDateString(
+                          lang === "en" ? "en-US" : "pl-PL",
+                          { year: "numeric", month: "short", day: "numeric" },
+                        )}
+                      </span>
+                    </div>
+                  ) : null;
+                })()}
+                {(() => {
+                  const treatmentName = getDocTreatmentName(selectedDoc);
+                  return treatmentName ? (
+                    <div className="flex items-center justify-between">
+                      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                        <Tag size={12} variant="stroke" />
+                        {t("gabinet.formDocuments.colTreatment", "Zabieg")}
+                      </span>
+                      <span className="text-xs font-semibold truncate max-w-[150px]">
+                        {treatmentName}
+                      </span>
+                    </div>
+                  ) : null;
+                })()}
+                {(() => {
                   let signerName = selectedDoc.signedByName;
                   if (!signerName) {
                     if (selectedDoc.entityType === "patient") {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5482.

Closes #5482

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 26068d14 fix(gabinet/documents): show linked client/visit/treatment in document side panel (closes #5482)

### Files changed

```
 .../dashboard/_layout.gabinet.documents.index.tsx  | 45 ++++++++++++++++++++++
 1 file changed, 45 insertions(+)
```