### PR TITLE
SP3: Platform Admin — Users & platform admins (search, detail, global suspension)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -38,6 +38,7 @@ import type * as admin_cleanup from "../admin/cleanup.js";
 import type * as admin_entitlements from "../admin/entitlements.js";
 import type * as admin_organizations from "../admin/organizations.js";
 import type * as admin_plans from "../admin/plans.js";
+import type * as admin_users from "../admin/users.js";
 import type * as app from "../app.js";
 import type * as auditLog from "../auditLog.js";
 import type * as auth from "../auth.js";
@@ -240,6 +241,7 @@ declare const fullApi: ApiFromModules<{
   "admin/entitlements": typeof admin_entitlements;
   "admin/organizations": typeof admin_organizations;
   "admin/plans": typeof admin_plans;
+  "admin/users": typeof admin_users;
   app: typeof app;
   auditLog: typeof auditLog;
   auth: typeof auth;

--- a/convex/_helpers/authAction.ts
+++ b/convex/_helpers/authAction.ts
@@ -126,6 +126,11 @@ export const verifyOrgAccess = internalAction({
       throw new Error("Organization suspended");
     }
 
+    const suspUser = await db.get("users", String(userId));
+    if (suspUser && (suspUser as UserRow).isSuspended) {
+      throw new Error("User suspended");
+    }
+
     return {
       userId: userId as Id<"users">,
       userName: user.name as string | undefined,
@@ -265,6 +270,7 @@ export const verifyPlatformAdmin = internalAction({
     const db = createSupabaseDb();
     const user = (await db.get("users", String(userId))) as UserRow | null;
     if (!user) throw new Error("User not found");
+    if (user.isSuspended) throw new Error("User suspended");
     if (!user.isPlatformAdmin) throw new Error("Platform admin access required");
     return { userId: userId as Id<"users"> };
   },

--- a/convex/_helpers/supabaseRows.ts
+++ b/convex/_helpers/supabaseRows.ts
@@ -6,9 +6,13 @@ import type { Doc, TableNames } from "../_generated/dataModel";
 // `undefined`; consumers that read those fields should coalesce with `??`.
 export type SupabaseRow<T extends TableNames> = Omit<Doc<T>, "_creationTime">;
 
-// Supabase users row extended with is_platform_admin (not in Convex schema;
-// Supabase is the sole authority for this flag after migration #4362).
-export type UserRow = SupabaseRow<"users"> & { isPlatformAdmin?: boolean | null };
+// Supabase users row extended with is_platform_admin and is_suspended (not in
+// Convex schema as authoritative fields; Supabase is the sole authority for
+// both flags after migrations #4362 / SP3 T2).
+export type UserRow = SupabaseRow<"users"> & {
+  isPlatformAdmin?: boolean | null;
+  isSuspended?: boolean | null;
+};
 
 export type DocumentAnalysisJobRow = SupabaseRow<"documentAnalysisJobs">;
 export type FormDocumentRow = SupabaseRow<"formDocuments">;

--- a/convex/admin/users.ts
+++ b/convex/admin/users.ts
@@ -1,0 +1,85 @@
+/**
+ * SP3 Task 1 — Platform-admin read action: getUserDetail.
+ *
+ * Returns a user's metadata + platform-admin/suspended flags + their
+ * organizations & roles.
+ *
+ * Every action first calls verifyPlatformAdmin to enforce the access guard.
+ *
+ * Read path: createSupabaseDb().get()/query().collect() returns rows with
+ * camelCase keys and `_id` as the primary key (mirrors
+ * convex/admin/organizations.ts accessor style exactly).
+ *
+ * Note: isSuspended reads the field added in Task 2. Until that migration
+ * runs the field is absent; Boolean(undefined) = false, so this is safe.
+ */
+
+import { v } from "convex/values";
+import { action } from "../_generated/server";
+import { internal } from "../_generated/api";
+import { createSupabaseDb } from "../_helpers/supabaseDb";
+
+// ---------------------------------------------------------------------------
+// Validators
+// ---------------------------------------------------------------------------
+
+const membershipRowValidator = v.object({
+  organizationId: v.string(),
+  organizationName: v.string(),
+  role: v.string(),
+  joinedAt: v.number(),
+});
+
+const userDetailValidator = v.object({
+  userId: v.string(),
+  name: v.union(v.string(), v.null()),
+  email: v.union(v.string(), v.null()),
+  username: v.union(v.string(), v.null()),
+  language: v.union(v.string(), v.null()),
+  theme: v.union(v.string(), v.null()),
+  timezone: v.union(v.string(), v.null()),
+  isPlatformAdmin: v.boolean(),
+  isSuspended: v.boolean(),
+  memberships: v.array(membershipRowValidator),
+});
+
+// ---------------------------------------------------------------------------
+// getUserDetail
+// ---------------------------------------------------------------------------
+
+export const getUserDetail = action({
+  args: { userId: v.id("users") },
+  returns: userDetailValidator,
+  handler: async (ctx, args) => {
+    await ctx.runAction(internal._helpers.authAction.verifyPlatformAdmin, {});
+    const db = createSupabaseDb();
+    const user = await db.get("users", String(args.userId));
+    if (!user) throw new Error("User not found");
+    const memberships = await db
+      .query("teamMemberships")
+      .eq("userId", String(args.userId))
+      .collect();
+    const orgIds = [...new Set(memberships.map((m) => String(m.organizationId)))];
+    const orgs = await db.getMany("organizations", orgIds);
+    const orgName = new Map(orgs.map((o) => [String(o._id), (o.name as string) ?? ""]));
+    return {
+      userId: String(user._id),
+      name: (user.name as string | null) ?? null,
+      email: (user.email as string | null) ?? null,
+      username: (user.username as string | null) ?? null,
+      language: (user.language as string | null) ?? null,
+      theme: (user.theme as string | null) ?? null,
+      timezone: (user.timezone as string | null) ?? null,
+      isPlatformAdmin: Boolean(user.isPlatformAdmin),
+      isSuspended: Boolean((user as Record<string, unknown>).isSuspended),
+      memberships: memberships
+        .map((m) => ({
+          organizationId: String(m.organizationId),
+          organizationName: orgName.get(String(m.organizationId)) ?? "",
+          role: String(m.role),
+          joinedAt: Number(m.joinedAt ?? 0),
+        }))
+        .sort((a, b) => a.organizationName.localeCompare(b.organizationName)),
+    };
+  },
+});

--- a/convex/admin/users.ts
+++ b/convex/admin/users.ts
@@ -103,6 +103,23 @@ export const setUserSuspended = action({
       throw new Error("You cannot suspend your own account");
     }
     const db = createSupabaseDb();
+    // Last-admin guard: refuse to suspend a platform-admin target if doing so
+    // would leave zero non-suspended platform admins in the system.
+    if (args.suspended) {
+      const target = await db.get("users", String(args.userId));
+      if (target && Boolean(target.isPlatformAdmin)) {
+        const allUsers = await db.query("users").collect();
+        const nonSuspendedAdminsAfter = allUsers.filter(
+          (u) =>
+            Boolean(u.isPlatformAdmin) &&
+            !Boolean(u.isSuspended) &&
+            String(u._id) !== String(args.userId),
+        );
+        if (nonSuspendedAdminsAfter.length === 0) {
+          throw new Error("Cannot suspend the last platform admin");
+        }
+      }
+    }
     await db.patch("users", String(args.userId), { isSuspended: args.suspended });
     console.info(
       `[admin/users] user_${args.suspended ? "suspended" : "unsuspended"} userId=${args.userId} by=${actorId}`,

--- a/convex/admin/users.ts
+++ b/convex/admin/users.ts
@@ -83,3 +83,30 @@ export const getUserDetail = action({
     };
   },
 });
+
+// ---------------------------------------------------------------------------
+// setUserSuspended
+// ---------------------------------------------------------------------------
+
+export const setUserSuspended = action({
+  args: {
+    userId: v.id("users"),
+    suspended: v.boolean(),
+  },
+  returns: v.object({ userId: v.string(), suspended: v.boolean() }),
+  handler: async (ctx, args) => {
+    const { userId: actorId } = await ctx.runAction(
+      internal._helpers.authAction.verifyPlatformAdmin,
+      {},
+    );
+    if (String(actorId) === String(args.userId)) {
+      throw new Error("You cannot suspend your own account");
+    }
+    const db = createSupabaseDb();
+    await db.patch("users", String(args.userId), { isSuspended: args.suspended });
+    console.info(
+      `[admin/users] user_${args.suspended ? "suspended" : "unsuspended"} userId=${args.userId} by=${actorId}`,
+    );
+    return { userId: String(args.userId), suspended: args.suspended };
+  },
+});

--- a/convex/schema/platform.ts
+++ b/convex/schema/platform.ts
@@ -40,6 +40,10 @@ export function createPlatformTables({
     // but existing Convex user docs carry this field, so it must be declared
     // here or schema validation rejects the extra field on deploy.
     isPlatformAdmin: v.optional(v.boolean()),
+    // Global suspension flag. Authoritative store is Supabase (is_suspended).
+    // Absent/false = active; true blocks token minting and all auth guards.
+    // Written only via the setUserSuspended admin action (SP3 T2).
+    isSuspended: v.optional(v.boolean()),
   })
     .index("email", ["email"])
     .index("customerId", ["customerId"]),

--- a/convex/supabase/jwt.ts
+++ b/convex/supabase/jwt.ts
@@ -72,6 +72,12 @@ export const mintUserToken = action({
     const user = await ctx.runQuery(internal._helpers.authAction._getAuthUser, { userId });
     if (!user) throw new Error("User not found");
 
+    const db = createSupabaseDb();
+    const u = await db.get("users", String(userId));
+    if (u && (u as { isSuspended?: boolean }).isSuspended) {
+      throw new Error("User suspended");
+    }
+
     if (!SUPABASE_JWT_SECRET) {
       throw new Error("SUPABASE_JWT_SECRET not configured");
     }

--- a/docs/superpowers/plans/2026-08-28-platform-admin-sp3-users.md
+++ b/docs/superpowers/plans/2026-08-28-platform-admin-sp3-users.md
@@ -1,0 +1,174 @@
+# Platform Admin — SP3 Users & Platform Admins Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Complete the users console — search + a per-user detail route (orgs/roles/metadata + platform-admin toggle) + global user suspension (a suspended user cannot obtain Supabase tokens or pass auth guards). Builds on the existing `platformAdmins.list`/`setRole` + `admin.users.tsx`.
+
+**Architecture:** Convex `action`s guarded by `verifyPlatformAdmin`, reading/writing Supabase via `createSupabaseDb()` (users/teamMemberships/organizations are Supabase; `isPlatformAdmin`/`isSuspended` are Supabase-authoritative admin flags). Frontend mirrors the existing admin routes.
+
+**Tech Stack:** Convex, self-hosted Supabase Postgres, React 19 + TanStack Router/Query, shadcn/ui.
+
+## Global Constraints
+
+- Every new backend `action` calls `await ctx.runAction(internal._helpers.authAction.verifyPlatformAdmin, {})` FIRST; capture `{ userId }` where needed.
+- `createSupabaseDb()` casing: `.query().collect()`/`.get()` RETURN camelCase + `_id`; `.patch()` ACCEPTS camelCase (→ snake via mapRowToSnake). So read `user.isPlatformAdmin`/`user.isSuspended`/`m.organizationId`, and patch `{ isSuspended: ... }`.
+- `users.isSuspended` is written Supabase-ONLY (mirrors `isPlatformAdmin`; all guards read it from Supabase). Migration `00151` is applied by CI on merge — never hand-run DDL.
+- No `logAudit` for platform-level admin-flag changes (audit_log.organization_id is NOT NULL FK) → `console.info`.
+- `setUserSuspended` MUST reject self-suspend (`userId === actorId`).
+- Convex tests: `cd convex && npx vitest run <name>`. Keep `npx tsc -p convex/tsconfig.json` clean.
+- Frontend: `npx tsc -p tsconfig.app.json --noEmit` (works now) + `npx vite build`.
+- Reuse only existing `src/components/ui/*`. No installs.
+
+---
+
+### Task 1: Backend — user detail
+
+**Files:**
+- Create: `convex/admin/users.ts`
+- Test: `tests/convex/adminUsers.test.ts` (new)
+
+**Interfaces:**
+- Produces: `getUserDetail({ userId }) → { userId, name, email, username, language, theme, timezone, isPlatformAdmin, isSuspended, memberships: Array<{ organizationId, organizationName, role, joinedAt }> }`.
+
+- [ ] **Step 1: Write failing tests.** `tests/convex/adminUsers.test.ts`, harness from `tests/convex/adminOrganizations.test.ts` (`createTestCtx`, `seedTestUser`; make caller admin via inserting the Supabase `users` row with `isPlatformAdmin:true`). Seed a target user + an org + a `teamMemberships` row linking them (camelCase keys with `_id`). Tests: (a) non-admin `getUserDetail` rejects `/platform admin/i`; (b) admin `getUserDetail(targetId)` returns the user's metadata + a membership with the org name + role.
+
+- [ ] **Step 2: Run** — `cd convex && npx vitest run adminUsers`. Expect FAIL.
+
+- [ ] **Step 3: Implement `convex/admin/users.ts`.** Mirror `convex/admin/organizations.ts` accessor style.
+
+```ts
+import { v } from "convex/values";
+import { action } from "../_generated/server";
+import { internal } from "../_generated/api";
+import { createSupabaseDb } from "../_helpers/supabaseDb";
+
+export const getUserDetail = action({
+  args: { userId: v.id("users") },
+  handler: async (ctx, args) => {
+    await ctx.runAction(internal._helpers.authAction.verifyPlatformAdmin, {});
+    const db = createSupabaseDb();
+    const user = await db.get("users", String(args.userId));
+    if (!user) throw new Error("User not found");
+    const memberships = await db
+      .query("teamMemberships")
+      .eq("userId", String(args.userId))
+      .collect();
+    const orgIds = [...new Set(memberships.map((m) => String(m.organizationId)))];
+    const orgs = await db.getMany("organizations", orgIds);
+    const orgName = new Map(orgs.map((o) => [String(o._id), (o.name as string) ?? ""]));
+    return {
+      userId: String(user._id),
+      name: (user.name as string | null) ?? null,
+      email: (user.email as string | null) ?? null,
+      username: (user.username as string | null) ?? null,
+      language: (user.language as string | null) ?? null,
+      theme: (user.theme as string | null) ?? null,
+      timezone: (user.timezone as string | null) ?? null,
+      isPlatformAdmin: Boolean(user.isPlatformAdmin),
+      isSuspended: Boolean(user.isSuspended),
+      memberships: memberships
+        .map((m) => ({
+          organizationId: String(m.organizationId),
+          organizationName: orgName.get(String(m.organizationId)) ?? "",
+          role: String(m.role),
+          joinedAt: Number(m.joinedAt ?? 0),
+        }))
+        .sort((a, b) => a.organizationName.localeCompare(b.organizationName)),
+    };
+  },
+});
+```
+
+Add a `returns:` validator mirroring the entitlements/organizations style. (`isSuspended` reads the field added in Task 2 — until then it is simply `false`/absent; the field access is safe.)
+
+- [ ] **Step 4: Run tests** — expect PASS. tsc convex clean.
+
+- [ ] **Step 5: Commit** — `feat(admin): getUserDetail action (SP3 T1)`.
+
+---
+
+### Task 2: Backend — user suspension (schema + migration + action + auth guards)
+
+**Files:**
+- Modify: `convex/schema/platform.ts` (users table: `isSuspended`)
+- Create: `supabase/migrations/00151_users_is_suspended.sql`
+- Modify: `convex/admin/users.ts` (add `setUserSuspended`)
+- Modify: `convex/_helpers/authAction.ts` (`verifyOrgAccess` + `verifyPlatformAdmin`)
+- Modify: `convex/supabase/jwt.ts` (`mintUserToken`)
+- Test: `tests/convex/adminUsers.test.ts` (extend) + `tests/convex/userSuspension.test.ts` (new)
+
+**Interfaces:**
+- Produces: `setUserSuspended({ userId, suspended })`; suspended users throw `/suspended/i` from `verifyOrgAccess`, `mintUserToken`, `verifyPlatformAdmin`.
+
+- [ ] **Step 1: Schema + migration.** In `convex/schema/platform.ts` `users` table add `isSuspended: v.optional(v.boolean())`. Create `supabase/migrations/00151_users_is_suspended.sql`:
+
+```sql
+-- Platform Admin SP3: global user suspension flag. Absent/false = active;
+-- true blocks the user from minting Supabase tokens and passing auth guards.
+-- Nullable + idempotent — existing rows read as active. Supabase-authoritative
+-- (mirrors is_platform_admin), written only via the setUserSuspended admin action.
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS is_suspended boolean;
+```
+
+- [ ] **Step 2: Write failing tests** in `tests/convex/userSuspension.test.ts` (harness from `orgSuspension.test.ts`): seed a member of an org; set their Supabase `users.is_suspended = true`; assert (a) an action that runs `verifyOrgAccess` (e.g. `api.organizations.getMembers`) rejects `/suspended/i`; (b) `api.supabase.jwt.mintUserToken` rejects `/suspended/i` for the suspended user; (c) `api.app.getIsPlatformAdmin`/a `verifyPlatformAdmin`-guarded action rejects a suspended admin. And in `adminUsers.test.ts`: (d) `setUserSuspended({userId,suspended:true})` by admin round-trips (Supabase `is_suspended` true); (e) non-admin `setUserSuspended` rejects; (f) `setUserSuspended` on the actor's OWN id rejects `/self|yourself|własne/i`.
+
+- [ ] **Step 3: Run** — `cd convex && npx vitest run userSuspension` + `adminUsers`. Expect FAIL.
+
+- [ ] **Step 4: Implement `setUserSuspended`** in `convex/admin/users.ts`:
+
+```ts
+export const setUserSuspended = action({
+  args: { userId: v.id("users"), suspended: v.boolean() },
+  returns: v.object({ userId: v.string(), suspended: v.boolean() }),
+  handler: async (ctx, args) => {
+    const { userId: actorId } = await ctx.runAction(internal._helpers.authAction.verifyPlatformAdmin, {});
+    if (String(actorId) === String(args.userId)) {
+      throw new Error("You cannot suspend your own account");
+    }
+    const db = createSupabaseDb();
+    await db.patch("users", String(args.userId), { isSuspended: args.suspended });
+    console.info(`[admin/users] user_${args.suspended ? "suspended" : "unsuspended"} userId=${args.userId} by=${actorId}`);
+    return { userId: String(args.userId), suspended: args.suspended };
+  },
+});
+```
+
+- [ ] **Step 5: Add the three auth guards.** Each fetches the Supabase user and throws `"User suspended"` when `isSuspended`:
+  - `convex/_helpers/authAction.ts` `verifyOrgAccess` — after auth + before/near the existing org-suspend check, add: `const suspUser = await db.get("users", String(userId)); if (suspUser && (suspUser as { isSuspended?: boolean }).isSuspended) throw new Error("User suspended");` (`db` = the existing `createSupabaseDb()` in that handler).
+  - `convex/_helpers/authAction.ts` `verifyPlatformAdmin` — it already fetches `const user = await db.get("users", String(userId))`; add `if ((user as { isSuspended?: boolean }).isSuspended) throw new Error("User suspended");` before the `isPlatformAdmin` check.
+  - `convex/supabase/jwt.ts` `mintUserToken` — after `auth.getUserId`, add `const db = createSupabaseDb(); const u = await db.get("users", String(userId)); if (u && (u as { isSuspended?: boolean }).isSuspended) throw new Error("User suspended");` before signing.
+
+- [ ] **Step 6: Run tests** — expect PASS. Also `cd convex && npx vitest run orgSuspension tenantIsolation` to confirm no regression (the new user-suspend check is a no-op for non-suspended users). tsc convex clean.
+
+- [ ] **Step 7: Commit** — `feat(admin): user suspension flag + setUserSuspended + auth guards (SP3 T2)`.
+
+---
+
+### Task 3: Frontend — users search + detail route
+
+**Files:**
+- Modify: `src/routes/_app/_auth/admin.users.tsx` (search + detail link)
+- Create: `src/routes/_app/_auth/admin.users.$userId.tsx`
+
+**Interfaces:**
+- Consumes: `api.platformAdmins.list` / `setRole`, `api.admin.users.getUserDetail` / `setUserSuspended`, `api.app.getIsPlatformAdmin`.
+
+- [ ] **Step 1: Extend `admin.users.tsx`.** Add a search `Input` filtering the `platformAdmins.list` rows by name/email (case-insensitive, null-safe). Add a "Szczegóły" link per row → `<Link to="/admin/users/$userId" params={{ userId: row._id }}>`. Keep the existing Grant/Revoke admin toggle + last-admin error toast. Do not remove existing behavior.
+
+- [ ] **Step 2: Create `admin.users.$userId.tsx`** at `createFileRoute("/_app/_auth/admin/users/$userId")`, admin gate (copy from `admin.organizations.$orgId.tsx`). `useAction(api.admin.users.getUserDetail)` + `useQuery(["admin","users",userId], enabled: admin)`; `userId` from `Route.useParams()`. Cards:
+  - **Profil**: read-only name/email/username/language/theme/timezone.
+  - **Status**: platform-admin `Switch` (bound to `detail.isPlatformAdmin`) → `useMutation(api.platformAdmins.setRole)` with `{ userId, isPlatformAdmin }` (surface the last-admin error as a toast); suspended `Switch` (bound to `detail.isSuspended`) → `useMutation(api.admin.users.setUserSuspended)` with `{ userId, suspended }`. Determine the viewer's own id (compare via `getIsPlatformAdmin`-adjacent identity, or just let the backend reject self-suspend and surface the toast) — at minimum the self-suspend backend error must be shown as a toast.
+  - **Organizacje**: `Table` of `detail.memberships` (org name, role Badge, joinedAt formatted).
+  - Back link to `/admin/users`.
+  - Invalidate `["admin","users",userId]` (and the `["adminUsers"]`/list key the existing page uses) on mutation success + `toast`.
+
+- [ ] **Step 3: Verify** — `npx vite build` (regenerates route tree + bundles) then `npx tsc -p tsconfig.app.json --noEmit` clean.
+
+- [ ] **Step 4: Commit** — `feat(admin): users search + detail route (SP3 T3)`.
+
+---
+
+## Rollout
+
+Migration 00151 applies via CI on merge. Convex deploy: `npx convex dev --once` (runs headless from the Bash tool — auth from cached convex login) after merge. Verify: `/admin/users` search + detail; suspend a throwaway user and confirm their `mintUserToken` throws (login blocked); unsuspend restores; self-suspend is refused.

--- a/docs/superpowers/specs/2026-08-28-platform-admin-sp3-users-design.md
+++ b/docs/superpowers/specs/2026-08-28-platform-admin-sp3-users-design.md
@@ -29,7 +29,7 @@ A suspended user must be unable to use the app. Add an `isSuspended` check in th
 - `mintUserToken` (`convex/supabase/jwt.ts`) — the user-scoped bootstrap token: fetch the user and throw if suspended, so a suspended user cannot obtain ANY Supabase token (no data, no org bootstrap).
 - `verifyPlatformAdmin` (`convex/_helpers/authAction.ts`) — throw if the (would-be admin) user is suspended, so a suspended platform admin can't use the admin panel either.
 
-This blocks a suspended user at the Supabase-token boundary (the app's whole read path) and at every write, mirroring how org-suspend works in SP2. (The raw Convex-auth session JWT is minted by `@convex-dev/auth` and is not gated here — but without a Supabase token the app is non-functional for them; a deeper auth-provider block is out of scope.)
+This blocks a suspended user at the Supabase-token boundary (the app's whole read path) and at every write, mirroring how org-suspend works in SP2. Note: suspension blocks minting NEW Supabase tokens (mintUserToken directly; mintSupabaseToken via verifyOrgAccess), but an already-issued org-scoped Supabase JWT remains valid until its ≤1h expiry, so a mid-session suspended user may keep reading Supabase-direct data until the token refreshes (~5 min before expiry the re-mint throws); writes are blocked immediately because every mutation re-runs verifyOrgAccess. This is the same accepted window as the SP2 org-suspend. (The raw Convex-auth session JWT is minted by `@convex-dev/auth` and is not gated here — but without a Supabase token the app is non-functional for them; a deeper auth-provider block is out of scope.)
 
 ## Frontend
 

--- a/docs/superpowers/specs/2026-08-28-platform-admin-sp3-users-design.md
+++ b/docs/superpowers/specs/2026-08-28-platform-admin-sp3-users-design.md
@@ -1,0 +1,46 @@
+# Platform Admin Console — SP3: Users & Platform Admins (Design Spec)
+
+**Date:** 2026-08-28
+**Status:** Design — scope approved
+**Sub-project:** SP3 of the Platform Admin Console (SP1 ✅ → SP2 ✅ → SP4 ✅ → **SP3 Users & platform admins** → SP5 Billing/Stripe → SP6 Settings/observability).
+
+## Goal
+
+Complete the users console. Today `admin.users.tsx` already lists all users and grants/revokes platform-admin (`platformAdmins.list` / `platformAdmins.setRole`, with a last-admin guard). SP3 adds: a client-side **search**, a per-user **detail** route (the user's organizations + roles + metadata + platform-admin toggle), and a **global user suspension** (block a suspended user from obtaining Supabase tokens / passing auth guards).
+
+## Architecture
+
+Backend is Convex `action`s guarded by `verifyPlatformAdmin`, reading Supabase via `createSupabaseDb()` (users, teamMemberships, organizations are all Supabase — like SP2). `isPlatformAdmin`/`isSuspended` are Supabase-authoritative admin flags (mirrors the existing `platformAdmins.setRole` which patches Supabase only). Frontend mirrors the existing admin routes (`getIsPlatformAdmin` gate → 403; list + detail like SP2's organizations).
+
+## Data-model change
+
+Add `users.isSuspended` (Convex `convex/schema/platform.ts`, optional; Supabase migration `00151` — `ALTER TABLE users ADD COLUMN IF NOT EXISTS is_suspended boolean`). Absent/false = active. Written Supabase-only (consistent with `isPlatformAdmin`; the auth guards read it from Supabase).
+
+## Backend — `convex/admin/users.ts` (new) + guards
+
+- `getUserDetail` action(`userId: Id<"users">`) → guard → `createSupabaseDb()` reads: the user row (name/email/username/language/theme/timezone/isPlatformAdmin/isSuspended/customerId), plus `teamMemberships` where `userId` = target → join `organizations` for names → `memberships: Array<{ organizationId, organizationName, role, joinedAt }>`. Returns `{ userId, name, email, username, language, theme, timezone, isPlatformAdmin, isSuspended, memberships }`.
+- `setUserSuspended` action(`userId`, `suspended: boolean`) → guard (capture actor `userId`) → reject if `userId === actorId` (no self-suspend, prevents self-lockout) → `db.patch("users", userId, { is_suspended: suspended })` (Supabase) → `console.info` (platform-level; no org-scoped `audit_log` fit, same as SP4).
+- Reuse existing `platformAdmins.list` (list) and `platformAdmins.setRole` (platform-admin toggle) unchanged.
+
+### Suspension enforcement (the invasive part — last)
+
+A suspended user must be unable to use the app. Add an `isSuspended` check in three Supabase-reading guards, each after the user is resolved:
+- `verifyOrgAccess` (`convex/_helpers/authAction.ts`) — throw `"User suspended"` if the caller's user `is_suspended` (gates every write mutation + Convex-action read). The org-suspend check from SP2 lives here already; add the user-suspend check alongside.
+- `mintUserToken` (`convex/supabase/jwt.ts`) — the user-scoped bootstrap token: fetch the user and throw if suspended, so a suspended user cannot obtain ANY Supabase token (no data, no org bootstrap).
+- `verifyPlatformAdmin` (`convex/_helpers/authAction.ts`) — throw if the (would-be admin) user is suspended, so a suspended platform admin can't use the admin panel either.
+
+This blocks a suspended user at the Supabase-token boundary (the app's whole read path) and at every write, mirroring how org-suspend works in SP2. (The raw Convex-auth session JWT is minted by `@convex-dev/auth` and is not gated here — but without a Supabase token the app is non-functional for them; a deeper auth-provider block is out of scope.)
+
+## Frontend
+
+- `src/routes/_app/_auth/admin.users.tsx` (extend the existing file): add a search `Input` (filter by name/email, client-side over `platformAdmins.list`), and a "Szczegóły" link per row → `/admin/users/$userId`. Keep the existing platform-admin grant/revoke toggle.
+- `src/routes/_app/_auth/admin.users.$userId.tsx` (new): admin gate; `getUserDetail`. Cards: Profil (name/email/username/language/theme/timezone read-only), Status (platform-admin `Switch` → `platformAdmins.setRole` with last-admin guard surfaced as a toast; suspended `Switch` → `setUserSuspended`, disabled on the self row), Organizacje (`Table`: org name, role Badge, joinedAt). Back link to `/admin/users`.
+- Hub tile "Platform administrators" → `/admin/users` already exists; optionally relabel to "Użytkownicy" (users + platform admins).
+
+## Non-goals (SP5 / later)
+
+Billing/subscription per user (SP5); bulk actions; per-user notes; hard-delete from the console (a self-serve `deleteCurrentUserAccount` already exists); deeper auth-provider-level login block beyond the token/guard boundary; platform-scoped audit log (SP6 — `audit_log` is org-scoped NOT NULL FK, so admin-flag changes log via `console.info`).
+
+## Testing
+
+`convex-test`: `getUserDetail` returns memberships with roles + rejects non-admin; `setUserSuspended` round-trip + rejects self-suspend + rejects non-admin; suspended user's `verifyOrgAccess` / `mintUserToken` / `verifyPlatformAdmin` all throw `/suspended/i` while an unsuspended user passes; last-admin guard on `setRole` still holds (existing). Drift-guard mindset: suspension must not accidentally grant access, and self-suspend must never succeed.

--- a/session_state.json
+++ b/session_state.json
@@ -1,18 +1,11 @@
 {
   "session_id": "S0132",
   "started_at": "2026-08-27T16:00:00Z",
-  "last_updated": "2026-08-27T16:12:00Z",
+  "last_updated": "2026-08-28T09:10:00Z",
   "status": "active",
-  "focus": "Platform Admin Console — migrations caught up (00135-00149 applied to prod), starting SP2 Organizations console",
-  "tasks_snapshot": {
-    "total": 6,
-    "not_started": 4,
-    "in_progress": 1,
-    "passing": 1,
-    "failing": 0,
-    "blocked": 0
-  },
-  "active_task_ids": [2],
+  "focus": "Platform Admin Console — SP2 + tsc-crash-fix + SP4 all merged; SP3/SP5/SP6 remain",
+  "tasks_snapshot": { "total": 6, "not_started": 3, "in_progress": 0, "passing": 3, "failing": 0, "blocked": 0 },
+  "active_task_ids": [],
   "blockers": [],
-  "notes": "SP1 DONE+deployed. SP-SEC DONE+merged. main deployed to prod helpful-mule-867 (Sejf+RBAC). Migrations 00135-00149 applied on prod (verified 4 probes 200). NEXT: SP2 Organizations console (design->plan->subagent-driven build). Roadmap: SP2->SP4->SP3->SP5->SP6."
+  "notes": "DONE this session: migrations 00135-00150 on prod; SP2 Organizations console (PR #5654); frontend tsc crash fix (PR #5655 — i18next resources); SP4 Plans/products catalog (PR #5656). All merged to main, Typecheck CI green. DEPLOY DEBT: SP2+SP4 backend need manual `npx convex dev --once` on helpful-mule-867 (TTY, Claude can't). Roadmap remaining: SP3 Users, SP5 Billing/Stripe, SP6 Settings/observability. Convex suite 640 pass, all 3 tsc targets clean, npm run build works."
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -52,6 +52,7 @@ import { Route as AppAuthDashboardLayoutDocumentEditorRouteImport } from './rout
 import { Route as AppAuthDashboardLayoutCheckoutRouteImport } from './routes/_app/_auth/dashboard/_layout.checkout'
 import { Route as AppAuthDashboardLayoutCalendarPreviewRouteImport } from './routes/_app/_auth/dashboard/_layout.calendar-preview'
 import { Route as AppAuthDashboardLayoutCalendarRouteImport } from './routes/_app/_auth/dashboard/_layout.calendar'
+import { Route as AppAuthAdminUsersUserIdRouteImport } from './routes/_app/_auth/admin.users.$userId'
 import { Route as AppAuthAdminOrganizationsOrgIdRouteImport } from './routes/_app/_auth/admin.organizations.$orgId'
 import { Route as AppAuthDashboardLayoutSettingsIndexRouteImport } from './routes/_app/_auth/dashboard/_layout.settings.index'
 import { Route as AppAuthDashboardLayoutProductsIndexRouteImport } from './routes/_app/_auth/dashboard/_layout.products.index'
@@ -366,6 +367,11 @@ const AppAuthDashboardLayoutCalendarRoute =
     path: '/calendar',
     getParentRoute: () => AppAuthDashboardLayoutRoute,
   } as any)
+const AppAuthAdminUsersUserIdRoute = AppAuthAdminUsersUserIdRouteImport.update({
+  id: '/$userId',
+  path: '/$userId',
+  getParentRoute: () => AppAuthAdminUsersRoute,
+} as any)
 const AppAuthAdminOrganizationsOrgIdRoute =
   AppAuthAdminOrganizationsOrgIdRouteImport.update({
     id: '/$orgId',
@@ -890,7 +896,7 @@ export interface FileRoutesByFullPath {
   '/admin/errors': typeof AppAuthAdminErrorsRoute
   '/admin/organizations': typeof AppAuthAdminOrganizationsRouteWithChildren
   '/admin/plans': typeof AppAuthAdminPlansRoute
-  '/admin/users': typeof AppAuthAdminUsersRoute
+  '/admin/users': typeof AppAuthAdminUsersRouteWithChildren
   '/dashboard': typeof AppAuthDashboardLayoutRouteWithChildren
   '/onboarding': typeof AppAuthOnboardingLayoutRouteWithChildren
   '/patient/appointments': typeof AppPatientLayoutAppointmentsRoute
@@ -903,6 +909,7 @@ export interface FileRoutesByFullPath {
   '/login/': typeof AppLoginLayoutIndexRoute
   '/patient/': typeof AppPatientLayoutIndexRoute
   '/admin/organizations/$orgId': typeof AppAuthAdminOrganizationsOrgIdRoute
+  '/admin/users/$userId': typeof AppAuthAdminUsersUserIdRoute
   '/dashboard/calendar': typeof AppAuthDashboardLayoutCalendarRoute
   '/dashboard/calendar-preview': typeof AppAuthDashboardLayoutCalendarPreviewRoute
   '/dashboard/checkout': typeof AppAuthDashboardLayoutCheckoutRoute
@@ -1011,7 +1018,7 @@ export interface FileRoutesByTo {
   '/admin/errors': typeof AppAuthAdminErrorsRoute
   '/admin/organizations': typeof AppAuthAdminOrganizationsRouteWithChildren
   '/admin/plans': typeof AppAuthAdminPlansRoute
-  '/admin/users': typeof AppAuthAdminUsersRoute
+  '/admin/users': typeof AppAuthAdminUsersRouteWithChildren
   '/onboarding': typeof AppAuthOnboardingLayoutRouteWithChildren
   '/patient/appointments': typeof AppPatientLayoutAppointmentsRoute
   '/patient/book': typeof AppPatientLayoutBookRoute
@@ -1023,6 +1030,7 @@ export interface FileRoutesByTo {
   '/login': typeof AppLoginLayoutIndexRoute
   '/patient': typeof AppPatientLayoutIndexRoute
   '/admin/organizations/$orgId': typeof AppAuthAdminOrganizationsOrgIdRoute
+  '/admin/users/$userId': typeof AppAuthAdminUsersUserIdRoute
   '/dashboard/calendar': typeof AppAuthDashboardLayoutCalendarRoute
   '/dashboard/calendar-preview': typeof AppAuthDashboardLayoutCalendarPreviewRoute
   '/dashboard/checkout': typeof AppAuthDashboardLayoutCheckoutRoute
@@ -1130,7 +1138,7 @@ export interface FileRoutesById {
   '/_app/_auth/admin/errors': typeof AppAuthAdminErrorsRoute
   '/_app/_auth/admin/organizations': typeof AppAuthAdminOrganizationsRouteWithChildren
   '/_app/_auth/admin/plans': typeof AppAuthAdminPlansRoute
-  '/_app/_auth/admin/users': typeof AppAuthAdminUsersRoute
+  '/_app/_auth/admin/users': typeof AppAuthAdminUsersRouteWithChildren
   '/_app/_auth/dashboard/_layout': typeof AppAuthDashboardLayoutRouteWithChildren
   '/_app/_auth/onboarding/_layout': typeof AppAuthOnboardingLayoutRouteWithChildren
   '/_app/patient/_layout/appointments': typeof AppPatientLayoutAppointmentsRoute
@@ -1143,6 +1151,7 @@ export interface FileRoutesById {
   '/_app/login/_layout/': typeof AppLoginLayoutIndexRoute
   '/_app/patient/_layout/': typeof AppPatientLayoutIndexRoute
   '/_app/_auth/admin/organizations/$orgId': typeof AppAuthAdminOrganizationsOrgIdRoute
+  '/_app/_auth/admin/users/$userId': typeof AppAuthAdminUsersUserIdRoute
   '/_app/_auth/dashboard/_layout/calendar': typeof AppAuthDashboardLayoutCalendarRoute
   '/_app/_auth/dashboard/_layout/calendar-preview': typeof AppAuthDashboardLayoutCalendarPreviewRoute
   '/_app/_auth/dashboard/_layout/checkout': typeof AppAuthDashboardLayoutCheckoutRoute
@@ -1268,6 +1277,7 @@ export interface FileRouteTypes {
     | '/login/'
     | '/patient/'
     | '/admin/organizations/$orgId'
+    | '/admin/users/$userId'
     | '/dashboard/calendar'
     | '/dashboard/calendar-preview'
     | '/dashboard/checkout'
@@ -1388,6 +1398,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/patient'
     | '/admin/organizations/$orgId'
+    | '/admin/users/$userId'
     | '/dashboard/calendar'
     | '/dashboard/calendar-preview'
     | '/dashboard/checkout'
@@ -1507,6 +1518,7 @@ export interface FileRouteTypes {
     | '/_app/login/_layout/'
     | '/_app/patient/_layout/'
     | '/_app/_auth/admin/organizations/$orgId'
+    | '/_app/_auth/admin/users/$userId'
     | '/_app/_auth/dashboard/_layout/calendar'
     | '/_app/_auth/dashboard/_layout/calendar-preview'
     | '/_app/_auth/dashboard/_layout/checkout'
@@ -1914,6 +1926,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/dashboard/calendar'
       preLoaderRoute: typeof AppAuthDashboardLayoutCalendarRouteImport
       parentRoute: typeof AppAuthDashboardLayoutRoute
+    }
+    '/_app/_auth/admin/users/$userId': {
+      id: '/_app/_auth/admin/users/$userId'
+      path: '/$userId'
+      fullPath: '/admin/users/$userId'
+      preLoaderRoute: typeof AppAuthAdminUsersUserIdRouteImport
+      parentRoute: typeof AppAuthAdminUsersRoute
     }
     '/_app/_auth/admin/organizations/$orgId': {
       id: '/_app/_auth/admin/organizations/$orgId'
@@ -2492,6 +2511,17 @@ const AppAuthAdminOrganizationsRouteWithChildren =
     AppAuthAdminOrganizationsRouteChildren,
   )
 
+interface AppAuthAdminUsersRouteChildren {
+  AppAuthAdminUsersUserIdRoute: typeof AppAuthAdminUsersUserIdRoute
+}
+
+const AppAuthAdminUsersRouteChildren: AppAuthAdminUsersRouteChildren = {
+  AppAuthAdminUsersUserIdRoute: AppAuthAdminUsersUserIdRoute,
+}
+
+const AppAuthAdminUsersRouteWithChildren =
+  AppAuthAdminUsersRoute._addFileChildren(AppAuthAdminUsersRouteChildren)
+
 interface AppAuthDashboardLayoutDocumentEditorRouteChildren {
   AppAuthDashboardLayoutDocumentEditorIdRoute: typeof AppAuthDashboardLayoutDocumentEditorIdRoute
   AppAuthDashboardLayoutDocumentEditorNewRoute: typeof AppAuthDashboardLayoutDocumentEditorNewRoute
@@ -2870,7 +2900,7 @@ interface AppAuthRouteChildren {
   AppAuthAdminErrorsRoute: typeof AppAuthAdminErrorsRoute
   AppAuthAdminOrganizationsRoute: typeof AppAuthAdminOrganizationsRouteWithChildren
   AppAuthAdminPlansRoute: typeof AppAuthAdminPlansRoute
-  AppAuthAdminUsersRoute: typeof AppAuthAdminUsersRoute
+  AppAuthAdminUsersRoute: typeof AppAuthAdminUsersRouteWithChildren
   AppAuthDashboardLayoutRoute: typeof AppAuthDashboardLayoutRouteWithChildren
   AppAuthOnboardingLayoutRoute: typeof AppAuthOnboardingLayoutRouteWithChildren
   AppAuthAdminIndexRoute: typeof AppAuthAdminIndexRoute
@@ -2882,7 +2912,7 @@ const AppAuthRouteChildren: AppAuthRouteChildren = {
   AppAuthAdminErrorsRoute: AppAuthAdminErrorsRoute,
   AppAuthAdminOrganizationsRoute: AppAuthAdminOrganizationsRouteWithChildren,
   AppAuthAdminPlansRoute: AppAuthAdminPlansRoute,
-  AppAuthAdminUsersRoute: AppAuthAdminUsersRoute,
+  AppAuthAdminUsersRoute: AppAuthAdminUsersRouteWithChildren,
   AppAuthDashboardLayoutRoute: AppAuthDashboardLayoutRouteWithChildren,
   AppAuthOnboardingLayoutRoute: AppAuthOnboardingLayoutRouteWithChildren,
   AppAuthAdminIndexRoute: AppAuthAdminIndexRoute,

--- a/src/routes/_app/_auth/admin.users.$userId.tsx
+++ b/src/routes/_app/_auth/admin.users.$userId.tsx
@@ -1,0 +1,293 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAction } from "convex/react";
+import { api } from "@cvx/_generated/api";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { formatActionError } from "@/lib/format-action-error";
+
+export const Route = createFileRoute("/_app/_auth/admin/users/$userId")({
+  component: AdminUserDetail,
+});
+
+function AdminUserDetail() {
+  const { userId } = Route.useParams();
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  // Admin gate
+  const getIsPlatformAdmin = useAction(api.app.getIsPlatformAdmin);
+  const { data: adminStatus, isLoading: adminLoading } = useQuery({
+    queryKey: ["isPlatformAdmin"],
+    queryFn: () => getIsPlatformAdmin({}),
+  });
+
+  // User detail query
+  const detailAction = useAction(api.admin.users.getUserDetail);
+  const detailQuery = useQuery({
+    queryKey: ["admin", "users", userId],
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore -- TS2589: type instantiation depth in generated api types
+    queryFn: () => detailAction({ userId }),
+    enabled: Boolean(adminStatus?.isPlatformAdmin),
+  });
+
+  const detail = detailQuery.data;
+
+  // Platform-admin toggle
+  const setRoleAction = useAction(api.platformAdmins.setRole);
+  const setRoleMutation = useMutation({
+    mutationFn: setRoleAction,
+    onSuccess: () => {
+      toast.success("Rola zaktualizowana");
+      void queryClient.invalidateQueries({ queryKey: ["admin", "users", userId] });
+      void queryClient.invalidateQueries({ queryKey: ["platformAdmins", "list"] });
+    },
+    onError: (e: Error) => {
+      toast.error(
+        formatActionError(e, t, {
+          key: "admin.users.errors.roleUpdateFailed",
+          defaultValue: "Nie udało się zmienić roli użytkownika.",
+        }),
+      );
+    },
+  });
+
+  // Suspend toggle
+  const setSuspendedAction = useAction(api.admin.users.setUserSuspended);
+  const setSuspendedMutation = useMutation({
+    mutationFn: setSuspendedAction,
+    onSuccess: () => {
+      toast.success("Status zawieszenia zaktualizowany");
+      void queryClient.invalidateQueries({ queryKey: ["admin", "users", userId] });
+    },
+    onError: (e: Error) => {
+      toast.error(
+        formatActionError(e, t, {
+          key: "admin.users.errors.suspendFailed",
+          defaultValue: "Nie udało się zmienić statusu zawieszenia.",
+        }),
+      );
+    },
+  });
+
+  if (adminLoading) {
+    return <div className="p-8 text-sm text-muted-foreground">Loading…</div>;
+  }
+
+  if (!adminStatus?.isPlatformAdmin) {
+    return (
+      <div className="mx-auto max-w-2xl p-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>403 — Platform admin required</CardTitle>
+            <CardDescription>
+              This page is only accessible to platform administrators.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Link to="/admin" className="text-sm underline">
+              Back to admin
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (detailQuery.isLoading) {
+    return <div className="p-8 text-sm text-muted-foreground">Ładowanie…</div>;
+  }
+
+  if (!detail) {
+    return (
+      <div className="mx-auto max-w-2xl p-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Nie znaleziono użytkownika</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Link to="/admin/users" className="text-sm underline">
+              Wróć do listy użytkowników
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-8">
+      {/* Back link */}
+      <div>
+        <Link
+          to="/admin/users"
+          className="text-sm text-muted-foreground underline hover:text-foreground"
+        >
+          ← Wróć do listy użytkowników
+        </Link>
+      </div>
+
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {detail.name || detail.email || "(brak nazwy)"}
+        </h1>
+        <p className="text-sm text-muted-foreground">ID: {userId}</p>
+      </div>
+
+      {/* Profil */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Profil</CardTitle>
+          <CardDescription>Dane konta użytkownika (tylko do odczytu).</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+            <div>
+              <dt className="font-medium text-muted-foreground">Imię i nazwisko</dt>
+              <dd>{detail.name ?? <span className="text-muted-foreground">—</span>}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-muted-foreground">E-mail</dt>
+              <dd>{detail.email ?? <span className="text-muted-foreground">—</span>}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-muted-foreground">Nazwa użytkownika</dt>
+              <dd>{detail.username ?? <span className="text-muted-foreground">—</span>}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-muted-foreground">Język</dt>
+              <dd>{detail.language ?? <span className="text-muted-foreground">—</span>}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-muted-foreground">Motyw</dt>
+              <dd>{detail.theme ?? <span className="text-muted-foreground">—</span>}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-muted-foreground">Strefa czasowa</dt>
+              <dd>{detail.timezone ?? <span className="text-muted-foreground">—</span>}</dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+
+      {/* Status */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Status</CardTitle>
+          <CardDescription>Zarządzaj uprawnieniami i zawieszeniem konta.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="admin-switch">Administrator platformy</Label>
+              <p className="text-xs text-muted-foreground">
+                Dostęp do stron /admin i ustawień globalnych.
+              </p>
+            </div>
+            <Switch
+              id="admin-switch"
+              checked={detail.isPlatformAdmin}
+              disabled={setRoleMutation.isPending}
+              onCheckedChange={(checked) =>
+                setRoleMutation.mutate({
+                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                  // @ts-ignore -- TS2589: type instantiation depth in generated api types
+                  userId,
+                  isPlatformAdmin: checked,
+                })
+              }
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="suspend-switch">Zawieszony</Label>
+              <p className="text-xs text-muted-foreground">
+                Zawieszony użytkownik nie może się zalogować.
+              </p>
+            </div>
+            <Switch
+              id="suspend-switch"
+              checked={detail.isSuspended}
+              disabled={setSuspendedMutation.isPending}
+              onCheckedChange={(checked) =>
+                setSuspendedMutation.mutate({
+                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                  // @ts-ignore -- TS2589: type instantiation depth in generated api types
+                  userId,
+                  suspended: checked,
+                })
+              }
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Organizacje */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Organizacje</CardTitle>
+          <CardDescription>
+            {detail.memberships.length} członkostwo
+            {detail.memberships.length !== 1 ? "w" : ""} w organizacjach.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Organizacja</TableHead>
+                <TableHead>Rola</TableHead>
+                <TableHead>Dołączył(a)</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {detail.memberships.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={3}
+                    className="py-6 text-center text-sm text-muted-foreground"
+                  >
+                    Brak członkostw.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                detail.memberships.map((m) => (
+                  <TableRow key={m.organizationId}>
+                    <TableCell className="font-medium">{m.organizationName}</TableCell>
+                    <TableCell>
+                      <Badge variant="secondary">{m.role}</Badge>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {m.joinedAt
+                        ? new Date(m.joinedAt).toLocaleDateString("pl-PL")
+                        : "—"}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/routes/_app/_auth/admin.users.tsx
+++ b/src/routes/_app/_auth/admin.users.tsx
@@ -5,10 +5,12 @@ import { convexQuery } from "@convex-dev/react-query";
 import { api } from "@cvx/_generated/api";
 import { Id } from "@cvx/_generated/dataModel";
 import { toast } from "sonner";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { formatActionError } from "@/lib/format-action-error";
 
 export const Route = createFileRoute("/_app/_auth/admin/users")({
@@ -18,6 +20,7 @@ export const Route = createFileRoute("/_app/_auth/admin/users")({
 function AdminUsers() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+  const [search, setSearch] = useState("");
 
   const { data: viewer, isLoading: viewerLoading } = useQuery(
     convexQuery(api.app.getCurrentUser, {}),
@@ -77,7 +80,15 @@ function AdminUsers() {
     );
   }
 
-  const users = usersQuery.data ?? [];
+  const allUsers = usersQuery.data ?? [];
+  const needle = search.trim().toLowerCase();
+  const users = needle
+    ? allUsers.filter(
+        (u) =>
+          (u.name ?? "").toLowerCase().includes(needle) ||
+          (u.email ?? "").toLowerCase().includes(needle),
+      )
+    : allUsers;
 
   const handleToggle = (userId: Id<"users">, current: boolean) => {
     setRoleMutation.mutate({ userId, isPlatformAdmin: !current });
@@ -99,12 +110,20 @@ function AdminUsers() {
 
       <Card>
         <CardHeader>
-          <CardTitle>All users ({users.length})</CardTitle>
+          <CardTitle>All users ({allUsers.length})</CardTitle>
           <CardDescription>
             Platform admins (highlighted) can access /admin pages and configure
             global settings.
           </CardDescription>
         </CardHeader>
+        <CardContent className="space-y-4">
+          <Input
+            placeholder="Szukaj po nazwie lub e-mailu…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="max-w-sm"
+          />
+        </CardContent>
         <CardContent className="p-0">
           <div className="divide-y">
             {usersQuery.isLoading && (
@@ -136,14 +155,23 @@ function AdminUsers() {
                       </div>
                     )}
                   </div>
-                  <Button
-                    size="sm"
-                    variant={u.isPlatformAdmin ? "outline" : "default"}
-                    disabled={setRoleMutation.isPending}
-                    onClick={() => handleToggle(u._id as Id<"users">, u.isPlatformAdmin)}
-                  >
-                    {u.isPlatformAdmin ? "Revoke admin" : "Grant admin"}
-                  </Button>
+                  <div className="flex items-center gap-2">
+                    <Link
+                      to="/admin/users/$userId"
+                      params={{ userId: u._id }}
+                      className="text-sm underline text-muted-foreground hover:text-foreground"
+                    >
+                      Szczegóły
+                    </Link>
+                    <Button
+                      size="sm"
+                      variant={u.isPlatformAdmin ? "outline" : "default"}
+                      disabled={setRoleMutation.isPending}
+                      onClick={() => handleToggle(u._id as Id<"users">, u.isPlatformAdmin)}
+                    >
+                      {u.isPlatformAdmin ? "Revoke admin" : "Grant admin"}
+                    </Button>
+                  </div>
                 </div>
               );
             })}

--- a/supabase/migrations/00151_users_is_suspended.sql
+++ b/supabase/migrations/00151_users_is_suspended.sql
@@ -1,0 +1,6 @@
+-- Platform Admin SP3 T2: global user suspension flag. Absent/false = active;
+-- true blocks the user from minting Supabase tokens and passing auth guards.
+-- Nullable + idempotent — existing rows read as active. Supabase-authoritative
+-- (mirrors is_platform_admin), written only via the setUserSuspended admin action.
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS is_suspended boolean;

--- a/tests/convex/adminUsers.test.ts
+++ b/tests/convex/adminUsers.test.ts
@@ -1,0 +1,148 @@
+/**
+ * SP3 Task 1 — getUserDetail action tests.
+ *
+ * Harness mirrors tests/convex/adminOrganizations.test.ts:
+ *   createTestCtx() + seedTestUser() + in-memory Supabase inserts.
+ */
+import { afterEach, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function makePlatformAdmin(userId: string) {
+  await createSupabaseDb().insert("users", {
+    _id: userId,
+    name: "Admin",
+    email: `admin-${userId}@example.com`,
+    isPlatformAdmin: true,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// getUserDetail tests
+// ---------------------------------------------------------------------------
+
+describe("admin/users.getUserDetail", () => {
+  test("rejects non-platform-admin callers", async () => {
+    const t = createTestCtx();
+    const { userId, identity } = await seedTestUser(t);
+
+    // Insert users row without isPlatformAdmin flag (or explicitly false).
+    await createSupabaseDb().insert("users", {
+      _id: String(userId),
+      name: "Nobody",
+      email: "nobody@example.com",
+      isPlatformAdmin: false,
+    });
+
+    await expect(
+      t.withIdentity(identity).action(api.admin.users.getUserDetail, {
+        userId,
+      }),
+    ).rejects.toThrow(/platform admin/i);
+  });
+
+  test("admin gets target user metadata and membership with org name and role", async () => {
+    const t = createTestCtx();
+
+    // Caller = platform admin (seeded org is also used as target's org).
+    const { organizationId, userId: callerUserId, identity } = await seedTestUser(t);
+    await makePlatformAdmin(String(callerUserId));
+
+    // Seed a TARGET user in Convex db.
+    const targetUserId = await t.run(async (ctx) => {
+      return ctx.db.insert("users", {
+        name: "Target User",
+        email: "target@example.com",
+      });
+    });
+
+    const db = createSupabaseDb();
+
+    // Mirror target user to Supabase in-memory stub.
+    await db.insert("users", {
+      _id: String(targetUserId),
+      name: "Target User",
+      email: "target@example.com",
+      isPlatformAdmin: false,
+    });
+
+    // Link target to the existing org via teamMemberships.
+    await db.insert("teamMemberships", {
+      _id: "m_target_1",
+      userId: String(targetUserId),
+      organizationId: String(organizationId),
+      role: "member",
+      joinedAt: 1700000000000,
+    });
+
+    const detail = await t
+      .withIdentity(identity)
+      .action(api.admin.users.getUserDetail, { userId: targetUserId });
+
+    expect(detail.userId).toBe(String(targetUserId));
+    expect(detail.name).toBe("Target User");
+    expect(detail.email).toBe("target@example.com");
+    expect(detail.isPlatformAdmin).toBe(false);
+    expect(detail.isSuspended).toBe(false);
+    expect(detail.memberships).toHaveLength(1);
+    expect(detail.memberships[0].organizationId).toBe(String(organizationId));
+    expect(detail.memberships[0].organizationName).toBe("Test Org");
+    expect(detail.memberships[0].role).toBe("member");
+    expect(detail.memberships[0].joinedAt).toBe(1700000000000);
+  });
+
+  test("returns empty memberships when target user belongs to no org", async () => {
+    const t = createTestCtx();
+    const { userId: callerUserId, identity } = await seedTestUser(t);
+    await makePlatformAdmin(String(callerUserId));
+
+    // Seed a standalone target user with no memberships.
+    const targetUserId = await t.run(async (ctx) => {
+      return ctx.db.insert("users", {
+        name: "Lone User",
+        email: "lone@example.com",
+      });
+    });
+
+    await createSupabaseDb().insert("users", {
+      _id: String(targetUserId),
+      name: "Lone User",
+      email: "lone@example.com",
+    });
+
+    const detail = await t
+      .withIdentity(identity)
+      .action(api.admin.users.getUserDetail, { userId: targetUserId });
+
+    expect(detail.userId).toBe(String(targetUserId));
+    expect(detail.memberships).toHaveLength(0);
+  });
+
+  test("throws when target user does not exist", async () => {
+    const t = createTestCtx();
+    const { userId: callerUserId, identity } = await seedTestUser(t);
+    await makePlatformAdmin(String(callerUserId));
+
+    // Reuse callerUserId as a fake non-existent target — it exists in Convex
+    // but we deliberately skip inserting it into the Supabase stub so the
+    // Supabase get() returns null.
+    // Insert a fresh Convex user so we have a valid Id<"users">.
+    const missingId = await t.run(async (ctx) => {
+      return ctx.db.insert("users", { name: "Ghost", email: "ghost@example.com" });
+    });
+    // Do NOT insert into Supabase stub — Supabase get() will return null.
+
+    await expect(
+      t.withIdentity(identity).action(api.admin.users.getUserDetail, { userId: missingId }),
+    ).rejects.toThrow(/User not found/i);
+  });
+});

--- a/tests/convex/adminUsers.test.ts
+++ b/tests/convex/adminUsers.test.ts
@@ -146,3 +146,83 @@ describe("admin/users.getUserDetail", () => {
     ).rejects.toThrow(/User not found/i);
   });
 });
+
+// ---------------------------------------------------------------------------
+// setUserSuspended tests (SP3 T2)
+// ---------------------------------------------------------------------------
+
+describe("admin/users.setUserSuspended", () => {
+  test("(d) admin can suspend a target user — round-trips to Supabase is_suspended=true", async () => {
+    const t = createTestCtx();
+
+    // Caller = platform admin.
+    const { userId: callerUserId, identity } = await seedTestUser(t);
+    await makePlatformAdmin(String(callerUserId));
+
+    // Target user — distinct from the caller.
+    const targetUserId = await t.run(async (ctx) => {
+      return ctx.db.insert("users", {
+        name: "Target",
+        email: "target-suspend@example.com",
+      });
+    });
+    await createSupabaseDb().insert("users", {
+      _id: String(targetUserId),
+      name: "Target",
+      email: "target-suspend@example.com",
+      isPlatformAdmin: false,
+    });
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.admin.users.setUserSuspended, {
+        userId: targetUserId,
+        suspended: true,
+      });
+
+    expect(result.userId).toBe(String(targetUserId));
+    expect(result.suspended).toBe(true);
+
+    // Verify the flag was written into the in-memory Supabase store.
+    const row = await createSupabaseDb().get("users", String(targetUserId));
+    expect((row as { isSuspended?: boolean } | null)?.isSuspended).toBe(true);
+  });
+
+  test("(e) non-platform-admin caller: setUserSuspended rejects with platform admin message", async () => {
+    const t = createTestCtx();
+
+    // Caller is a plain member, NOT a platform admin.
+    const { userId: callerUserId, identity } = await seedTestUser(t);
+    await createSupabaseDb().insert("users", {
+      _id: String(callerUserId),
+      name: "Plain",
+      email: "plain@example.com",
+      isPlatformAdmin: false,
+    });
+
+    const targetUserId = await t.run(async (ctx) => {
+      return ctx.db.insert("users", { name: "Target2", email: "t2@example.com" });
+    });
+
+    await expect(
+      t.withIdentity(identity).action(api.admin.users.setUserSuspended, {
+        userId: targetUserId,
+        suspended: true,
+      }),
+    ).rejects.toThrow(/platform admin/i);
+  });
+
+  test("(f) self-suspend: setUserSuspended on own userId rejects", async () => {
+    const t = createTestCtx();
+
+    const { userId: callerUserId, identity } = await seedTestUser(t);
+    await makePlatformAdmin(String(callerUserId));
+
+    await expect(
+      t.withIdentity(identity).action(api.admin.users.setUserSuspended, {
+        userId: callerUserId,
+        suspended: true,
+      }),
+    ).rejects.toThrow(/suspend your own/i);
+  });
+});

--- a/tests/convex/adminUsers.test.ts
+++ b/tests/convex/adminUsers.test.ts
@@ -225,4 +225,120 @@ describe("admin/users.setUserSuspended", () => {
       }),
     ).rejects.toThrow(/suspend your own/i);
   });
+
+  // ---------------------------------------------------------------------------
+  // Last-admin guard tests
+  //
+  // The guard throws "Cannot suspend the last platform admin" when suspending a
+  // platform-admin target would leave zero non-suspended platform admins.
+  //
+  // NOTE: The pure-lockout rejection case (0 remaining admins) is
+  // unconstructible in a single-caller test. The caller must pass
+  // verifyPlatformAdmin, which requires them to be a non-suspended platform
+  // admin. Since the caller != target (self-suspend is already blocked), the
+  // caller is always counted as a remaining non-suspended admin — so the count
+  // is always ≥1. The guard exists as defense-in-depth against concurrent
+  // races (two admins mutually suspending). The tests below verify the guard
+  // does NOT break normal flows and that the guard logic is exercised for
+  // admin targets.
+  // ---------------------------------------------------------------------------
+
+  test("(g) last-admin guard: suspending a platform-admin target succeeds when another non-suspended admin (the actor) remains", async () => {
+    const t = createTestCtx();
+
+    // Actor = platform admin (non-suspended, counted as remaining after target suspended).
+    const { userId: callerUserId, identity } = await seedTestUser(t);
+    await makePlatformAdmin(String(callerUserId));
+
+    // Target = a second platform admin.
+    const targetUserId = await t.run(async (ctx) => {
+      return ctx.db.insert("users", {
+        name: "Second Admin",
+        email: "second-admin@example.com",
+      });
+    });
+    await createSupabaseDb().insert("users", {
+      _id: String(targetUserId),
+      name: "Second Admin",
+      email: "second-admin@example.com",
+      isPlatformAdmin: true,
+      isSuspended: false,
+    });
+
+    // Guard should pass: actor (non-suspended admin) remains after target suspended.
+    const result = await t
+      .withIdentity(identity)
+      .action(api.admin.users.setUserSuspended, {
+        userId: targetUserId,
+        suspended: true,
+      });
+
+    expect(result.suspended).toBe(true);
+
+    // Verify Supabase row updated.
+    const row = await createSupabaseDb().get("users", String(targetUserId));
+    expect((row as { isSuspended?: boolean } | null)?.isSuspended).toBe(true);
+  });
+
+  test("(h) last-admin guard: suspending a NON-admin target always succeeds regardless of admin count", async () => {
+    const t = createTestCtx();
+
+    const { userId: callerUserId, identity } = await seedTestUser(t);
+    await makePlatformAdmin(String(callerUserId));
+
+    // Target is NOT a platform admin — guard should not fire.
+    const targetUserId = await t.run(async (ctx) => {
+      return ctx.db.insert("users", {
+        name: "Regular User",
+        email: "regular@example.com",
+      });
+    });
+    await createSupabaseDb().insert("users", {
+      _id: String(targetUserId),
+      name: "Regular User",
+      email: "regular@example.com",
+      isPlatformAdmin: false,
+    });
+
+    const result = await t
+      .withIdentity(identity)
+      .action(api.admin.users.setUserSuspended, {
+        userId: targetUserId,
+        suspended: true,
+      });
+
+    expect(result.suspended).toBe(true);
+  });
+
+  test("(i) last-admin guard: unsuspending a platform-admin target always succeeds", async () => {
+    const t = createTestCtx();
+
+    const { userId: callerUserId, identity } = await seedTestUser(t);
+    await makePlatformAdmin(String(callerUserId));
+
+    // Target = already-suspended platform admin.
+    const targetUserId = await t.run(async (ctx) => {
+      return ctx.db.insert("users", {
+        name: "Suspended Admin",
+        email: "suspended-admin@example.com",
+      });
+    });
+    await createSupabaseDb().insert("users", {
+      _id: String(targetUserId),
+      name: "Suspended Admin",
+      email: "suspended-admin@example.com",
+      isPlatformAdmin: true,
+      isSuspended: true,
+    });
+
+    // Unsuspend — guard only runs on suspended:true, should be a no-op here.
+    const result = await t
+      .withIdentity(identity)
+      .action(api.admin.users.setUserSuspended, {
+        userId: targetUserId,
+        suspended: false,
+      });
+
+    expect(result.suspended).toBe(false);
+  });
 });

--- a/tests/convex/userSuspension.test.ts
+++ b/tests/convex/userSuspension.test.ts
@@ -1,0 +1,169 @@
+/**
+ * SP3 T2 — user suspension enforcement tests.
+ *
+ * Verifies that a user with `is_suspended = true` in Supabase is blocked by:
+ *   (a) verifyOrgAccess  → api.organizations.getMembers
+ *   (b) mintUserToken    → api.supabase.jwt.mintUserToken
+ *   (c) verifyPlatformAdmin → api.platformAdmins.list
+ *
+ * Non-suspended control cases must continue to pass for each guard.
+ *
+ * NOTE: seedTestUser() does NOT insert into the Supabase `users` table
+ * (only into Supabase organizations + teamMemberships). We must insert the
+ * users row explicitly before patching it with isSuspended. This mirrors
+ * the pattern in impersonation.test.ts.
+ */
+
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { createTestCtx, seedTestUser } from "../../convex/_test_helpers";
+import { createSupabaseDb } from "../../convex/_helpers/supabaseDb";
+
+// SUPABASE_JWT_SECRET must be set for JWT signing in jwt.ts to run.
+// A fixed test secret is enough — it just needs to be non-empty for jose.
+beforeAll(() => {
+  process.env.SUPABASE_JWT_SECRET =
+    process.env.SUPABASE_JWT_SECRET ?? "test-secret-for-vitest-only-not-used-in-prod";
+});
+
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Insert a user row into in-memory Supabase and mark them as suspended. */
+async function seedAndSuspendUser(userId: string) {
+  const db = createSupabaseDb();
+  await db.insert("users", {
+    _id: userId,
+    name: "Suspended User",
+    email: `suspended-${userId}@example.com`,
+    isPlatformAdmin: false,
+    isSuspended: true,
+  });
+}
+
+/** Insert a user row into in-memory Supabase as a non-suspended plain user. */
+async function seedUserInSupabase(userId: string) {
+  const db = createSupabaseDb();
+  await db.insert("users", {
+    _id: userId,
+    name: "Active User",
+    email: `active-${userId}@example.com`,
+    isPlatformAdmin: false,
+  });
+}
+
+/** Insert a user row into in-memory Supabase as a platform admin. */
+async function seedAdminInSupabase(userId: string) {
+  const db = createSupabaseDb();
+  await db.insert("users", {
+    _id: userId,
+    name: "Platform Admin",
+    email: `admin-${userId}@example.com`,
+    isPlatformAdmin: true,
+  });
+}
+
+/** Insert a user row into in-memory Supabase as a suspended platform admin. */
+async function seedSuspendedAdminInSupabase(userId: string) {
+  const db = createSupabaseDb();
+  await db.insert("users", {
+    _id: userId,
+    name: "Suspended Admin",
+    email: `suspended-admin-${userId}@example.com`,
+    isPlatformAdmin: true,
+    isSuspended: true,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// (a) verifyOrgAccess — api.organizations.getMembers
+// ---------------------------------------------------------------------------
+
+describe("user suspension — verifyOrgAccess", () => {
+  test("suspended user: org action rejects with 'User suspended'", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    await seedAndSuspendUser(String(userId));
+
+    await expect(
+      t.withIdentity(identity).action(api.organizations.getMembers, {
+        organizationId,
+      }),
+    ).rejects.toThrow(/suspended/i);
+  });
+
+  test("non-suspended user: org action succeeds", async () => {
+    const t = createTestCtx();
+    const { organizationId, userId, identity } = await seedTestUser(t);
+
+    await seedUserInSupabase(String(userId));
+
+    await expect(
+      t.withIdentity(identity).action(api.organizations.getMembers, {
+        organizationId,
+      }),
+    ).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) mintUserToken — api.supabase.jwt.mintUserToken
+// ---------------------------------------------------------------------------
+
+describe("user suspension — mintUserToken", () => {
+  test("suspended user: mintUserToken rejects with 'User suspended'", async () => {
+    const t = createTestCtx();
+    const { userId, identity } = await seedTestUser(t);
+
+    await seedAndSuspendUser(String(userId));
+
+    await expect(
+      t.withIdentity(identity).action(api.supabase.jwt.mintUserToken, {}),
+    ).rejects.toThrow(/suspended/i);
+  });
+
+  test("non-suspended user: mintUserToken succeeds", async () => {
+    const t = createTestCtx();
+    const { userId, identity } = await seedTestUser(t);
+
+    await seedUserInSupabase(String(userId));
+
+    await expect(
+      t.withIdentity(identity).action(api.supabase.jwt.mintUserToken, {}),
+    ).resolves.toHaveProperty("token");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) verifyPlatformAdmin — api.platformAdmins.list
+// ---------------------------------------------------------------------------
+
+describe("user suspension — verifyPlatformAdmin", () => {
+  test("suspended platform admin: admin action rejects with 'User suspended'", async () => {
+    const t = createTestCtx();
+    const { userId, identity } = await seedTestUser(t);
+
+    await seedSuspendedAdminInSupabase(String(userId));
+
+    await expect(
+      t.withIdentity(identity).action(api.platformAdmins.list, {}),
+    ).rejects.toThrow(/suspended/i);
+  });
+
+  test("non-suspended platform admin: admin action succeeds", async () => {
+    const t = createTestCtx();
+    const { userId, identity } = await seedTestUser(t);
+
+    await seedAdminInSupabase(String(userId));
+
+    await expect(
+      t.withIdentity(identity).action(api.platformAdmins.list, {}),
+    ).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Platform Admin Console — SP3 (Users & platform admins)

Completes the users console (built on the existing `platformAdmins.list`/`setRole` + `admin.users.tsx`). Subagent-driven: 3 tasks + per-task reviews + final opus whole-branch review + a security fix.

### What ships
- **`/admin/users`**: existing user list + platform-admin grant/revoke (last-admin guarded) — now with a **search** (name/email) and a **"Szczegóły"** link per row.
- **`/admin/users/$userId`** (new): user detail — Profil (metadata), Status (platform-admin `Switch` → `setRole`; **Zawieszony** `Switch` → `setUserSuspended`), Organizacje (the user's orgs + roles from `teamMemberships`).
- **Global user suspension**: `users.is_suspended` (migration `00151`). A suspended user is blocked at three auth guards — `verifyOrgAccess` (writes + Convex-action reads), `mintUserToken` (user-scoped Supabase token), `verifyPlatformAdmin` (admin panel). No new Supabase token can be minted → the app is non-functional for them.

### Backend (`convex/admin/users.ts`)
`getUserDetail` + `setUserSuspended`, both `verifyPlatformAdmin`-guarded, reading/writing Supabase (`is_suspended` Supabase-authoritative, like `is_platform_admin`). `console.info` audit (audit_log is org-scoped NOT NULL FK).

### Security
- `setUserSuspended` refuses **self-suspend** and refuses to **suspend the last non-suspended platform admin** (mirrors `setRole`'s last-admin guard) — no in-app admin lockout.
- Final opus review: 0 Critical. The ≤1h already-minted-JWT residual read window is documented (same accepted window as SP2 org-suspend); writes blocked immediately.

### Verification
- `tsc -p convex/tsconfig.json` / `tsconfig.app.json` / `tsconfig.node.json` → 0; `vite build` clean.
- Convex suite: 79 files / 653 tests pass. New: `adminUsers.test.ts` (10), `userSuspension.test.ts` (6); `orgSuspension` + `tenantIsolation` 34/34 (no regression from the new suspend check).

### Post-merge
Migration 00151 applies via CI on merge. Convex deploy: `npx convex dev --once` (headless from CLI). Verify `/admin/users` search + detail; suspend a throwaway user → their token mint throws; unsuspend restores; self-suspend + last-admin-suspend refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)