### PR TITLE
Add PLN revenue breakdown per employee to reports

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -742,7 +742,7 @@ function EmployeeUtilizationChart({
   data,
   rangeLabel,
 }: {
-  data: { name: string; count: number; completedCount: number }[];
+  data: { name: string; count: number; completedCount: number; revenue: number }[];
   rangeLabel: string;
 }) {
   const { t } = useTranslation();
@@ -824,9 +824,16 @@ function EmployeeUtilizationChart({
                     <span className="text-sm font-medium truncate">
                       {emp.name}
                     </span>
-                    <span className="text-sm text-muted-foreground ml-2 shrink-0">
-                      {emp.count} {t("gabinet.reports.appointmentsShort")}
-                    </span>
+                    <div className="flex items-center gap-2 ml-2 shrink-0">
+                      {emp.revenue > 0 && (
+                        <span className="text-sm font-medium">
+                          {formatCurrencyPLN(emp.revenue)}
+                        </span>
+                      )}
+                      <span className="text-sm text-muted-foreground">
+                        {emp.count} {t("gabinet.reports.appointmentsShort")}
+                      </span>
+                    </div>
                   </div>
                   <div className="h-2 rounded-full bg-muted overflow-hidden">
                     <div
@@ -2026,8 +2033,8 @@ function GabinetReports() {
 
   // Employee utilization
   const employeeStats = useMemo(
-    () => computeEmployeeStats(appointments ?? [], employeeMap),
-    [appointments, employeeMap]
+    () => computeEmployeeStats(appointments ?? [], employeeMap, treatmentMap, gratisBarterIds ?? new Set()),
+    [appointments, employeeMap, treatmentMap, gratisBarterIds]
   );
 
   // Revenue: relative to the selected date range (endDate = last day of range)
@@ -2165,7 +2172,7 @@ function GabinetReports() {
         section: "employee",
         metric: e.name,
         value: e.count,
-        revenue: e.completedCount,
+        revenue: e.revenue,
       });
     }
     for (const pm of paymentMethodBreakdown) {

--- a/src/routes/_app/_auth/dashboard/gabinet-report-utils.test.ts
+++ b/src/routes/_app/_auth/dashboard/gabinet-report-utils.test.ts
@@ -280,41 +280,77 @@ describe("computeEmployeeStats", () => {
     ["e1", "Anna Kowalska"],
     ["e2", "Jan Nowak"],
   ]);
+  const treatmentMap = new Map([
+    ["t1", { name: "Massage", price: 100, currency: "PLN" }],
+    ["t2", { name: "Facial", price: 200, currency: "PLN" }],
+  ]);
+  const noGratis = new Set<string>();
 
   it("returns empty array for no appointments", () => {
-    expect(computeEmployeeStats([], employeeMap)).toEqual([]);
+    expect(computeEmployeeStats([], employeeMap, treatmentMap, noGratis)).toEqual([]);
   });
 
   it("resolves employee names from the map, falls back to id when missing", () => {
     const appts = [
-      { employeeId: "e1", status: "completed" },
-      { employeeId: "e_unknown", status: "completed" },
+      { _id: "a1", employeeId: "e1", status: "completed", date: "2025-01-01" },
+      { _id: "a2", employeeId: "e_unknown", status: "completed", date: "2025-01-01" },
     ];
-    const result = computeEmployeeStats(appts, employeeMap);
+    const result = computeEmployeeStats(appts, employeeMap, treatmentMap, noGratis);
     expect(result.find((r) => r.name === "Anna Kowalska")).toBeTruthy();
     expect(result.find((r) => r.name === "e_unknown")).toBeTruthy();
   });
 
   it("counts total and completed appointments per employee", () => {
     const appts = [
-      { employeeId: "e1", status: "completed" },
-      { employeeId: "e1", status: "completed" },
-      { employeeId: "e1", status: "cancelled" },
-      { employeeId: "e2", status: "completed" },
+      { _id: "a1", employeeId: "e1", status: "completed", date: "2025-01-01" },
+      { _id: "a2", employeeId: "e1", status: "completed", date: "2025-01-01" },
+      { _id: "a3", employeeId: "e1", status: "cancelled", date: "2025-01-01" },
+      { _id: "a4", employeeId: "e2", status: "completed", date: "2025-01-01" },
     ];
-    const result = computeEmployeeStats(appts, employeeMap);
+    const result = computeEmployeeStats(appts, employeeMap, treatmentMap, noGratis);
     const anna = result.find((r) => r.name === "Anna Kowalska");
     expect(anna?.count).toBe(3);
     expect(anna?.completedCount).toBe(2);
   });
 
+  it("sums PLN revenue for completed non-gratis appointments", () => {
+    const appts = [
+      { _id: "a1", employeeId: "e1", treatmentId: "t1", status: "completed", date: "2025-01-01" },
+      { _id: "a2", employeeId: "e1", treatmentId: "t1", status: "completed", date: "2025-01-01" },
+      { _id: "a3", employeeId: "e1", treatmentId: "t1", status: "cancelled", date: "2025-01-01" },
+    ];
+    const result = computeEmployeeStats(appts, employeeMap, treatmentMap, noGratis);
+    const anna = result.find((r) => r.name === "Anna Kowalska");
+    expect(anna?.revenue).toBe(200); // 2 completed × 100 PLN
+  });
+
+  it("excludes gratis/barter appointments from revenue", () => {
+    const appts = [
+      { _id: "a1", employeeId: "e1", treatmentId: "t1", status: "completed", date: "2025-01-01" },
+      { _id: "a2", employeeId: "e1", treatmentId: "t1", status: "completed", date: "2025-01-01" },
+    ];
+    const gratis = new Set(["a2"]);
+    const result = computeEmployeeStats(appts, employeeMap, treatmentMap, gratis);
+    const anna = result.find((r) => r.name === "Anna Kowalska");
+    expect(anna?.revenue).toBe(100); // only a1 contributes
+  });
+
+  it("uses priceAtBooking over treatment price when set", () => {
+    const appts = [
+      { _id: "a1", employeeId: "e1", treatmentId: "t1", status: "completed", date: "2025-01-01", priceAtBooking: 150 },
+    ];
+    const result = computeEmployeeStats(appts, employeeMap, treatmentMap, noGratis);
+    const anna = result.find((r) => r.name === "Anna Kowalska");
+    expect(anna?.revenue).toBe(150);
+  });
+
   it("sorts by total count descending", () => {
     const appts = [
-      { employeeId: "e1", status: "scheduled" },
-      { employeeId: "e2", status: "completed" },
-      { employeeId: "e2", status: "completed" },
+      { _id: "a1", employeeId: "e1", status: "scheduled", date: "2025-01-01" },
+      { _id: "a2", employeeId: "e2", status: "completed", date: "2025-01-01" },
+      { _id: "a3", employeeId: "e2", status: "completed", date: "2025-01-01" },
     ];
-    const result = computeEmployeeStats(appts, employeeMap);
+    const result = computeEmployeeStats(appts, employeeMap, treatmentMap, noGratis);
     expect(result[0]!.name).toBe("Jan Nowak");
   });
 });

--- a/src/routes/_app/_auth/dashboard/gabinet-report-utils.ts
+++ b/src/routes/_app/_auth/dashboard/gabinet-report-utils.ts
@@ -112,16 +112,24 @@ export function computeDailyStats(
 }
 
 export function computeEmployeeStats(
-  appointments: Pick<AppointmentForStats, "employeeId" | "status">[],
+  appointments: AppointmentForStats[],
   employeeMap: Map<string, string>,
-): { name: string; count: number; completedCount: number }[] {
-  const map = new Map<string, { count: number; completedCount: number }>();
+  treatmentMap: Map<string, TreatmentInfo>,
+  gratisBarterIds: Set<string>,
+): { name: string; count: number; completedCount: number; revenue: number }[] {
+  const map = new Map<string, { count: number; completedCount: number; revenue: number }>();
   for (const a of appointments) {
     const uid = a.employeeId;
-    const prev = map.get(uid) ?? { count: 0, completedCount: 0 };
+    const prev = map.get(uid) ?? { count: 0, completedCount: 0, revenue: 0 };
+    const isCompleted = a.status === "completed";
+    const price =
+      isCompleted && !gratisBarterIds.has(a._id)
+        ? (a.priceAtBooking ?? treatmentMap.get(a.treatmentId ?? "")?.price ?? 0)
+        : 0;
     map.set(uid, {
       count: prev.count + 1,
-      completedCount: prev.completedCount + (a.status === "completed" ? 1 : 0),
+      completedCount: prev.completedCount + (isCompleted ? 1 : 0),
+      revenue: prev.revenue + price,
     });
   }
   return Array.from(map.entries())
@@ -129,6 +137,7 @@ export function computeEmployeeStats(
       name: employeeMap.get(userId) ?? userId,
       count: stats.count,
       completedCount: stats.completedCount,
+      revenue: stats.revenue,
     }))
     .sort((a, b) => b.count - a.count);
 }


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5617.

Closes #5617

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 95929b14 feat(gabinet/reports): add PLN revenue breakdown per employee (closes #5617)

### Files changed

```
 .../dashboard/_layout.gabinet.reports.lazy.tsx     | 21 +++++---
 .../_auth/dashboard/gabinet-report-utils.test.ts   | 62 +++++++++++++++++-----
 .../_app/_auth/dashboard/gabinet-report-utils.ts   | 19 +++++--
 3 files changed, 77 insertions(+), 25 deletions(-)
```