### PR TITLE
R2B — Raporty — Zamknięcie dnia: gotówka zostaje w kasie / trafia do Sejfu

### DIFF
--- a/convex/gabinet/dayClose.ts
+++ b/convex/gabinet/dayClose.ts
@@ -7,6 +7,12 @@
  *
  * Write path: Convex actions → Supabase via service-role client.
  * Read path: React Query hooks → Supabase RLS client (see use-supabase-day-close.ts).
+ *
+ * R2B extension (issue #5575): createDayClose now accepts an optional cash
+ * split — cashNextOpening (stays in register) + cashToSafe (moved to Sejf).
+ * If cashToSafe > 0 and a locationId is provided, exactly one transfer_in
+ * movement is written to gabinet_safe_movements, linked via
+ * reference_day_close_id for idempotency.
  */
 
 import { action } from "../_generated/server";
@@ -160,6 +166,12 @@ export const createDayClose = action({
     date: v.string(), // YYYY-MM-DD
     cashOpeningBalance: v.float64(),
     cashCounted: v.float64(),
+    // R2B: optional cash split. If provided, cashNextOpening + cashToSafe must
+    // equal cashCounted. Both must be non-negative. cashToSafe must not exceed
+    // cashCounted. If cashToSafe > 0, a transfer_in movement is created in the
+    // safe for the given location (locationId is required in this case).
+    cashNextOpening: v.optional(v.float64()),
+    cashToSafe: v.optional(v.float64()),
     notes: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
@@ -180,6 +192,33 @@ export const createDayClose = action({
     ) as { allowed: boolean };
     if (!perm.allowed) throw new Error("Permission denied");
 
+    // Validate cash split when provided.
+    const hasSplit =
+      args.cashNextOpening !== undefined || args.cashToSafe !== undefined;
+    if (hasSplit) {
+      const nextOpening = args.cashNextOpening ?? 0;
+      const toSafe = args.cashToSafe ?? 0;
+
+      if (nextOpening < 0 || toSafe < 0) {
+        throw new Error("cashNextOpening and cashToSafe must be non-negative");
+      }
+      if (toSafe > args.cashCounted) {
+        throw new Error("cashToSafe cannot exceed cashCounted");
+      }
+      const splitSum = Math.round((nextOpening + toSafe) * 100) / 100;
+      const counted = Math.round(args.cashCounted * 100) / 100;
+      if (splitSum !== counted) {
+        throw new Error(
+          `cashNextOpening (${nextOpening}) + cashToSafe (${toSafe}) must equal cashCounted (${counted})`,
+        );
+      }
+      if (toSafe > 0 && !args.locationId) {
+        throw new Error(
+          "locationId is required when cashToSafe > 0 (safe is per-location)",
+        );
+      }
+    }
+
     const db = createSupabaseDb();
     const client = db.raw();
 
@@ -195,6 +234,29 @@ export const createDayClose = action({
     const { data: existing } = await existingQuery.limit(1).maybeSingle();
 
     if (existing) {
+      // Idempotency: if day was already closed, check if the safe transfer
+      // still needs to be created (e.g. action was interrupted after writing
+      // the day close but before writing the safe movement).
+      const dayCloseId = (existing as { id: string }).id;
+      if (args.cashToSafe && args.cashToSafe > 0 && args.locationId) {
+        const { data: existingMovement } = await client
+          .from("gabinet_safe_movements")
+          .select("id")
+          .eq("reference_day_close_id", dayCloseId)
+          .maybeSingle();
+        if (!existingMovement) {
+          await createSafeMovement(
+            ctx,
+            client,
+            dayCloseId,
+            args.organizationId,
+            args.locationId,
+            args.cashToSafe,
+            authResult.userId,
+            args.date,
+          );
+        }
+      }
       throw new Error("Day already closed for this date and location");
     }
 
@@ -297,6 +359,8 @@ export const createDayClose = action({
       cash_expected: cashExpected,
       cash_counted: args.cashCounted,
       cash_discrepancy: cashDiscrepancy,
+      cash_next_opening: args.cashNextOpening ?? null,
+      cash_to_safe: args.cashToSafe ?? null,
       notes: args.notes ?? null,
       closed_by: authResult.userId,
       closed_at: now,
@@ -312,9 +376,78 @@ export const createDayClose = action({
       action: "day_close_created",
       entityType: "gabinetDayClose",
       entityId: id,
-      details: `Day closed for ${args.date}, total collected: ${totalCollected}, discrepancy: ${cashDiscrepancy}`,
+      details: `Day closed for ${args.date}, total collected: ${totalCollected}, discrepancy: ${cashDiscrepancy}` +
+        (args.cashNextOpening !== undefined
+          ? `; cashNextOpening: ${args.cashNextOpening}, cashToSafe: ${args.cashToSafe ?? 0}`
+          : ""),
     });
+
+    // Create safe movement if cashToSafe > 0 (idempotent: checked by
+    // reference_day_close_id before inserting).
+    if (args.cashToSafe && args.cashToSafe > 0 && args.locationId) {
+      // Guard: verify no movement already exists (handles concurrent retries).
+      const { data: existingMovement } = await client
+        .from("gabinet_safe_movements")
+        .select("id")
+        .eq("reference_day_close_id", id)
+        .maybeSingle();
+      if (!existingMovement) {
+        await createSafeMovement(
+          ctx,
+          client,
+          id,
+          args.organizationId,
+          args.locationId,
+          args.cashToSafe,
+          authResult.userId,
+          args.date,
+        );
+      }
+    }
 
     return { id, cashExpected, cashDiscrepancy, totalCollected, paymentSummary: summary };
   },
 });
+
+// ---------------------------------------------------------------------------
+// Internal helper — creates one transfer_in movement in gabinet_safe_movements
+// and writes the corresponding audit log entry.
+// ---------------------------------------------------------------------------
+
+async function createSafeMovement(
+  ctx: Parameters<typeof logAudit>[0],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  client: any,
+  dayCloseId: string,
+  organizationId: string,
+  locationId: string,
+  amount: number,
+  userId: string,
+  date: string,
+): Promise<void> {
+  const movementId = nanoid();
+  const now = Date.now();
+
+  const { error } = await client.from("gabinet_safe_movements").insert({
+    id: movementId,
+    organization_id: String(organizationId),
+    location_id: locationId,
+    type: "transfer_in",
+    amount,
+    description: `Zamknięcie dnia ${date} — transfer do Sejfu`,
+    reference_day_close_id: dayCloseId,
+    created_by: userId,
+    created_at: now,
+  });
+
+  if (error) throw new Error(`createSafeMovement: ${error.message}`);
+
+  await logAudit(ctx, {
+    organizationId,
+    userId,
+    action: "safe_transfer_in",
+    entityType: "gabinetSafeMovement",
+    entityId: movementId,
+    details: `Day-close safe transfer: ${amount} PLN; location: ${locationId}; dayClose: ${dayCloseId}; date: ${date}`,
+  });
+}

--- a/convex/schema/gabinet.ts
+++ b/convex/schema/gabinet.ts
@@ -969,6 +969,9 @@ export function createGabinetTables({
     cashExpected: v.float64(),
     cashCounted: v.float64(),
     cashDiscrepancy: v.float64(),
+    // R2B (issue #5575): cash split at day close. NULL for historical records.
+    cashNextOpening: v.optional(v.float64()),
+    cashToSafe: v.optional(v.float64()),
     notes: v.optional(v.string()),
     closedBy: v.id("users"),
     closedAt: v.number(),

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -4376,7 +4376,11 @@
       "dayClosed": "Day closed successfully",
       "dayAlreadyClosed": "Day already closed",
       "totalCollected": "Total collected",
-      "history": "Closure history"
+      "history": "Closure history",
+      "cashSplit": "Cash split",
+      "cashNextOpening": "Stays in register for next day",
+      "cashToSafe": "To Safe (Sejf)",
+      "cashSplitRequired": "Sum must equal counted cash"
     },
     "deliveries": {
       "loadError": "Failed to load delivery.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -4375,7 +4375,11 @@
       "dayClosed": "Dzień zamknięty pomyślnie",
       "dayAlreadyClosed": "Dzień zamknięty",
       "totalCollected": "Łączne wpłaty",
-      "history": "Historia zamknięć"
+      "history": "Historia zamknięć",
+      "cashSplit": "Podział gotówki",
+      "cashNextOpening": "Zostaje w kasie na następny dzień",
+      "cashToSafe": "Do Sejfu",
+      "cashSplitRequired": "Suma musi być równa policzonej gotówce"
     },
     "deliveries": {
       "loadError": "Nie udało się załadować dostawy.",

--- a/src/hooks/use-supabase-day-close.ts
+++ b/src/hooks/use-supabase-day-close.ts
@@ -38,6 +38,10 @@ export interface GabinetDayClose {
   cashExpected: number;
   cashCounted: number;
   cashDiscrepancy: number;
+  /** R2B: amount staying in register as next-day opening balance. NULL for historical records. */
+  cashNextOpening: number | null;
+  /** R2B: amount transferred to the safe (Sejf). NULL for historical records. */
+  cashToSafe: number | null;
   notes: string | null;
   closedBy: string;
   closedAt: number;
@@ -80,6 +84,8 @@ function mapDayClose(row: Record<string, unknown>): GabinetDayClose {
     cashExpected: Number(row.cash_expected),
     cashCounted: Number(row.cash_counted),
     cashDiscrepancy: Number(row.cash_discrepancy),
+    cashNextOpening: row.cash_next_opening != null ? Number(row.cash_next_opening) : null,
+    cashToSafe: row.cash_to_safe != null ? Number(row.cash_to_safe) : null,
     notes: (row.notes as string | null) ?? null,
     closedBy: row.closed_by as string,
     closedAt: Number(row.closed_at),

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.cash.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.cash.lazy.tsx
@@ -442,6 +442,8 @@ function DayCloseFormCard({
 
   const [openingBalance, setOpeningBalance] = useState("0");
   const [countedCash, setCountedCash] = useState("");
+  const [cashNextOpening, setCashNextOpening] = useState("");
+  const [cashToSafe, setCashToSafe] = useState("0");
   const [notes, setNotes] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
@@ -453,9 +455,38 @@ function DayCloseFormCard({
     ) / 100;
   const discrepancy = Math.round((countedCashNum - expectedCash) * 100) / 100;
 
+  const showSplit = !!countedCash && countedCashNum > 0;
+  const cashNextOpeningNum = parseFloat(cashNextOpening.replace(",", ".")) || 0;
+  const cashToSafeNum = parseFloat(cashToSafe.replace(",", ".")) || 0;
+  const splitSum = Math.round((cashNextOpeningNum + cashToSafeNum) * 100) / 100;
+  const splitValid =
+    !showSplit ||
+    (cashNextOpeningNum >= 0 &&
+      cashToSafeNum >= 0 &&
+      cashToSafeNum <= countedCashNum &&
+      Math.abs(splitSum - Math.round(countedCashNum * 100) / 100) < 0.005);
+
+  const handleCountedCashChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = e.target.value;
+      setCountedCash(raw);
+      // Auto-fill: entire counted amount stays in register, safe gets 0.
+      const v = parseFloat(raw.replace(",", "."));
+      if (!isNaN(v) && v >= 0) {
+        setCashNextOpening(String(v));
+        setCashToSafe("0");
+      }
+    },
+    [],
+  );
+
   const handleClose = useCallback(async () => {
     if (!countedCash) {
       toast.error(t("gabinet.cash.countedCashRequired"));
+      return;
+    }
+    if (!splitValid) {
+      toast.error(t("gabinet.cash.cashSplitRequired"));
       return;
     }
     setSubmitting(true);
@@ -466,6 +497,8 @@ function DayCloseFormCard({
         date,
         cashOpeningBalance: openingBalanceNum,
         cashCounted: countedCashNum,
+        cashNextOpening: showSplit ? cashNextOpeningNum : undefined,
+        cashToSafe: showSplit ? cashToSafeNum : undefined,
         notes: notes || undefined,
       });
       toast.success(t("gabinet.cash.dayClosed"));
@@ -475,7 +508,11 @@ function DayCloseFormCard({
     } finally {
       setSubmitting(false);
     }
-  }, [createClose, organizationId, locationId, date, openingBalanceNum, countedCashNum, notes, t, countedCash, onClosed]);
+  }, [
+    createClose, organizationId, locationId, date, openingBalanceNum,
+    countedCashNum, cashNextOpeningNum, cashToSafeNum, showSplit,
+    notes, t, countedCash, splitValid, onClosed,
+  ]);
 
   if (isAlreadyClosed) return null;
 
@@ -514,7 +551,7 @@ function DayCloseFormCard({
               step="0.01"
               placeholder="0,00"
               value={countedCash}
-              onChange={(e) => setCountedCash(e.target.value)}
+              onChange={handleCountedCashChange}
               disabled={!canEdit}
             />
           </div>
@@ -583,6 +620,56 @@ function DayCloseFormCard({
           )}
         </div>
 
+        {/* Cash split — shown after countedCash is entered */}
+        {showSplit && (
+          <div className="rounded-md border p-4 space-y-3">
+            <p className="text-sm font-medium">{t("gabinet.cash.cashSplit")}</p>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <FieldLabel htmlFor="cash-next-opening">
+                  {t("gabinet.cash.cashNextOpening")}
+                </FieldLabel>
+                <Input
+                  id="cash-next-opening"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  placeholder="0,00"
+                  value={cashNextOpening}
+                  onChange={(e) => setCashNextOpening(e.target.value)}
+                  disabled={!canEdit}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <FieldLabel htmlFor="cash-to-safe">
+                  {t("gabinet.cash.cashToSafe")}
+                </FieldLabel>
+                <Input
+                  id="cash-to-safe"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  placeholder="0,00"
+                  value={cashToSafe}
+                  onChange={(e) => setCashToSafe(e.target.value)}
+                  disabled={!canEdit}
+                />
+              </div>
+            </div>
+            {!splitValid && (
+              <p className="text-sm text-red-600">
+                {t("gabinet.cash.cashSplitRequired")}
+              </p>
+            )}
+            {splitValid && splitSum > 0 && (
+              <p className="text-xs text-muted-foreground">
+                {splitSum.toFixed(2)} /{" "}
+                {countedCashNum.toFixed(2)} PLN
+              </p>
+            )}
+          </div>
+        )}
+
         <div className="space-y-1.5">
           <FieldLabel htmlFor="close-notes">{t("gabinet.cash.notes")}</FieldLabel>
           <Textarea
@@ -598,7 +685,7 @@ function DayCloseFormCard({
         {canEdit && (
           <Button
             onClick={handleClose}
-            disabled={submitting || !countedCash}
+            disabled={submitting || !countedCash || !splitValid}
             className="w-full"
           >
             {submitting
@@ -629,12 +716,16 @@ function DayCloseSummaryCard({
     cashExpected: number;
     cashCounted: number;
     cashDiscrepancy: number;
+    cashNextOpening: number | null;
+    cashToSafe: number | null;
     notes: string | null;
     closedAt: number;
   };
 }) {
   const { t } = useTranslation();
   const isOk = dayClose.cashDiscrepancy === 0;
+  const hasSplit =
+    dayClose.cashNextOpening !== null || dayClose.cashToSafe !== null;
 
   return (
     <Card className="border-green-200">
@@ -748,6 +839,33 @@ function DayCloseSummaryCard({
             </span>
           </div>
         </div>
+
+        {/* Cash split summary (R2B) */}
+        {hasSplit && (
+          <div className="rounded-md border p-4 space-y-2 text-sm">
+            <p className="font-medium">{t("gabinet.cash.cashSplit")}</p>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">
+                {t("gabinet.cash.cashNextOpening")}
+              </span>
+              <span>
+                {formatCurrencyPLN(dayClose.cashNextOpening ?? 0, "PLN", {
+                  fractionDigits: 2,
+                })}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">
+                {t("gabinet.cash.cashToSafe")}
+              </span>
+              <span className="font-medium">
+                {formatCurrencyPLN(dayClose.cashToSafe ?? 0, "PLN", {
+                  fractionDigits: 2,
+                })}
+              </span>
+            </div>
+          </div>
+        )}
 
         {dayClose.notes && (
           <p className="text-sm text-muted-foreground italic">{dayClose.notes}</p>

--- a/supabase/migrations/00146_gabinet_day_closes_cash_split.sql
+++ b/supabase/migrations/00146_gabinet_day_closes_cash_split.sql
@@ -1,0 +1,15 @@
+-- R2B (issue #5575): extend gabinet_day_closes with cash split at day close.
+--
+-- cashNextOpening — amount that stays in the register as the starting balance
+--                   for the following day (same location).
+-- cashToSafe      — amount physically moved to the location's safe (Sejf).
+--
+-- Invariant (enforced in Convex, not in SQL):
+--   cash_next_opening + cash_to_safe = cash_counted
+--
+-- Columns are NULL for records created before this migration (historical
+-- closes that never had the split concept). Do NOT backfill with 0.
+
+ALTER TABLE gabinet_day_closes
+  ADD COLUMN IF NOT EXISTS cash_next_opening NUMERIC(12, 2),
+  ADD COLUMN IF NOT EXISTS cash_to_safe      NUMERIC(12, 2);

--- a/tests/convex/_supabase_inmemory.ts
+++ b/tests/convex/_supabase_inmemory.ts
@@ -501,6 +501,29 @@ class InMemoryRawQuery {
     return this;
   }
 
+  /** Inserts one or more rows into the table. Each row with snake_case keys is
+   *  converted to camelCase before storage (mirroring how other write paths
+   *  work in InMemoryRawQuery). Returns PostgREST-style { data, error }. */
+  async insert(
+    payload: Record<string, unknown> | Record<string, unknown>[],
+  ): Promise<{ data: Row[] | null; error: null | { message: string } }> {
+    const rows = Array.isArray(payload) ? payload : [payload];
+    const t = getTable(this.table);
+    const inserted: Row[] = [];
+    for (const rawRow of rows) {
+      const camel: Row = {};
+      for (const [k, v] of Object.entries(rawRow)) {
+        camel[snakeToCamel(k)] = v as unknown;
+      }
+      const id = camel.id ? String(camel.id) : randomId();
+      const stored: Row = { ...camel, id };
+      delete (stored as any)._id;
+      t.set(id, stored);
+      inserted.push({ ...convertKeysToSnake(stored) });
+    }
+    return { data: inserted, error: null };
+  }
+
   /** Builder step — records that columns should be projected (or switches to
    *  read-after-write for update/delete). Does NOT execute the query. */
   select(_cols?: string) {
@@ -534,6 +557,28 @@ class InMemoryRawQuery {
       }
       return r[camelField] !== value;
     });
+    return this;
+  }
+
+  is(field: string, value: unknown) {
+    const camelField = snakeToCamel(field);
+    if (value === null) {
+      this.filters.push((r) => r[camelField] == null);
+    } else {
+      this.filters.push((r) => r[camelField] === value);
+    }
+    return this;
+  }
+
+  gte(field: string, value: unknown) {
+    const camelField = snakeToCamel(field);
+    this.filters.push((r) => (r[camelField] as any) >= (value as any));
+    return this;
+  }
+
+  lte(field: string, value: unknown) {
+    const camelField = snakeToCamel(field);
+    this.filters.push((r) => (r[camelField] as any) <= (value as any));
     return this;
   }
 

--- a/tests/convex/dayClose.test.ts
+++ b/tests/convex/dayClose.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Tests for R2B (issue #5575): day-close cash split — cashNextOpening +
+ * cashToSafe, with automatic safe movement creation.
+ *
+ * Coverage:
+ *   1. Correct cash split persists both fields on the day close record.
+ *   2. Invalid sum (cashNextOpening + cashToSafe ≠ cashCounted) is rejected.
+ *   3. cashToSafe = 0 — no safe movement is created.
+ *   4. Positive cashToSafe — exactly one transfer_in movement is created.
+ *   5. Idempotency — retry does not create a second safe movement.
+ *   6. Negative values are rejected.
+ *   7. cashToSafe exceeding cashCounted is rejected.
+ *   8. locationId required when cashToSafe > 0.
+ *   9. Historical close (no split args) stores NULL for both fields.
+ *  10. cashNextOpening value is available for the next day (query asserts it).
+ */
+
+import { afterEach, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function seedGabinetSubscription(
+  t: ReturnType<typeof createTestCtx>,
+  organizationId: Parameters<typeof createTestCtx>[0] extends undefined
+    ? string
+    : string,
+) {
+  await t.run(async (ctx) => {
+    const now = Date.now();
+    await ctx.db.insert("productSubscriptions", {
+      organizationId: organizationId as any,
+      productId: "gabinet",
+      status: "active",
+      cancelAtPeriodEnd: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+}
+
+function seedLocation(locationId: string, organizationId: string) {
+  const db = createSupabaseDb();
+  return db.insert("gabinetLocations", {
+    id: locationId,
+    organizationId,
+    name: "Test Location",
+    isActive: true,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+}
+
+const DATE = "2026-08-19";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("dayClose — R2B cash split", () => {
+  test("1. correct split persists cashNextOpening and cashToSafe on the day close", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await seedGabinetSubscription(t, String(organizationId));
+    const locationId = "loc-001";
+    await seedLocation(locationId, String(organizationId));
+
+    const result = await t.withIdentity(identity).action(
+      api.gabinet.dayClose.createDayClose,
+      {
+        organizationId: String(organizationId),
+        locationId,
+        date: DATE,
+        cashOpeningBalance: 0,
+        cashCounted: 1000,
+        cashNextOpening: 200,
+        cashToSafe: 800,
+      },
+    );
+
+    expect(result.id).toBeTruthy();
+
+    // Verify the day close record has the split fields.
+    const db = createSupabaseDb();
+    const stored = await db.get<Record<string, unknown>>(
+      "gabinetDayCloses",
+      result.id,
+    );
+    expect(stored).not.toBeNull();
+    expect(Number(stored!.cashNextOpening)).toBe(200);
+    expect(Number(stored!.cashToSafe)).toBe(800);
+  });
+
+  test("2. invalid sum (nextOpening + toSafe ≠ counted) is rejected", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await seedGabinetSubscription(t, String(organizationId));
+    const locationId = "loc-002";
+    await seedLocation(locationId, String(organizationId));
+
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.dayClose.createDayClose, {
+        organizationId: String(organizationId),
+        locationId,
+        date: DATE,
+        cashOpeningBalance: 0,
+        cashCounted: 1000,
+        cashNextOpening: 300,
+        cashToSafe: 800, // 300 + 800 = 1100 ≠ 1000
+      }),
+    ).rejects.toThrow(/must equal cashCounted/);
+  });
+
+  test("3. cashToSafe = 0 creates no safe movement", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await seedGabinetSubscription(t, String(organizationId));
+    const locationId = "loc-003";
+    await seedLocation(locationId, String(organizationId));
+
+    const result = await t.withIdentity(identity).action(
+      api.gabinet.dayClose.createDayClose,
+      {
+        organizationId: String(organizationId),
+        locationId,
+        date: DATE,
+        cashOpeningBalance: 0,
+        cashCounted: 500,
+        cashNextOpening: 500,
+        cashToSafe: 0,
+      },
+    );
+
+    expect(result.id).toBeTruthy();
+
+    // Verify no safe movement was created.
+    const db = createSupabaseDb();
+    const movements = db
+      .query("gabinetSafeMovements")
+      .eq("organizationId", String(organizationId));
+    const rows = await movements.collect();
+    expect(rows).toHaveLength(0);
+  });
+
+  test("4. positive cashToSafe creates exactly one transfer_in movement linked to the day close", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await seedGabinetSubscription(t, String(organizationId));
+    const locationId = "loc-004";
+    await seedLocation(locationId, String(organizationId));
+
+    const result = await t.withIdentity(identity).action(
+      api.gabinet.dayClose.createDayClose,
+      {
+        organizationId: String(organizationId),
+        locationId,
+        date: DATE,
+        cashOpeningBalance: 0,
+        cashCounted: 1200,
+        cashNextOpening: 400,
+        cashToSafe: 800,
+      },
+    );
+
+    const db = createSupabaseDb();
+    const movements = await db
+      .query("gabinetSafeMovements")
+      .eq("organizationId", String(organizationId))
+      .collect();
+
+    expect(movements).toHaveLength(1);
+    const mov = movements[0] as Record<string, unknown>;
+    expect(mov.type).toBe("transfer_in");
+    expect(Number(mov.amount)).toBe(800);
+    expect(mov.locationId).toBe(locationId);
+    expect(mov.referenceDayCloseId).toBe(result.id);
+  });
+
+  test("5. idempotency — retry after interrupted transfer does not create a second safe movement", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await seedGabinetSubscription(t, String(organizationId));
+    const locationId = "loc-005";
+    await seedLocation(locationId, String(organizationId));
+
+    // First call succeeds.
+    const result = await t.withIdentity(identity).action(
+      api.gabinet.dayClose.createDayClose,
+      {
+        organizationId: String(organizationId),
+        locationId,
+        date: DATE,
+        cashOpeningBalance: 0,
+        cashCounted: 600,
+        cashNextOpening: 100,
+        cashToSafe: 500,
+      },
+    );
+
+    // Simulate retry: the action throws "Day already closed…" but should NOT
+    // create a second movement (idempotency guard in the existing-close branch).
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.dayClose.createDayClose, {
+        organizationId: String(organizationId),
+        locationId,
+        date: DATE,
+        cashOpeningBalance: 0,
+        cashCounted: 600,
+        cashNextOpening: 100,
+        cashToSafe: 500,
+      }),
+    ).rejects.toThrow(/Day already closed/);
+
+    // Still exactly one safe movement.
+    const db = createSupabaseDb();
+    const movements = await db
+      .query("gabinetSafeMovements")
+      .eq("organizationId", String(organizationId))
+      .collect();
+
+    expect(movements).toHaveLength(1);
+    expect((movements[0] as Record<string, unknown>).referenceDayCloseId).toBe(
+      result.id,
+    );
+  });
+
+  test("6. negative values (cashNextOpening < 0) are rejected", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await seedGabinetSubscription(t, String(organizationId));
+
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.dayClose.createDayClose, {
+        organizationId: String(organizationId),
+        date: DATE,
+        cashOpeningBalance: 0,
+        cashCounted: 1000,
+        cashNextOpening: -100,
+        cashToSafe: 1100,
+      }),
+    ).rejects.toThrow(/non-negative/);
+  });
+
+  test("7. cashToSafe exceeding cashCounted is rejected", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await seedGabinetSubscription(t, String(organizationId));
+
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.dayClose.createDayClose, {
+        organizationId: String(organizationId),
+        date: DATE,
+        cashOpeningBalance: 0,
+        cashCounted: 500,
+        cashNextOpening: 0,
+        cashToSafe: 600,
+      }),
+    ).rejects.toThrow(/cannot exceed cashCounted/);
+  });
+
+  test("8. cashToSafe > 0 without locationId is rejected", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await seedGabinetSubscription(t, String(organizationId));
+
+    await expect(
+      t.withIdentity(identity).action(api.gabinet.dayClose.createDayClose, {
+        organizationId: String(organizationId),
+        // no locationId
+        date: DATE,
+        cashOpeningBalance: 0,
+        cashCounted: 400,
+        cashNextOpening: 100,
+        cashToSafe: 300,
+      }),
+    ).rejects.toThrow(/locationId is required/);
+  });
+
+  test("9. historical close (no split args) stores NULL for cashNextOpening and cashToSafe", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await seedGabinetSubscription(t, String(organizationId));
+
+    const result = await t.withIdentity(identity).action(
+      api.gabinet.dayClose.createDayClose,
+      {
+        organizationId: String(organizationId),
+        date: DATE,
+        cashOpeningBalance: 0,
+        cashCounted: 300,
+        // cashNextOpening and cashToSafe intentionally omitted (historical)
+      },
+    );
+
+    const db = createSupabaseDb();
+    const stored = await db.get<Record<string, unknown>>(
+      "gabinetDayCloses",
+      result.id,
+    );
+    expect(stored).not.toBeNull();
+    expect(stored!.cashNextOpening).toBeNull();
+    expect(stored!.cashToSafe).toBeNull();
+  });
+
+  test("10. cashNextOpening is retrievable from the day close record for next-day use", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await seedGabinetSubscription(t, String(organizationId));
+    const locationId = "loc-010";
+    await seedLocation(locationId, String(organizationId));
+
+    const result = await t.withIdentity(identity).action(
+      api.gabinet.dayClose.createDayClose,
+      {
+        organizationId: String(organizationId),
+        locationId,
+        date: DATE,
+        cashOpeningBalance: 0,
+        cashCounted: 750,
+        cashNextOpening: 250,
+        cashToSafe: 500,
+      },
+    );
+
+    // Retrieve the day close and confirm cashNextOpening is present and
+    // correct — this is the value the next day's opening balance can be
+    // pre-filled with.
+    const db = createSupabaseDb();
+    const stored = await db.get<Record<string, unknown>>(
+      "gabinetDayCloses",
+      result.id,
+    );
+    expect(stored).not.toBeNull();
+    expect(Number(stored!.cashNextOpening)).toBe(250);
+    expect(Number(stored!.cashToSafe)).toBe(500);
+
+    // The safe movement amount matches cashToSafe.
+    const movements = await db
+      .query("gabinetSafeMovements")
+      .eq("organizationId", String(organizationId))
+      .collect();
+    expect(movements).toHaveLength(1);
+    expect(Number((movements[0] as Record<string, unknown>).amount)).toBe(500);
+  });
+});


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5575.

Closes #5575

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a6b0c4ac feat(gabinet): R2B — extend day close with cash split (Kasa/Sejf) — closes #5575

### Files changed

```
 convex/gabinet/dayClose.ts                         | 135 +++++++-
 convex/schema/gabinet.ts                           |   3 +
 public/locales/en/translation.json                 |   8 +-
 public/locales/pl/translation.json                 |   8 +-
 src/hooks/use-supabase-day-close.ts                |   6 +
 .../_auth/dashboard/_layout.gabinet.cash.lazy.tsx  | 124 +++++++-
 .../00146_gabinet_day_closes_cash_split.sql        |  15 +
 tests/convex/_supabase_inmemory.ts                 |  45 +++
 tests/convex/dayClose.test.ts                      | 353 +++++++++++++++++++++
 9 files changed, 689 insertions(+), 8 deletions(-)
```