### PR TITLE
Add `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` to GitHub Secrets for CI

### DIFF
--- a/.github/workflows/secrets-health.yml
+++ b/.github/workflows/secrets-health.yml
@@ -67,3 +67,29 @@ jobs:
           else
             echo "::warning::SUPABASE_DB_URL is unset — psql fallback unavailable. HTTP transport covers migrations."
           fi
+
+      - name: Check E2E build-time secrets
+        # VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY are injected at vite build
+        # time in e2e.yml. If either is missing the CI build produces a bundle that
+        # cannot connect to Supabase, silently breaking all E2E tests.
+        # See: .github/workflows/e2e.yml Build step and issue #5640.
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+        run: |
+          failed=false
+          if [ -z "${VITE_SUPABASE_URL:-}" ]; then
+            echo "::error::VITE_SUPABASE_URL is unset — E2E build will produce a bundle without a Supabase URL."
+            echo "::error::Add it under Settings -> Secrets and variables -> Actions (issue #5640)."
+            failed=true
+          else
+            echo "VITE_SUPABASE_URL present."
+          fi
+          if [ -z "${VITE_SUPABASE_ANON_KEY:-}" ]; then
+            echo "::error::VITE_SUPABASE_ANON_KEY is unset — E2E build will produce a bundle without an anon key."
+            echo "::error::Add it under Settings -> Secrets and variables -> Actions (issue #5640)."
+            failed=true
+          else
+            echo "VITE_SUPABASE_ANON_KEY present."
+          fi
+          [ "$failed" = "false" ]


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5640.

Closes #5640

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 33571517 ci(secrets-health): add VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY checks — closes #5640

### Files changed

```
 .github/workflows/secrets-health.yml | 26 ++++++++++++++++++++++++++
 1 file changed, 26 insertions(+)
```