### PR TITLE
Pre-fill openingBalance from previous day's cashNextOpening in UI

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -4380,7 +4380,8 @@
       "cashSplit": "Cash split",
       "cashNextOpening": "Stays in register for next day",
       "cashToSafe": "To Safe (Sejf)",
-      "cashSplitRequired": "Sum must equal counted cash"
+      "cashSplitRequired": "Sum must equal counted cash",
+      "openingBalancePreFilled": "Auto-filled from previous day close"
     },
     "deliveries": {
       "loadError": "Failed to load delivery.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -4379,7 +4379,8 @@
       "cashSplit": "Podział gotówki",
       "cashNextOpening": "Zostaje w kasie na następny dzień",
       "cashToSafe": "Do Sejfu",
-      "cashSplitRequired": "Suma musi być równa policzonej gotówce"
+      "cashSplitRequired": "Suma musi być równa policzonej gotówce",
+      "openingBalancePreFilled": "Uzupełnione automatycznie z poprzedniego zamknięcia dnia"
     },
     "deliveries": {
       "loadError": "Nie udało się załadować dostawy.",

--- a/src/hooks/use-supabase-day-close.ts
+++ b/src/hooks/use-supabase-day-close.ts
@@ -176,6 +176,50 @@ export function useSupabaseGabinetDayCloseByDate(
 }
 
 // ---------------------------------------------------------------------------
+// Most recent Day Close before a given date (used to pre-fill opening balance)
+// ---------------------------------------------------------------------------
+
+export function useSupabaseGabinetPreviousDayClose(
+  organizationId: string,
+  date: string,
+  options: { enabled?: boolean; locationId?: string } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true, locationId } = options;
+
+  return useQuery<GabinetDayClose | null, Error>({
+    queryKey: [
+      ...supabaseKeys.gabinetDayCloses.list(organizationId),
+      "previous",
+      date,
+      locationId ?? "",
+    ],
+    queryFn: async (): Promise<GabinetDayClose | null> => {
+      if (!client) throw new Error("Supabase client not ready");
+
+      let q = client
+        .from("gabinet_day_closes")
+        .select("*")
+        .eq("organization_id", organizationId)
+        .lt("date", date)
+        .order("date", { ascending: false });
+
+      if (locationId) {
+        q = q.eq("location_id", locationId);
+      } else {
+        q = q.is("location_id", null);
+      }
+
+      const { data, error } = await q.limit(1).maybeSingle();
+      if (error) throw error;
+      if (!data) return null;
+      return mapDayClose(data as Record<string, unknown>);
+    },
+    enabled: enabled && isReady && !!organizationId && !!date,
+  } satisfies UseQueryOptions<GabinetDayClose | null, Error>);
+}
+
+// ---------------------------------------------------------------------------
 // Recent Day Closes list
 // ---------------------------------------------------------------------------
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.cash.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.cash.lazy.tsx
@@ -1,5 +1,5 @@
 import { createLazyFileRoute } from "@tanstack/react-router";
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useAction } from "convex/react";
 import { useQueryClient } from "@tanstack/react-query";
@@ -38,6 +38,7 @@ import {
   useSupabaseGabinetCashTransactions,
   useSupabaseGabinetDayCloseByDate,
   useSupabaseGabinetDayClosesList,
+  useSupabaseGabinetPreviousDayClose,
 } from "@/hooks/use-supabase-day-close";
 import { useSupabasePaymentsRevenueByDateRange } from "@/hooks/use-supabase-payments";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
@@ -425,6 +426,7 @@ function DayCloseFormCard({
   cashWithdrawals,
   canEdit,
   isAlreadyClosed,
+  previousCashNextOpening,
   onClosed,
 }: {
   organizationId: string;
@@ -435,14 +437,22 @@ function DayCloseFormCard({
   cashWithdrawals: number;
   canEdit: boolean;
   isAlreadyClosed: boolean;
+  previousCashNextOpening: number | null | undefined;
   onClosed: () => void;
 }) {
   const { t } = useTranslation();
   const createClose = useAction(api.gabinet.dayClose.createDayClose);
 
   const [openingBalance, setOpeningBalance] = useState("0");
+  const [openingBalanceTouched, setOpeningBalanceTouched] = useState(false);
   const [countedCash, setCountedCash] = useState("");
   const [cashNextOpening, setCashNextOpening] = useState("");
+
+  useEffect(() => {
+    if (!openingBalanceTouched && previousCashNextOpening != null) {
+      setOpeningBalance(previousCashNextOpening.toFixed(2));
+    }
+  }, [previousCashNextOpening, openingBalanceTouched]);
   const [cashToSafe, setCashToSafe] = useState("0");
   const [notes, setNotes] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -536,9 +546,17 @@ function DayCloseFormCard({
               step="0.01"
               placeholder="0,00"
               value={openingBalance}
-              onChange={(e) => setOpeningBalance(e.target.value)}
+              onChange={(e) => {
+                setOpeningBalance(e.target.value);
+                setOpeningBalanceTouched(true);
+              }}
               disabled={!canEdit}
             />
+            {previousCashNextOpening != null && !openingBalanceTouched && (
+              <p className="text-xs text-muted-foreground">
+                {t("gabinet.cash.openingBalancePreFilled")}
+              </p>
+            )}
           </div>
           <div className="space-y-1.5">
             <FieldLabel htmlFor="counted-cash">
@@ -1035,6 +1053,13 @@ function GabinetCash() {
       locationId: selectedLocationId,
     });
 
+  // Previous day close — used to pre-fill opening balance when not yet closed.
+  const { data: prevDayClose } = useSupabaseGabinetPreviousDayClose(
+    organizationId,
+    selectedDate,
+    { locationId: selectedLocationId, enabled: !loadingDayClose && !dayClose },
+  );
+
   const handleClosed = useCallback(() => {
     qc.invalidateQueries({
       queryKey: supabaseKeys.gabinetDayCloses.list(organizationId),
@@ -1138,6 +1163,7 @@ function GabinetCash() {
           cashWithdrawals={cashWithdrawals}
           canEdit={canEdit}
           isAlreadyClosed={isAlreadyClosed}
+          previousCashNextOpening={prevDayClose?.cashNextOpening ?? null}
           onClosed={handleClosed}
         />
       )}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5578.

Closes #5578

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4356ec91 feat(gabinet): pre-fill openingBalance from previous day cashNextOpening (closes #5578)

### Files changed

```
 public/locales/en/translation.json                 |  3 +-
 public/locales/pl/translation.json                 |  3 +-
 src/hooks/use-supabase-day-close.ts                | 44 ++++++++++++++++++++++
 .../_auth/dashboard/_layout.gabinet.cash.lazy.tsx  | 30 ++++++++++++++-
 4 files changed, 76 insertions(+), 4 deletions(-)
```