### PR TITLE
Add E2E/unit tests for gabinet reports page

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -36,6 +36,17 @@ import { useSidebarDispatch } from "@/components/layout/sidebar-context";
 import { Input } from "@/components/ui/input";
 import { Label as FieldLabel } from "@/components/ui/label";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  bucketizePairs,
+  computeDailyStats,
+  computeEmployeeStats,
+  computePaymentMethodBreakdown,
+  computeStatusStats,
+  computeTreatmentStats,
+  getPresetDateRange,
+  slugify,
+  type DateRangeKey,
+} from "./gabinet-report-utils";
 import { useTranslation } from "react-i18next";
 import { EllipsisVerticalIcon } from "@/lib/ez-icons";
 import {
@@ -139,58 +150,6 @@ const UTILIZATION_COLORS = [
   "var(--chart-5)",
 ];
 
-type DateRangeKey = "today" | "yesterday" | "7d" | "30d" | "90d" | "365d" | "custom";
-
-function getPresetDateRange(key: Exclude<DateRangeKey, "custom">): {
-  startDate: string;
-  endDate: string;
-} {
-  const today = new Date();
-  if (key === "today") {
-    const iso = today.toISOString().split("T")[0];
-    return { startDate: iso, endDate: iso };
-  }
-  if (key === "yesterday") {
-    const yesterday = new Date(today);
-    yesterday.setDate(yesterday.getDate() - 1);
-    const iso = yesterday.toISOString().split("T")[0];
-    return { startDate: iso, endDate: iso };
-  }
-  const past = new Date(today);
-  const days = key === "7d" ? 7 : key === "30d" ? 30 : key === "90d" ? 90 : 365;
-  past.setDate(past.getDate() - days);
-  return {
-    startDate: past.toISOString().split("T")[0],
-    endDate: today.toISOString().split("T")[0],
-  };
-}
-
-function slugify(s: string): string {
-  return (
-    s
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-|-$/g, "") || "other"
-  );
-}
-
-function bucketizePairs(
-  pairs: [string, number][],
-): { index: number; count: number }[] {
-  if (!pairs.length)
-    return Array.from({ length: 7 }, (_, i) => ({ index: i, count: 0 }));
-  const sorted = [...pairs].sort((a, b) => a[0]!.localeCompare(b[0]!));
-  const bucketSize = Math.max(1, Math.ceil(sorted.length / 7));
-  const buckets: { index: number; count: number }[] = [];
-  for (let i = 0; i < sorted.length; i += bucketSize) {
-    const slice = sorted.slice(i, i + bucketSize);
-    buckets.push({
-      index: buckets.length,
-      count: slice.reduce((s, d) => s + d[1], 0),
-    });
-  }
-  return buckets;
-}
 
 function CardMenu() {
   const { t } = useTranslation();
@@ -1854,26 +1813,10 @@ function GabinetReports() {
   }, [packagesListData]);
 
   // Treatment stats: count + estimated revenue (completed only, gratis/barter excluded from revenue)
