### PR TITLE
Add audit log action name for reactivation

### DIFF
--- a/convex/gabinet/patients.ts
+++ b/convex/gabinet/patients.ts
@@ -681,16 +681,19 @@ export const _updateSideEffects = internalMutation({
     lastName: v.string(),
     updatedBy: v.string(),
     actorLabel: v.optional(v.string()),
+    auditAction: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const updatedByUserId = args.updatedBy;
+    const auditAction = args.auditAction ?? "patient_updated";
+    const fullName = `${args.firstName} ${args.lastName}`;
 
     await logActivity({
       organizationId: args.organizationId,
       entityType: "gabinetPatient",
       entityId: args.patientId as Id<"gabinetPatients">,
       action: "updated",
-      description: `Updated patient ${args.firstName} ${args.lastName}`,
+      description: `Updated patient ${fullName}`,
       performedBy: updatedByUserId,
       actorLabel: args.actorLabel,
     });
@@ -698,10 +701,10 @@ export const _updateSideEffects = internalMutation({
     await logAudit(ctx, {
       organizationId: args.organizationId,
       userId: updatedByUserId,
-      action: "patient_updated",
+      action: auditAction,
       entityType: "gabinetPatient",
       entityId: args.patientId,
-      details: `Updated patient ${args.firstName} ${args.lastName}`,
+      details: `Updated patient ${fullName}`,
     });
   },
 });
@@ -1220,6 +1223,7 @@ export const reactivate = action({
         lastName: (patient.lastName as string) ?? "",
         updatedBy: String(authResult.userId),
         actorLabel: authResult.userName ?? authResult.userEmail,
+        auditAction: "patient_reactivated",
       });
     } catch (e) {
       console.error("[patients.reactivate] Side effects FAILED for patient", args.patientId, ":", e);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5517.

Closes #5517

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 44eb2770 feat(gabinet): add patient_reactivated audit action (closes #5517)

### Files changed

```
 convex/gabinet/patients.ts | 10 +++++++---
 1 file changed, 7 insertions(+), 3 deletions(-)
```