### PR TITLE
R3C — Raporty — walidacja końcowa i decyzja o zamknięciu modułu

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -4001,6 +4001,7 @@
         "cash": "Cash",
         "card": "Card",
         "transfer": "Transfer",
+        "package": "Package",
         "other": "Other"
       },
       "packageSales": "Package Sales",
@@ -4030,7 +4031,8 @@
       "netProductRevenue": "Net Revenue",
       "noProductSales": "No product sales in this period",
       "perProductBreakdown": "By Product",
-      "perEmployeeProductSales": "By Employee"
+      "perEmployeeProductSales": "By Employee",
+      "unattributedReturnsNote": "{{count}} return(s) totalling {{amount}} have no payment method and could not be deducted from any category"
     },
     "bodyChart": {
       "description": "Mark body areas related to the appointment",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -4000,6 +4000,7 @@
         "cash": "Gotówka",
         "card": "Karta",
         "transfer": "Przelew",
+        "package": "Pakiet",
         "other": "Inne"
       },
       "packageSales": "Sprzedaż pakietów",
@@ -4029,7 +4030,8 @@
       "netProductRevenue": "Przychód netto",
       "noProductSales": "Brak sprzedaży produktów w tym okresie",
       "perProductBreakdown": "Wg. produktu",
-      "perEmployeeProductSales": "Wg. pracownika"
+      "perEmployeeProductSales": "Wg. pracownika",
+      "unattributedReturnsNote": "{{count}} zwrot(ów) na łączną kwotę {{amount}} nie ma przypisanej metody płatności i nie zostało odjęte od żadnej kategorii"
     },
     "bodyChart": {
       "description": "Zaznacz obszary ciała powiązane z wizytą",


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5626.

Closes #5626

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- e6bdc028 fix(i18n): add missing gabinet.reports translation keys for package payment method and unattributed returns note (closes #5626)

### Files changed

```
 public/locales/en/translation.json | 4 +++-
 public/locales/pl/translation.json | 4 +++-
 2 files changed, 6 insertions(+), 2 deletions(-)
```