### PR TITLE
Add `reserved` stock movement type for planned appointments

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -1647,6 +1647,25 @@ export const create = action({
       }
     }
 
+    // --- Write informational stock reservation movements (#5532) ---
+    // Non-blocking: failures do not prevent appointment creation.
+    {
+      const allAppointmentIds = [firstId, ...recurringAppointments.map((r) => r.appointmentId)];
+      const locationId = (args.locationId ?? null) as string | null;
+      for (const aptId of allAppointmentIds) {
+        try {
+          await ctx.runAction(internal.magazyn.movements.reserveStockForAppointment, {
+            organizationId: String(args.organizationId),
+            appointmentId: aptId,
+            locationId,
+            performedBy: String(authResult.userId),
+          });
+        } catch (e) {
+          console.warn("[create] stock reservation failed for appointment", aptId, ":", e);
+        }
+      }
+    }
+
     // --- Insert scheduledActivities directly to Supabase (primary) ---
     const dueDateMs = new Date(`${args.date}T${args.startTime}:00`).getTime();
     const endDateMs = new Date(`${args.date}T${args.endTime}:00`).getTime();
@@ -2672,6 +2691,44 @@ export const updateStatus = action({
       }
     }
 
+    // Re-reserve stock when reverting from completed to a planned status (#5532).
+    // Informational only: failures are non-blocking.
+    if (
+      appt.status === "completed" &&
+      args.status !== "cancelled" &&
+      args.status !== "no_show"
+    ) {
+      try {
+        await ctx.runAction(internal.magazyn.movements.reserveStockForAppointment, {
+          organizationId: String(args.organizationId),
+          appointmentId: args.appointmentId,
+          locationId: (appt.locationId ?? null) as string | null,
+          performedBy: authResult.userId,
+        });
+      } catch (e) {
+        console.warn("[updateStatus] re-reservation failed for appointment", args.appointmentId, ":", e);
+      }
+    }
+
+    // Release reservation when reverting from cancelled/no_show to a planned status (#5532).
+    if (
+      (appt.status === "cancelled" || appt.status === "no_show") &&
+      args.status !== "cancelled" &&
+      args.status !== "no_show" &&
+      args.status !== "completed"
+    ) {
+      try {
+        await ctx.runAction(internal.magazyn.movements.reserveStockForAppointment, {
+          organizationId: String(args.organizationId),
+          appointmentId: args.appointmentId,
+          locationId: (appt.locationId ?? null) as string | null,
+          performedBy: authResult.userId,
+        });
+      } catch (e) {
+        console.warn("[updateStatus] re-reservation (from cancelled/no_show) failed for appointment", args.appointmentId, ":", e);
+      }
+    }
+
     // Package return: when reverting from completed, restore one package entry
     // per junction treatment. cas_return_package_entry atomically flips the CAS
     // flag and decrements usedCount in a single Postgres transaction, preventing
@@ -2701,6 +2758,20 @@ export const updateStatus = action({
             pkgReturnError,
           );
         }
+      }
+    }
+
+    // Release stock reservation when appointment reaches a terminal state (#5532).
+    // Informational only: failures are non-blocking.
+    if (args.status === "completed" || args.status === "cancelled" || args.status === "no_show") {
+      try {
+        await ctx.runAction(internal.magazyn.movements.releaseReservationForAppointment, {
+          organizationId: String(args.organizationId),
+          appointmentId: args.appointmentId,
+          performedBy: authResult.userId,
+        });
+      } catch (e) {
+        console.warn("[updateStatus] reservation release failed for appointment", args.appointmentId, ":", e);
       }
     }
 

