### PR TITLE
Fix regression in `backfillEntitlements.test.ts` (1 test)

### DIFF
--- a/convex/admin/entitlements.ts
+++ b/convex/admin/entitlements.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { action, internalAction, internalMutation } from "../_generated/server";
+import { action, internalAction, internalMutation, internalQuery } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { logAudit } from "../auditLog";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
@@ -86,6 +86,21 @@ export const _listEntitlementsInternal = internalAction({
   handler: async (): Promise<Array<{ organizationId: string; productId: string; status: string }>> => {
     const db = createSupabaseDb();
     const rows = await db.query("productSubscriptions").collect();
+    return rows.map((r) => ({
+      organizationId: String(r.organizationId),
+      productId: String(r.productId),
+      status: String(r.status),
+    }));
+  },
+});
+
+// Reads productSubscriptions from Convex ctx.db — used by the backfill migration
+// for idempotency checks, since _upsertEntitlement writes to Convex, not Supabase.
+export const _listEntitlementsFromConvex = internalQuery({
+  args: {},
+  returns: v.array(entitlementRowValidator),
+  handler: async (ctx): Promise<Array<{ organizationId: string; productId: string; status: string }>> => {
+    const rows = await ctx.db.query("productSubscriptions").collect();
     return rows.map((r) => ({
       organizationId: String(r.organizationId),
       productId: String(r.productId),

--- a/convex/migrations/backfillEntitlements.ts
+++ b/convex/migrations/backfillEntitlements.ts
@@ -21,8 +21,8 @@ export const run = internalAction({
     const dryRun = args.dryRun ?? false;
     const db = createSupabaseDb();
     const orgs = await db.query("organizations").collect();
-    const existing = await ctx.runAction(
-      internal.admin.entitlements._listEntitlementsInternal,
+    const existing = await ctx.runQuery(
+      internal.admin.entitlements._listEntitlementsFromConvex,
       {},
     );
     const has = (orgId: string, productId: string) =>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5503.

Closes #5503

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 497930e6 fix(tests): align backfillEntitlements idempotency check with Convex write path (closes #5503)

### Files changed

```
 convex/admin/entitlements.ts              | 17 ++++++++++++++++-
 convex/migrations/backfillEntitlements.ts |  4 ++--
 2 files changed, 18 insertions(+), 3 deletions(-)
```