### PR TITLE
R2C1 — Gabinet — Narzędzia dodatkowe: przeniesienie wejścia do Kasy

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -138,7 +138,8 @@
       "leaves": "Leaves",
       "myLeaves": "My Leave Requests",
       "documentTemplates": "Document Templates",
-      "cash": "Cash Register"
+      "cash": "Cash Register",
+      "additionalTools": "Additional Tools"
     },
     "sections": {
       "main": "Main",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -138,7 +138,8 @@
       "leaves": "Urlopy",
       "myLeaves": "Moje urlopy",
       "documentTemplates": "Szablony dokumentów",
-      "cash": "Kasa"
+      "cash": "Kasa",
+      "additionalTools": "Narzędzia dodatkowe"
     },
     "sections": {
       "main": "Główne",

--- a/src/components/layout/app-sidebar.test.tsx
+++ b/src/components/layout/app-sidebar.test.tsx
@@ -53,7 +53,10 @@ vi.mock("@/components/ui/sidebar", () => ({
   SidebarMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SidebarMenuButton: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SidebarMenuItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  useSidebar: () => ({ isMobile: false, setOpenMobile: vi.fn() }),
+  SidebarMenuSub: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarMenuSubButton: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SidebarMenuSubItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  useSidebar: () => ({ isMobile: false, setOpenMobile: vi.fn(), state: "expanded" }),
 }));
 
 vi.mock("convex/react", () => ({

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -15,6 +15,9 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
   useSidebar,
 } from "@/components/ui/sidebar";
 import { useSidebarActions } from "@/components/layout/sidebar-context";
@@ -44,6 +47,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { DayTimeline } from "@/components/sidebar-widgets/day-timeline";
 import { getModuleById, getVisibleModules, moduleRegistry } from "@/modules/registry";
+import type { ModuleNavGroup, ModuleNavItem } from "@/modules/types";
+import { ChevronDown } from "@/lib/ez-icons";
 
 const routeAwareModules = [...moduleRegistry].sort(
   (left, right) => right.workspaceRoot.length - left.workspaceRoot.length,
@@ -55,7 +60,7 @@ export function AppSidebar() {
   const matchRoute = useMatchRoute();
   const { t } = useTranslation();
   const { openQuickCreate, navigateTo, dispatch } = useSidebarActions();
-  const { isMobile, setOpenMobile } = useSidebar();
+  const { isMobile, setOpenMobile, state: sidebarState } = useSidebar();
   const navigate = useNavigate();
   const [pendingNavHref, setPendingNavHref] = useState<string | null>(null);
   const [dontShowAgain, setDontShowAgain] = useState(false);
@@ -63,6 +68,20 @@ export function AppSidebar() {
   const closeMobile = () => {
     if (isMobile) setOpenMobile(false);
   };
+
+  const [openGroups, setOpenGroups] = useState<Set<string>>(new Set());
+
+  const toggleGroup = (key: string) => {
+    setOpenGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const isNavGroup = (item: ModuleNavItem | ModuleNavGroup): item is ModuleNavGroup =>
+    "children" in item;
 
   const handleCrossModuleClick = (href: string) => {
     const dismissed = localStorage.getItem(CROSS_MODULE_DISMISSED_KEY) === "true";
@@ -196,6 +215,65 @@ export function AppSidebar() {
             <SidebarGroupContent>
               <SidebarMenu>
                 {navItems.map((item) => {
+                  if (isNavGroup(item)) {
+                    const hasActiveChild = item.children.some((child) =>
+                      !!matchRoute({ to: child.href, fuzzy: true }),
+                    );
+                    const isOpen = openGroups.has(item.labelKey) || hasActiveChild;
+                    const firstChild = item.children[0];
+                    return (
+                      <SidebarMenuItem key={item.labelKey}>
+                        {sidebarState === "collapsed" && firstChild ? (
+                          <SidebarMenuButton
+                            className="[&>svg]:text-primary [&>easier-icon]:text-primary group-data-[collapsible=icon]:size-10! [&>svg]:size-4 [&>easier-icon]:size-4"
+                            tooltip={t(item.labelKey)}
+                            isActive={hasActiveChild}
+                            asChild
+                          >
+                            <Link to={firstChild.href} onClick={closeMobile}>
+                              <item.icon variant="stroke" />
+                              <span>{t(item.labelKey)}</span>
+                            </Link>
+                          </SidebarMenuButton>
+                        ) : (
+                          <>
+                            <SidebarMenuButton
+                              className="[&>svg]:text-primary [&>easier-icon]:text-primary group-data-[collapsible=icon]:size-10! [&>svg]:size-4 [&>easier-icon]:size-4"
+                              tooltip={t(item.labelKey)}
+                              isActive={hasActiveChild}
+                              onClick={() => toggleGroup(item.labelKey)}
+                            >
+                              <item.icon variant="stroke" />
+                              <span className="flex-1">{t(item.labelKey)}</span>
+                              <ChevronDown
+                                className={cn(
+                                  "size-4 transition-transform duration-200",
+                                  isOpen && "rotate-180",
+                                )}
+                              />
+                            </SidebarMenuButton>
+                            {isOpen && (
+                              <SidebarMenuSub>
+                                {item.children.map((child) => {
+                                  const isChildActive = !!matchRoute({ to: child.href, fuzzy: true });
+                                  return (
+                                    <SidebarMenuSubItem key={child.href}>
+                                      <SidebarMenuSubButton asChild isActive={isChildActive}>
+                                        <Link to={child.href} onClick={closeMobile}>
+                                          {t(child.labelKey)}
+                                        </Link>
+                                      </SidebarMenuSubButton>
+                                    </SidebarMenuSubItem>
+                                  );
+                                })}
+                              </SidebarMenuSub>
+                            )}
+                          </>
+                        )}
+                      </SidebarMenuItem>
+                    );
+                  }
+
                   const isActive =
                     item.activeMatch === "exact"
                       ? !!matchRoute({ to: item.href })

--- a/src/modules/gabinet/manifest.ts
+++ b/src/modules/gabinet/manifest.ts
@@ -18,6 +18,7 @@ import {
   PlusCircle,
   SearchIcon,
   Settings,
+  Settings2,
   Stethoscope,
   Tag,
   TrendingUp,
@@ -58,7 +59,14 @@ export const gabinetManifest: ModuleManifest = {
     { labelKey: "nav.gabinet.myLeaves", href: "/dashboard/gabinet/my-leaves", icon: CalendarCheck },
     { labelKey: "nav.gabinet.documents", href: "/dashboard/gabinet/documents", icon: ClipboardList },
     { labelKey: "nav.gabinet.deliveries", href: "/dashboard/gabinet/deliveries", icon: TruckIcon },
-    { labelKey: "nav.gabinet.cash", href: "/dashboard/gabinet/cash", icon: DollarSign },
+    {
+      type: "group" as const,
+      labelKey: "nav.gabinet.additionalTools",
+      icon: Settings2,
+      children: [
+        { labelKey: "nav.gabinet.cash", href: "/dashboard/gabinet/cash", icon: DollarSign },
+      ],
+    },
     { labelKey: "nav.gabinet.reports", href: "/dashboard/gabinet/reports", icon: PieChart },
     { labelKey: "nav.notifications", href: "/dashboard/notifications", icon: Bell, crossModule: true },
   ],

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -26,6 +26,13 @@ export interface ModuleNavItem {
   crossModule?: boolean;
 }
 
+export interface ModuleNavGroup {
+  type: "group";
+  labelKey: string;
+  icon: ElementType;
+  children: ModuleNavItem[];
+}
+
 export interface ModuleContextSubAction {
   labelKey: string;
   dispatch?: string;
@@ -70,7 +77,7 @@ export interface ModuleManifest {
   workspaceRoot: string;
   settingsRoots: string[];
   workspace: ModuleWorkspaceOption;
-  primaryNav: ModuleNavItem[];
+  primaryNav: (ModuleNavItem | ModuleNavGroup)[];
   settingsNav: ModuleSettingsNavItem[];
   pageContexts: ModulePageContext[];
   fallbackPageContextKey?: string;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5585.

Closes #5585

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 6163a635 feat(gabinet): add Narzędzia dodatkowe group and move Kasa under it (closes #5585)

### Files changed

```
 public/locales/en/translation.json         |  3 +-
 public/locales/pl/translation.json         |  3 +-
 src/components/layout/app-sidebar.test.tsx |  5 +-
 src/components/layout/app-sidebar.tsx      | 80 +++++++++++++++++++++++++++++-
 src/modules/gabinet/manifest.ts            | 10 +++-
 src/modules/types.ts                       |  9 +++-
 6 files changed, 104 insertions(+), 6 deletions(-)
```