### PR TITLE
Regenerate `database.types.ts` to include `gratis_reason` and `barter_descriptio

### DIFF
--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -331,6 +331,7 @@ export interface Database {
           created_at: number | null;
           updated_at: number | null;
           is_platform_admin: boolean | null;
+          is_suspended: boolean | null;
         };
         Insert: {
           id?: string;
@@ -350,6 +351,7 @@ export interface Database {
           created_at?: number | null;
           updated_at?: number | null;
           is_platform_admin?: boolean | null;
+          is_suspended?: boolean | null;
         };
         Update: {
           id?: string;
@@ -369,6 +371,7 @@ export interface Database {
           created_at?: number | null;
           updated_at?: number | null;
           is_platform_admin?: boolean | null;
+          is_suspended?: boolean | null;
         };
         Relationships: [];
       };
@@ -3555,6 +3558,8 @@ export interface Database {
           fiscal_error: string | null;
           refund_amount: number | null;
           refunded_at: number | null;
+          gratis_reason: string | null;
+          barter_description: string | null;
         };
         Insert: {
           id?: string;
@@ -3582,6 +3587,8 @@ export interface Database {
           fiscal_error?: string | null;
           refund_amount?: number | null;
           refunded_at?: number | null;
+          gratis_reason?: string | null;
+          barter_description?: string | null;
         };
         Update: {
           id?: string;
@@ -3609,6 +3616,8 @@ export interface Database {
           fiscal_error?: string | null;
           refund_amount?: number | null;
           refunded_at?: number | null;
+          gratis_reason?: string | null;
+          barter_description?: string | null;
         };
         Relationships: [
           {


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5672.

Closes #5672

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 9df2e647 fix(types): add gratis_reason, barter_description, is_suspended to database.types.ts (issue #5672)

### Files changed

```
 src/lib/supabase/database.types.ts | 9 +++++++++
 1 file changed, 9 insertions(+)
```