### PR TITLE
Make `backfillEntitlements.run` also write to Supabase after each `_upsertEntitl

### DIFF
--- a/convex/migrations/backfillEntitlements.ts
+++ b/convex/migrations/backfillEntitlements.ts
@@ -38,6 +38,34 @@ export const run = internalAction({
     }
 
     // A system actor id for grantedByUserId: reuse the first org owner if present.
+    const upsertToSupabase = async (orgId: string, productId: "crm" | "gabinet", grantedBy: string) => {
+      const now = Date.now();
+      const existingRow = await db
+        .query("productSubscriptions")
+        .eq("organizationId", orgId)
+        .eq("productId", productId)
+        .unique();
+      if (existingRow) {
+        await db.patch("productSubscriptions", String(existingRow._id), {
+          status: "active",
+          source: "manual",
+          grantedByUserId: grantedBy,
+          updatedAt: now,
+        });
+      } else {
+        await db.insert("productSubscriptions", {
+          organizationId: orgId,
+          productId,
+          status: "active",
+          cancelAtPeriodEnd: false,
+          source: "manual",
+          grantedByUserId: grantedBy,
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+    };
+
     let crmGranted = 0;
     let gabinetGranted = 0;
     for (const o of orgs) {
@@ -52,6 +80,7 @@ export const run = internalAction({
             grant: true,
             grantedByUserId: grantedBy as unknown as Id<"users">,
           });
+          await upsertToSupabase(orgId, "crm", grantedBy);
         }
       }
       if (gabinetOrgIds.has(orgId) && !has(orgId, "gabinet")) {
@@ -63,6 +92,7 @@ export const run = internalAction({
             grant: true,
             grantedByUserId: grantedBy as unknown as Id<"users">,
           });
+          await upsertToSupabase(orgId, "gabinet", grantedBy);
         }
       }
     }

--- a/tests/convex/backfillEntitlements.test.ts
+++ b/tests/convex/backfillEntitlements.test.ts
@@ -37,6 +37,18 @@ describe("migrations/backfillEntitlements.run", () => {
     expect(crm?.status).toBe("active");
     expect(gab?.status).toBe("active");
 
+    // Verify Supabase rows are also written (listOrgEntitlements reads from Supabase).
+    const db = createSupabaseDb();
+    const supabaseRows = await db.query("productSubscriptions").collect();
+    const sbCrm = supabaseRows.find(
+      (r) => String(r.organizationId) === String(organizationId) && r.productId === "crm",
+    );
+    const sbGab = supabaseRows.find(
+      (r) => String(r.organizationId) === String(organizationId) && r.productId === "gabinet",
+    );
+    expect(sbCrm?.status).toBe("active");
+    expect(sbGab?.status).toBe("active");
+
     // Idempotent: second run grants nothing new.
     const res2 = await t.action(internal.migrations.backfillEntitlements.run, {
       dryRun: false,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5505.

Closes #5505

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- b5cdae39 fix(backfill): dual-write productSubscriptions to Supabase in backfillEntitlements.run (closes #5505)

### Files changed

```
 convex/migrations/backfillEntitlements.ts | 30 ++++++++++++++++++++++++++++++
 tests/convex/backfillEntitlements.test.ts | 12 ++++++++++++
 2 files changed, 42 insertions(+)
```