### PR TITLE
Fix TS2345 string-vs-Id errors in `convex/gabinet/onboarding.ts`

### DIFF
--- a/convex/gabinet/onboarding.ts
+++ b/convex/gabinet/onboarding.ts
@@ -5,6 +5,7 @@
 import { action, internalMutation, internalQuery } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { v } from "convex/values";
+import type { Id } from "../_generated/dataModel";
 import { createSupabaseDb } from "../_helpers/supabaseDb";
 
 /**
@@ -17,7 +18,7 @@ export const _getOnboardingFlag = internalQuery({
     organizationId: v.string(),
   },
   handler: async (ctx, args): Promise<boolean> => {
-    const org = await ctx.db.get(args.organizationId);
+    const org = await ctx.db.get(args.organizationId as Id<"organizations">);
     return org?.onboardingCompleted ?? false;
   },
 });
@@ -233,7 +234,7 @@ export const _completeSetupSideEffects = internalMutation({
     organizationId: v.string(),
   },
   handler: async (ctx, args) => {
-    await ctx.db.patch(args.organizationId, {
+    await ctx.db.patch(args.organizationId as Id<"organizations">, {
       onboardingCompleted: true,
       updatedAt: Date.now(),
     });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5547.

Closes #5547

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- ad9b679e fix(types): resolve TS2345 string-vs-Id errors in gabinet/onboarding.ts (closes #5547)

### Files changed

```
 convex/gabinet/onboarding.ts | 5 +++--
 1 file changed, 3 insertions(+), 2 deletions(-)
```