### PR TITLE
Add partial refund support to `payments.refund` action

### DIFF
--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -673,6 +673,9 @@ export const refund = action({
     organizationId: v.string(),
     paymentId: v.string(),
     reason: v.optional(v.string()),
+    // Optional partial-refund amount (issue #5595). Defaults to the full
+    // payment amount. Must be positive and must not exceed the original charge.
+    refundAmount: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runAction(
@@ -688,6 +691,19 @@ export const refund = action({
 
     if (payment.status !== "completed") {
       throw new Error(`Cannot refund a ${payment.status} payment`);
+    }
+
+    const fullAmount = payment.amount as number;
+    const effectiveRefundAmount =
+      args.refundAmount !== undefined ? args.refundAmount : fullAmount;
+
+    if (!Number.isFinite(effectiveRefundAmount) || effectiveRefundAmount <= 0) {
+      throw new Error("Refund amount must be positive");
+    }
+    if (effectiveRefundAmount > fullAmount + 0.005) {
+      throw new Error(
+        `Refund amount ${effectiveRefundAmount} exceeds payment amount ${fullAmount}`,
+      );
     }
 
     // Block refund on the secondary leg of a split payment (issue #3776).
@@ -713,7 +729,7 @@ export const refund = action({
     const now = Date.now();
     await db.patch("payments", args.paymentId, {
       status: "refunded",
-      refundAmount: payment.amount,
+      refundAmount: effectiveRefundAmount,
       refundedAt: now,
       notes: args.reason
         ? `${payment.notes ? (payment.notes as string) + "\n" : ""}Refund: ${args.reason}`
@@ -727,7 +743,7 @@ export const refund = action({
         paymentId: args.paymentId,
         organizationId: args.organizationId,
         userId: authResult.userId,
-        amount: payment.amount as number,
+        amount: effectiveRefundAmount,
         reason: args.reason,
       });
     } catch {

--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -186,6 +186,63 @@ describe("payments", () => {
     expect(refunded.refundedAt).toBeLessThanOrEqual(afterRefund);
   });
 
+  test("partial refund stores the specified refundAmount (issue #5595)", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const paymentId = await t.withIdentity(identity).action(
+      api.payments.create,
+      {
+        organizationId,
+        amount: 300,
+        currency: "PLN",
+        paymentMethod: "card",
+      },
+    );
+
+    await t.withIdentity(identity).action(api.payments.refund, {
+      organizationId,
+      paymentId,
+      refundAmount: 100,
+      reason: "Partial cancellation",
+    });
+
+    const result = await t.withIdentity(identity).action(api.payments.list, {
+      organizationId,
+      paginationOpts: { numItems: 10, cursor: null },
+    });
+
+    const refunded = result.page[0];
+    expect(refunded.status).toBe("refunded");
+    expect(refunded.refundAmount).toBe(100);
+    expect(typeof refunded.refundedAt).toBe("number");
+    // Original amount is preserved
+    expect(refunded.amount).toBe(300);
+  });
+
+  test("refundAmount exceeding payment amount is rejected (issue #5595)", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+
+    const paymentId = await t.withIdentity(identity).action(
+      api.payments.create,
+      {
+        organizationId,
+        amount: 100,
+        currency: "PLN",
+        paymentMethod: "cash",
+      },
+    );
+
+    await expect(
+      t.withIdentity(identity).action(api.payments.refund, {
+        organizationId,
+        paymentId,
+        refundAmount: 200,
+      }),
+    ).rejects.toThrow(/exceeds payment amount/);
+  });
+
   test("cannot refund a pending payment", async () => {
     const t = createTestCtx();
     const { organizationId, identity } = await seedTestUser(t);


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5595.

Closes #5595

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a7e992e1 feat(payments): add refundAmount param for partial refunds (closes #5595)

### Files changed

```
 convex/payments.ts            | 20 +++++++++++++--
 tests/convex/payments.test.ts | 57 +++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 75 insertions(+), 2 deletions(-)
```