### PR TITLE
fix(types): resolve string-not-assignable-to-Id<organizations> errors in appointments (closes #5538)

### DIFF
--- a/convex/gabinet/_helpers/autoGenerateDocuments.ts
+++ b/convex/gabinet/_helpers/autoGenerateDocuments.ts
@@ -36,7 +36,7 @@ function hasFormFields(node: unknown): boolean {
 export async function autoGenerateAppointmentDocuments(
   ctx: MutationCtx,
   args: {
-    organizationId: Id<"organizations">;
+    organizationId: string;
     appointmentId: Id<"gabinetAppointments">;
     treatmentId: Id<"gabinetTreatments">;
     patientId: Id<"gabinetPatients">;

--- a/convex/gabinet/appointmentSms.ts
+++ b/convex/gabinet/appointmentSms.ts
@@ -63,7 +63,7 @@ function buildConfirmationMessage(args: {
 async function logSmsSharedActivities(
   ctx: MutationCtx,
   args: {
-    organizationId: Id<"organizations">;
+    organizationId: string;
     appointmentId?: Id<"gabinetAppointments">;
     patientId?: Id<"gabinetPatients">;
     action: "sms_sent" | "sms_received";

--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -102,7 +102,7 @@ async function assertRequiredEquipmentAtLocation(
 async function emitAutomationEvent(
   ctx: MutationCtx,
   args: {
-    organizationId: Id<"organizations">;
+    organizationId: string;
     module: "gabinet" | "crm" | "platform";
     eventType: string;
     entityType?: string;
@@ -132,7 +132,7 @@ async function applyAppointmentStatusChange(
   ctx: MutationCtx,
   args: {
     appointment: Doc<"gabinetAppointments">;
-    organizationId: Id<"organizations">;
+    organizationId: string;
     nextStatus: Doc<"gabinetAppointments">["status"];
     actorUserId: string;
     auditAction: string;
@@ -1091,7 +1091,7 @@ export const _generateDocsOnSync = internalMutation({
   },
   handler: async (ctx, args) => {
     await autoGenerateAppointmentDocuments(ctx, {
-      organizationId: args.organizationId as Id<"organizations">,
+      organizationId: args.organizationId,
       appointmentId: args.appointmentId as Id<"gabinetAppointments">,
       treatmentId: args.treatmentId as Id<"gabinetTreatments">,
       patientId: args.patientId as Id<"gabinetPatients">,
@@ -1099,7 +1099,7 @@ export const _generateDocsOnSync = internalMutation({
       timing: "before_start",
     });
     await autoGenerateAppointmentDocuments(ctx, {
-      organizationId: args.organizationId as Id<"organizations">,
+      organizationId: args.organizationId,
       appointmentId: args.appointmentId as Id<"gabinetAppointments">,
       treatmentId: args.treatmentId as Id<"gabinetTreatments">,
       patientId: args.patientId as Id<"gabinetPatients">,
@@ -1144,7 +1144,7 @@ export const _syncCreatedSideEffects = internalMutation({
     }
 
     await emitAutomationEvent(ctx, {
-      organizationId: args.organizationId as Id<"organizations">,
+      organizationId: args.organizationId,
       module: "gabinet",
       eventType: "gabinet.appointment.created",
       entityType: "gabinetAppointment",
@@ -2425,7 +2425,7 @@ export const _updateSideEffects = internalMutation({
       }
 
       await autoGenerateAppointmentDocuments(ctx, {
-        organizationId: args.organizationId as Id<"organizations">,
+        organizationId: args.organizationId,
         appointmentId: args.appointmentId as Id<"gabinetAppointments">,
         treatmentId: args.treatmentId as Id<"gabinetTreatments">,
         patientId: args.patientId as Id<"gabinetPatients">,
@@ -2433,7 +2433,7 @@ export const _updateSideEffects = internalMutation({
         timing: "before_start",
       });
       await autoGenerateAppointmentDocuments(ctx, {
-        organizationId: args.organizationId as Id<"organizations">,
+        organizationId: args.organizationId,
         appointmentId: args.appointmentId as Id<"gabinetAppointments">,
         treatmentId: args.treatmentId as Id<"gabinetTreatments">,
         patientId: args.patientId as Id<"gabinetPatients">,
@@ -3374,7 +3374,7 @@ export const _cancelSideEffects = internalMutation({
 async function resolveAutoPackageUsageSupabase(
   db: ReturnType<typeof createSupabaseDb>,
   args: {
-    organizationId: Id<"organizations">;
+    organizationId: string;
     patientId: string;
     treatmentId: string;
     treatment: GabinetTreatmentRow;
@@ -3462,7 +3462,7 @@ async function resolveAutoPackageUsageSupabase(
 async function handleAppointmentCompletion(
   ctx: MutationCtx,
   args: {
-    organizationId: Id<"organizations">;
+    organizationId: string;
     appointmentId: Id<"gabinetAppointments">;
     patientId: Id<"gabinetPatients">;
     treatmentId: Id<"gabinetTreatments">;


### PR DESCRIPTION
## Summary

- Changed `organizationId` parameter type from `Id<"organizations">` to `string` in six internal helper functions across `appointments.ts`, `appointmentSms.ts`, and `autoGenerateDocuments.ts`
- Removed the workaround `as Id<"organizations">` casts that had been added at call sites

## Root cause

These internal helpers (`emitAutomationEvent`, `applyAppointmentStatusChange`, `resolveAutoPackageUsageSupabase`, `handleAppointmentCompletion`, `autoGenerateAppointmentDocuments`, `logSmsSharedActivities`) were annotated with `organizationId: Id<"organizations">` but:
- All callers pass `args.organizationId` from Convex action/mutation args typed as `v.string()` (Supabase UUID strings)
- The function bodies always convert the value via `String(args.organizationId)` before using it in Supabase queries
- None of them use the value as a Convex `Id<>` branded type (no `ctx.db` access with it)

This produced 12 `Type 'string' is not assignable to type 'Id<"organizations">'` errors: 9 in `appointments.ts` and 3 in `appointmentSms.ts`.

## Test plan
- [x] TypeScript check on Convex files shows no `string is not assignable to Id<"organizations">` errors in the changed files
- [x] All changed functions still receive the correct data — only the overly strict annotation was relaxed, no runtime behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)