### PR TITLE
D33 — Dokumenty — produkty i LOT w historii wykonanego Zabiegu

### DIFF
--- a/src/components/gabinet/appointments/appointment-history-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-history-tab.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/card";
 import {
   Activity,
+  Archive,
   Calendar,
   CreditCard,
   History,
@@ -16,6 +17,7 @@ import {
   Plus,
   Star,
 } from "@/lib/ez-icons";
+import type { AppointmentUsedProduct } from "@/hooks/use-supabase-products";
 import type { TFunction } from "i18next";
 import { formatCurrencyPLN } from "@/lib/format-currency";
 import { EmptyState } from "@/components/layout/empty-state";
@@ -60,6 +62,7 @@ export function AppointmentHistoryTab({
   loyaltyTier,
   loyaltyTransactions,
   allPatientPayments,
+  appointmentUsedProducts,
   canEdit,
   onUseMultiple,
   formatDate,
@@ -74,6 +77,7 @@ export function AppointmentHistoryTab({
   loyaltyTier: string | null | undefined;
   loyaltyTransactions: Record<string, unknown>[] | null | undefined;
   allPatientPayments: Record<string, unknown>[] | null | undefined;
+  appointmentUsedProducts?: AppointmentUsedProduct[];
   canEdit: boolean;
   onUseMultiple: (pkg: PackageUsageEntry) => void;
   formatDate: (dateStr: string) => string;
@@ -103,6 +107,95 @@ export function AppointmentHistoryTab({
           />
         </CardContent>
       </Card>
+
+      {/* Used Products / LOT */}
+      {appointmentUsedProducts !== undefined && (
+        <Card>
+          <CardHeader className="px-6 py-3 border-b">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Archive className="h-4 w-4" variant="stroke" />
+              {t(
+                "gabinet.appointments.usedProducts",
+                "Zużyte produkty",
+              )}
+            </CardTitle>
+            <CardDescription className="text-xs">
+              {t(
+                "gabinet.appointments.usedProductsDesc",
+                "Produkty pobrane z magazynu podczas tej wizyty",
+              )}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="px-6 py-4">
+            {appointmentUsedProducts.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                {t(
+                  "gabinet.appointments.noUsedProducts",
+                  "Brak zarejestrowanych ruchów magazynowych dla tej wizyty.",
+                )}
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b">
+                      <th className="text-left py-2 pr-4 font-medium text-muted-foreground">
+                        {t("gabinet.appointments.usedProductName", "Produkt")}
+                      </th>
+                      <th className="text-right py-2 pr-4 font-medium text-muted-foreground">
+                        {t("gabinet.appointments.usedProductQty", "Ilość")}
+                      </th>
+                      <th className="text-left py-2 pr-4 font-medium text-muted-foreground">
+                        {t("gabinet.appointments.usedProductLot", "Nr LOT")}
+                      </th>
+                      <th className="text-left py-2 font-medium text-muted-foreground">
+                        {t(
+                          "gabinet.appointments.usedProductExpiry",
+                          "Data ważności",
+                        )}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {appointmentUsedProducts.map((item) => (
+                      <tr
+                        key={item._id}
+                        className="border-b last:border-0"
+                      >
+                        <td className="py-2 pr-4 font-medium">
+                          {item.productName}
+                        </td>
+                        <td className="py-2 pr-4 text-right tabular-nums">
+                          {item.quantity}
+                          {item.stockUnit ? (
+                            <span className="ml-1 text-muted-foreground">
+                              {item.stockUnit}
+                            </span>
+                          ) : null}
+                        </td>
+                        <td className="py-2 pr-4">
+                          {item.lotNumber ?? (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                        </td>
+                        <td className="py-2">
+                          {item.expiryDate ? (
+                            new Date(item.expiryDate).toLocaleDateString(
+                              language,
+                            )
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       {/* Past Appointments Timeline */}
       <Card>

--- a/src/hooks/use-supabase-products.ts
+++ b/src/hooks/use-supabase-products.ts
@@ -445,3 +445,79 @@ export function useSupabaseOrgExpiringLotBatches(
     enabled: enabled && isReady && !!organizationId,
   });
 }
+
+// ---------------------------------------------------------------------------
+// Appointment Used Products (#5484)
+//
+// Fetches all appointment_use stock movements for a given appointment,
+// joining products to get the name and unit. Used in the appointment history
+// tab to show which products (and LOT batches) were actually consumed.
+// ---------------------------------------------------------------------------
+
+export interface AppointmentUsedProduct {
+  _id: string;
+  productId: string;
+  productName: string;
+  quantity: number;
+  stockUnit: string | null;
+  lotNumber: string | null;
+  expiryDate: string | null;
+  treatmentId: string | null;
+}
+
+export function useSupabaseAppointmentStockMovements(
+  organizationId: string,
+  appointmentId: string | null | undefined,
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  return useQuery<AppointmentUsedProduct[], Error>({
+    queryKey: [
+      "supabase",
+      "appointmentStockMovements",
+      organizationId,
+      appointmentId ?? "",
+    ],
+    queryFn: async (): Promise<AppointmentUsedProduct[]> => {
+      if (!client || !appointmentId) return [];
+
+      const { data, error } = await client
+        .from("product_stock_movements")
+        .select(
+          `id, product_id, delta, lot_number, expiry_date, treatment_id,
+           products!product_stock_movements_product_id_fkey(name, stock_unit)`,
+        )
+        .eq("organization_id", organizationId)
+        .eq("source_type", "appointment")
+        .eq("source_id", appointmentId)
+        .eq("reason", "appointment_use")
+        .order("created_at", { ascending: true });
+
+      if (error) throw error;
+
+      type Row = {
+        id: string;
+        product_id: string;
+        delta: number;
+        lot_number: string | null;
+        expiry_date: string | null;
+        treatment_id: string | null;
+        products: { name: string; stock_unit: string | null } | null;
+      };
+
+      return ((data ?? []) as Row[]).map((row) => ({
+        _id: row.id,
+        productId: row.product_id,
+        productName: row.products?.name ?? row.product_id,
+        quantity: Math.abs(Number(row.delta)),
+        stockUnit: row.products?.stock_unit ?? null,
+        lotNumber: row.lot_number,
+        expiryDate: row.expiry_date,
+        treatmentId: row.treatment_id,
+      }));
+    },
+    enabled: enabled && isReady && !!organizationId && !!appointmentId,
+  });
+}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -15,6 +15,7 @@ import { useSupabaseGabinetEquipmentList } from "@/hooks/use-supabase-gabinet-eq
 import { useSupabaseGabinetSameDayAppointments } from "@/hooks/use-supabase-gabinet-appointments";
 import { useSupabaseAutomationEntityRuns } from "@/hooks/use-supabase-automation";
 import { useSupabaseGabinetReceiptsByAppointment } from "@/hooks/use-supabase-gabinet-receipts";
+import { useSupabaseAppointmentStockMovements } from "@/hooks/use-supabase-products";
 
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -382,6 +383,9 @@ function AppointmentDetail() {
     organizationId,
     appointmentId,
   );
+
+  const { data: appointmentUsedProducts = [] } =
+    useSupabaseAppointmentStockMovements(organizationId, appointmentId);
 
   // Which additional same-day appointments to include in the batch settlement.
   const [selectedAdditionalIds, setSelectedAdditionalIds] = useState<Set<string>>(
@@ -1181,6 +1185,7 @@ function AppointmentDetail() {
           loyaltyTier={loyaltyTier as string | null | undefined}
           loyaltyTransactions={loyaltyTransactions as Record<string, unknown>[] | null | undefined}
           allPatientPayments={allPatientPayments as Record<string, unknown>[] | null | undefined}
+          appointmentUsedProducts={appointmentUsedProducts}
           canEdit={canEdit}
           onUseMultiple={(pkg) => {
             setUsageDialogPkgId(pkg._id);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5484.

Closes #5484

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4a13faa7 feat(gabinet/appointments): show used products and LOT in appointment history tab (closes #5484)

### Files changed

```
 .../appointments/appointment-history-tab.tsx       | 93 ++++++++++++++++++++++
 src/hooks/use-supabase-products.ts                 | 76 ++++++++++++++++++
 ...ut.gabinet.appointments.$appointmentId.lazy.tsx |  5 ++
 3 files changed, 174 insertions(+)
```