--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -23,6 +23,8 @@ const REASON_VALIDATOR = v.union(
   v.literal("inventory_adjustment"),
   v.literal("appointment_use"),
   v.literal("appointment_return"),
+  v.literal("reserved"),
+  v.literal("reservation_release"),
   v.literal("direct_sale"),
   v.literal("deal_close"),
   v.literal("deal_reopen"),
@@ -30,6 +32,12 @@ const REASON_VALIDATOR = v.union(
   v.literal("transfer_out"),
   v.literal("other"),
 );
+
+// Informational-only movement reasons: written to the audit trail but do NOT
+// update product_stock_levels (on-hand balance is unchanged). Used for
+// reservation tracking so warehouse reports can see stock committed to
+// future appointments without affecting the available quantity.
+const INFORMATIONAL_REASONS = new Set(["reserved", "reservation_release"]);
 
 export interface ProductStockSummary {
   productId: string;
@@ -192,8 +200,10 @@ export async function applyMovementInternal(
     newBalance = previousBalance + resolvedDelta;
   }
 
+  const isInformational = INFORMATIONAL_REASONS.has(params.reason);
+
   let warning: string | null = null;
-  if (trackStock && newBalance < 0) {
+  if (!isInformational && trackStock && newBalance < 0) {
     // Warn-and-allow (#1700): negative stock is permitted but the caller is
     // expected to surface this in the UI so staff can correct it.
     warning = "negative_stock";
@@ -223,7 +233,7 @@ export async function applyMovementInternal(
 
   const now = Date.now();
 
-  if (trackStock) {
+  if (trackStock && !isInformational) {
     if (level) {
       await db.patch("productStockLevels", String(level._id), {
         quantity: newBalance,
@@ -249,7 +259,7 @@ export async function applyMovementInternal(
     productId: params.productId,
     locationId: params.locationId,
     delta: resolvedDelta,
-    balanceAfter: trackStock ? newBalance : null,
+    balanceAfter: (trackStock && !isInformational) ? newBalance : null,
     reason: params.reason,
     sourceType: params.sourceType ?? null,
     sourceId: params.sourceId ?? null,

--- a/convex/magazyn/movements.ts
+++ b/convex/magazyn/movements.ts
@@ -165,6 +165,145 @@ export const returnStockForAppointment = internalAction({
   },
 });
 
+// Write informational `reserved` movements for all products consumed by the
+// appointment's treatments. These do NOT update product_stock_levels — they
+// exist purely so warehouse reports can see stock committed to future
+// appointments. Idempotent: skips products that already have a `reserved`
+// movement for this appointment with no matching `reservation_release`.
+export const reserveStockForAppointment = internalAction({
+  args: {
+    organizationId: v.string(),
+    appointmentId: v.string(),
+    locationId: v.union(v.string(), v.null()),
+    performedBy: v.string(),
+  },
+  handler: async (_ctx, args): Promise<void> => {
+    const db = createSupabaseDb();
+
+    const { data: junctionRows } = await db.raw()
+      .from("gabinet_appointment_treatments")
+      .select("treatment_id")
+      .eq("appointment_id", args.appointmentId);
+    const treatmentIds = (junctionRows ?? [])
+      .map((r: { treatment_id: string | null }) => r.treatment_id)
+      .filter((id): id is string => !!id);
+
+    for (const treatmentId of treatmentIds) {
+      const { data: links } = await db.raw()
+        .from("gabinet_treatment_products")
+        .select("product_id, quantity")
+        .eq("organization_id", args.organizationId)
+        .eq("treatment_id", treatmentId);
+      for (const link of (links ?? []) as Array<{ product_id: string; quantity: number }>) {
+        if (!link.quantity || Number(link.quantity) <= 0) continue;
+        const productId = link.product_id;
+
+        // Idempotency: skip if unreleased `reserved` movement already exists.
+        const { data: existing } = await db.raw()
+          .from("product_stock_movements")
+          .select("id")
+          .eq("source_type", "appointment")
+          .eq("source_id", args.appointmentId)
+          .eq("product_id", productId)
+          .eq("reason", "reserved")
+          .limit(1);
+        if (Array.isArray(existing) && existing.length > 0) {
+          const { data: released } = await db.raw()
+            .from("product_stock_movements")
+            .select("id")
+            .eq("source_type", "appointment")
+            .eq("source_id", args.appointmentId)
+            .eq("product_id", productId)
+            .eq("reason", "reservation_release")
+            .limit(1);
+          if (!Array.isArray(released) || released.length === 0) continue;
+        }
+
+        try {
+          await applyMovementInternal({
+            organizationId: args.organizationId,
+            productId,
+            locationId: args.locationId,
+            delta: -Number(link.quantity),
+            reason: "reserved",
+            sourceType: "appointment",
+            sourceId: args.appointmentId,
+            treatmentId,
+            performedBy: args.performedBy,
+          });
+        } catch (e) {
+          console.warn(
+            "[reserveStockForAppointment] failed for product",
+            productId,
+            ":",
+            e,
+          );
+        }
+      }
+    }
+  },
+});
+
+// Write informational `reservation_release` movements inverting the `reserved`
+// movements for this appointment. Idempotent: skips if release already exists.
+export const releaseReservationForAppointment = internalAction({
+  args: {
+    organizationId: v.string(),
+    appointmentId: v.string(),
+    performedBy: v.string(),
+  },
+  handler: async (_ctx, args): Promise<void> => {
+    const db = createSupabaseDb();
+
+    const { data: reservedMovements } = await db.raw()
+      .from("product_stock_movements")
+      .select("product_id, delta, location_id, treatment_id")
+      .eq("source_type", "appointment")
+      .eq("source_id", args.appointmentId)
+      .eq("reason", "reserved");
+    const movements = (reservedMovements ?? []) as Array<{
+      product_id: string;
+      delta: number;
+      location_id: string | null;
+      treatment_id: string | null;
+    }>;
+    if (movements.length === 0) return;
+
+    // Idempotency: skip if release movements already exist for this appointment.
+    const { data: existingReleases } = await db.raw()
+      .from("product_stock_movements")
+      .select("id")
+      .eq("source_type", "appointment")
+      .eq("source_id", args.appointmentId)
+      .eq("reason", "reservation_release")
+      .limit(1);
+    if (Array.isArray(existingReleases) && existingReleases.length > 0) return;
+
+    for (const mv of movements) {
+      try {
+        await applyMovementInternal({
+          organizationId: args.organizationId,
+          productId: mv.product_id,
+          locationId: mv.location_id ?? null,
+          delta: -Number(mv.delta), // original delta was negative; negating restores
+          reason: "reservation_release",
+          sourceType: "appointment",
+          sourceId: args.appointmentId,
+          treatmentId: mv.treatment_id ?? undefined,
+          performedBy: args.performedBy,
+        });
+      } catch (e) {
+        console.warn(
+          "[releaseReservationForAppointment] failed for product",
+          mv.product_id,
+          ":",
+          e,
+        );
+      }
+    }
+  },
+});
+
 // Sell a product directly without an appointment.
 // Applies FEFO lot selection exactly like consumeForAppointment: if tracked
 // lots exist they are drained in ascending expiry order; any remainder is


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5532.

Closes #5532

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- cfa7df60 feat(magazyn): add reserved stock movement type for planned appointments (closes #5532)

### Files changed

```
 convex/gabinet/appointments.ts |  71 +++++++++++++++++++++
 convex/inventory.ts            |  16 ++++-
 convex/magazyn/movements.ts    | 139 +++++++++++++++++++++++++++++++++++++++++
 3 files changed, 223 insertions(+), 3 deletions(-)
```