### PR TITLE
Add `employeeId` field to `sellProductStandalone` and `productStockMovements`

### DIFF
--- a/convex/inventory.ts
+++ b/convex/inventory.ts
@@ -169,6 +169,7 @@ interface ApplyMovementParams {
   expiryDate?: string | null;
   treatmentId?: string | null;
   appointmentId?: string | null;
+  employeeId?: string | null;
   performedBy: string;
 }
 
@@ -273,6 +274,7 @@ export async function applyMovementInternal(
     ...(params.expiryDate ? { expiryDate: params.expiryDate } : {}),
     ...(params.treatmentId ? { treatmentId: params.treatmentId } : {}),
     ...(params.appointmentId ? { appointmentId: params.appointmentId } : {}),
+    ...(params.employeeId ? { employeeId: params.employeeId } : {}),
     performedBy: params.performedBy,
     createdAt: now,
   });

--- a/convex/magazyn/movements.ts
+++ b/convex/magazyn/movements.ts
@@ -324,6 +324,7 @@ export const sellProductStandalone = action({
     clientId: v.optional(v.string()),
     paymentMethod: v.optional(v.string()),
     appointmentId: v.optional(v.string()),
+    employeeId: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<{ negativeStock: boolean }> => {
     const auth = await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
@@ -348,6 +349,7 @@ export const sellProductStandalone = action({
       unitPrice: args.salePrice,
       paymentMethod: args.paymentMethod ?? null,
       appointmentId: args.appointmentId ?? null,
+      employeeId: args.employeeId ?? null,
       performedBy: String(auth.userId),
     };
 
@@ -401,6 +403,7 @@ export const sellReturnStandalone = action({
     paymentMethod: v.optional(v.string()),
     note: v.optional(v.string()),
     appointmentId: v.optional(v.string()),
+    employeeId: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<{ movementId: string; balanceAfter: number }> => {
     const auth = await ctx.runAction(internal._helpers.authAction.verifyOrgAccess, {
@@ -427,6 +430,7 @@ export const sellReturnStandalone = action({
       paymentMethod: args.paymentMethod ?? null,
       note: args.note ?? null,
       appointmentId: args.appointmentId ?? null,
+      employeeId: args.employeeId ?? null,
       performedBy: String(auth.userId),
     });
 

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -404,6 +404,7 @@ export function createCrmTables({
     expiryDate: v.optional(v.string()),       // ISO date YYYY-MM-DD (#2989)
     treatmentId: v.optional(v.string()),      // which treatment drove the deduction (#5198)
     appointmentId: v.optional(v.string()),   // appointment during which a direct sale occurred (#5601)
+    employeeId: v.optional(v.id("gabinetEmployees")), // gabinet employee who performed the sale (#5598)
     performedBy: v.id("users"),
     createdAt: v.number(),
   })

--- a/supabase/migrations/00149_product_stock_movements_employee_id.sql
+++ b/supabase/migrations/00149_product_stock_movements_employee_id.sql
@@ -1,0 +1,19 @@
+-- Link stock movements to a gabinet employee (#5598).
+--
+-- `performed_by` captures the authenticated user but cannot distinguish which
+-- gabinet employee performed the sale when a single user account is shared or
+-- when a manager records a sale on behalf of a therapist. `employee_id` fills
+-- that gap and enables per-employee sales reporting without schema-level joins
+-- through the users table.
+--
+-- Nullable so that:
+--   • existing movements without an employee context are unaffected,
+--   • non-gabinet sales (CRM deal close, warehouse adjustments, etc.) remain
+--     valid without ever setting this field.
+
+ALTER TABLE product_stock_movements
+  ADD COLUMN IF NOT EXISTS employee_id TEXT REFERENCES gabinet_employees(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS product_stock_movements_employee_idx
+  ON product_stock_movements (employee_id)
+  WHERE employee_id IS NOT NULL;


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5598.

Closes #5598

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 7be6f0fb feat(inventory): add employeeId to sellProductStandalone, sellReturnStandalone and productStockMovements (closes #5598)

### Files changed

```
 convex/inventory.ts                                   |  2 ++
 convex/magazyn/movements.ts                           |  4 ++++
 convex/schema/crm.ts                                  |  1 +
 .../00149_product_stock_movements_employee_id.sql     | 19 +++++++++++++++++++
 4 files changed, 26 insertions(+)
```