### PR TITLE
Prevent gratis from appearing as a split-payment method option

### DIFF
--- a/src/components/gabinet/appointment-shared/settlement-form.tsx
+++ b/src/components/gabinet/appointment-shared/settlement-form.tsx
@@ -95,6 +95,9 @@ const PAYMENT_METHODS = [
 // section, not a payment method.
 const PAY_METHODS = PAYMENT_METHODS.filter((m) => m !== "package");
 
+// Split-payment legs cannot use "gratis" (backend enforces this in splitMarkPaid).
+const SPLIT_PAY_METHODS = PAY_METHODS.filter((m) => m !== "gratis");
+
 export function SettlementForm({
   organizationId,
   appointmentId,
@@ -1132,7 +1135,7 @@ export function SettlementForm({
                       <SelectLabel>
                         {t("gabinet.payments.groupPayment", "Metody płatności")}
                       </SelectLabel>
-                      {PAY_METHODS.map((m) => (
+                      {SPLIT_PAY_METHODS.map((m) => (
                         <SelectItem key={m} value={m}>
                           {t(`gabinet.payments.methods.${m}`)}
                         </SelectItem>
@@ -1222,7 +1225,7 @@ export function SettlementForm({
                       <SelectLabel>
                         {t("gabinet.payments.groupPayment", "Metody płatności")}
                       </SelectLabel>
-                      {PAY_METHODS.map((m) => (
+                      {SPLIT_PAY_METHODS.map((m) => (
                         <SelectItem key={m} value={m}>
                           {t(`gabinet.payments.methods.${m}`)}
                         </SelectItem>


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5667.

Closes #5667

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- f9a06f5f fix(gabinet): exclude gratis from split-payment method selects (issue #5667)

### Files changed

```
 src/components/gabinet/appointment-shared/settlement-form.tsx | 7 +++++--
 1 file changed, 5 insertions(+), 2 deletions(-)
```