### PR TITLE
Fix `purgeStaleLocationMemberships.test.ts`

### DIFF
--- a/tests/convex/purgeStaleLocationMemberships.test.ts
+++ b/tests/convex/purgeStaleLocationMemberships.test.ts
@@ -81,8 +81,15 @@ describe("admin/cleanup.purgeStaleConvexIdLocationMemberships", () => {
 
   test("rejects non-platform-admin callers", async () => {
     const t = createTestCtx();
-    const { identity } = await seedTestUser(t);
-    // NOT calling makePlatformAdmin — user is a regular org member
+    const { userId, identity } = await seedTestUser(t);
+    // Insert user into Supabase without isPlatformAdmin so the guard reaches
+    // the isPlatformAdmin check (not the "User not found" early exit).
+    await createSupabaseDb().insert("users", {
+      _id: String(userId),
+      name: "Regular User",
+      email: `user-${String(userId)}@example.com`,
+      isPlatformAdmin: false,
+    });
 
     await expect(
       t


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5497.

Closes #5497

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 6d595647 fix(tests): seed Supabase users row in purgeStaleLocationMemberships auth test (closes #5497)

### Files changed

```
 tests/convex/purgeStaleLocationMemberships.test.ts | 11 +++++++++--
 1 file changed, 9 insertions(+), 2 deletions(-)
```