### PR TITLE
Implement `barter` rules symmetrically

### DIFF
--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -146,6 +146,10 @@ export const create = action({
     // Required when paymentMethod="gratis" (issue #5659). Captures the
     // business reason (complaint, promo, gift, etc.). Ignored for other methods.
     gratisReason: v.optional(v.string()),
+    // Required when paymentMethod="barter" (issue #5665). Captures what was
+    // exchanged (e.g. "Instagram collaboration", "service exchange"). Ignored
+    // for other methods. Symmetric with gratisReason.
+    barterDescription: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runAction(
@@ -165,6 +169,38 @@ export const create = action({
       args.creditApplied !== undefined && args.creditApplied !== 0
         ? args.creditApplied
         : null;
+
+    // Method-specific rules fire before generic credit validation so callers
+    // get the most actionable error message when multiple constraints apply.
+
+    // Gratis business rules (issue #5659):
+    //  - amount is forced to 0 by the backend regardless of what was passed
+    //  - gratisReason is mandatory (captures complaint / promo / gift rationale)
+    //  - patient credit cannot be applied or earned (no monetary leg)
+    if (args.paymentMethod === "gratis") {
+      const reason = args.gratisReason?.trim();
+      if (!reason) {
+        throw new Error("gratisReason is required for gratis payments");
+      }
+      if (creditApplied !== null) {
+        throw new Error("gratis payments cannot apply patient credit");
+      }
+      if (creditEarned !== null) {
+        throw new Error("gratis payments cannot earn patient credit");
+      }
+    }
+
+    // Barter business rules (issue #5665):
+    //  - barterDescription is mandatory (captures what was exchanged)
+    //  - cannot be split (non-cash exchange has no partial legs)
+    //  - amount is preserved (barter has real value, excluded from turnover by
+    //    the reporting layer — see dayClose.ts which skips barter like gratis)
+    if (args.paymentMethod === "barter") {
+      const desc = args.barterDescription?.trim();
+      if (!desc) {
+        throw new Error("barterDescription is required for barter payments");
+      }
+    }
 
     if (creditEarned !== null) {
       if (!Number.isFinite(creditEarned) || creditEarned < 0) {
@@ -190,23 +226,6 @@ export const create = action({
         throw new Error(
           `creditApplied ${creditApplied} exceeds available balance ${balance}`,
         );
-      }
-    }
-
-    // Gratis business rules (issue #5659):
-    //  - amount is forced to 0 by the backend regardless of what was passed
-    //  - gratisReason is mandatory (captures complaint / promo / gift rationale)
-    //  - patient credit cannot be applied or earned (no monetary leg)
-    if (args.paymentMethod === "gratis") {
-      const reason = args.gratisReason?.trim();
-      if (!reason) {
-        throw new Error("gratisReason is required for gratis payments");
-      }
-      if (creditApplied !== null) {
-        throw new Error("gratis payments cannot apply patient credit");
-      }
-      if (creditEarned !== null) {
-        throw new Error("gratis payments cannot earn patient credit");
       }
     }
 
@@ -239,6 +258,8 @@ export const create = action({
       insertRow.discountPercent = args.discountPercent;
     if (args.paymentMethod === "gratis" && args.gratisReason?.trim())
       insertRow.gratisReason = args.gratisReason.trim();
+    if (args.paymentMethod === "barter" && args.barterDescription?.trim())
+      insertRow.barterDescription = args.barterDescription.trim();
 
     const paymentId = await db.insert("payments", insertRow);
 
@@ -592,6 +613,9 @@ export const splitMarkPaid = action({
 
     if (args.firstMethod === "gratis" || args.secondMethod === "gratis") {
       throw new Error("gratis payments cannot be split");
+    }
+    if (args.firstMethod === "barter" || args.secondMethod === "barter") {
+      throw new Error("barter payments cannot be split");
     }
     if (args.firstMethod === args.secondMethod) {
       throw new Error("Split methods must differ");

--- a/supabase/migrations/00153_payments_barter_description.sql
+++ b/supabase/migrations/00153_payments_barter_description.sql
@@ -1,0 +1,7 @@
+-- Add barter_description column to payments (issue #5665).
+--
+-- Required at the application layer when payment_method = 'barter'.
+-- NULL is intentionally allowed at the DB level so legacy rows remain
+-- valid; the mandatory-description constraint lives in convex/payments.ts.
+-- Symmetric with gratis_reason added in migration 00152.
+ALTER TABLE payments ADD COLUMN IF NOT EXISTS barter_description TEXT;

--- a/tests/convex/payments.test.ts
+++ b/tests/convex/payments.test.ts
@@ -1241,4 +1241,116 @@ describe("payments", () => {
       expect(payment!.amount).toBe(0);
     });
   });
+
+  describe("barter payments", () => {
+    test("creates a barter payment preserving the amount", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      const paymentId = await t.withIdentity(identity).action(
+        api.payments.create,
+        {
+          organizationId,
+          amount: 300,
+          currency: "PLN",
+          paymentMethod: "barter",
+          barterDescription: "Instagram collaboration",
+        },
+      );
+
+      const result = await t.withIdentity(identity).action(api.payments.list, {
+        organizationId,
+        paginationOpts: { numItems: 10, cursor: null },
+      });
+
+      const payment = result.page.find((p: any) => p._id === paymentId);
+      expect(payment).toBeTruthy();
+      expect(payment!.amount).toBe(300);
+      expect(payment!.paymentMethod).toBe("barter");
+    });
+
+    test("requires barterDescription — rejects when missing", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      await expect(
+        t.withIdentity(identity).action(api.payments.create, {
+          organizationId,
+          amount: 100,
+          currency: "PLN",
+          paymentMethod: "barter",
+          // barterDescription intentionally omitted
+        }),
+      ).rejects.toThrow("barterDescription is required for barter payments");
+    });
+
+    test("requires barterDescription — rejects empty string", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      await expect(
+        t.withIdentity(identity).action(api.payments.create, {
+          organizationId,
+          amount: 100,
+          currency: "PLN",
+          paymentMethod: "barter",
+          barterDescription: "   ",
+        }),
+      ).rejects.toThrow("barterDescription is required for barter payments");
+    });
+
+    test("splitMarkPaid rejects barter as first method", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      const paymentId = await t.withIdentity(identity).action(
+        api.payments.create,
+        {
+          organizationId,
+          amount: 200,
+          currency: "PLN",
+          paymentMethod: "cash",
+          status: "pending",
+        },
+      );
+
+      await expect(
+        t.withIdentity(identity).action(api.payments.splitMarkPaid, {
+          organizationId,
+          paymentId,
+          firstMethod: "barter",
+          firstAmount: 100,
+          secondMethod: "cash",
+          secondAmount: 100,
+        }),
+      ).rejects.toThrow("barter payments cannot be split");
+    });
+
+    test("splitMarkPaid rejects barter as second method", async () => {
+      const t = createTestCtx();
+      const { organizationId, identity } = await seedTestUser(t);
+
+      const paymentId = await t.withIdentity(identity).action(
+        api.payments.create,
+        {
+          organizationId,
+          amount: 200,
+          currency: "PLN",
+          paymentMethod: "cash",
+          status: "pending",
+        },
+      );
+
+      await expect(
+        t.withIdentity(identity).action(api.payments.splitMarkPaid, {
+          organizationId,
+          paymentId,
+          firstMethod: "cash",
+          firstAmount: 100,
+          secondMethod: "barter",
+          secondAmount: 100,
+        }),
+      ).rejects.toThrow("barter payments cannot be split");
+    });
+  });
 });


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5665.

Closes #5665

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 155956f3 fix(payments): enforce barter rules symmetrically (issue #5665)

### Files changed

```
 convex/payments.ts                                 |  58 +++++++----
 .../00153_payments_barter_description.sql          |   7 ++
 tests/convex/payments.test.ts                      | 112 +++++++++++++++++++++
 3 files changed, 160 insertions(+), 17 deletions(-)
```