### PR TITLE
Fix TS2345 string-vs-Id in `convex/gabinet/patientAuth.ts

### DIFF
--- a/convex/gabinet/patientAuth.ts
+++ b/convex/gabinet/patientAuth.ts
@@ -6,6 +6,7 @@ import { validatePortalSessionSupabase } from "../_helpers/portalSession";
 import { v } from "convex/values";
 import { sendEmail } from "@cvx/email";
 import { AUTH_RESEND_KEY } from "@cvx/env";
+import type { Id } from "../_generated/dataModel";
 
 // ---------------------------------------------------------------------------
 // Crypto helpers
@@ -173,7 +174,7 @@ export const _sendOtpEmail = internalAction({
         text: `Twój kod weryfikacyjny: ${args.otp}\n\nKod jest ważny przez 10 minut.`,
         log: {
           ctx,
-          organizationId: args.organizationId,
+          organizationId: args.organizationId as Id<"organizations">,
           source: "system",
           recipientName: args.patientName,
           relatedEntityType: "gabinetPatient",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5548.

Closes #5548

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f65db3a4 fix(types): resolve TS2345 string-vs-Id in gabinet/patientAuth.ts (closes #5548)

### Files changed

```
 convex/gabinet/patientAuth.ts | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```