### PR TITLE
Backend: logika rozliczenia wizyty dla gratis

### DIFF
--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -143,6 +143,9 @@ export const create = action({
     // discountPercent: percentage discount (0–100).
     discountAmount: v.optional(v.number()),
     discountPercent: v.optional(v.number()),
+    // Required when paymentMethod="gratis" (issue #5659). Captures the
+    // business reason (complaint, promo, gift, etc.). Ignored for other methods.
+    gratisReason: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runAction(
@@ -190,16 +193,35 @@ export const create = action({
       }
     }
 
+    // Gratis business rules (issue #5659):
+    //  - amount is forced to 0 by the backend regardless of what was passed
+    //  - gratisReason is mandatory (captures complaint / promo / gift rationale)
+    //  - patient credit cannot be applied or earned (no monetary leg)
+    if (args.paymentMethod === "gratis") {
+      const reason = args.gratisReason?.trim();
+      if (!reason) {
+        throw new Error("gratisReason is required for gratis payments");
+      }
+      if (creditApplied !== null) {
+        throw new Error("gratis payments cannot apply patient credit");
+      }
+      if (creditEarned !== null) {
+        throw new Error("gratis payments cannot earn patient credit");
+      }
+    }
+
     // Build INSERT defensively — migration 00008 columns (kind, creditEarned,
     // creditApplied) may not exist on pre-00008 environments; only include them
     // when non-null. kind=NULL is treated as "payment" by the DB check
     // constraint, so omitting it is always safe.
+    const effectiveAmount =
+      args.paymentMethod === "gratis" ? 0 : args.amount;
     const insertRow: Record<string, unknown> = {
       organizationId: String(args.organizationId),
       patientId: args.patientId ?? null,
       appointmentId: args.appointmentId ?? null,
       packageUsageId: args.packageUsageId ?? null,
-      amount: args.amount,
+      amount: effectiveAmount,
       currency: args.currency,
       paymentMethod: args.paymentMethod,
       status,
@@ -215,6 +237,8 @@ export const create = action({
       insertRow.discountAmount = args.discountAmount;
     if (args.discountPercent !== undefined && args.discountPercent > 0)
       insertRow.discountPercent = args.discountPercent;
+    if (args.paymentMethod === "gratis" && args.gratisReason?.trim())
+      insertRow.gratisReason = args.gratisReason.trim();
 
     const paymentId = await db.insert("payments", insertRow);
 
@@ -566,6 +590,9 @@ export const splitMarkPaid = action({
       { organizationId: args.organizationId },
     );
 
+    if (args.firstMethod === "gratis" || args.secondMethod === "gratis") {
+      throw new Error("gratis payments cannot be split");
+    }
     if (args.firstMethod === args.secondMethod) {
       throw new Error("Split methods must differ");
     }

--- a/convex/schema/crm.ts
+++ b/convex/schema/crm.ts
@@ -645,6 +645,9 @@ export function createCrmTables({
     ),
     fiscalAttempts: v.optional(v.number()),
     fiscalError: v.optional(v.string()),
+    // Mandatory for paymentMethod="gratis" (issue #5659).
+    // Captures the business reason (e.g. "complaint", "promo", "gift").
+    gratisReason: v.optional(v.string()),
     createdBy: v.id("users"),
     createdAt: v.number(),
     updatedAt: v.number(),

--- a/supabase/migrations/00152_payments_gratis_reason.sql
+++ b/supabase/migrations/00152_payments_gratis_reason.sql
@@ -1,0 +1,6 @@
+-- Add gratis_reason column to payments (issue #5659).
+--
+-- Required at the application layer when payment_method = 'gratis'.
+-- NULL is intentionally allowed at the DB level so legacy rows remain
+-- valid; the mandatory-reason constraint lives in convex/payments.ts.
+ALTER TABLE payments ADD COLUMN IF NOT EXISTS gratis_reason TEXT;

--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -1053,4 +1053,192 @@ describe("payments", () => {
       expect(credit.balance).toBe(350);
     });
   });
+
+  // Gratis payment rules (issue #5659) ----------------------------------------
+
+  describe("gratis payments", () => {
+    test("forces amount to 0 regardless of what the caller passes", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      const paymentId = await t.withIdentity(identity).action(
+        api.payments.create,
+        {
+          organizationId,
+          amount: 250,
+          currency: "PLN",
+          paymentMethod: "gratis",
+          gratisReason: "promotional visit",
+        },
+      );
+
+      const result = await t.withIdentity(identity).action(api.payments.list, {
+        organizationId,
+        paginationOpts: { numItems: 10, cursor: null },
+      });
+
+      const payment = result.page.find((p: any) => p._id === paymentId);
+      expect(payment).toBeTruthy();
+      expect(payment!.amount).toBe(0);
+      expect(payment!.paymentMethod).toBe("gratis");
+    });
+
+    test("requires gratisReason — rejects when missing", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      await expect(
+        t.withIdentity(identity).action(api.payments.create, {
+          organizationId,
+          amount: 100,
+          currency: "PLN",
+          paymentMethod: "gratis",
+          // gratisReason intentionally omitted
+        }),
+      ).rejects.toThrow("gratisReason is required for gratis payments");
+    });
+
+    test("requires gratisReason — rejects empty string", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      await expect(
+        t.withIdentity(identity).action(api.payments.create, {
+          organizationId,
+          amount: 100,
+          currency: "PLN",
+          paymentMethod: "gratis",
+          gratisReason: "   ",
+        }),
+      ).rejects.toThrow("gratisReason is required for gratis payments");
+    });
+
+    test("rejects creditApplied for gratis payment", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+      const patientId = "test-patient-gratis-1";
+
+      // Seed credit balance via a regular overpayment first.
+      await t.withIdentity(identity).action(api.payments.create, {
+        organizationId,
+        patientId,
+        amount: 500,
+        currency: "PLN",
+        paymentMethod: "cash",
+        creditEarned: 500,
+      });
+
+      await expect(
+        t.withIdentity(identity).action(api.payments.create, {
+          organizationId,
+          patientId,
+          amount: 100,
+          currency: "PLN",
+          paymentMethod: "gratis",
+          gratisReason: "complaint",
+          creditApplied: 50,
+        }),
+      ).rejects.toThrow("gratis payments cannot apply patient credit");
+    });
+
+    test("rejects creditEarned for gratis payment", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      await expect(
+        t.withIdentity(identity).action(api.payments.create, {
+          organizationId,
+          amount: 0,
+          currency: "PLN",
+          paymentMethod: "gratis",
+          gratisReason: "complaint",
+          creditEarned: 10,
+        }),
+      ).rejects.toThrow("gratis payments cannot earn patient credit");
+    });
+
+    test("splitMarkPaid rejects gratis as first method", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      // Create a pending payment to split.
+      const paymentId = await t.withIdentity(identity).action(
+        api.payments.create,
+        {
+          organizationId,
+          amount: 200,
+          currency: "PLN",
+          paymentMethod: "cash",
+          status: "pending",
+        },
+      );
+
+      await expect(
+        t.withIdentity(identity).action(api.payments.splitMarkPaid, {
+          organizationId,
+          paymentId,
+          firstMethod: "gratis",
+          firstAmount: 100,
+          secondMethod: "cash",
+          secondAmount: 100,
+        }),
+      ).rejects.toThrow("gratis payments cannot be split");
+    });
+
+    test("splitMarkPaid rejects gratis as second method", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      const paymentId = await t.withIdentity(identity).action(
+        api.payments.create,
+        {
+          organizationId,
+          amount: 200,
+          currency: "PLN",
+          paymentMethod: "cash",
+          status: "pending",
+        },
+      );
+
+      await expect(
+        t.withIdentity(identity).action(api.payments.splitMarkPaid, {
+          organizationId,
+          paymentId,
+          firstMethod: "cash",
+          firstAmount: 100,
+          secondMethod: "gratis",
+          secondAmount: 100,
+        }),
+      ).rejects.toThrow("gratis payments cannot be split");
+    });
+
+    test("gratis payment is excluded from dayClose revenue totals", async () => {
+      // dayClose.ts excludes gratis/barter from totals (line 307). We verify
+      // that a gratis payment recorded with amount=0 does not affect the
+      // numeric totals — the business rule is already enforced by the amount
+      // being 0, so this is a consistency check.
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      const paymentId = await t.withIdentity(identity).action(
+        api.payments.create,
+        {
+          organizationId,
+          amount: 999,
+          currency: "PLN",
+          paymentMethod: "gratis",
+          gratisReason: "promotional campaign",
+        },
+      );
+
+      const result = await t.withIdentity(identity).action(api.payments.list, {
+        organizationId,
+        paginationOpts: { numItems: 10, cursor: null },
+      });
+
+      const payment = result.page.find((p: any) => p._id === paymentId);
+      // Backend forced amount to 0; it cannot contribute to revenue totals.
+      expect(payment!.amount).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5659.

Closes #5659

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- c799ed18 feat(payments): enforce gratis settlement rules (issue #5659)

### Files changed

```
 convex/payments.ts                                 |  29 +++-
 convex/schema/crm.ts                               |   3 +
 .../migrations/00152_payments_gratis_reason.sql    |   6 +
 tests/convex/payments.test.ts                      | 188 +++++++++++++++++++++
 4 files changed, 225 insertions(+), 1 deletion(-)
```