### PR TITLE
fix(schema): declare users.isPlatformAdmin (unblock convex deploy)

### DIFF
--- a/convex/schema/platform.ts
+++ b/convex/schema/platform.ts
@@ -36,6 +36,10 @@ export function createPlatformTables({
       v.union(v.literal("light"), v.literal("dark"), v.literal("system")),
     ),
     timezone: v.optional(v.string()),
+    // Platform-admin flag. Authoritative store is Supabase (is_platform_admin),
+    // but existing Convex user docs carry this field, so it must be declared
+    // here or schema validation rejects the extra field on deploy.
+    isPlatformAdmin: v.optional(v.boolean()),
   })
     .index("email", ["email"])
     .index("customerId", ["customerId"]),


### PR DESCRIPTION
Deploying current main to prod failed schema validation: the Convex `users` doc for amiesak carries `isPlatformAdmin` but the schema (recently) dropped it. Re-declares `isPlatformAdmin: v.optional(v.boolean())` on the users table so deploy validates. Already deployed to helpful-mule-867. Type-only alignment (UserRow already augments this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)