### PR TITLE
Fix test 5 ("new erasure activity entry does not contain original patient name")

### DIFF
--- a/tests/convex/gdprErase.test.ts
+++ b/tests/convex/gdprErase.test.ts
@@ -191,14 +191,18 @@ describe("gabinet/patients.gdprErase — activity and note anonymization", () =>
       patientId: patientIdStr,
     });
 
-    const activities = await t.run(async (ctx) =>
-      ctx.db
-        .query("activities")
-        .withIndex("by_entity", (q) =>
-          q.eq("entityType", "gabinetPatient").eq("entityId", patientIdStr),
-        )
-        .collect(),
-    );
+    // logActivity writes to Supabase (via publishActivityEnvelope → createSupabaseDb),
+    // so read from Supabase — not from Convex — to actually see the erasure entry.
+    const activities = await createSupabaseDb()
+      .query("activities")
+      .eq("organizationId", String(organizationId))
+      .eq("entityType", "gabinetPatient")
+      .eq("entityId", patientIdStr)
+      .collect();
+
+    // The erasure side-effect writes exactly one activity entry; guard against
+    // the loop running vacuously if that write is ever broken.
+    expect(activities.length).toBeGreaterThanOrEqual(1);
 
     // Every activity entry — including the new deletion event — must be PII-free
     for (const activity of activities) {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5507.

Closes #5507

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- ba5fe06b fix(tests): read erasure activity from Supabase in gdprErase test 5 (closes #5507)

### Files changed

```
 tests/convex/gdprErase.test.ts | 20 ++++++++++++--------
 1 file changed, 12 insertions(+), 8 deletions(-)
```