### PR TITLE
Deduct partial refund_amount from actual revenue in reports

### DIFF
--- a/src/hooks/use-supabase-payments.ts
+++ b/src/hooks/use-supabase-payments.ts
@@ -173,7 +173,7 @@ export function useSupabasePaymentsRevenueByDateRange(
 
       let paymentsQuery = client
         .from("payments")
-        .select("amount, paid_at, currency, payment_method")
+        .select("amount, refund_amount, paid_at, currency, payment_method")
         .eq("organization_id", organizationId)
         .eq("status", "completed")
         .neq("payment_method", "gratis")
@@ -204,7 +204,7 @@ export function useSupabasePaymentsRevenueByDateRange(
       if (error) throw error;
 
       return (data ?? []).map((row) => ({
-        amount: Number(row.amount),
+        amount: Number(row.amount) - (Number(row.refund_amount) || 0),
         paidAt: Number(row.paid_at ?? 0),
         currency: (row.currency as string) ?? "PLN",
         paymentMethod: (row.payment_method as string | null) ?? undefined,


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5616.

Closes #5616

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 7db651c9 fix(reports): deduct refund_amount from actual revenue in useSupabasePaymentsRevenueByDateRange (closes #5616)

### Files changed

```
 src/hooks/use-supabase-payments.ts | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```