### PR TITLE
Add patient reactivation path

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -1170,6 +1170,65 @@ export const _mergeSideEffects = internalMutation({
   },
 });
 
+export const reactivate = action({
+  args: {
+    organizationId: v.string(),
+    patientId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const authResult = await ctx.runAction(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      {
+        organizationId: args.organizationId,
+        feature: "gabinet_patients",
+        action: "edit",
+      },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    const db = createSupabaseDb();
+
+    const patient = await db.get("gabinetPatients", args.patientId);
+    if (!patient || String(patient.organizationId) !== String(args.organizationId)) {
+      throw new Error("Patient not found");
+    }
+    if (perm.scope === "own") {
+      const hasAppt = await db
+        .query("gabinetAppointments")
+        .eq("organizationId", String(args.organizationId))
+        .eq("employeeId", String(authResult.userId))
+        .eq("patientId", args.patientId)
+        .first();
+      if (!hasAppt) throw new Error("Permission denied: you can only edit your own records");
+    }
+
+    await db.patch("gabinetPatients", args.patientId, {
+      isActive: true,
+      updatedAt: Date.now(),
+    });
+
+    try {
+      await ctx.runMutation(internal.gabinet.patients._updateSideEffects, {
+        patientId: args.patientId,
+        organizationId: args.organizationId,
+        firstName: (patient.firstName as string) ?? "",
+        lastName: (patient.lastName as string) ?? "",
+        updatedBy: String(authResult.userId),
+        actorLabel: authResult.userName ?? authResult.userEmail,
+      });
+    } catch (e) {
+      console.error("[patients.reactivate] Side effects FAILED for patient", args.patientId, ":", e);
+    }
+
+    return args.patientId;
+  },
+});
+
 export const gdprErase = action({
   args: {
     organizationId: v.string(),

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -50,6 +50,7 @@ import { ActivityFeed } from "@/components/crm/activity-feed";
 import { activitiesToFeedEntries } from "@/components/crm/activity-feed-adapter";
 import { EntityDocumentsTab } from "@/components/documents/entity-documents-tab";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PatientPhotosTab } from "@/components/gabinet/patient-photos-tab";
 import { plateJsonToText } from "@/components/gabinet/rich-text-editor";
@@ -125,6 +126,8 @@ function PatientDetail() {
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen for this action
   const removePatient = useAction(api.gabinet.patients.remove);
   // @ts-ignore — TS2589: deep type instantiation in Convex codegen for this action
+  const reactivatePatient = useAction(api.gabinet.patients.reactivate);
+  // @ts-ignore — TS2589: deep type instantiation in Convex codegen for this action
   const gdprErasePatient = useAction(api.gabinet.patients.gdprErase);
   const updatePaymentAction = useAction(api.payments.update);
   const createPaymentAction = useAction(api.payments.create);
@@ -147,6 +150,7 @@ function PatientDetail() {
 
   const [editDrawerOpen, setEditDrawerOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isReactivating, setIsReactivating] = useState(false);
   const [gdprDialogOpen, setGdprDialogOpen] = useState(false);
   const [gdprConfirmText, setGdprConfirmText] = useState("");
   const [isGdprSubmitting, setIsGdprSubmitting] = useState(false);
@@ -522,6 +526,31 @@ function PatientDetail() {
   const fullName = patient
     ? `${patient.firstName} ${patient.lastName}`.trim()
     : "";
+
+  const handleReactivate = async () => {
+    setIsReactivating(true);
+    try {
+      await reactivatePatient({ organizationId, patientId });
+      void queryClient.invalidateQueries({
+        queryKey: supabaseKeys.gabinetPatients.detail(organizationId, patientId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: supabaseKeys.gabinetPatients.list(organizationId),
+      });
+      toast.success(
+        t("gabinet.patients.reactivateSuccess", "Klient został przywrócony."),
+      );
+    } catch (e) {
+      toast.error(
+        formatActionError(e, t, {
+          key: "common.error",
+          defaultValue: "Wystąpił błąd podczas przywracania klienta.",
+        }),
+      );
+    } finally {
+      setIsReactivating(false);
+    }
+  };
 
   const handleEditSubmit = async (formData: {
     firstName: string;
@@ -1106,6 +1135,10 @@ function PatientDetail() {
         }
         onEdit={canEdit ? () => setEditDrawerOpen(true) : undefined}
         secondaryActions={[
+          ...(patient && !patient.isActive && canEdit ? [{
+            label: t("gabinet.patients.reactivate", "Przywróć klienta"),
+            onClick: handleReactivate,
+          }] : []),
           {
             label: t("gabinet.patients.merge.action", { defaultValue: "Scal z..." }),
             onClick: () => setMergeDialogOpen(true),
@@ -1128,6 +1161,26 @@ function PatientDetail() {
               ]
             : []),
         ]}
+        beforeTabs={
+          patient && !patient.isActive ? (
+            <div className="flex items-center justify-between rounded-md border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-800 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-200">
+              <span>{t("gabinet.patients.inactiveBanner", "Ten klient jest nieaktywny (usunięty). Możesz go przywrócić.")}</span>
+              {canEdit && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={isReactivating}
+                  onClick={handleReactivate}
+                  className="ml-4 shrink-0"
+                >
+                  {isReactivating
+                    ? t("common.saving", "Zapisywanie...")
+                    : t("gabinet.patients.reactivate", "Przywróć klienta")}
+                </Button>
+              )}
+            </div>
+          ) : undefined
+        }
         fields={detailFields}
         expandedFieldCount={4}
         sidebarExtra={


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5513.

Closes #5513

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 03fdf06f feat(gabinet): add patient reactivation path (closes #5513)

### Files changed

```
 convex/gabinet/patients.ts                         | 59 ++++++++++++++++++++++
 .../_layout.gabinet.patients.$patientId.tsx        | 53 +++++++++++++++++++
 2 files changed, 112 insertions(+)
```