### PR TITLE
Appointment series editing UI is create-only — there is no UI path to edit an ex

### DIFF
--- a/convex/gabinet/appointments.ts
+++ b/convex/gabinet/appointments.ts
@@ -3687,6 +3687,111 @@ export const cancelRecurringSeries = action({
 });
 
 /**
+ * Apply a new start/end time to all future occurrences of a recurring series.
+ * Dates are kept as-is; only the clock time is shifted. Skips cancelled and
+ * completed occurrences. Requires `gabinet_appointments.edit` permission.
+ */
+export const rescheduleSeries = action({
+  args: {
+    organizationId: v.string(),
+    recurringGroupId: v.string(),
+    fromDate: v.string(),       // YYYY-MM-DD — update this date and all after
+    newStartTime: v.string(),   // HH:MM
+    newEndTime: v.string(),     // HH:MM
+  },
+  handler: async (ctx, args) => {
+    const authResult = await ctx.runAction(
+      internal._helpers.authAction.verifyOrgAccess,
+      { organizationId: args.organizationId },
+    );
+    await ctx.runQuery(internal._helpers.products.verifyGabinetAccess, { organizationId: args.organizationId });
+    const perm = await ctx.runAction(
+      internal._helpers.authAction.checkPermission,
+      {
+        organizationId: args.organizationId,
+        feature: "gabinet_appointments",
+        action: "edit",
+      },
+    ) as { allowed: boolean; scope: string };
+    if (!perm.allowed) throw new Error("Permission denied");
+
+    const db = createSupabaseDb();
+
+    const appointments = await db.query("gabinetAppointments")
+      .eq("organizationId", String(args.organizationId))
+      .eq("recurringGroupId", args.recurringGroupId)
+      .collect();
+
+    const allApptIds = appointments.map((a) => String(a._id));
+    const junctionMap = await getJunctionTreatmentIds(db, allApptIds);
+
+    const now = Date.now();
+    let count = 0;
+    for (const appt of appointments) {
+      if (appt.status === "cancelled" || appt.status === "completed") continue;
+      if ((appt.date as string) < args.fromDate) continue;
+
+      const appointmentId = appt._id as string;
+
+      await db.patch("gabinetAppointments", appointmentId, {
+        startTime: args.newStartTime,
+        endTime: args.newEndTime,
+        updatedAt: now,
+      });
+
+      if (appt.scheduledActivityId) {
+        try {
+          await db.patch("scheduledActivities", appt.scheduledActivityId as string, {
+            startTime: args.newStartTime,
+            endTime: args.newEndTime,
+            updatedAt: now,
+          });
+        } catch (e) {
+          console.warn("[rescheduleSeries] scheduledActivity patch failed (non-fatal):", e);
+        }
+      }
+
+      const primaryTreatmentId = (junctionMap.get(appointmentId) ?? [])[0]?.treatmentId;
+      try {
+        await ctx.runMutation(
+          internal.gabinet.appointments._updateSideEffects,
+          {
+            appointmentId,
+            organizationId: args.organizationId,
+            actorUserId: authResult.userId,
+            previousStatus: appt.status as string,
+            previousDate: appt.date as string,
+            previousStartTime: appt.startTime as string,
+            previousEndTime: appt.endTime as string,
+            previousEmployeeId: appt.employeeId as string,
+            scheduledActivityId: (appt.scheduledActivityId as string) ?? undefined,
+            patientId: appt.patientId as string,
+            treatmentId: primaryTreatmentId,
+            createdBy: appt.createdBy as string,
+            newDate: appt.date as string,
+            newStartTime: args.newStartTime,
+            newEndTime: args.newEndTime,
+            newEmployeeId: appt.employeeId as string,
+            newStatus: appt.status as string,
+            dateChanged: false,
+            employeeChanged: false,
+            updatedFields: ["startTime", "endTime"],
+            updatedAt: now,
+            actorLabel: authResult.userName ?? authResult.userEmail,
+          },
+        );
+      } catch (e) {
+        console.error("[rescheduleSeries] Side effects FAILED for appointment", appointmentId, ":", e);
+      }
+
+      count++;
+    }
+
+    return { updated: count };
+  },
+});
+
+/**
  * Treatment usage entry within an enriched package usage row — the raw
  * `treatmentsUsed` array is augmented with a resolved `treatmentName`.
  */

