### PR TITLE
Raporty: gratis i barter widoczne osobno w raportach finansowych

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -4032,7 +4032,20 @@
       "noProductSales": "No product sales in this period",
       "perProductBreakdown": "By Product",
       "perEmployeeProductSales": "By Employee",
-      "unattributedReturnsNote": "{{count}} return(s) totalling {{amount}} have no payment method and could not be deducted from any category"
+      "unattributedReturnsNote": "{{count}} return(s) totalling {{amount}} have no payment method and could not be deducted from any category",
+      "gratisBarterTitle": "Gratis & Barter",
+      "gratis": "Gratis",
+      "barter": "Barter",
+      "gratisNote": "Services provided free of charge – not counted toward revenue",
+      "barterNote": "Accounting reference value – not cash income",
+      "referenceValue": "Reference value",
+      "barterAccountingValue": "Accounting value",
+      "settlementType": "Settlement type",
+      "settlementAll": "All",
+      "settlementStandard": "Standard only",
+      "settlementGratis": "Gratis only",
+      "settlementBarter": "Barter only",
+      "noGratisBarter": "No gratis or barter settlements in this period"
     },
     "bodyChart": {
       "description": "Mark body areas related to the appointment",

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -4031,7 +4031,20 @@
       "noProductSales": "Brak sprzedaży produktów w tym okresie",
       "perProductBreakdown": "Wg. produktu",
       "perEmployeeProductSales": "Wg. pracownika",
-      "unattributedReturnsNote": "{{count}} zwrot(ów) na łączną kwotę {{amount}} nie ma przypisanej metody płatności i nie zostało odjęte od żadnej kategorii"
+      "unattributedReturnsNote": "{{count}} zwrot(ów) na łączną kwotę {{amount}} nie ma przypisanej metody płatności i nie zostało odjęte od żadnej kategorii",
+      "gratisBarterTitle": "Gratis i barter",
+      "gratis": "Gratis",
+      "barter": "Barter",
+      "gratisNote": "Usługi wykonane nieodpłatnie – nie wliczane do obrotu",
+      "barterNote": "Wartość ewidencyjna – nie jest przychodem pieniężnym",
+      "referenceValue": "Wartość referencyjna",
+      "barterAccountingValue": "Wartość ewidencyjna",
+      "settlementType": "Typ rozliczenia",
+      "settlementAll": "Wszystkie",
+      "settlementStandard": "Tylko standardowe",
+      "settlementGratis": "Tylko gratis",
+      "settlementBarter": "Tylko barter",
+      "noGratisBarter": "Brak rozliczeń gratis lub barter w wybranym okresie"
     },
     "bodyChart": {
       "description": "Zaznacz obszary ciała powiązane z wizytą",

--- a/src/hooks/use-supabase-payments.ts
+++ b/src/hooks/use-supabase-payments.ts
@@ -61,6 +61,91 @@ export function useSupabaseGratisBarterAppointmentIds(
 }
 
 // ---------------------------------------------------------------------------
+// Gratis/Barter Details (split by method, with amounts)
+// ---------------------------------------------------------------------------
+
+export interface GratisBarterDetail {
+  appointmentId: string;
+  paymentMethod: "gratis" | "barter";
+  amount: number;
+  gratisReason?: string;
+  barterDescription?: string;
+}
+
+export interface GratisBarterDetailsResult {
+  allIds: Set<string>;
+  gratisIds: Set<string>;
+  barterIds: Set<string>;
+  details: GratisBarterDetail[];
+}
+
+/**
+ * Like useSupabaseGratisBarterAppointmentIds but returns richer data: the IDs
+ * split by method (gratis vs. barter) plus payment amounts for each, used by
+ * the reports page to show a separate Gratis/Barter section (issue #5662).
+ */
+export function useSupabaseGratisBarterDetails(
+  organizationId: string,
+  appointmentIds: string[],
+  options: { enabled?: boolean } = {},
+) {
+  const { client, isReady } = useSupabase();
+  const { enabled = true } = options;
+  const stableIds = [...appointmentIds].sort();
+
+  return useQuery<GratisBarterDetailsResult, Error>({
+    queryKey: [
+      ...supabaseKeys.payments.list(organizationId),
+      "gratisBarterDetails",
+      stableIds.join(","),
+    ],
+    queryFn: async (): Promise<GratisBarterDetailsResult> => {
+      const allIds = new Set<string>();
+      const gratisIds = new Set<string>();
+      const barterIds = new Set<string>();
+      const details: GratisBarterDetail[] = [];
+
+      if (!client) throw new Error("Supabase client not ready");
+      if (stableIds.length === 0) return { allIds, gratisIds, barterIds, details };
+
+      const { data, error } = await client
+        .from("payments")
+        .select("appointment_id, payment_method, amount, gratis_reason, barter_description")
+        .eq("organization_id", organizationId)
+        .eq("status", "completed")
+        .in("payment_method", ["gratis", "barter"])
+        .in("appointment_id", stableIds);
+
+      if (error) throw error;
+
+      for (const row of (data ?? []) as {
+        appointment_id: string | null;
+        payment_method: string;
+        amount: number;
+        gratis_reason: string | null;
+        barter_description: string | null;
+      }[]) {
+        if (!row.appointment_id) continue;
+        const method = row.payment_method as "gratis" | "barter";
+        allIds.add(row.appointment_id);
+        if (method === "gratis") gratisIds.add(row.appointment_id);
+        else barterIds.add(row.appointment_id);
+        details.push({
+          appointmentId: row.appointment_id,
+          paymentMethod: method,
+          amount: Number(row.amount) || 0,
+          gratisReason: row.gratis_reason ?? undefined,
+          barterDescription: row.barter_description ?? undefined,
+        });
+      }
+
+      return { allIds, gratisIds, barterIds, details };
+    },
+    enabled: enabled && isReady && !!organizationId && stableIds.length > 0,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Patient Credit Balances (bulk)
 // ---------------------------------------------------------------------------
 

--- a/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
+++ b/src/routes/_app/_auth/dashboard/_layout.gabinet.reports.lazy.tsx
@@ -4,8 +4,9 @@ import Papa from "papaparse";
 import { toast } from "sonner";
 import { useSupabaseGabinetAppointmentsByDateRange } from "@/hooks/use-supabase-gabinet-appointments";
 import {
-  useSupabaseGratisBarterAppointmentIds,
+  useSupabaseGratisBarterDetails,
   useSupabasePaymentsRevenueByDateRange,
+  type GratisBarterDetail,
 } from "@/hooks/use-supabase-payments";
 import {
   useSupabaseGabinetDayClosesInRange,
@@ -45,6 +46,7 @@ import {
   computeDailyStats,
   computeEmployeeStats,
   computeDirectSalesPaymentBreakdown,
+  computeGratisBarterStats,
   computePaymentMethodBreakdown,
   computeStatusStats,
   computeTreatmentStats,
@@ -1854,6 +1856,86 @@ function SafeReportSection({
   );
 }
 
+/* ─── Gratis & Barter Section ─── */
+
+function GratisBarterSection({
+  details,
+  currency,
+  rangeLabel,
+}: {
+  details: GratisBarterDetail[];
+  currency: string;
+  rangeLabel: string;
+}) {
+  const { t } = useTranslation();
+  const stats = useMemo(() => computeGratisBarterStats(details), [details]);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold">{t("gabinet.reports.gratisBarterTitle")}</h2>
+        <p className="text-muted-foreground text-sm">{rangeLabel}</p>
+      </div>
+      {details.length === 0 ? (
+        <Card>
+          <CardContent className="flex items-center justify-center py-8">
+            <span className="text-muted-foreground text-sm">
+              {t("gabinet.reports.noGratisBarter")}
+            </span>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Card>
+            <CardHeader className="border-b">
+              <span className="font-semibold">{t("gabinet.reports.gratis")}</span>
+            </CardHeader>
+            <CardContent className="pt-4">
+              <p className="text-muted-foreground text-xs">
+                {t("gabinet.reports.gratisNote")}
+              </p>
+              <div className="mt-3 grid grid-cols-2 gap-4">
+                <div>
+                  <p className="text-muted-foreground text-sm">{t("gabinet.reports.appointments")}</p>
+                  <p className="mt-1 text-2xl font-bold">{stats.gratisCount}</p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground text-sm">{t("gabinet.reports.referenceValue")}</p>
+                  <p className="mt-1 text-2xl font-bold">
+                    {formatCurrencyPLN(stats.gratisValue, currency, { fractionDigits: 0 })}
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="border-b">
+              <span className="font-semibold">{t("gabinet.reports.barter")}</span>
+            </CardHeader>
+            <CardContent className="pt-4">
+              <p className="text-muted-foreground text-xs">
+                {t("gabinet.reports.barterNote")}
+              </p>
+              <div className="mt-3 grid grid-cols-2 gap-4">
+                <div>
+                  <p className="text-muted-foreground text-sm">{t("gabinet.reports.appointments")}</p>
+                  <p className="mt-1 text-2xl font-bold">{stats.barterCount}</p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground text-sm">{t("gabinet.reports.barterAccountingValue")}</p>
+                  <p className="mt-1 text-2xl font-bold">
+                    {formatCurrencyPLN(stats.barterValue, currency, { fractionDigits: 0 })}
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}
+
 /* ─── Main Page ─── */
 
 function GabinetReports() {
@@ -1862,6 +1944,7 @@ function GabinetReports() {
   const { activeLocationId, setActiveLocationId } = useActiveLocation();
   const [dateRange, setDateRange] = useState<DateRangeKey>("30d");
   const [dateFilterPanelOpen, setDateFilterPanelOpen] = useState(false);
+  const [settlementType, setSettlementType] = useState<"all" | "standard" | "gratis" | "barter">("all");
   const todayIso = new Date().toISOString().split("T")[0];
   const defaultCustomStart = useMemo(() => {
     const d = new Date();
@@ -1936,8 +2019,24 @@ function GabinetReports() {
       .map((a) => a._id);
   }, [appointments]);
 
-  const { data: gratisBarterIds, isLoading: loadingGratisBarter } =
-    useSupabaseGratisBarterAppointmentIds(organizationId, completedAppointmentIds);
+  const { data: gratisBarterData, isLoading: loadingGratisBarter } =
+    useSupabaseGratisBarterDetails(organizationId, completedAppointmentIds);
+
+  const gratisBarterIds = useMemo(
+    () => gratisBarterData?.allIds ?? new Set<string>(),
+    [gratisBarterData],
+  );
+
+  const filteredAppointments = useMemo(() => {
+    const appts = appointments ?? [];
+    if (settlementType === "standard")
+      return appts.filter((a) => !gratisBarterIds.has(a._id));
+    if (settlementType === "gratis")
+      return appts.filter((a) => gratisBarterData?.gratisIds.has(a._id));
+    if (settlementType === "barter")
+      return appts.filter((a) => gratisBarterData?.barterIds.has(a._id));
+    return appts;
+  }, [appointments, settlementType, gratisBarterIds, gratisBarterData]);
 
   const { data: actualPayments, isLoading: loadingActualPayments } =
     useSupabasePaymentsRevenueByDateRange(organizationId, startDate, endDate, {
@@ -2027,8 +2126,8 @@ function GabinetReports() {
 
   // Treatment stats: count + estimated revenue (completed only, gratis/barter excluded from revenue)
   const treatmentStats = useMemo(
-    () => computeTreatmentStats(appointments ?? [], treatmentMap, gratisBarterIds ?? new Set()),
-    [appointments, treatmentMap, gratisBarterIds]
+    () => computeTreatmentStats(filteredAppointments, treatmentMap, gratisBarterIds),
+    [filteredAppointments, treatmentMap, gratisBarterIds]
   );
 
   const topByRevenue = useMemo(
@@ -2041,20 +2140,20 @@ function GabinetReports() {
 
   // Status distribution
   const statusStats = useMemo(
-    () => computeStatusStats(appointments ?? []),
-    [appointments]
+    () => computeStatusStats(filteredAppointments),
+    [filteredAppointments]
   );
 
   // Daily appointment counts
   const dailyStats = useMemo(
-    () => computeDailyStats(appointments ?? []),
-    [appointments]
+    () => computeDailyStats(filteredAppointments),
+    [filteredAppointments]
   );
 
   // Employee utilization
   const employeeStats = useMemo(
-    () => computeEmployeeStats(appointments ?? [], employeeMap, treatmentMap, gratisBarterIds ?? new Set()),
-    [appointments, employeeMap, treatmentMap, gratisBarterIds]
+    () => computeEmployeeStats(filteredAppointments, employeeMap, treatmentMap, gratisBarterIds),
+    [filteredAppointments, employeeMap, treatmentMap, gratisBarterIds]
   );
 
   // Revenue: relative to the selected date range (endDate = last day of range)
@@ -2115,11 +2214,9 @@ function GabinetReports() {
     [actualPayments]
   );
 
-  const totalAppointments = appointments?.length ?? 0;
-  const completedCount =
-    appointments?.filter((a) => a.status === "completed").length ?? 0;
-  const cancelledCount =
-    appointments?.filter((a) => a.status === "cancelled").length ?? 0;
+  const totalAppointments = filteredAppointments.length;
+  const completedCount = filteredAppointments.filter((a) => a.status === "completed").length;
+  const cancelledCount = filteredAppointments.filter((a) => a.status === "cancelled").length;
   const completionRate =
     totalAppointments > 0
       ? Math.round((completedCount / totalAppointments) * 100)
@@ -2181,6 +2278,11 @@ function GabinetReports() {
     rows.push({ section: "revenue_actual", metric: "lastDay", value: actualLastDay, revenue: "" });
     rows.push({ section: "revenue_actual", metric: "last7days", value: actualLast7, revenue: "" });
     rows.push({ section: "revenue_actual", metric: "total", value: actualTotal, revenue: "" });
+    const gbStats = computeGratisBarterStats(gratisBarterData?.details ?? []);
+    rows.push({ section: "gratis_barter", metric: "gratis_count", value: gbStats.gratisCount, revenue: "" });
+    rows.push({ section: "gratis_barter", metric: "gratis_reference_value", value: "", revenue: gbStats.gratisValue });
+    rows.push({ section: "gratis_barter", metric: "barter_count", value: gbStats.barterCount, revenue: "" });
+    rows.push({ section: "gratis_barter", metric: "barter_accounting_value", value: "", revenue: gbStats.barterValue });
     for (const tr of treatmentStats) {
       rows.push({ section: "treatment", metric: tr.name, value: tr.count, revenue: tr.revenue });
     }
@@ -2289,6 +2391,7 @@ function GabinetReports() {
     employeeMap,
     employeeMapById,
     directSales,
+    gratisBarterData,
     startDate,
     endDate,
     t,
@@ -2357,6 +2460,17 @@ function GabinetReports() {
               </SelectContent>
             </Select>
           )}
+          <Select value={settlementType} onValueChange={(v) => setSettlementType(v as typeof settlementType)}>
+            <SelectTrigger className="w-44" aria-label={t("gabinet.reports.settlementType")}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">{t("gabinet.reports.settlementAll")}</SelectItem>
+              <SelectItem value="standard">{t("gabinet.reports.settlementStandard")}</SelectItem>
+              <SelectItem value="gratis">{t("gabinet.reports.settlementGratis")}</SelectItem>
+              <SelectItem value="barter">{t("gabinet.reports.settlementBarter")}</SelectItem>
+            </SelectContent>
+          </Select>
           <Select
             value={dateRange}
             onValueChange={(v) => {
@@ -2432,6 +2546,13 @@ function GabinetReports() {
           actualTotal={actualTotal}
         />
       </div>
+
+      {/* Gratis & Barter */}
+      <GratisBarterSection
+        details={gratisBarterData?.details ?? []}
+        currency={defaultCurrency}
+        rangeLabel={rangeLabel}
+      />
 
       {/* Payment Methods Breakdown */}
       <PaymentMethodsCard

--- a/src/routes/_app/_auth/dashboard/gabinet-report-utils.test.ts
+++ b/src/routes/_app/_auth/dashboard/gabinet-report-utils.test.ts
@@ -4,6 +4,7 @@ import {
   computeDailyStats,
   computeDirectSalesPaymentBreakdown,
   computeEmployeeStats,
+  computeGratisBarterStats,
   computePaymentMethodBreakdown,
   computeStatusStats,
   computeTreatmentStats,
@@ -514,5 +515,59 @@ describe("computeDirectSalesPaymentBreakdown", () => {
       computeDirectSalesPaymentBreakdown(sales, returns);
     const breakdownSum = breakdown.reduce((s, b) => s + b.total, 0);
     expect(breakdownSum).toBe(netRevenue + unattributedReturnAmount);
+  });
+});
+
+// ─── computeGratisBarterStats ─────────────────────────────────────────────────
+
+describe("computeGratisBarterStats", () => {
+  it("returns zeros for empty input", () => {
+    const result = computeGratisBarterStats([]);
+    expect(result).toEqual({ gratisCount: 0, gratisValue: 0, barterCount: 0, barterValue: 0 });
+  });
+
+  it("counts gratis and barter entries separately", () => {
+    const details = [
+      { appointmentId: "a1", paymentMethod: "gratis" as const, amount: 100 },
+      { appointmentId: "a2", paymentMethod: "gratis" as const, amount: 150 },
+      { appointmentId: "a3", paymentMethod: "barter" as const, amount: 200 },
+    ];
+    const result = computeGratisBarterStats(details);
+    expect(result.gratisCount).toBe(2);
+    expect(result.barterCount).toBe(1);
+  });
+
+  it("sums amounts per category", () => {
+    const details = [
+      { appointmentId: "a1", paymentMethod: "gratis" as const, amount: 100 },
+      { appointmentId: "a2", paymentMethod: "gratis" as const, amount: 50 },
+      { appointmentId: "a3", paymentMethod: "barter" as const, amount: 300 },
+      { appointmentId: "a4", paymentMethod: "barter" as const, amount: 120 },
+    ];
+    const result = computeGratisBarterStats(details);
+    expect(result.gratisValue).toBe(150);
+    expect(result.barterValue).toBe(420);
+  });
+
+  it("handles gratis-only input", () => {
+    const details = [
+      { appointmentId: "a1", paymentMethod: "gratis" as const, amount: 200 },
+    ];
+    const result = computeGratisBarterStats(details);
+    expect(result.gratisCount).toBe(1);
+    expect(result.gratisValue).toBe(200);
+    expect(result.barterCount).toBe(0);
+    expect(result.barterValue).toBe(0);
+  });
+
+  it("handles barter-only input", () => {
+    const details = [
+      { appointmentId: "a1", paymentMethod: "barter" as const, amount: 500 },
+    ];
+    const result = computeGratisBarterStats(details);
+    expect(result.gratisCount).toBe(0);
+    expect(result.gratisValue).toBe(0);
+    expect(result.barterCount).toBe(1);
+    expect(result.barterValue).toBe(500);
   });
 });

--- a/src/routes/_app/_auth/dashboard/gabinet-report-utils.ts
+++ b/src/routes/_app/_auth/dashboard/gabinet-report-utils.ts
@@ -142,6 +142,33 @@ export function computeEmployeeStats(
     .sort((a, b) => b.count - a.count);
 }
 
+export interface GratisBarterDetail {
+  appointmentId: string;
+  paymentMethod: "gratis" | "barter";
+  amount: number;
+  gratisReason?: string;
+  barterDescription?: string;
+}
+
+export function computeGratisBarterStats(details: GratisBarterDetail[]): {
+  gratisCount: number;
+  gratisValue: number;
+  barterCount: number;
+  barterValue: number;
+} {
+  let gratisCount = 0, gratisValue = 0, barterCount = 0, barterValue = 0;
+  for (const d of details) {
+    if (d.paymentMethod === "gratis") {
+      gratisCount++;
+      gratisValue += d.amount;
+    } else {
+      barterCount++;
+      barterValue += d.amount;
+    }
+  }
+  return { gratisCount, gratisValue, barterCount, barterValue };
+}
+
 const PAYMENT_CATEGORIES = ["cash", "card", "transfer", "package", "other"] as const;
 export type PaymentCategory = (typeof PAYMENT_CATEGORIES)[number];
 


### PR DESCRIPTION
Auto-generated by Claude in response to issue #5662.

Closes #5662

---

## Claude summary

_Claude's narrative summary referenced files that are not in this PR's diff and was discarded ([#1586](https://github.com/aleksanderem/crm_new/issues/1586))._

### Commits

- 532deec1 feat(gabinet): show gratis/barter separately in financial reports (issue #5662)

### Files changed

```
 public/locales/en/translation.json                 |  15 +-
 public/locales/pl/translation.json                 |  15 +-
 src/hooks/use-supabase-payments.ts                 |  85 ++++++++++++
 .../dashboard/_layout.gabinet.reports.lazy.tsx     | 153 ++++++++++++++++++---
 .../_auth/dashboard/gabinet-report-utils.test.ts   |  55 ++++++++
 .../_app/_auth/dashboard/gabinet-report-utils.ts   |  27 ++++
 6 files changed, 332 insertions(+), 18 deletions(-)
```