### PR TITLE
Add refund tracking to payments schema

### DIFF
--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -710,12 +710,15 @@ export const refund = action({
       }
     }
 
+    const now = Date.now();
     await db.patch("payments", args.paymentId, {
       status: "refunded",
+      refundAmount: payment.amount,
+      refundedAt: now,
       notes: args.reason
         ? `${payment.notes ? (payment.notes as string) + "\n" : ""}Refund: ${args.reason}`
         : (payment.notes as string) ?? null,
-      updatedAt: Date.now(),
+      updatedAt: now,
     });
 
     // Side effects via internal mutation

--- a/supabase/migrations/00147_payments_refund_amount.sql
+++ b/supabase/migrations/00147_payments_refund_amount.sql
@@ -1,0 +1,22 @@
+-- Add refund tracking columns to the payments table (issue #5591).
+--
+-- refund_amount: the amount actually returned to the patient. For a full refund
+--   this equals `amount`; for a partial refund (future path) it may be less.
+--   Kept separate from `amount` so the original charge is preserved for audit.
+--
+-- refunded_at: epoch-ms timestamp when the refund was processed. Allows
+--   time-bounded net-revenue queries without parsing the `notes` column.
+--
+-- Both columns are nullable so existing rows remain valid without a backfill —
+-- payments that were marked refunded before this migration simply have NULL
+-- in both columns.
+
+ALTER TABLE payments
+  ADD COLUMN IF NOT EXISTS refund_amount NUMERIC,
+  ADD COLUMN IF NOT EXISTS refunded_at   BIGINT;
+
+ALTER TABLE payments
+  DROP CONSTRAINT IF EXISTS payments_refund_amount_check;
+ALTER TABLE payments
+  ADD CONSTRAINT payments_refund_amount_check
+  CHECK (refund_amount IS NULL OR refund_amount > 0);

--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -151,6 +151,41 @@ describe("payments", () => {
     expect(result.page[0].notes).toContain("Refund: Patient request");
   });
 
+  test("refund stores refund_amount and refunded_at (issue #5591)", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const paymentId = await t.withIdentity(identity).action(
+      api.payments.create,
+      {
+        organizationId,
+        amount: 150,
+        currency: "PLN",
+        paymentMethod: "cash",
+      },
+    );
+
+    const beforeRefund = Date.now();
+    await t.withIdentity(identity).action(api.payments.refund, {
+      organizationId,
+      paymentId,
+      reason: "Test",
+    });
+    const afterRefund = Date.now();
+
+    const result = await t.withIdentity(identity).action(api.payments.list, {
+      organizationId,
+      paginationOpts: { numItems: 10, cursor: null },
+    });
+
+    const refunded = result.page[0];
+    expect(refunded.status).toBe("refunded");
+    expect(refunded.refundAmount).toBe(150);
+    expect(typeof refunded.refundedAt).toBe("number");
+    expect(refunded.refundedAt).toBeGreaterThanOrEqual(beforeRefund);
+    expect(refunded.refundedAt).toBeLessThanOrEqual(afterRefund);
+  });
+
   test("cannot refund a pending payment", async () => {
     const t = createTestCtx();
     const { organizationId, identity } = await seedTestUser(t);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5591.

Closes #5591

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 16ad1c7a feat(payments): add refund_amount and refunded_at columns (closes #5591)

### Files changed

```
 convex/payments.ts                                 |  5 +++-
 .../migrations/00147_payments_refund_amount.sql    | 22 ++++++++++++++
 tests/convex/payments.test.ts                      | 35 ++++++++++++++++++++++
 3 files changed, 61 insertions(+), 1 deletion(-)
```