### PR TITLE
Fix TS2345 string-vs-Id in `convex/gabinet/receipts.ts`

### DIFF
--- a/convex/gabinet/receipts.ts
+++ b/convex/gabinet/receipts.ts
@@ -350,7 +350,7 @@ async function buildReceiptPdf(params: {
 export const _getOrgName = internalQuery({
   args: { organizationId: v.string() },
   handler: async (ctx, args) => {
-    const org = await ctx.db.get(args.organizationId);
+    const org = await ctx.db.get(args.organizationId as Id<"organizations">);
     return (org as Record<string, unknown> | null)?.name as string | undefined;
   },
 });
@@ -821,7 +821,7 @@ export const _createReceiptRowForPayment = internalMutation({
     const amount = payment.amount as number;
     if (!args.isRefund && amount <= 0) return;
 
-    const orgDoc = await ctx.db.get(args.organizationId);
+    const orgDoc = await ctx.db.get(args.organizationId as Id<"organizations">);
     const orgName =
       (orgDoc as Record<string, unknown> | null)?.name as string ??
       "Placówka medyczna";
@@ -988,7 +988,7 @@ export const _createSplitReceiptRow = internalMutation({
     const primaryPayment = await db.get("payments", args.primaryPaymentId);
     if (!primaryPayment) return;
 
-    const orgDoc = await ctx.db.get(args.organizationId);
+    const orgDoc = await ctx.db.get(args.organizationId as Id<"organizations">);
     const orgName =
       (orgDoc as Record<string, unknown> | null)?.name as string ??
       "Placówka medyczna";


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5549.

Closes #5549

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 19638dec fix(types): resolve TS2345 string-vs-Id in gabinet/receipts.ts (closes #5549)

### Files changed

```
 convex/gabinet/receipts.ts | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```