### PR TITLE
R2C — Raporty — Sejf: UI, saldo, historia ruchów i wypłata

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -124,6 +124,7 @@ import type * as gabinet_patientAuth from "../gabinet/patientAuth.js";
 import type * as gabinet_patientPortal from "../gabinet/patientPortal.js";
 import type * as gabinet_patients from "../gabinet/patients.js";
 import type * as gabinet_receipts from "../gabinet/receipts.js";
+import type * as gabinet_safe from "../gabinet/safe.js";
 import type * as gabinet_scheduling from "../gabinet/scheduling.js";
 import type * as gabinet_seed from "../gabinet/seed.js";
 import type * as gabinet_sidebarWidgets from "../gabinet/sidebarWidgets.js";
@@ -323,6 +324,7 @@ declare const fullApi: ApiFromModules<{
   "gabinet/patientPortal": typeof gabinet_patientPortal;
   "gabinet/patients": typeof gabinet_patients;
   "gabinet/receipts": typeof gabinet_receipts;
+  "gabinet/safe": typeof gabinet_safe;
   "gabinet/scheduling": typeof gabinet_scheduling;
   "gabinet/seed": typeof gabinet_seed;
   "gabinet/sidebarWidgets": typeof gabinet_sidebarWidgets;

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -4381,7 +4381,32 @@
       "cashNextOpening": "Stays in register for next day",
       "cashToSafe": "To Safe (Sejf)",
       "cashSplitRequired": "Sum must equal counted cash",
-      "openingBalancePreFilled": "Auto-filled from previous day close"
+      "openingBalancePreFilled": "Auto-filled from previous day close",
+      "tabKasa": "Cash Register",
+      "tabSejf": "Safe (Sejf)"
+    },
+    "safe": {
+      "title": "Safe (Sejf)",
+      "noLocation": "Select a location to view safe data",
+      "balance": "Safe Balance",
+      "balanceDescription": "Balance is calculated from movement history",
+      "totalIn": "Total in",
+      "totalOut": "Total out",
+      "movements": "Movement History",
+      "noMovements": "No safe movements",
+      "typeTransferIn": "Transfer to Safe",
+      "typeWithdrawal": "Withdrawal from Safe",
+      "withdrawButton": "Safe Withdrawal",
+      "withdrawForm": "Safe Withdrawal",
+      "withdrawAmount": "Amount",
+      "withdrawReason": "Reason",
+      "withdrawReasonPlaceholder": "e.g. expenses, supplies",
+      "withdraw": "Withdraw",
+      "withdrawSuccess": "Withdrawal recorded",
+      "invalidAmount": "Amount must be greater than 0",
+      "insufficientBalance": "Amount exceeds available safe balance ({{balance}} PLN)",
+      "dayCloseRef": "Day close reference",
+      "description": "Description"
     },
     "deliveries": {
       "loadError": "Failed to load delivery.",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -4380,7 +4380,32 @@
       "cashNextOpening": "Zostaje w kasie na następny dzień",
       "cashToSafe": "Do Sejfu",
       "cashSplitRequired": "Suma musi być równa policzonej gotówce",
-      "openingBalancePreFilled": "Uzupełnione automatycznie z poprzedniego zamknięcia dnia"
+      "openingBalancePreFilled": "Uzupełnione automatycznie z poprzedniego zamknięcia dnia",
+      "tabKasa": "Kasa",
+      "tabSejf": "Sejf"
+    },
+    "safe": {
+      "title": "Sejf",
+      "noLocation": "Wybierz lokalizację, aby zobaczyć dane Sejfu",
+      "balance": "Saldo Sejfu",
+      "balanceDescription": "Saldo wyliczone z historii ruchów",
+      "totalIn": "Łącznie wpłynęło",
+      "totalOut": "Łącznie wypłacono",
+      "movements": "Historia ruchów",
+      "noMovements": "Brak ruchów w Sejfie",
+      "typeTransferIn": "Wpłata do Sejfu",
+      "typeWithdrawal": "Wypłata z Sejfu",
+      "withdrawButton": "Wypłata z Sejfu",
+      "withdrawForm": "Wypłata z Sejfu",
+      "withdrawAmount": "Kwota",
+      "withdrawReason": "Powód",
+      "withdrawReasonPlaceholder": "np. zakupy, opłaty bieżące",
+      "withdraw": "Wypłać",
+      "withdrawSuccess": "Wypłata z Sejfu zarejestrowana",
+      "invalidAmount": "Kwota musi być większa niż 0",
+      "insufficientBalance": "Kwota przekracza dostępne saldo Sejfu ({{balance}} PLN)",
+      "dayCloseRef": "Zamknięcie dnia",
+      "description": "Opis"
     },
     "deliveries": {
       "loadError": "Nie udało się załadować dostawy.",

--- a/src/hooks/use-supabase-safe.ts
+++ b/src/hooks/use-supabase-safe.ts
@@ -1,0 +1,101 @@
+/**
+ * React Query hooks for reading Gabinet safe (Sejf) movements from Supabase.
+ * Balance is always derived from the movement history — there is no separate
+ * balance column (see migration 00145_gabinet_safe_movements.sql).
+ */
+
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+import { useSupabase } from "@/components/supabase-provider";
+import { supabaseKeys } from "@/lib/supabase/query-keys";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GabinetSafeMovement {
+  id: string;
+  organizationId: string;
+  locationId: string;
+  type: "transfer_in" | "withdrawal";
+  amount: number;
+  description: string | null;
+  referenceDayCloseId: string | null;
+  createdBy: string;
+  createdAt: number;
+}
+
+export interface GabinetSafeData {
+  movements: GabinetSafeMovement[];
+  balance: number;
+  totalIn: number;
+  totalOut: number;
+}
+
+function mapSafeMovement(row: Record<string, unknown>): GabinetSafeMovement {
+  return {
+    id: row.id as string,
+    organizationId: row.organization_id as string,
+    locationId: row.location_id as string,
+    type: row.type as "transfer_in" | "withdrawal",
+    amount: Number(row.amount),
+    description: (row.description as string | null) ?? null,
+    referenceDayCloseId: (row.reference_day_close_id as string | null) ?? null,
+    createdBy: row.created_by as string,
+    createdAt: Number(row.created_at),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// useSupabaseGabinetSafeMovements
+// ---------------------------------------------------------------------------
+// Returns the full safe data for a specific location:
+//   - movement list (newest first)
+//   - computed balance, totalIn, totalOut
+
+export function useSupabaseGabinetSafeMovements(
+  organizationId: string,
+  locationId: string | undefined,
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+
+  return useQuery<GabinetSafeData, Error>({
+    queryKey: [
+      ...supabaseKeys.gabinetSafeMovements.list(organizationId),
+      locationId ?? "",
+    ],
+    queryFn: async (): Promise<GabinetSafeData> => {
+      if (!client) throw new Error("Supabase client not ready");
+      if (!locationId) throw new Error("locationId is required");
+
+      const { data, error } = await client
+        .from("gabinet_safe_movements")
+        .select("*")
+        .eq("organization_id", organizationId)
+        .eq("location_id", locationId)
+        .order("created_at", { ascending: false });
+
+      if (error) throw error;
+
+      const rows = (data ?? []).map((r: Record<string, unknown>) =>
+        mapSafeMovement(r),
+      );
+
+      let totalIn = 0;
+      let totalOut = 0;
+      for (const m of rows) {
+        if (m.type === "transfer_in") {
+          totalIn = Math.round((totalIn + m.amount) * 100) / 100;
+        } else {
+          totalOut = Math.round((totalOut + m.amount) * 100) / 100;
+        }
+      }
+      const balance = Math.round((totalIn - totalOut) * 100) / 100;
+
+      return { movements: rows, balance, totalIn, totalOut };
+    },
+    enabled:
+      enabled && isReady && !!organizationId && !!locationId,
+  } satisfies UseQueryOptions<GabinetSafeData, Error>);
+}

--- a/src/lib/supabase/query-keys.ts
+++ b/src/lib/supabase/query-keys.ts
@@ -96,6 +96,7 @@ export const supabaseKeys = {
   gabinetReceipts: entityKeys("gabinetReceipts"),
   gabinetCashTransactions: entityKeys("gabinetCashTransactions"),
   gabinetDayCloses: entityKeys("gabinetDayCloses"),
+  gabinetSafeMovements: entityKeys("gabinetSafeMovements"),
   warehouseDeliveries: entityKeys("warehouseDeliveries"),
 
   // ── Google Calendar ───────────────────────────────────────────────────────

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.cash.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.cash.lazy.tsx
@@ -16,6 +16,7 @@ import { Label as FieldLabel } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import {
   Card,
   CardContent,
@@ -30,9 +31,12 @@ import {
 } from "@/components/ui/select";
 import {
   AlertTriangle,
+  ArrowDownIcon,
+  ArrowUpIcon,
   CheckCircle,
   PlusCircle,
   Trash2Icon,
+  WalletIcon,
 } from "@/lib/ez-icons";
 import {
   useSupabaseGabinetCashTransactions,
@@ -42,6 +46,7 @@ import {
 } from "@/hooks/use-supabase-day-close";
 import { useSupabasePaymentsRevenueByDateRange } from "@/hooks/use-supabase-payments";
 import { useSupabaseGabinetLocationsList } from "@/hooks/use-supabase-gabinet-locations";
+import { useSupabaseGabinetSafeMovements } from "@/hooks/use-supabase-safe";
 import { supabaseKeys } from "@/lib/supabase/query-keys";
 
 function GabinetCashSkeleton() {
@@ -961,6 +966,312 @@ function DayCloseHistoryCard({
 }
 
 // ---------------------------------------------------------------------------
+// Safe Balance Card
+// ---------------------------------------------------------------------------
+
+function SafeBalanceCard({
+  balance,
+  totalIn,
+  totalOut,
+  isLoading,
+}: {
+  balance: number;
+  totalIn: number;
+  totalOut: number;
+  isLoading: boolean;
+}) {
+  const { t } = useTranslation();
+
+  if (isLoading) return <Skeleton className="h-32 rounded-lg" />;
+
+  return (
+    <Card>
+      <CardHeader className="border-b">
+        <div className="flex items-center gap-2">
+          <WalletIcon className="h-5 w-5 text-muted-foreground" variant="stroke" />
+          <span className="text-lg font-semibold">{t("gabinet.safe.balance")}</span>
+        </div>
+      </CardHeader>
+      <CardContent className="pt-4 space-y-3">
+        <div className="flex items-baseline gap-2">
+          <span className="text-3xl font-bold">
+            {formatCurrencyPLN(balance, "PLN", { fractionDigits: 2 })}
+          </span>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {t("gabinet.safe.balanceDescription")}
+        </p>
+        <div className="flex gap-6 text-sm border-t pt-3">
+          <div className="flex items-center gap-1.5">
+            <ArrowDownIcon className="h-3.5 w-3.5 text-green-600" variant="stroke" />
+            <span className="text-muted-foreground">{t("gabinet.safe.totalIn")}:</span>
+            <span className="font-medium text-green-600">
+              {formatCurrencyPLN(totalIn, "PLN", { fractionDigits: 2 })}
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <ArrowUpIcon className="h-3.5 w-3.5 text-red-600" variant="stroke" />
+            <span className="text-muted-foreground">{t("gabinet.safe.totalOut")}:</span>
+            <span className="font-medium text-red-600">
+              {formatCurrencyPLN(totalOut, "PLN", { fractionDigits: 2 })}
+            </span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Safe Movements Card
+// ---------------------------------------------------------------------------
+
+function SafeMovementsCard({
+  movements,
+  isLoading,
+  canEdit,
+  safeBalance,
+  organizationId,
+  locationId,
+  onWithdrawn,
+}: {
+  movements: { id: string; type: "transfer_in" | "withdrawal"; amount: number; description: string | null; referenceDayCloseId: string | null; createdBy: string; createdAt: number }[];
+  isLoading: boolean;
+  canEdit: boolean;
+  safeBalance: number;
+  organizationId: string;
+  locationId: string;
+  onWithdrawn: () => void;
+}) {
+  const { t } = useTranslation();
+  const qc = useQueryClient();
+  const withdrawFromSafe = useAction(api.gabinet.safe.withdrawFromSafe);
+
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [withdrawAmount, setWithdrawAmount] = useState("");
+  const [withdrawReason, setWithdrawReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleWithdraw = useCallback(async () => {
+    const amount = parseFloat(withdrawAmount.replace(",", "."));
+    if (isNaN(amount) || amount <= 0) {
+      toast.error(t("gabinet.safe.invalidAmount"));
+      return;
+    }
+    if (amount > safeBalance) {
+      toast.error(
+        t("gabinet.safe.insufficientBalance", {
+          balance: safeBalance.toFixed(2),
+        }),
+      );
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await withdrawFromSafe({
+        organizationId: organizationId as Id<"organizations">,
+        locationId,
+        amount,
+        description: withdrawReason || undefined,
+      });
+      toast.success(t("gabinet.safe.withdrawSuccess"));
+      setPanelOpen(false);
+      setWithdrawAmount("");
+      setWithdrawReason("");
+      qc.invalidateQueries({
+        queryKey: supabaseKeys.gabinetSafeMovements.list(organizationId),
+      });
+      onWithdrawn();
+    } catch (e) {
+      toast.error((e as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [withdrawFromSafe, organizationId, locationId, withdrawAmount, withdrawReason, safeBalance, t, qc, onWithdrawn]);
+
+  if (isLoading) return <Skeleton className="h-40 rounded-lg" />;
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex justify-between border-b">
+          <span className="text-lg font-semibold">{t("gabinet.safe.movements")}</span>
+          {canEdit && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPanelOpen(true)}
+            >
+              <ArrowUpIcon className="mr-1.5 h-4 w-4" variant="stroke" />
+              {t("gabinet.safe.withdrawButton")}
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent className="pt-0">
+          {movements.length === 0 ? (
+            <p className="text-muted-foreground text-sm py-6 text-center">
+              {t("gabinet.safe.noMovements")}
+            </p>
+          ) : (
+            <div className="divide-y">
+              {movements.map((m) => (
+                <div
+                  key={m.id}
+                  className="flex items-start justify-between py-3 text-sm gap-3"
+                >
+                  <div className="flex items-start gap-2 min-w-0">
+                    <span
+                      className={`mt-0.5 shrink-0 rounded-full p-1 ${
+                        m.type === "transfer_in"
+                          ? "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-400"
+                          : "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400"
+                      }`}
+                    >
+                      {m.type === "transfer_in" ? (
+                        <ArrowDownIcon className="h-3 w-3" variant="stroke" />
+                      ) : (
+                        <ArrowUpIcon className="h-3 w-3" variant="stroke" />
+                      )}
+                    </span>
+                    <div className="min-w-0">
+                      <p className="font-medium leading-none">
+                        {m.type === "transfer_in"
+                          ? t("gabinet.safe.typeTransferIn")
+                          : t("gabinet.safe.typeWithdrawal")}
+                      </p>
+                      {m.description && (
+                        <p className="text-muted-foreground text-xs mt-1 truncate">
+                          {m.description}
+                        </p>
+                      )}
+                      {m.referenceDayCloseId && (
+                        <p className="text-muted-foreground text-xs mt-0.5">
+                          {t("gabinet.safe.dayCloseRef")}
+                        </p>
+                      )}
+                      <p className="text-muted-foreground text-xs mt-1">
+                        {formatTs(m.createdAt)}
+                      </p>
+                    </div>
+                  </div>
+                  <span
+                    className={`shrink-0 font-semibold tabular-nums ${
+                      m.type === "transfer_in" ? "text-green-600" : "text-red-600"
+                    }`}
+                  >
+                    {m.type === "transfer_in" ? "+" : "-"}
+                    {formatCurrencyPLN(m.amount, "PLN", { fractionDigits: 2 })}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <SidePanel
+        open={panelOpen}
+        onOpenChange={setPanelOpen}
+        title={t("gabinet.safe.withdrawForm")}
+        onSubmit={handleWithdraw}
+        submitLabel={t("gabinet.safe.withdraw")}
+        isSubmitting={submitting}
+      >
+        <div className="space-y-4">
+          <div className="rounded-md border bg-muted/30 p-3 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">{t("gabinet.safe.balance")}</span>
+              <span className="font-semibold">
+                {formatCurrencyPLN(safeBalance, "PLN", { fractionDigits: 2 })}
+              </span>
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>{t("gabinet.safe.withdrawAmount")}</FieldLabel>
+            <Input
+              type="number"
+              min="0.01"
+              step="0.01"
+              max={safeBalance}
+              placeholder="0,00"
+              value={withdrawAmount}
+              onChange={(e) => setWithdrawAmount(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <FieldLabel>{t("gabinet.safe.withdrawReason")}</FieldLabel>
+            <Textarea
+              placeholder={t("gabinet.safe.withdrawReasonPlaceholder")}
+              value={withdrawReason}
+              onChange={(e) => setWithdrawReason(e.target.value)}
+              rows={2}
+            />
+          </div>
+        </div>
+      </SidePanel>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Safe Tab Content
+// ---------------------------------------------------------------------------
+
+function SafeTabContent({
+  organizationId,
+  locationId,
+  canEdit,
+}: {
+  organizationId: string;
+  locationId: string | undefined;
+  canEdit: boolean;
+}) {
+  const { t } = useTranslation();
+  const qc = useQueryClient();
+
+  const { data: safeData, isLoading } = useSupabaseGabinetSafeMovements(
+    organizationId,
+    locationId,
+    { enabled: !!locationId },
+  );
+
+  const handleWithdrawn = useCallback(() => {
+    qc.invalidateQueries({
+      queryKey: supabaseKeys.gabinetSafeMovements.list(organizationId),
+    });
+  }, [qc, organizationId]);
+
+  if (!locationId) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center gap-3">
+        <WalletIcon className="h-10 w-10 text-muted-foreground/40" variant="stroke" />
+        <p className="text-muted-foreground">{t("gabinet.safe.noLocation")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 sm:gap-6">
+      <SafeBalanceCard
+        balance={safeData?.balance ?? 0}
+        totalIn={safeData?.totalIn ?? 0}
+        totalOut={safeData?.totalOut ?? 0}
+        isLoading={isLoading}
+      />
+      <SafeMovementsCard
+        movements={safeData?.movements ?? []}
+        isLoading={isLoading}
+        canEdit={canEdit}
+        safeBalance={safeData?.balance ?? 0}
+        organizationId={organizationId}
+        locationId={locationId}
+        onWithdrawn={handleWithdrawn}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main Page
 // ---------------------------------------------------------------------------
 
@@ -975,6 +1286,7 @@ function GabinetCash() {
   );
   const { allowed: canEdit } = usePermission("gabinet_reports", "edit");
 
+  const [activeTab, setActiveTab] = useState<"kasa" | "sejf">("kasa");
   const [selectedDate, setSelectedDate] = useState(todayIso);
   const [selectedLocationId, setSelectedLocationId] = useState<
     string | undefined
@@ -1118,61 +1430,83 @@ function GabinetCash() {
               </SelectContent>
             </Select>
           )}
-          <Input
-            type="date"
-            className="w-40"
-            value={selectedDate}
-            max={todayIso()}
-            onChange={(e) => setSelectedDate(e.target.value)}
-          />
+          {activeTab === "kasa" && (
+            <Input
+              type="date"
+              className="w-40"
+              value={selectedDate}
+              max={todayIso()}
+              onChange={(e) => setSelectedDate(e.target.value)}
+            />
+          )}
         </div>
       </div>
 
-      {/* Already closed banner / form */}
-      {loadingDayClose ? (
-        <Skeleton className="h-16 rounded-lg" />
-      ) : isAlreadyClosed ? (
-        <DayCloseSummaryCard dayClose={dayClose!} />
-      ) : null}
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as "kasa" | "sejf")}
+      >
+        <TabsList>
+          <TabsTrigger value="kasa">{t("gabinet.cash.tabKasa")}</TabsTrigger>
+          <TabsTrigger value="sejf">{t("gabinet.cash.tabSejf")}</TabsTrigger>
+        </TabsList>
 
-      {/* Payment Summary */}
-      <PaymentSummaryCard
-        summary={paymentSummary}
-        totalCollected={totalCollected}
-        currency="PLN"
-        isLoading={loadingPayments}
-      />
+        <TabsContent value="kasa" className="flex flex-col gap-4 sm:gap-6 mt-4">
+          {/* Already closed banner / form */}
+          {loadingDayClose ? (
+            <Skeleton className="h-16 rounded-lg" />
+          ) : isAlreadyClosed ? (
+            <DayCloseSummaryCard dayClose={dayClose!} />
+          ) : null}
 
-      {/* Cash Transactions */}
-      <CashTransactionsCard
-        organizationId={organizationId}
-        date={selectedDate}
-        locationId={selectedLocationId}
-        canEdit={canEdit && !isAlreadyClosed}
-        isLoading={loadingDayClose}
-      />
+          {/* Payment Summary */}
+          <PaymentSummaryCard
+            summary={paymentSummary}
+            totalCollected={totalCollected}
+            currency="PLN"
+            isLoading={loadingPayments}
+          />
 
-      {/* Day Close Form (only when not yet closed) */}
-      {!loadingDayClose && !isAlreadyClosed && (
-        <DayCloseFormCard
-          organizationId={organizationId}
-          date={selectedDate}
-          locationId={selectedLocationId}
-          cashFromPayments={cashFromPayments}
-          cashDeposits={cashDeposits}
-          cashWithdrawals={cashWithdrawals}
-          canEdit={canEdit}
-          isAlreadyClosed={isAlreadyClosed}
-          previousCashNextOpening={prevDayClose?.cashNextOpening ?? null}
-          onClosed={handleClosed}
-        />
-      )}
+          {/* Cash Transactions */}
+          <CashTransactionsCard
+            organizationId={organizationId}
+            date={selectedDate}
+            locationId={selectedLocationId}
+            canEdit={canEdit && !isAlreadyClosed}
+            isLoading={loadingDayClose}
+          />
 
-      {/* History */}
-      <DayCloseHistoryCard
-        organizationId={organizationId}
-        locationId={selectedLocationId}
-      />
+          {/* Day Close Form (only when not yet closed) */}
+          {!loadingDayClose && !isAlreadyClosed && (
+            <DayCloseFormCard
+              organizationId={organizationId}
+              date={selectedDate}
+              locationId={selectedLocationId}
+              cashFromPayments={cashFromPayments}
+              cashDeposits={cashDeposits}
+              cashWithdrawals={cashWithdrawals}
+              canEdit={canEdit}
+              isAlreadyClosed={isAlreadyClosed}
+              previousCashNextOpening={prevDayClose?.cashNextOpening ?? null}
+              onClosed={handleClosed}
+            />
+          )}
+
+          {/* History */}
+          <DayCloseHistoryCard
+            organizationId={organizationId}
+            locationId={selectedLocationId}
+          />
+        </TabsContent>
+
+        <TabsContent value="sejf" className="mt-4">
+          <SafeTabContent
+            organizationId={organizationId}
+            locationId={selectedLocationId}
+            canEdit={canEdit}
+          />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5579.

Closes #5579

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 0d8ee6ef feat(gabinet): R2C — add Sejf (safe) tab to Kasa page with balance, history and withdrawal (closes #5579)

### Files changed

```
 convex/_generated/api.d.ts                         |   2 +
 public/locales/en/translation.json                 |  27 +-
 public/locales/pl/translation.json                 |  27 +-
 src/hooks/use-supabase-safe.ts                     | 101 +++++
 src/lib/supabase/query-keys.ts                     |   1 +
 .../_auth/dashboard/_layout.gabinet.cash.lazy.tsx  | 432 ++++++++++++++++++---
 6 files changed, 539 insertions(+), 51 deletions(-)
```