### PR TITLE
Add tests for `sellProductStandalone`

### DIFF
--- a/tests/convex/sellStandalone.test.ts
+++ b/tests/convex/sellStandalone.test.ts
@@ -6,6 +6,7 @@ import {
   seedTestUser,
 } from "../../convex/_test_helpers";
 import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+import { applyMovementInternal } from "../../convex/inventory";
 
 afterEach(async () => {
   await new Promise((resolve) => setTimeout(resolve, 0));
@@ -199,5 +200,182 @@ describe("sellReturnStandalone (#5599)", () => {
         },
       ),
     ).rejects.toThrow("Permission denied");
+  });
+});
+
+describe("sellProductStandalone — FEFO lot selection (#5600)", () => {
+  test("single lot: deduction movement carries lotNumber and expiryDate", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await seedTrackedProduct(String(organizationId));
+
+    // Seed a lot receipt so selectFefoLotsForProduct finds it.
+    await applyMovementInternal({
+      organizationId: String(organizationId),
+      productId: PRODUCT_ID,
+      locationId: null,
+      delta: 10,
+      reason: "warehouse_receive",
+      lotNumber: "LOT-A",
+      expiryDate: "2026-12-31",
+      performedBy: "system",
+    });
+
+    const result = await t.withIdentity(identity).action(
+      api["magazyn/movements"].sellProductStandalone,
+      {
+        organizationId: String(organizationId),
+        productId: PRODUCT_ID,
+        quantity: 4,
+        salePrice: 25,
+        locationId: null,
+      },
+    );
+
+    expect(result.negativeStock).toBe(false);
+
+    const db = createSupabaseDb();
+    const saleMoves = (await db
+      .query("productStockMovements")
+      .eq("productId", PRODUCT_ID)
+      .eq("reason", "direct_sale")
+      .collect()) as Array<Record<string, unknown>>;
+    expect(saleMoves).toHaveLength(1);
+    expect(saleMoves[0].lotNumber).toBe("LOT-A");
+    expect(saleMoves[0].expiryDate).toBe("2026-12-31");
+    expect(Number(saleMoves[0].delta)).toBe(-4);
+  });
+
+  test("two lots: earliest-expiring lot is consumed first (FEFO order)", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await seedTrackedProduct(String(organizationId));
+
+    // LOT-A expires later; LOT-B expires sooner → LOT-B should be drained first.
+    await applyMovementInternal({
+      organizationId: String(organizationId),
+      productId: PRODUCT_ID,
+      locationId: null,
+      delta: 5,
+      reason: "warehouse_receive",
+      lotNumber: "LOT-A",
+      expiryDate: "2026-12-01",
+      performedBy: "system",
+    });
+    await applyMovementInternal({
+      organizationId: String(organizationId),
+      productId: PRODUCT_ID,
+      locationId: null,
+      delta: 5,
+      reason: "warehouse_receive",
+      lotNumber: "LOT-B",
+      expiryDate: "2026-06-01",
+      performedBy: "system",
+    });
+
+    await t.withIdentity(identity).action(
+      api["magazyn/movements"].sellProductStandalone,
+      {
+        organizationId: String(organizationId),
+        productId: PRODUCT_ID,
+        quantity: 3,
+        salePrice: 25,
+        locationId: null,
+      },
+    );
+
+    const db = createSupabaseDb();
+    const saleMoves = (await db
+      .query("productStockMovements")
+      .eq("productId", PRODUCT_ID)
+      .eq("reason", "direct_sale")
+      .collect()) as Array<Record<string, unknown>>;
+    expect(saleMoves).toHaveLength(1);
+    expect(saleMoves[0].lotNumber).toBe("LOT-B");
+    expect(Number(saleMoves[0].delta)).toBe(-3);
+  });
+
+  test("lot exhaustion: remainder written as unlotted direct_sale movement", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await seedTrackedProduct(String(organizationId));
+
+    // Only 3 units in LOT-A; selling 5 should drain the lot then deduct 2 without lot.
+    await applyMovementInternal({
+      organizationId: String(organizationId),
+      productId: PRODUCT_ID,
+      locationId: null,
+      delta: 3,
+      reason: "warehouse_receive",
+      lotNumber: "LOT-A",
+      expiryDate: "2026-12-31",
+      performedBy: "system",
+    });
+
+    const result = await t.withIdentity(identity).action(
+      api["magazyn/movements"].sellProductStandalone,
+      {
+        organizationId: String(organizationId),
+        productId: PRODUCT_ID,
+        quantity: 5,
+        salePrice: 25,
+        locationId: null,
+      },
+    );
+
+    // Balance was 3, deducting 5 → -2 (warn-and-allow policy).
+    expect(result.negativeStock).toBe(true);
+
+    const db = createSupabaseDb();
+    const saleMoves = (await db
+      .query("productStockMovements")
+      .eq("productId", PRODUCT_ID)
+      .eq("reason", "direct_sale")
+      .collect()) as Array<Record<string, unknown>>;
+    expect(saleMoves).toHaveLength(2);
+    const lotMove = saleMoves.find((m) => m.lotNumber != null);
+    const unlottedMove = saleMoves.find((m) => m.lotNumber == null);
+    expect(lotMove).toBeTruthy();
+    expect(Number(lotMove!.delta)).toBe(-3);
+    expect(unlottedMove).toBeTruthy();
+    expect(Number(unlottedMove!.delta)).toBe(-2);
+  });
+
+  test("throws when quantity is zero or negative", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await seedTrackedProduct(String(organizationId));
+
+    await expect(
+      t.withIdentity(identity).action(
+        api["magazyn/movements"].sellProductStandalone,
+        {
+          organizationId: String(organizationId),
+          productId: PRODUCT_ID,
+          quantity: 0,
+          salePrice: 25,
+          locationId: null,
+        },
+      ),
+    ).rejects.toThrow("Quantity must be positive");
+  });
+
+  test("throws when salePrice is negative", async () => {
+    const t = createTestCtx();
+    const { organizationId, identity } = await seedTestUser(t);
+    await seedTrackedProduct(String(organizationId));
+
+    await expect(
+      t.withIdentity(identity).action(
+        api["magazyn/movements"].sellProductStandalone,
+        {
+          organizationId: String(organizationId),
+          productId: PRODUCT_ID,
+          quantity: 1,
+          salePrice: -5,
+          locationId: null,
+        },
+      ),
+    ).rejects.toThrow("Sale price must be non-negative");
   });
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5600.

Closes #5600

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 8a1edeb6 test(inventory): add FEFO lot selection tests for sellProductStandalone (closes #5600)

### Files changed

```
 tests/convex/sellStandalone.test.ts | 178 ++++++++++++++++++++++++++++++++++++
 1 file changed, 178 insertions(+)
```