### PR TITLE
M2-ENV — E2E — przygotowanie środowiska browserowego dla QUERA

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,11 +37,13 @@ jobs:
 
       - name: Build
         run: npx vite build
+        env:
+          VITE_CONVEX_URL: ${{ secrets.VITE_CONVEX_URL }}
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
 
       - name: Start preview server
         run: npx vite preview --port 5173 &
-        env:
-          VITE_CONVEX_URL: ${{ secrets.VITE_CONVEX_URL }}
 
       - name: Wait for server
         run: npx wait-on http://localhost:5173 --timeout 30000
@@ -50,8 +52,8 @@ jobs:
         run: npx playwright test
         env:
           CI: true
-          E2E_USER_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
-          E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
+          PLAYWRIGHT_TEST_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
+          PLAYWRIGHT_TEST_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
           # Some specs (e.g. e2e/gabinet/appointments.spec.ts) build a
           # ConvexHttpClient at module load and look up VITE_CONVEX_URL.
           # Without this the test discovery throws before any test runs.


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5638.

Closes #5638

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- a6695cd4 fix(e2e): move VITE_* vars to build step and fix test credential env names — closes #5638

### Files changed

```
 .github/workflows/e2e.yml | 10 ++++++----
 1 file changed, 6 insertions(+), 4 deletions(-)
```