-  const treatmentStats = useMemo(() => {
-    if (!appointments) return [];
-    const map = new Map<string, { count: number; revenue: number }>();
-    for (const a of appointments) {
-      const tid = a.treatmentId as string;
-      const prev = map.get(tid) ?? { count: 0, revenue: 0 };
-      const price = a.status === "completed" && !gratisBarterIds?.has(a._id)
-        ? (a.priceAtBooking ?? treatmentMap.get(tid)?.price ?? 0)
-        : 0;
-      map.set(tid, { count: prev.count + 1, revenue: prev.revenue + price });
-    }
-    return Array.from(map.entries())
-      .map(([id, stats]) => ({
-        name: treatmentMap.get(id)?.name ?? id,
-        count: stats.count,
-        revenue: stats.revenue,
-      }))
-      .sort((a, b) => b.count - a.count)
-      .slice(0, 10);
-  }, [appointments, treatmentMap, gratisBarterIds]);
+  const treatmentStats = useMemo(
+    () => computeTreatmentStats(appointments ?? [], treatmentMap, gratisBarterIds ?? new Set()),
+    [appointments, treatmentMap, gratisBarterIds]
+  );
 
   const topByRevenue = useMemo(
     () =>
@@ -1884,50 +1827,22 @@ function GabinetReports() {
   );
 
   // Status distribution
-  const statusStats = useMemo(() => {
-    if (!appointments) return [];
-    const map = new Map<string, number>();
-    for (const a of appointments) {
-      map.set(a.status, (map.get(a.status) ?? 0) + 1);
-    }
-    return Array.from(map.entries())
-      .map(([status, count]) => ({ status, count }))
-      .sort((a, b) => b.count - a.count);
-  }, [appointments]);
+  const statusStats = useMemo(
+    () => computeStatusStats(appointments ?? []),
+    [appointments]
+  );
 
   // Daily appointment counts
-  const dailyStats = useMemo(() => {
-    if (!appointments) return [];
-    const map = new Map<string, number>();
-    for (const a of appointments) {
-      map.set(a.date, (map.get(a.date) ?? 0) + 1);
-    }
-    return Array.from(map.entries())
-      .map(([date, count]) => ({ date, count }))
-      .sort((a, b) => a.date.localeCompare(b.date));
-  }, [appointments]);
+  const dailyStats = useMemo(
+    () => computeDailyStats(appointments ?? []),
+    [appointments]
+  );
 
   // Employee utilization
-  const employeeStats = useMemo(() => {
-    if (!appointments) return [];
-    const map = new Map<string, { count: number; completedCount: number }>();
-    for (const a of appointments) {
-      const uid = a.employeeId as string;
-      const prev = map.get(uid) ?? { count: 0, completedCount: 0 };
-      map.set(uid, {
-        count: prev.count + 1,
-        completedCount:
-          prev.completedCount + (a.status === "completed" ? 1 : 0),
-      });
-    }
-    return Array.from(map.entries())
-      .map(([userId, stats]) => ({
-        name: employeeMap.get(userId) ?? userId,
-        count: stats.count,
-        completedCount: stats.completedCount,
-      }))
-      .sort((a, b) => b.count - a.count);
-  }, [appointments, employeeMap]);
+  const employeeStats = useMemo(
+    () => computeEmployeeStats(appointments ?? [], employeeMap),
+    [appointments, employeeMap]
+  );
 
   // Revenue: relative to the selected date range (endDate = last day of range)
   const sevenDaysBeforeEnd = useMemo(() => {
@@ -1979,24 +1894,10 @@ function GabinetReports() {
   }, [actualPayments, sevenDaysBeforeEnd, endDate]);
 
   // Maps raw payment_method values to display categories (cash/card/transfer/package/other)
-  const paymentMethodBreakdown = useMemo(() => {
-    const categoryOf = (method: string | undefined): string => {
-      if (method === "cash" || method === "card" || method === "transfer" || method === "package")
-        return method;
-      return "other";
-    };
-    const map = new Map<string, { total: number; count: number }>();
-    for (const p of actualPayments ?? []) {
-      const cat = categoryOf(p.paymentMethod);
-      const prev = map.get(cat) ?? { total: 0, count: 0 };
-      map.set(cat, { total: prev.total + p.amount, count: prev.count + 1 });
-    }
-    return (["cash", "card", "transfer", "package", "other"] as const).map((key) => ({
-      method: key,
-      total: map.get(key)?.total ?? 0,
-      count: map.get(key)?.count ?? 0,
-    }));
-  }, [actualPayments]);
+  const paymentMethodBreakdown = useMemo(
+    () => computePaymentMethodBreakdown(actualPayments ?? []),
+    [actualPayments]
+  );
 
   const totalAppointments = appointments?.length ?? 0;
   const completedCount =

--- a/src/routes/_app/_auth/dashboard/gabinet-report-utils.test.ts
+++ b/src/routes/_app/_auth/dashboard/gabinet-report-utils.test.ts
@@ -1,0 +1,370 @@
+import { describe, expect, it } from "vitest";
+import {
+  bucketizePairs,
+  computeDailyStats,
+  computeEmployeeStats,
+  computePaymentMethodBreakdown,
+  computeStatusStats,
+  computeTreatmentStats,
+  getPresetDateRange,
+  slugify,
+} from "./gabinet-report-utils";
+
+// ─── getPresetDateRange ───────────────────────────────────────────────────────
+
+describe("getPresetDateRange", () => {
+  it("today: startDate === endDate === today's ISO date", () => {
+    const today = new Date().toISOString().split("T")[0];
+    const result = getPresetDateRange("today");
+    expect(result.startDate).toBe(today);
+    expect(result.endDate).toBe(today);
+  });
+
+  it("yesterday: startDate === endDate === yesterday's ISO date", () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const iso = yesterday.toISOString().split("T")[0];
+    const result = getPresetDateRange("yesterday");
+    expect(result.startDate).toBe(iso);
+    expect(result.endDate).toBe(iso);
+  });
+
+  it("7d: endDate is today, startDate is 7 days ago", () => {
+    const today = new Date();
+    const past = new Date(today);
+    past.setDate(past.getDate() - 7);
+    const result = getPresetDateRange("7d");
+    expect(result.endDate).toBe(today.toISOString().split("T")[0]);
+    expect(result.startDate).toBe(past.toISOString().split("T")[0]);
+  });
+
+  it("30d: correct span", () => {
+    const today = new Date();
+    const past = new Date(today);
+    past.setDate(past.getDate() - 30);
+    const result = getPresetDateRange("30d");
+    expect(result.startDate).toBe(past.toISOString().split("T")[0]);
+    expect(result.endDate).toBe(today.toISOString().split("T")[0]);
+  });
+
+  it("90d: correct span", () => {
+    const today = new Date();
+    const past = new Date(today);
+    past.setDate(past.getDate() - 90);
+    expect(getPresetDateRange("90d").startDate).toBe(past.toISOString().split("T")[0]);
+  });
+
+  it("365d: correct span", () => {
+    const today = new Date();
+    const past = new Date(today);
+    past.setDate(past.getDate() - 365);
+    expect(getPresetDateRange("365d").startDate).toBe(past.toISOString().split("T")[0]);
+  });
+});
+
+// ─── slugify ─────────────────────────────────────────────────────────────────
+
+describe("slugify", () => {
+  it("lowercases input", () => {
+    expect(slugify("Hello World")).toBe("hello-world");
+  });
+
+  it("replaces spaces and special chars with hyphens", () => {
+    expect(slugify("in_progress")).toBe("in-progress");
+    expect(slugify("No Show!")).toBe("no-show");
+  });
+
+  it("collapses multiple non-alphanumeric chars into a single hyphen", () => {
+    expect(slugify("a -- b")).toBe("a-b");
+  });
+
+  it("strips leading and trailing hyphens", () => {
+    expect(slugify("-hello-")).toBe("hello");
+  });
+
+  it("returns 'other' for empty or all-special strings", () => {
+    expect(slugify("")).toBe("other");
+    expect(slugify("---")).toBe("other");
+  });
+
+  it("leaves valid alphanumeric strings unchanged", () => {
+    expect(slugify("completed")).toBe("completed");
+    expect(slugify("abc123")).toBe("abc123");
+  });
+});
+
+// ─── bucketizePairs ───────────────────────────────────────────────────────────
+
+describe("bucketizePairs", () => {
+  it("returns 7 zero-count buckets for empty input", () => {
+    const result = bucketizePairs([]);
+    expect(result).toHaveLength(7);
+    expect(result.every((b) => b.count === 0)).toBe(true);
+    expect(result.map((b) => b.index)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+  });
+
+  it("single pair produces one bucket with its count", () => {
+    const result = bucketizePairs([["2025-01-01", 5]]);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.count).toBe(5);
+  });
+
+  it("exactly 7 pairs produce 7 buckets each with one entry", () => {
+    const pairs: [string, number][] = Array.from({ length: 7 }, (_, i) => [
+      `2025-01-0${i + 1}`,
+      i + 1,
+    ]);
+    const result = bucketizePairs(pairs);
+    expect(result).toHaveLength(7);
+    result.forEach((b, i) => {
+      expect(b.index).toBe(i);
+      expect(b.count).toBe(i + 1);
+    });
+  });
+
+  it("sorts pairs by date before bucketing", () => {
+    const pairs: [string, number][] = [
+      ["2025-01-03", 3],
+      ["2025-01-01", 1],
+      ["2025-01-02", 2],
+    ];
+    const result = bucketizePairs(pairs);
+    const total = result.reduce((s, b) => s + b.count, 0);
+    expect(total).toBe(6);
+  });
+
+  it("sums counts within each bucket", () => {
+    // 14 pairs → bucketSize = ceil(14/7) = 2, each bucket sums 2 values
+    const pairs: [string, number][] = Array.from({ length: 14 }, (_, i) => [
+      `2025-${String(i + 1).padStart(2, "0")}-01`,
+      10,
+    ]);
+    const result = bucketizePairs(pairs);
+    expect(result).toHaveLength(7);
+    expect(result.every((b) => b.count === 20)).toBe(true);
+  });
+});
+
+// ─── computeTreatmentStats ────────────────────────────────────────────────────
+
+describe("computeTreatmentStats", () => {
+  const treatmentMap = new Map([
+    ["t1", { name: "Massage", price: 100, currency: "PLN" }],
+    ["t2", { name: "Facial", price: 200, currency: "PLN" }],
+  ]);
+
+  it("returns empty array for no appointments", () => {
+    expect(computeTreatmentStats([], treatmentMap, new Set())).toEqual([]);
+  });
+
+  it("counts all appointments regardless of status", () => {
+    const appts = [
+      { _id: "a1", treatmentId: "t1", employeeId: "e1", date: "2025-01-01", status: "completed" },
+      { _id: "a2", treatmentId: "t1", employeeId: "e1", date: "2025-01-02", status: "cancelled" },
+    ];
+    const result = computeTreatmentStats(appts, treatmentMap, new Set());
+    expect(result[0]!.name).toBe("Massage");
+    expect(result[0]!.count).toBe(2);
+  });
+
+  it("only adds revenue for completed, non-gratis appointments", () => {
+    const appts = [
+      { _id: "a1", treatmentId: "t1", employeeId: "e1", date: "2025-01-01", status: "completed" },
+      { _id: "a2", treatmentId: "t1", employeeId: "e1", date: "2025-01-02", status: "completed" },
+      { _id: "a3", treatmentId: "t1", employeeId: "e1", date: "2025-01-03", status: "cancelled" },
+    ];
+    const gratisIds = new Set(["a2"]);
+    const result = computeTreatmentStats(appts, treatmentMap, gratisIds);
+    expect(result[0]!.revenue).toBe(100); // only a1 contributes
+    expect(result[0]!.count).toBe(3);
+  });
+
+  it("uses priceAtBooking when available instead of treatment price", () => {
+    const appts = [
+      { _id: "a1", treatmentId: "t1", employeeId: "e1", date: "2025-01-01", status: "completed", priceAtBooking: 150 },
+    ];
+    const result = computeTreatmentStats(appts, treatmentMap, new Set());
+    expect(result[0]!.revenue).toBe(150);
+  });
+
+  it("sorts by count descending and limits to 10", () => {
+    const manyTreatments = new Map(
+      Array.from({ length: 12 }, (_, i) => [`t${i}`, { name: `T${i}`, price: 10, currency: "PLN" }])
+    );
+    // t0 gets 12 appointments, t1 gets 11, ..., t11 gets 1
+    const appts = Array.from({ length: 12 }, (_, i) =>
+      Array.from({ length: 12 - i }, (__, j) => ({
+        _id: `a${i}_${j}`,
+        treatmentId: `t${i}`,
+        employeeId: "e1",
+        date: "2025-01-01",
+        status: "scheduled",
+      }))
+    ).flat();
+    const result = computeTreatmentStats(appts, manyTreatments, new Set());
+    expect(result).toHaveLength(10);
+    expect(result[0]!.count).toBeGreaterThanOrEqual(result[1]!.count);
+  });
+});
+
+// ─── computeStatusStats ───────────────────────────────────────────────────────
+
+describe("computeStatusStats", () => {
+  it("returns empty array for no appointments", () => {
+    expect(computeStatusStats([])).toEqual([]);
+  });
+
+  it("counts each status correctly", () => {
+    const appts = [
+      { status: "completed" },
+      { status: "completed" },
+      { status: "cancelled" },
+      { status: "no_show" },
+    ];
+    const result = computeStatusStats(appts);
+    const completed = result.find((r) => r.status === "completed");
+    const cancelled = result.find((r) => r.status === "cancelled");
+    const noShow = result.find((r) => r.status === "no_show");
+    expect(completed?.count).toBe(2);
+    expect(cancelled?.count).toBe(1);
+    expect(noShow?.count).toBe(1);
+  });
+
+  it("sorts by count descending", () => {
+    const appts = [
+      { status: "cancelled" },
+      { status: "completed" },
+      { status: "completed" },
+      { status: "completed" },
+    ];
+    const result = computeStatusStats(appts);
+    expect(result[0]!.status).toBe("completed");
+    expect(result[0]!.count).toBe(3);
+  });
+});
+
+// ─── computeDailyStats ───────────────────────────────────────────────────────
+
+describe("computeDailyStats", () => {
+  it("returns empty array for no appointments", () => {
+    expect(computeDailyStats([])).toEqual([]);
+  });
+
+  it("counts appointments per date", () => {
+    const appts = [
+      { date: "2025-01-01" },
+      { date: "2025-01-01" },
+      { date: "2025-01-02" },
+    ];
+    const result = computeDailyStats(appts);
+    expect(result).toHaveLength(2);
+    expect(result.find((r) => r.date === "2025-01-01")?.count).toBe(2);
+    expect(result.find((r) => r.date === "2025-01-02")?.count).toBe(1);
+  });
+
+  it("sorts by date ascending", () => {
+    const appts = [
+      { date: "2025-01-03" },
+      { date: "2025-01-01" },
+      { date: "2025-01-02" },
+    ];
+    const result = computeDailyStats(appts);
+    expect(result.map((r) => r.date)).toEqual(["2025-01-01", "2025-01-02", "2025-01-03"]);
+  });
+});
+
+// ─── computeEmployeeStats ─────────────────────────────────────────────────────
+
+describe("computeEmployeeStats", () => {
+  const employeeMap = new Map([
+    ["e1", "Anna Kowalska"],
+    ["e2", "Jan Nowak"],
+  ]);
+
+  it("returns empty array for no appointments", () => {
+    expect(computeEmployeeStats([], employeeMap)).toEqual([]);
+  });
+
+  it("resolves employee names from the map, falls back to id when missing", () => {
+    const appts = [
+      { employeeId: "e1", status: "completed" },
+      { employeeId: "e_unknown", status: "completed" },
+    ];
+    const result = computeEmployeeStats(appts, employeeMap);
+    expect(result.find((r) => r.name === "Anna Kowalska")).toBeTruthy();
+    expect(result.find((r) => r.name === "e_unknown")).toBeTruthy();
+  });
+
+  it("counts total and completed appointments per employee", () => {
+    const appts = [
+      { employeeId: "e1", status: "completed" },
+      { employeeId: "e1", status: "completed" },
+      { employeeId: "e1", status: "cancelled" },
+      { employeeId: "e2", status: "completed" },
+    ];
+    const result = computeEmployeeStats(appts, employeeMap);
+    const anna = result.find((r) => r.name === "Anna Kowalska");
+    expect(anna?.count).toBe(3);
+    expect(anna?.completedCount).toBe(2);
+  });
+
+  it("sorts by total count descending", () => {
+    const appts = [
+      { employeeId: "e1", status: "scheduled" },
+      { employeeId: "e2", status: "completed" },
+      { employeeId: "e2", status: "completed" },
+    ];
+    const result = computeEmployeeStats(appts, employeeMap);
+    expect(result[0]!.name).toBe("Jan Nowak");
+  });
+});
+
+// ─── computePaymentMethodBreakdown ───────────────────────────────────────────
+
+describe("computePaymentMethodBreakdown", () => {
+  it("returns all 5 categories with zero counts for empty input", () => {
+    const result = computePaymentMethodBreakdown([]);
+    expect(result).toHaveLength(5);
+    expect(result.every((r) => r.total === 0 && r.count === 0)).toBe(true);
+    expect(result.map((r) => r.method)).toEqual(["cash", "card", "transfer", "package", "other"]);
+  });
+
+  it("maps known methods to their categories", () => {
+    const payments = [
+      { paymentMethod: "cash", amount: 100 },
+      { paymentMethod: "card", amount: 200 },
+      { paymentMethod: "transfer", amount: 50 },
+      { paymentMethod: "package", amount: 75 },
+    ];
+    const result = computePaymentMethodBreakdown(payments);
+    expect(result.find((r) => r.method === "cash")?.total).toBe(100);
+    expect(result.find((r) => r.method === "card")?.total).toBe(200);
+    expect(result.find((r) => r.method === "transfer")?.total).toBe(50);
+    expect(result.find((r) => r.method === "package")?.total).toBe(75);
+    expect(result.find((r) => r.method === "other")?.total).toBe(0);
+  });
+
+  it("groups unknown methods into 'other'", () => {
+    const payments = [
+      { paymentMethod: "blik", amount: 30 },
+      { paymentMethod: "voucher", amount: 20 },
+      { paymentMethod: "cash", amount: 10 },
+    ];
+    const result = computePaymentMethodBreakdown(payments);
+    expect(result.find((r) => r.method === "other")?.total).toBe(50);
+    expect(result.find((r) => r.method === "other")?.count).toBe(2);
+    expect(result.find((r) => r.method === "cash")?.count).toBe(1);
+  });
+
+  it("aggregates multiple payments of the same method", () => {
+    const payments = [
+      { paymentMethod: "card", amount: 100 },
+      { paymentMethod: "card", amount: 150 },
+      { paymentMethod: "card", amount: 50 },
+    ];
+    const result = computePaymentMethodBreakdown(payments);
+    const card = result.find((r) => r.method === "card");
+    expect(card?.total).toBe(300);
+    expect(card?.count).toBe(3);
+  });
+});

--- a/src/routes/_app/_auth/dashboard/gabinet-report-utils.ts
+++ b/src/routes/_app/_auth/dashboard/gabinet-report-utils.ts
@@ -1,0 +1,163 @@
+export type DateRangeKey = "today" | "yesterday" | "7d" | "30d" | "90d" | "365d" | "custom";
+
+export function getPresetDateRange(key: Exclude<DateRangeKey, "custom">): {
+  startDate: string;
+  endDate: string;
+} {
+  const today = new Date();
+  if (key === "today") {
+    const iso = today.toISOString().split("T")[0];
+    return { startDate: iso!, endDate: iso! };
+  }
+  if (key === "yesterday") {
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const iso = yesterday.toISOString().split("T")[0];
+    return { startDate: iso!, endDate: iso! };
+  }
+  const past = new Date(today);
+  const days = key === "7d" ? 7 : key === "30d" ? 30 : key === "90d" ? 90 : 365;
+  past.setDate(past.getDate() - days);
+  return {
+    startDate: past.toISOString().split("T")[0]!,
+    endDate: today.toISOString().split("T")[0]!,
+  };
+}
+
+export function slugify(s: string): string {
+  return (
+    s
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "") || "other"
+  );
+}
+
+export function bucketizePairs(
+  pairs: [string, number][],
+): { index: number; count: number }[] {
+  if (!pairs.length)
+    return Array.from({ length: 7 }, (_, i) => ({ index: i, count: 0 }));
+  const sorted = [...pairs].sort((a, b) => a[0]!.localeCompare(b[0]!));
+  const bucketSize = Math.max(1, Math.ceil(sorted.length / 7));
+  const buckets: { index: number; count: number }[] = [];
+  for (let i = 0; i < sorted.length; i += bucketSize) {
+    const slice = sorted.slice(i, i + bucketSize);
+    buckets.push({
+      index: buckets.length,
+      count: slice.reduce((s, d) => s + d[1]!, 0),
+    });
+  }
+  return buckets;
+}
+
+export type AppointmentForStats = {
+  _id: string;
+  treatmentId?: string;
+  employeeId: string;
+  date: string;
+  status: string;
+  priceAtBooking?: number;
+};
+
+export type TreatmentInfo = { name: string; price: number; currency: string };
+
+export function computeTreatmentStats(
+  appointments: AppointmentForStats[],
+  treatmentMap: Map<string, TreatmentInfo>,
+  gratisBarterIds: Set<string>,
+): { name: string; count: number; revenue: number }[] {
+  const map = new Map<string, { count: number; revenue: number }>();
+  for (const a of appointments) {
+    const tid = a.treatmentId ?? "";
+    const prev = map.get(tid) ?? { count: 0, revenue: 0 };
+    const price =
+      a.status === "completed" && !gratisBarterIds.has(a._id)
+        ? (a.priceAtBooking ?? treatmentMap.get(tid)?.price ?? 0)
+        : 0;
+    map.set(tid, { count: prev.count + 1, revenue: prev.revenue + price });
+  }
+  return Array.from(map.entries())
+    .map(([id, stats]) => ({
+      name: treatmentMap.get(id)?.name ?? id,
+      count: stats.count,
+      revenue: stats.revenue,
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+}
+
+export function computeStatusStats(
+  appointments: Pick<AppointmentForStats, "status">[],
+): { status: string; count: number }[] {
+  const map = new Map<string, number>();
+  for (const a of appointments) {
+    map.set(a.status, (map.get(a.status) ?? 0) + 1);
+  }
+  return Array.from(map.entries())
+    .map(([status, count]) => ({ status, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+export function computeDailyStats(
+  appointments: Pick<AppointmentForStats, "date">[],
+): { date: string; count: number }[] {
+  const map = new Map<string, number>();
+  for (const a of appointments) {
+    map.set(a.date, (map.get(a.date) ?? 0) + 1);
+  }
+  return Array.from(map.entries())
+    .map(([date, count]) => ({ date, count }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+export function computeEmployeeStats(
+  appointments: Pick<AppointmentForStats, "employeeId" | "status">[],
+  employeeMap: Map<string, string>,
+): { name: string; count: number; completedCount: number }[] {
+  const map = new Map<string, { count: number; completedCount: number }>();
+  for (const a of appointments) {
+    const uid = a.employeeId;
+    const prev = map.get(uid) ?? { count: 0, completedCount: 0 };
+    map.set(uid, {
+      count: prev.count + 1,
+      completedCount: prev.completedCount + (a.status === "completed" ? 1 : 0),
+    });
+  }
+  return Array.from(map.entries())
+    .map(([userId, stats]) => ({
+      name: employeeMap.get(userId) ?? userId,
+      count: stats.count,
+      completedCount: stats.completedCount,
+    }))
+    .sort((a, b) => b.count - a.count);
+}
+
+const PAYMENT_CATEGORIES = ["cash", "card", "transfer", "package", "other"] as const;
+type PaymentCategory = (typeof PAYMENT_CATEGORIES)[number];
+
+export function computePaymentMethodBreakdown(
+  payments: { paymentMethod: string; amount: number }[],
+): { method: PaymentCategory; total: number; count: number }[] {
+  const categoryOf = (method: string): PaymentCategory => {
+    if (
+      method === "cash" ||
+      method === "card" ||
+      method === "transfer" ||
+      method === "package"
+    )
+      return method;
+    return "other";
+  };
+  const map = new Map<PaymentCategory, { total: number; count: number }>();
+  for (const p of payments) {
+    const cat = categoryOf(p.paymentMethod);
+    const prev = map.get(cat) ?? { total: 0, count: 0 };
+    map.set(cat, { total: prev.total + p.amount, count: prev.count + 1 });
+  }
+  return PAYMENT_CATEGORIES.map((key) => ({
+    method: key,
+    total: map.get(key)?.total ?? 0,
+    count: map.get(key)?.count ?? 0,
+  }));
+}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5592.

Closes #5592

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8de27070 feat(gabinet): extract report aggregation utils and add unit tests (closes #5592)

### Files changed

```
 .../dashboard/_layout.gabinet.reports.lazy.tsx     | 161 ++-------
 .../_auth/dashboard/gabinet-report-utils.test.ts   | 370 +++++++++++++++++++++
 .../_app/_auth/dashboard/gabinet-report-utils.ts   | 163 +++++++++
 3 files changed, 564 insertions(+), 130 deletions(-)
```