### PR TITLE
Add `gratisReason`/`barterDescription` to the edit-payment dialog

### DIFF
--- a/convex/payments.ts
+++ b/convex/payments.ts
@@ -480,6 +480,8 @@ export const update = action({
     notes: v.optional(v.union(v.string(), v.null())),
     discountAmount: v.optional(v.union(v.number(), v.null())),
     discountPercent: v.optional(v.union(v.number(), v.null())),
+    gratisReason: v.optional(v.string()),
+    barterDescription: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const authResult = await ctx.runAction(
@@ -497,12 +499,17 @@ export const update = action({
       throw new Error(`Cannot edit a ${payment.status} payment`);
     }
 
+    const effectiveMethod = args.paymentMethod ?? (payment.paymentMethod as string);
+
     const updates: Record<string, unknown> = { updatedAt: Date.now() };
     if (args.amount !== undefined) {
-      if (!Number.isFinite(args.amount) || args.amount <= 0) {
+      if (effectiveMethod === "gratis") {
+        updates.amount = 0; // gratis is always 0 (issue #5659)
+      } else if (!Number.isFinite(args.amount) || args.amount <= 0) {
         throw new Error("Amount must be a positive number");
+      } else {
+        updates.amount = args.amount;
       }
-      updates.amount = args.amount;
     }
     if (args.paymentMethod !== undefined) {
       updates.paymentMethod = args.paymentMethod;
@@ -515,6 +522,28 @@ export const update = action({
     }
     if (args.discountPercent !== undefined) {
       updates.discountPercent = args.discountPercent;
+    }
+
+    // Gratis: require reason, update field, clear when switching away
+    if (effectiveMethod === "gratis") {
+      const reason = args.gratisReason?.trim();
+      if (!reason) {
+        throw new Error("gratisReason is required for gratis payments");
+      }
+      updates.gratisReason = reason;
+    } else if (args.paymentMethod !== undefined) {
+      updates.gratisReason = null;
+    }
+
+    // Barter: require description, update field, clear when switching away
+    if (effectiveMethod === "barter") {
+      const desc = args.barterDescription?.trim();
+      if (!desc) {
+        throw new Error("barterDescription is required for barter payments");
+      }
+      updates.barterDescription = desc;
+    } else if (args.paymentMethod !== undefined) {
+      updates.barterDescription = null;
     }
 
     await db.patch("payments", args.paymentId, updates);

--- a/src/components/gabinet/patients/edit-payment-dialog.tsx
+++ b/src/components/gabinet/patients/edit-payment-dialog.tsx
@@ -19,6 +19,8 @@ import {
 import type { TFunction } from "i18next";
 import type { MappedGabinetAppointment } from "@/lib/supabase/mappers/gabinet/appointments";
 
+type PaymentMethod = "cash" | "card" | "transfer" | "package" | "gratis" | "barter" | "other";
+
 export function EditPaymentDialog({
   editingPaymentId,
   paymentEditAmount,
@@ -32,6 +34,10 @@ export function EditPaymentDialog({
   setPaymentEditDiscountType,
   paymentEditDiscountValue,
   setPaymentEditDiscountValue,
+  paymentEditGratisReason,
+  setPaymentEditGratisReason,
+  paymentEditBarterDescription,
+  setPaymentEditBarterDescription,
   isPaymentEditSubmitting,
   onClose,
   onSubmit,
@@ -42,8 +48,8 @@ export function EditPaymentDialog({
   editingPaymentId: string | null;
   paymentEditAmount: string;
   setPaymentEditAmount: (v: string) => void;
-  paymentEditMethod: "cash" | "card" | "transfer" | "package" | "other";
-  setPaymentEditMethod: (v: "cash" | "card" | "transfer" | "package" | "other") => void;
+  paymentEditMethod: PaymentMethod;
+  setPaymentEditMethod: (v: PaymentMethod) => void;
   paymentEditNotes: string;
   setPaymentEditNotes: (v: string) => void;
   paymentEditAppointmentId: string | null;
@@ -51,6 +57,10 @@ export function EditPaymentDialog({
   setPaymentEditDiscountType: (v: "amount" | "percent") => void;
   paymentEditDiscountValue: string;
   setPaymentEditDiscountValue: (v: string) => void;
+  paymentEditGratisReason: string;
+  setPaymentEditGratisReason: (v: string) => void;
+  paymentEditBarterDescription: string;
+  setPaymentEditBarterDescription: (v: string) => void;
   isPaymentEditSubmitting: boolean;
   onClose: () => void;
   onSubmit: () => Promise<void>;
@@ -58,6 +68,8 @@ export function EditPaymentDialog({
   getApptPrice: (apt?: MappedGabinetAppointment | null) => number;
   t: TFunction;
 }) {
+  const isFixedAmount = paymentEditMethod === "gratis";
+
   return (
     <Dialog
       open={editingPaymentId !== null}
@@ -78,7 +90,8 @@ export function EditPaymentDialog({
             <Input
               type="text"
               inputMode="decimal"
-              value={paymentEditAmount}
+              value={isFixedAmount ? "0.00" : paymentEditAmount}
+              disabled={isFixedAmount}
               onChange={(e) => {
                 const v = e.target.value;
                 if (v === "" || /^[0-9]*[.,]?[0-9]*$/.test(v)) {
@@ -87,16 +100,23 @@ export function EditPaymentDialog({
               }}
               placeholder="0.00"
             />
+            {isFixedAmount && (
+              <p className="text-xs text-muted-foreground mt-1">
+                {t("gabinet.payments.amountLockedToTreatment")}
+              </p>
+            )}
           </div>
           <div>
             <Label>{t("gabinet.payments.method")}</Label>
             <Select
               value={paymentEditMethod}
-              onValueChange={(v) =>
-                setPaymentEditMethod(
-                  v as "cash" | "card" | "transfer" | "package" | "other",
-                )
-              }
+              onValueChange={(v) => {
+                const method = v as PaymentMethod;
+                setPaymentEditMethod(method);
+                if (method !== "gratis") setPaymentEditGratisReason("");
+                if (method !== "barter") setPaymentEditBarterDescription("");
+                if (method === "gratis") setPaymentEditAmount("0");
+              }}
             >
               <SelectTrigger>
                 <SelectValue />
@@ -114,13 +134,47 @@ export function EditPaymentDialog({
                 <SelectItem value="package">
                   {t("gabinet.payments.methods.package")}
                 </SelectItem>
+                <SelectItem value="gratis">
+                  {t("gabinet.payments.methods.gratis")}
+                </SelectItem>
+                <SelectItem value="barter">
+                  {t("gabinet.payments.methods.barter")}
+                </SelectItem>
                 <SelectItem value="other">
                   {t("gabinet.payments.methods.other")}
                 </SelectItem>
               </SelectContent>
             </Select>
           </div>
+          {paymentEditMethod === "gratis" && (
+            <div>
+              <Label>{t("gabinet.payments.gratisReason", "Powód gratis")}</Label>
+              <Input
+                value={paymentEditGratisReason}
+                onChange={(e) => setPaymentEditGratisReason(e.target.value)}
+                placeholder={t(
+                  "gabinet.payments.gratisReasonPlaceholder",
+                  "Np. reklamacja, promocja, upominek...",
+                )}
+              />
+            </div>
+          )}
+          {paymentEditMethod === "barter" && (
+            <div>
+              <Label>{t("gabinet.payments.barterDescription", "Opis barteru")}</Label>
+              <Input
+                value={paymentEditBarterDescription}
+                onChange={(e) => setPaymentEditBarterDescription(e.target.value)}
+                placeholder={t(
+                  "gabinet.payments.barterDescriptionPlaceholder",
+                  "Np. współpraca Instagram, wymiana usług...",
+                )}
+              />
+            </div>
+          )}
           {paymentEditAppointmentId &&
+            paymentEditMethod !== "gratis" &&
+            paymentEditMethod !== "barter" &&
             (() => {
               const apt = (patientAppointments ?? []).find(
                 (a) => a._id === paymentEditAppointmentId,

--- a/src/components/gabinet/patients/patient-payments-tab.tsx
+++ b/src/components/gabinet/patients/patient-payments-tab.tsx
@@ -36,6 +36,8 @@ type Payment = {
   notes?: string;
   discountAmount?: number | null;
   discountPercent?: number | null;
+  gratisReason?: string;
+  barterDescription?: string;
 };
 
 type PackageUsage = { _id: string; packageId: string };
@@ -111,6 +113,8 @@ export function PatientPaymentsTab({
     appointmentId?: string;
     discountAmount?: number | null;
     discountPercent?: number | null;
+    gratisReason?: string;
+    barterDescription?: string;
   }) => void;
   openCancelDialog: (paymentId: string) => void;
   navigate: (opts: { to: string; params?: Record<string, string> }) => void;
@@ -356,6 +360,8 @@ export function PatientPaymentsTab({
                                       appointmentId: payment.appointmentId,
                                       discountAmount: payment.discountAmount,
                                       discountPercent: payment.discountPercent,
+                                      gratisReason: payment.gratisReason,
+                                      barterDescription: payment.barterDescription,
                                     });
                                   }}
                                 >

--- a/src/lib/supabase/mappers/payments.ts
+++ b/src/lib/supabase/mappers/payments.ts
@@ -28,6 +28,8 @@ export interface MappedPayment {
   kind?: string;
   discountAmount?: number;
   discountPercent?: number;
+  gratisReason?: string;
+  barterDescription?: string;
   _source: "supabase";
 }
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.patients.$patientId.tsx
@@ -179,7 +179,7 @@ function PatientDetail() {
   const [editingPaymentId, setEditingPaymentId] = useState<string | null>(null);
   const [paymentEditAmount, setPaymentEditAmount] = useState("");
   const [paymentEditMethod, setPaymentEditMethod] = useState<
-    "cash" | "card" | "transfer" | "package" | "other"
+    "cash" | "card" | "transfer" | "package" | "gratis" | "barter" | "other"
   >("cash");
   const [paymentEditNotes, setPaymentEditNotes] = useState("");
   const [paymentEditAppointmentId, setPaymentEditAppointmentId] = useState<
@@ -189,6 +189,8 @@ function PatientDetail() {
     "amount" | "percent"
   >("amount");
   const [paymentEditDiscountValue, setPaymentEditDiscountValue] = useState("");
+  const [paymentEditGratisReason, setPaymentEditGratisReason] = useState("");
+  const [paymentEditBarterDescription, setPaymentEditBarterDescription] = useState("");
   const [isPaymentEditSubmitting, setIsPaymentEditSubmitting] = useState(false);
 
   const [refundDialogOpen, setRefundDialogOpen] = useState(false);
@@ -614,6 +616,8 @@ function PatientDetail() {
     appointmentId?: string;
     discountAmount?: number | null;
     discountPercent?: number | null;
+    gratisReason?: string;
+    barterDescription?: string;
   }) => {
     setEditingPaymentId(payment._id);
     setPaymentEditAmount(String(payment.amount));
@@ -622,12 +626,16 @@ function PatientDetail() {
       | "card"
       | "transfer"
       | "package"
+      | "gratis"
+      | "barter"
       | "other";
     setPaymentEditMethod(
       method === "cash" ||
         method === "card" ||
         method === "transfer" ||
         method === "package" ||
+        method === "gratis" ||
+        method === "barter" ||
         method === "other"
         ? method
         : "cash",
@@ -644,6 +652,8 @@ function PatientDetail() {
       setPaymentEditDiscountType("amount");
       setPaymentEditDiscountValue("");
     }
+    setPaymentEditGratisReason(payment.gratisReason ?? "");
+    setPaymentEditBarterDescription(payment.barterDescription ?? "");
   };
 
   const closeEditPaymentDialog = () => {
@@ -652,14 +662,24 @@ function PatientDetail() {
     setPaymentEditNotes("");
     setPaymentEditAppointmentId(null);
     setPaymentEditDiscountValue("");
+    setPaymentEditGratisReason("");
+    setPaymentEditBarterDescription("");
   };
 
   const handleUpdatePayment = async () => {
     if (!editingPaymentId) return;
     const normalized = paymentEditAmount.replace(",", ".").trim();
     const amount = parseFloat(normalized);
-    if (!Number.isFinite(amount) || amount <= 0) {
+    if (paymentEditMethod !== "gratis" && (!Number.isFinite(amount) || amount <= 0)) {
       toast.error(t("gabinet.payments.amountRequired"));
+      return;
+    }
+    if (paymentEditMethod === "gratis" && !paymentEditGratisReason.trim()) {
+      toast.error(t("gabinet.payments.gratisReasonRequired", "Powód gratis jest wymagany"));
+      return;
+    }
+    if (paymentEditMethod === "barter" && !paymentEditBarterDescription.trim()) {
+      toast.error(t("gabinet.payments.barterDescriptionRequired", "Opis barteru jest wymagany"));
       return;
     }
     const discountVal =
@@ -681,11 +701,17 @@ function PatientDetail() {
       await updatePaymentAction({
         organizationId,
         paymentId: editingPaymentId,
-        amount,
+        amount: paymentEditMethod === "gratis" ? 0 : amount,
         paymentMethod: paymentEditMethod,
         notes: paymentEditNotes.trim() ? paymentEditNotes.trim() : null,
         discountAmount,
         discountPercent,
+        ...(paymentEditMethod === "gratis"
+          ? { gratisReason: paymentEditGratisReason.trim() }
+          : {}),
+        ...(paymentEditMethod === "barter"
+          ? { barterDescription: paymentEditBarterDescription.trim() }
+          : {}),
       });
       toast.success(t("gabinet.payments.updated"));
       void queryClient.invalidateQueries({ queryKey: supabaseKeys.payments.all });
@@ -1310,6 +1336,10 @@ function PatientDetail() {
         setPaymentEditDiscountType={setPaymentEditDiscountType}
         paymentEditDiscountValue={paymentEditDiscountValue}
         setPaymentEditDiscountValue={setPaymentEditDiscountValue}
+        paymentEditGratisReason={paymentEditGratisReason}
+        setPaymentEditGratisReason={setPaymentEditGratisReason}
+        paymentEditBarterDescription={paymentEditBarterDescription}
+        setPaymentEditBarterDescription={setPaymentEditBarterDescription}
         isPaymentEditSubmitting={isPaymentEditSubmitting}
         onClose={closeEditPaymentDialog}
         onSubmit={handleUpdatePayment}


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5679.

Closes #5679

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 7d23b8f0 fix(gabinet): add gratisReason/barterDescription to edit-payment dialog (issue #5679)

### Files changed

```
 convex/payments.ts                                 | 33 +++++++++-
 .../gabinet/patients/edit-payment-dialog.tsx       | 70 +++++++++++++++++++---
 .../gabinet/patients/patient-payments-tab.tsx      |  6 ++
 src/lib/supabase/mappers/payments.ts               |  2 +
 .../_layout.gabinet.patients.$patientId.tsx        | 36 ++++++++++-
 5 files changed, 134 insertions(+), 13 deletions(-)
```