### PR TITLE
Add payment-method sub-breakdown to ProductSalesSection

### DIFF
--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -1369,6 +1369,14 @@ function ProductSalesSection({
 
   const maxProductRevenue = useMemo(() => Math.max(...perProduct.map((p) => p.revenue), 1), [perProduct]);
 
+  const paymentMethodBreakdown = useMemo(
+    () =>
+      computePaymentMethodBreakdown(
+        sales.map((m) => ({ paymentMethod: m.paymentMethod ?? "other", amount: m.revenue })),
+      ),
+    [sales],
+  );
+
   if (isLoading) {
     return (
       <div className="space-y-4">
@@ -1486,6 +1494,10 @@ function ProductSalesSection({
             </CardContent>
           </Card>
         </div>
+      )}
+
+      {movements.length > 0 && (
+        <PaymentMethodsCard data={paymentMethodBreakdown} currency={currency} rangeLabel={rangeLabel} />
       )}
     </div>
   );


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5622.

Closes #5622

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 79b2d67d feat(gabinet/reports): add payment-method breakdown to ProductSalesSection (closes #5622)

### Files changed

```
 .../_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx    | 12 ++++++++++++
 1 file changed, 12 insertions(+)
```