### PR TITLE
`calendar-week-view.tsx` retains `@ts-nocheck` at line 1 (present since the file

### DIFF
--- a/src/components/gabinet/calendar/calendar-week-view.tsx
+++ b/src/components/gabinet/calendar/calendar-week-view.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { DraggableAppointment } from "./draggable-appointment";


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5539.

Closes #5539

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- eaf18fcb chore(gabinet): remove @ts-nocheck from calendar-week-view.tsx (closes #5539)

### Files changed

```
 src/components/gabinet/calendar/calendar-week-view.tsx | 1 -
 1 file changed, 1 deletion(-)
```