### PR TITLE
fix(build): resolve long-standing app-typecheck crash + 36 hidden type errors

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -36,6 +36,7 @@ import type * as activities from "../activities.js";
 import type * as activityTypes from "../activityTypes.js";
 import type * as admin_cleanup from "../admin/cleanup.js";
 import type * as admin_entitlements from "../admin/entitlements.js";
+import type * as admin_organizations from "../admin/organizations.js";
 import type * as app from "../app.js";
 import type * as auditLog from "../auditLog.js";
 import type * as auth from "../auth.js";
@@ -236,6 +237,7 @@ declare const fullApi: ApiFromModules<{
   activityTypes: typeof activityTypes;
   "admin/cleanup": typeof admin_cleanup;
   "admin/entitlements": typeof admin_entitlements;
+  "admin/organizations": typeof admin_organizations;
   app: typeof app;
   auditLog: typeof auditLog;
   auth: typeof auth;

--- a/src/components/gabinet/appointments/appointment-details-tab.tsx
+++ b/src/components/gabinet/appointments/appointment-details-tab.tsx
@@ -49,7 +49,7 @@ type TreatmentListItem = {
 
 type JunctionTreatment = {
   id: string;
-  treatmentId: string;
+  treatmentId: string | null;
   variantId?: string | null;
   variantName?: string | null;
   priceAtBooking?: number | null;

--- a/src/components/gabinet/appointments/payment-appointment-dialog.tsx
+++ b/src/components/gabinet/appointments/payment-appointment-dialog.tsx
@@ -9,10 +9,11 @@ import {
 import { SettlementForm } from "@/components/gabinet/appointment-shared/settlement-form";
 import type { TFunction } from "i18next";
 import { formatCurrencyPLN } from "@/lib/format-currency";
+import type { Id } from "@cvx/_generated/dataModel";
 
 type JunctionTreatment = {
   id: string;
-  treatmentId: string;
+  treatmentId: string | null;
   priceAtBooking?: number | null;
 };
 
@@ -138,7 +139,7 @@ export function PaymentAppointmentDialog({
         )}
         {open && (
           <SettlementForm
-            organizationId={organizationId}
+            organizationId={organizationId as Id<"organizations">}
             appointmentId={appointmentId}
             patientId={patientId}
             junctionTreatments={junctionTreatments}

--- a/src/components/gabinet/calendar/event-dialog.tsx
+++ b/src/components/gabinet/calendar/event-dialog.tsx
@@ -146,12 +146,14 @@ export function EventDialog({
   );
 
   const employeeOptions = useMemo(() => {
-    return (employees ?? []).map((e) => ({
-      userId: e.userId,
-      name:
-        [e.firstName, e.lastName].filter(Boolean).join(" ").trim() ||
-        t("gabinet.calendar.unnamedEmployee", "Bez nazwy"),
-    }));
+    return (employees ?? [])
+      .filter((e): e is typeof e & { userId: string } => !!e.userId)
+      .map((e) => ({
+        userId: e.userId,
+        name:
+          [e.firstName, e.lastName].filter(Boolean).join(" ").trim() ||
+          t("gabinet.calendar.unnamedEmployee", "Bez nazwy"),
+      }));
   }, [employees, t]);
 
   const toggleEmployee = useCallback((userId: string) => {

--- a/src/components/gabinet/deliveries/deliveries-page.tsx
+++ b/src/components/gabinet/deliveries/deliveries-page.tsx
@@ -40,7 +40,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Plus, Trash2, TruckIcon, Loader2, CheckCircle, FileText, Sparkles, RefreshCw, AlertCircle, X } from "@/lib/ez-icons";
+import { Plus, Trash2, TruckIcon, Loader2, CheckCircle, FileText, Sparkles, RefreshCw } from "@/lib/ez-icons";
 import { formatActionError } from "@/lib/format-action-error";
 import {
   Tooltip,

--- a/src/components/gabinet/patient-packages-card.tsx
+++ b/src/components/gabinet/patient-packages-card.tsx
@@ -106,8 +106,8 @@ export function PatientPackagesCard({ patientId, organizationId }: PatientPackag
     patientId,
   );
 
-  const treatmentMap = new Map(
-    (treatments ?? []).map((tr) => [tr._id, tr.name])
+  const treatmentMap = new Map<string, string>(
+    (treatments ?? []).map((tr) => [tr._id as string, tr.name])
   );
 
   const packageMap = new Map(
@@ -712,7 +712,7 @@ interface PackageDetailDialogProps {
     status: string;
     paidAmount: number;
     paymentMethod?: string | null;
-    treatmentsUsed: Array<{ treatmentId: Id<"gabinetTreatments">; usedCount: number; totalCount: number }>;
+    treatmentsUsed: Array<{ treatmentId: string; usedCount: number; totalCount: number }>;
   } | null;
   pkg: {
     name: string;
@@ -720,7 +720,7 @@ interface PackageDetailDialogProps {
     totalPrice: number;
     currency?: string;
   } | null;
-  treatmentMap: Map<Id<"gabinetTreatments">, string>;
+  treatmentMap: Map<string, string>;
   scheduledByTreatment: Map<string, number> | null;
 }
 

--- a/src/components/gabinet/patient-treatments-card.tsx
+++ b/src/components/gabinet/patient-treatments-card.tsx
@@ -53,7 +53,7 @@ export function PatientTreatmentsCard({ patientId, organizationId }: PatientTrea
     enabled: !!organizationId,
   });
 
-  const treatmentMap = new Map((treatments ?? []).map((tr) => [tr._id, tr.name]));
+  const treatmentMap = new Map<string, string>((treatments ?? []).map((tr) => [tr._id as string, tr.name]));
   const packageMap = new Map((allPackages ?? []).map((p) => [p._id, p]));
 
   // Single-session purchases of one treatment ("zabieg"). Multi-session sales

--- a/src/components/gabinet/patients/patient-loyalty-tab.tsx
+++ b/src/components/gabinet/patients/patient-loyalty-tab.tsx
@@ -11,7 +11,7 @@ type LoyaltyBalance = {
 
 type LoyaltyTransaction = {
   _id: string;
-  type: "earn" | "spend" | "adjust";
+  type: string;
   points: number;
   reason?: string;
   createdAt: number;

--- a/src/components/gabinet/patients/patient-sidebar-extra.tsx
+++ b/src/components/gabinet/patients/patient-sidebar-extra.tsx
@@ -6,6 +6,7 @@ import { PatientTreatmentsCard } from "@/components/gabinet/patient-treatments-c
 import { plateJsonToText } from "@/components/gabinet/rich-text-editor";
 import { formatCurrencyPLN } from "@/lib/format-currency";
 import { groupIntakeSummary } from "./intake-utils";
+import type { Id } from "@cvx/_generated/dataModel";
 
 type LatestIntake = { intakeSummary: string[] } | null | undefined;
 type LoyaltyBalance = { balance: number } | null | undefined;
@@ -124,7 +125,7 @@ export function PatientSidebarExtra({
         </div>
         {(() => {
           const medicalNotesText = plateJsonToText(
-            patient.medicalNotes ?? undefined,
+            patient.medicalNotes as string | null | undefined,
           ).trim();
           if (!medicalNotesText) return null;
           return (
@@ -141,8 +142,8 @@ export function PatientSidebarExtra({
           );
         })()}
       </div>
-      <PatientPackagesCard patientId={patientId} organizationId={organizationId} />
-      <PatientTreatmentsCard patientId={patientId} organizationId={organizationId} />
+      <PatientPackagesCard patientId={patientId} organizationId={organizationId as Id<"organizations">} />
+      <PatientTreatmentsCard patientId={patientId} organizationId={organizationId as Id<"organizations">} />
     </div>
   );
 }

--- a/src/components/impersonation-context.tsx
+++ b/src/components/impersonation-context.tsx
@@ -43,7 +43,7 @@ export interface ImpersonationState {
 
 interface ImpersonationContextValue {
   impersonation: ImpersonationState | null;
-  startImpersonation: (state: ImpersonationState) => void;
+  startImpersonation: (state: Omit<ImpersonationState, "adminUserId">) => void;
   stopImpersonation: () => void;
 }
 
@@ -107,7 +107,7 @@ function saveToSession(state: ImpersonationState | null): void {
 
 const ImpersonationContext = createContext<ImpersonationContextValue>({
   impersonation: null,
-  startImpersonation: () => {},
+  startImpersonation: (_state: Omit<ImpersonationState, "adminUserId">) => {},
   stopImpersonation: () => {},
 });
 
@@ -132,7 +132,7 @@ export function ImpersonationProvider({
   }, [impersonation]);
 
   const startImpersonation = useCallback(
-    (state: ImpersonationState) => {
+    (state: Omit<ImpersonationState, "adminUserId">) => {
       // Always stamp adminUserId from the current authenticated user so that
       // the persisted token cannot be rehydrated by a different user.
       setImpersonation({ ...state, adminUserId: currentUserId });

--- a/src/hooks/use-supabase-gabinet-employees.ts
+++ b/src/hooks/use-supabase-gabinet-employees.ts
@@ -67,7 +67,7 @@ export function useSupabaseGabinetEmployeesList(
         .limit(limit);
 
       if (error) throw error;
-      return (data ?? []).map((row) => mapGabinetEmployeeFromSupabase(row as GabinetEmployeeRow));
+      return (data ?? []).map((row) => mapGabinetEmployeeFromSupabase(row as unknown as GabinetEmployeeRow));
     },
     enabled: enabled && isReady && !!organizationId,
   } satisfies UseQueryOptions<MappedGabinetEmployee[], Error>);

--- a/src/i18next.d.ts
+++ b/src/i18next.d.ts
@@ -1,10 +1,18 @@
+// i18next type augmentation.
+//
+// NOTE: we deliberately do NOT type `resources` here. Typing it with the full
+// public/locales/en/translation.json (~208KB, ~4371 keys) makes i18next's
+// TFunction overload union so large that the TypeScript checker crashes with
+// "Debug Failure. No error for last overload signature" during whole-program
+// overload resolution (crashes tsc -p tsconfig.app.json / `npm run build` /
+// the Typecheck CI). Translation-key existence is instead guarded at CI by
+// scripts/check-i18n-coverage.mjs (i18n-coverage.yml). See the debugging notes
+// in the SP2/tsc-fix work.
 import "i18next";
-import type translation from "../public/locales/en/translation.json";
 
 declare module "i18next" {
   interface CustomTypeOptions {
     returnNull: false;
     returnObjects: false;
-    resources: { translation: typeof translation };
   }
 }

--- a/src/lib/supabase/database.columns.ts
+++ b/src/lib/supabase/database.columns.ts
@@ -148,6 +148,13 @@
  *   • 00141_drop_document_instances.sql
  *   • 00142_form_documents_expires_at.sql
  *   • 00143_form_documents_is_required.sql
+ *   • 00144_form_documents_audit_fields.sql
+ *   • 00145_gabinet_safe_movements.sql
+ *   • 00146_gabinet_day_closes_cash_split.sql
+ *   • 00147_payments_refund_amount.sql
+ *   • 00148_product_stock_movements_appointment_id.sql
+ *   • 00149_product_stock_movements_employee_id.sql
+ *   • 00150_organizations_admin_fields.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  */
@@ -256,7 +263,8 @@ export type TableName =
   | "gabinet_cash_transactions"
   | "gabinet_day_closes"
   | "gabinet_waitlist"
-  | "lead_stage_history";
+  | "lead_stage_history"
+  | "gabinet_safe_movements";
 
 /**
  * Column names per table, as a runtime-checkable Set.
@@ -271,7 +279,7 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   plans: new Set(["id", "key", "stripe_id", "name", "description", "seat_limit", "prices", "product_key"]),
   subscriptions: new Set(["id", "user_id", "plan_id", "price_stripe_id", "stripe_id", "currency", "interval", "status", "current_period_start", "current_period_end", "cancel_at_period_end", "product_key", "trial_end_date"]),
   platform_products: new Set(["id", "product_id", "name", "description", "is_active", "prices", "stripe_product_id", "created_at", "updated_at"]),
-  organizations: new Set(["id", "name", "slug", "owner_id", "logo", "website", "created_at", "updated_at", "onboarding_completed"]),
+  organizations: new Set(["id", "name", "slug", "owner_id", "logo", "website", "created_at", "updated_at", "onboarding_completed", "status", "suspended_reason", "seat_limit_override"]),
   product_subscriptions: new Set(["id", "organization_id", "product_id", "stripe_subscription_id", "status", "current_period_start", "current_period_end", "cancel_at_period_end", "created_at", "updated_at", "trial_end_date", "source", "granted_by_user_id"]),
   team_memberships: new Set(["id", "user_id", "organization_id", "role", "invited_by", "joined_at"]),
   org_settings: new Set(["id", "organization_id", "allow_custom_lost_reason", "lost_reason_required", "default_currency", "timezone", "resource_sharing_enabled", "reminder_enabled", "reminder_hours_before", "created_at", "updated_at", "reminder_sms_48h", "reminder_sms_24h", "reminder_email_48h", "reminder_email_24h", "patient_retention_months"]),
@@ -317,7 +325,7 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   oauth_connections: new Set(["id", "organization_id", "provider", "provider_account_id", "user_id", "access_token", "refresh_token", "expires_at", "scope", "token_type", "is_active", "last_synced_at", "connected_by", "created_at", "updated_at"]),
   google_calendar_sync_configs: new Set(["id", "organization_id", "user_id", "connection_id", "google_calendar_id", "google_calendar_name", "is_org_default", "target_module", "target_activity_type", "visibility", "sync_enabled", "last_sync_token", "last_sync_at", "sync_status", "sync_error"]),
   scheduled_activities: new Set(["id", "organization_id", "title", "activity_type", "due_date", "end_date", "is_completed", "completed_at", "owner_id", "description", "linked_entity_type", "linked_entity_id", "location", "meeting_url", "google_event_id", "google_calendar_id", "last_google_sync_at", "requires_completion", "source_type", "sync_config_id", "visibility_override", "module_ref", "resource_id", "tag_ids", "category_id", "created_by", "created_at", "updated_at"]),
-  payments: new Set(["id", "organization_id", "patient_id", "appointment_id", "package_usage_id", "amount", "currency", "payment_method", "status", "paid_at", "notes", "created_by", "created_at", "updated_at", "credit_earned", "credit_applied", "kind", "discount_amount", "discount_percent", "fiscal_receipt_id", "fiscal_status", "fiscal_attempts", "fiscal_error"]),
+  payments: new Set(["id", "organization_id", "patient_id", "appointment_id", "package_usage_id", "amount", "currency", "payment_method", "status", "paid_at", "notes", "created_by", "created_at", "updated_at", "credit_earned", "credit_applied", "kind", "discount_amount", "discount_percent", "fiscal_receipt_id", "fiscal_status", "fiscal_attempts", "fiscal_error", "refund_amount", "refunded_at"]),
   org_sms_config: new Set(["id", "organization_id", "provider", "api_token", "api_secret", "sender_id", "from_number", "is_active", "created_at", "updated_at"]),
   gabinet_locations: new Set(["id", "organization_id", "name", "address", "phone", "email", "color", "is_active", "created_by", "created_at", "updated_at", "fiscal_register_id"]),
   gabinet_rooms: new Set(["id", "organization_id", "location_id", "name", "description", "floor", "is_active", "created_at"]),
@@ -344,13 +352,13 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   appointment_sms_events: new Set(["id", "organization_id", "appointment_id", "patient_id", "normalized_phone", "direction", "provider", "event_type", "provider_message_id", "correlation_key", "reply_to_event_id", "raw_body", "normalized_body", "parsed_intent", "processing_status", "processing_error", "webhook_signature_verified", "metadata", "idempotency_key", "processed_at", "created_at", "updated_at"]),
   signature_requests: new Set(["id", "organization_id", "instance_id", "slot_id", "token", "signer_email", "signer_name", "signer_phone", "signer_user_id", "verification_method", "status", "otp_hash", "otp_sent_at", "otp_attempts", "expires_at", "signed_at", "created_at", "document_title", "rendered_content", "document_created_by", "slot_label", "signature_data"]),
   form_templates: new Set(["id", "organization_id", "name", "description", "category", "folder_path", "template_type", "form_json", "content_json", "theme_json", "modules", "entity_types", "variable_bindings", "requires_signature", "signature_config", "access_roles", "version", "is_active", "created_by", "created_at", "updated_at", "is_org_required", "updated_by"]),
-  form_documents: new Set(["id", "organization_id", "template_id", "title", "response_data", "entity_type", "entity_id", "scope_entities", "status", "signature_data", "signed_at", "signed_by_name", "signed_by_email", "signed_by_ip", "signature_verification_method", "signing_token", "signing_token_expires_at", "signing_email_sent_at", "signing_reminder_count", "timing", "auto_generated", "pdf_storage_id", "pdf_generated_at", "created_by", "created_at", "updated_at", "sort_order", "generated_for_treatment_id", "template_version", "content_json_snapshot", "expires_at", "document_validity_days", "is_required"]),
+  form_documents: new Set(["id", "organization_id", "template_id", "title", "response_data", "entity_type", "entity_id", "scope_entities", "status", "signature_data", "signed_at", "signed_by_name", "signed_by_email", "signed_by_ip", "signature_verification_method", "signing_token", "signing_token_expires_at", "signing_email_sent_at", "signing_reminder_count", "timing", "auto_generated", "pdf_storage_id", "pdf_generated_at", "created_by", "created_at", "updated_at", "sort_order", "generated_for_treatment_id", "template_version", "content_json_snapshot", "expires_at", "document_validity_days", "is_required", "sent_by_user_id", "voided_by_user_id", "voided_at"]),
   automation_rules: new Set(["id", "organization_id", "name", "description", "module", "event_type", "entity_type", "trigger", "graph", "definition_version", "conditions", "actions", "enabled", "created_by", "created_at", "updated_at"]),
   automation_runs: new Set(["id", "organization_id", "rule_id", "module", "event_type", "entity_type", "entity_id", "event_idempotency_key", "correlation_key", "payload_snapshot", "actor_user_id", "status", "error_message", "occurred_at", "processed_at", "created_at", "updated_at"]),
   automation_run_steps: new Set(["id", "organization_id", "run_id", "rule_id", "action_index", "action_type", "idempotency_key", "status", "recipient", "recipient_name", "linked_entity_type", "linked_entity_id", "rendered_subject", "rendered_body", "metadata_snapshot", "error_message", "email_event_log_id", "appointment_sms_event_id", "processed_at", "created_at", "updated_at"]),
   document_components: new Set(["id", "organization_id", "scope", "created_by", "name", "description", "category", "content_json", "protected", "position_constraint", "version", "is_active", "created_at", "updated_at"]),
   product_stock_levels: new Set(["id", "organization_id", "product_id", "location_id", "quantity", "updated_at", "avg_cost"]),
-  product_stock_movements: new Set(["id", "organization_id", "product_id", "location_id", "delta", "balance_after", "reason", "source_type", "source_id", "note", "performed_by", "created_at", "unit_price", "avg_cost_after", "lot_number", "expiry_date", "payment_method", "treatment_id"]),
+  product_stock_movements: new Set(["id", "organization_id", "product_id", "location_id", "delta", "balance_after", "reason", "source_type", "source_id", "note", "performed_by", "created_at", "unit_price", "avg_cost_after", "lot_number", "expiry_date", "payment_method", "treatment_id", "appointment_id", "employee_id"]),
   gabinet_treatment_products: new Set(["id", "organization_id", "treatment_id", "product_id", "product_section", "quantity", "unit", "created_at", "updated_at"]),
   gabinet_payment_methods: new Set(["id", "organization_id", "key", "name", "is_system", "is_active", "order", "available_for_settlement", "available_for_sales", "available_for_refund", "locks_amount_to_treatment_price", "is_package_coverage", "created_by", "created_at", "updated_at"]),
   gabinet_employee_locations: new Set(["id", "organization_id", "employee_id", "location_id", "is_primary", "created_at", "role"]),
@@ -363,7 +371,8 @@ export const TABLE_COLUMNS: Readonly<Record<TableName, ReadonlySet<string>>> = {
   gabinet_receipt_sequences: new Set(["id", "organization_id", "location_id", "year", "last_number", "updated_at"]),
   gabinet_loyalty_tiers: new Set(["id", "organization_id", "tier", "name", "threshold", "color", "is_active", "created_at", "updated_at"]),
   gabinet_cash_transactions: new Set(["id", "organization_id", "location_id", "date", "type", "amount", "reason", "created_by", "created_at", "updated_at"]),
-  gabinet_day_closes: new Set(["id", "organization_id", "location_id", "date", "payment_summary", "total_collected", "cash_from_payments", "cash_opening_balance", "cash_deposits", "cash_withdrawals", "cash_expected", "cash_counted", "cash_discrepancy", "notes", "closed_by", "closed_at", "created_at", "updated_at"]),
+  gabinet_day_closes: new Set(["id", "organization_id", "location_id", "date", "payment_summary", "total_collected", "cash_from_payments", "cash_opening_balance", "cash_deposits", "cash_withdrawals", "cash_expected", "cash_counted", "cash_discrepancy", "notes", "closed_by", "closed_at", "created_at", "updated_at", "cash_next_opening", "cash_to_safe"]),
   gabinet_waitlist: new Set(["id", "organization_id", "patient_id", "treatment_id", "employee_id", "preferred_dates", "preferred_times", "notes", "status", "notified_at", "priority", "created_by", "created_at", "updated_at"]),
   lead_stage_history: new Set(["id", "organization_id", "lead_id", "stage_id", "entered_at", "exited_at"]),
+  gabinet_safe_movements: new Set(["id", "organization_id", "location_id", "type", "amount", "description", "reference_day_close_id", "created_by", "created_at"]),
 };

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -149,6 +149,12 @@
  *   • 00142_form_documents_expires_at.sql
  *   • 00143_form_documents_is_required.sql
  *   • 00144_form_documents_audit_fields.sql
+ *   • 00145_gabinet_safe_movements.sql
+ *   • 00146_gabinet_day_closes_cash_split.sql
+ *   • 00147_payments_refund_amount.sql
+ *   • 00148_product_stock_movements_appointment_id.sql
+ *   • 00149_product_stock_movements_employee_id.sql
+ *   • 00150_organizations_admin_fields.sql
  *
  * Re-generate: npx tsx scripts/gen-db-types.mjs
  *   (or: node scripts/gen-db-types.mjs)
@@ -509,6 +515,9 @@ export interface Database {
           created_at: number;
           updated_at: number;
           onboarding_completed: boolean | null;
+          status: string | null;
+          suspended_reason: string | null;
+          seat_limit_override: number | null;
         };
         Insert: {
           id?: string;
@@ -520,6 +529,9 @@ export interface Database {
           created_at: number;
           updated_at: number;
           onboarding_completed?: boolean | null;
+          status?: string | null;
+          suspended_reason?: string | null;
+          seat_limit_override?: number | null;
         };
         Update: {
           id?: string;
@@ -531,6 +543,9 @@ export interface Database {
           created_at?: number;
           updated_at?: number;
           onboarding_completed?: boolean | null;
+          status?: string | null;
+          suspended_reason?: string | null;
+          seat_limit_override?: number | null;
         };
         Relationships: [
           {
@@ -3538,6 +3553,8 @@ export interface Database {
           fiscal_status: string | null;
           fiscal_attempts: number | null;
           fiscal_error: string | null;
+          refund_amount: number | null;
+          refunded_at: number | null;
         };
         Insert: {
           id?: string;
@@ -3563,6 +3580,8 @@ export interface Database {
           fiscal_status?: string | null;
           fiscal_attempts?: number | null;
           fiscal_error?: string | null;
+          refund_amount?: number | null;
+          refunded_at?: number | null;
         };
         Update: {
           id?: string;
@@ -3588,6 +3607,8 @@ export interface Database {
           fiscal_status?: string | null;
           fiscal_attempts?: number | null;
           fiscal_error?: string | null;
+          refund_amount?: number | null;
+          refunded_at?: number | null;
         };
         Relationships: [
           {
@@ -6423,6 +6444,8 @@ export interface Database {
           expiry_date: string | null;
           payment_method: string | null;
           treatment_id: string | null;
+          appointment_id: string | null;
+          employee_id: string | null;
         };
         Insert: {
           id?: string;
@@ -6443,6 +6466,8 @@ export interface Database {
           expiry_date?: string | null;
           payment_method?: string | null;
           treatment_id?: string | null;
+          appointment_id?: string | null;
+          employee_id?: string | null;
         };
         Update: {
           id?: string;
@@ -6463,6 +6488,8 @@ export interface Database {
           expiry_date?: string | null;
           payment_method?: string | null;
           treatment_id?: string | null;
+          appointment_id?: string | null;
+          employee_id?: string | null;
         };
         Relationships: [
           {
@@ -6498,6 +6525,20 @@ export interface Database {
             columns: ["treatment_id"];
             isOneToOne: false;
             referencedRelation: "gabinet_treatments";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "product_stock_movements_appointment_id_fkey";
+            columns: ["appointment_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_appointments";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "product_stock_movements_employee_id_fkey";
+            columns: ["employee_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_employees";
             referencedColumns: ["id"];
           },
         ];
@@ -7316,6 +7357,8 @@ export interface Database {
           closed_at: number;
           created_at: number;
           updated_at: number;
+          cash_next_opening: number | null;
+          cash_to_safe: number | null;
         };
         Insert: {
           id?: string;
@@ -7336,6 +7379,8 @@ export interface Database {
           closed_at: number;
           created_at: number;
           updated_at: number;
+          cash_next_opening?: number | null;
+          cash_to_safe?: number | null;
         };
         Update: {
           id?: string;
@@ -7356,6 +7401,8 @@ export interface Database {
           closed_at?: number;
           created_at?: number;
           updated_at?: number;
+          cash_next_opening?: number | null;
+          cash_to_safe?: number | null;
         };
         Relationships: [
           {
@@ -7513,6 +7560,71 @@ export interface Database {
             columns: ["stage_id"];
             isOneToOne: false;
             referencedRelation: "pipeline_stages";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      gabinet_safe_movements: {
+        Row: {
+          id: string;
+          organization_id: string;
+          location_id: string;
+          type: string;
+          amount: number;
+          description: string | null;
+          reference_day_close_id: string | null;
+          created_by: string;
+          created_at: number;
+        };
+        Insert: {
+          id?: string;
+          organization_id: string;
+          location_id: string;
+          type: string;
+          amount: number;
+          description?: string | null;
+          reference_day_close_id?: string | null;
+          created_by: string;
+          created_at: number;
+        };
+        Update: {
+          id?: string;
+          organization_id?: string;
+          location_id?: string;
+          type?: string;
+          amount?: number;
+          description?: string | null;
+          reference_day_close_id?: string | null;
+          created_by?: string;
+          created_at?: number;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "gabinet_safe_movements_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organizations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gabinet_safe_movements_location_id_fkey";
+            columns: ["location_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_locations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gabinet_safe_movements_reference_day_close_id_fkey";
+            columns: ["reference_day_close_id"];
+            isOneToOne: false;
+            referencedRelation: "gabinet_day_closes";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "gabinet_safe_movements_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "users";
             referencedColumns: ["id"];
           },
         ];

--- a/src/lib/supabase/mappers/google-calendar-sync-configs.ts
+++ b/src/lib/supabase/mappers/google-calendar-sync-configs.ts
@@ -2,7 +2,9 @@
  * Google Calendar Sync Configs Mapper — Supabase ↔ Frontend
  */
 
-import type { GoogleCalendarSyncConfigRow } from "../database.types";
+import type { Database } from "../database.types";
+
+type GoogleCalendarSyncConfigRow = Database["public"]["Tables"]["google_calendar_sync_configs"]["Row"];
 import { createEntityMapper } from "./generic";
 
 export interface MappedGoogleCalendarSyncConfig {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.appointments.$appointmentId.lazy.tsx
@@ -49,7 +49,6 @@ import { PermissionGate, usePermission } from "@/hooks/use-permission";
 import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { useTagDefinitions } from "@/hooks/use-tag-definitions";
-import { appointmentStatusBadgeClass } from "@/lib/gabinet-appointment-status";
 import { ChangeEmployeeModal } from "@/components/gabinet/change-employee-modal";
 import { DocumentationTab } from "@/components/gabinet/documentation-tab";
 
@@ -1168,7 +1167,6 @@ function AppointmentDetail() {
         <AppointmentPaymentsTab
           appointment={appointment}
           payments={payments as Record<string, unknown>[]}
-          junctionTreatments={junctionTreatments}
           treatmentPrice={treatmentPrice}
           totalPaid={totalPaid}
           outstanding={outstanding}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.calendar.index.lazy.tsx
@@ -1359,7 +1359,7 @@ function GabinetCalendarPage() {
     if (emp.firstName || emp.lastName) {
       return `${emp.firstName ?? ""} ${emp.lastName ?? ""}`.trim();
     }
-    return userMap.get(emp.userId) || emp.specialization || emp.role;
+    return (emp.userId ? userMap.get(emp.userId) : undefined) || emp.specialization || emp.role;
   }
 
   function getEmployeeInitials(name: string): string {

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.$employeeId.tsx
@@ -728,7 +728,7 @@ function EmployeeDetail() {
       content: employee.userId ? (
         <FlexibleScheduleEditor
           organizationId={organizationId}
-          userId={employee.userId}
+          userId={employee.userId as Id<"users">}
           periods={schedulePeriods}
           clinicHours={clinicHours ?? []}
           onSavePeriod={async (a) => { await saveSchedulePeriod(a); invalidateScheduleCache(); }}
@@ -813,7 +813,7 @@ function EmployeeDetail() {
             content: employee.userId ? (
               <EmployeePermissionsTab
                 organizationId={organizationId}
-                userId={employee.userId}
+                userId={employee.userId as Id<"users">}
                 gabinetRole={employee.role}
                 t={t}
               />

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.employees.index.tsx
@@ -231,19 +231,19 @@ function EmployeesIndex() {
     return pendingGabinetInvitations.filter((inv) => !employeeEmails.has(inv.email));
   }, [pendingGabinetInvitations, employees]);
 
-  function getDisplayName(emp: { firstName?: string; lastName?: string; userId: string }) {
+  function getDisplayName(emp: { firstName?: string; lastName?: string; userId?: string }) {
     if (emp.firstName || emp.lastName) {
       return `${emp.firstName ?? ""} ${emp.lastName ?? ""}`.trim();
     }
-    const user = userMap.get(emp.userId);
+    const user = emp.userId ? userMap.get(emp.userId) : undefined;
     return user?.name || user?.email || t("common.unknown");
   }
 
-  function getInitials(emp: { firstName?: string; lastName?: string; userId: string }) {
+  function getInitials(emp: { firstName?: string; lastName?: string; userId?: string }) {
     if (emp.firstName || emp.lastName) {
       return `${(emp.firstName ?? "")[0] ?? ""}${(emp.lastName ?? "")[0] ?? ""}`.toUpperCase();
     }
-    const user = userMap.get(emp.userId);
+    const user = emp.userId ? userMap.get(emp.userId) : undefined;
     const name = user?.name || user?.email || "?";
     return name.substring(0, 2).toUpperCase();
   }
@@ -258,7 +258,7 @@ function EmployeesIndex() {
       render: (item) => {
         const displayName = getDisplayName(item);
         const initials = getInitials(item);
-        const user = userMap.get(item.userId);
+        const user = item.userId ? userMap.get(item.userId) : undefined;
         return (
           <div className="flex items-center gap-3">
             <Avatar size="sm" initials={initials} />
@@ -557,7 +557,7 @@ function EmployeesIndex() {
         // EventDialog identifies employees by userId (it creates one
         // scheduledActivity per resourceId=userId so the block lands in each
         // selected employee's calendar column).
-        setEventDefaultUserIds(selectedRows.map((row) => row.userId));
+        setEventDefaultUserIds(selectedRows.map((row) => row.userId).filter((id): id is string => !!id));
         setEventDialogOpen(true);
       } else if (action === "edit") {
         const first = selectedRows[0];

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -1292,7 +1292,7 @@ function PatientDetail() {
             organizationId={organizationId}
             tagDefinitions={orgTags}
             categoryDefinitions={patientCategories}
-            locations={orgLocations.map((l) => ({ id: l.id, name: l.name }))}
+            locations={orgLocations.map((l) => ({ id: l._id, name: l.name }))}
           />
         </SidePanel>
       )}

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.index.tsx
@@ -785,7 +785,7 @@ function PatientsIndex() {
           organizationId={organizationId}
           tagDefinitions={tags}
           categoryDefinitions={categories}
-          locations={locations.map((l) => ({ id: l.id, name: l.name }))}
+          locations={locations.map((l) => ({ id: l._id, name: l.name }))}
         />
       </SidePanel>
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -1988,12 +1988,12 @@ function GabinetReports() {
   // Employee map: userId → name (for fallback attribution via createdBy)
   const employeeMap = useMemo(() => {
     if (!employees) return new Map<string, string>();
-    return new Map(
-      employees.map((e) => [
-        e.userId,
-        [e.firstName, e.lastName].filter(Boolean).join(" ") || e.userId,
-      ])
-    );
+    const entries: [string, string][] = [];
+    for (const e of employees) {
+      if (!e.userId) continue;
+      entries.push([e.userId, [e.firstName, e.lastName].filter(Boolean).join(" ") || e.userId]);
+    }
+    return new Map<string, string>(entries);
   }, [employees]);
 
   // Employee map: employeeId → name (for soldByEmployeeId attribution)
@@ -2108,7 +2108,10 @@ function GabinetReports() {
 
   // Maps raw payment_method values to display categories (cash/card/transfer/package/other)
   const paymentMethodBreakdown = useMemo(
-    () => computePaymentMethodBreakdown(actualPayments ?? []),
+    () => computePaymentMethodBreakdown(
+      (actualPayments ?? [])
+        .filter((p): p is typeof p & { paymentMethod: string } => !!p.paymentMethod)
+    ),
     [actualPayments]
   );
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.settings.equipment.tsx
@@ -214,9 +214,9 @@ function TransferHistoryPanel({
           <span className="text-muted-foreground">
             {new Date(tr.transferredAt).toLocaleDateString()}
           </span>
-          <span>{getLocationName(tr.fromLocationId)}</span>
+          <span>{getLocationName(tr.fromLocationId as Id<"gabinetLocations"> | undefined)}</span>
           <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" variant="stroke" />
-          <span className="font-medium">{getLocationName(tr.toLocationId)}</span>
+          <span className="font-medium">{getLocationName(tr.toLocationId as Id<"gabinetLocations">)}</span>
           {tr.notes && (
             <span className="ml-auto text-muted-foreground truncate max-w-[160px]">
               {tr.notes}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,7 +20,11 @@
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    // noUnusedParameters intentionally OFF: this project (composite) must include
+    // convex/ source (src imports @cvx/*), and convex handlers idiomatically carry
+    // unused ctx/args params that convex/tsconfig.json (their authority) allows.
+    // noUnusedLocals stays on to catch unused imports/vars in frontend code.
+    "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
 
     /* Alias */


### PR DESCRIPTION
## What & why

The **Typecheck** CI workflow's `app-typecheck` job (`tsc -p tsconfig.app.json`) has been RED for dozens of commits, and `npm run build` (`tsc -b && vite build`) has been broken locally — the TypeScript checker crashed whole-program with:

```
Error: Debug Failure. No error for last overload signature
  at chooseOverload / getSignatureApplicabilityError / checkExpressionWithContextualType
```

### Root cause (systematic-debugging)
`src/i18next.d.ts` typed i18next `resources` with the full `public/locales/en/translation.json` (~208 KB, ~4371 keys). That makes i18next's `TFunction` overload union so large that tsc's overload resolution crashes. Confirmed by neutralizing the `resources` type → crash gone. Version-stable across TS 5.4–5.9 (not a version regression); only manifests whole-program (per-file isolation didn't reproduce), which is why it was hard to localize. `--generateTrace` + a hypothesis test pinned it to the i18next augmentation.

### Fix (commit 1 — structural)
- `src/i18next.d.ts`: drop `resources` typing. Translation-key existence is already guarded at CI by `scripts/check-i18n-coverage.mjs` (`i18n-coverage.yml`), so no safety is lost.
- `tsconfig.app.json`: `noUnusedParameters: false`. The composite app project must include `convex/` source (src imports `@cvx/*`), and convex handlers idiomatically carry unused `ctx` params that `convex/tsconfig.json` (their authority) allows. `noUnusedLocals` stays on.
- Regenerate `_generated/api.d.ts` (adds `admin/organizations`) + `database.types.ts`/`database.columns.ts` from all 150 migrations (adds `refund_amount`, `employee_id`, `safe_movements`, …). These stale generated files caused ~25 of the errors the crash was hiding.

### Fix (commit 2 — the 36 revealed errors)
With the compiler finally running, 36 real type errors surfaced (accumulated invisibly while typecheck crashed). Fixed across 19 files: `string → Id<"X">` boundary casts at Supabase→Convex seams, `string | undefined` guards, `Mapped*` hook-type reconciliations, an over-strict `startImpersonation` signature (`Omit<ImpersonationState,"adminUserId">`), a stale `GoogleCalendarSyncConfigRow` import, and a Supabase ParserError cast. **No blanket `any`/`@ts-ignore`** introduced (audited).

## Verification
- `tsc -p tsconfig.app.json` → 0 errors (was: crash)
- `tsc -p convex/tsconfig.json` → 0 errors
- `tsc -p tsconfig.node.json` → 0 errors
- `npm run build` (`tsc -b && vite build`) → succeeds
- The **Typecheck** CI workflow should go green on this branch for the first time in a long while.

## Note for reviewer
The 36-error fix includes a few type *widenings* (e.g. `JunctionTreatment.treatmentId → string | null`, `MappedGabinetLoyaltyTransaction.type → string`) chosen to match the mapper's actual runtime shape — worth a glance to confirm they reflect real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)