### PR TITLE
Consider `appointmentId` linkage in `sellProductStandalone`

### DIFF
--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -168,6 +168,7 @@ interface ApplyMovementParams {
   lotNumber?: string | null;
   expiryDate?: string | null;
   treatmentId?: string | null;
+  appointmentId?: string | null;
   performedBy: string;
 }
 
@@ -271,6 +272,7 @@ export async function applyMovementInternal(
     ...(params.lotNumber ? { lotNumber: params.lotNumber } : {}),
     ...(params.expiryDate ? { expiryDate: params.expiryDate } : {}),
     ...(params.treatmentId ? { treatmentId: params.treatmentId } : {}),
+    ...(params.appointmentId ? { appointmentId: params.appointmentId } : {}),
     performedBy: params.performedBy,
     createdAt: now,
   });

--- a/convex/magazyn/movements.ts
+++ b/convex/magazyn/movements.ts
@@ -323,6 +323,7 @@ export const sellProductStandalone = action({
     locationId: v.union(v.string(), v.null()),
     clientId: v.optional(v.string()),
     paymentMethod: v.optional(v.string()),
+    appointmentId: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<{ negativeStock: boolean }> => {
     const auth = await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
@@ -346,6 +347,7 @@ export const sellProductStandalone = action({
       sourceId: args.clientId ?? null,
       unitPrice: args.salePrice,
       paymentMethod: args.paymentMethod ?? null,
+      appointmentId: args.appointmentId ?? null,
       performedBy: String(auth.userId),
     };
 
@@ -398,6 +400,7 @@ export const sellReturnStandalone = action({
     clientId: v.optional(v.string()),
     paymentMethod: v.optional(v.string()),
     note: v.optional(v.string()),
+    appointmentId: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<{ movementId: string; balanceAfter: number }> => {
     const auth = await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
@@ -423,6 +426,7 @@ export const sellReturnStandalone = action({
       unitPrice: args.salePrice,
       paymentMethod: args.paymentMethod ?? null,
       note: args.note ?? null,
+      appointmentId: args.appointmentId ?? null,
       performedBy: String(auth.userId),
     });
 

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -403,6 +403,7 @@ export function createCrmTables({
     lotNumber: v.optional(v.string()),        // LOT/batch number (#2989)
     expiryDate: v.optional(v.string()),       // ISO date YYYY-MM-DD (#2989)
     treatmentId: v.optional(v.string()),      // which treatment drove the deduction (#5198)
+    appointmentId: v.optional(v.string()),   // appointment during which a direct sale occurred (#5601)
     performedBy: v.id("users"),
     createdAt: v.number(),
   })

--- a/supabase/migrations/00148_product_stock_movements_appointment_id.sql
+++ b/supabase/migrations/00148_product_stock_movements_appointment_id.sql
@@ -1,0 +1,18 @@
+-- Link direct-sale stock movements to an appointment (#5601).
+--
+-- Clinics often sell products (creams, supplements, etc.) to patients at the
+-- time of a visit. Previously `sellProductStandalone` stored the client as
+-- `source_id` but had no column to capture which appointment the sale happened
+-- during. This column fills that gap.
+--
+-- appointment_id is nullable so that:
+--   • existing movements without an appointment context are unaffected,
+--   • non-appointment direct sales (counter sales, online orders, etc.) remain
+--     valid without ever setting this field.
+
+ALTER TABLE product_stock_movements
+  ADD COLUMN IF NOT EXISTS appointment_id TEXT REFERENCES gabinet_appointments(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS product_stock_movements_appointment_idx
+  ON product_stock_movements (appointment_id)
+  WHERE appointment_id IS NOT NULL;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5601.

Closes #5601

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 4c2eda90 feat(inventory): add appointmentId linkage to sellProductStandalone (closes #5601)

### Files changed

```
 convex/inventory.ts                                    |  2 ++
 convex/magazyn/movements.ts                            |  4 ++++
 convex/schema/crm.ts                                   |  1 +
 .../00148_product_stock_movements_appointment_id.sql   | 18 ++++++++++++++++++
 4 files changed, 25 insertions(+)
```