### PR TITLE
Fix regression in `gdprErase.test.ts` (3 tests)

### DIFF
--- a/tests/convex/gdprErase.test.ts
+++ b/tests/convex/gdprErase.test.ts
@@ -18,27 +18,27 @@ describe("gabinet/patients.gdprErase — activity and note anonymization", () =>
     const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
     const patientIdStr = String(patientId);
 
-    // Seed two activity entries referencing this patient in Convex
-    await t.run(async (ctx) => {
-      const now = Date.now();
-      await ctx.db.insert("activities", {
-        organizationId,
-        entityType: "gabinetPatient",
-        entityId: patientIdStr,
-        action: "created",
-        description: "Utworzono pacjenta Jan Kowalski",
-        performedBy: userId,
-        createdAt: now,
-      });
-      await ctx.db.insert("activities", {
-        organizationId,
-        entityType: "gabinetPatient",
-        entityId: patientIdStr,
-        action: "updated",
-        description: "Zaktualizowano dane Jana Kowalskiego",
-        performedBy: userId,
-        createdAt: now + 1,
-      });
+    // Seed two activity entries referencing this patient in Supabase (where
+    // gdprErase anonymizes them via db.raw() and where logActivity writes).
+    const db = createSupabaseDb();
+    const now = Date.now();
+    await db.insert("activities", {
+      organizationId: String(organizationId),
+      entityType: "gabinetPatient",
+      entityId: patientIdStr,
+      action: "created",
+      description: "Utworzono pacjenta Jan Kowalski",
+      performedBy: String(userId),
+      createdAt: now,
+    });
+    await db.insert("activities", {
+      organizationId: String(organizationId),
+      entityType: "gabinetPatient",
+      entityId: patientIdStr,
+      action: "updated",
+      description: "Zaktualizowano dane Jana Kowalskiego",
+      performedBy: String(userId),
+      createdAt: now + 1,
     });
 
     await t.withIdentity(identity).action(api.gabinet.patients.gdprErase, {
@@ -46,14 +46,12 @@ describe("gabinet/patients.gdprErase — activity and note anonymization", () =>
       patientId: patientIdStr,
     });
 
-    const activities = await t.run(async (ctx) =>
-      ctx.db
-        .query("activities")
-        .withIndex("by_entity", (q) =>
-          q.eq("entityType", "gabinetPatient").eq("entityId", patientIdStr),
-        )
-        .collect(),
-    );
+    const activities = await createSupabaseDb()
+      .query("activities")
+      .eq("organizationId", String(organizationId))
+      .eq("entityType", "gabinetPatient")
+      .eq("entityId", patientIdStr)
+      .collect();
 
     for (const activity of activities) {
       expect(activity.description).not.toContain("Kowalski");
@@ -69,17 +67,17 @@ describe("gabinet/patients.gdprErase — activity and note anonymization", () =>
     const { patientId } = await seedGabinetPrereqs(t, organizationId, userId);
     const patientIdStr = String(patientId);
 
+    // Seed note in Supabase where gdprErase anonymizes via db.raw()
+    const db = createSupabaseDb();
     const now = Date.now();
-    await t.run(async (ctx) => {
-      await ctx.db.insert("notes", {
-        organizationId,
-        entityType: "gabinetPatient",
-        entityId: patientIdStr,
-        content: "Pacjent Jan Kowalski skarżył się na ból głowy.",
-        createdBy: userId,
-        createdAt: now,
-        updatedAt: now,
-      });
+    await db.insert("notes", {
+      organizationId: String(organizationId),
+      entityType: "gabinetPatient",
+      entityId: patientIdStr,
+      content: "Pacjent Jan Kowalski skarżył się na ból głowy.",
+      createdBy: String(userId),
+      createdAt: now,
+      updatedAt: now,
     });
 
     await t.withIdentity(identity).action(api.gabinet.patients.gdprErase, {
@@ -87,14 +85,12 @@ describe("gabinet/patients.gdprErase — activity and note anonymization", () =>
       patientId: patientIdStr,
     });
 
-    const notes = await t.run(async (ctx) =>
-      ctx.db
-        .query("notes")
-        .withIndex("by_entity", (q) =>
-          q.eq("entityType", "gabinetPatient").eq("entityId", patientIdStr),
-        )
-        .collect(),
-    );
+    const notes = await createSupabaseDb()
+      .query("notes")
+      .eq("organizationId", String(organizationId))
+      .eq("entityType", "gabinetPatient")
+      .eq("entityId", patientIdStr)
+      .collect();
 
     expect(notes).toHaveLength(1);
     expect(notes[0].content).not.toContain("Kowalski");
@@ -112,29 +108,29 @@ describe("gabinet/patients.gdprErase — activity and note anonymization", () =>
     );
     const patientIdStr = String(patientId);
 
-    await t.run(async (ctx) => {
-      const now = Date.now();
-      await ctx.db.insert("gabinetAppointments", {
-        organizationId,
-        patientId,
-        employeeId: userId,
-        date: "2026-01-15",
-        startTime: "09:00",
-        endTime: "10:00",
-        status: "completed",
-        notes: "Jan Kowalski wymaga specjalnej opieki.",
-        internalNotes: "Historia choroby Jana Kowalskiego.",
-        interviewNotes: "Pacjent Jan Kowalski skarżył się na ból pleców.",
-        clinicalRemarks: "Kowalski ma alergię na lateks.",
-        bodyChartData: JSON.stringify({ marks: ["lower_back"] }),
-        treatmentParameterValues: JSON.stringify([
-          { name: "Waga", value: "85kg" },
-        ]),
-        isRecurring: false,
-        createdBy: userId,
-        createdAt: now,
-        updatedAt: now,
-      });
+    // Seed appointment in Supabase where gdprErase nulls clinical fields via db.raw()
+    const db = createSupabaseDb();
+    const now = Date.now();
+    await db.insert("gabinetAppointments", {
+      organizationId: String(organizationId),
+      patientId: patientIdStr,
+      employeeId: String(userId),
+      date: "2026-01-15",
+      startTime: "09:00",
+      endTime: "10:00",
+      status: "completed",
+      notes: "Jan Kowalski wymaga specjalnej opieki.",
+      internalNotes: "Historia choroby Jana Kowalskiego.",
+      interviewNotes: "Pacjent Jan Kowalski skarżył się na ból pleców.",
+      clinicalRemarks: "Kowalski ma alergię na lateks.",
+      bodyChartData: JSON.stringify({ marks: ["lower_back"] }),
+      treatmentParameterValues: JSON.stringify([
+        { name: "Waga", value: "85kg" },
+      ]),
+      isRecurring: false,
+      createdBy: String(userId),
+      createdAt: now,
+      updatedAt: now,
     });
 
     await t.withIdentity(identity).action(api.gabinet.patients.gdprErase, {
@@ -142,22 +138,22 @@ describe("gabinet/patients.gdprErase — activity and note anonymization", () =>
       patientId: patientIdStr,
     });
 
-    const appointments = await t.run(async (ctx) =>
-      ctx.db
-        .query("gabinetAppointments")
-        .withIndex("by_orgAndPatient", (q) =>
-          q.eq("organizationId", organizationId).eq("patientId", patientId),
-        )
-        .collect(),
-    );
+    // Read from Supabase (the store that gdprErase updated) using the same
+    // patientIdStr filter that the action used.
+    const appointments = await createSupabaseDb()
+      .query("gabinetAppointments")
+      .eq("organizationId", String(organizationId))
+      .eq("patientId", patientIdStr)
+      .collect();
 
     expect(appointments).toHaveLength(1);
-    expect(appointments[0].interviewNotes).toBeUndefined();
-    expect(appointments[0].notes).toBeUndefined();
-    expect(appointments[0].internalNotes).toBeUndefined();
-    expect(appointments[0].clinicalRemarks).toBeUndefined();
-    expect(appointments[0].bodyChartData).toBeUndefined();
-    expect(appointments[0].treatmentParameterValues).toBeUndefined();
+    // Supabase stores null (not undefined) for cleared fields
+    expect(appointments[0].interviewNotes).toBeNull();
+    expect(appointments[0].notes).toBeNull();
+    expect(appointments[0].internalNotes).toBeNull();
+    expect(appointments[0].clinicalRemarks).toBeNull();
+    expect(appointments[0].bodyChartData).toBeNull();
+    expect(appointments[0].treatmentParameterValues).toBeNull();
   });
 
   test("writes an audit log entry with action gdpr_patient_erased", async () => {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5502.

Closes #5502

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 82d3d751 fix(tests): seed/read gdprErase test data via Supabase in-memory mock (closes #5502)

### Files changed

```
 tests/convex/gdprErase.test.ts | 164 ++++++++++++++++++++---------------------
 1 file changed, 80 insertions(+), 84 deletions(-)
```