### PR TITLE
D34 — Dokumenty — uprawnienia modułu Dokumentacja

### DIFF
--- a/convex/documents/documents.ts
+++ b/convex/documents/documents.ts
@@ -25,6 +25,11 @@ export const listAll = action({
     await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_documents", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
     const db = createSupabaseDb();
     let q = db
       .query("formDocuments")
@@ -48,6 +53,11 @@ export const listByEntity = action({
     await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_documents", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
     const db = createSupabaseDb();
     const docs = (await db
       .query("formDocuments")
@@ -81,6 +91,11 @@ export const reorderByEntity = action({
     await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_documents", action: "edit" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
     const now = Date.now();
@@ -113,6 +128,11 @@ export const getById = action({
     await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_documents", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
     const db = createSupabaseDb();
     const doc = await db.get("formDocuments", args.documentId);
     if (!doc || String(doc.organizationId) !== String(args.organizationId))
@@ -171,6 +191,11 @@ export const listByTemplate = action({
     await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_documents", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
     const db = createSupabaseDb();
     return (await db
       .query("formDocuments")
@@ -189,6 +214,11 @@ export const listByStatus = action({
     await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_documents", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
     const db = createSupabaseDb();
     return (await db
       .query("formDocuments")
@@ -224,6 +254,11 @@ export const getLatestSignedIntakeByPatient = action({
     await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
       organizationId: args.organizationId,
     });
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_documents", action: "view" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
     const orgIdStr = String(args.organizationId);
@@ -338,6 +373,11 @@ export const create = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_documents", action: "create" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
 
     const now = Date.now();
     const db = createSupabaseDb();
@@ -408,15 +448,22 @@ export const updateStatus = action({
       );
     }
 
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
-    );
+    ) as { userId: string };
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_documents", action: "edit" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
     const doc = await db.get("formDocuments", args.documentId);
     if (!doc || String(doc.organizationId) !== String(args.organizationId))
       throw new Error("Document not found");
+    if (perm.scope === "own" && String(doc.createdBy) !== String(authResult.userId))
+      throw new Error("Permission denied: you can only update your own documents");
 
     await db.patch("formDocuments", args.documentId, {
       status: args.status,
@@ -433,15 +480,22 @@ export const updateResponseData = action({
     responseData: v.string(),
   },
   handler: async (ctx, args) => {
-    await ctx.runAction(
+    const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
-    );
+    ) as { userId: string };
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_documents", action: "edit" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
     const doc = await db.get("formDocuments", args.documentId);
     if (!doc || String(doc.organizationId) !== String(args.organizationId))
       throw new Error("Document not found");
+    if (perm.scope === "own" && String(doc.createdBy) !== String(authResult.userId))
+      throw new Error("Permission denied: you can only update your own documents");
     if (doc.status !== "draft")
       throw new Error("Can only update response data on draft documents");
 
@@ -528,11 +582,18 @@ export const submitEmployeeFormFields = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     ) as { userId: string };
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "gabinet_documents", action: "edit" },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
     const doc = await db.get("formDocuments", args.documentId);
     if (!doc || String(doc.organizationId) !== String(args.organizationId))
       throw new Error("Document not found");
+    if (perm.scope === "own" && String(doc.createdBy) !== String(authResult.userId))
+      throw new Error("Permission denied: you can only update your own documents");
     if (doc.status !== "draft")
       throw new Error("Document is not in draft status");
 

--- a/convex/documents/templates.ts
+++ b/convex/documents/templates.ts
@@ -142,14 +142,15 @@ export const create = action({
     isOrgRequired: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
-    // requireOrgAdmin via authAction
     const authResult = await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
-    if (authResult.role !== "owner" && authResult.role !== "admin") {
-      throw new Error("Admin access required");
-    }
+    const createPerm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "document_templates", action: "create" },
+    ) as { allowed: boolean; scope: string };
+    if (!createPerm.allowed) throw new Error("Permission denied");
 
     const now = Date.now();
     const db = createSupabaseDb();
@@ -191,9 +192,11 @@ export const duplicate = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
-    if (authResult.role !== "owner" && authResult.role !== "admin") {
-      throw new Error("Admin access required");
-    }
+    const createPerm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "document_templates", action: "create" },
+    ) as { allowed: boolean; scope: string };
+    if (!createPerm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
     const source = await db.get("formTemplates", args.templateId);
@@ -271,9 +274,11 @@ export const update = action({
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
-    if (authResult.role !== "owner" && authResult.role !== "admin") {
-      throw new Error("Admin access required");
-    }
+    const editPerm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "document_templates", action: "edit" },
+    ) as { allowed: boolean; scope: string };
+    if (!editPerm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
     const tmpl = await db.get("formTemplates", args.templateId);
@@ -305,13 +310,15 @@ export const remove = action({
     templateId: v.string(),
   },
   handler: async (ctx, args) => {
-    const authResult = await ctx.runAction(
+    await ctx.runAction(
       internal._helpers.authAction.verifyOrgAccess,
       { organizationId: args.organizationId },
     );
-    if (authResult.role !== "owner" && authResult.role !== "admin") {
-      throw new Error("Admin access required");
-    }
+    const deletePerm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      { organizationId: args.organizationId, feature: "document_templates", action: "delete" },
+    ) as { allowed: boolean; scope: string };
+    if (!deletePerm.allowed) throw new Error("Permission denied");
 
     const db = createSupabaseDb();
     const tmpl = await db.get("formTemplates", args.templateId);

--- a/src/components/documents/appointment-document-checklist.tsx
+++ b/src/components/documents/appointment-document-checklist.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import type { TFunction } from "i18next";
+import { usePermission } from "@/hooks/use-permission";
 import { useQuery } from "@tanstack/react-query";
 import { useAction } from "convex/react";
 import { toast } from "sonner";
@@ -102,6 +103,7 @@ export function AppointmentDocumentChecklist({
   onDocumentClick,
 }: AppointmentDocumentChecklistProps) {
   const { t, i18n } = useTranslation();
+  const { allowed: canCreateDocuments } = usePermission("gabinet_documents", "create");
 
   const [viewingDocId, setViewingDocId] =
     useState<Id<"formDocuments"> | null>(null);
@@ -209,10 +211,12 @@ export function AppointmentDocumentChecklist({
             "Zabieg nie ma przypisanych szablonow dokumentow. Mozesz wygenerowac dokument recznie.",
           )}
           action={
-            <Button onClick={() => setGenerateOpen(true)}>
-              <Plus className="mr-2 h-4 w-4" variant="stroke" />
-              {t("documents.generate", "Wygeneruj dokument")}
-            </Button>
+            canCreateDocuments ? (
+              <Button onClick={() => setGenerateOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" variant="stroke" />
+                {t("documents.generate", "Wygeneruj dokument")}
+              </Button>
+            ) : undefined
           }
         />
 
@@ -276,16 +280,18 @@ export function AppointmentDocumentChecklist({
         )}
 
         {/* Generate additional document button */}
-        <div className="flex justify-end">
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => setGenerateOpen(true)}
-          >
-            <Plus className="mr-2 h-4 w-4" variant="stroke" />
-            {t("documents.generateAdditional", "Wygeneruj dodatkowy dokument")}
-          </Button>
-        </div>
+        {canCreateDocuments && (
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setGenerateOpen(true)}
+            >
+              <Plus className="mr-2 h-4 w-4" variant="stroke" />
+              {t("documents.generateAdditional", "Wygeneruj dodatkowy dokument")}
+            </Button>
+          </div>
+        )}
       </div>
 
       {/* Generate dialog */}
@@ -429,6 +435,7 @@ function DocumentSection({
   const resendSigningEmail = useAction(api.documents.documents.resendSigningEmail);
   const [resendingDocId, setResendingDocId] = useState<string | null>(null);
   const [resendSuccess, setResendSuccess] = useState<string | null>(null);
+  const { allowed: canEditDocuments } = usePermission("gabinet_documents", "edit");
 
   const handleResend = useCallback(
     async (e: React.MouseEvent, docId: Id<"formDocuments">) => {
@@ -517,7 +524,7 @@ function DocumentSection({
                   </Button>
                 ) : doc.status === "voided" || doc.status === "expired" ? null : (
                   <>
-                    {canResend && (
+                    {canResend && canEditDocuments && (
                       <Button
                         size="sm"
                         variant="ghost"

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -189,6 +189,7 @@ function AppointmentDetail() {
   const { t, i18n } = useTranslation();
   const { allowed: canEdit } = usePermission("gabinet_appointments", "edit");
   const { allowed: canDelete } = usePermission("gabinet_appointments", "delete");
+  const { allowed: canViewDocuments } = usePermission("gabinet_documents", "view");
   const { allowed: canCreatePayment } = usePermission("gabinet_payments", "create");
   const { allowed: canEditPayment } = usePermission("gabinet_payments", "edit");
   const { allowed: canRefundPayment } = usePermission("gabinet_payments", "refund");
@@ -1228,7 +1229,7 @@ function AppointmentDetail() {
         />
       ),
     },
-    {
+    ...(canViewDocuments ? [{
       label: t("gabinet.appointments.tabs.documents", "Dokumenty"),
       content: (
         <AppointmentDocumentChecklist
@@ -1237,7 +1238,7 @@ function AppointmentDetail() {
           treatmentId={detail.treatments?.[0]?.treatmentId ?? undefined}
         />
       ),
-    },
+    }] : []),
     {
       label: t("gabinet.receipts.receiptHistory", "Paragony"),
       count: appointmentReceipts.length > 0 ? appointmentReceipts.length : undefined,

--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMutation, useAction } from "convex/react";
 import { api } from "@cvx/_generated/api";
 import { useOrganization } from "@/components/org-context";
+import { usePermission } from "@/hooks/use-permission";
 import { useTranslation } from "react-i18next";
 import { SectionHeader } from "@untitled/app/section-headers/section-headers";
 import { UntitledAlert } from "@/components/ui/untitled-alert";
@@ -615,6 +616,10 @@ export function FormTemplatesListPage() {
   const { organizationId } = useOrganization();
   const navigate = useNavigate();
 
+  const { allowed: canCreateTemplate } = usePermission("document_templates", "create");
+  const { allowed: canEditTemplate } = usePermission("document_templates", "edit");
+  const { allowed: canDeleteTemplate } = usePermission("document_templates", "delete");
+
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("active");
   const [categoryFilter, setCategoryFilter] = useState<string>("all");
@@ -950,15 +955,19 @@ export function FormTemplatesListPage() {
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            <Button size="sm" variant="outline" onClick={() => setScanOpen(true)}>
-              {t("settings.formTemplates.scanNew", "Nowy ze skanu")}
-            </Button>
-            <Button size="sm" variant="outline" asChild>
-              <Link to="/dashboard/document-editor/new">
-                <Plus className="mr-2 h-4 w-4" variant="stroke" />
-                {t("settings.formTemplates.newTemplate")}
-              </Link>
-            </Button>
+            {canCreateTemplate && (
+              <Button size="sm" variant="outline" onClick={() => setScanOpen(true)}>
+                {t("settings.formTemplates.scanNew", "Nowy ze skanu")}
+              </Button>
+            )}
+            {canCreateTemplate && (
+              <Button size="sm" variant="outline" asChild>
+                <Link to="/dashboard/document-editor/new">
+                  <Plus className="mr-2 h-4 w-4" variant="stroke" />
+                  {t("settings.formTemplates.newTemplate")}
+                </Link>
+              </Button>
+            )}
           </SectionHeader.Actions>
         </SectionHeader.Group>
         <UntitledAlert>{t("settings.formTemplates.description")}</UntitledAlert>
@@ -1015,12 +1024,14 @@ export function FormTemplatesListPage() {
           title={t("settings.formTemplates.emptyTitle")}
           description={t("settings.formTemplates.emptyDescription")}
           action={
-            <Button asChild>
-              <Link to="/dashboard/document-editor/new">
-                <Plus className="mr-2 h-4 w-4" variant="stroke" />
-                {t("settings.formTemplates.newTemplate")}
-              </Link>
-            </Button>
+            canCreateTemplate ? (
+              <Button asChild>
+                <Link to="/dashboard/document-editor/new">
+                  <Plus className="mr-2 h-4 w-4" variant="stroke" />
+                  {t("settings.formTemplates.newTemplate")}
+                </Link>
+              </Button>
+            ) : undefined
           }
         />
       ) : (

--- a/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.settings.form-templates.index.tsx
@@ -281,6 +281,9 @@ function TemplateTree({
   onMoveTemplate,
   onRenameFolder,
   onDeleteFolder,
+  canEdit,
+  canDelete,
+  canCreate,
   t,
 }: {
   templates: FormTemplateRecord[];
@@ -296,6 +299,9 @@ function TemplateTree({
   ) => void;
   onRenameFolder: (oldPath: string, newName: string) => void;
   onDeleteFolder: (folderPath: string) => void;
+  canEdit: boolean;
+  canDelete: boolean;
+  canCreate: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   t: any;
 }) {
@@ -375,7 +381,7 @@ function TemplateTree({
                       </span>
                     </span>
                   </TreeItemLabel>
-                  {data.folderFullPath && (
+                  {(canEdit || canDelete) && data.folderFullPath && (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         {/* Rendered as a <div> rather than <Button> because
@@ -392,36 +398,40 @@ function TemplateTree({
                         </div>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
-                        <DropdownMenuItem
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            const currentName =
-                              data.folderFullPath!.split("/").pop() ?? "";
-                            const newName = window.prompt(
-                              t(
-                                "settings.formTemplates.renameFolderPrompt",
-                                "Nowa nazwa folderu:",
-                              ),
-                              currentName,
-                            );
-                            if (newName && newName !== currentName) {
-                              onRenameFolder(data.folderFullPath!, newName);
-                            }
-                          }}
-                        >
-                          <Pencil className="mr-2 h-4 w-4" />
-                          {t("settings.formTemplates.renameFolder", "Zmień nazwę")}
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          className="text-destructive"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onDeleteFolder(data.folderFullPath!);
-                          }}
-                        >
-                          <Trash2 className="mr-2 h-4 w-4" />
-                          {t("settings.formTemplates.deleteFolder", "Usuń folder")}
-                        </DropdownMenuItem>
+                        {canEdit && (
+                          <DropdownMenuItem
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              const currentName =
+                                data.folderFullPath!.split("/").pop() ?? "";
+                              const newName = window.prompt(
+                                t(
+                                  "settings.formTemplates.renameFolderPrompt",
+                                  "Nowa nazwa folderu:",
+                                ),
+                                currentName,
+                              );
+                              if (newName && newName !== currentName) {
+                                onRenameFolder(data.folderFullPath!, newName);
+                              }
+                            }}
+                          >
+                            <Pencil className="mr-2 h-4 w-4" />
+                            {t("settings.formTemplates.renameFolder", "Zmień nazwę")}
+                          </DropdownMenuItem>
+                        )}
+                        {canDelete && (
+                          <DropdownMenuItem
+                            className="text-destructive"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onDeleteFolder(data.folderFullPath!);
+                            }}
+                          >
+                            <Trash2 className="mr-2 h-4 w-4" />
+                            {t("settings.formTemplates.deleteFolder", "Usuń folder")}
+                          </DropdownMenuItem>
+                        )}
                       </DropdownMenuContent>
                     </DropdownMenu>
                   )}
@@ -454,13 +464,15 @@ function TemplateTree({
                     className="flex-1 min-w-0 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
                     onClick={(e) => {
                       e.stopPropagation();
-                      onEditTemplate(tpl._id);
+                      if (canEdit) onEditTemplate(tpl._id);
+                      else onPreviewTemplate(tpl._id);
                     }}
                     onKeyDown={(e) => {
                       if (e.key === "Enter" || e.key === " ") {
                         e.preventDefault();
                         e.stopPropagation();
-                        onEditTemplate(tpl._id);
+                        if (canEdit) onEditTemplate(tpl._id);
+                        else onPreviewTemplate(tpl._id);
                       }
                     }}
                   >
@@ -498,30 +510,32 @@ function TemplateTree({
                     <button role="switch"> and the outer TreeItem wrapper is
                     already a <button>. Nested buttons are invalid HTML
                     (#1912, same pattern as #1907, #1910). */}
-                <div
-                  role="switch"
-                  tabIndex={0}
-                  aria-checked={tpl.isActive}
-                  aria-label={t("settings.formTemplates.toggleActive")}
-                  data-state={tpl.isActive ? "checked" : "unchecked"}
-                  className="peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-input"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onToggleActive(tpl, !tpl.isActive);
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === " " || e.key === "Enter") {
-                      e.preventDefault();
+                {canEdit && (
+                  <div
+                    role="switch"
+                    tabIndex={0}
+                    aria-checked={tpl.isActive}
+                    aria-label={t("settings.formTemplates.toggleActive")}
+                    data-state={tpl.isActive ? "checked" : "unchecked"}
+                    className="peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-input"
+                    onClick={(e) => {
                       e.stopPropagation();
                       onToggleActive(tpl, !tpl.isActive);
-                    }
-                  }}
-                >
-                  <span
-                    data-state={tpl.isActive ? "checked" : "unchecked"}
-                    className="pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
-                  />
-                </div>
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === " " || e.key === "Enter") {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        onToggleActive(tpl, !tpl.isActive);
+                      }
+                    }}
+                  >
+                    <span
+                      data-state={tpl.isActive ? "checked" : "unchecked"}
+                      className="pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+                    />
+                  </div>
+                )}
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     {/* Rendered as a <div> rather than <Button> because the
@@ -538,15 +552,17 @@ function TemplateTree({
                     </div>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onEditTemplate(tpl._id);
-                      }}
-                    >
-                      <Pencil className="mr-2 h-4 w-4" />
-                      {t("common.edit")}
-                    </DropdownMenuItem>
+                    {canEdit && (
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onEditTemplate(tpl._id);
+                        }}
+                      >
+                        <Pencil className="mr-2 h-4 w-4" />
+                        {t("common.edit")}
+                      </DropdownMenuItem>
+                    )}
                     <DropdownMenuItem
                       onClick={(e) => {
                         e.stopPropagation();
@@ -556,15 +572,17 @@ function TemplateTree({
                       <Eye className="mr-2 h-4 w-4" />
                       {t("settings.formTemplates.preview", "Podgląd")}
                     </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onDuplicateTemplate(tpl);
-                      }}
-                    >
-                      <CopyIcon className="mr-2 h-4 w-4" />
-                      {t("settings.formTemplates.duplicate")}
-                    </DropdownMenuItem>
+                    {canCreate && (
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDuplicateTemplate(tpl);
+                        }}
+                      >
+                        <CopyIcon className="mr-2 h-4 w-4" />
+                        {t("settings.formTemplates.duplicate")}
+                      </DropdownMenuItem>
+                    )}
                     <DropdownMenuSeparator />
                     <TooltipProvider delayDuration={200}>
                       <Tooltip>
@@ -584,17 +602,19 @@ function TemplateTree({
                         </TooltipContent>
                       </Tooltip>
                     </TooltipProvider>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      className="text-destructive"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onDeleteTemplate(tpl);
-                      }}
-                    >
-                      <Trash2 className="mr-2 h-4 w-4" />
-                      {t("common.delete")}
-                    </DropdownMenuItem>
+                    {canDelete && <DropdownMenuSeparator />}
+                    {canDelete && (
+                      <DropdownMenuItem
+                        className="text-destructive"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDeleteTemplate(tpl);
+                        }}
+                      >
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        {t("common.delete")}
+                      </DropdownMenuItem>
+                    )}
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
@@ -1054,6 +1074,9 @@ export function FormTemplatesListPage() {
               onMoveTemplate={handleMoveTemplate}
               onRenameFolder={handleRenameFolder}
               onDeleteFolder={handleDeleteFolder}
+              canEdit={canEditTemplate}
+              canDelete={canDeleteTemplate}
+              canCreate={canCreateTemplate}
               t={t}
             />
           </div>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5486.

Closes #5486

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a88883ba fix(settings/form-templates): gate per-row edit/delete/duplicate/toggle on document_templates permissions
- 831eafdf feat(gabinet/documents): enforce gabinet_documents permissions across all document operations (closes #5486)

### Files changed

```
 convex/documents/documents.ts                      |  69 +++++-
 convex/documents/templates.ts                      |  35 ++--
 .../documents/appointment-document-checklist.tsx   |  37 ++--
 ...ut.gabinet.appointments.$appointmentId.lazy.tsx |   5 +-
 .../_layout.settings.form-templates.index.tsx      | 232 ++++++++++++---------
 5 files changed, 244 insertions(+), 134 deletions(-)
```