--- a/src/components/gabinet/appointments/reschedule-appointment-dialog.tsx
+++ b/src/components/gabinet/appointments/reschedule-appointment-dialog.tsx
@@ -9,10 +9,13 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import type { TFunction } from "i18next";
 import { TimePicker5Min } from "@/components/gabinet/calendar/time-picker-5min";
 import { Loader2 } from "@/lib/ez-icons";
 import { cn } from "@/lib/utils";
+
+type RescheduleScope = "single" | "series";
 
 interface RescheduleAppointmentDialogProps {
   open: boolean;
@@ -21,7 +24,9 @@ interface RescheduleAppointmentDialogProps {
   currentStartTime: string; // HH:MM
   currentEndTime: string; // HH:MM
   isSaving: boolean;
-  onSave: (date: string, startTime: string, endTime: string) => void;
+  onSave: (date: string, startTime: string, endTime: string, scope: RescheduleScope) => void;
+  /** When true, shows a scope selector so the user can reschedule the whole series. */
+  isRecurring?: boolean;
   t: TFunction;
 }
 
@@ -33,11 +38,13 @@ export function RescheduleAppointmentDialog({
   currentEndTime,
   isSaving,
   onSave,
+  isRecurring,
   t,
 }: RescheduleAppointmentDialogProps) {
   const [date, setDate] = useState(currentDate);
   const [startTime, setStartTime] = useState(currentStartTime);
   const [endTime, setEndTime] = useState(currentEndTime);
+  const [scope, setScope] = useState<RescheduleScope>("single");
 
   // Reset to current values when the dialog opens
   useEffect(() => {
@@ -45,18 +52,23 @@ export function RescheduleAppointmentDialog({
       setDate(currentDate);
       setStartTime(currentStartTime);
       setEndTime(currentEndTime);
+      setScope("single");
     }
   }, [open, currentDate, currentStartTime, currentEndTime]);
 
   const isTimeValid = startTime < endTime;
+  // For series scope only time matters (dates stay per-occurrence), so only
+  // require time to differ from current. For single scope, date may also change.
   const isUnchanged =
-    date === currentDate &&
-    startTime === currentStartTime &&
-    endTime === currentEndTime;
+    scope === "series"
+      ? startTime === currentStartTime && endTime === currentEndTime
+      : date === currentDate && startTime === currentStartTime && endTime === currentEndTime;
 
   const handleSubmit = () => {
     if (!isTimeValid || isUnchanged) return;
-    onSave(date, startTime, endTime);
+    // For series rescheduling the date field is irrelevant; pass currentDate so
+    // the handler can use it as `fromDate` to filter occurrences.
+    onSave(scope === "series" ? currentDate : date, startTime, endTime, scope);
   };
 
   return (
@@ -75,23 +87,46 @@ export function RescheduleAppointmentDialog({
         </DialogHeader>
 
         <div className="space-y-4">
-          <div className="space-y-1.5">
-            <Label htmlFor="reschedule-date">
-              {t("common.date", "Data")}
-            </Label>
-            <input
-              id="reschedule-date"
-              type="date"
-              value={date}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => setDate(e.target.value)}
-              disabled={isSaving}
-              className={cn(
-                "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm",
-                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-                "disabled:cursor-not-allowed disabled:opacity-50",
-              )}
-            />
-          </div>
+          {isRecurring && (
+            <RadioGroup
+              value={scope}
+              onValueChange={(v) => setScope(v as RescheduleScope)}
+              className="gap-2"
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="single" id="reschedule-scope-single" />
+                <Label htmlFor="reschedule-scope-single" className="cursor-pointer font-normal">
+                  {t("gabinet.appointments.rescheduleScope.single", "Tylko ta wizyta")}
+                </Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="series" id="reschedule-scope-series" />
+                <Label htmlFor="reschedule-scope-series" className="cursor-pointer font-normal">
+                  {t("gabinet.appointments.rescheduleScope.series", "Ta i wszystkie następne")}
+                </Label>
+              </div>
+            </RadioGroup>
+          )}
+
+          {scope === "single" && (
+            <div className="space-y-1.5">
+              <Label htmlFor="reschedule-date">
+                {t("common.date", "Data")}
+              </Label>
+              <input
+                id="reschedule-date"
+                type="date"
+                value={date}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setDate(e.target.value)}
+                disabled={isSaving}
+                className={cn(
+                  "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm",
+                  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                  "disabled:cursor-not-allowed disabled:opacity-50",
+                )}
+              />
+            </div>
+          )}
 
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
@@ -140,7 +175,7 @@ export function RescheduleAppointmentDialog({
           </Button>
           <Button
             onClick={handleSubmit}
-            disabled={isSaving || !isTimeValid || isUnchanged || !date}
+            disabled={isSaving || !isTimeValid || isUnchanged || (scope === "single" && !date)}
           >
             {isSaving ? (
               <>

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -253,6 +253,7 @@ function AppointmentDetail() {
   const updateStatus = useAction(api.gabinet.appointments.updateStatus);
   const updateAppointment = useAction(api.gabinet.appointments.update);
   const cancelRecurringSeries = useAction(api.gabinet.appointments.cancelRecurringSeries);
+  const rescheduleSeriesAction = useAction(api.gabinet.appointments.rescheduleSeries);
   const trackView = useAction(api.recentlyViewed.track);
   const sendReminderNow = useAction(api.gabinet.appointmentReminders.sendReminderNow);
   const [isSendingReminder, setIsSendingReminder] = useState(false);
@@ -736,17 +737,28 @@ function AppointmentDetail() {
     }
   };
 
-  const handleReschedule = async (date: string, startTime: string, endTime: string) => {
+  const handleReschedule = async (date: string, startTime: string, endTime: string, scope: "single" | "series") => {
     setIsRescheduling(true);
     try {
-      await updateAppointment({
-        organizationId,
-        appointmentId: appointment._id,
-        date,
-        startTime,
-        endTime,
-      });
-      toast.success(t("gabinet.appointments.rescheduled", "Wizyta przeniesiona"));
+      if (scope === "series" && appointment.recurringGroupId) {
+        await rescheduleSeriesAction({
+          organizationId,
+          recurringGroupId: String(appointment.recurringGroupId),
+          fromDate: date,
+          newStartTime: startTime,
+          newEndTime: endTime,
+        });
+        toast.success(t("gabinet.appointments.seriesRescheduled", "Seria wizyt przeniesiona"));
+      } else {
+        await updateAppointment({
+          organizationId,
+          appointmentId: appointment._id,
+          date,
+          startTime,
+          endTime,
+        });
+        toast.success(t("gabinet.appointments.rescheduled", "Wizyta przeniesiona"));
+      }
       setRescheduleOpen(false);
       await invalidateAppointmentCaches();
       await refetch();
@@ -1338,6 +1350,7 @@ function AppointmentDetail() {
         currentEndTime={appointment.endTime as string}
         isSaving={isRescheduling}
         onSave={handleReschedule}
+        isRecurring={!!(appointment.isRecurring && appointment.recurringGroupId)}
         t={t}
       />
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5540.

Closes #5540

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 980ed6a8 feat(gabinet): add series-scope reschedule for recurring appointments (closes #5540)

### Files changed

```
 convex/gabinet/appointments.ts                     | 105 +++++++++++++++++++++
 .../appointments/reschedule-appointment-dialog.tsx |  81 +++++++++++-----
 ...ut.gabinet.appointments.$appointmentId.lazy.tsx |  31 ++++--
 3 files changed, 185 insertions(+), 32 deletions(-)
```